### PR TITLE
Fixes bans not saving properly

### DIFF
--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -70,6 +70,11 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 		if(banned_mob.client)
 			computerid = banned_mob.client.computer_id
 			ip = banned_mob.client.address
+		else
+			if(banned_mob.lastKnownIP)
+				ip = banned_mob.lastKnownIP
+			if(banned_mob.computer_id)
+				computerid = banned_mob.computer_id
 	else if(banckey)
 		ckey = ckey(banckey)
 		computerid = bancid

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1005,15 +1005,7 @@
 				var/reason = input(usr,"Please state the reason","Reason") as message|null
 				if(!reason)
 					return
-				switch(alert(usr,"IP ban?",,"Yes","No","Cancel"))
-					if("Cancel")
-						return
-					if("Yes")
-						M = admin_ban_mobsearch(M, ban_ckey_param, usr)
-						AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0, M.lastKnownIP)
-					if("No")
-						M = admin_ban_mobsearch(M, ban_ckey_param, usr)
-						AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0)
+				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0, M.lastKnownIP)
 				to_chat(M, "<span class='warning'><BIG><B>You have been banned by [usr.client.ckey].\nReason: [reason].</B></BIG></span>")
 				to_chat(M, "<span class='warning'>This is a permanent ban.</span>")
 				if(config.banappeals)
@@ -1553,12 +1545,12 @@
 
 	else if(href_list["take_question"])
 		var/index = text2num(href_list["take_question"])
-		
+
 		if(href_list["is_mhelp"])
 			SSmentor_tickets.takeTicket(index)
 		else //Ahelp
 			SStickets.takeTicket(index)
-	
+
 	else if(href_list["cult_nextobj"])
 		if(alert(usr, "Validate the current Cult objective and unlock the next one?", "Cult Cheat Code", "Yes", "No") != "Yes")
 			return


### PR DESCRIPTION
:cl: Kyep
fix: bans issued by admins via the Player Panel no longer incorrectly omit IP/etc information
tweak: admins issuing permanent bans are no longer presented with an "ip ban?" prompt, as all bans include IP/CID information now. This prompt was a legacy thing from back when the filesystem was used to store bans, and hasn't ever affected how DB-based bans were stored.
/:cl:

Primary fix:
In proc/DB_ban_record, almost all bans are passed with a banned_mob, which, due to the "if(banned_mob.client)" check, means IP/CID information is not saved for bans unless the banned mob has a client. This means that when an admin bans any mob without a connected client (e.g: someone who disconnected before they were banned), IP/CID data is not saved for the ban. This is bad as it means that IP/CID data is not saved for ~30% of bans. This PR fixes it such that IP/CID information is always saved with the ban if it is available, even if the mob being banned has no connected client.

Secondary change:
Adding a permaban via PP is handled by admin/topic.dm. During this process, it will ask you if you want to include an IP ban. But this prompt is a lie. The prompt only affects how the ban is stored via AddBan, in the filesystem. It has zero effect on the call to DB_ban_record, which is how the ban is really stored for us (since we use database backend). This PR removes the prompt entirely, since it is misleading.