### PR TITLE
Tweaks to the Antagonist sound themes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -870,6 +870,7 @@
 					special_role = SPECIAL_ROLE_WIZARD
 					//ticker.mode.learn_basic_spells(current)
 					ticker.mode.update_wiz_icons_added(src)
+					SEND_SOUND(current, 'sound/ambience/antag/ragesmages.ogg')
 					to_chat(current, "<span class='danger'>You are a Space Wizard!</span>")
 					current.faction = list("wizard")
 					log_admin("[key_name(usr)] has wizarded [key_name(current)]")
@@ -911,6 +912,7 @@
 					ticker.mode.grant_changeling_powers(current)
 					ticker.mode.update_change_icons_added(src)
 					special_role = SPECIAL_ROLE_CHANGELING
+					SEND_SOUND(current, 'sound/ambience/antag/ling_aler.ogg')
 					to_chat(current, "<B><font color='red'>Your powers have awoken. A flash of memory returns to us... we are a changeling!</font></B>")
 					log_admin("[key_name(usr)] has changelinged [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has changelinged [key_name_admin(current)]")
@@ -955,6 +957,7 @@
 					slaved.masters += src
 					som = slaved //we MIGT want to mindslave someone
 					special_role = SPECIAL_ROLE_VAMPIRE
+					SEND_SOUND(current, 'sound/ambience/antag/vampalert.ogg')
 					to_chat(current, "<B><font color='red'>Your powers have awoken. Your lust for blood grows... You are a Vampire!</font></B>")
 					log_admin("[key_name(usr)] has vampired [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has vampired [key_name_admin(current)]")
@@ -1157,6 +1160,9 @@
 					if(isAI(current))
 						var/mob/living/silicon/ai/A = current
 						ticker.mode.add_law_zero(A)
+						SEND_SOUND(current, 'sound/ambience/antag/malf.ogg')
+					else
+						SEND_SOUND(current, 'sound/ambience/antag/tatoralert.ogg')
 					ticker.mode.update_traitor_icons_added(src)
 
 			if("autoobjectives")

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -130,8 +130,10 @@
 				forge_traitor_objectives(newtraitor.mind)
 
 				if(istype(newtraitor, /mob/living/silicon))
+					SEND_SOUND(newtraitor, 'sound/ambience/antag/malf.ogg')
 					add_law_zero(newtraitor)
 				else
+					SEND_SOUND(newtraitor, 'sound/ambience/antag/tatoralert.ogg')
 					equip_traitor(newtraitor)
 
 				traitors += newtraitor.mind

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -185,6 +185,7 @@ var/global/list/all_cults = list()
 		cult_mind.current.faction |= "cult"
 		var/datum/action/innate/cultcomm/C = new()
 		C.Grant(cult_mind.current)
+		SEND_SOUND(cult_mind.current, 'sound/ambience/antag/bloodcult.ogg')
 		cult_mind.current.create_attack_log("<span class='danger'>Has been converted to the cult!</span>")
 		if(jobban_isbanned(cult_mind.current, ROLE_CULTIST) || jobban_isbanned(cult_mind.current, ROLE_SYNDICATE))
 			replace_jobbanned_player(cult_mind.current, ROLE_CULTIST)


### PR DESCRIPTION
**What does this PR do:**
This PR changes 3 things regarding Antagonist sound themes:

1) Appropriate antag sound theme now plays for a new antag when he is chosen via administrative Traitor Panel. Immersion.

2) Cult sound theme now plays for a new cult converts, this change is not only for immersion - some new players could miss explanatory text when they got converted, and kept struggling against their new allies. This change could be a new cue for them to realize that they have switched sides.

3) Traitor/Malfunction sound themes now play for autotraitored crew/AI, again, not only for immersion, but also for them to realize that they have been chosen for antagonist if they have been not paying attention to a chat.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Appropriate antagonist sound theme now plays when an antagonist is selected via Traitor Panel
tweak: Cult sound theme now plays for a new cult converts
tweak: Traitor/Malfunction sound theme now plays for newly autotraitored crew/AI
/:cl: