### PR TITLE
Better SSD management

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -122,6 +122,10 @@
 		throw_item(A)
 		return
 
+	if(isLivingSSD(A))
+		if(client && client.send_ssd_warning(A))
+			return
+
 	var/obj/item/W = get_active_hand()
 
 	if(W == A)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -69,6 +69,8 @@
 	var/assistantlimit = 0 //enables assistant limiting
 	var/assistantratio = 2 //how many assistants to security members
 
+	var/auto_cryo_ssd_mins = 0
+
 	var/prob_free_golems = 75 //chance for free golems spawners to appear roundstart
 	var/unrestricted_free_golems = FALSE //if true, free golems can appear on all roundtypes
 
@@ -213,7 +215,7 @@
 
 	// Automatic localhost admin disable
 	var/disable_localhost_admin = 0
-	
+
 	//Start now warning
 	var/start_now_confirmation = 0
 
@@ -293,6 +295,9 @@
 				if("shadowling_max_age")
 					config.shadowling_max_age = text2num(value)
 
+				if("auto_cryo_ssd_mins")
+					config.auto_cryo_ssd_mins = text2num(value)
+
 				if("log_ooc")
 					config.log_ooc = 1
 
@@ -358,10 +363,10 @@
 
 				if("no_dead_vote")
 					config.vote_no_dead = 1
-					
+
 				if("vote_autotransfer_initial")
 					config.vote_autotransfer_initial = text2num(value)
-					
+
 				if("vote_autotransfer_interval")
 					config.vote_autotransfer_interval = text2num(value)
 
@@ -645,7 +650,7 @@
 
 				if("disable_karma")
 					config.disable_karma = 1
-					
+
 				if("start_now_confirmation")
 					config.start_now_confirmation = 1
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -70,6 +70,7 @@
 	var/assistantratio = 2 //how many assistants to security members
 
 	var/auto_cryo_ssd_mins = 0
+	var/ssd_warning = 0
 
 	var/prob_free_golems = 75 //chance for free golems spawners to appear roundstart
 	var/unrestricted_free_golems = FALSE //if true, free golems can appear on all roundtypes
@@ -297,6 +298,9 @@
 
 				if("auto_cryo_ssd_mins")
 					config.auto_cryo_ssd_mins = text2num(value)
+
+				if("ssd_warning")
+					config.ssd_warning = 1
 
 				if("log_ooc")
 					config.log_ooc = 1

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -63,6 +63,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/xenobiology_compatible = FALSE //Can the Xenobio management console transverse this area by default?
 	var/nad_allowed = FALSE //is the station NAD allowed on this area?
 
+	var/fast_despawn = FALSE
+
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 var/list/teleportlocs = list()
@@ -855,10 +857,12 @@ var/list/ghostteleportlocs = list()
 /area/prison/solitary
 	name = "\improper Solitary Confinement"
 	icon_state = "brig"
+	fast_despawn = TRUE
 
 /area/prison/cell_block
 	name = "\improper Prison Cell Block"
 	icon_state = "brig"
+	fast_despawn = TRUE
 
 /area/prison/cell_block/A
 	name = "\improper Prison Cell Block A"
@@ -1676,6 +1680,7 @@ var/list/ghostteleportlocs = list()
 /area/security/permabrig
 	name = "\improper Prison Wing"
 	icon_state = "sec_prison_perma"
+	fast_despawn = TRUE
 
 /area/security/prison
 	name = "\improper Prison Wing"

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -46,7 +46,7 @@
 	var/received_irc_pm = -99999
 	var/irc_admin			//IRC admin that spoke with them last.
 	var/mute_irc = 0
-
+	var/ssd_warning_acknowledged = FALSE
 
 		////////////////////////////////////
 		//things that require the database//

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -9,6 +9,7 @@
 #define MIN_CLIENT_VERSION	0		//Just an ambiguously low version for now, I don't want to suddenly stop people playing.
 									//I would just like the code ready should it ever need to be used.
 #define SUGGESTED_CLIENT_VERSION	511		// only integers (e.g: 510, 511) useful here. Does not properly handle minor versions (e.g: 510.58, 511.848)
+#define SSD_WARNING_TIMER 30 // cycles, not seconds, so 30=60s
 
 	/*
 	When somebody clicks a link in game, this Topic is called first.
@@ -780,8 +781,9 @@
 		return FALSE
 	if(ssd_warning_acknowledged)
 		return FALSE
-	if(M && M.player_logged < 30) // Give it ~60 seconds, just in case they drop SSD during combat.
+	if(M && M.player_logged < SSD_WARNING_TIMER)
 		return FALSE
 	to_chat(src, "Interacting with SSD players is against server rules unless you've ahelped first for permission. If you have, <a href='byond://?src=[UID()];ssdwarning=accepted'>confirm that</A> and proceed.")
 	return TRUE
 
+#undef SSD_WARNING_TIMER

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -225,6 +225,9 @@
 						vote_on_poll(pollid, optionid, 1)
 		src << browse(null, "window=playerpoll")
 		handle_player_polling()
+	if(href_list["ssdwarning"])
+		ssd_warning_acknowledged = TRUE
+		to_chat(src, "<span class='notice'>SSD warning acknowledged.</span>")
 
 	switch(href_list["action"])
 		if("openLink")
@@ -770,3 +773,15 @@
 			winset(src, "rpane.changelog", "background-color=#40628a;text-color=#FFFFFF")
 		else
 			winset(src, "rpane.changelog", "background-color=none;text-color=#000000")
+
+
+/client/proc/send_ssd_warning(mob/M)
+	if(!config.ssd_warning)
+		return FALSE
+	if(ssd_warning_acknowledged)
+		return FALSE
+	if(M && M.player_logged < 30) // Give it ~60 seconds, just in case they drop SSD during combat.
+		return FALSE
+	to_chat(src, "Interacting with SSD players is against server rules unless you've ahelped first for permission. If you have, <a href='byond://?src=[UID()];ssdwarning=accepted'>confirm that</A> and proceed.")
+	return TRUE
+

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -50,11 +50,11 @@
 				force_cryo_human(src)
 
 /mob/living/carbon/human/proc/handle_ssd()
-	if(player_logged > 0 && config.auto_cryo_ssd_mins && stat != DEAD && job)
+	if(player_logged > 0 && stat != DEAD && job)
 		player_logged++
 		if(istype(loc, /obj/machinery/cryopod))
 			return
-		if((player_logged >= (config.auto_cryo_ssd_mins * 30)) && player_logged % 30 == 0)
+		if(config.auto_cryo_ssd_mins && (player_logged >= (config.auto_cryo_ssd_mins * 30)) && player_logged % 30 == 0)
 			var/turf/T = get_turf(src)
 			if(!is_station_level(T.z))
 				return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -38,6 +38,7 @@
 			regenerate_icons() // Make sure the inventory updates
 
 	handle_ghosted()
+	handle_ssd()
 
 /mob/living/carbon/human/proc/handle_ghosted()
 	if(player_ghosted > 0 && stat == CONSCIOUS && job && !restrained())
@@ -47,6 +48,12 @@
 			player_ghosted++
 			if(player_ghosted % 150 == 0)
 				force_cryo_human(src)
+
+/mob/living/carbon/human/proc/handle_ssd()
+	if(player_logged > 0 && config.auto_cryo_ssd_mins && stat != DEAD && job)
+		player_logged++
+		if((player_logged >= (config.auto_cryo_ssd_mins * 30)) && player_logged % 30 == 0)
+			cryo_ssd(src)
 
 /mob/living/carbon/human/calculate_affecting_pressure(var/pressure)
 	..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -52,8 +52,16 @@
 /mob/living/carbon/human/proc/handle_ssd()
 	if(player_logged > 0 && config.auto_cryo_ssd_mins && stat != DEAD && job)
 		player_logged++
+		if(istype(loc, /obj/machinery/cryopod))
+			return
 		if((player_logged >= (config.auto_cryo_ssd_mins * 30)) && player_logged % 30 == 0)
+			var/turf/T = get_turf(src)
+			if(!is_station_level(T.z))
+				return
+			var/area/A = get_area(src)
 			cryo_ssd(src)
+			if(A.fast_despawn)
+				force_cryo_human(src)
 
 /mob/living/carbon/human/calculate_affecting_pressure(var/pressure)
 	..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -60,7 +60,7 @@
 				return
 			var/area/A = get_area(src)
 			if(cryo_ssd(src))
-				var/obj/effect/portal/P = new /obj/effect/portal(T, null, null, 100)
+				var/obj/effect/portal/P = new /obj/effect/portal(T, null, null, 40)
 				P.name = "NT SSD Teleportation Portal"
 			if(A.fast_despawn)
 				force_cryo_human(src)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -59,7 +59,9 @@
 			if(!is_station_level(T.z))
 				return
 			var/area/A = get_area(src)
-			cryo_ssd(src)
+			if(cryo_ssd(src))
+				var/obj/effect/portal/P = new /obj/effect/portal(T, null, null, 100)
+				P.name = "NT SSD Teleportation Portal"
 			if(A.fast_despawn)
 				force_cryo_human(src)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -901,13 +901,18 @@ var/list/slot_equipment_priority = list( \
 /mob/MouseDrop(mob/M as mob)
 	..()
 	if(M != usr) return
-	if(isliving(M)) // Ewww
+	if(isliving(M))
 		var/mob/living/L = M
 		if(L.mob_size <= MOB_SIZE_SMALL)
 			return // Stops pAI drones and small mobs (borers, parrots, crabs) from stripping people. --DZD
-	if(!M.can_strip) return
-	if(usr == src) return
-	if(!Adjacent(usr)) return
+	if(!M.can_strip)
+		return
+	if(usr == src)
+		return
+	if(!Adjacent(usr))
+		return
+	if(isLivingSSD(src) && M.client && M.client.send_ssd_warning(src))
+		return
 	show_inv(usr)
 
 /mob/proc/can_use_hands()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -253,6 +253,9 @@ ASSISTANT_RATIO 2
 # Mins before SSD crew are cryoed.
 AUTO_CRYO_SSD_MINS 15
 
+# If enabled, prevents people interacting with SSD players unless they acknowledge they have read the server rules.
+SSD_WARNING
+
 ## Remove the # to make rounds which end instantly (Rev, Wizard, Malf) to continue until the shuttle is called or the station is nuked.
 ## Malf and Rev will let the shuttle be called when the antags/protags are dead.
 #CONTINUOUS_ROUNDS

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -250,6 +250,9 @@ ASSISTANT_LIMIT
 ## If you enabled assistant limiting set the ratio of assistants to security members default is 2 assistants to 1 officer
 ASSISTANT_RATIO 2
 
+# Mins before SSD crew are cryoed.
+AUTO_CRYO_SSD_MINS 15
+
 ## Remove the # to make rounds which end instantly (Rev, Wizard, Malf) to continue until the shuttle is called or the station is nuked.
 ## Malf and Rev will let the shuttle be called when the antags/protags are dead.
 #CONTINUOUS_ROUNDS


### PR DESCRIPTION
:cl: Kyep
add: Added a config file option which allows SSD crew members to be moved to cryo after a defined amount of minutes.
add: Added a config file option which causes most people trying to attack/loot/interact with a SSD character to need to confirm they've read the rules before being able to do so.
/:cl:

**1st feature: moving SSDs to cryo**

Example:
- Config option is set to 15 minutes
- Someone who remains alive but SSD for 15 minutes in a row is moved to cryo. They are not despawned immediately - that requires the additional full cryo timer.
- Since the minutes have to be uninterrupted, someone who reconnects after, say, 10 minutes, then goes SSD for another 10 still won't be moved, because the timer was interrupted and reset back to 15.
- Dead SSDs are not eligible, so if someone died and then ghosted, their mob will NEVER be moved.
- Non-crew are not eligible, so you will never get messages about nuke-ops going to cryo.
- Non-humans are not eligible, so cyborgs/etc are unaffected.

Why this is a good idea:
- Admins already send people to cryo after 10-20 minutes using manual tools. This simply automates that process.
- We do want SSD people to be cryo'ed in a reasonable amount of time. While they're not cryoed they're still taking job slots, serving as un-attackable objective targets, and so on. This is especially important as in future, we will likely add a population cap for civilian job slots, to act as a sort of population cap for the server. So, we need people, even civilians, to be moved to cryo reliably.
- Relying on crew to drag people to cryo simply doesn't work - the playerbase as a whole doesn't do it. Relying on admins to do it manually results in a LOT of unnecessary checking and manual fiddling. An automated solution is better.

Some questions I know I will get:
- What happens if someone's internet dies for 45 minutes? They end up as a ghost, they ahelp it, and we use "send back to lobby" to let them rejoin if they want. I'd much rather deal with the rare case where someone's internet dies for 45m early in the round and they want to rejoin, than deal with the literally dozens of cases EVERY ROUND where people go SSD and we end up manually moving them each and every time.
- What happens if it tries to send someone to cryo, but all cryopods are full? It will try again every minute until it succeeds.
- What if they're ALREADY in a cryopod? Will it move them between pods? No, silly.
- What if they're in perma? Can they disconnect for 45 minutes and be moved out of perma? No. Permabrig, brig cells and solitary have an exception. People who SSD in these places get completely despawned when they reach the timer, rather than just being put in cryo.
- What if they're off-station? SSD people offstation are ignored.
- How do the people nearby know what happened to the SSD person? When someone is moved by this system, it creates a temporary bluespace portal effect on the turf they were moved from. This blue portal effect is named "NT SSD Teleportation Portal" and lasts for 4 seconds. Nobody else can enter it (trying will make it disappear). It looks the same as portals generated from other NT teleportation tech, such as the hand tele.

**2nd feature: confirmation to interact with SSDs**

How it works when enabled in config:
- A player who tries to attack or loot a SSD character gets the message "_Interacting with SSD players is against server rules unless you've ahelped first for permission. If you have, [confirm that] and proceed._" in their chat box. Once they click the '_confirm that_' link, they can then attack/loot SSDs as normal for the rest of the round.
- If someone drops SSD while you're fighting them, the protection won't slow you down, as it does not kick in until 60 seconds after they go SSD. 
- Overall, this provides a speed bump so that new players won't accidentally break the rules by attacking a SSD without even realizing its something they shouldn't do.
- If they're determined to mess with SSDs, even after being informed its against the rules, then this system can still help because the admins don't need to spend time telling them its against the rules (the notice already told them). So, even if someone's determined to break the rules, at least this system can save the admins some time.