### PR TITLE
Fixes Russian Revolver

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1395,7 +1395,12 @@ obj/item/toy/cards/deck/syndicate/black
 /obj/item/toy/russian_revolver/attack(mob/M, mob/living/user)
 	return
 
-/obj/item/toy/russian_revolver/afterattack(atom/target, mob/user, proximity)
+/obj/item/toy/russian_revolver/afterattack(atom/target, mob/user, flag, params)
+	if(flag)
+		if(target in user.contents)
+			return
+		if(!ismob(target))
+			return
 	shoot_gun(user)
 
 /obj/item/toy/russian_revolver/proc/spin_cylinder()


### PR DESCRIPTION
Fixes Russian revolvers always triggering, no matter where you clicked them.

fixes: https://github.com/ParadiseSS13/Paradise/issues/11262

Sorry about that guys, usually I'm better at testing things than that.

:cl: Fox McCloud
fix: Fixes Russian revolvers triggering no matter where you clicked
/:cl: