### PR TITLE
[Goonchem] Reagent tweaks

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -76,10 +76,10 @@
 		F = new /obj/effect/particle_effect/foam(T, metal)
 		F.amount = amount
 		if(!metal)
-			F.create_reagents(15)
+			F.create_reagents(25)
 			if(reagents)
 				for(var/datum/reagent/R in reagents.reagent_list)
-					F.reagents.add_reagent(R.id, min(R.volume, 3), R.data, reagents.chem_temp)
+					F.reagents.add_reagent(R.id, min(R.volume, 5), R.data, reagents.chem_temp)
 				F.color = mix_color_from_reagents(reagents.reagent_list)
 
 // foam disolves when heated
@@ -149,14 +149,14 @@
 		F.amount = amount
 
 		if(!metal)			// don't carry other chemicals if a metal foam
-			F.create_reagents(15)
+			F.create_reagents(25)
 
 			if(carried_reagents)
 				for(var/id in carried_reagents)
 					if(banned_reagents.Find("[id]"))
 						continue
 					var/datum/reagent/reagent_volume = carried_reagents[id]
-					F.reagents.add_reagent(id, min(reagent_volume, 3), null, temperature)
+					F.reagents.add_reagent(id, min(reagent_volume, 5), null, temperature)
 				F.color = mix_color_from_reagents(F.reagents.reagent_list)
 			else
 				F.reagents.add_reagent("cleaner", 1)

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -56,6 +56,9 @@
 
 /datum/species/grey/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	if(R.id == "sacid")
-		H.reagents.del_reagent(R.id)
-		return 0
+		H.reagents.remove_reagent(R.id, REAGENTS_METABOLISM)
+		return FALSE
+	if(R.id == "water")
+		H.adjustFireLoss(1)
+		return TRUE
 	return ..()

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -188,6 +188,6 @@
 		H.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
 		H.adjustPlasma(20)
 		H.reagents.remove_reagent(R.id, REAGENTS_METABOLISM)
-		return 0 //Handling reagent removal on our own. Prevents plasma from dealing toxin damage to Plasmamen.
+		return FALSE //Handling reagent removal on our own. Prevents plasma from dealing toxin damage to Plasmamen.
 
 	return ..()

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -41,7 +41,7 @@
 /datum/species/skeleton/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	// Crazylemon is still silly
 	if(R.id == "milk")
-		H.heal_overall_damage(4,4)
+		H.heal_overall_damage(4, 4)
 		if(prob(5)) // 5% chance per proc to find a random limb, and mend it
 			var/list/our_organs = H.bodyparts.Copy()
 			shuffle(our_organs)
@@ -54,7 +54,7 @@
 						L.perma_injury = 0
 					break // We're only checking one limb here, bucko
 		if(prob(3))
-			H.say(pick("Thanks Mr Skeltal", "Thank for strong bones", "Doot doot!"))
-		return 1
+			H.say(pick("Thanks Mr. Skeltal", "Thank for strong bones", "Doot doot!"))
+		return TRUE
 
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -22,7 +22,7 @@
 	M.adjust_fire_stacks(mob_burning)
 	M.IgniteMob()
 	if(method == INGEST)
-		M.adjustFireLoss(min(max(15, volume * 3), 45))
+		M.adjustFireLoss(min(max(10, volume * 2), 45))
 		to_chat(M, "<span class='warning'>It burns!</span>")
 		M.emote("scream")
 
@@ -242,7 +242,7 @@
 		M.adjust_fire_stacks(10)
 		M.IgniteMob()
 	if(method == INGEST)
-		M.adjustFireLoss(min(max(30, volume * 6), 90))
+		M.adjustFireLoss(min(max(15, volume * 2.5), 90))
 		to_chat(M, "<span class='warning'>It burns!</span>")
 		M.emote("scream")
 

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -606,13 +606,12 @@
 		if(method == TOUCH)
 			if(volume > 9)
 				if(!H.wear_mask && !H.head)
-					if(!H.unacidable)
-						var/obj/item/organ/external/affecting = H.get_organ("head")
-						if(affecting)
-							affecting.disfigure()
-						H.adjustFireLoss(min(max(8, (volume - 5) * 3), 75))
-						H.emote("scream")
-						return
+					var/obj/item/organ/external/affecting = H.get_organ("head")
+					if(affecting)
+						affecting.disfigure()
+					H.adjustFireLoss(min(max(8, (volume - 5) * 3), 75))
+					H.emote("scream")
+					return
 				else
 					var/melted_something = FALSE
 					if(H.wear_mask && !H.wear_mask.unacidable)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -245,7 +245,7 @@
 	id = "sacid"
 	description = "A strong mineral acid with the molecular formula H2SO4."
 	reagent_state = LIQUID
-	color = "#00D72B"
+	color = "#00FF32"
 	process_flags = ORGANIC | SYNTHETIC
 	taste_message = "<span class='userdanger'>ACID</span>"
 
@@ -254,58 +254,34 @@
 	update_flags |= M.adjustFireLoss(1, FALSE)
 	return ..() | update_flags
 
-/datum/reagent/sacid/reaction_mob(mob/living/M, method=TOUCH, volume)
-	if(method == TOUCH)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(isgrey(H))
-				return
-
+/datum/reagent/sacid/reaction_mob(mob/living/M, method = TOUCH, volume)
+	if(ishuman(M) && !isgrey(M))
+		var/mob/living/carbon/human/H = M
+		if(method == TOUCH)
 			if(volume > 25)
-
 				if(H.wear_mask)
-					to_chat(H, "<span class='danger'>Your mask protects you from the acid!</span>")
+					to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
 					return
 
 				if(H.head)
-					to_chat(H, "<span class='danger'>Your helmet protects you from the acid!</span>")
+					to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
 					return
 
-				if(!M.unacidable)
-					if(prob(75))
-						var/obj/item/organ/external/affecting = H.get_organ("head")
-						if(affecting)
-							affecting.receive_damage(5, 10)
-							H.UpdateDamageIcon()
-							H.emote("scream")
-					else
-						M.take_organ_damage(5,10)
+				if(prob(75))
+					H.take_organ_damage(5, 10)
+					H.emote("scream")
+					var/obj/item/organ/external/affecting = H.get_organ("head")
+					if(affecting)
+						affecting.disfigure()
+				else
+					H.take_organ_damage(5, 10)
 			else
-				M.take_organ_damage(5,10)
-
-	if(method == INGEST)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-
-			if(isgrey(H))
-				return
-
-			if(volume >=10 && volume <=25)
-				if(!H.unacidable)
-					M.take_organ_damage(0,min(max(volume-10,2)*2,20))
-					M.emote("scream")
-
-
-			if(volume > 25)
-				if(!M.unacidable)
-					if(prob(75))
-						var/obj/item/organ/external/affecting = H.get_organ("head")
-						if(affecting)
-							affecting.receive_damage(0, 20)
-							H.UpdateDamageIcon()
-							H.emote("scream")
-					else
-						M.take_organ_damage(0,20)
+				H.take_organ_damage(5, 10)
+		else
+			to_chat(H, "<span class='warning'>The greenish acidic substance stings[volume < 10 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
+			if(volume >= 10)
+				H.adjustFireLoss(min(max(4, (volume - 10) * 2), 20))
+				H.emote("scream")
 
 /datum/reagent/sacid/reaction_obj(obj/O, volume)
 	if((istype(O,/obj/item) || istype(O,/obj/structure/glowshroom)) && prob(40))
@@ -614,7 +590,7 @@
 	id = "facid"
 	description = "Fluorosulfuric acid is a an extremely corrosive super-acid."
 	reagent_state = LIQUID
-	color = "#4141D2"
+	color = "#5050FF"
 	process_flags = ORGANIC | SYNTHETIC
 	taste_message = "<span class='userdanger'>ACID</span>"
 
@@ -624,47 +600,39 @@
 	update_flags |= M.adjustFireLoss(1, FALSE)
 	return ..() | update_flags
 
-/datum/reagent/facid/reaction_mob(mob/living/M, method=TOUCH, volume)
-	if(method == TOUCH || method == INGEST)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
+/datum/reagent/facid/reaction_mob(mob/living/M, method = TOUCH, volume)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(method == TOUCH)
+			if(volume > 9)
+				if(!H.wear_mask && !H.head)
+					if(!H.unacidable)
+						var/obj/item/organ/external/affecting = H.get_organ("head")
+						if(affecting)
+							affecting.disfigure()
+						H.adjustFireLoss(min(max(8, (volume - 5) * 3), 75))
+						H.emote("scream")
+						return
+				else
+					var/melted_something = FALSE
+					if(H.wear_mask && !H.wear_mask.unacidable)
+						qdel(H.wear_mask)
+						H.update_inv_wear_mask()
+						to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
+						melted_something = TRUE
 
-			if(volume < 5)
-				to_chat(M, "<span class='danger'>The blueish acidic substance stings you, but isn't concentrated enough to harm you!</span>")
-
-			if(volume >=5 && volume <=10)
-				if(!H.unacidable)
-					M.take_organ_damage(0,max(volume-5,2)*4)
-					M.emote("scream")
-
-
-			if(volume > 10)
-
-				if(method == TOUCH)
-					if(H.wear_mask)
-						if(!H.wear_mask.unacidable)
-							qdel(H.wear_mask)
-							H.update_inv_wear_mask()
-							to_chat(H, "<span class='warning'>Your mask melts away but protects you from the acid!</span>")
-						else
-							to_chat(H, "<span class='warning'>Your mask protects you from the acid!</span>")
+					if(H.head && !H.head.unacidable)
+						qdel(H.head)
+						H.update_inv_head()
+						to_chat(H, "<span class='danger'>Your [H.head] melts away!</span>")
+						melted_something = TRUE
+					if(melted_something)
 						return
 
-					if(H.head)
-						if(!H.head.unacidable)
-							qdel(H.head)
-							H.update_inv_head()
-							to_chat(H, "<span class='warning'>Your helmet melts away but protects you from the acid</span>")
-						else
-							to_chat(H, "<span class='warning'>Your helmet protects you from the acid!</span>")
-						return
-
-				if(!H.unacidable)
-					var/obj/item/organ/external/head/affecting = H.get_organ("head")
-					if(affecting)
-						affecting.receive_damage(0, 75)
-					H.UpdateDamageIcon()
-					H.emote("scream")
+		if(volume >= 5)
+			H.emote("scream")
+			H.adjustFireLoss(min(max(8, (volume - 5) * 3), 75))
+		to_chat(H, "<span class='warning'>The blueish acidic substance stings[volume < 5 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 
 /datum/reagent/facid/reaction_obj(obj/O, volume)
 	if((istype(O, /obj/item) || istype(O, /obj/structure/glowshroom)))

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -24,61 +24,34 @@
 	if(method == TOUCH)
 		// Put out fire
 		M.adjust_fire_stacks(-(volume * 0.2))
-		if(ishuman(M))
 
-			var/mob/living/carbon/human/H = M
-
-			if(!isgrey(H)) //God this is so gross I hate it.
-				return
-
+	if(isgrey(M)) // You gosh darn snowflakes
+		var/mob/living/carbon/human/G = M
+		if(method == TOUCH)
 			if(volume > 25)
-
-				if(H.wear_mask)
-					to_chat(H, "<span class='danger'>Your mask protects you from the water!</span>")
+				if(G.wear_mask)
+					to_chat(G, "<span class='danger'>Your [G.wear_mask] protects you from the acid!</span>")
 					return
 
-				if(H.head)
-					to_chat(H, "<span class='danger'>Your helmet protects you from the water!</span>")
+				if(G.head)
+					to_chat(G, "<span class='danger'>Your [G.wear_mask] protects you from the acid!</span>")
 					return
 
-				if(!M.unacidable)
-					if(prob(75))
-						var/obj/item/organ/external/affecting = H.get_organ("head")
-						if(affecting)
-							affecting.receive_damage(5, 10)
-							H.UpdateDamageIcon()
-							H.emote("scream")
-					else
-						M.take_organ_damage(5,10)
+				if(prob(75))
+					G.take_organ_damage(5, 10)
+					G.emote("scream")
+					var/obj/item/organ/external/affecting = G.get_organ("head")
+					if(affecting)
+						affecting.disfigure()
+				else
+					G.take_organ_damage(5, 10)
 			else
-				M.take_organ_damage(5,10)
-
-	if(method == INGEST)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-
-			if(!isgrey(H))
-				return
-
-			if(volume < 10)
-				to_chat(M, "<span class='danger'>The watery solvent substance stings you, but isn't concentrated enough to harm you!</span>")
-
-			if(volume >=10 && volume <=25)
-				if(!H.unacidable)
-					M.take_organ_damage(0,min(max(volume-10,2)*2,20))
-					M.emote("scream")
-
-
-			if(volume > 25)
-				if(!M.unacidable)
-					if(prob(75))
-						var/obj/item/organ/external/affecting = H.get_organ("head")
-						if(affecting)
-							affecting.receive_damage(0, 20)
-							H.UpdateDamageIcon()
-							H.emote("scream")
-					else
-						M.take_organ_damage(0,20)
+				G.take_organ_damage(5, 10)
+		else
+			to_chat(G, "<span class='warning'>The water stings[volume < 10 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
+			if(volume >= 10)
+				G.adjustFireLoss(min(max(4, (volume - 10) * 2), 20))
+				G.emote("scream")
 
 /datum/reagent/water/reaction_turf(turf/simulated/T, volume)
 	if(!istype(T))


### PR DESCRIPTION
Largely a balance PR.

Adjusts a few chems so they're note quite so strong at low volumes.

- CLF3, Phlogiston, and Fluorosulfuric acid all require greater volumes to achieve their upper damage limits
- CLF3 and Phlogiston have lower minimum damage
- Grey's more accurately mimc how water acts like acid to them; this includes when they ingest water
- Grey's no longer delete acid; they remove it at the regular normal rate, but they do not take damage from it
- Both acids will disfigure your face, regardless of damage, if they're past particular thresholds

Foam:
- Foam transfers 5 reagents, up from 3
- Foam holds a total of 25 reagents, up from 15

reasoning: Foam is really pretty crap right now, especially when it's competing against smoke

:cl: Fox McCloud
tweak: CLF3, Phlogiston, and Fluorosulfuric acid all require greater volumes to achieve their upper damage limits
tweak: CLF3 and Phlogiston have lower minimum damage
fix: Grey's treat water more closely to sulfuric acid (including passive damage while it's in them)
tweak: Grey's don't instantly purge all sulfuric acid from their system; it depletes at the normal rate, but doens't cause damage
tweak: Foam altered to be a bit more viable compared to smoke
/:cl: