### PR TITLE
Revert "Timer Subsystem Update"

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -71,6 +71,7 @@ SUBSYSTEM_DEF(timer)
 		for(var/I in second_queue)
 			log_world(get_timer_debug_string(I))
 
+	var/cut_start_index = 1
 	var/next_clienttime_timer_index = 0
 	var/len = length(clienttime_timers)
 
@@ -93,14 +94,14 @@ SUBSYSTEM_DEF(timer)
 
 		if(ctime_timer.flags & TIMER_LOOP)
 			ctime_timer.spent = 0
-			ctime_timer.timeToRun = REALTIMEOFDAY + ctime_timer.wait
-			BINARY_INSERT(ctime_timer, clienttime_timers, datum/timedevent, timeToRun)
+			clienttime_timers.Insert(ctime_timer, 1)
+			cut_start_index++
 		else
 			qdel(ctime_timer)
 
 
 	if(next_clienttime_timer_index)
-		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
+		clienttime_timers.Cut(cut_start_index,next_clienttime_timer_index+1)
 
 	if(MC_TICK_CHECK)
 		return
@@ -268,7 +269,7 @@ SUBSYSTEM_DEF(timer)
 	var/new_bucket_count
 	var/i = 1
 	for(i in 1 to length(alltimers))
-		var/datum/timedevent/timer = alltimers[i]
+		var/datum/timedevent/timer = alltimers[1]
 		if(!timer)
 			continue
 
@@ -410,8 +411,10 @@ SUBSYSTEM_DEF(timer)
 		prev.next = next
 		next.prev = prev
 	else
-		prev?.next = null
-		next?.prev = null
+		if(prev)
+			prev.next = null
+		if(next)
+			next.prev = null
 	prev = next = null
 
 /datum/timedevent/proc/bucketJoin()


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#11188

So. After looking at the git, talking on Discord, and Slith more or less confirming it was this PR. We believe that this PR is the reason that stuns are currently bugged. Unsure if you can testmerge revert PR's, but if you can it should be done. Or just full on reverted in the very likely case that this is the cause for stuns of all kinds(including resting) being broken.