### PR TITLE
Fixes Some Species Having Oxy Damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -172,6 +172,7 @@
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/adjustOxyLoss(amount)
 	if(NO_BREATHE in dna.species.species_traits)
+		oxyloss = 0
 		return FALSE
 	if(dna.species && amount > 0)
 		amount = amount * dna.species.oxy_mod
@@ -179,6 +180,7 @@
 
 /mob/living/carbon/human/setOxyLoss(amount)
 	if(NO_BREATHE in dna.species.species_traits)
+		oxyloss = 0
 		return FALSE
 	if(dna.species && amount > 0)
 		amount = amount * dna.species.oxy_mod

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/human/SetLoseBreath(amount)
 	if(NO_BREATHE in dna.species.species_traits)
+		losebreath = 0
 		return FALSE
 	. = ..()
 

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -122,8 +122,10 @@
 
 /mob/living/proc/adjustOxyLoss(amount, updating_health = TRUE)
 	if(status_flags & GODMODE)
+		oxyloss = 0
 		return FALSE	//godmode
 	if(BREATHLESS in mutations)
+		oxyloss = 0
 		return FALSE
 	var/old_oxyloss = oxyloss
 	oxyloss = max(oxyloss + amount, 0)
@@ -137,8 +139,10 @@
 
 /mob/living/proc/setOxyLoss(amount, updating_health = TRUE)
 	if(status_flags & GODMODE)
+		oxyloss = 0
 		return FALSE	//godmode
 	if(BREATHLESS in mutations)
+		oxyloss = 0
 		return FALSE
 	var/old_oxyloss = oxyloss
 	oxyloss = amount

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -298,6 +298,7 @@
 
 /mob/living/SetLoseBreath(amount)
 	if(BREATHLESS in mutations)
+		losebreath = 0
 		return FALSE
 	losebreath = max(amount, 0)
 


### PR DESCRIPTION
In the newcrit PR, how OxyLoss and Losebreath was checked for was improved, in that it was checked for immediately when the damage was applied as opposed to relying on a species special life loop to set oxyloss and losebreath back to zero (which could hypothetically allow for weird edge cases of getting dealt 1000 oxy damage but still dying--this was a problem way before newcrit).

What I failed to account for is that in some situations, you could have Oxy damage and *become* a species that is immune to O2 damage or acquire a gene that makes you immune to it. 

At this point, you're forever locked with whatever losebreath and O2 damage you have.

This is what was happening with the necromantic stone: if the person had O2 damage, they'd get changed to a skeleton, they'd get rejuvinated, and because they were O2 immune, at that point, even rejuv couldn't set their oxyloss to 0.

This correct all of that by just having it so that if you have those mutations and a proc is called on you, it set your oxyloss/losebreath to `0` before returning.


Bug has nothing to do with newcrit and all to do with damage handling refactor done in the same PR.

Fixes: https://github.com/ParadiseSS13/Paradise/issues/11181

@KasparoVy since you commented on and noticed this refactor in the crit PR.

:cl: Fox McCloud
fix: Fixes necromantic stone not working properly and other edge cases where you had O2 damage and could become O2 damage immune
/:cl: