### PR TITLE
Refactors puke to make it less lag inducing

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -643,8 +643,8 @@ var/list/blood_splatter_icons = list()
 
 
 /atom/proc/add_vomit_floor(toxvomit = 0, type = /obj/effect/decal/cleanable/vomit)
+	playsound(src, 'sound/effects/splat.ogg', 50, 1)
 	if(istype(src, /turf/simulated))
-		playsound(src, 'sound/effects/splat.ogg', 50, 1)
 		if(locate(type) in get_turf(src))
 			return //Performance improvement
 		var/obj/effect/decal/cleanable/vomit/this = new type(src)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -644,9 +644,9 @@ var/list/blood_splatter_icons = list()
 
 /atom/proc/add_vomit_floor(toxvomit = 0, green = FALSE)
 	playsound(src, 'sound/effects/splat.ogg', 50, 1)
-	var/type = green ? /obj/effect/decal/cleanable/vomit/green : /obj/effect/decal/cleanable/vomit
-	var/vomit_reagent = green ? "green_vomit" : "vomit"
-	if(istype(src, /turf/simulated))
+	if(!isspaceturf(src))
+		var/type = green ? /obj/effect/decal/cleanable/vomit/green : /obj/effect/decal/cleanable/vomit
+		var/vomit_reagent = green ? "green_vomit" : "vomit"
 		for(var/obj/effect/decal/cleanable/vomit/V in get_turf(src))
 			if(V.type == type)
 				if(V.scoop_reagents[vomit_reagent])

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -642,14 +642,16 @@ var/list/blood_splatter_icons = list()
 	update_icons()	//apply the now updated overlays to the mob
 
 
-/atom/proc/add_vomit_floor(mob/living/carbon/M as mob, var/toxvomit = 0)
-	if( istype(src, /turf/simulated) )
-		var/obj/effect/decal/cleanable/vomit/this = new /obj/effect/decal/cleanable/vomit(src)
+/atom/proc/add_vomit_floor(toxvomit = 0, type = /obj/effect/decal/cleanable/vomit)
+	if(istype(src, /turf/simulated))
+		if(locate(type) in get_turf(src))
+			return //Performance improvement
+		var/obj/effect/decal/cleanable/vomit/this = new type(src)
 
 		// Make toxins vomit look different
 		if(toxvomit)
 			this.icon_state = "vomittox_[pick(1,4)]"
-
+		playsound(src, 'sound/effects/splat.ogg', 50, 1)
 
 /atom/proc/get_global_map_pos()
 	if(!islist(global_map) || isemptylist(global_map)) return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -649,10 +649,7 @@ var/list/blood_splatter_icons = list()
 		var/vomit_reagent = green ? "green_vomit" : "vomit"
 		for(var/obj/effect/decal/cleanable/vomit/V in get_turf(src))
 			if(V.type == type)
-				if(V.scoop_reagents[vomit_reagent])
-					V.scoop_reagents[vomit_reagent] += 5
-				else
-					V.scoop_reagents[vomit_reagent] = 5
+				V.scoop_reagents[vomit_reagent] += 5
 				return
 			
 		var/obj/effect/decal/cleanable/vomit/this = new type(src)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -644,6 +644,7 @@ var/list/blood_splatter_icons = list()
 
 /atom/proc/add_vomit_floor(toxvomit = 0, type = /obj/effect/decal/cleanable/vomit)
 	if(istype(src, /turf/simulated))
+		playsound(src, 'sound/effects/splat.ogg', 50, 1)
 		if(locate(type) in get_turf(src))
 			return //Performance improvement
 		var/obj/effect/decal/cleanable/vomit/this = new type(src)
@@ -651,7 +652,6 @@ var/list/blood_splatter_icons = list()
 		// Make toxins vomit look different
 		if(toxvomit)
 			this.icon_state = "vomittox_[pick(1,4)]"
-		playsound(src, 'sound/effects/splat.ogg', 50, 1)
 
 /atom/proc/get_global_map_pos()
 	if(!islist(global_map) || isemptylist(global_map)) return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -649,7 +649,7 @@ var/list/blood_splatter_icons = list()
 		var/vomit_reagent = green ? "green_vomit" : "vomit"
 		for(var/obj/effect/decal/cleanable/vomit/V in get_turf(src))
 			if(V.type == type)
-				V.scoop_reagents[vomit_reagent] += 5
+				V.reagents.add_reagent(vomit_reagent, 5)
 				return
 			
 		var/obj/effect/decal/cleanable/vomit/this = new type(src)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -642,11 +642,19 @@ var/list/blood_splatter_icons = list()
 	update_icons()	//apply the now updated overlays to the mob
 
 
-/atom/proc/add_vomit_floor(toxvomit = 0, type = /obj/effect/decal/cleanable/vomit)
+/atom/proc/add_vomit_floor(toxvomit = 0, green = FALSE)
 	playsound(src, 'sound/effects/splat.ogg', 50, 1)
+	var/type = green ? /obj/effect/decal/cleanable/vomit/green : /obj/effect/decal/cleanable/vomit
+	var/vomit_reagent = green ? "green_vomit" : "vomit"
 	if(istype(src, /turf/simulated))
-		if(locate(type) in get_turf(src))
-			return //Performance improvement
+		for(var/obj/effect/decal/cleanable/vomit/V in get_turf(src))
+			if(V.type == type)
+				if(V.scoop_reagents[vomit_reagent])
+					V.scoop_reagents[vomit_reagent] += 5
+				else
+					V.scoop_reagents[vomit_reagent] = 5
+				return
+			
 		var/obj/effect/decal/cleanable/vomit/this = new type(src)
 
 		// Make toxins vomit look different

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -762,6 +762,7 @@
 		B.chemicals -= 100
 		var/turf/T = get_turf(src)
 		T.add_vomit_floor()
+		new /mob/living/simple_animal/borer(T, B.generation + 1)
 
 	else
 		to_chat(src, "You need 100 chemicals to reproduce!")

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -760,10 +760,8 @@
 		to_chat(src, "<span class='danger'>Your host twitches and quivers as you rapdly excrete several larvae from your sluglike body.</span>")
 		visible_message("<span class='danger'>[src] heaves violently, expelling a rush of vomit and a wriggling, sluglike creature!</span>")
 		B.chemicals -= 100
-
-		new /obj/effect/decal/cleanable/vomit(get_turf(src))
-		playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-		new /mob/living/simple_animal/borer(get_turf(src),B.generation + 1)
+		var/turf/T = get_turf(src)
+		T.add_vomit_floor()
 
 	else
 		to_chat(src, "You need 100 chemicals to reproduce!")

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -470,7 +470,7 @@
 						M.nutrition -= 50 //lose a lot of food
 						var/turf/location = usr.loc
 						if(istype(location, /turf/simulated))
-							location.add_vomit_floor(src, 1)
+							location.add_vomit_floor(TRUE)
 				if(ORION_TRAIL_FLUX)
 					if(prob(75))
 						M.Weaken(3)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -701,8 +701,7 @@
 							H.nutrition -= 20
 							H.adjustToxLoss(-3)
 							var/turf/T = get_turf(H)
-							T.add_vomit_floor(H)
-							playsound(H, 'sound/effects/splat.ogg', 50, 1)
+							T.add_vomit_floor()
 		else
 			visible_message("<span class='warning'>[src] flickers and fails, due to bluespace interference!</span>")
 			qdel(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -109,7 +109,7 @@
 					adjustBruteLoss(3)
 			else
 				if(T)
-					T.add_vomit_floor(src)
+					T.add_vomit_floor()
 				nutrition -= lost_nutrition
 				if(stun)
 					adjustToxLoss(-3)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1176,7 +1176,7 @@ var/list/slot_equipment_priority = list( \
 		if(green)
 			if(!no_text)
 				visible_message("<span class='warning'>[src] vomits up some green goo!</span>","<span class='warning'>You vomit up some green goo!</span>")
-			location.add_vomit_floor(FALSE, /obj/effect/decal/cleanable/vomit/green)
+			location.add_vomit_floor(FALSE, TRUE)
 		else
 			if(!no_text)
 				visible_message("<span class='warning'>[src] pukes all over [p_them()]self!</span>","<span class='warning'>You puke all over yourself!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1176,12 +1176,11 @@ var/list/slot_equipment_priority = list( \
 		if(green)
 			if(!no_text)
 				visible_message("<span class='warning'>[src] vomits up some green goo!</span>","<span class='warning'>You vomit up some green goo!</span>")
-			new /obj/effect/decal/cleanable/vomit/green(location)
+			location.add_vomit_floor(FALSE, /obj/effect/decal/cleanable/vomit/green)
 		else
 			if(!no_text)
 				visible_message("<span class='warning'>[src] pukes all over [p_them()]self!</span>","<span class='warning'>You puke all over yourself!</span>")
-			location.add_vomit_floor(src, 1)
-		playsound(location, 'sound/effects/splat.ogg', 50, 1)
+			location.add_vomit_floor(TRUE)
 
 /mob/proc/AddSpell(obj/effect/proc_holder/spell/S)
 	mob_spell_list += S

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -917,7 +917,7 @@
 
 /datum/reagent/greenvomit/reaction_turf(turf/T, volume)
 	if(volume >= 5 && !isspaceturf(T))
-		T.add_vomit_floor(FALSE, /obj/effect/decal/cleanable/vomit/green)
+		T.add_vomit_floor(FALSE, TRUE)
 
 ////Lavaland Flora Reagents////
 

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -905,8 +905,7 @@
 
 /datum/reagent/vomit/reaction_turf(turf/T, volume)
 	if(volume >= 5 && !isspaceturf(T))
-		new /obj/effect/decal/cleanable/vomit(T)
-		playsound(T, 'sound/effects/splat.ogg', 50, 1, -3)
+		T.add_vomit_floor()
 
 /datum/reagent/greenvomit
 	name = "Green vomit"
@@ -918,8 +917,7 @@
 
 /datum/reagent/greenvomit/reaction_turf(turf/T, volume)
 	if(volume >= 5 && !isspaceturf(T))
-		new /obj/effect/decal/cleanable/vomit/green(T)
-		playsound(T, 'sound/effects/splat.ogg', 50, 1, -3)
+		T.add_vomit_floor(FALSE, /obj/effect/decal/cleanable/vomit/green)
 
 ////Lavaland Flora Reagents////
 


### PR DESCRIPTION
**What does this PR do:**
Puke now won't appear on a turf if there is already puke there
The chemicals will instead be added to the existing puke.

**Changelog:**
:cl:
tweak: Makes puke less lag inducing
tweak: Puke can now appear on all kinds of turfs except spess
/:cl:

