### PR TITLE
Remaps Toxins

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -92414,7 +92414,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/binary/pump/highcap{
+/obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -92426,7 +92426,7 @@
 /obj/structure/sign/fire{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/binary/pump/highcap{
+/obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -61241,13 +61241,6 @@
 /area/shuttle/administration)
 "cgy" = (
 /obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/machinery/door/poddoor{
 	id_tag = "ToxinsVenting";
 	name = "Toxins Venting Bay Door";
 	use_power = 0
@@ -64263,6 +64256,10 @@
 	id = "air_in";
 	on = 1
 	},
+/obj/machinery/sparker{
+	id = "toxinsigniter";
+	pixel_x = -20
+	},
 /turf/simulated/floor/engine/insulated/vacuum,
 /area/toxins/mixing)
 "cly" = (
@@ -64278,11 +64275,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "clz" = (
-/obj/machinery/igniter{
-	icon_state = "igniter0";
-	id = "ToxinsIgnitor";
-	on = 0
-	},
 /turf/simulated/floor/engine/insulated/vacuum,
 /area/toxins/mixing)
 "clA" = (
@@ -65091,12 +65083,12 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "cmW" = (
-/obj/structure/closet/wardrobe/toxins_white,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "station intercom (General)";
 	pixel_y = 25
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -65110,19 +65102,20 @@
 	dir = 1;
 	in_use = 1
 	},
+/obj/item/grenade/chem_grenade/firefighting,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
 "cmY" = (
-/obj/structure/closet/wardrobe/toxins_white,
 /obj/machinery/camera{
 	c_tag = "Research Toxins Mixing West";
 	dir = 2;
 	network = list("Research","SS13");
 	pixel_x = 0
 	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -65133,6 +65126,7 @@
 	pixel_y = 25
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
+/obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -65152,6 +65146,7 @@
 	},
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
+/obj/item/grenade/chem_grenade/firefighting,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -67122,10 +67117,10 @@
 	},
 /area/toxins/mixing)
 "cqf" = (
-/obj/machinery/atmospherics/binary/pump/highcap{
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -67146,8 +67141,8 @@
 	},
 /area/toxins/mixing)
 "cqh" = (
-/obj/machinery/atmospherics/binary/pump/highcap,
 /obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -67160,7 +67155,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/ignition_switch{
-	id = "ToxinsIgnitor";
+	id = "toxinsigniter";
 	pixel_x = 6;
 	pixel_y = 25
 	},
@@ -67175,12 +67170,14 @@
 	},
 /area/toxins/mixing)
 "cqj" = (
-/obj/machinery/portable_atmospherics/pump,
 /obj/machinery/camera{
 	c_tag = "Research Toxins Mixing East";
 	dir = 2;
 	network = list("Research","SS13");
 	pixel_x = 0
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -67220,12 +67217,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
-	},
-/area/toxins/mixing)
-"cqo" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
 	},
 /area/toxins/mixing)
 "cqp" = (
@@ -68442,6 +68433,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -69351,12 +69343,6 @@
 /area/medical/research{
 	name = "Research Division"
 	})
-"ctD" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/mixing)
 "ctE" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -69395,14 +69381,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "ctI" = (
-/obj/structure/table,
 /obj/structure/cable,
-/obj/item/storage/toolbox/mechanical,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24;
 	shock_proof = 0
+	},
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/stack/cable_coil,
+/obj/item/analyzer{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/taperecorder{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -69428,38 +69426,12 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
-"ctK" = (
-/obj/structure/table,
-/obj/item/assembly/signaler{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/mixing)
 "ctL" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70182,13 +70154,11 @@
 	},
 /area/toxins/explab)
 "cuT" = (
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
 /obj/structure/table,
-/obj/item/transfer_valve,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70288,25 +70258,28 @@
 	},
 /area/toxins/mixing)
 "cvc" = (
-/obj/item/assembly/prox_sensor{
-	pixel_x = -5;
-	pixel_y = -5
+/obj/item/transfer_valve{
+	pixel_x = 4;
+	pixel_y = -4
 	},
-/obj/item/assembly/prox_sensor{
+/obj/item/transfer_valve{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/transfer_valve{
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/structure/table,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -5;
-	pixel_y = -5
+/obj/item/transfer_valve{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/item/assembly/prox_sensor,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70325,27 +70298,6 @@
 	},
 /area/medical/virology)
 "cve" = (
-/obj/item/assembly/timer,
-/obj/item/assembly/timer{
-	pixel_x = 6
-	},
-/obj/item/assembly/timer{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/structure/table,
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = -4
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/assembly/timer,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
 /obj/machinery/light,
 /obj/machinery/requests_console{
 	department = "Science";
@@ -70354,6 +70306,7 @@
 	pixel_x = 0;
 	pixel_y = -30
 	},
+/obj/machinery/vending/plasmaresearch,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -77251,7 +77204,7 @@
 	},
 /area/toxins/misc_lab)
 "cHq" = (
-/obj/machinery/atmospherics/binary/pump/highcap{
+/obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -88768,11 +88721,10 @@
 /turf/space,
 /area/space)
 "dca" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
+/obj/machinery/atmospherics/unary/passive_vent{
+	dir = 8
 	},
-/turf/space,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "dcb" = (
 /turf/simulated/floor/plasteel{
@@ -88781,13 +88733,7 @@
 	},
 /area/hallway/primary/central/north)
 "dcc" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "co2_in";
-	pixel_y = 1
-	},
-/turf/simulated/floor/plating/airless,
+/turf/space,
 /area/toxins/mixing)
 "dcd" = (
 /obj/structure/cable{
@@ -96601,6 +96547,143 @@
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plating,
 /area/storage/secure)
+"duq" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/space,
+/area/space)
+"gMZ" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/toxins/mixing)
+"hsy" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/toxins/mixing)
+"izn" = (
+/obj/machinery/atmospherics/unary/passive_vent{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"iJf" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/obj/structure/window/plasmareinforced,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/toxins/mixing)
+"iNz" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/toxins/launch{
+	name = "Toxins Launch Room"
+	})
+"kOE" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"nMi" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area/space)
+"pZO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area/space)
+"qUv" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/space)
+"uxy" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/space,
+/area/space)
+"uDK" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/space,
+/area/space)
+"vup" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"xAw" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"xWg" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/space,
+/area/space)
 
 (1,1,1) = {"
 aaa
@@ -146099,7 +146182,7 @@ cnf
 cqe
 crI
 csg
-ctK
+cqk
 cuT
 cgs
 bGG
@@ -146356,7 +146439,7 @@ cgu
 cqg
 crI
 csg
-ctD
+cqk
 cuU
 cgs
 bGG
@@ -146862,7 +146945,7 @@ dbH
 aYS
 aaa
 dbZ
-cgu
+cgy
 cia
 cke
 clz
@@ -147119,7 +147202,7 @@ ccP
 aYS
 aaa
 dbX
-cgu
+cgy
 cib
 cjX
 cnE
@@ -147634,10 +147717,10 @@ aYS
 aaa
 dca
 dcc
-aaa
-aaa
-afO
-cgs
+xWg
+duq
+xAw
+iJf
 cqj
 crI
 csh
@@ -147891,11 +147974,11 @@ aYS
 aaa
 aaa
 aaa
+uxy
 aaa
-aaa
-afO
-cgs
-cqo
+kOE
+gMZ
+cqe
 crI
 csg
 cqk
@@ -148146,12 +148229,12 @@ baT
 bgm
 aYS
 aaa
-aaa
-aaa
-aaa
-aaa
-afO
-cgs
+xWg
+qUv
+nMi
+xWg
+djc
+hsy
 cqm
 crN
 csi
@@ -148403,12 +148486,12 @@ baT
 baT
 aYS
 aaa
-aaa
-aaa
-aaa
-aaa
-afO
-cgE
+pZO
+uDK
+xWg
+nMi
+aab
+iNz
 cgE
 crS
 cgE
@@ -148660,12 +148743,12 @@ baT
 baT
 aYS
 aaa
-aaa
-aaa
-aaa
-aaa
+xWg
+nMi
+pZO
+uDK
 afO
-cgE
+iNz
 cqp
 crQ
 csn
@@ -148917,12 +149000,12 @@ baU
 bgd
 aYS
 aaa
-aaa
-aaa
-aaa
-aaa
+pZO
+uDK
+xWg
+nMi
 afO
-cgE
+iNz
 cqq
 crT
 crw
@@ -149174,12 +149257,12 @@ baV
 baV
 daC
 aaa
-aaa
-aaa
-aaa
-aaa
+xWg
+nMi
+pZO
+uDK
 afO
-cgE
+iNz
 coG
 cqx
 csq
@@ -149431,12 +149514,12 @@ aaa
 aaa
 daD
 aaa
-aaa
-aaa
-aaa
-aaa
+uxy
+xWg
+uDK
+uxy
 afO
-cgE
+iNz
 coI
 cqC
 csr
@@ -149688,13 +149771,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+uxy
+uxy
+uxy
+uxy
 afO
-aaa
-aab
+vup
+izn
 aab
 aab
 aab
@@ -149945,10 +150028,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+pZO
+nMi
+pZO
+nMi
 afO
 aaa
 aab

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -34,12 +34,6 @@ Thus, the two variables affect pump operation are set in New():
 	radio_connection = null
 	return ..()
 
-/obj/machinery/atmospherics/binary/pump/highcap
-	name = "High capacity gas pump"
-	desc = "A high capacity pump"
-
-	target_pressure = 15000000
-
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"
 	on = 1

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1055,10 +1055,9 @@
 /obj/machinery/vending/plasmaresearch
 	name = "\improper Toximate 3000"
 	desc = "All the fine parts you need in one vending machine!"
-	products = list(/obj/item/clothing/under/rank/scientist = 6,/obj/item/clothing/suit/bio_suit = 6,/obj/item/clothing/head/bio_hood = 6,
-					/obj/item/transfer_valve = 6,/obj/item/assembly/timer = 6,/obj/item/assembly/signaler = 6,
-					/obj/item/assembly/prox_sensor = 6,/obj/item/assembly/igniter = 6)
-	contraband = list(/obj/item/assembly/health = 3)
+	products = list(/obj/item/assembly/prox_sensor = 8, /obj/item/assembly/igniter = 8, /obj/item/assembly/signaler = 8,
+					/obj/item/wirecutters = 1, /obj/item/assembly/timer = 8)
+	contraband = list(/obj/item/flashlight = 5, /obj/item/assembly/voice = 3, /obj/item/assembly/health = 3, /obj/item/assembly/infra = 3)
 
 /obj/machinery/vending/wallmed1
 	name = "\improper NanoMed"

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -446,6 +446,23 @@
 	update_icon()
 
 
+/obj/item/grenade/chem_grenade/firefighting
+	payload_name = "fire fighting grenade"
+	desc = "Can help to put out dangerous fires from a distance."
+	stage = READY
+
+/obj/item/grenade/chem_grenade/firefighting/New()
+	..()
+	var/obj/item/reagent_containers/glass/beaker/B1 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/B2 = new(src)
+
+	B1.reagents.add_reagent("firefighting_foam", 30)
+	B2.reagents.add_reagent("firefighting_foam", 30)
+
+	beakers += B1
+	beakers += B2
+	update_icon()
+
 /obj/item/grenade/chem_grenade/incendiary
 	payload_name = "incendiary"
 	desc = "Used for clearing rooms of living things."

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -13,6 +13,7 @@
 	new /obj/item/storage/backpack/science(src)
 	new /obj/item/storage/backpack/satchel_tox(src)
 	new /obj/item/clothing/under/rank/scientist(src)
+	new /obj/item/clothing/under/rank/scientist/skirt(src)
 	//new /obj/item/clothing/suit/labcoat/science(src)
 	new /obj/item/clothing/suit/storage/labcoat/science(src)
 	new /obj/item/clothing/shoes/white(src)


### PR DESCRIPTION
Remaps toxins a bit, as it was kinda dated.

A picture is worth a thousand words for maps, so:

![img](https://i.gyazo.com/614a1aac669f187edfc2d07162c90871.png)
![img](https://i.gyazo.com/2f0032d307b8c58d87be38267e751e3a.png)

Changes
- Removed the ultra high volume pumps
  - These really aren't needed, to be honest and they can't be built anyway
- Replaced a lot of the assembly clutter wtih a ToxiMate Vending machine that has a whole bunch of different assemblies in it (even more if you hack it)
- Replaced the wardrobes with a firefighting closet and water tank
- Added 2 firefighting grenades to toxins
- Added a space loop for cooling off gases in addition to a vent
  - Before you mention the heat exchanger being able to dump to space, I know, but maybe you don't want to contaminate that loop
- Moved the light switch so you can actually see it
- More blast doors on the burn chamber to vent gas faster

:cl: Fox McCloud
add: Remapped toxins to be more compatible with the modern age
/:cl: