### PR TITLE
Holo parasites now unmanifest once summoner reaches -100

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -65,6 +65,12 @@
 			visible_message("<span class='danger'>The [src] dies along with its user!</span>")
 			ghostize()
 			qdel(src)
+			return
+		if(summoner.health <= -100 && loc != summoner) // Fucking invinsible holoparasites
+			to_chat(src, "<span class='danger'>Your summoner has become to weak to substain you manifested!</span>")
+			visible_message("<span class='danger'>The [src] slowly fades away!</span>")
+			Recall(TRUE)
+			return
 	snapback()
 	if(summoned && !summoner && !adminseal)
 		to_chat(src, "<span class='danger'>You somehow lack a summoner! As a result, you dispel!</span>")
@@ -147,6 +153,8 @@
 	if(cooldown > world.time)
 		return
 	if(!summoner) return
+	if(summoner.health <= -100)
+		return
 	if(loc == summoner)
 		forceMove(get_turf(summoner))
 		src.client.eye = loc


### PR DESCRIPTION
**What does this PR do:**
Makes it so that holo parasites no longer stay manifested till RNG kicks in and kills the user at -800 damage.
Holo parasites now unmanifest at -100 damage on the host. They can still attack while unmanifested but that's another issue.

**Changelog:**
:cl:
balance: Holo parasites now can't manifest and get recalled when the summoner is at atleast -100 health
/:cl:

