### PR TITLE
Shadowling Collective Mind ability now fully scales with required thralls threshold

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -53,6 +53,7 @@ Made by Xhuis
 	var/objective_explanation
 	var/warning_threshold
 	var/victory_warning_announced = FALSE
+	var/thrall_ratio = 1
 
 /proc/is_thrall(var/mob/living/M)
 	return istype(M) && M.mind && ticker && ticker.mode && (M.mind in ticker.mode.shadowling_thralls)
@@ -101,6 +102,7 @@ Made by Xhuis
 
 	var/thrall_scaling = round(num_players() / 3)
 	required_thralls = Clamp(thrall_scaling, 15, 25)
+	thrall_ratio = required_thralls / 15
 
 	warning_threshold = round(0.66 * required_thralls)
 

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -359,23 +359,23 @@
 			to_chat(target, "<span class='warning'>Your concentration has been broken. The mental hooks you have sent out now retract into your mind.</span>")
 			return
 
-		if(thralls >= 3 && !screech_acquired)
+		if(thralls >= CEILING(3 * ticker.mode.thrall_ratio, 1) && !screech_acquired)
 			screech_acquired = 1
 			to_chat(target, "<span class='shadowling'><i>The power of your thralls has granted you the <b>Sonic Screech</b> ability. This ability will shatter nearby windows and deafen enemies, plus stunning silicon lifeforms.</span>")
 			target.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/unearthly_screech(null))
 
-		if(thralls >= 5 && !blind_smoke_acquired)
+		if(thralls >= CEILING(5 * ticker.mode.thrall_ratio, 1) && !blind_smoke_acquired)
 			blind_smoke_acquired = 1
 			to_chat(target, "<span class='shadowling'><i>The power of your thralls has granted you the <b>Blinding Smoke</b> ability. \
 			It will create a choking cloud that will blind any non-thralls who enter.</i></span>")
 			target.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/blindness_smoke(null))
 
-		if(thralls >= 7 && !drainLifeAcquired)
+		if(thralls >= CEILING(7 * ticker.mode.thrall_ratio, 1) && !drainLifeAcquired)
 			drainLifeAcquired = 1
 			to_chat(target, "<span class='shadowling'><i>The power of your thralls has granted you the <b>Drain Life</b> ability. You can now drain the health of nearby humans to heal yourself.</i></span>")
 			target.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/drainLife(null))
 
-		if(thralls >= 9 && !reviveThrallAcquired)
+		if(thralls >= CEILING(9 * ticker.mode.thrall_ratio, 1) && !reviveThrallAcquired)
 			reviveThrallAcquired = 1
 			to_chat(target, "<span class='shadowling'><i>The power of your thralls has granted you the <b>Black Recuperation</b> ability. \
 			This will, after a short time, bring a dead thrall completely back to life with no bodily defects.</i></span>")


### PR DESCRIPTION
**What does this PR do:**
Number of required thralls that Shadowlings need to ascend properly scales with server population, ie. higher server population means that Shadowlings need to enthrall more crew than when server population is low. What does NOT scale is a rate at which they gain new abilities using their Collective Mind ability, currently Shadowlings get their new abilities at 3, 5, 7 and 9 thralls at ALL instances, no matter the amount of required thralls needed to ascend, this PR changes that. Examples below will ilustrate how the new system works.

**Practical Examples:**
1) Server population is low. Shadowlings have the minimum possible amount of thralls they need to ascend - 15. They gain their new abilities at 3, 5, 7 and 9 thralls.

2) Server population is very high. Shadowlings have the maximum possible amount of thralls they need to ascend - 25. They gain their new abilities at 5, 9, 12 and 15 thralls.

This change will help with Shadowling snowball - previously they got their new abilities too soon and used them to crush the opposition, so higher amount of required thralls did not even matter much, it was just a busy work.

Ported from yogstation13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Shadowling Collective Mind ability now fully scales with required thralls threshold. This means that Shadowlings will obtain their new abilities at a slower rate during high population rounds.
/:cl: