### PR TITLE
excluded trick revolver from surplus

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -189,6 +189,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/toy/russian_revolver/trick_revolver
 	cost = 1
 	job = list("Clown")
+	surplus = 0
 
 //mime
 /datum/uplink_item/jobspecific/caneshotgun


### PR DESCRIPTION
**What does this PR do:**
The trick revolver looks like a normal revolver to the unsuspecting traitor. Usually, this wouldn't be an issue, but you can also get it in a surplus crate. It is possible to tell if you got a trick or real revolver in a surplus by summing up the tc cost of all the stuff you got or trying to unload the revolver, but that's very niche. The trick revolver as it currently exists is a noob trap when gotten in surplus crates, and having your traitor round ruined because you don't know we added a new item that kills you if used sounds very unfun.

Thus, this PR makes it so trick revolvers can't show up in surplus crates. You can only get it after buying it specifically in the uplink, so you know what you're getting.

**Images of sprite/map changes (IF APPLICABLE):**

**Changelog:**
:cl:
tweak: Excluded trick revolver from surplus.
/:cl:

