### PR TITLE
Small law upload console tweak

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -28,6 +28,9 @@
 
 	attackby(obj/item/O as obj, mob/user as mob, params)
 		if(istype(O, /obj/item/aiModule))
+			if(!current)//no AI selected
+				to_chat(user, "<span class='danger'>No AI selected. Please chose a target before proceeding with upload.")
+				return
 			var/turf/T = get_turf(current)
 			if(!atoms_share_level(T, src))
 				to_chat(user, "<span class='danger'>Unable to establish a connection</span>: You're too far away from the target silicon!")
@@ -73,6 +76,9 @@
 
 	attackby(obj/item/aiModule/module as obj, mob/user as mob, params)
 		if(istype(module, /obj/item/aiModule))
+			if(!current)//no borg selected
+				to_chat(user, "<span class='danger'>No borg selected. Please chose a target before proceeding with upload.")
+				return
 			var/turf/T = get_turf(current)
 			if(!atoms_share_level(T, src))
 				to_chat(user, "<span class='danger'>Unable to establish a connection</span>: You're too far away from the target silicon!")


### PR DESCRIPTION
**What does this PR do:**
The ai law upload and borg law upload consoles now give a more helpful and correct error message when no ai/borg is selected, rather than the very misleading 'ai is out of range'. This happens quite a bit to traitors that build an AI upload for the first time, forget to click on it first to chose the ai, then wonder if they build their ai upload in the wrong place because it says it's out of range. Inspired by an mhelp I got last round.

**Changelog:**
:cl:
tweak: upload consoles now tell you if you forgot to select an ai/borg before using an upload module.
/:cl:

