### PR TITLE
Descriptions now show with a mouse hover over action buttons

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -25,6 +25,7 @@
 	button.name = name
 	if(desc)
 		button.desc = desc
+
 /datum/action/Destroy()
 	if(owner)
 		Remove(owner)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -23,7 +23,8 @@
 	button = new
 	button.linked_action = src
 	button.name = name
-
+	if(desc)
+		button.desc = desc
 /datum/action/Destroy()
 	if(owner)
 		Remove(owner)
@@ -82,6 +83,7 @@
 	if(button)
 		button.icon = button_icon
 		button.icon_state = background_icon_state
+		button.desc = desc
 
 		ApplyIcon(button)
 
@@ -434,6 +436,7 @@
 	var/obj/effect/proc_holder/spell/S = target
 	S.action = src
 	name = S.name
+	desc = S.desc
 	button_icon = S.action_icon
 	button_icon_state = S.action_icon_state
 	background_icon_state = S.action_background_icon_state


### PR DESCRIPTION
**What does this PR do:**
Ported from /tg/station13.

Descriptions now show with a mouse hover over any action button, if available. Examples are below.
This will be immensely useful especially for a new players, who can with a simple mouse hover get basic information about what that button does.

Tested locally without any issue.

**Images of sprite/map changes (IF APPLICABLE):**
![VampireTooltip](https://user-images.githubusercontent.com/43862960/55648304-3e3d3400-57e0-11e9-83f8-6b54df15fd87.png)

![WizardDesc](https://user-images.githubusercontent.com/43862960/55648307-4006f780-57e0-11e9-9690-5d827b0a5c7d.png)

**Changelog:**
:cl: Arkatos
tweak: Descriptions now show with a mouse hover over action buttons
/:cl: