### PR TITLE
Fixes Reagents Not Updating

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -765,7 +765,7 @@
 /datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/M)
 	if(M.bodytemperature < 360)
 		M.bodytemperature = min(360, M.bodytemperature + (50 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
-	..()
+	return ..()
 
 /datum/reagent/consumable/ethanol/devilskiss
 	name = "Devils Kiss"
@@ -819,7 +819,7 @@
 /datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/M)
 	if(M.bodytemperature > 270)
 		M.bodytemperature = max(270, M.bodytemperature - (20 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
-	..()
+	return ..()
 
 /datum/reagent/consumable/ethanol/grog
 	name = "Grog"
@@ -1178,7 +1178,7 @@
 		if(prob(25))
 			holder.remove_reagent(id, 15)
 			M.fakevomit()
-	..()
+	return ..()
 
 /datum/reagent/consumable/ethanol/synthanol/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(M.isSynthetic())

--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -42,7 +42,7 @@
 
 /datum/reagent/consumable/drink/cold/ice/on_mob_life(mob/living/M)
 	M.bodytemperature = max(M.bodytemperature - 5 * TEMPERATURE_DAMAGE_COEFFICIENT, 0)
-	..()
+	return ..()
 
 /datum/reagent/consumable/drink/cold/space_cola
 	name = "Cola"

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -448,7 +448,7 @@
 /datum/reagent/consumable/egg/on_mob_life(mob/living/M)
 	if(prob(3))
 		M.reagents.add_reagent("cholesterol", rand(1,2))
-	..()
+	return ..()
 
 /datum/reagent/consumable/corn_starch
 	name = "Corn Starch"
@@ -642,9 +642,6 @@
 	reagent_state = LIQUID
 	color = "#684435"
 	taste_message = "burritos"
-
-/datum/reagent/consumable/beans/on_mob_life(mob/living/M)
-	return ..()
 
 /datum/reagent/consumable/bread
 	name = "Bread"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -5,6 +5,7 @@
 /datum/reagent/medicine/on_mob_life(mob/living/M)
 	current_cycle++
 	holder.remove_reagent(id, (metabolization_rate / M.metabolism_efficiency) * M.digestion_ratio) //medicine reagents stay longer if you have a better metabolism
+	return STATUS_UPDATE_NONE
 
 /datum/reagent/medicine/hydrocodone
 	name = "Hydrocodone"
@@ -526,6 +527,7 @@
 	taste_message = "a delightful numbing"
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
 	M.AdjustJitter(-25)
 	switch(current_cycle)
 		if(1 to 15)
@@ -534,9 +536,9 @@
 		if(16 to 35)
 			M.Drowsy(20)
 		if(36 to INFINITY)
-			M.Paralyse(15)
+			update_flags |= M.Paralyse(15, FALSE)
 			M.Drowsy(20)
-	..()
+	return ..() | update_flags
 
 /datum/reagent/medicine/oculine
 	name = "Oculine"
@@ -759,7 +761,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.update_mutations()
-	..()
+	return ..()
 
 /datum/reagent/medicine/antihol
 	name = "Antihol"
@@ -857,6 +859,7 @@
 
 /datum/reagent/medicine/insulin/on_mob_life(mob/living/M)
 	M.reagents.remove_reagent("sugar", 5)
+	return ..()
 
 /datum/reagent/medicine/teporone
 	name = "Teporone"
@@ -873,7 +876,7 @@
 		M.bodytemperature = max(310, M.bodytemperature - (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	else if(M.bodytemperature < 311)
 		M.bodytemperature = min(310, M.bodytemperature + (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
-	..()
+	return ..()
 
 /datum/reagent/medicine/haloperidol
 	name = "Haloperidol"
@@ -916,6 +919,7 @@
 	taste_message = "sleepiness"
 
 /datum/reagent/medicine/ether/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
 	M.AdjustJitter(-25)
 	switch(current_cycle)
 		if(1 to 30)
@@ -924,9 +928,9 @@
 		if(31 to 40)
 			M.Drowsy(20)
 		if(41 to INFINITY)
-			M.Paralyse(15)
+			update_flags |= M.Paralyse(15, FALSE)
 			M.Drowsy(20)
-	..()
+	return ..() | update_flags
 
 /datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs
 	name = "Restorative Nanites"

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -162,7 +162,7 @@
 		if(!H.dna.species.exotic_blood && !(NO_BLOOD in H.dna.species.species_traits))
 			if(H.blood_volume < BLOOD_VOLUME_NORMAL)
 				H.blood_volume += 0.8
-	..()
+	return ..()
 
 /datum/reagent/iron/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(M.has_bane(BANE_IRON) && holder && holder.chem_temp < 150) //If the target is weak to cold iron, then poison them.

--- a/code/modules/reagents/chemistry/reagents/paradise_pop.dm
+++ b/code/modules/reagents/chemistry/reagents/paradise_pop.dm
@@ -31,7 +31,7 @@
 		var/turf/simulated/T = get_turf(M)
 		goonchem_vortex(T, 1, 0)
 		to_chat(M, "<span class='notice'>You briefly feel super-massive, like a black hole. Probably just your imagination...</span>")
-	..()
+	return ..()
 
 //Berry Banned: This one is tasty and safe to drink, might have a low chance of healing a random damage type?
 /datum/reagent/consumable/drink/berry_banned

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1156,12 +1156,16 @@
 	M.apply_effect(2, IRRADIATE, 0, negate_armor = 1)
 	if(!M.dna)
 		return
+	var/did_mutation = FALSE
 	if(prob(15))
 		randmutb(M)
+		did_mutation = TRUE
 	if(prob(3))
 		randmutg(M)
-	domutcheck(M, null)
-	M.UpdateAppearance()
+		did_mutation = TRUE
+	if(did_mutation)
+		domutcheck(M, null)
+		M.UpdateAppearance()
 	return ..()
 
 /datum/reagent/ants


### PR DESCRIPTION
@Crazylemon64 refactored reagents to only call updates when they absolutely need to.

The refactor was great, but uh....it looks like nearly all medical reagents were never calling updates at all (OUCH).

It also seems some reagents weren't returning `..()` either.

In the case of insulin, it just wouldn't even deplete.

:cl: Fox McCloud
fix: Fixes some reagents not causing status updates
/:cl: