### PR TITLE
Fixes Mob Performance Issue

### DIFF
--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -18,23 +18,11 @@
 
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()
-	var/list/blood_data = get_blood_data(get_blood_id())//PROCCEPTION
-
 	if(NO_BLOOD in dna.species.species_traits)
 		bleed_rate = 0
 		return
 
 	if(bodytemperature >= 225 && !(NOCLONE in mutations)) //cryosleep or husked people do not pump the blood.
-
-		//Blood regeneration if there is some space
-		if(blood_volume < max_blood && blood_volume)
-			if(mind) //Handles vampires "eating" blood that isn't their own.
-				if(mind in ticker.mode.vampires)
-					if(nutrition >= NUTRITION_LEVEL_WELL_FED)
-						return //We don't want blood tranfusions making vampires fat.
-					if(blood_data["donor"] != src)
-						nutrition += (15 * REAGENTS_METABOLISM)
-						return //Only process one blood per tick, to maintain the same metabolism as nutriment for non-vampires.
 		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			blood_volume += 0.1 // regenerate blood VERY slowly
 
@@ -56,7 +44,7 @@
 				if(prob(15))
 					Paralyse(rand(1,3))
 					to_chat(src, "<span class='warning'>You feel extremely [word].</span>")
-			if(0 to BLOOD_VOLUME_SURVIVE)
+			if(-INFINITY to BLOOD_VOLUME_SURVIVE)
 				death()
 
 		var/temp_bleed = 0


### PR DESCRIPTION
I noticed that `handle_blood` was profiling incredibly high on the live server and was wondering what the heck was going on.

Turns out the stable mutagen PR that has blood hold a mob's DNA is the reason why; `Clone`ing DNA is expensive.

On its own, this isn't bad as long as you only fetch blood data when it's necessary.

The problem? Every single human mob was making a copy of their own blood's data every single `Life`, then immediately not doing anything with the list, because it was only ever used for vampires. 

Upon closer inspection, I figured `if(blood_data["donor"] != src)` was a useless check, since it will *always*  be `FALSE`, since `get_blood_data` always applies to `src`. I conferred with @Crazylemon64 and he confirmed my suspicions.

EIther way, I suspect `var/list/blood_data = get_blood_data(get_blood_id())` is a faulty refactor inclusion when our blood system was changed over to the new system, and was more relevant with the old system when mobs had *actual* reagent containers filled with *actual* reagent blood (which was dumb).

Vampires don't get their nutrition this way, anyway; they get it via blood sucking, directly.

This is a huge hit to the server right now, which is why it's marked high priority.

also fixes an edge case where having negative blood meant you would never die from blood loss (or suffer any ill effects really).

![img](https://i.gyazo.com/991bf07cb68889779f9de8283fe4e8d9.png)

:cl: Fox McCloud
fix: Dramatically improves human life performance (sorry, doesn't fix your actual crappy real life)
/:cl: