### PR TITLE
Flash Powder, Sonic Powder, and Flashbang Refactor

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -6,6 +6,7 @@
 	light_power = 10
 	light_color = LIGHT_COLOR_WHITE
 	var/light_time = 2
+	var/range = 7
 
 /obj/item/grenade/flashbang/prime()
 	update_mob()
@@ -15,60 +16,65 @@
 
 	set_light(7)
 
-	for(var/mob/living/M in hearers(7, flashbang_turf))
-		bang(get_turf(M), M)
+	do_sparks(rand(5, 9), FALSE, src)
+	playsound(flashbang_turf, 'sound/effects/bang.ogg', 25, 1)
+	bang(flashbang_turf, range, src)
 
-	for(var/obj/structure/blob/B in hear(8,flashbang_turf))     		//Blob damage here
-		var/damage = round(30/(get_dist(B,get_turf(src))+1))
+	for(var/obj/structure/blob/B in hear(8, flashbang_turf))     		//Blob damage here
+		var/damage = round(30 / (get_dist(B, get_turf(src)) + 1))
 		B.health -= damage
 		B.update_icon()
 
 	spawn(light_time)
 		qdel(src)
 
-/obj/item/grenade/flashbang/proc/bang(var/turf/T , var/mob/living/M)
-	M.show_message("<span class='warning'>BANG</span>", 2)
-	playsound(loc, 'sound/effects/bang.ogg', 25, 1)
+/proc/bang(turf/T, atom/A, range = 7, flash = TRUE, bang = TRUE)
+	for(var/mob/living/M in hearers(range, T))
+		if(M.stat == DEAD)
+			continue
+		M.show_message("<span class='warning'>BANG</span>", 2)
 
-//Checking for protections
-	var/ear_safety = M.check_ear_prot()
-	var/distance = max(1,get_dist(src,T))
+		//Checking for protections
+		var/ear_safety = M.check_ear_prot()
+		var/distance = max(1, get_dist(get_turf(A), get_turf(M)))
 
-//Flash
-	if(M.weakeyes)
-		M.visible_message("<span class='disarm'><b>[M]</b> screams and collapses!</span>")
-		to_chat(M, "<span class='userdanger'><font size=3>AAAAGH!</font></span>")
-		M.Weaken(15) //hella stunned
-		M.Stun(15)
-		if(ishuman(M))
-			M.emote("scream")
-			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
-			if(E)
-				E.receive_damage(8, 1)
+		//Flash
+		if(flash)
+			if(M.weakeyes)
+				M.visible_message("<span class='disarm'><b>[M]</b> screams and collapses!</span>")
+				to_chat(M, "<span class='userdanger'><font size=3>AAAAGH!</font></span>")
+				M.Weaken(15) //hella stunned
+				M.Stun(15)
+				if(ishuman(M))
+					M.emote("scream")
+					var/mob/living/carbon/human/H = M
+					var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
+					if(E)
+						E.receive_damage(8, 1)
 
-	if(M.flash_eyes(affect_silicon = 1))
-		M.Stun(max(10/distance, 3))
-		M.Weaken(max(10/distance, 3))
+			if(M.flash_eyes(affect_silicon = TRUE))
+				M.Stun(max(10 / distance, 3))
+				M.Weaken(max(10 / distance, 3))
 
 
-//Bang
-	if(get_turf(M) == get_turf(src))//Holding on person or being exactly where lies is significantly more dangerous and voids protection
-		M.Stun(10)
-		M.Weaken(10)
-	if(!ear_safety)
-		M.Stun(max(10/distance, 3))
-		M.Weaken(max(10/distance, 3))
-		M.AdjustEarDamage(rand(0, 5), 15)
-		if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
-			if(istype(ears))
-				if(ears.ear_damage >= 15)
-					to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
-					if(prob(ears.ear_damage - 5))
-						to_chat(M, "<span class='warning'>You can't hear anything!</span>")
-						M.BecomeDeaf()
-				else
-					if(ears.ear_damage >= 5)
-						to_chat(M, "<span class='warning'>Your ears start to ring!</span>")
+		//Bang
+		if(bang)
+			if(!distance || A.loc == M || A.loc == M.loc) //Holding on person or being exactly where lies is significantly more dangerous and voids protection
+				M.Stun(10)
+				M.Weaken(10)
+			if(!ear_safety)
+				M.Stun(max(10 / distance, 3))
+				M.Weaken(max(10 / distance, 3))
+				M.AdjustEarDamage(rand(0, 5), 15)
+				if(iscarbon(M))
+					var/mob/living/carbon/C = M
+					var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
+					if(istype(ears))
+						if(ears.ear_damage >= 15)
+							to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
+							if(prob(ears.ear_damage - 5))
+								to_chat(M, "<span class='warning'>You can't hear anything!</span>")
+								M.BecomeDeaf()
+						else
+							if(ears.ear_damage >= 5)
+								to_chat(M, "<span class='warning'>Your ears start to ring!</span>")

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -466,7 +466,7 @@ var/const/INGEST = 2
 
 					var/list/seen = viewers(4, get_turf(my_atom))
 					for(var/mob/M in seen)
-						if(!C.no_message)
+						if(C.mix_message)
 							to_chat(M, "<span class='notice'>[bicon(my_atom)] [C.mix_message]</span>")
 
 					if(istype(my_atom, /obj/item/slime_extract))
@@ -478,7 +478,8 @@ var/const/INGEST = 2
 								ME2.name = "used slime extract"
 								ME2.desc = "This extract has been used up."
 
-					playsound(get_turf(my_atom), C.mix_sound, 80, 1)
+					if(C.mix_sound)
+						playsound(get_turf(my_atom), C.mix_sound, 80, 1)
 
 					C.on_reaction(src, created_volume)
 					reaction_occured = 1

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -465,7 +465,7 @@ var/const/INGEST = 2
 							add_reagent(S, C.result_amount * C.secondary_results[S] * multiplier)
 
 					var/list/seen = viewers(4, get_turf(my_atom))
-					for(var/mob/M in seen)
+					for(var/mob/living/M in seen)
 						if(C.mix_message)
 							to_chat(M, "<span class='notice'>[bicon(my_atom)] [C.mix_message]</span>")
 

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -262,12 +262,6 @@
 		T.create_reagents(50)
 	T.reagents.add_reagent("sorium", 5)
 
-/datum/reagent/sorium_vortex
-	name = "sorium_vortex"
-	id = "sorium_vortex"
-	reagent_state = LIQUID
-	color = "#FFA500"
-
 /datum/reagent/liquid_dark_matter
 	name = "Liquid Dark Matter"
 	id = "liquid_dark_matter"
@@ -284,12 +278,6 @@
 	if(!T.reagents)
 		T.create_reagents(50)
 	T.reagents.add_reagent("liquid_dark_matter", 5)
-
-/datum/reagent/ldm_vortex
-	name = "LDM Vortex"
-	id = "ldm_vortex"
-	reagent_state = LIQUID
-	color = "#800080"
 
 /datum/reagent/blackpowder
 	name = "Black Powder"

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -11,13 +11,11 @@
 	var/required_other = 0 // an integer required for the reaction to happen
 
 	var/result_amount = 0
-	var/secondary = 0 // set to nonzero if secondary reaction
 	var/list/secondary_results = list()		//additional reagents produced by the reaction
 	var/min_temp = 0		//Minimum temperature required for the reaction to occur (heat to/above this). min_temp = 0 means no requirement
 	var/max_temp = 9999		//Maximum temperature allowed for the reaction to occur (cool to/below this).
 	var/mix_message = "The solution begins to bubble."
 	var/mix_sound = 'sound/effects/bubbles.ogg'
-	var/no_message = 0
 
 /datum/chemical_reaction/proc/on_reaction(datum/reagents/holder, created_volume)
 	return

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -89,55 +89,59 @@
 	name = "Sorium"
 	id = "sorium"
 	result = "sorium"
-	required_reagents = list("mercury" = 1, "oxygen" = 1, "nitrogen" = 1, "carbon" = 1)
+	required_reagents = list("mercury" = 1, "carbon" = 1, "nitrogen" = 1, "oxygen" = 1, "stabilizing_agent" = 1)
 	result_amount = 4
+	mix_message = "The mixture pops and crackles before settling down."
 
-/datum/chemical_reaction/sorium/on_reaction(datum/reagents/holder, created_volume)
-	if(holder.has_reagent("stabilizing_agent"))
+/datum/chemical_reaction/sorium_explosion
+	name = "Sorium Explosion"
+	id = "sorium_explosion"
+	required_reagents = list("mercury" = 1, "carbon" = 1, "nitrogen" = 1, "oxygen" = 1)
+	result_amount = 1
+	mix_message = "The mixture explodes with a big bang."
+
+/datum/chemical_reaction/sorium_explosion/on_reaction(datum/reagents/holder, created_volume)
+	var/turf/T = get_turf(holder.my_atom)
+	if(!T)
 		return
-	var/turf/simulated/T = get_turf(holder.my_atom)
 	goonchem_vortex(T, 0, created_volume)
-	holder.remove_reagent("sorium", created_volume)
 
-/datum/chemical_reaction/sorium_vortex
+/datum/chemical_reaction/sorium_explosion/sorium
 	name = "sorium_vortex"
 	id = "sorium_vortex"
-	result = "sorium_vortex"
 	required_reagents = list("sorium" = 1)
-	result_amount = 1
 	min_temp = T0C + 200
-
-/datum/chemical_reaction/sorium_vortex/on_reaction(datum/reagents/holder, created_volume)
-	var/turf/simulated/T = get_turf(holder.my_atom)
-	goonchem_vortex(T, 0, created_volume)
-	holder.remove_reagent("sorium_vortex", created_volume)
+	mix_sound = null
+	mix_message = null
 
 /datum/chemical_reaction/liquid_dark_matter
 	name = "Liquid Dark Matter"
 	id = "liquid_dark_matter"
 	result = "liquid_dark_matter"
+	required_reagents = list("plasma" = 1, "radium" = 1, "carbon" = 1, "stabilizing_agent" = 1)
+	result_amount = 4
+	mix_message = "The mixture begins to glow in a dark purple."
+
+/datum/chemical_reaction/ldm_implosion
+	name = "Implosion"
+	id = "implosion"
 	required_reagents = list("plasma" = 1, "radium" = 1, "carbon" = 1)
-	result_amount = 3
+	result_amount = 1
+	mix_message = "The mixture implodes suddenly."
 
-/datum/chemical_reaction/liquid_dark_matter/on_reaction(datum/reagents/holder, created_volume)
-	if(holder.has_reagent("stabilizing_agent"))
-		return
+/datum/chemical_reaction/ldm_implosion/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/simulated/T = get_turf(holder.my_atom)
+	if(!T)
+		return
 	goonchem_vortex(T, 1, created_volume)
-	holder.remove_reagent("liquid_dark_matter", created_volume)
 
-/datum/chemical_reaction/ldm_vortex
+/datum/chemical_reaction/ldm_implosion/liquid_dark_matter
 	name = "LDM Vortex"
 	id = "ldm_vortex"
-	result = "ldm_vortex"
 	required_reagents = list("liquid_dark_matter" = 1)
-	result_amount = 1
 	min_temp = T0C + 200
-
-/datum/chemical_reaction/ldm_vortex/on_reaction(datum/reagents/holder, created_volume)
-	var/turf/simulated/T = get_turf(holder.my_atom)
-	goonchem_vortex(T, 1, created_volume)
-	holder.remove_reagent("ldm_vortex", created_volume)
+	mix_sound = null
+	mix_message = null
 
 /datum/chemical_reaction/blackpowder
 	name = "Black Powder"
@@ -154,7 +158,7 @@
 	required_reagents = list("blackpowder" = 1)
 	result_amount = 1
 	min_temp = T0C + 200
-	no_message = 1
+	mix_message = null
 	mix_sound = null
 
 /datum/chemical_reaction/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
@@ -175,42 +179,35 @@
 		spawn(0)
 			qdel(holder.my_atom)
 
-datum/chemical_reaction/flash_powder
+/datum/chemical_reaction/flash_powder
 	name = "Flash powder"
 	id = "flash_powder"
 	result = "flash_powder"
-	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1, "chlorine" = 1)
-	result_amount = 3
+	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1, "chlorine" = 1, "stabilizing_agent" = 1)
+	result_amount = 5
+	mix_message = "The chemicals hiss and fizz briefly before falling still."
 
-/datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, created_volume)
-	if(holder.has_reagent("stabilizing_agent"))
-		return
-	var/location = get_turf(holder.my_atom)
-	do_sparks(2, 1, location)
-	for(var/mob/living/carbon/C in viewers(5, location))
-		if(C.flash_eyes())
-			if(get_dist(C, location) < 4)
-				C.Weaken(5)
-				continue
-			C.Stun(5)
-	holder.remove_reagent("flash_powder", created_volume)
-
-/datum/chemical_reaction/flash_powder_flash
-	name = "Flash powder activation"
-	id = "flash_powder_flash"
+/datum/chemical_reaction/flash
+	name = "Flash"
+	id = "flash"
 	result = null
+	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1, "chlorine" = 1)
+	mix_message = "The chemicals catch fire, burning brightly and violently!"
+	mix_sound = 'sound/effects/bang.ogg'
+
+/datum/chemical_reaction/flash/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	if(!location)
+		return
+	do_sparks(2, 1, location)
+	bang(location, holder.my_atom, 5, flash = TRUE, bang = FALSE)
+
+/datum/chemical_reaction/flash/flash_powder
+	name = "flash_powder_flash"
+	id = "flash_powder_flash"
 	required_reagents = list("flash_powder" = 1)
 	min_temp = T0C + 100
-
-/datum/chemical_reaction/flash_powder_flash/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	do_sparks(2, 1, location)
-	for(var/mob/living/carbon/C in viewers(5, location))
-		if(C.flash_eyes())
-			if(get_dist(C, location) < 4)
-				C.Weaken(5)
-				continue
-			C.Stun(5)
+	mix_message = null
 
 /datum/chemical_reaction/phlogiston
 	name = "Phlogiston"
@@ -250,7 +247,7 @@ datum/chemical_reaction/flash_powder
 	name = "smoke_powder"
 	id = "smoke_powder"
 	result = "smoke_powder"
-	required_reagents = list("stabilizing_agent" = 1, "potassium" = 1, "sugar" = 1, "phosphorus" = 1)
+	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1, "stabilizing_agent" = 1)
 	result_amount = 3
 	mix_message = "The mixture sets into a greyish powder!"
 
@@ -285,7 +282,6 @@ datum/chemical_reaction/flash_powder
 	id = "smoke_powder_smoke"
 	required_reagents = list("smoke_powder" = 1)
 	min_temp = T0C + 100
-	secondary = 1
 	result_amount = 1
 	forbidden_reagents = list("stimulants")
 	mix_sound = null
@@ -294,78 +290,30 @@ datum/chemical_reaction/flash_powder
 	name = "sonic_powder"
 	id = "sonic_powder"
 	result = "sonic_powder"
+	required_reagents = list("oxygen" = 1, "cola" = 1, "phosphorus" = 1, "stabilizing_agent" = 1)
+	result_amount = 2
+	mix_message = "The mixture begins to bubble slighly!"
+
+/datum/chemical_reaction/sonic_deafen
+	name = "sonic_deafen"
+	id = "sonic_deafen"
+	result = null
 	required_reagents = list("oxygen" = 1, "cola" = 1, "phosphorus" = 1)
-	result_amount = 3
+	mix_message = "The mixture begins to bubble furiously!"
+	mix_sound = 'sound/effects/bang.ogg'
 
-/datum/chemical_reaction/sonic_powder/on_reaction(datum/reagents/holder, created_volume)
-	if(holder.has_reagent("stabilizing_agent"))
-		return
+/datum/chemical_reaction/sonic_deafen/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	playsound(location, 'sound/effects/bang.ogg', 25, 1)
-	for(var/mob/living/M in hearers(5, location))
-		var/ear_safety = 0
-		var/distance = max(1,get_dist(src,T))
-		if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			if(ishuman(C))
-				var/mob/living/carbon/human/H = C
-				if((H.r_ear && (H.r_ear.flags & EARBANGPROTECT)) || (H.l_ear && (H.l_ear.flags & EARBANGPROTECT)) || (H.head && (H.head.flags & HEADBANGPROTECT)))
-					ear_safety++
-			to_chat(C, "<span class='warning'>BANG</span>")
-		if(!ear_safety)
-			M.Stun(max(10/distance, 3))
-			M.Weaken(max(10/distance, 3))
-			M.AdjustEarDamage(rand(0, 5), 15)
-			if(iscarbon(M))
-				var/mob/living/carbon/C = M
-				var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
-				if(istype(ears))
-					if(ears.ear_damage >= 15)
-						to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
-						if(prob(ears.ear_damage - 5))
-							to_chat(M, "<span class='warning'>You can't hear anything!</span>")
-							M.BecomeDeaf()
-					else
-						if(ears.ear_damage >= 5)
-							to_chat(M, "<span class='warning'>Your ears start to ring!</span>")
-	holder.remove_reagent("sonic_powder", created_volume)
+	if(!location)
+		return
+	bang(location, holder.my_atom, 5, flash = FALSE, bang = TRUE)
 
-/datum/chemical_reaction/sonic_powder_deafen
+/datum/chemical_reaction/sonic_deafen/sonic_powder
 	name = "sonic_powder_deafen"
 	id = "sonic_powder_deafen"
-	result = null
 	required_reagents = list("sonic_powder" = 1)
 	min_temp = T0C + 100
-
-/datum/chemical_reaction/sonic_powder_deafen/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	playsound(location, 'sound/effects/bang.ogg', 25, 1)
-	for(var/mob/living/M in hearers(5, location))
-		var/ear_safety = 0
-		var/distance = max(1,get_dist(src,T))
-		if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			if(ishuman(C))
-				var/mob/living/carbon/human/H = C
-				if((H.r_ear && (H.r_ear.flags & EARBANGPROTECT)) || (H.l_ear && (H.l_ear.flags & EARBANGPROTECT)) || (H.head && (H.head.flags & HEADBANGPROTECT)))
-					ear_safety++
-		to_chat(M, "<span class='warning'>BANG</span>")
-		if(!ear_safety)
-			M.Stun(max(10/distance, 3))
-			M.Weaken(max(10/distance, 3))
-			M.AdjustEarDamage(rand(0, 5), 15)
-			if(iscarbon(M))
-				var/mob/living/carbon/C = M
-				var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
-				if(istype(ears))
-					if(ears.ear_damage >= 15)
-						to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
-						if(prob(ears.ear_damage - 5))
-							to_chat(M, "<span class='warning'>You can't hear anything!</span>")
-							M.BecomeDeaf()
-					else
-						if(ears.ear_damage >= 5)
-							to_chat(M, "<span class='warning'>Your ears start to ring!</span>")
+	mix_message = null
 
 /datum/chemical_reaction/cryostylane
 	name = "cryostylane"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -15,7 +15,7 @@
 	result_amount = 1
 	min_temp = T0C + 400
 	mix_sound = null
-	no_message = 1
+	mix_message = null
 
 /datum/chemical_reaction/cyanide
 	name = "Cyanide"


### PR DESCRIPTION
Refactors flashbangs, flashpowder, and sonic powder.

This is largely to reduce copy-pasta and use a unified proc.

Flashbangs do the same as they do before, though they also cause sparks prior to going off and generate their bang sound at their location rather than playing the sound for every mob in range. If desire, flashbangs with longer range could be created, if desired.

Also fixes a bug where mechs users were stunning themselves with their own flashbangs.

Flash Powder and sonic powder have both been refactored to utilize the same proc flashbangs does. For the most part, this doesn't really have that much balance implications; they do virtually the same thing, at the same range (5); this isn't about buffing/nerfing so much as reducing copy-pasta nightmare.

Also, since someone will probably ask: no, flash powder and sonic powder do NOT damage blobs--this behavior is isolated to actual flashbangs.

Cleans up some other reagent code to be more consistent:

- stabilizing agent gets used up when mixing sorium, liquid dark matter, flash powder, and sonic powder
- got rid of unnecessary sorium vortex and liquid dark matter vortex reagents (these aren't needed anymore with the previous pyrotechnic refactor)
- Removed `no_mix_message`. Just set `mix_message` to `null` if you want no mix message, now
- Removed unused `secondary_reaction` var
- Fixes bug where abstract camera mobs were broadcast messages they weren't supposed to receive

:cl: Fox McCloud
tweak: stabilizing agent gets used up in reactions that utilize it
tweak: flashbangs spark when they initially go off
fix: Fixes mech users being stunned by their own flashbangs
/:cl: