### PR TITLE
Fixes PM's when the client left going to another client

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -78,6 +78,9 @@
 			C = M.client
 		if(!C) // Might be a stealthmin ID, so pass it in straight
 			C = href_list["priv_msg"]
+		else if(C.UID() != href_list["priv_msg"])
+			to_chat(src, "<span class='danger'>Error: Private-Message: Client not found.</span>")
+			return
 		cmd_admin_pm(C, null, href_list["type"])
 		return
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -79,8 +79,7 @@
 		if(!C) // Might be a stealthmin ID, so pass it in straight
 			C = href_list["priv_msg"]
 		else if(C.UID() != href_list["priv_msg"])
-			to_chat(src, "<span class='danger'>Error: Private-Message: Client not found.</span>")
-			return
+			C = null // 404 client not found. Let cmd_admin_pm handle the error
 		cmd_admin_pm(C, null, href_list["type"])
 		return
 


### PR DESCRIPTION
**What does this PR do:**
Fixes PM's going to the wrong client when the target client left.
Weird thing it seems that byond just picks a random client if you try to parse an invalid reference.

I couldn't find any other instances where these references go wrong. If you know of them do comment.

#11295 

**Changelog:**
:cl:
fix: PM's now shouldn't go to the wrong client anymore when the target left.
/:cl:

