### PR TITLE
Emote Refactor

### DIFF
--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -98,7 +98,7 @@
 		if(isovermind(M) || isobserver(M))
 			M.show_message(rendered, 2)
 
-/mob/camera/blob/emote(var/act,var/m_type=1,var/message = null)
+/mob/camera/blob/emote(act, m_type = 1, message = null, force)
 	return
 
 /mob/camera/blob/blob_act()

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -32,7 +32,7 @@
 		return FALSE
 	return B.host.say_understands(other, speaking)
 
-/mob/living/captive_brain/emote(var/message)
+/mob/living/captive_brain/emote(act, m_type = 1, message = null, force)
 	return
 
 /mob/living/captive_brain/resist()
@@ -157,7 +157,7 @@
 		if(!istype(S.speaking, /datum/language/corticalborer) && loc == host && !talk_inside_host)
 			to_chat(src, "<span class='warning'>You've disabled audible speech while inside a host! Re-enable it under the borer tab, or stick to borer communications.</span>")
 			return
-	
+
 	. = ..()
 
 /mob/living/simple_animal/borer/verb/Communicate()
@@ -475,7 +475,7 @@
 	set category = "Borer"
 	set name = "Dominate Victim"
 	set desc = "Freeze the limbs of a potential host with supernatural fear."
-	
+
 	if(world.time - used_dominate < 150)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
@@ -487,22 +487,22 @@
 	if(stat)
 		to_chat(src, "You cannot do that in your current state.")
 		return
-		
+
 	if(attempting_to_dominate)
 		to_chat(src, "You're already targeting someone!")
 		return
-	
+
 	var/list/choices = list()
 	for(var/mob/living/carbon/C in view(3,src))
 		if(C.stat != DEAD)
 			choices += C
-	
+
 	if(world.time - used_dominate < 300)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
-		
+
 	attempting_to_dominate = TRUE
-	
+
 	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") in null|choices
 
 	if(!M)
@@ -519,8 +519,8 @@
 
 	if(incapacitated())
 		attempting_to_dominate = FALSE
-		return 
-		
+		return
+
 	if(get_dist(src, M) > 7) //to avoid people remotely doing from across the map etc, 7 is the default view range
 		to_chat(src, "<span class='warning'>You're too far away!</span>")
 		attempting_to_dominate = FALSE

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -14,7 +14,7 @@
 	flags = DROPDEL
 
 
-/obj/item/implant/proc/trigger(emote, mob/source)
+/obj/item/implant/proc/trigger(emote, mob/source, force)
 	return
 
 /obj/item/implant/proc/activate()

--- a/code/game/objects/items/weapons/implants/implant_chem.dm
+++ b/code/game/objects/items/weapons/implants/implant_chem.dm
@@ -33,8 +33,8 @@
 
 
 
-/obj/item/implant/chem/trigger(emote, mob/source)
-	if(emote == "deathgasp")
+/obj/item/implant/chem/trigger(emote, mob/source, force)
+	if(force && emote == "deathgasp")
 		activate(reagents.total_volume)
 
 /obj/item/implant/chem/activate(cause)

--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -20,8 +20,8 @@
 				"}
 	return dat
 
-/obj/item/implant/explosive/trigger(emote, mob/source)
-	if(emote == "deathgasp")
+/obj/item/implant/explosive/trigger(emote, mob/source, force)
+	if(force && emote == "deathgasp")
 		activate("death")
 
 /obj/item/implant/explosive/activate(cause)
@@ -148,8 +148,8 @@
 				"}
 	return dat
 
-/obj/item/implant/dust/trigger(emote, mob/source)
-	if(emote == "deathgasp")
+/obj/item/implant/dust/trigger(emote, mob/source, force)
+	if(force && emote == "deathgasp")
 		activate("death")
 
 /obj/item/implant/dust/activate(cause)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -17,7 +17,7 @@
 	. = src.say_dead(message)
 
 
-/mob/dead/observer/emote(var/act, var/type, var/message)
+/mob/dead/observer/emote(act, type, message, force)
 	message = sanitize(copytext(message, 1, MAX_MESSAGE_LEN))
 
 	if(!message)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -2,15 +2,20 @@
 
 //Emote Cooldown System (it's so simple!)
 /mob/proc/handle_emote_CD(cooldown = EMOTE_COOLDOWN)
-	if(emote_cd == 2) return 1			// Cooldown emotes were disabled by an admin, prevent use
-	if(src.emote_cd == 1) return 1		// Already on CD, prevent use
+	if(emote_cd == 3) //Spam those emotes
+		return FALSE
+	if(emote_cd == 2) // Cooldown emotes were disabled by an admin, prevent use
+		return TRUE
+	if(emote_cd == 1)  // Already on CD, prevent use
+		return TRUE
 
-	src.emote_cd = 1		// Starting cooldown
+	emote_cd = TRUE	// Starting cooldown
 	spawn(cooldown)
-		if(emote_cd == 2) return 1		// Don't reset if cooldown emotes were disabled by an admin during the cooldown
-		src.emote_cd = 0				// Cooldown complete, ready for more!
+		if(emote_cd == 2)
+			return TRUE // Don't reset if cooldown emotes were disabled by an admin during the cooldown
+		emote_cd = FALSE // Cooldown complete, ready for more!
+	return FALSE // Proceed with emote
 
-	return 0		// Proceed with emote
 //--FalseIncarnate
 
 /mob/proc/handle_emote_param(var/target, var/not_self, var/vicinity, var/return_mob) //Only returns not null if the target param is valid.

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/alien/humanoid/emote(var/act,var/m_type=1,var/message = null)
+/mob/living/carbon/alien/humanoid/emote(act, m_type = 1, message = null, force)
 	var/param = null
 	if(findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)
@@ -25,7 +25,7 @@
 		if("flip")
 			on_CD = handle_emote_CD()
 
-	if(on_CD)
+	if(!force && on_CD == 1)
 		return
 
 	switch(act)
@@ -138,4 +138,4 @@
 			playsound(src.loc, 'sound/voice/hiss1.ogg', 30, 1, 1)
 		if(act == "gnarl")
 			playsound(src.loc, 'sound/voice/hiss4.ogg', 30, 1, 1)
-		..(act, m_type, message)
+		..()

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/alien/larva/emote(var/act,var/m_type=1,var/message = null)
+/mob/living/carbon/alien/larva/emote(act, m_type = 1, message = null, force)
 	var/param = null
 	if(findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/brain/emote(var/act,var/m_type=1,var/message = null)
+/mob/living/carbon/brain/emote(act,m_type = 1, message = null, force)
 	if(!(container && istype(container, /obj/item/mmi)))//No MMI, no emotes
 		return
 
@@ -48,4 +48,4 @@
 			to_chat(src, "alarm, alert, notice, flash,blink, whistle, beep, boop")
 
 	if(message && !stat)
-		..(act, m_type, message)
+		..()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -93,7 +93,7 @@
 
 /mob/living/carbon/human/death(gibbed)
 	if(can_die() && !gibbed && deathgasp_on_death)
-		emote("deathgasp") //let the world KNOW WE ARE DEAD
+		emote("deathgasp", force = TRUE) //let the world KNOW WE ARE DEAD
 
 	// Only execute the below if we successfully died
 	. = ..(gibbed)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/emote(var/act,var/m_type=1,var/message = null,var/force)
+/mob/living/carbon/human/emote(act, m_type = 1, message = null, force)
 
 	if((stat == DEAD) || (status_flags & FAKEDEATH))
 		return // No screaming bodies
@@ -13,22 +13,22 @@
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
 		if(M.mute == MUZZLE_MUTE_NONE)
-			muzzled = 0 //Not all muzzles block sound
+			muzzled = FALSE //Not all muzzles block sound
 	if(!can_speak())
-		muzzled = 1
+		muzzled = TRUE
 	//var/m_type = 1
 
 	for(var/obj/item/implant/I in src)
 		if(I.implanted)
-			I.trigger(act, src)
+			I.trigger(act, src, force)
 
-	var/miming = 0
+	var/miming = FALSE
 	if(mind)
 		miming = mind.miming
 
 	//Emote Cooldown System (it's so simple!)
-	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
-	var/on_CD = 0
+	//handle_emote_CD() located in [code\modules\mob\emote.dm]
+	var/on_CD = FALSE
 	act = lowertext(act)
 	switch(act)
 		//Cooldown-inducing emotes
@@ -61,16 +61,16 @@
 			else
 				return
 		if("squish", "squishes")
-			var/found_slime_bodypart = 0
+			var/found_slime_bodypart = FALSE
 
 			if(isslimeperson(src))	//Only Slime People can squish
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
-				found_slime_bodypart = 1
+				found_slime_bodypart = TRUE
 			else
 				for(var/obj/item/organ/external/L in bodyparts) // if your limbs are squishy you can squish too!
 					if(istype(L.dna.species, /datum/species/slime))
 						on_CD = handle_emote_CD()
-						found_slime_bodypart = 1
+						found_slime_bodypart = TRUE
 						break
 
 			if(!found_slime_bodypart)								//Everyone else fails, skip the emote attempt
@@ -118,9 +118,9 @@
 			on_CD = handle_emote_CD()
 		//Everything else, including typos of the above emotes
 		else
-			on_CD = 0	//If it doesn't induce the cooldown, we won't check for the cooldown
+			on_CD = FALSE	//If it doesn't induce the cooldown, we won't check for the cooldown
 
-	if(on_CD == 1)		// Check if we need to suppress the emote attempt.
+	if(!force && on_CD == 1)		// Check if we need to suppress the emote attempt.
 		return			// Suppress emote, you're still cooling off.
 
 	switch(act)

--- a/code/modules/mob/living/carbon/slime/emote.dm
+++ b/code/modules/mob/living/carbon/slime/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/slime/emote(act, m_type = 1, message = null)
+/mob/living/carbon/slime/emote(act, m_type = 1, message = null, force)
 	if(findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)
 		//param = copytext(act, t1 + 1, length(act) + 1)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -57,7 +57,7 @@
 	SetLoseBreath(0)
 
 	if(!gibbed && deathgasp_on_death)
-		emote("deathgasp")
+		emote("deathgasp", force = TRUE)
 
 	if(mind && suiciding)
 		mind.suicided = TRUE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -275,7 +275,7 @@ proc/get_radio_key_from_channel(var/channel)
 /mob/living/proc/GetVoice()
 	return name
 
-/mob/living/emote(var/act, var/type, var/message) //emote code is terrible, this is so that anything that isn't already snowflaked to shit can call the parent and handle emoting sanely
+/mob/living/emote(act, type, message, force) //emote code is terrible, this is so that anything that isn't already snowflaked to shit can call the parent and handle emoting sanely
 	if(client)
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
@@ -284,7 +284,7 @@ proc/get_radio_key_from_channel(var/channel)
 	if(stat)
 		return 0
 
-	if(..(act, type, message))
+	if(..())
 		return 1
 
 	if(act && type && message) //parent call
@@ -306,7 +306,8 @@ proc/get_radio_key_from_channel(var/channel)
 				return 1
 
 	else //everything else failed, emote is probably invalid
-		if(act == "help")	return //except help, because help is handled individually
+		if(act == "help")
+			return //except help, because help is handled individually
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 
 /mob/living/whisper(message as text)

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/emote(var/act, var/m_type=1, var/message = null)
+/mob/living/silicon/emote(act, m_type=1, message = null, force)
 	var/param = null
 	if(findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)
@@ -6,7 +6,7 @@
 		act = copytext(act, 1, t1)
 
 	//Emote Cooldown System (it's so simple!)
-	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
+	//handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
 	act = lowertext(act)
 	switch(act)
@@ -20,7 +20,7 @@
 		else
 			on_CD = 0	//If it doesn't induce the cooldown, we won't check for the cooldown
 
-	if(on_CD == 1)		// Check if we need to suppress the emote attempt.
+	if(!force && on_CD == 1)		// Check if we need to suppress the emote attempt.
 		return			// Suppress emote, you're still cooling off.
 	//--FalseIncarnate
 
@@ -78,4 +78,4 @@
 		if("help")
 			to_chat(src, "yes, no, beep, ping, buzz, scream, buzz2")
 
-	..(act, m_type, message)
+	..()

--- a/code/modules/mob/living/silicon/pai/emote.dm
+++ b/code/modules/mob/living/silicon/pai/emote.dm
@@ -1,2 +1,0 @@
-/mob/living/silicon/pai/emote(var/act, var/m_type=1, var/message = null)
-	..(act, m_type, message)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -50,7 +50,7 @@
 /mob/living/silicon/robot/death(gibbed)
 	if(can_die())
 		if(!gibbed && deathgasp_on_death)
-			emote("deathgasp")
+			emote("deathgasp", force = TRUE)
 
 		if(module)
 			module.handle_death(gibbed)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/silicon/robot/emote(var/act, var/m_type=1, var/message = null)
+/mob/living/silicon/robot/emote(act, m_type=1, message = null, force)
 	var/param = null
 	if(findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)
@@ -6,7 +6,7 @@
 		act = copytext(act, 1, t1)
 
 	//Emote Cooldown System (it's so simple!)
-	//proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
+	//handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
 	act = lowertext(act)
 	switch(act)
@@ -17,7 +17,7 @@
 		else
 			on_CD = 0	//If it doesn't induce the cooldown, we won't check for the cooldown
 
-	if(on_CD == 1)		// Check if we need to suppress the emote attempt.
+	if(!force && on_CD == 1)		// Check if we need to suppress the emote attempt.
 		return			// Suppress emote, you're still cooling off.
 	//--FalseIncarnate
 
@@ -160,7 +160,7 @@
 		if("help")
 			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitches, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look,\n law, halt")
 
-	..(act, m_type, message)
+	..()
 
 /mob/living/silicon/robot/verb/powerwarn()
 	set category = "Robot Commands"

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -103,7 +103,7 @@
 		return
 	return 1
 
-/mob/living/silicon/ai/emote(var/act, var/type, var/message)
+/mob/living/silicon/ai/emote(act, type, message, force)
 	var/obj/machinery/hologram/holopad/T = current
 	if(istype(T) && T.masters[src])//Is the AI using a holopad?
 		src.holopad_emote(message)

--- a/code/modules/mob/living/simple_animal/bot/emote.dm
+++ b/code/modules/mob/living/simple_animal/bot/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/bot/emote(act, m_type=1, message = null)
+/mob/living/simple_animal/bot/emote(act, m_type = 1, message = null, force)
 	var/param = null
 	if(findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)
@@ -9,7 +9,7 @@
 		act = copytext(act,1,length(act))
 
 	//Emote Cooldown System (it's so simple!)
-	//proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
+	//handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
 	act = lowertext(act)
 	switch(act)
@@ -22,7 +22,7 @@
 		else
 			on_CD = 0	//If it doesn't induce the cooldown, we won't check for the cooldown
 
-	if(on_CD == 1)		// Check if we need to suppress the emote attempt.
+	if(!force && on_CD == 1)		// Check if we need to suppress the emote attempt.
 		return			// Suppress emote, you're still cooling off.
 	//--FalseIncarnate
 
@@ -71,4 +71,4 @@
 
 		if("help")
 			to_chat(src, "scream(s), yes, no, beep, buzz, ping")
-	..(act, m_type, message)
+	..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -147,7 +147,7 @@
 				stop_automated_movement = 1
 				walk_to(src,movement_target,0,3)
 
-/mob/living/simple_animal/pet/cat/emote(act, m_type=1, message = null)
+/mob/living/simple_animal/pet/cat/emote(act, m_type = 1, message = null, force)
 	if(stat != CONSCIOUS)
 		return
 
@@ -163,9 +163,9 @@
 		else
 			on_CD = 0
 
-	if(on_CD == 1)
+	if(!force && on_CD == 1)
 		return
-	
+
 	switch(act)
 		if("meow")
 			message = "<B>[src]</B> [pick(emote_hear)]!"
@@ -225,9 +225,9 @@
 	maxHealth = 50
 	harm_intent_damage = 10
 	butcher_results = list(
-		/obj/item/organ/internal/brain = 1, 
-		/obj/item/organ/internal/heart = 1, 
-		/obj/item/reagent_containers/food/snacks/birthdaycakeslice = 3,  
+		/obj/item/organ/internal/brain = 1,
+		/obj/item/organ/internal/heart = 1,
+		/obj/item/reagent_containers/food/snacks/birthdaycakeslice = 3,
 		/obj/item/reagent_containers/food/snacks/meat/slab = 2
 	)
 	response_harm = "takes a bite out of"

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -368,7 +368,7 @@
 				name = "Definitely Not [real_name]"
 				desc = "That's Definitely Not [real_name]"
 				valid = 1
-			
+
 			if(/obj/item/clothing/head/beret/centcom/officer, /obj/item/clothing/head/beret/centcom/officer/navy)
 				name = "Blueshield [real_name]"
 				desc = "Will stand by you until the bitter end."
@@ -407,7 +407,7 @@
 	playsound(src, yelp_sound, 75, 1)
 	..()
 
-/mob/living/simple_animal/pet/corgi/emote(act, m_type=1, message = null)
+/mob/living/simple_animal/pet/corgi/emote(act, m_type = 1, message = null, force)
 	if(stat != CONSCIOUS)
 		return
 
@@ -421,9 +421,9 @@
 		else
 			on_CD = 0
 
-	if(on_CD == 1)
+	if(!force && on_CD == 1)
 		return
-	
+
 	switch(act)
 		if("bark")
 			message = "<B>[src]</B> [pick(src.speak_emote)]!"

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -60,7 +60,7 @@
 /datum/action/innate/diona/merge/Activate()
 	var/mob/living/simple_animal/diona/user = owner
 	user.merge()
-	
+
 /datum/action/innate/diona/evolve
 	name = "Evolve"
 	icon_icon = 'icons/obj/cloning.dmi'
@@ -109,7 +109,7 @@
 			forceMove(M)
 		else
 			get_scooped(M)
-	else 
+	else
 		..()
 
 /mob/living/simple_animal/diona/proc/merge()
@@ -151,7 +151,7 @@
 	to_chat(loc, "You feel a pang of loss as [src] splits away from your biomass.")
 	to_chat(src, "You wiggle out of the depths of [loc]'s biomass and plop to the ground.")
 	forceMove(T)
-	
+
 	var/hasMobs = FALSE
 	for(var/atom/A in D.contents)
 		if(istype(A, /mob/) || istype(A, /obj/item/holder))
@@ -163,9 +163,9 @@
 	return TRUE
 
 /mob/living/simple_animal/diona/proc/evolve()
-	if(stat != CONSCIOUS)		
+	if(stat != CONSCIOUS)
 		return FALSE
-	
+
 	if(donors.len < evolve_donors)
 		to_chat(src, "<span class='warning'>You need more blood in order to ascend to a new state of consciousness...</span>")
 		return FALSE
@@ -176,7 +176,7 @@
 
 	if(isdiona(loc) && !split()) //if it's merged with diona, needs to able to split before evolving
 		return FALSE
-	
+
 	visible_message("<span class='danger'>[src] begins to shift and quiver, and erupts in a shower of shed bark as it splits into a tangle of nearly a dozen new dionaea.</span>","<span class='danger'>You begin to shift and quiver, feeling your awareness splinter. All at once, we consume our stored nutrients to surge with growth, splitting into a tangle of at least a dozen new dionaea. We have attained our gestalt form.</span>")
 
 	var/mob/living/carbon/human/diona/adult = new(get_turf(loc))
@@ -202,14 +202,14 @@
 	qdel(src)
 	return TRUE
 
-/mob/living/simple_animal/diona/proc/steal_blood() 
-	if(stat != CONSCIOUS)		
+/mob/living/simple_animal/diona/proc/steal_blood()
+	if(stat != CONSCIOUS)
 		return FALSE
-	
+
 	var/list/choices = list()
 	for(var/mob/living/carbon/human/H in oview(1,src))
 		if(Adjacent(H) && H.dna && !(NO_BLOOD in H.dna.species.species_traits))
-			choices += H		
+			choices += H
 
 	if(!choices.len)
 		to_chat(src, "<span class='warning'>No suitable blood donors nearby.</span>")
@@ -260,7 +260,7 @@
 	to_chat(src, "<span class='warning'>You don't have any hands!</span>")
 	return
 
-/mob/living/simple_animal/diona/emote(act, m_type=1, message = null)
+/mob/living/simple_animal/diona/emote(act, m_type = 1, message = null, force)
 	if(stat != CONSCIOUS)
 		return
 
@@ -272,7 +272,7 @@
 		else
 			on_CD = 0
 
-	if(on_CD == 1)
+	if(!force && on_CD == 1)
 		return
 
 	switch(act) //IMPORTANT: Emotes MUST NOT CONFLICT anywhere along the chain.
@@ -283,4 +283,4 @@
 		if("help")
 			to_chat(src, "scream, chirp")
 
-	..(act, m_type, message)
+	..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -109,7 +109,7 @@
 	if(client)
 		client.time_died_as_mouse = world.time
 
-/mob/living/simple_animal/mouse/emote(act, m_type=1, message = null)
+/mob/living/simple_animal/mouse/emote(act, m_type = 1, message = null, force)
 	if(stat != CONSCIOUS)
 		return
 
@@ -121,7 +121,7 @@
 		else
 			on_CD = 0
 
-	if(on_CD == 1)
+	if(!force && on_CD == 1)
 		return
 
 	switch(act)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -258,7 +258,7 @@
 	adjustBruteLoss(20)
 	return
 
-/mob/living/simple_animal/emote(var/act, var/m_type=1, var/message = null)
+/mob/living/simple_animal/emote(act, m_type = 1, message = null, force)
 	if(stat)
 		return
 	act = lowertext(act)
@@ -269,7 +269,7 @@
 		if("help")
 			to_chat(src, "scream")
 
-	..(act, m_type, message)
+	..()
 
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -98,7 +98,7 @@
 	return verb
 
 
-/mob/proc/emote(var/act, var/type, var/message)
+/mob/proc/emote(act, type, message, force)
 	if(act == "me")
 		return custom_emote(type, message)
 
@@ -184,7 +184,7 @@
 		var/current = prefix_locations[i] // ["Common", keypos]
 
 		// There are a few things that will make us want to ignore all other languages in - namely, HIVEMIND languages.
-		var/datum/language/L = current[1] 
+		var/datum/language/L = current[1]
 		if(L && L.flags & HIVEMIND)
 			. = new /datum/multilingual_say_piece(L, trim(strip_prefixes(message)))
 			break

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -169,7 +169,7 @@
 		return
 	if(M.mind && M.mind.changeling && M.mind.changeling.regenerating) //no messing with changeling's fake death
 		return
-	M.visible_message("<B>[M]</B> seizes up and falls limp, [M.p_their()] eyes dead and lifeless...") //so you can't trigger deathgasp emote on people. Edge case, but necessary.
+	M.emote("deathgasp")
 	M.status_flags |= FAKEDEATH
 	M.update_stat("fakedeath reagent")
 	M.med_hud_set_health()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1802,7 +1802,6 @@
 #include "code\modules\mob\living\silicon\decoy\decoy.dm"
 #include "code\modules\mob\living\silicon\decoy\life.dm"
 #include "code\modules\mob\living\silicon\pai\death.dm"
-#include "code\modules\mob\living\silicon\pai\emote.dm"
 #include "code\modules\mob\living\silicon\pai\life.dm"
 #include "code\modules\mob\living\silicon\pai\pai.dm"
 #include "code\modules\mob\living\silicon\pai\personality.dm"


### PR DESCRIPTION
Refactors emotes a bit so all their arguments are the same. Also adds in a new `force` var for specific emote behavior. Lastly, allows admins to 'bus  a mob so that it has no cooldown for its emotes.

The `force` var is primarily used for two things: when you want to force an emote to occur, regardless of cooldown (but not explicitly set the cooldown to 0 then bother with other checks); this could be useful for if one emote will conditionally call the other, but they both have cooldowns (for a **hypothetical** example, maybe if you want to make it so you automatically scream if you flip and it fails or something like that).

The other thing `force` is utilized for is implants. Currently, impant activation that checks for *deathgasp will require the `force` var be set to `TRUE` to trigger. Just typing out *deathgasp or having another source trigger it via a direct call (`emote("deathgasp")`) or what have will NOT have `force` set to `TRUE`, as such, you can't cheese activating the implants under some conditions or if you forget about it and accidentally *deathgasp as a joke.

When mobs die, however, they do call *deathgasp with the `force` var set to `TRUE`, so implants will trigger, then.

:cl: Fox McCloud
fix: Fixes a few potential exploits with forcing chem, dust, and explosive implants  activating with the deathgasp emote, prior to death
/:cl: