### PR TITLE
Lets nukies buy plasmagrenades again (and other hijack gear)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1330,13 +1330,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	hijack_only = TRUE //This is an item only useful for a hijack traitor, as such, it should only be available in those scenarios.
 	cant_discount = TRUE
-	excludefrom = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/device_tools/singularity_beacon/nuke
-	reference = "SNGBN"
-	hijack_only = FALSE // This inherited version exists so nukies can use it while keeping the original hijack only
-	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/syndicate_detonator
 	name = "Syndicate Detonator"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/uplink/U)
 
-	if(hijack_only && !GAMEMODE_IS_NUCLEAR)//nukies get items that regular traitors only get with hijack. If a hijack-only item is not for nukies, then exclude it via the gamemode list.
+	if(hijack_only && !(usr.mind.special_role == SPECIAL_ROLE_NUKEOPS))//nukies get items that regular traitors only get with hijack. If a hijack-only item is not for nukies, then exclude it via the gamemode list.
 		if(!(locate(/datum/objective/hijack) in usr.mind.objectives))
 			to_chat(usr, "<span class='warning'>The Syndicate will only issue this extremely dangerous item to agents assigned the Hijack objective.</span>")
 			return

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/uplink/U)
 
-	if(hijack_only)
+	if(hijack_only && !GAMEMODE_IS_NUCLEAR)//nukies get items that regular traitors only get with hijack. If a hijack-only item is not for nukies, then exclude it via the gamemode list.
 		if(!(locate(/datum/objective/hijack) in usr.mind.objectives))
 			to_chat(usr, "<span class='warning'>The Syndicate will only issue this extremely dangerous item to agents assigned the Hijack objective.</span>")
 			return


### PR DESCRIPTION
**What does this PR do:**
A PR a while back prevented non-hijack traitors from buying certain, very dangerous items. This also applied to nukies, who were not allowed to buy plasma grenades anymore. This PR fixes that, letting them bypass the hijack check.
It also fixes the rather weird way that nukies were given a singulo beacon by making a subtype of the beacon that isn't hijack only but is exclusive to the nukie gamemode.
In the future, if an item is intended for hijack-only traitors and shouldn't be available to nukies, it can be made a job item (like several items already are) or simply excluded from the gamemode.

fixes #11269
**Changelog:**
:cl:
tweak: nukies can buy plasma grenades again
/:cl:

