### PR TITLE
Esword actually reflects energy projectiles now

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -228,5 +228,5 @@
 
 /obj/item/melee/energy/sword/IsReflect()
 	if(active)
-		return TRUE
+		return 0.05
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -225,3 +225,8 @@
 	desc = "An extremely sharp blade made out of hard light. Packs quite a punch."
 	icon_state = "lightblade"
 	item_state = "lightblade"
+
+/obj/item/melee/energy/sword/IsReflect()
+	if(active)
+		return TRUE
+


### PR DESCRIPTION
**What does this PR do:**
Allows normal eswords to reflect energy projectiles while active, I assume the fact that they DID NOT before was due to a bug considering the information on the wiki and the description of the weapon.
NOTE: Esword now has 100% block chance for energy projectiles. I assume this is intended because of what's written on the wiki
**Changelog:**
:cl:
fix: esword now reflects energy projectiles like it should
/:cl:

