### PR TITLE
Hotkey mode handling is now instantaneous

### DIFF
--- a/code/datums/helper_datums/hotkey_modes.dm
+++ b/code/datums/helper_datums/hotkey_modes.dm
@@ -1,0 +1,19 @@
+/datum/hotkey_mode
+	var/name
+	var/macro_hotkeys_inactive
+	var/macro_hotkeys_active
+
+/datum/hotkey_mode/qwerty
+	name = "QWERTY"
+	macro_hotkeys_inactive = "macro"
+	macro_hotkeys_active = "hotkeymode"
+
+/datum/hotkey_mode/azerty
+	name = "AZERTY"
+	macro_hotkeys_inactive = "azertymacro"
+	macro_hotkeys_active = "azertyhotkeymode"
+
+/datum/hotkey_mode/cyborg
+	name = "Cyborg"
+	macro_hotkeys_inactive = "borgmacro"
+	macro_hotkeys_active = "borghotkeymode"

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -65,25 +65,6 @@
 	// Set on login.
 	var/datum/media_manager/media = null
 
-	/////////////////////////////////////////////////////////////////////
-	//adv. hotkey mode vars, code using them in /interface/interface.dm//
-	/////////////////////////////////////////////////////////////////////
-
-	var/hotkeytype = "QWERTY" //what set of hotkeys is in use(defaulting to QWERTY because I can't be bothered to make this save on SQL)
-	var/hotkeyon = 0 //is the hotkey on?
-
-	var/hotkeylist = list( //list defining hotkey types, look at lists in place for structure if adding any if the future
-		"QWERTY" = list(
-			"on" = "hotkeymode",
-			"off" = "macro"),
-		"AZERTY" = list(
-			"on" = "AZERTYon",
-			"off" = "AZERTYoff"),
-		"Cyborg" = list(
-			"on" = "borghotkeymode",
-			"off" = "borgmacro")
-	)
-
 	var/topic_debugging = 0 //if set to true, allows client to see nanoUI errors -- yes i realize this is messy but it'll make live testing infinitely easier
 
 	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_SKIN | CONTROL_FREAK_MACROS

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -17,4 +17,3 @@
 
 /mob/camera/Login()
 	..()
-	update_interface()

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -14,6 +14,3 @@
 
 /mob/camera/experience_pressure_difference()
 	return
-
-/mob/camera/Login()
-	..()

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -7,5 +7,3 @@
 	if(GLOB.non_respawnable_keys[ckey])
 		can_reenter_corpse = 0
 		GLOB.respawnable_list -= src
-	
-	update_interface()

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -17,6 +17,4 @@
 	//Should update regardless of if we can ventcrawl, since we can end up in pipes in other ways.
 	update_pipe_vision()
 
-	update_interface()
-
 	return .

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -1,6 +1,7 @@
 /mob/living/silicon/robot/Login()
 	..()
-	if(client)
-		client.hotkeytype = "Cyborg"
 	regenerate_icons()
 	show_laws(0)
+
+	var/datum/hotkey_mode/cyborg/C = new()
+	winset(src, null, "mainwindow.macro_hotkey_mode_inactive=[C.macro_hotkeys_inactive] mainwindow.macro_hotkey_mode_active=[C.macro_hotkeys_active] mainwindow.macro=[C.macro_hotkeys_inactive] hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -72,29 +72,3 @@
 	update_client_colour(0)
 
 	callHook("mob_login", list("client" = client, "mob" = src))
-
-// Calling update_interface() in /mob/Login() causes the Cyborg to immediately be ghosted; because of winget().
-// Calling it in the overriden Login, such as /mob/living/Login() doesn't cause this.
-/mob/proc/update_interface()
-	spawn() // Spawn off so winget/winset don't delay callers.
-		if(client)
-			if(winget(src, "mainwindow.hotkey_toggle", "is-checked") == "true")
-				update_hotkey_mode()
-			else
-				update_normal_mode()
-
-/mob/proc/update_hotkey_mode()
-	var/hotkeyname = "hotkeymode"
-	if(client)
-		var/hotkeys = client.hotkeylist[client.hotkeytype]
-		hotkeyname = hotkeys[client.hotkeyon ? "on" : "off"]
-		client.hotkeyon = 1
-		winset(src, null, "mainwindow.macro=[hotkeyname] hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0")
-
-/mob/proc/update_normal_mode()
-	var/hotkeyname = "macro"
-	if(client)
-		var/hotkeys = client.hotkeylist[client.hotkeytype]//get the list containing the hotkey names
-		hotkeyname = hotkeys[client.hotkeyon ? "on" : "off"]//get the name of the hotkey, to not clutter winset() to much
-		client.hotkeyon = 0
-		winset(src, null, "mainwindow.macro=[hotkeyname] hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -52,7 +52,6 @@
 		src << link(config.forumurl)
 	else
 		to_chat(src, "<span class='danger'>The forum URL is not set in the server configuration.</span>")
-	return
 
 /client/verb/rules()
 	set name = "Rules"
@@ -64,7 +63,6 @@
 		src << link(config.rulesurl)
 	else
 		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
-	return
 
 /client/verb/github()
 	set name = "GitHub"
@@ -76,7 +74,6 @@
 		src << link(config.githuburl)
 	else
 		to_chat(src, "<span class='danger'>The GitHub URL is not set in the server configuration.</span>")
-	return
 
 /client/verb/discord()
 	set name = "Discord"
@@ -88,7 +85,6 @@
 		src << link(config.discordurl)
 	else
 		to_chat(src, "<span class='danger'>The Discord URL is not set in the server configuration.</span>")
-	return
 	
 /client/verb/donate()
 	set name = "Donate"
@@ -100,8 +96,28 @@
 		src << link(config.donationsurl)
 	else
 		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
-	return
 
+/client/verb/hotkey_mode()
+	set name = "Set Hotkey Mode"
+	set category = "Preferences"
+
+	var/list/hotkey_modes = list()
+	for(var/hotkey_mode in subtypesof(/datum/hotkey_mode))
+		var/datum/hotkey_mode/H = hotkey_mode
+		hotkey_modes[initial(H.name)] = H
+
+	var/chosen_mode_name = input("Choose your preferred hotkey mode.", "Hotkey mode selection") as null|anything in hotkey_modes
+	if(!chosen_mode_name)
+		return
+
+	var/datum/hotkey_mode/chosen_mode = hotkey_modes[chosen_mode_name] 
+	var/datum/hotkey_mode/hotkey_mode = new chosen_mode()
+	
+	winset(mob, null, "mainwindow.macro_hotkey_mode_inactive=[hotkey_mode.macro_hotkeys_inactive] mainwindow.macro_hotkey_mode_active=[hotkey_mode.macro_hotkeys_active] mainwindow.macro=[hotkey_mode.macro_hotkeys_inactive] hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")
+	to_chat(usr, "<span class='info'>Your hotkey mode has been changed to [hotkey_mode.name].</span>")
+
+	qdel(hotkey_mode)
+	
 /client/verb/hotkeys_help()
 	set name = "Hotkey Help"
 	set category = "OOC"
@@ -234,32 +250,3 @@ Any-Mode: (hotkey doesn't need to be on)
 
 	to_chat(src, hotkey_mode)
 	to_chat(src, other)
-
-//adv. hotkey mode verbs, vars located in /code/modules/client/client defines.dm
-/client/verb/hotkey_toggle()//toggles hotkey mode between on and off, respects selected type
-	set name = ".Toggle Hotkey Mode"
-
-	hotkeyon = !hotkeyon//toggle the var
-	to_chat(usr, (hotkeyon ? "Hotkey mode enabled." : "Hotkey mode disabled."))//feedback to the user
-
-	if(hotkeyon)//using an if statement because I don't want to clutter winset() with ? operators
-		winset(usr, "mainwindow.hotkey_toggle", "is-checked=true")//checks the button
-	else
-		winset(usr, "mainwindow.hotkey_toggle", "is-checked=false")//unchecks the button
-	if(mob)
-		mob.update_interface()
-
-/client/verb/hotkey_mode()//asks user for the hotkey type and changes the macro accordingly
-	set name = "Set Hotkey Mode"
-	set category = "Preferences"
-
-	var/hkt = input("Choose hotkey mode", "Hotkey mode") as null|anything in hotkeylist//ask the user for the hotkey type
-	if(!hkt)
-		return
-	hotkeytype = hkt
-
-	var/hotkeys = hotkeylist[hotkeytype]//get the list containing the hotkey names
-	var/hotkeyname = hotkeys[hotkeyon ? "on" : "off"]//get the name of the hotkey, to not clutter winset() to much
-
-	winset(usr, "mainwindow", "macro=[hotkeyname]")//change the hotkey
-	to_chat(usr, "Hotkey mode changed to [hotkeytype].")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,713 +1,7 @@
-macro "AZERTYoff"
-	elem "AZRFF-TAB"
-		name = "TAB"
-		command = ".Toggle-hotkey-mode"
-		is-disabled = false
-	elem "AZRFF-CENTER+REP"
-		name = "CENTER+REP"
-		command = ".center"
-		is-disabled = false
-	elem "AZRFF-NORTHEAST"
-		name = "NORTHEAST"
-		command = ".northeast"
-		is-disabled = false
-	elem "AZRFF-SOUTHEAST"
-		name = "SOUTHEAST"
-		command = ".southeast"
-		is-disabled = false
-	elem "AZRFF-SOUTHWEST"
-		name = "SOUTHWEST"
-		command = ".southwest"
-		is-disabled = false
-	elem "AZRFF-NORTHWEST"
-		name = "NORTHWEST"
-		command = ".northwest"
-		is-disabled = false
-	elem "AZRFF-CTRL+WEST"
-		name = "CTRL+WEST"
-		command = "westface"
-		is-disabled = false
-	elem "AZRFF-WEST+REP"
-		name = "WEST+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "AZRFF-CTRL+NORTH"
-		name = "CTRL+NORTH"
-		command = "northface"
-		is-disabled = false
-	elem "AZRFF-NORTH+REP"
-		name = "NORTH+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "AZRFF-CTRL+EAST"
-		name = "CTRL+EAST"
-		command = "eastface"
-		is-disabled = false
-	elem "AZRFF-EAST+REP"
-		name = "EAST+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "AZRFF-CTRL+SOUTH"
-		name = "CTRL+SOUTH"
-		command = "southface"
-		is-disabled = false
-	elem "AZRFF-SOUTH+REP"
-		name = "SOUTH+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "AZRFF-INSERT"
-		name = "INSERT"
-		command = "a-intent right"
-		is-disabled = false
-	elem "AZRFF-DELETE"
-		name = "DELETE"
-		command = "delete-key-pressed"
-		is-disabled = false
-	elem "AZRFF-CTRL+1"
-		name = "CTRL+1"
-		command = "a-intent help"
-		is-disabled = false
-	elem "AZRFF-CTRL+2"
-		name = "CTRL+2"
-		command = "a-intent disarm"
-		is-disabled = false
-	elem "AZRFF-CTRL+3"
-		name = "CTRL+3"
-		command = "a-intent grab"
-		is-disabled = false
-	elem "AZRFF-CTRL+4"
-		name = "CTRL+4"
-		command = "a-intent harm"
-		is-disabled = false
-	elem "AZRFF-CTRL+A"
-		name = "CTRL+A"
-		command = ".northwest"
-		is-disabled = false
-	elem "AZRFF-CTRL+D+REP"
-		name = "CTRL+D+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "AZRFF-CTRL+B"
-		name = "CTRL+B"
-		command = "resist"
-		is-disabled = false
-	elem "AZRFF-CTRL+E"
-		name = "CTRL+E"
-		command = "quick-equip"
-		is-disabled = false
-	elem "AZRFF-CTRL+F"
-		name = "CTRL+F"
-		command = "a-intent left"
-		is-disabled = false
-	elem "AZRFF-CTRL+G"
-		name = "CTRL+G"
-		command = "a-intent right"
-		is-disabled = false
-	elem "AZRFF-CTRL+Q+REP"
-		name = "CTRL+Q+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "AZRFF-CTRL+R"
-		name = "CTRL+R"
-		command = ".southwest"
-		is-disabled = false
-	elem "AZRFF-CTRL+S+REP"
-		name = "CTRL+S+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "AZRFF-CTRL+W"
-		name = "CTRL+W"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "AZRFF-CTRL+X"
-		name = "CTRL+X"
-		command = ".northeast"
-		is-disabled = false
-	elem "AZRFF-CTRL+Y"
-		name = "CTRL+Y"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "AZRFF-CTRL+Z+REP"
-		name = "CTRL+Z+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "AZRFF-F1"
-		name = "F1"
-		command = "adminhelp"
-		is-disabled = false
-	elem "AZRFF-CTRL+SHIFT+F1+REP"
-		name = "CTRL+SHIFT+F1+REP"
-		command = ".options"
-		is-disabled = false
-	elem "AZRFF-F2"
-		name = "F2"
-		command = "ooc"
-		is-disabled = false
-	elem "AZRFF-F2+REP"
-		name = "F2+REP"
-		command = ".screenshot auto"
-		is-disabled = false
-	elem "AZRFF-SHIFT+F2+REP"
-		name = "SHIFT+F2+REP"
-		command = ".screenshot"
-		is-disabled = false
-	elem "AZRFF-F3"
-		name = "F3"
-		command = ".say"
-		is-disabled = false
-	elem "AZRFF-F4"
-		name = "F4"
-		command = ".me"
-		is-disabled = false
-	elem "AZRFF-F5"
-		name = "F5"
-		command = "asay"
-		is-disabled = false
-	elem "AZRFF-F6"
-		name = "F6"
-		command = "Aghost"
-		is-disabled = false
-	elem "AZRFF-F7"
-		name = "F7"
-		command = "player-panel-new"
-		is-disabled = false
-	elem "AZRFF-F8"
-		name = "F8"
-		command = "admin-pm-key"
-		is-disabled = false
-	elem "AZRFF-F9"
-		name = "F9"
-		command = "Invisimin"
-		is-disabled = false
-	elem "AZRFF-F12"
-		name = "F12"
-		command = "F12"
-		is-disabled = false
-
-macro "AZERTYon"
-	elem "AZRON-TAB"
-		name = "TAB"
-		command = ".Toggle-hotkey-mode"
-		is-disabled = false
-	elem "AZRON-CENTER+REP"
-		name = "CENTER+REP"
-		command = ".center"
-		is-disabled = false
-	elem "AZRON-NORTHEAST"
-		name = "NORTHEAST"
-		command = ".northeast"
-		is-disabled = false
-	elem "AZRON-SOUTHEAST"
-		name = "SOUTHEAST"
-		command = ".southeast"
-		is-disabled = false
-	elem "AZRON-SOUTHWEST"
-		name = "SOUTHWEST"
-		command = ".southwest"
-		is-disabled = false
-	elem "AZRON-NORTHWEST"
-		name = "NORTHWEST"
-		command = ".northwest"
-		is-disabled = false
-	elem "AZRON-CTRL+WEST"
-		name = "CTRL+WEST"
-		command = "westface"
-		is-disabled = false
-	elem "AZRON-WEST+REP"
-		name = "WEST+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "AZRON-CTRL+NORTH"
-		name = "CTRL+NORTH"
-		command = "northface"
-		is-disabled = false
-	elem "AZRON-NORTH+REP"
-		name = "NORTH+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "AZRON-CTRL+EAST"
-		name = "CTRL+EAST"
-		command = "eastface"
-		is-disabled = false
-	elem "AZRON-EAST+REP"
-		name = "EAST+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "AZRON-CTRL+SOUTH"
-		name = "CTRL+SOUTH"
-		command = "southface"
-		is-disabled = false
-	elem "AZRON-SOUTH+REP"
-		name = "SOUTH+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "AZRON-INSERT"
-		name = "INSERT"
-		command = "a-intent right"
-		is-disabled = false
-	elem "AZRON-DELETE"
-		name = "DELETE"
-		command = "delete-key-pressed"
-		is-disabled = false
-	elem "AZRON-1"
-		name = "1"
-		command = "a-intent help"
-		is-disabled = false
-	elem "AZRON-CTRL+1"
-		name = "CTRL+1"
-		command = "a-intent help"
-		is-disabled = false
-	elem "AZRON-2"
-		name = "2"
-		command = "a-intent disarm"
-		is-disabled = false
-	elem "AZRON-CTRL+2"
-		name = "CTRL+2"
-		command = "a-intent disarm"
-		is-disabled = false
-	elem "AZRON-3"
-		name = "3"
-		command = "a-intent grab"
-		is-disabled = false
-	elem "AZRON-CTRL+3"
-		name = "CTRL+3"
-		command = "a-intent grab"
-		is-disabled = false
-	elem "AZRON-4"
-		name = "4"
-		command = "a-intent harm"
-		is-disabled = false
-	elem "AZRON-CTRL+4"
-		name = "CTRL+4"
-		command = "a-intent harm"
-		is-disabled = false
-	elem "AZRON-A"
-		name = "A"
-		command = ".northwest"
-		is-disabled = false
-	elem "AZRON-CTRL+A"
-		name = "CTRL+A"
-		command = ".northwest"
-		is-disabled = false
-	elem "AZRON-D+REP"
-		name = "D+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "AZRON-CTRL+D+REP"
-		name = "CTRL+D+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "AZRON-CTRL+B"
-		name = "CTRL+B"
-		command = "resist"
-		is-disabled = false
-	elem "AZRON-E"
-		name = "E"
-		command = "quick-equip"
-		is-disabled = false
-	elem "AZRON-CTRL+E"
-		name = "CTRL+E"
-		command = "quick-equip"
-		is-disabled = false
-	elem "AZRON-F"
-		name = "F"
-		command = "a-intent left"
-		is-disabled = false
-	elem "AZRON-CTRL+F"
-		name = "CTRL+F"
-		command = "a-intent left"
-		is-disabled = false
-	elem "AZRON-G"
-		name = "G"
-		command = "a-intent right"
-		is-disabled = false
-	elem "AZRON-CTRL+G"
-		name = "CTRL+G"
-		command = "a-intent right"
-		is-disabled = false
-	elem "AZRON-H"
-		name = "H"
-		command = "holster"
-		is-disabled = false
-	elem "AZRON-CTRL+H"
-		name = "CTRL+H"
-		command = "holster"
-		is-disabled = false
-	elem "AZRON-Q+REP"
-		name = "Q+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "AZRON-CTRL+Q+REP"
-		name = "CTRL+Q+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "AZRON-R"
-		name = "R"
-		command = ".southwest"
-		is-disabled = false
-	elem "AZRON-CTRL+R"
-		name = "CTRL+R"
-		command = ".southwest"
-		is-disabled = false
-	elem "s_key"
-		name = "S+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "AZRON-CTRL+S+REP"
-		name = "CTRL+S+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "AZRON-T"
-		name = "T"
-		command = ".say"
-		is-disabled = false
-	elem "AZRON-O"
-		name = "O"
-		command = "ooc"
-		is-disabled = false
-	elem "AZRON-M"
-		name = "M"
-		command = ".me"
-		is-disabled = false
-	elem "AZRON-W"
-		name = "W"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "AZRON-CTRL+W"
-		name = "CTRL+W"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "AZRON-X"
-		name = "X"
-		command = ".northeast"
-		is-disabled = false
-	elem "AZRON-CTRL+X"
-		name = "CTRL+X"
-		command = ".northeast"
-		is-disabled = false
-	elem "AZRON-Y"
-		name = "Y"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "AZRON-CTRL+Y"
-		name = "CTRL+Y"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "w_key"
-		name = "Z+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "AZRON-CTRL+Z+REP"
-		name = "CTRL+Z+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "AZRON-F1"
-		name = "F1"
-		command = "adminhelp"
-		is-disabled = false
-	elem "AZRON-CTRL+SHIFT+F1+REP"
-		name = "CTRL+SHIFT+F1+REP"
-		command = ".options"
-		is-disabled = false
-	elem "AZRON-F2"
-		name = "F2"
-		command = "ooc"
-		is-disabled = false
-	elem "AZRON-F2+REP"
-		name = "F2+REP"
-		command = ".screenshot auto"
-		is-disabled = false
-	elem "AZRON-SHIFT+F2+REP"
-		name = "SHIFT+F2+REP"
-		command = ".screenshot"
-		is-disabled = false
-	elem "AZRON-F3"
-		name = "F3"
-		command = ".say"
-		is-disabled = false
-	elem "AZRON-F4"
-		name = "F4"
-		command = ".me"
-		is-disabled = false
-	elem "AZRON-F5"
-		name = "F5"
-		command = "asay"
-		is-disabled = false
-	elem "AZRON-F6"
-		name = "F6"
-		command = "Aghost"
-		is-disabled = false
-	elem "AZRON-F7"
-		name = "F7"
-		command = "player-panel-new"
-		is-disabled = false
-	elem "AZRON-F8"
-		name = "F8"
-		command = "admin-pm-key"
-		is-disabled = false
-	elem "AZRON-F9"
-		name = "F9"
-		command = "Invisimin"
-		is-disabled = false
-	elem "AZRON-F12"
-		name = "F12"
-		command = "F12"
-		is-disabled = false
-
-macro "borghotkeymode"
-	elem "BRGHK-TAB"
-		name = "TAB"
-		command = ".winset \"mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5\""
-		is-disabled = false
-	elem "BRGHK-CENTER+REP"
-		name = "CENTER+REP"
-		command = ".center"
-		is-disabled = false
-	elem "BRGHK-NORTHEAST"
-		name = "NORTHEAST"
-		command = ".northeast"
-		is-disabled = false
-	elem "BRGHK-SOUTHEAST"
-		name = "SOUTHEAST"
-		command = ".southeast"
-		is-disabled = false
-	elem "BRGHK-NORTHWEST"
-		name = "NORTHWEST"
-		command = "unequip-module"
-		is-disabled = false
-	elem "BRGHK-CTRL+WEST"
-		name = "CTRL+WEST"
-		command = "westface"
-		is-disabled = false
-	elem "BRGHK-WEST+REP"
-		name = "WEST+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "BRGHK-CTRL+NORTH"
-		name = "CTRL+NORTH"
-		command = "northface"
-		is-disabled = false
-	elem "BRGHK-NORTH+REP"
-		name = "NORTH+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "BRGHK-CTRL+EAST"
-		name = "CTRL+EAST"
-		command = "eastface"
-		is-disabled = false
-	elem "BRGHK-EAST+REP"
-		name = "EAST+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "BRGHK-CTRL+SOUTH"
-		name = "CTRL+SOUTH"
-		command = "southface"
-		is-disabled = false
-	elem "BRGHK-SOUTH+REP"
-		name = "SOUTH+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "BRGHK-INSERT"
-		name = "INSERT"
-		command = "a-intent right"
-		is-disabled = false
-	elem "BRGHK-DELETE"
-		name = "DELETE"
-		command = "delete-key-pressed"
-		is-disabled = false
-	elem "BRGHK-1"
-		name = "1"
-		command = "toggle-module 1"
-		is-disabled = false
-	elem "BRGHK-CTRL+1"
-		name = "CTRL+1"
-		command = "toggle-module 1"
-		is-disabled = false
-	elem "BRGHK-2"
-		name = "2"
-		command = "toggle-module 2"
-		is-disabled = false
-	elem "BRGHK-CTRL+2"
-		name = "CTRL+2"
-		command = "toggle-module 2"
-		is-disabled = false
-	elem "BRGHK-3"
-		name = "3"
-		command = "toggle-module 3"
-		is-disabled = false
-	elem "BRGHK-CTRL+3"
-		name = "CTRL+3"
-		command = "toggle-module 3"
-		is-disabled = false
-	elem "BRGHK-4"
-		name = "4"
-		command = "a-intent left"
-		is-disabled = false
-	elem "BRGHK-CTRL+4"
-		name = "CTRL+4"
-		command = "a-intent left"
-		is-disabled = false
-	elem "BRGHK-A+REP"
-		name = "A+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "BRGHK-CTRL+A+REP"
-		name = "CTRL+A+REP"
-		command = ".moveleft"
-		is-disabled = false
-	elem "BRGHK-B"
-		name = "B"
-		command = "resist"
-		is-disabled = false
-	elem "BRGHK-CTRL+B"
-		name = "CTRL+B"
-		command = "resist"
-		is-disabled = false
-	elem "BRGHK-T"
-		name = "T"
-		command = ".say"
-		is-disabled = false
-	elem "BRGHK-O"
-		name = "O"
-		command = "ooc"
-		is-disabled = false
-	elem "BRGHK-M"
-		name = "M"
-		command = ".me"
-		is-disabled = false
-	elem "BRGHK-CTRL+O"
-		name = "CTRL+O"
-		command = "ooc"
-		is-disabled = false
-	elem "BRGHK-D+REP"
-		name = "D+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "BRGHK-CTRL+D+REP"
-		name = "CTRL+D+REP"
-		command = ".moveright"
-		is-disabled = false
-	elem "BRGHK-F"
-		name = "F"
-		command = "a-intent left"
-		is-disabled = false
-	elem "BRGHK-CTRL+F"
-		name = "CTRL+F"
-		command = "a-intent left"
-		is-disabled = false
-	elem "BRGHK-G"
-		name = "G"
-		command = "a-intent right"
-		is-disabled = false
-	elem "BRGHK-CTRL+G"
-		name = "CTRL+G"
-		command = "a-intent right"
-		is-disabled = false
-	elem "BRGHK-Q"
-		name = "Q"
-		command = "unequip-module"
-		is-disabled = false
-	elem "BRGHK-CTRL+Q"
-		name = "CTRL+Q"
-		command = "unequip-module"
-		is-disabled = false
-	elem "s_key"
-		name = "S+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "BRGHK-CTRL+S+REP"
-		name = "CTRL+S+REP"
-		command = ".movedown"
-		is-disabled = false
-	elem "w_key"
-		name = "W+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "BRGHK-CTRL+W+REP"
-		name = "CTRL+W+REP"
-		command = ".moveup"
-		is-disabled = false
-	elem "BRGHK-X"
-		name = "X"
-		command = ".northeast"
-		is-disabled = false
-	elem "BRGHK-CTRL+X"
-		name = "CTRL+X"
-		command = ".northeast"
-		is-disabled = false
-	elem "BRGHK-Y"
-		name = "Y"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "BRGHK-CTRL+Y"
-		name = "CTRL+Y"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "BRGHK-Z"
-		name = "Z"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "BRGHK-CTRL+Z"
-		name = "CTRL+Z"
-		command = "Activate-Held-Object"
-		is-disabled = false
-	elem "BRGHK-F1"
-		name = "F1"
-		command = "adminhelp"
-		is-disabled = false
-	elem "BRGHK-CTRL+SHIFT+F1+REP"
-		name = "CTRL+SHIFT+F1+REP"
-		command = ".options"
-		is-disabled = false
-	elem "BRGHK-F2"
-		name = "F2"
-		command = "ooc"
-		is-disabled = false
-	elem "BRGHK-F2+REP"
-		name = "F2+REP"
-		command = ".screenshot auto"
-		is-disabled = false
-	elem "BRGHK-SHIFT+F2+REP"
-		name = "SHIFT+F2+REP"
-		command = ".screenshot"
-		is-disabled = false
-	elem "BRGHK-F3"
-		name = "F3"
-		command = ".say"
-		is-disabled = false
-	elem "BRGHK-F4"
-		name = "F4"
-		command = ".me"
-		is-disabled = false
-	elem "BRGHK-F5"
-		name = "F5"
-		command = "asay"
-		is-disabled = false
-	elem "BRGHK-F6"
-		name = "F6"
-		command = "Aghost"
-		is-disabled = false
-	elem "BRGHK-F7"
-		name = "F7"
-		command = "player-panel-new"
-		is-disabled = false
-	elem "BRGHK-F8"
-		name = "F8"
-		command = "admin-pm-key"
-		is-disabled = false
-	elem "BRGHK-F9"
-		name = "F9"
-		command = "Invisimin"
-		is-disabled = false
-	elem "BRGHK-F12"
-		name = "F12"
-		command = "F12"
-		is-disabled = false
-
 macro "macro"
 	elem "MACRO-TAB"
 		name = "TAB"
-		command = ".Toggle-hotkey-mode"
+		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#f0f0f0\""
 		is-disabled = false
 	elem "MACRO-CENTER+REP"
 		name = "CENTER+REP"
@@ -893,7 +187,7 @@ macro "macro"
 macro "hotkeymode"
 	elem "HKMODE-TAB"
 		name = "TAB"
-		command = ".Toggle-hotkey-mode"
+		command = ".winset \"mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5\""
 		is-disabled = false
 	elem "HKMODE-CENTER+REP"
 		name = "CENTER+REP"
@@ -1346,6 +640,712 @@ macro "borgmacro"
 		command = "F12"
 		is-disabled = false
 
+macro "borghotkeymode"
+	elem "BRGHK-TAB"
+		name = "TAB"
+		command = ".winset \"mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5\""
+		is-disabled = false
+	elem "BRGHK-CENTER+REP"
+		name = "CENTER+REP"
+		command = ".center"
+		is-disabled = false
+	elem "BRGHK-NORTHEAST"
+		name = "NORTHEAST"
+		command = ".northeast"
+		is-disabled = false
+	elem "BRGHK-SOUTHEAST"
+		name = "SOUTHEAST"
+		command = ".southeast"
+		is-disabled = false
+	elem "BRGHK-NORTHWEST"
+		name = "NORTHWEST"
+		command = "unequip-module"
+		is-disabled = false
+	elem "BRGHK-CTRL+WEST"
+		name = "CTRL+WEST"
+		command = "westface"
+		is-disabled = false
+	elem "BRGHK-WEST+REP"
+		name = "WEST+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "BRGHK-CTRL+NORTH"
+		name = "CTRL+NORTH"
+		command = "northface"
+		is-disabled = false
+	elem "BRGHK-NORTH+REP"
+		name = "NORTH+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "BRGHK-CTRL+EAST"
+		name = "CTRL+EAST"
+		command = "eastface"
+		is-disabled = false
+	elem "BRGHK-EAST+REP"
+		name = "EAST+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "BRGHK-CTRL+SOUTH"
+		name = "CTRL+SOUTH"
+		command = "southface"
+		is-disabled = false
+	elem "BRGHK-SOUTH+REP"
+		name = "SOUTH+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "BRGHK-INSERT"
+		name = "INSERT"
+		command = "a-intent right"
+		is-disabled = false
+	elem "BRGHK-DELETE"
+		name = "DELETE"
+		command = "delete-key-pressed"
+		is-disabled = false
+	elem "BRGHK-1"
+		name = "1"
+		command = "toggle-module 1"
+		is-disabled = false
+	elem "BRGHK-CTRL+1"
+		name = "CTRL+1"
+		command = "toggle-module 1"
+		is-disabled = false
+	elem "BRGHK-2"
+		name = "2"
+		command = "toggle-module 2"
+		is-disabled = false
+	elem "BRGHK-CTRL+2"
+		name = "CTRL+2"
+		command = "toggle-module 2"
+		is-disabled = false
+	elem "BRGHK-3"
+		name = "3"
+		command = "toggle-module 3"
+		is-disabled = false
+	elem "BRGHK-CTRL+3"
+		name = "CTRL+3"
+		command = "toggle-module 3"
+		is-disabled = false
+	elem "BRGHK-4"
+		name = "4"
+		command = "a-intent left"
+		is-disabled = false
+	elem "BRGHK-CTRL+4"
+		name = "CTRL+4"
+		command = "a-intent left"
+		is-disabled = false
+	elem "BRGHK-A+REP"
+		name = "A+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "BRGHK-CTRL+A+REP"
+		name = "CTRL+A+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "BRGHK-B"
+		name = "B"
+		command = "resist"
+		is-disabled = false
+	elem "BRGHK-CTRL+B"
+		name = "CTRL+B"
+		command = "resist"
+		is-disabled = false
+	elem "BRGHK-T"
+		name = "T"
+		command = ".say"
+		is-disabled = false
+	elem "BRGHK-O"
+		name = "O"
+		command = "ooc"
+		is-disabled = false
+	elem "BRGHK-M"
+		name = "M"
+		command = ".me"
+		is-disabled = false
+	elem "BRGHK-CTRL+O"
+		name = "CTRL+O"
+		command = "ooc"
+		is-disabled = false
+	elem "BRGHK-D+REP"
+		name = "D+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "BRGHK-CTRL+D+REP"
+		name = "CTRL+D+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "BRGHK-F"
+		name = "F"
+		command = "a-intent left"
+		is-disabled = false
+	elem "BRGHK-CTRL+F"
+		name = "CTRL+F"
+		command = "a-intent left"
+		is-disabled = false
+	elem "BRGHK-G"
+		name = "G"
+		command = "a-intent right"
+		is-disabled = false
+	elem "BRGHK-CTRL+G"
+		name = "CTRL+G"
+		command = "a-intent right"
+		is-disabled = false
+	elem "BRGHK-Q"
+		name = "Q"
+		command = "unequip-module"
+		is-disabled = false
+	elem "BRGHK-CTRL+Q"
+		name = "CTRL+Q"
+		command = "unequip-module"
+		is-disabled = false
+	elem "s_key"
+		name = "S+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "BRGHK-CTRL+S+REP"
+		name = "CTRL+S+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "w_key"
+		name = "W+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "BRGHK-CTRL+W+REP"
+		name = "CTRL+W+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "BRGHK-X"
+		name = "X"
+		command = ".northeast"
+		is-disabled = false
+	elem "BRGHK-CTRL+X"
+		name = "CTRL+X"
+		command = ".northeast"
+		is-disabled = false
+	elem "BRGHK-Y"
+		name = "Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "BRGHK-CTRL+Y"
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "BRGHK-Z"
+		name = "Z"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "BRGHK-CTRL+Z"
+		name = "CTRL+Z"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "BRGHK-F1"
+		name = "F1"
+		command = "adminhelp"
+		is-disabled = false
+	elem "BRGHK-CTRL+SHIFT+F1+REP"
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+		is-disabled = false
+	elem "BRGHK-F2"
+		name = "F2"
+		command = "ooc"
+		is-disabled = false
+	elem "BRGHK-F2+REP"
+		name = "F2+REP"
+		command = ".screenshot auto"
+		is-disabled = false
+	elem "BRGHK-SHIFT+F2+REP"
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+		is-disabled = false
+	elem "BRGHK-F3"
+		name = "F3"
+		command = ".say"
+		is-disabled = false
+	elem "BRGHK-F4"
+		name = "F4"
+		command = ".me"
+		is-disabled = false
+	elem "BRGHK-F5"
+		name = "F5"
+		command = "asay"
+		is-disabled = false
+	elem "BRGHK-F6"
+		name = "F6"
+		command = "Aghost"
+		is-disabled = false
+	elem "BRGHK-F7"
+		name = "F7"
+		command = "player-panel-new"
+		is-disabled = false
+	elem "BRGHK-F8"
+		name = "F8"
+		command = "admin-pm-key"
+		is-disabled = false
+	elem "BRGHK-F9"
+		name = "F9"
+		command = "Invisimin"
+		is-disabled = false
+	elem "BRGHK-F12"
+		name = "F12"
+		command = "F12"
+		is-disabled = false
+
+macro "azertymacro"
+	elem "AZRFF-TAB"
+		name = "TAB"
+		command = ".winset \"mainwindow.macro=borghotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0\""
+		is-disabled = false
+	elem "AZRFF-CENTER+REP"
+		name = "CENTER+REP"
+		command = ".center"
+		is-disabled = false
+	elem "AZRFF-NORTHEAST"
+		name = "NORTHEAST"
+		command = ".northeast"
+		is-disabled = false
+	elem "AZRFF-SOUTHEAST"
+		name = "SOUTHEAST"
+		command = ".southeast"
+		is-disabled = false
+	elem "AZRFF-SOUTHWEST"
+		name = "SOUTHWEST"
+		command = ".southwest"
+		is-disabled = false
+	elem "AZRFF-NORTHWEST"
+		name = "NORTHWEST"
+		command = ".northwest"
+		is-disabled = false
+	elem "AZRFF-CTRL+WEST"
+		name = "CTRL+WEST"
+		command = "westface"
+		is-disabled = false
+	elem "AZRFF-WEST+REP"
+		name = "WEST+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "AZRFF-CTRL+NORTH"
+		name = "CTRL+NORTH"
+		command = "northface"
+		is-disabled = false
+	elem "AZRFF-NORTH+REP"
+		name = "NORTH+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "AZRFF-CTRL+EAST"
+		name = "CTRL+EAST"
+		command = "eastface"
+		is-disabled = false
+	elem "AZRFF-EAST+REP"
+		name = "EAST+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "AZRFF-CTRL+SOUTH"
+		name = "CTRL+SOUTH"
+		command = "southface"
+		is-disabled = false
+	elem "AZRFF-SOUTH+REP"
+		name = "SOUTH+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "AZRFF-INSERT"
+		name = "INSERT"
+		command = "a-intent right"
+		is-disabled = false
+	elem "AZRFF-DELETE"
+		name = "DELETE"
+		command = "delete-key-pressed"
+		is-disabled = false
+	elem "AZRFF-CTRL+1"
+		name = "CTRL+1"
+		command = "a-intent help"
+		is-disabled = false
+	elem "AZRFF-CTRL+2"
+		name = "CTRL+2"
+		command = "a-intent disarm"
+		is-disabled = false
+	elem "AZRFF-CTRL+3"
+		name = "CTRL+3"
+		command = "a-intent grab"
+		is-disabled = false
+	elem "AZRFF-CTRL+4"
+		name = "CTRL+4"
+		command = "a-intent harm"
+		is-disabled = false
+	elem "AZRFF-CTRL+A"
+		name = "CTRL+A"
+		command = ".northwest"
+		is-disabled = false
+	elem "AZRFF-CTRL+D+REP"
+		name = "CTRL+D+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "AZRFF-CTRL+B"
+		name = "CTRL+B"
+		command = "resist"
+		is-disabled = false
+	elem "AZRFF-CTRL+E"
+		name = "CTRL+E"
+		command = "quick-equip"
+		is-disabled = false
+	elem "AZRFF-CTRL+F"
+		name = "CTRL+F"
+		command = "a-intent left"
+		is-disabled = false
+	elem "AZRFF-CTRL+G"
+		name = "CTRL+G"
+		command = "a-intent right"
+		is-disabled = false
+	elem "AZRFF-CTRL+Q+REP"
+		name = "CTRL+Q+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "AZRFF-CTRL+R"
+		name = "CTRL+R"
+		command = ".southwest"
+		is-disabled = false
+	elem "AZRFF-CTRL+S+REP"
+		name = "CTRL+S+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "AZRFF-CTRL+W"
+		name = "CTRL+W"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "AZRFF-CTRL+X"
+		name = "CTRL+X"
+		command = ".northeast"
+		is-disabled = false
+	elem "AZRFF-CTRL+Y"
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "AZRFF-CTRL+Z+REP"
+		name = "CTRL+Z+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "AZRFF-F1"
+		name = "F1"
+		command = "adminhelp"
+		is-disabled = false
+	elem "AZRFF-CTRL+SHIFT+F1+REP"
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+		is-disabled = false
+	elem "AZRFF-F2"
+		name = "F2"
+		command = "ooc"
+		is-disabled = false
+	elem "AZRFF-F2+REP"
+		name = "F2+REP"
+		command = ".screenshot auto"
+		is-disabled = false
+	elem "AZRFF-SHIFT+F2+REP"
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+		is-disabled = false
+	elem "AZRFF-F3"
+		name = "F3"
+		command = ".say"
+		is-disabled = false
+	elem "AZRFF-F4"
+		name = "F4"
+		command = ".me"
+		is-disabled = false
+	elem "AZRFF-F5"
+		name = "F5"
+		command = "asay"
+		is-disabled = false
+	elem "AZRFF-F6"
+		name = "F6"
+		command = "Aghost"
+		is-disabled = false
+	elem "AZRFF-F7"
+		name = "F7"
+		command = "player-panel-new"
+		is-disabled = false
+	elem "AZRFF-F8"
+		name = "F8"
+		command = "admin-pm-key"
+		is-disabled = false
+	elem "AZRFF-F9"
+		name = "F9"
+		command = "Invisimin"
+		is-disabled = false
+	elem "AZRFF-F12"
+		name = "F12"
+		command = "F12"
+		is-disabled = false
+
+macro "azertyhotkeymode"
+	elem "AZRON-TAB"
+		name = "TAB"
+		command = ".winset \"mainwindow.macro=AZERTYmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5\""
+		is-disabled = false
+	elem "AZRON-CENTER+REP"
+		name = "CENTER+REP"
+		command = ".center"
+		is-disabled = false
+	elem "AZRON-NORTHEAST"
+		name = "NORTHEAST"
+		command = ".northeast"
+		is-disabled = false
+	elem "AZRON-SOUTHEAST"
+		name = "SOUTHEAST"
+		command = ".southeast"
+		is-disabled = false
+	elem "AZRON-SOUTHWEST"
+		name = "SOUTHWEST"
+		command = ".southwest"
+		is-disabled = false
+	elem "AZRON-NORTHWEST"
+		name = "NORTHWEST"
+		command = ".northwest"
+		is-disabled = false
+	elem "AZRON-CTRL+WEST"
+		name = "CTRL+WEST"
+		command = "westface"
+		is-disabled = false
+	elem "AZRON-WEST+REP"
+		name = "WEST+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "AZRON-CTRL+NORTH"
+		name = "CTRL+NORTH"
+		command = "northface"
+		is-disabled = false
+	elem "AZRON-NORTH+REP"
+		name = "NORTH+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "AZRON-CTRL+EAST"
+		name = "CTRL+EAST"
+		command = "eastface"
+		is-disabled = false
+	elem "AZRON-EAST+REP"
+		name = "EAST+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "AZRON-CTRL+SOUTH"
+		name = "CTRL+SOUTH"
+		command = "southface"
+		is-disabled = false
+	elem "AZRON-SOUTH+REP"
+		name = "SOUTH+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "AZRON-INSERT"
+		name = "INSERT"
+		command = "a-intent right"
+		is-disabled = false
+	elem "AZRON-DELETE"
+		name = "DELETE"
+		command = "delete-key-pressed"
+		is-disabled = false
+	elem "AZRON-1"
+		name = "1"
+		command = "a-intent help"
+		is-disabled = false
+	elem "AZRON-CTRL+1"
+		name = "CTRL+1"
+		command = "a-intent help"
+		is-disabled = false
+	elem "AZRON-2"
+		name = "2"
+		command = "a-intent disarm"
+		is-disabled = false
+	elem "AZRON-CTRL+2"
+		name = "CTRL+2"
+		command = "a-intent disarm"
+		is-disabled = false
+	elem "AZRON-3"
+		name = "3"
+		command = "a-intent grab"
+		is-disabled = false
+	elem "AZRON-CTRL+3"
+		name = "CTRL+3"
+		command = "a-intent grab"
+		is-disabled = false
+	elem "AZRON-4"
+		name = "4"
+		command = "a-intent harm"
+		is-disabled = false
+	elem "AZRON-CTRL+4"
+		name = "CTRL+4"
+		command = "a-intent harm"
+		is-disabled = false
+	elem "AZRON-A"
+		name = "A"
+		command = ".northwest"
+		is-disabled = false
+	elem "AZRON-CTRL+A"
+		name = "CTRL+A"
+		command = ".northwest"
+		is-disabled = false
+	elem "AZRON-D+REP"
+		name = "D+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "AZRON-CTRL+D+REP"
+		name = "CTRL+D+REP"
+		command = ".moveright"
+		is-disabled = false
+	elem "AZRON-CTRL+B"
+		name = "CTRL+B"
+		command = "resist"
+		is-disabled = false
+	elem "AZRON-E"
+		name = "E"
+		command = "quick-equip"
+		is-disabled = false
+	elem "AZRON-CTRL+E"
+		name = "CTRL+E"
+		command = "quick-equip"
+		is-disabled = false
+	elem "AZRON-F"
+		name = "F"
+		command = "a-intent left"
+		is-disabled = false
+	elem "AZRON-CTRL+F"
+		name = "CTRL+F"
+		command = "a-intent left"
+		is-disabled = false
+	elem "AZRON-G"
+		name = "G"
+		command = "a-intent right"
+		is-disabled = false
+	elem "AZRON-CTRL+G"
+		name = "CTRL+G"
+		command = "a-intent right"
+		is-disabled = false
+	elem "AZRON-H"
+		name = "H"
+		command = "holster"
+		is-disabled = false
+	elem "AZRON-CTRL+H"
+		name = "CTRL+H"
+		command = "holster"
+		is-disabled = false
+	elem "AZRON-Q+REP"
+		name = "Q+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "AZRON-CTRL+Q+REP"
+		name = "CTRL+Q+REP"
+		command = ".moveleft"
+		is-disabled = false
+	elem "AZRON-R"
+		name = "R"
+		command = ".southwest"
+		is-disabled = false
+	elem "AZRON-CTRL+R"
+		name = "CTRL+R"
+		command = ".southwest"
+		is-disabled = false
+	elem "s_key"
+		name = "S+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "AZRON-CTRL+S+REP"
+		name = "CTRL+S+REP"
+		command = ".movedown"
+		is-disabled = false
+	elem "AZRON-T"
+		name = "T"
+		command = ".say"
+		is-disabled = false
+	elem "AZRON-O"
+		name = "O"
+		command = "ooc"
+		is-disabled = false
+	elem "AZRON-M"
+		name = "M"
+		command = ".me"
+		is-disabled = false
+	elem "AZRON-W"
+		name = "W"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "AZRON-CTRL+W"
+		name = "CTRL+W"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "AZRON-X"
+		name = "X"
+		command = ".northeast"
+		is-disabled = false
+	elem "AZRON-CTRL+X"
+		name = "CTRL+X"
+		command = ".northeast"
+		is-disabled = false
+	elem "AZRON-Y"
+		name = "Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "AZRON-CTRL+Y"
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "w_key"
+		name = "Z+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "AZRON-CTRL+Z+REP"
+		name = "CTRL+Z+REP"
+		command = ".moveup"
+		is-disabled = false
+	elem "AZRON-F1"
+		name = "F1"
+		command = "adminhelp"
+		is-disabled = false
+	elem "AZRON-CTRL+SHIFT+F1+REP"
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+		is-disabled = false
+	elem "AZRON-F2"
+		name = "F2"
+		command = "ooc"
+		is-disabled = false
+	elem "AZRON-F2+REP"
+		name = "F2+REP"
+		command = ".screenshot auto"
+		is-disabled = false
+	elem "AZRON-SHIFT+F2+REP"
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+		is-disabled = false
+	elem "AZRON-F3"
+		name = "F3"
+		command = ".say"
+		is-disabled = false
+	elem "AZRON-F4"
+		name = "F4"
+		command = ".me"
+		is-disabled = false
+	elem "AZRON-F5"
+		name = "F5"
+		command = "asay"
+		is-disabled = false
+	elem "AZRON-F6"
+		name = "F6"
+		command = "Aghost"
+		is-disabled = false
+	elem "AZRON-F7"
+		name = "F7"
+		command = "player-panel-new"
+		is-disabled = false
+	elem "AZRON-F8"
+		name = "F8"
+		command = "admin-pm-key"
+		is-disabled = false
+	elem "AZRON-F9"
+		name = "F9"
+		command = "Invisimin"
+		is-disabled = false
+	elem "AZRON-F12"
+		name = "F12"
+		command = "F12"
+		is-disabled = false
+
 menu "menu"
 	elem
 		name = "&File"
@@ -1526,6 +1526,8 @@ window "mainwindow"
 		icon = 'icons\\paradise.png'
 		menu = "menu"
 		macro = "macro"
+		macro_hotkey_mode_inactive = "macro"
+		macro_hotkey_mode_active = "hotkeymode"
 		saved-params = "pos;size;is-minimized;is-maximized"
 	elem "asset_cache_browser"
 		type = BROWSER
@@ -1537,11 +1539,11 @@ window "mainwindow"
 		size = 80x20
 		anchor1 = 100,100
 		anchor2 = none
+		background-color = none
+		saved-params = ""
 		is-flat = false
 		text = "Hotkey Toggle"
-		command = ".Toggle-hotkey-mode"
-		is-checked = false
-		saved-params = "is-checked"
+		command = ".winset \"mainwindow.macro != mainwindow.macro_hotkey_mode_inactive ? mainwindow.macro=mainwindow.macro_hotkey_mode_inactive hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5 : mainwindow.macro=mainwindow.macro_hotkey_mode_active hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#f0f0f0\""
 	elem "mainvsplit"
 		type = CHILD
 		pos = 3,0

--- a/paradise.dme
+++ b/paradise.dme
@@ -329,6 +329,7 @@
 #include "code\datums\helper_datums\construction_datum.dm"
 #include "code\datums\helper_datums\events.dm"
 #include "code\datums\helper_datums\global_iterator.dm"
+#include "code\datums\helper_datums\hotkey_modes.dm"
 #include "code\datums\helper_datums\icon_snapshot.dm"
 #include "code\datums\helper_datums\map_template.dm"
 #include "code\datums\helper_datums\teleport.dm"


### PR DESCRIPTION
**What does this PR do:**
This pull request reworks https://github.com/ParadiseSS13/Paradise/pull/121. Hotkey mode toggling has been moved back to the client side, which means that toggling it is now instantaneous. There is also no longer any lag when switching between modes.

Support for AZERTY has been maintained: the "Set Hotkey Mode" option is still present in the preferences menu.

Fixes https://github.com/ParadiseSS13/Paradise/issues/5841.

**Changelog:**
:cl: Markolie
fix: Changing your hotkey mode now happens instantaneously and no longer lags.
/:cl:

