### PR TITLE
Fixes Clonepods

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -34,7 +34,7 @@
 
 	var/obj/effect/countdown/clonepod/countdown
 
-	var/list/brine_types = list("corazone", "salbutamol", "epinephrine", "salglu_solution") //stops heart attacks, heart failure, shock, and keeps their O2 levels normal
+	var/list/brine_types = list("corazone", "perfluorodecalin", "epinephrine", "salglu_solution") //stops heart attacks, heart failure, shock, and keeps their O2 levels normal
 	var/list/missing_organs
 	var/organs_number = 0
 
@@ -341,7 +341,7 @@
 			check_brine()
 
 			//Also heal some oxyloss ourselves just in case!!
-			occupant.adjustOxyLoss(-4)
+			occupant.adjustOxyLoss(-10)
 
 			use_power(7500) //This might need tweaking.
 
@@ -476,6 +476,10 @@
 	for(var/i in missing_organs)
 		qdel(i)
 	missing_organs.Cut()
+	occupant.SetLoseBreath(0) // Stop friggin' dying, gosh damn
+	occupant.setOxyLoss(0)
+	for(var/datum/disease/critical/crit in occupant.viruses)
+		crit.cure()
 	occupant.forceMove(get_turf(src))
 	occupant.update_body()
 	domutcheck(occupant) //Waiting until they're out before possible notransform.


### PR DESCRIPTION
clonepods sometimes pop people out with a lot of O2 damage or conditions. This really shouldn't happen, but RNG can be RNG.

Either way, this should help resolve that:

- Perfluorodecalin instead of salbutamol for better O2 healing in the pod
- Increased O2 healing passively by the pod
- Upon ejection, the occupant's OxyLoss and losebreath are both set to 0
- Shock and Cardiac failure will be cured (the pod injects corazone on its own, which prevents cardiac arrest).

:cl: Fox McCloud
fix: Fixes people popping out of cloning taking tons of damage
/:cl: