### PR TITLE
Shield Blobs automatically spawned around Blob Cores now give no refund

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -82,7 +82,7 @@
 			continue
 		var/obj/structure/blob/normal/B = locate() in get_step(src, b_dir)
 		if(B)
-			B.change_to(/obj/structure/blob/shield)
+			B.change_to(/obj/structure/blob/shield/core)
 			if(B && overmind)
 				B.color = overmind.blob_reagent_datum.color
 			else

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -8,6 +8,9 @@
 	point_return = 4
 	var/maxHealth = 75
 
+/obj/structure/blob/shield/core
+	point_return = 0
+
 /obj/structure/blob/shield/update_icon()
 	if(health <= 0)
 		qdel(src)


### PR DESCRIPTION
**What does this PR do:**
Ported from /tg/station13.

Shield Blobs that automatically spawn around Blob Cores now give no refund to the Blob Overmind upon removal, as they could abuse this to get large amount of resources periodically.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Shield Blobs automatically spawned around Blob Cores now give no refund upon removing. No freebies.
/:cl: