### PR TITLE
Trick revolver comes in a box.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -186,7 +186,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Trick Revolver"
 	desc = "A revolver that will fire backwards and kill whoever attempts to use it. Perfect for those pesky vigilante or just a good laugh."
 	reference = "CTR"
-	item = /obj/item/toy/russian_revolver/trick_revolver
+	item = /obj/item/storage/box/syndie_kit/fake_revolver
 	cost = 1
 	job = list("Clown")
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -254,6 +254,13 @@
 	new /obj/item/ammo_casing/shotgun/assassination(src)
 	new /obj/item/gun/projectile/revolver/doublebarrel/improvised/cane(src)
 
+/obj/item/storage/box/syndie_kit/fake_revolver
+	name = "trick revolver kit"
+
+/obj/item/storage/box/syndie_kit/fake_revolver/New()
+	..()
+	new /obj/item/toy/russian_revolver/trick_revolver(src)
+
 /obj/item/storage/box/syndie_kit/mimery
 	name = "advanced mimery kit"
 


### PR DESCRIPTION
**What does this PR do:**
Alternative to #11209 , trick revolver comes in a box labelled 'trick revolver kit' so you can tell what it is in a surplus crate. Seemed like the best alternative proposed, and the box can easily be folded into cardboard afterwards. Thanks to EvadableMoxie for the idea.


**Changelog:**
:cl:
tweak: trick revolver comes in a box, so you can tell what it is when getting it in a surplus crate.
/:cl:

