### PR TITLE
Tweaks Reagent Bodytemp Interaction

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -218,7 +218,7 @@ var/const/INGEST = 2
 
 /datum/reagents/proc/metabolize(mob/living/M)
 	if(M)
-		set_reagent_temp(M.bodytemperature)
+		temperature_reagents(M.bodytemperature - 30)
 
 	// a bitfield filled in by each reagent's `on_mob_life` to find out which states to update
 	var/update_flags = STATUS_UPDATE_NONE


### PR DESCRIPTION
Instead of reagents just setting their temperature, instantly, to what the body is, it'll try to adjust to the body's temperature, over time.

Now that newcrit is in and the pyrotechnics for Goonchem are better filled in and fleshed out, it's time to turn this on.

:cl: Fox McCloud
tweak: Reagents will now adjust to the body temperature over time as opposed to all at once
/:cl: