### PR TITLE
Updates and Buffs Power Gloves

### DIFF
--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -74,7 +74,7 @@
 				L.Weaken(3)
 			else
 				if(P.unlimited_power)
-					L.electrocute_act(1000, P, 0) //Just kill them
+					L.electrocute_act(1000, P, 0, TRUE) //Just kill them
 				else
 					electrocute_mob(L, C, P)
 			break

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -74,7 +74,7 @@
 				L.Weaken(3)
 			else
 				if(P.unlimited_power)
-					L.electrocute_act(1000, P, 0, TRUE) //Just kill them
+					L.electrocute_act(1000, P, 0) //Just kill them
 				else
 					electrocute_mob(L, C, P)
 			break

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -12,6 +12,9 @@
 	description_antag = "These are a pair of power gloves, and can be used to fire bolts of electricity while standing over powered power cables."
 	var/old_mclick_override
 	var/datum/middleClickOverride/power_gloves/mclick_override = new /datum/middleClickOverride/power_gloves
+	var/last_shocked = 0
+	var/shock_delay = 40
+	var/unlimited_power = FALSE // Does this really need explanation?
 
 /obj/item/clothing/gloves/color/yellow/power/equipped(mob/user, slot)
 	if(!ishuman(user))
@@ -21,7 +24,10 @@
 		if(H.middleClickOverride)
 			old_mclick_override = H.middleClickOverride
 		H.middleClickOverride = mclick_override
-		to_chat(H, "<span class='notice'>You feel electricity begin to build up in [src].</span>")
+		if(!unlimited_power)
+			to_chat(H, "<span class='notice'>You feel electricity begin to build up in [src].</span>")
+		else
+			to_chat(H, "<span class='biggerdanger'>You feel like you have UNLIMITED POWER!!</span>")
 
 /obj/item/clothing/gloves/color/yellow/power/dropped(mob/user, slot)
 	if(!ishuman(user))
@@ -33,6 +39,12 @@
 			old_mclick_override = null
 		else
 			H.middleClickOverride = null
+
+/obj/item/clothing/gloves/color/yellow/power/unlimited
+	name = "UNLIMITED POWER gloves"
+	desc = "These gloves possess UNLIMITED POWER."
+	shock_delay = 0
+	unlimited_power = TRUE
 
 /obj/item/clothing/gloves/color/yellow/fake
 	desc = "These gloves will protect the wearer from electric shock. They don't feel like rubber..."


### PR DESCRIPTION
Power gloves aren't particularly strong, at the moment, so I decided to look into them. Ideas taken from Goon, as that's where these originate from.

- Cooldown lowered from 12 to 4
- Power gloves electricity will now bounce if you target something other than a mob
  - If a bounce hit's a mob, it "grounds out" and doesn't bounce to more mobs; you can't hit more than one mob with one shock
- The temp is raised at the point of shock (you can now light plasma fires, heat up reagents or what have you)
- If you're on disarm intent, the gloves will deal no damage and will just weaken instead

Did some additional refactoring of power gloves to have their cooldown based on the gloves, themselves, in case an admin wants to raise/lower their cooldown or something.

- Adds a badmin variant of the gloves: UNLIMITED POWER gloves

I don't think these need explanation, but just in case: they don't require the powergrid to use, always deal absurd damage,  have no cooldown, and bypass electrical resistance.

:cl: Fox McCloud
add: Power gloves electric shocks can target anything now (still only damages mobs)
add: Power gloves electric arcs will bounce around (if it happens to target a mob though, it'll ground out and not bounce any more)
tweak: Power gloves cooldown lowered from 12 to 4
tweak: Power gloves heat up the turf they target
tweak: Using power gloves on disarm intent will weaken your target instead of dealing damage
/:cl: