### PR TITLE
Perps no longer need glasses to be set

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -363,7 +363,7 @@
 					for(var/datum/data/record/R in data_core.security)
 						if(R.fields["id"] == E.fields["id"])
 							criminal = R.fields["criminal"]
-			var/criminal_status = hasHUD(user, "read_only_security") ? "\[[criminal]\]" : "<a href='?src=[UID()];criminal=[glasses]'>\[[criminal]\]</a>"
+			var/criminal_status = hasHUD(user, "read_only_security") ? "\[[criminal]\]" : "<a href='?src=[UID()];criminal=1'>\[[criminal]\]</a>"
 			msg += "<span class = 'deptradio'>Criminal status:</span> [criminal_status]\n"
 			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=[UID()];secrecord=`'>\[View\]</a>  <a href='?src=[UID()];secrecordadd=`'>\[Add comment\]</a>\n"
 


### PR DESCRIPTION
**What does this PR do:**
Perps no longer need glasses to be set to arrest by sec huds.
Bug occured in #10421 due to the use of glasses there to set the criminal href

Fixes #11238

Thanks to @Couls and @dovydas12345 to help find the problem 

**Changelog:**
:cl:
fix: Sec huds work again. No longer does the perp need glasses to be set to arrest. Cool does not equal arrest now
/:cl:

