### PR TITLE
Makes the plasma cutter less shit

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -259,19 +259,19 @@
 
 /obj/item/projectile/plasma/on_hit(atom/target)
 	. = ..()
-	if(istype(target, /turf/simulated/mineral))
+	if(ismineralturf(target))
+		forcedodge = 1
 		var/turf/simulated/mineral/M = target
 		M.gets_drilled(firer)
-		Range()
-		if(range > 0)
-			return -1
+	else
+		forcedodge = 0
 
 /obj/item/projectile/plasma/adv
-	range = 5
+	range = 6
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 10
-	range = 6
+	range = 9
 
 /obj/item/projectile/energy/teleport
 	name = "teleportation burst"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -974,9 +974,9 @@
 	desc = "A device that shoots resonant plasma bursts at extreme velocity. The blasts are capable of crushing rock and demolishing solid obstacles."
 	id = "mech_plasma_cutter"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 3, "materials" = 3, "plasmatech" = 4)
+	req_tech = list("engineering" = 4, "materials" = 5, "plasmatech" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
-	materials = list(MAT_METAL = 8000, MAT_GLASS = 1000, MAT_PLASMA = 2000)
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 2000, MAT_PLASMA = 6000)
 	construction_time = 100
 	category = list("Exosuit Equipment")
 

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -27,7 +27,7 @@
 	id = "plasmacutter"
 	req_tech = list("materials" = 3, "plasmatech" = 3, "magnets" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_PLASMA = 400)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000, MAT_PLASMA = 1500)
 	build_path = /obj/item/gun/energy/plasmacutter
 	category = list("Mining")
 
@@ -37,7 +37,7 @@
 	id = "plasmacutter_adv"
 	req_tech = list("materials" = 4, "plasmatech" = 4, "engineering" = 2, "combat" = 3, "magnets" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 500)
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000, MAT_PLASMA = 4000, MAT_GOLD = 500)
 	build_path = /obj/item/gun/energy/plasmacutter/adv
 	category = list("Mining")
 


### PR DESCRIPTION
**What does this PR do:**
With lavaland around the corner and a shit load of changes to mining, I thought why not do this, it's definitely about time.

This PR buffs the plasma cutter quite significantly, to make it actually viable and somewhat on par with the KA. It will now break through different amounts of turf depending on which version you use. This also increases the cost of the plasma cutters as well as the research required to make as they're a lot more powerful, nothing ridiculous though. The actual values can be debated and changed if needed, but I think these are fine. The regular plasma cutter will cut through 3 tiles, the advanced one 6 and the mech version 9. Yes, I suppose this could be an indirect buff to ripleys which are never used by miners because an upgraded KA is way better.

Personally I think the other mining tools will need a buff too, but that can be for another PR.

**Changelog:**
:cl: CornMyCob
tweak: The plasma cutter now cuts through multiple rock tiles.
/:cl:

