### PR TITLE
Changes Dehydrated Space Carp TC cost from 3 to 2

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -893,7 +893,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Just add water to make your very own hostile to everything space carp. It looks just like a plushie. The first person to squeeze it will be registered as its owner, who it will not attack. If no owner is registered, it'll just attack everyone."
 	reference = "DSC"
 	item = /obj/item/toy/carpplushie/dehy_carp
-	cost = 3
+	cost = 2
 
 // GRENADES AND EXPLOSIVES
 


### PR DESCRIPTION
**What does this PR do:**
Dehydrated Space Carp is quite an underused traitor item, and rightfully so. Predicting the effect that Space Carp will have is extremely difficult, and can result in absolutely nothing due to the carp AI, which makes traitors buy something else that they have more control of. 

This PR changes Dehydrated Space Carp TC cost from 3 to 2, and even then I believe it will be still highly situational item, just not that much overpriced for its effect.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Dehydrated Space Carp TC cost changed from 3 to 2
/:cl: