### PR TITLE
Fixes Runtime with Multi Tile Airlocks

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -542,7 +542,7 @@
 	icon = 'icons/obj/doors/airlocks/glass_large/glass_large.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/glass_large/overlays.dmi'
 	note_overlay_file = 'icons/obj/doors/airlocks/glass_large/overlays.dmi'
-	assemblytype = "obj/structure/door_assembly/multi_tile"
+	assemblytype = /obj/structure/door_assembly/multi_tile
 
 /obj/machinery/door/airlock/multi_tile/narsie_act()
 	return


### PR DESCRIPTION
When I was fiddling with explosions, I was noticing runtimes with this, being unable to create objects of type `null`.

Turns out airlock construction's previously atrocious code was responsible for this

:cl: Fox McCloud
fix: Fixes multi-tile airlocks breaking and not leaving behind an assembly
/:cl: