### PR TITLE
Nations Update

### DIFF
--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -16,9 +16,8 @@ datum/game_mode/nations
 		set_ai()
 		assign_leaders()
 //		remove_access()
-		for(var/mob/M in GLOB.player_list)
-			if(!istype(M,/mob/new_player))
-				M << sound('sound/effects/purge_siren.ogg')
+		set_security_level("epsilon")
+	
 
 	return ..()
 


### PR DESCRIPTION
**What does this PR do:**
Makes nations set epsilon security level


🆑 
fix: Nations mode sets the security level to epsilon
/ 🆑 