### PR TITLE
Safe refactor

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -59728,7 +59728,7 @@
 	req_access_txt = "63"
 	},
 /obj/structure/safe/floor{
-	knownby = list("captain")
+	known_by = list("captain")
 	},
 /obj/item/gun/projectile/revolver/russian,
 /obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -37724,7 +37724,7 @@
 /area/security/brig)
 "bnv" = (
 /obj/structure/safe{
-	knownby = list("captain")
+	known_by = list("captain")
 	},
 /obj/item/clothing/head/bearpelt,
 /obj/item/folder/documents,
@@ -44634,7 +44634,7 @@
 /area/crew_quarters/heads)
 "byk" = (
 /obj/structure/safe/floor{
-	knownby = list("captain")
+	known_by = list("captain")
 	},
 /obj/item/gun/projectile/revolver/russian,
 /obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -28410,7 +28410,7 @@
 /area/security/nuke_storage)
 "aZq" = (
 /obj/structure/safe{
-	knownby = list("captain")
+	known_by = list("captain")
 	},
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -53021,7 +53021,7 @@
 /area/engine/gravitygenerator)
 "bTj" = (
 /obj/structure/safe/floor{
-	knownby = list("captain")
+	known_by = list("captain")
 	},
 /obj/item/gun/projectile/revolver/russian,
 /obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -2,8 +2,8 @@
 CONTAINS:
 SAFES
 FLOOR SAFES
-Safe Codes
-Safe Internals
+SAFE INTERNALS
+SAFE CODES
 */
 
 GLOBAL_LIST_EMPTY(safes)
@@ -14,18 +14,25 @@ GLOBAL_LIST_EMPTY(safes)
 	desc = "A huge chunk of metal with a dial embedded in it. Fine print on the dial reads \"Scarborough Arms - 2 tumbler safe, guaranteed thermite resistant, explosion resistant, and assistant resistant.\""
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "safe"
-	anchored = 1
-	density = 1
-	var/open = FALSE	//is the safe open?
+	
+	anchored = TRUE
+	density = TRUE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	unacidable = TRUE
+
+	var/open = FALSE
 	var/locked = TRUE
-	var/tumbler_1_pos	//the tumbler position- from 0 to 72
-	var/tumbler_1_open	//the tumbler position to open at- 0 to 72
+	var/dial = 0		//the position the dial is pointing to
+
+	var/tumbler_1_pos	//the tumbler position, between 0 and 99
+	var/tumbler_1_open	//the tumbler position to open the safe, between 0 and 99
 	var/tumbler_2_pos
 	var/tumbler_2_open
-	var/open_pos
-	var/dial = 0		//where is the dial pointing?
+	var/open_pos		//the position to open the safe
+
 	var/space = 0		//the combined w_class of everything in the safe
 	var/maxspace = 24	//the maximum combined w_class of stuff in the safe
+
 	var/obj/item/thermal_drill/drill = null
 	var/drill_timer
 	var/time_to_drill
@@ -33,31 +40,45 @@ GLOBAL_LIST_EMPTY(safes)
 	var/drill_start_time
 	var/drill_x_offset = -13
 	var/drill_y_offset = -3
-	var/knownby = list()
-
+	var/known_by = list()
 
 /obj/structure/safe/New()
 	GLOB.safes += src
-	tumbler_1_pos = rand(0, 71)
-	tumbler_1_open = rand(0, 71)
-	
-	tumbler_2_pos = rand(0, 71) // first value in the combination set first
-	tumbler_2_open = rand(0, 71)
 
-/obj/structure/safe/Initialize()
-	..()
+	tumbler_1_pos = rand(0, 99)
+	tumbler_1_open = rand(0, 99)
+	
+	tumbler_2_pos = rand(0, 99)
+	tumbler_2_open = rand(0, 99)
+
+/obj/structure/safe/Initialize(mapload)
+	. = ..()
 	for(var/obj/item/I in loc)
 		if(space >= maxspace)
 			return
 		if(I.w_class + space <= maxspace)
 			space += I.w_class
-			I.loc = src
+			I.forceMove(src)
 
+/obj/structure/safe/Destroy()
+	GLOB.safes -= src
+	drill?.soundloop?.stop()
+	return ..()
+
+/obj/structure/safe/blob_act()
+	return
+
+/obj/structure/safe/ex_act(severity)
+	return
+
+/obj/structure/safe/examine_status(mob/user)
+	return
 
 /obj/structure/safe/proc/check_unlocked()
 	if(tumbler_1_pos == tumbler_1_open && tumbler_2_pos == tumbler_2_open && dial == open_pos)
 		locked = FALSE
 		return TRUE
+
 	locked = TRUE
 	return FALSE
 
@@ -73,9 +94,10 @@ GLOBAL_LIST_EMPTY(safes)
 			to_chat(user, "<span class='italics'>You hear a [pick("tonk", "krunk", "plunk")] from [src].</span>")
 		if(tumbler_2_pos == tumbler_2_open && turns_total == 1 && tum2) // You cant hear tumblers if you spin fast!
 			to_chat(user, "<span class='italics'>You hear a [pick("tink", "krink", "plink")] from [src].</span>")
+
 	if(!locked)
 		if(user)
-			visible_message("<i><b>[pick("Spring", "Sprang", "Sproing", "Clunk", "Krunk")]!</b></i>")
+			visible_message("<span class='boldnotice'>[pick("Spring", "Sprang", "Sproing", "Clunk", "Krunk")]!</span>")
 
 /obj/structure/safe/update_icon()
 	if(open)
@@ -88,21 +110,20 @@ GLOBAL_LIST_EMPTY(safes)
 			icon_state = "[initial(icon_state)]-broken"
 		else
 			icon_state = initial(icon_state)
+
 	overlays.Cut()
-	if(istype(drill, /obj/item/thermal_drill/diamond_drill))
+
+	if(istype(drill, /obj/item/thermal_drill))
+		var/drill_icon = istype(drill, /obj/item/thermal_drill/diamond_drill) ? "d" : "h"
 		if(drill_timer)
-			overlays += image(icon = 'icons/effects/drill.dmi', icon_state = "[initial(icon_state)]_d-drill-on", pixel_x = drill_x_offset, pixel_y = drill_y_offset)
+			overlays += image(icon = 'icons/effects/drill.dmi', icon_state = "[initial(icon_state)]_[drill_icon]-drill-on", pixel_x = drill_x_offset, pixel_y = drill_y_offset)
 		else
-			overlays += image(icon = 'icons/effects/drill.dmi', icon_state = "[initial(icon_state)]_d-drill-off", pixel_x = drill_x_offset, pixel_y = drill_y_offset)
-	else if(istype(drill, /obj/item/thermal_drill))
-		if(drill_timer)
-			overlays += image(icon = 'icons/effects/drill.dmi', icon_state = "[initial(icon_state)]_h-drill-on", pixel_x = drill_x_offset, pixel_y = drill_y_offset)
-		else
-			overlays += image(icon = 'icons/effects/drill.dmi', icon_state = "[initial(icon_state)]_h-drill-off", pixel_x = drill_x_offset, pixel_y = drill_y_offset)
+			overlays += image(icon = 'icons/effects/drill.dmi', icon_state = "[initial(icon_state)]_[drill_icon]-drill-off", pixel_x = drill_x_offset, pixel_y = drill_y_offset)
 
 /obj/structure/safe/attack_hand(mob/user)
 	if(..())
 		return TRUE
+
 	if(drill)
 		switch(alert("What would you like to do?", "Thermal Drill", "Turn [drill_timer ? "Off" : "On"]", "Remove Drill", "Cancel"))
 			if("Turn On")
@@ -130,7 +151,6 @@ GLOBAL_LIST_EMPTY(safes)
 				return
 	else
 		ui_interact(user)
-	return
 
 /obj/structure/safe/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
@@ -146,30 +166,29 @@ GLOBAL_LIST_EMPTY(safes)
 		for(var/obj/O in contents)
 			contents_names[++contents_names.len] = list("name" = O.name, "index" = contents.Find(O), "sprite" = O.icon_state)
 			user << browse_rsc(icon(O.icon, O.icon_state), "[O.icon_state].png")
-	else
-		contents_names = list(list("name" = "you're"), list("name" = "a"), list("name" = "cheater"))
 
 	data["dial"] = dial
 	data["open"] = open
 	data["locked"] = locked
-	data["rotation"] = "[-dial*3.6]deg"
+	data["rotation"] = "[-dial * 3.6]deg"
 	data["contents"] = contents_names
 
 	return data
-
 
 /obj/structure/safe/Topic(href, href_list)
 	if(..())
 		return TRUE
 
-	var/canhear = 0
-	if(!ishuman(usr))
-		to_chat(usr, "You don't have hands to operate the safe!")
-		return FALSE
+	var/mob/user = usr
+	if (!user.IsAdvancedToolUser() && !isobserver(user))
+		to_chat(user, "<span class='warning'>You're not able to operate the safe.</span>")
+		return
 
-	var/mob/living/carbon/human/user = usr
-	if(istype(user.l_hand, /obj/item/clothing/accessory/stethoscope) || istype(user.r_hand, /obj/item/clothing/accessory/stethoscope))
-		canhear = 1
+	var/canhear = FALSE
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.is_in_hands(/obj/item/clothing/accessory/stethoscope))
+			canhear = TRUE
 
 	if(href_list["open"])
 		if(check_unlocked() || open || broken)
@@ -177,20 +196,21 @@ GLOBAL_LIST_EMPTY(safes)
 			open = !open
 			update_icon()
 		else
-			to_chat(user, "<span class='warning'>You can't open [src], the lock is engaged!</span>")
-		.= TRUE
-		SSnanoui.update_uis(src)
+			to_chat(user, "<span class='warning'>You can't open [src], as its lock is engaged!</span>")
+		. = TRUE
 
 	if(href_list["decrement"])
-		var/ticks = text2num(href_list["decrement"])
 		if(open)
 			return
+
 		if(broken)
-			to_chat(user, "The dial will not turn, the mechanism is destroyed.")
+			to_chat(user, "<span class='warning'>The dial will not turn, as the mechanism is destroyed.</span>")
 			return
-		for(var/i=1 to ticks)
+
+		var/ticks = text2num(href_list["decrement"])
+		for(var/i = 1 to ticks)
 			if(!check_unlocked())
-				dial = Wrap(dial - 1, 0 ,100)
+				dial = Wrap(dial - 1, 0, 100)
 				if(dial == tumbler_1_pos + 1 || dial == tumbler_1_pos - 99)
 					tumbler_1_pos = Wrap(tumbler_1_pos - 1, 0, 100)
 					make_noise(i, ticks, 1, 0, user, canhear)
@@ -201,16 +221,18 @@ GLOBAL_LIST_EMPTY(safes)
 			check_unlocked()
 			SSnanoui.update_uis(src)
 		make_noise(0, 0, 0, 0, user, canhear)
-		.= TRUE
+		. = TRUE
 
 	if(href_list["increment"])
-		var/ticks = text2num(href_list["increment"])
 		if(open)
 			return
+
 		if(broken)
-			to_chat(user, "The dial will not turn, the mechanism is destroyed.")
+			to_chat(user, "<span class='warning'>The dial will not turn, as the mechanism is destroyed.</span>")
 			return
-		for(var/i=1 to ticks)
+
+		var/ticks = text2num(href_list["increment"])
+		for(var/i = 1 to ticks)
 			check_unlocked()
 			dial = Wrap(dial + 1, 0, 100)
 			if(dial == tumbler_1_pos - 1 || dial == tumbler_1_pos + 99)
@@ -222,7 +244,7 @@ GLOBAL_LIST_EMPTY(safes)
 			sleep(1)
 			SSnanoui.update_uis(src)
 		make_noise(0, 0, 0, 0, user, canhear)
-		.= TRUE
+		. = TRUE
 
 	if(href_list["retrieve"])
 		var/index = text2num(href_list["retrieve"])
@@ -232,51 +254,41 @@ GLOBAL_LIST_EMPTY(safes)
 				if(P && in_range(src, user))
 					user.put_in_hands(P)
 					space -= P.w_class
-		SSnanoui.update_uis(src)
-		.= TRUE
-
-
-	updateUsrDialog()
-	return
-
+		. = TRUE
 
 /obj/structure/safe/attackby(obj/item/I, mob/user, params)
 	if(open)
 		if(broken && istype(I, /obj/item/safe_internals) && do_after(user, 2 SECONDS, target = src))
-			to_chat(user, "You replace the broken mechanism.")
+			to_chat(user, "<span class='notice'>You replace the broken mechanism.</span>")
 			qdel(I)
 			broken = !broken
 			update_icon()
-			return
 		else if(I.w_class + space <= maxspace)
-			space += I.w_class
 			if(!user.drop_item())
 				to_chat(user, "<span class='warning'>\The [I] is stuck to your hand, you cannot put it in the safe!</span>")
 				return
-			I.loc = src
+			space += I.w_class
+			I.forceMove(src)
 			to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
-			updateUsrDialog()
-			return
 		else
 			to_chat(user, "<span class='notice'>[I] won't fit in [src].</span>")
-			return
 	else
 		if(istype(I, /obj/item/clothing/accessory/stethoscope))
 			to_chat(user, "<span class='warning'>Hold [I] in one of your hands while you manipulate the dial!</span>")
 			return
 		else if(istype(I, /obj/item/thermal_drill))
 			if(drill)
-				to_chat(user, "There is already a drill attached!")
+				to_chat(user, "<span class='warning'>There is already a drill attached!</span>")
 			else if(do_after(user, 2 SECONDS, target = src))
 				if(!user.drop_item())
 					to_chat(user, "<span class='warning'>[I] is stuck to your hand, you cannot put it in the safe!</span>")
 					return
-				I.loc = src
+				I.forceMove(src)
 				drill = I
 				time_to_drill = 300 SECONDS * drill.time_multiplier
 				update_icon()
 		else
-			to_chat(user, "<span class='warning'>You can't put [I] in into the safe while it is closed!</span>")
+			to_chat(user, "<span class='warning'>You can't put [I] into the safe while it is closed!</span>")
 			return
 
 /obj/structure/safe/proc/drill_open()
@@ -285,20 +297,6 @@ GLOBAL_LIST_EMPTY(safes)
 	drill.soundloop.stop()
 	update_icon()
 	processing_objects.Remove(src)
-
-/obj/structure/safe/blob_act()
-	return
-
-/obj/structure/safe/ex_act(severity)
-	return
-
-/obj/structure/safe/examine_status(mob/user)
-	return
-
-/obj/structure/safe/Destroy()
-	GLOB.safes -= src
-	drill?.soundloop?.stop()
-	return ..()
 
 /obj/structure/safe/process()
 	if(drill_timer)
@@ -317,19 +315,19 @@ GLOBAL_LIST_EMPTY(safes)
 /obj/structure/safe/floor
 	name = "floor safe"
 	icon_state = "floorsafe"
-	density = 0
-	level = 1	//underfloor
-	layer = 2.5
+	density = FALSE
+	level = 1 //Under the floor
+	layer = LOW_OBJ_LAYER
 	drill_x_offset = -1
 	drill_y_offset = 20
 
 /obj/structure/safe/floor/Initialize()
-	..()
+	. = ..()
 	var/turf/T = loc
 	hide(T.intact)
 
-/obj/structure/safe/floor/hide(var/intact)
-	invisibility = intact ? 101 : 0
+/obj/structure/safe/floor/hide(intact)
+	invisibility = intact ? INVISIBILITY_MAXIMUM : 0
 
 /obj/item/safe_internals
 	name = "safe internals"
@@ -341,14 +339,11 @@ GLOBAL_LIST_EMPTY(safes)
 	var/owner
 	info = "<div style='text-align:center;'><img src='ntlogo.png'><center><h3>Safe Codes</h3></center>"
 
-/obj/item/paper/safe_code/New()
-	..()
-	addtimer(CALLBACK(src, .proc/populate_codes), 10)
-
-/obj/item/paper/safe_code/proc/populate_codes()
+/obj/item/paper/safe_code/Initialize(mapload)
+	. = ..()
 	for(var/safe in GLOB.safes)
 		var/obj/structure/safe/S = safe
-		if(owner in S.knownby)
+		if(owner in S.known_by)
 			info += "<br> The combination for the safe located in the [get_area(S).name] is: [S.tumbler_1_open] - [S.tumbler_2_open]]<br>"
 			info_links = info
 			update_icon()

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -129,6 +129,9 @@ GLOBAL_LIST_EMPTY(safes)
 			overlays += image(icon = 'icons/effects/drill.dmi', icon_state = "[initial(icon_state)]_[drill_icon]-drill-off", pixel_x = drill_x_offset, pixel_y = drill_y_offset)
 
 /obj/structure/safe/attack_ghost(mob/user)
+	if(..() || drill)
+		return TRUE
+
 	ui_interact(user)
 
 /obj/structure/safe/attack_hand(mob/user)
@@ -186,7 +189,10 @@ GLOBAL_LIST_EMPTY(safes)
 
 	return data
 
-/obj/structure/safe/proc/notify_user(user, sounds, total_ticks, current_tick)
+/obj/structure/safe/proc/notify_user(user, canhear, sounds, total_ticks, current_tick)
+	if (!canhear)
+		return
+
 	if (current_tick == 2)
 		to_chat(user, "<span class='italics'>The sounds from [src] are too fast and blend together.</span>")
 	
@@ -205,7 +211,7 @@ GLOBAL_LIST_EMPTY(safes)
 	var/canhear = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.is_in_hands(/obj/item/clothing/accessory/stethoscope))
+		if(H.can_hear() && H.is_in_hands(/obj/item/clothing/accessory/stethoscope))
 			canhear = TRUE
 
 	if(href_list["open"])
@@ -235,10 +241,10 @@ GLOBAL_LIST_EMPTY(safes)
 				current_tumbler_index = 1
 			
 			if(!invalid_turn && dial == tumblers[current_tumbler_index])
-				notify_user(user, list("tink", "krink", "plink"), ticks, i)
+				notify_user(user, canhear, list("tink", "krink", "plink"), ticks, i)
 				current_tumbler_index++
 			else
-				notify_user(user, list("clack", "scrape", "clank"), ticks, i)
+				notify_user(user, canhear, list("clack", "scrape", "clank"), ticks, i)
 
 			sleep(1)
 			check_unlocked(user, canhear)
@@ -263,10 +269,10 @@ GLOBAL_LIST_EMPTY(safes)
 				current_tumbler_index = 1
 
 			if(!invalid_turn && dial == tumblers[current_tumbler_index])
-				notify_user(user, list("tonk", "krunk", "plunk"), ticks, i)
+				notify_user(user, canhear, list("tonk", "krunk", "plunk"), ticks, i)
 				current_tumbler_index++
 			else
-				notify_user(user, list("click", "chink", "clink"), ticks, i)
+				notify_user(user, canhear, list("click", "chink", "clink"), ticks, i)
 
 			sleep(1)
 			check_unlocked(user, canhear)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -59,6 +59,8 @@ GLOBAL_LIST_EMPTY(safes)
 /obj/structure/safe/Destroy()
 	GLOB.safes -= src
 	drill?.soundloop?.stop()
+	drill?.forceMove(loc)
+	drill = null
 	return ..()
 
 /obj/structure/safe/process()
@@ -102,7 +104,7 @@ GLOBAL_LIST_EMPTY(safes)
 		looped++
 		combination += "[tumbler]"
 
-		if (looped < LAZYLEN(tumblers))
+		if(looped < LAZYLEN(tumblers))
 			combination += ", "
 
 	return combination
@@ -190,13 +192,13 @@ GLOBAL_LIST_EMPTY(safes)
 	return data
 
 /obj/structure/safe/proc/notify_user(user, canhear, sounds, total_ticks, current_tick)
-	if (!canhear)
+	if(!canhear)
 		return
 
-	if (current_tick == 2)
+	if(current_tick == 2)
 		to_chat(user, "<span class='italics'>The sounds from [src] are too fast and blend together.</span>")
 	
-	if (total_ticks == 1 || prob(10))
+	if(total_ticks == 1 || prob(10))
 		to_chat(user, "<span class='italics'>You hear a [pick(sounds)] from [src].</span>")
 
 /obj/structure/safe/Topic(href, href_list)
@@ -204,7 +206,7 @@ GLOBAL_LIST_EMPTY(safes)
 		return TRUE
 
 	var/mob/user = usr
-	if (!user.IsAdvancedToolUser() && !isobserver(user))
+	if(!user.IsAdvancedToolUser() && !isobserver(user))
 		to_chat(user, "<span class='warning'>You're not able to operate the safe.</span>")
 		return
 

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -63,11 +63,14 @@ GLOBAL_LIST_EMPTY(safes)
 	drill?.soundloop?.stop()
 	drill?.forceMove(loc)
 	drill = null
+
+	qdel(progress_bar)
+	qdel(drill_overlay)
 	return ..()
 
 /obj/structure/safe/process()
 	if(drill_timer)
-		cut_overlay(list(progress_bar))
+		cut_overlay(progress_bar)
 		progress_bar = image('icons/effects/progessbar.dmi', src, "prog_bar_[round((((world.time - drill_start_time) / time_to_drill) * 100), 5)]", HUD_LAYER)
 		add_overlay(progress_bar)
 		if(prob(15))

--- a/nano/templates/safe.tmpl
+++ b/nano/templates/safe.tmpl
@@ -29,14 +29,14 @@
 	</div>
 	<div>
 		<div style='text-align: center; margin: 0px 0px 0px 28px'>
-			<div style='display: inline-block;'>{{:helper.link('Left 50', 'arrow-left', {'increment': 50})}} </div>
-			<div style='display: inline-block;'>{{:helper.link('Left 10', 'arrow-left', {'increment': 10})}} </div>
-			<div style='display: inline-block;'>{{:helper.link('Left 1', 'arrow-left', {'increment': 1})}} </div>
+			<div style='display: inline-block;'>{{:helper.link('Left 50', 'arrow-left', {'turnleft': 50})}} </div>
+			<div style='display: inline-block;'>{{:helper.link('Left 10', 'arrow-left', {'turnleft': 10})}} </div>
+			<div style='display: inline-block;'>{{:helper.link('Left 1', 'arrow-left', {'turnleft': 1})}} </div>
 			<div style='display: inline-block;'><div class="link yellowButton"> {{:data.dial}} </div></div>
 			{{if data.locked}}
-				<div style='display: inline-block;'>{{:helper.link('Right 1', 'arrow-right', {'decrement': 1})}} </div>
-				<div style='display: inline-block;'>{{:helper.link('Right 10', 'arrow-right', {'decrement': 10})}} </div>
-				<div style='display: inline-block;'>{{:helper.link('Right 50', 'arrow-right', {'decrement': 50})}} </div>
+				<div style='display: inline-block;'>{{:helper.link('Right 1', 'arrow-right', {'turnright': 1})}} </div>
+				<div style='display: inline-block;'>{{:helper.link('Right 10', 'arrow-right', {'turnright': 10})}} </div>
+				<div style='display: inline-block;'>{{:helper.link('Right 50', 'arrow-right', {'turnright': 50})}} </div>
 			{{else}}
 				<div style='display: inline-block;'>{{:helper.link('Right 1', 'arrow-right', null, 'disabled')}} </div>
 				<div style='display: inline-block;'>{{:helper.link('Right 10', 'arrow-right', null, 'disabled')}} </div>
@@ -51,15 +51,13 @@
 		<div style='display: inline-block;'> <img src="safe_dial.png" style='transform: rotate({{:data.rotation}}); z-index: -1;'></div>
 	</div>
 	<div style='text-align: center;'>
-		<div style='font-weight: bold;'>How to open your Scarborough Arms - 2 tumbler safe.</div> 
+		<div style='font-weight: bold;'>How to open your Scarborough Arms tumbler safe.</div> 
 		<div style='display: inline-block; text-align: left;'>
-			<div>1. Turn the dial right two full turns.</div>
-			<div>2. Keep turning right and stop on first number.</div>
-			<div>3. Turn the dial left one full turn.</div>
-			<div>4. Turn left to second number. Do not go past it.</div>
-			<div>5. Turn the dial right until it stops.</div>
-			<div style='height: 32px;'>6. Open the safe.</div>
+			<div>1. Turn the dial right to the first number.</div>
+			<div>2. Turn the dial left to the second number.</div>
+			<div>3. Continue repeating this process for each number, switching between right and left each time.</div>
+			<div>4. Open the safe.</div>
 		</div>	
-		<div style='font-weight: bold;'>To lock fully, turn the dial to the left for three rotations.</div>
+		<div style='font-weight: bold;'>To lock fully, turn the dial to the left after closing the safe.</div>
 	</div>
 {{/if}}


### PR DESCRIPTION
**What does this PR do:**
Safes have been refactored, as their code needed a bit of work. The primary change is the tumbler mechanism. Safes can now have a variable number of tumblers and the code to open tumblers is a lot more robust. 

You no longer need to turn the dial right/or left at the start or the end of opening it anymore. This makes cracking safes a little easier, so all safes now have three tumblers by default.

Safes are also lava/fire/acid resistant now, with Lavaland coming.

Fixes https://github.com/ParadiseSS13/Paradise/issues/11250.

**Changelog:**
:cl: Markolie
add: Safes can now consist of more than two tumblers.
tweak: All safes now have three tumblers by default, instead of two.
tweak: The safe opening mechanism has changed slightly. This is described on the safe cracking UI.
/:cl: