### PR TITLE
Fixes Sending Faxes Using Toner

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -283,6 +283,7 @@ var/global/list/fax_blacklist = list()
 
 	use_power(200)
 
+	if(!(istype(copyitem, /obj/item/paper) || istype(copyitem, /obj/item/paper_bundle) || istype(copyitem, /obj/item/photo)))
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -283,8 +283,7 @@ var/global/list/fax_blacklist = list()
 
 	use_power(200)
 
-	if((istype(copyitem, /obj/item/paper))||(istype(copyitem, /obj/item/photo))||(istype(copyitem, /obj/item/paper_bundle)))
-	else
+	if((!istype(copyitem, /obj/item/paper))&&(!istype(copyitem, /obj/item/photo))&&(!istype(copyitem, /obj/item/paper_bundle)))
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -283,7 +283,6 @@ var/global/list/fax_blacklist = list()
 
 	use_power(200)
 
-	if(!istype(copyitem, /obj/item/paper)&&!istype(copyitem, /obj/item/photo)&&!istype(copyitem, /obj/item/paper_bundle))
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -283,7 +283,7 @@ var/global/list/fax_blacklist = list()
 
 	use_power(200)
 
-	if((!istype(copyitem, /obj/item/paper))&&(!istype(copyitem, /obj/item/photo))&&(!istype(copyitem, /obj/item/paper_bundle)))
+	if(!istype(copyitem, /obj/item/paper)&&!istype(copyitem, /obj/item/photo)&&!istype(copyitem, /obj/item/paper_bundle))
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -283,34 +283,26 @@ var/global/list/fax_blacklist = list()
 
 	use_power(200)
 
-	var/obj/item/rcvdcopy
-	if(istype(copyitem, /obj/item/paper))
-		rcvdcopy = copy(copyitem)
-	else if(istype(copyitem, /obj/item/photo))
-		rcvdcopy = photocopy(copyitem)
-	else if(istype(copyitem, /obj/item/paper_bundle))
-		rcvdcopy = bundlecopy(copyitem)
+	if((istype(copyitem, /obj/item/paper))||(istype(copyitem, /obj/item/photo))||(istype(copyitem, /obj/item/paper_bundle)))
 	else
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
 
-	rcvdcopy.loc = null //hopefully this shouldn't cause trouble
-
 	var/datum/fax/admin/A = new /datum/fax/admin()
-	A.name = rcvdcopy.name
+	A.name = copyitem.name
 	A.from_department = department
 	A.to_department = destination
 	A.origin = src
-	A.message = rcvdcopy
+	A.message = copyitem
 	A.sent_by = sender
 	A.sent_at = world.time
 
 	//message badmins that a fax has arrived
 	switch(destination)
 		if("Central Command")
-			message_admins(sender, "CENTCOM FAX", destination, rcvdcopy, "#006100")
+			message_admins(sender, "CENTCOM FAX", destination, copyitem, "#006100")
 		if("Syndicate")
-			message_admins(sender, "SYNDICATE FAX", destination, rcvdcopy, "#DC143C")
+			message_admins(sender, "SYNDICATE FAX", destination, copyitem, "#DC143C")
 	for(var/obj/machinery/photocopier/faxmachine/F in allfaxes)
 		if(F.department == destination)
 			F.receivefax(copyitem)


### PR DESCRIPTION
As the code currently stands, whenever you send a fax to Central Command
or the Syndicate, it makes a non-existant copy of the fax using toner
from your own machine. This fix removes unnecessary code and no longer
requires toner to send a fax.

Edit: I changed the sanity check from a positive empty check to a negative cannot do check, so its one line less.

Fixes: #11172

:cl: Twinmold
Fix: No longer costs toner to send a fax to Central Command
/:cl: