### PR TITLE
Refactors Electrocution

### DIFF
--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -74,7 +74,7 @@
 				L.Weaken(3)
 			else
 				if(P.unlimited_power)
-					L.electrocute_act(1000, P, 0) //Just kill them
+					L.electrocute_act(1000, P, safety = TRUE, override = TRUE) //Just kill them
 				else
 					electrocute_mob(L, C, P)
 			break

--- a/code/datums/spells/lightning.dm
+++ b/code/datums/spells/lightning.dm
@@ -88,7 +88,7 @@ obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 	var/mob/living/current = target
 	if(bounces < 1)
 		if(damaging)
-			current.electrocute_act(bolt_energy,"Lightning Bolt",safety=1)
+			current.electrocute_act(bolt_energy, "Lightning Bolt", safety = TRUE)
 		else
 			current.AdjustJitter(1000) //High numbers for violent convulsions
 			current.do_jitter_animation(current.jitteriness)
@@ -99,7 +99,7 @@ obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 		playsound(get_turf(current), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 	else
 		if(damaging)
-			current.electrocute_act(bolt_energy,"Lightning Bolt",safety=1)
+			current.electrocute_act(bolt_energy, "Lightning Bolt", safety = TRUE)
 		else
 			current.AdjustJitter(1000) //High numbers for violent convulsions
 			current.do_jitter_animation(current.jitteriness)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -393,6 +393,11 @@
 									break
 			return
 
+/mob/living/simple_animal/hostile/swarmer/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+	if(!tesla_shock)
+		return FALSE
+	return ..()
+
 /mob/living/simple_animal/hostile/swarmer/proc/DismantleMachine(var/obj/machinery/target)
 	do_attack_animation(target)
 	to_chat(src, "<span class='info'>We begin to dismantle this machine. We will need to be uninterrupted.</span>")
@@ -513,7 +518,7 @@
 		var/mob/living/L = AM
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
-			L.electrocute_act(0, src, 1, 1)
+			L.electrocute_act(0, src, 1, TRUE, TRUE)
 			if(isrobot(L) || L.isSynthetic())
 				L.Weaken(5)
 			qdel(src)

--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -99,7 +99,6 @@
 				if(istype(G) && G.summoner == summoner)
 					continue
 				if(successfulshocks > 4)
-					//L.electrocute_act(30, src) //shocks for 30 burn damage
 					L.visible_message(
 						"<span class='danger'>[L] was shocked by the lightning chain!</span>", \
 						"<span class='userdanger'>You are shocked by the lightning chain!</span>", \

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -215,7 +215,7 @@
 						if(!L.on) //wait, wait, don't shock me
 							return
 						flick("[L.base_state]2", L)
-						for(var/mob/living/carbon/human/M in view(shock_range, L))
+						for(var/mob/living/M in view(shock_range, L))
 							if(M == user)
 								return
 							M.Beam(L,icon_state="purple_lightning",icon='icons/effects/effects.dmi',time=5)

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -219,7 +219,7 @@
 							if(M == user)
 								return
 							M.Beam(L,icon_state="purple_lightning",icon='icons/effects/effects.dmi',time=5)
-							M.electrocute_act(shock_damage, "[L.name]", safety=1)
+							M.electrocute_act(shock_damage, L, safety = TRUE)
 							do_sparks(4, 0, M)
 							playsound(M, 'sound/machines/defib_zap.ogg', 50, 1, -1)
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -81,6 +81,7 @@
 	power_channel = ENVIRON
 	req_one_access = list(access_atmospherics, access_engine_equip)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100)
+	siemens_strength = 1
 	var/alarm_id = null
 	var/frequency = ATMOS_VENTSCRUB
 	//var/skipprocess = 0 //Experimenting

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -174,10 +174,8 @@ About the new airlock wires panel:
 			else /*if(justzap)*/
 				return
 		else if(user.hallucination > 50 && prob(10) && !operating)
-			to_chat(user, "<span class='danger'>You feel a powerful shock course through your body!</span>")
-			user.adjustStaminaLoss(50)
-			user.AdjustStunned(5)
-			return
+			if(user.electrocute_act(50, src, 1, illusion = TRUE)) // We'll just go with a flat 50 damage, instead of doing powernet checks
+				return
 	..(user)
 
 /obj/machinery/door/airlock/bumpopen(mob/living/simple_animal/user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -51,6 +51,7 @@ var/list/airlock_overlays = list()
 	explosion_block = 1
 	assemblytype = /obj/structure/door_assembly
 	normalspeed = 1
+	siemens_strength = 1
 	var/security_level = 0 //How much are wires secured
 	var/aiControlDisabled = FALSE //If TRUE, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = FALSE // if TRUE, this door can't be hacked by the AI
@@ -70,7 +71,7 @@ var/list/airlock_overlays = list()
 	var/lockdownbyai = 0
 	var/justzap = 0
 	var/obj/item/airlock_electronics/electronics
-	var/hasShocked = 0 //Prevents multiple shocks from happening
+	var/shockCooldown = FALSE //Prevents multiple shocks from happening
 	var/obj/item/note //Any papers pinned to the airlock
 	var/previous_airlock = /obj/structure/door_assembly //what airlock assembly mineral plating was applied to
 	var/airlock_material //material of inner filling; if its an airlock with glass, this should be set to "glass"
@@ -296,16 +297,14 @@ About the new airlock wires panel:
 // The preceding comment was borrowed from the grille's shock script
 /obj/machinery/door/airlock/shock(mob/user, prb)
 	if(!arePowerSystemsOn())
-		return 0
-	if(hasShocked)
-		return 0	//Already shocked someone recently?
+		return FALSE
+	if(shockCooldown > world.time)
+		return FALSE	//Already shocked someone recently?
 	if(..())
-		hasShocked = 1
-		sleep(10)
-		hasShocked = 0
-		return 1
+		shockCooldown = world.time + 10
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 //Checks if the user can get shocked and shocks him if it can. Returns TRUE if it happened
 /obj/machinery/door/airlock/proc/shock_user(mob/user, prob)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -119,6 +119,7 @@ Class Procs:
 	var/list/settagwhitelist = list()//WHITELIST OF VARIABLES THAT THE set_tag HREF CAN MODIFY, DON'T PUT SHIT YOU DON'T NEED ON HERE, AND IF YOU'RE GONNA USE set_tag (format_tag() proc), ADD TO THIS LIST.
 	atom_say_verb = "beeps"
 	var/defer_process = 0
+	var/siemens_strength = 0.7 // how badly will it shock you?
 
 /obj/machinery/Initialize()
 	addAtProcessing()
@@ -575,16 +576,13 @@ Class Procs:
 
 /obj/machinery/proc/shock(mob/user, prb)
 	if(inoperable())
-		return 0
+		return FALSE
 	if(!prob(prb))
-		return 0
-	if((TK in user.mutations) && !Adjacent(user))
-		return 0
+		return FALSE
 	do_sparks(5, 1, src)
-	if(electrocute_mob(user, get_area(src), src, 0.7))
-		if(user.stunned)
-			return 1
-	return 0
+	if(electrocute_mob(user, get_area(src), src, siemens_strength, TRUE))
+		return TRUE
+	return FALSE
 
 //called on machinery construction (i.e from frame to machinery) but not on initialization
 /obj/machinery/proc/on_construction()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -427,8 +427,8 @@
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(5, 1, src)
 		s.start()
-		if(electrocute_mob(user, get_area(src), src, 1))
-			return 1
+		if(electrocute_mob(user, src, src, 1, TRUE))
+			return TRUE
 
 /obj/machinery/suit_storage_unit/relaymove(mob/user)
 	if(locked)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -245,20 +245,20 @@
 
 /obj/structure/grille/proc/shock(mob/user, prb)
 	if(!anchored || broken)		// unanchored/broken grilles are never connected
-		return 0
+		return FALSE
 	if(!prob(prb))
-		return 0
+		return FALSE
 	if(!in_range(src, user))//To prevent TK and mech users from getting shocked
-		return 0
+		return FALSE
 	var/turf/T = get_turf(src)
 	var/obj/structure/cable/C = T.get_cable_node()
 	if(C)
-		if(electrocute_mob(user, C, src))
+		if(electrocute_mob(user, C, src, 1, TRUE))
 			do_sparks(3, 1, src)
-			return 1
+			return TRUE
 		else
-			return 0
-	return 0
+			return FALSE
+	return FALSE
 
 /obj/structure/grille/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -118,7 +118,7 @@
 	if(!shockcd)
 		if(ismob(user))
 			var/mob/living/M = user
-			M.electrocute_act(15,"Energy Barrier", safety=1)
+			M.electrocute_act(15, "Energy Barrier", safety = TRUE)
 			shockcd = TRUE
 			addtimer(CALLBACK(src, .proc/cooldown), 5)
 
@@ -130,6 +130,6 @@
 		return
 
 	var/mob/living/M = AM
-	M.electrocute_act(15, "Energy Barrier", safety = 1)
+	M.electrocute_act(15, "Energy Barrier", safety = TRUE)
 	shockcd = TRUE
 	addtimer(CALLBACK(src, .proc/cooldown), 5)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -116,7 +116,7 @@
 	if(.)
 		return
 	if(!shockcd)
-		if(ismob(user))
+		if(isliving(user))
 			var/mob/living/M = user
 			M.electrocute_act(15, "Energy Barrier", safety = TRUE)
 			shockcd = TRUE

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1553,12 +1553,12 @@
 
 	else if(href_list["take_question"])
 		var/index = text2num(href_list["take_question"])
-		
+
 		if(href_list["is_mhelp"])
 			SSmentor_tickets.takeTicket(index)
 		else //Ahelp
 			SStickets.takeTicket(index)
-	
+
 	else if(href_list["cult_nextobj"])
 		if(alert(usr, "Validate the current Cult objective and unlock the next one?", "Cult Cheat Code", "Yes", "No") != "Yes")
 			return
@@ -1886,7 +1886,7 @@
 		var/logmsg = null
 		switch(punishment)
 			if("Lightning bolt")
-				M.electrocute_act(5, "Lightning Bolt", safety=1)
+				M.electrocute_act(5, "Lightning Bolt", safety = TRUE, override = TRUE)
 				playsound(get_turf(M), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 				M.adjustFireLoss(75)
 				M.Weaken(5)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -234,14 +234,14 @@
 /datum/plant_gene/trait/cell_charge/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
 	var/power = G.seed.potency*rate
 	if(prob(power))
-		C.electrocute_act(round(power), G, 1, 1)
+		C.electrocute_act(round(power), G, 1, TRUE)
 
 /datum/plant_gene/trait/cell_charge/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		var/power = G.seed.potency*rate
 		if(prob(power))
-			C.electrocute_act(round(power), G, 1, 1)
+			C.electrocute_act(round(power), G, 1, TRUE)
 
 /datum/plant_gene/trait/cell_charge/on_consume(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
 	if(!G.reagents.total_volume)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -237,7 +237,7 @@
 		C.electrocute_act(round(power), G, 1, TRUE)
 
 /datum/plant_gene/trait/cell_charge/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
-	if(iscarbon(target))
+	if(isliving(target))
 		var/mob/living/carbon/C = target
 		var/power = G.seed.potency*rate
 		if(prob(power))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -135,6 +135,7 @@
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
 
 /mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage)
 	if(status_flags & GODMODE)	//godmode
 		return FALSE
 	if(NO_SHOCK in mutations) //shockproof

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -134,43 +134,47 @@
 		M.forceMove(get_turf(src))
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
 
-/mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, override = 0, tesla_shock = 0)
+/mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
 	if(status_flags & GODMODE)	//godmode
-		return 0
+		return FALSE
 	if(NO_SHOCK in mutations) //shockproof
-		return 0
+		return FALSE
 	if(tesla_shock && tesla_ignore)
 		return FALSE
 	shock_damage *= siemens_coeff
-	if(shock_damage<1 && !override)
-		return 0
+	if(dna && dna.species)
+		shock_damage *= dna.species.siemens_coeff
+	if(shock_damage < 1 && !override)
+		return FALSE
 	if(reagents.has_reagent("teslium"))
 		shock_damage *= 1.5 //If the mob has teslium in their body, shocks are 50% more damaging!
-	take_overall_damage(0,shock_damage, TRUE, used_weapon = "Electrocution")
-	shock_internal_organs(shock_damage)
+	if(illusion)
+		adjustStaminaLoss(shock_damage)
+	else
+		take_overall_damage(0, shock_damage, TRUE, used_weapon = "Electrocution")
+		shock_internal_organs(shock_damage)
 	visible_message(
-		"<span class='danger'>[src] was shocked by \the [source]!</span>", \
-		"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>", \
-		"<span class='italics'>You hear a heavy electrical crack.</span>" \
-	)
+		"<span class='danger'>[src] was shocked by \the [source]!</span>",
+		"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>",
+		"<span class='italics'>You hear a heavy electrical crack.</span>")
 	AdjustJitter(1000) //High numbers for violent convulsions
 	do_jitter_animation(jitteriness)
 	AdjustStuttering(2)
-	if(!tesla_shock || (tesla_shock && siemens_coeff > 0.5))
+	if((!tesla_shock || (tesla_shock && siemens_coeff > 0.5)) && stun)
 		Stun(2)
 	spawn(20)
 		AdjustJitter(-1000, bound_lower = 10) //Still jittery, but vastly less
-		if(!tesla_shock || (tesla_shock && siemens_coeff > 0.5))
+		if((!tesla_shock || (tesla_shock && siemens_coeff > 0.5)) && stun)
 			Stun(3)
 			Weaken(3)
 	if(shock_damage > 200)
 		src.visible_message(
-			"<span class='danger'>[src] was arc flashed by the [source]!</span>", \
-			"<span class='userdanger'>The [source] arc flashes and electrocutes you!</span>", \
-			"<span class='italics'>You hear a lightning-like crack!</span>" \
-		)
+			"<span class='danger'>[src] was arc flashed by the [source]!</span>",
+			"<span class='userdanger'>The [source] arc flashes and electrocutes you!</span>",
+			"<span class='italics'>You hear a lightning-like crack!</span>")
 		playsound(loc, 'sound/effects/eleczap.ogg', 50, 1, -1)
-		explosion(src.loc,-1,0,2,2)
+		explosion(loc, -1, 0, 2, 2)
+
 	if(override)
 		return override
 	else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -551,13 +551,8 @@
 
 	dna.species.update_sight(src)
 
-//Removed the horrible safety parameter. It was only being used by ninja code anyways.
-//Now checks siemens_coefficient of the affected area by default
-/mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0)
-	if(status_flags & GODMODE)	//godmode
-		return 0
-	if(NO_SHOCK in mutations) //shockproof
-		return 0
+//Added a safety check in case you want to shock a human mob directly through electrocute_act.
+/mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
 	if(tesla_shock)
 		var/total_coeff = 1
 		if(gloves)
@@ -575,20 +570,18 @@
 			siemens_coeff = 0
 	else if(!safety)
 		var/gloves_siemens_coeff = 1
-		var/species_siemens_coeff = 1
 		if(gloves)
 			var/obj/item/clothing/gloves/G = gloves
 			gloves_siemens_coeff = G.siemens_coefficient
-		if(dna.species)
-			species_siemens_coeff = dna.species.siemens_coeff
-		siemens_coeff = gloves_siemens_coeff * species_siemens_coeff
-	if(undergoing_cardiac_arrest())
+		siemens_coeff = gloves_siemens_coeff
+	if(undergoing_cardiac_arrest() && !illusion)
 		if(shock_damage * siemens_coeff >= 1 && prob(25))
 			set_heartattack(FALSE)
 			if(stat == CONSCIOUS)
 				to_chat(src, "<span class='notice'>You feel your heart beating again!</span>")
-	. = ..()
 
+	dna.species.spec_electrocute_act(src, shock_damage, source, siemens_coeff, safety, override, tesla_shock, illusion, stun)
+	. = ..(shock_damage, source, siemens_coeff, safety, override, tesla_shock, illusion, stun)
 
 /mob/living/carbon/human/Topic(href, href_list)
 	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -309,6 +309,9 @@
 /datum/species/proc/handle_death(mob/living/carbon/human/H) //Handles any species-specific death events (such as dionaea nymph spawns).
 	return
 
+/datum/species/proc/spec_electrocute_act(mob/living/carbon/human/H, shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+	return
+
 /datum/species/proc/help(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.help_act(user, target))//adminfu only...
 		return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -55,8 +55,22 @@
 /mob/living/proc/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	return 0
 
-/mob/living/proc/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0)
-	  return 0 //only carbon liveforms have this proc
+/mob/living/proc/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+	SEND_SIGNAL(src, COMSIG_LIVING_ELECTROCUTE_ACT, shock_damage)
+	if(status_flags & GODMODE)	//godmode
+		return FALSE
+	if(NO_SHOCK in mutations) //shockproof
+		return FALSE
+	if(tesla_shock && tesla_ignore)
+		return FALSE
+	if(shock_damage > 0)
+		if(!illusion)
+			adjustFireLoss(shock_damage)
+		visible_message(
+			"<span class='danger'>[src] was shocked by \the [source]!</span>",
+			"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>",
+			"<span class='italics'>You hear a heavy electrical crack.</span>")
+		return shock_damage
 
 /mob/living/emp_act(severity)
 	var/list/L = src.get_contents()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -71,6 +71,9 @@
 /mob/living/silicon/drop_item()
 	return
 
+/mob/living/silicon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+	return FALSE //So borgs they don't die trying to fix wiring
+
 /mob/living/silicon/emp_act(severity)
 	switch(severity)
 		if(1)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -85,6 +85,9 @@
 /mob/living/simple_animal/hostile/construct/narsie_act()
 	return
 
+/mob/living/simple_animal/hostile/construct/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+	return FALSE
+
 /////////////////Juggernaut///////////////
 
 

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -142,7 +142,7 @@
 	return
 
 
-/mob/living/simple_animal/hostile/floor_cluwne/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)//prevents runtimes with machine fuckery
+/mob/living/simple_animal/hostile/floor_cluwne/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE) //prevents runtimes with machine fuckery
 	return FALSE
 
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -49,6 +49,7 @@
 	anchored = 1
 	use_power = NO_POWER_USE
 	req_access = list(access_engine_equip)
+	siemens_strength = 1
 	var/spooky=0
 	var/area/area
 	var/areastring = null
@@ -535,7 +536,7 @@
 			if(C.amount >= 10 && !terminal && opened && has_electronics != 2)
 				var/turf/T = get_turf(src)
 				var/obj/structure/cable/N = T.get_cable_node()
-				if(prob(50) && electrocute_mob(usr, N, N))
+				if(prob(50) && electrocute_mob(usr, N, N, 1, TRUE))
 					do_sparks(5, 1, src)
 					return
 				C.use(10)
@@ -1237,13 +1238,13 @@
 			if(prob(5))
 				var/list/shock_mobs = list()
 				for(var/C in view(get_turf(src), 5)) //We only want to shock a single random mob in range, not every one.
-					if(iscarbon(C))
+					if(isliving(C))
 						shock_mobs +=C
 				if(shock_mobs.len)
-					var/mob/living/carbon/S = pick(shock_mobs)
-					S.electrocute_act(rand(5,25), "electrical arc")
-					playsound(get_turf(S), 'sound/effects/eleczap.ogg', 75, 1)
-					Beam(S,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
+					var/mob/living/L = pick(shock_mobs)
+					L.electrocute_act(rand(5, 25), "electrical arc")
+					playsound(get_turf(L), 'sound/effects/eleczap.ogg', 75, 1)
+					Beam(L, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/effects.dmi', time = 5)
 
 	else // no cell, switch everything off
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1239,7 +1239,7 @@
 				var/list/shock_mobs = list()
 				for(var/C in view(get_turf(src), 5)) //We only want to shock a single random mob in range, not every one.
 					if(isliving(C))
-						shock_mobs +=C
+						shock_mobs += C
 				if(shock_mobs.len)
 					var/mob/living/L = pick(shock_mobs)
 					L.electrocute_act(rand(5, 25), "electrical arc")

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -191,14 +191,14 @@ By design, d1 is the smallest direction and d2 is the highest
 	src.add_fingerprint(user)
 
 // shock the user with probability prb
-/obj/structure/cable/proc/shock(mob/user, prb, var/siemens_coeff = 1.0)
+/obj/structure/cable/proc/shock(mob/user, prb, siemens_coeff = 1)
 	if(!prob(prb))
-		return 0
+		return FALSE
 	if(electrocute_mob(user, powernet, src, siemens_coeff))
 		do_sparks(5, 1, src)
-		return 1
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 //explosion handling
 /obj/structure/cable/ex_act(severity)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -162,23 +162,10 @@
 	ex_act(EXPLODE_DEVASTATE)
 
 /obj/item/stock_parts/cell/proc/get_electrocute_damage()
-	switch(charge)
-		if(5000000 to INFINITY)
-			return min(rand(200, 300),rand(200, 300))
-		if(4000000 to 5000000 - 1)
-			return min(rand(80, 180),rand(80, 180))
-		if(1000000 to 4000000 - 1)
-			return min(rand(50, 160),rand(50, 160))
-		if(200000 to 1000000 - 1)
-			return min(rand(25, 80),rand(25, 80))
-		if(100000 to 200000 - 1)//Ave powernet
-			return min(rand(20, 60),rand(20, 60))
-		if(50000 to 100000 - 1)
-			return min(rand(15, 40),rand(15, 40))
-		if(1000 to 50000 - 1)
-			return min(rand(10, 20),rand(10, 20))
-		else
-			return 0
+	if(charge >= 1000)
+		return Clamp(20 + round(charge / 25000), 20, 195) + rand(-5, 5)
+	else
+		return 0
 
 // Cell variants
 /obj/item/stock_parts/cell/empty/New()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -353,7 +353,7 @@
 				M.show_message("[user.name] smashed the light!", 3, "You hear a tinkle of breaking glass", 2)
 			if(on && (W.flags & CONDUCT))
 				if(prob(12))
-					electrocute_mob(user, get_area(src), src, 0.3)
+					electrocute_mob(user, get_area(src), src, 0.3, TRUE)
 			broken()
 
 		else
@@ -387,7 +387,7 @@
 		if(has_power() && (W.flags & CONDUCT))
 			do_sparks(3, 1, src)
 			if(prob(75))
-				electrocute_mob(user, get_area(src), src, rand(0.7,1.0))
+				electrocute_mob(user, get_area(src), src, rand(0.7, 1), TRUE)
 
 
 // returns whether this light has power

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -298,34 +298,37 @@
 //power_source is a source of electricity, can be powercell, area, apc, cable, powernet or null
 //source is an object caused electrocuting (airlock, grille, etc)
 //No animations will be performed by this proc.
-/proc/electrocute_mob(mob/living/carbon/M as mob, var/power_source, var/obj/source, var/siemens_coeff = 1.0)
+/proc/electrocute_mob(mob/living/M, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE)
 	if(!istype(M))
-		return 0
+		return FALSE
 	if(istype(M.loc,/obj/mecha))
-		return 0	//feckin mechs are dumb
+		return FALSE	//feckin mechs are dumb
+	if(dist_check)
+		if(!in_range(source, M))
+			return FALSE
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		if(H.gloves)
 			var/obj/item/clothing/gloves/G = H.gloves
 			if(G.siemens_coefficient == 0)
-				return 0		//to avoid spamming with insulated glvoes on
+				return FALSE		//to avoid spamming with insulated glvoes on
 
 	var/area/source_area
-	if(istype(power_source,/area))
+	if(istype(power_source, /area))
 		source_area = power_source
 		power_source = source_area.get_apc()
-	if(istype(power_source,/obj/structure/cable))
+	if(istype(power_source, /obj/structure/cable))
 		var/obj/structure/cable/Cable = power_source
 		power_source = Cable.powernet
 
 	var/datum/powernet/PN
 	var/obj/item/stock_parts/cell/cell
 
-	if(istype(power_source,/datum/powernet))
+	if(istype(power_source, /datum/powernet))
 		PN = power_source
 	else if(istype(power_source,/obj/item/stock_parts/cell))
 		cell = power_source
-	else if(istype(power_source,/obj/machinery/power/apc))
+	else if(istype(power_source, /obj/machinery/power/apc))
 		var/obj/machinery/power/apc/apc = power_source
 		cell = apc.cell
 		if(apc.terminal)
@@ -344,7 +347,7 @@
 	if(cell)
 		cell_damage = cell.get_electrocute_damage()
 	var/shock_damage = 0
-	if(PN_damage>=cell_damage)
+	if(PN_damage >= cell_damage)
 		power_source = PN
 		shock_damage = PN_damage
 	else

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -128,23 +128,10 @@
 	newavail = 0
 
 /datum/powernet/proc/get_electrocute_damage()
-	switch(avail)
-		if(5000000 to INFINITY)
-			return min(rand(200,300),rand(200,300))
-		if(4000000 to 5000000)
-			return min(rand(80,180),rand(80,180))
-		if(1000000 to 4000000)
-			return min(rand(50,160),rand(50,160))
-		if(200000 to 1000000)
-			return min(rand(25,80),rand(25,80))
-		if(100000 to 200000)//Ave powernet
-			return min(rand(20,60),rand(20,60))
-		if(50000 to 100000)
-			return min(rand(15,40),rand(15,40))
-		if(1000 to 50000)
-			return min(rand(10,20),rand(10,20))
-		else
-			return 0
+	if(avail >= 1000)
+		return Clamp(20 + round(avail / 25000), 20, 195) + rand(-5, 5)
+	else
+		return 0
 
 ////////////////////////////////////////////////
 // Misc.

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -78,7 +78,7 @@
 	if(isliving(user))
 		var/shock_damage = min(rand(30,40),rand(30,40))
 
-		if(iscarbon(user))
+		if(isliving(user) && !issilicon(user))
 			var/stun = min(shock_damage, 15)
 			user.Stun(stun)
 			user.Weaken(10)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -183,7 +183,7 @@
 		playsound(src.loc, I.usesound, 50, 1)
 
 		if(do_after(user, 50 * I.toolspeed, target = src))
-			if(prob(50) && electrocute_mob(usr, terminal.powernet, terminal)) //animate the electrocution if uncautious and unlucky
+			if(prob(50) && electrocute_mob(usr, terminal.powernet, terminal, 1, TRUE)) //animate the electrocution if uncautious and unlucky
 				do_sparks(5, 1, src)
 				return
 
@@ -320,7 +320,7 @@
 	if(do_after(user, 50, target = src))
 		var/turf/T = get_turf(user)
 		var/obj/structure/cable/N = T.get_cable_node() //get the connecting node cable, if there's one
-		if(prob(50) && electrocute_mob(user, N, N)) //animate the electrocution if uncautious and unlucky
+		if(prob(50) && electrocute_mob(usr, N, N, 1, TRUE)) //animate the electrocution if uncautious and unlucky
 			do_sparks(5, 1, src)
 			return
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -169,7 +169,6 @@
 	var/static/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 										/obj/machinery/power/emitter,
 										/obj/machinery/field/generator,
-										/mob/living/simple_animal,
 										/obj/machinery/particle_accelerator/control_box,
 										/obj/structure/particle_accelerator/fuel_chamber,
 										/obj/structure/particle_accelerator/particle_emitter/center,

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -115,6 +115,16 @@
 /obj/singularity/energy_ball/Bumped(atom/A)
 	dust_mobs(A)
 
+/obj/singularity/energy_ball/attack_tk(mob/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		to_chat(C, "<span class='userdanger'>That was a shockingly dumb idea.</span>")
+		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
+		C.ghostize(0)
+		if(B)
+			B.remove(C)
+			qdel(B)
+
 /obj/singularity/energy_ball/orbit(obj/singularity/energy_ball/target)
 	if(istype(target))
 		target.orbiting_balls += src
@@ -130,6 +140,10 @@
 		qdel(src)
 
 /obj/singularity/energy_ball/proc/dust_mobs(atom/A)
+	if(isliving(A))
+		var/mob/living/L = A
+		if(L.incorporeal_move || L.status_flags & GODMODE)
+			return
 	if(!iscarbon(A))
 		return
 	for(var/obj/machinery/power/grounding_rod/GR in orange(src, 2))
@@ -165,6 +179,9 @@
 										/obj/structure/particle_accelerator/end_cap,
 										/obj/machinery/field/containment,
 										/obj/structure/disposalpipe,
+										/obj/structure/disposaloutlet,
+										/obj/machinery/disposal/deliveryChute,
+										/obj/machinery/camera,
 										/obj/structure/sign,
 										/obj/machinery/gateway,
 										/obj/structure/grille,
@@ -255,7 +272,7 @@
 
 	else if(closest_mob)
 		var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5, 5)
-		closest_mob.electrocute_act(shock_damage, source, 1, tesla_shock = 1)
+		closest_mob.electrocute_act(shock_damage, source, 1, tesla_shock = TRUE)
 		if(issilicon(closest_mob))
 			var/mob/living/silicon/S = closest_mob
 			if(stun_mobs)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1171,6 +1171,6 @@
 	shock_timer++
 	if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
 		shock_timer = 0
-		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
+		M.electrocute_act(rand(5, 20), "Teslium in their body", 1, TRUE) //Override because it's caused from INSIDE of you
 		playsound(M, "sparks", 50, 1)
 	return ..()

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -376,9 +376,9 @@
 
 /datum/chemical_reaction/shock_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/T = get_turf(holder.my_atom)
-	for(var/mob/living/carbon/C in view(min(8, round(created_volume * 2)), T))
-		C.Beam(T,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5) //What? Why are we beaming from the mob to the turf? Turf to mob generates really odd results.
-		C.electrocute_act(3.5, "electrical blast")
+	for(var/mob/living/L in view(min(8, round(created_volume * 2)), T))
+		L.Beam(T, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/effects.dmi', time = 5) //What? Why are we beaming from the mob to the turf? Turf to mob generates really odd results.
+		L.electrocute_act(3.5, "electrical blast")
 	holder.del_reagent("teslium") //Clear all remaining Teslium and Uranium, but leave all other reagents untouched.
 	holder.del_reagent("uranium")
 


### PR DESCRIPTION
What a freaking mess.

Largely from TG.

- Refactors `electrocute_act` to have consistent arguments across all mobs, thus ensuring proper behavior
- Adjusts machinery's `shock` proc so some machines can shock harder than others
  - Airlocks, APCs, and air alarms shock a bit harder than other machines
- Fixes unlimited power gloves not being able to bypass glove immunity
- Better cooldown logic for airlocks (no more sleep, yay)
- Range checks for equipment that shocks you; no more TK shocking yourself
- Simple Mobs can now actually be shocked. Woo!
- Adds support for special species shock behavior
- Adds support for being able to have fake shocks
- Trying to touch the energy ball with TK will have uh... *shocking* consequences
- Blacklists disposals and cameras from tesla shocking
- Ensures incorporeal moving and godmode mobs cannot be dusted by the Tesla
- Adjusted shock damage to scale more linearly instead of being segmented `switch` with a great deal of randomness 

:cl: Fox McCloud
tweak: Tesla can't zap cameras and other disposal structures anymore
add: Simple mobs can now be shocked
tweak: Electrocution damage scales a bit more linearly up to its maximum potential instead of being heavily random
fix: Fixes being able to shock yourself with TK, at range, on electrical equipment
add: simple mobs can now be shocked by the tesla and other sources
/:cl: