### PR TITLE
Ghosts now orbit around their followed targets

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -395,3 +395,10 @@
 // Defib stats
 #define DEFIB_TIME_LIMIT 120
 #define DEFIB_TIME_LOSS 60
+
+//Ghost orbit types:
+#define GHOST_ORBIT_CIRCLE		"circle"
+#define GHOST_ORBIT_TRIANGLE	"triangle"
+#define GHOST_ORBIT_HEXAGON		"hexagon"
+#define GHOST_ORBIT_SQUARE		"square"
+#define GHOST_ORBIT_PENTAGON	"pentagon"


### PR DESCRIPTION
**What does this PR do:**
Ported from /tg/station13.

Ghosts now orbit around their followed targets, example gif below. Ghost verb "Follow" renamed to "Orbit" to reflect this change. Improves aesthetics and observing experience.

**Images of sprite/map changes (IF APPLICABLE):**
<a href="https://gyazo.com/f05dec3fc9df0beab52a23bdcb1b8c8a"><img src="https://i.gyazo.com/f05dec3fc9df0beab52a23bdcb1b8c8a.gif" alt="Image from Gyazo" width="172"/></a>

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Ghosts now orbit around their followed targets
/:cl: