### PR TITLE
Shadowling Destroy Engines ability rework + changes to Shadowling End Round messages

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -262,15 +262,19 @@ Made by Xhuis
 /datum/game_mode/shadowling/declare_completion()
 	if(check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE) //Doesn't end instantly - this is hacky and I don't know of a better way ~X
 		feedback_set_details("round_end_result","shadowling win - shadowling ascension")
+		to_chat(world, "<FONT size = 3><B>Shadowling Victory</B></FONT>")
 		to_chat(world, "<span class='greentext'><b>The shadowlings have ascended and taken over the station!</b></span>")
 	else if(shadowling_dead && !check_shadow_victory()) //If the shadowlings have ascended, they can not lose the round
 		feedback_set_details("round_end_result","shadowling loss - shadowling killed")
+		to_chat(world, "<FONT size = 3><B>Crew Major Victory</B></FONT>")
 		to_chat(world, "<span class='redtext'><b>The shadowlings have been killed by the crew!</b></span>")
 	else if(!check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
 		feedback_set_details("round_end_result","shadowling loss - crew escaped")
+		to_chat(world, "<FONT size = 3><B>Crew Minor Victory</B></FONT>")
 		to_chat(world, "<span class='redtext'><b>The crew escaped the station before the shadowlings could ascend!</b></span>")
 	else
 		feedback_set_details("round_end_result","shadowling loss - generic failure")
+		to_chat(world, "<FONT size = 3><B>Crew Major Victory</B></FONT>")
 		to_chat(world, "<span class='redtext'><b>The shadowlings have failed!</b></span>")
 	..()
 	return 1

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -620,23 +620,28 @@
 
 /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle
 	name = "Destroy Engines"
-	desc = "Extends the time of the emergency shuttle's arrival by fifteen minutes. This can only be used once."
+	desc = "Extends the time of the emergency shuttle's arrival by ten minutes using a life force of our enemy. Shuttle will be unable to be recalled. This can only be used once."
 	panel = "Shadowling Abilities"
 	range = 1
 	clothes_req = 0
 	charge_max = 600
 	action_icon_state = "extend_shuttle"
+	var/global/extendlimit = 0
 
 /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle/cast(list/targets, mob/user = usr)
 	if(!shadowling_check(user))
+		charge_counter = charge_max
+		return
+	if(extendlimit == 1)
+		to_chat(user, "<span class='warning'>Shuttle was already delayed.</span>")
 		charge_counter = charge_max
 		return
 	for(var/mob/living/carbon/human/target in targets)
 		if(target.stat)
 			charge_counter = charge_max
 			return
-		if(!is_thrall(target))
-			to_chat(user, "<span class='warning'>[target] must be a thrall.</span>")
+		if(is_shadow_or_thrall(target))
+			to_chat(user, "<span class='warning'>[target] must not be an ally.</span>")
 			charge_counter = charge_max
 			return
 		if(SSshuttle.emergency.mode != SHUTTLE_CALL)
@@ -648,7 +653,9 @@
 						  "<span class='notice'>You begin to draw [M]'s life force.</span>")
 		M.visible_message("<span class='warning'>[M]'s face falls slack, [M.p_their()] jaw slightly distending.</span>", \
 						  "<span class='boldannounce'>You are suddenly transported... far, far away...</span>")
-		if(!do_after(user, 50, target = M))
+		extendlimit = 1
+		if(!do_after(user, 150, target = M))
+			extendlimit = 0
 			to_chat(M, "<span class='warning'>You are snapped back to reality, your haze dissipating!</span>")
 			to_chat(user, "<span class='warning'>You have been interrupted. The draw has failed.</span>")
 			return
@@ -657,10 +664,9 @@
 						  "<span class='warning'><b>...speeding by... ...pretty blue glow... ...touch it... ...no glow now... ...no light... ...nothing at all...</span>")
 		M.death()
 		if(SSshuttle.emergency.mode == SHUTTLE_CALL)
-			var/more_minutes = 9000
-			var/timer = SSshuttle.emergency.timeLeft()
-			timer += more_minutes
-			event_announcement.Announce("Major system failure aboard the emergency shuttle. This will extend its arrival time by approximately 15 minutes and the shuttle is unable to be recalled.", "System Failure", 'sound/misc/notice1.ogg')
+			var/more_minutes = 6000
+			var/timer = SSshuttle.emergency.timeLeft(1) + more_minutes
+			event_announcement.Announce("Major system failure aboard the emergency shuttle. This will extend its arrival time by approximately 10 minutes and the shuttle is unable to be recalled.", "System Failure", 'sound/misc/notice1.ogg')
 			SSshuttle.emergency.setTimer(timer)
 			SSshuttle.emergency.canRecall = FALSE
 		user.mind.spell_list.Remove(src) //Can only be used once!


### PR DESCRIPTION
**What does this PR do:**
This PR has 2 parts, lets get through them:

1) Shadowling Destroy Engines ability reworked. This ability previously allowed Shadowling to sacrifice a thrall to delay shuttle by 15 minutes, and shuttle became unable to be recalled. This ability had many problems:
a) **It did not even work properly, not properly adding the extra time to the duration of the shuttle ETA**
b) Even though ability is said to be able to be used only once, it was not coded properly. The ability, after its suscesful use was removed **only** from the Shadowling that used it. Not others. The other shadowlings could still use the ability, further extending shuttle arrival duration (if it had even worked properly, that is)
c) Sacrifing the thrall is pointless, as by the time shuttle is called Shadowlings have Black Recuperation ability, which simply allows them to revive them the sacrificed thrall. Thrall just got a trip to deadchat for 20 seconds, thats it. No consequences for using the ability whatsover.
... and more

I have reworked the ability followingly:
a) It is extending shuttle duration arrival correctly now.
b) Shuttle can be delayed only once using this ability, no matter how many shadowlings try it.
c) Shuttle delay changed from 15 to 10 minutes. Escaping from the Shadowlings while they are nearing ascension should be a valid option.
d) In order to use this ability, Shadowlings have to sacrifice non-ally target, which slows them a bit and depraves them of a potentional new thrall. Target, while sacrificed and unable to be revived by Shadowlings Black Recuperation ability, **is still able to be revived via traditional medical means, no permakill.**
e) Duration that takes to sacrifice the target changed from few second BZZZZZZZZZZ to a duration similiar to the enthralling non-shielded personnel. Shadowling must not be interruped, or he will have to start a process anew.

2) Changes to Shadowling End Round messages. When the round of Shadowlings ends, the victor status will be displayed above the traditional game ending message, similiarly to the Nukie rounds. Messages are as follows:
a) The shadowlings have ascended and taken over the station! ---> Shadowling Victory
b) The shadowlings have been killed by the crew!  ---> Crew Major Victory
c) The crew escaped the station before the shadowlings could ascend!  ---> Crew Minor Victory

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Added victory message to the End Round messages in the Shadowlings Rounds
tweak: Shadowling Destroy Engines ability reworked. You now need to sacrifice non-ally target to delay the emergency shuttle arrival by 10 minutes, and shuttle will be unable to be recalled. This ability can be used only once across ALL Shadowlings.
/:cl: