### PR TITLE
Shadowlings now have a slightly bigger colored text when speaking in the Shadowling Hivemind

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -523,7 +523,9 @@
 	flags = RESTRICTED | HIVEMIND
 
 /datum/language/shadowling/broadcast(mob/living/speaker, message, speaker_mask)
-	if(speaker.mind && speaker.mind.special_role)
+	if(speaker.mind && speaker.mind.special_role == SPECIAL_ROLE_SHADOWLING)
+		..(speaker,"<font size=3>[message]</font>", "<font size=3>([speaker.mind.special_role]) [speaker]</font>")
+	else if(speaker.mind && speaker.mind.special_role)
 		..(speaker, message, "([speaker.mind.special_role]) [speaker]")
 	else
 		..(speaker, message)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -524,7 +524,7 @@
 
 /datum/language/shadowling/broadcast(mob/living/speaker, message, speaker_mask)
 	if(speaker.mind && speaker.mind.special_role == SPECIAL_ROLE_SHADOWLING)
-		..(speaker,"<font size=3>[message]</font>", "<span class='shadowling'><font size=3>([speaker.mind.special_role]) [speaker]</font></span>")
+		..(speaker,"<font size=3><b>[message]</b></font>", "<span class='shadowling'><font size=3>([speaker.mind.special_role]) [speaker]</font></span>")
 	else if(speaker.mind && speaker.mind.special_role)
 		..(speaker, message, "([speaker.mind.special_role]) [speaker]")
 	else

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -524,7 +524,7 @@
 
 /datum/language/shadowling/broadcast(mob/living/speaker, message, speaker_mask)
 	if(speaker.mind && speaker.mind.special_role == SPECIAL_ROLE_SHADOWLING)
-		..(speaker,"<font size=3>[message]</font>", "<font size=3>([speaker.mind.special_role]) [speaker]</font>")
+		..(speaker,"<font size=3>[message]</font>", "<span class='shadowling'><font size=3>([speaker.mind.special_role]) [speaker]</font></span>")
 	else if(speaker.mind && speaker.mind.special_role)
 		..(speaker, message, "([speaker.mind.special_role]) [speaker]")
 	else


### PR DESCRIPTION
**What does this PR do:**
Pretty straightforward PR - Shadowlings now have a slightly bigger text font when speaking in the Shadowling Hivemind.

Thralls are required to listen to their Shadowling masters, but it might be hard for them to realize when they are giving their orders via Shadowling Hivemind, as they have the same text size as a regular thralls. This PR gives them a slightly bigger text size to differentiate them from thralls, which will hopefully hopefully lead to fewer instances of thralls ignoring their masters orders.

Picture of the new Shadowling text size in the Shadowling Hivemind
![New](https://user-images.githubusercontent.com/43862960/55431027-c11b8000-558f-11e9-9776-19058cc35f81.png)

Old size was the same size as the thrall one:
![old](https://user-images.githubusercontent.com/43862960/55431128-063fb200-5590-11e9-958b-3ff03d7735d8.png)

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Shadowlings now have a slightly bigger colored text when speaking in the Shadowling Hivemind
/:cl: