### PR TITLE
Newcrit Death Tweak

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -1,7 +1,7 @@
 /obj/item/organ/internal/brain
 	name = "brain"
 	health = 400 //They need to live awhile longer than other organs.
-	max_damage = 200
+	max_damage = 120
 	icon_state = "brain2"
 	force = 1.0
 	w_class = WEIGHT_CLASS_SMALL
@@ -99,6 +99,19 @@
 	else
 		log_debug("Multibrain shenanigans at ([target.x],[target.y],[target.z]), mob '[target]'")
 	..(target, special = special)
+
+/obj/item/organ/internal/brain/receive_damage(amount, silent = 0) //brains are special; if they receive damage by other means, we really just want the damage to be passed ot the owner and back onto the brain.
+	if(owner)
+		owner.adjustBrainLoss(amount)
+
+/obj/item/organ/internal/brain/necrotize(update_sprite = TRUE) //Brain also has special handling for when it necrotizes
+	damage = max_damage
+	status |= ORGAN_DEAD
+	processing_objects -= src
+	if(dead_icon && !is_robotic())
+		icon_state = dead_icon
+	if(owner && vital)
+		owner.setBrainLoss(120)
 
 /obj/item/organ/internal/brain/prepare_eat()
 	return // Too important to eat.

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -31,7 +31,10 @@
 		if(sponge)
 			if(dna.species && amount > 0)
 				amount = amount * dna.species.brain_mod
-			sponge.receive_damage(amount, 1)
+			sponge.damage = Clamp(sponge.damage + amount, 0, 120)
+			if(sponge.damage >= 120)
+				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
+				death()
 	if(updating)
 		update_stat("adjustBrainLoss")
 	return STATUS_UPDATE_STAT
@@ -45,7 +48,10 @@
 		if(sponge)
 			if(dna.species && amount > 0)
 				amount = amount * dna.species.brain_mod
-			sponge.damage = min(max(amount, 0), (maxHealth*2))
+			sponge.damage = Clamp(amount, 0, 120)
+			if(sponge.damage >= 120)
+				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
+				death()
 	if(updating)
 		update_stat("setBrainLoss")
 	return STATUS_UPDATE_STAT

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -779,7 +779,6 @@
 		handle_organs()
 
 		if(getBrainLoss() >= 120 || (health + (getOxyLoss() / 2)) <= -500)
-			visible_message("<span class='alert'><B>[src]</B> goes limp, their facial expression utterly blank.</span>")
 			death()
 			return
 

--- a/code/modules/mob/living/carbon/human/update_stat.dm
+++ b/code/modules/mob/living/carbon/human/update_stat.dm
@@ -2,16 +2,7 @@
 	if(status_flags & GODMODE)
 		return
 	..(reason)
-	if(stat != DEAD)
-		switch(getBrainLoss())
-			if(100 to 120)
-				Weaken(20)
-				create_debug_log("collapsed from brain damage, trigger reason: [reason]")
-			if(120 to INFINITY)
-				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
-				death()
-				create_debug_log("died of brain damage, trigger reason: [reason]")
-	else
+	if(stat == DEAD)
 		if(dna.species && dna.species.can_revive_by_healing)
 			var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
 			if(B)


### PR DESCRIPTION
Just a minor tweak to newcrit death, to make things a bit more clear when someone has and has not died to brain death.

- Now *only* brain death will trigger the `goes limp, their facial expression utterly blank` Message; if you managed to hit the upper damage limit of a mob and they died, it'd still show this message.
  - Should cut down on confusion of "he won't die, and he only died to brain death!
- Brain damage is clamped to 0 and 120; you could previously go over 120 damage in some situations, this should prevent that.


:cl: Fox McCloud
tweak: the message for brain death will now properly and only occur when they have truly died from brain damage
fix: Fixes being able to attain brain damage over 120
/:cl: