### PR TITLE
Adds combined sensor augmentation option to silicons

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -244,7 +244,7 @@
 
 
 /mob/living/silicon/proc/toggle_sensor_mode()
-	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Diagnostic","Disable")
+	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Diagnostic","Combined","Disable")
 	remove_med_sec_hud()
 	switch(sensor_type)
 		if("Security")
@@ -256,6 +256,11 @@
 		if("Diagnostic")
 			add_diag_hud()
 			to_chat(src, "<span class='notice'>Robotics diagnostic overlay enabled.</span>")
+		if("Combined")
+			add_sec_hud()
+			add_med_hud()
+			add_diag_hud()
+			to_chat(src, "<span class='notice'>Combined overlay enabled.</span>")
 		if("Disable")
 			to_chat(src, "Sensor augmentations disabled.")
 


### PR DESCRIPTION
**What does this PR do:**
This PR adds a new sensor augmentation option to silicons (AI, cyborgs), called combined.

Currently, silicions have three options when choosing their sensor augmentation - Security, Medical or Diagnostic. Combined has all these in one. 

Advantage of the combined option is that you have all information you may possible need on screen. Disadvantage is that you truly have ALL the information on the screen, which might end up cluttering your screen a bit, getting less clear. It's up to the individual AI/cyborg preference if he wants to have all the information on the screen at once, or that he would rather switch between them as needed.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Added combined sensor augmentation option to silicons
/:cl: