### PR TITLE
Remove infinite claw sharpening with whetstones

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -201,7 +201,7 @@
 	increment = 5
 	max = 40
 	prefix = "darkened"
-	claw_damage_increase = 2
+	claw_damage_increase = 4
 
 /obj/item/whetstone/cult/update_icon()
 	icon_state = "cult_sharpener[used ? "_used" : ""]"

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -10,7 +10,7 @@
 	var/max = 30
 	var/prefix = "sharpened"
 	var/requires_sharpness = 1
-	var/claw_damage_increase = 1
+	var/claw_damage_increase = 2
 
 
 /obj/item/whetstone/attackby(obj/item/I, mob/user, params)
@@ -58,13 +58,18 @@
 		var/mob/living/carbon/human/H = user
 		var/datum/unarmed_attack/attack = H.dna.species.unarmed
 		if(istype(attack, /datum/unarmed_attack/claws))
-			attack.damage += claw_damage_increase
-			H.visible_message("<span class='notice'>[H] sharpens [H.p_their()] claws on [src]!</span>", "<span class='notice'>You sharpen your claws on [src].</span>")
-			playsound(get_turf(H), usesound, 50, 1)
-			name = "worn out [name]"
-			desc = "[desc] At least, it used to."
-			used = TRUE
-			update_icon()
+			var/datum/unarmed_attack/claws/C = attack
+			if(!C.has_been_sharpened)
+				C.has_been_sharpened = TRUE
+				attack.damage += claw_damage_increase
+				H.visible_message("<span class='notice'>[H] sharpens [H.p_their()] claws on [src]!</span>", "<span class='notice'>You sharpen your claws on [src].</span>")
+				playsound(get_turf(H), usesound, 50, 1)
+				name = "worn out [name]"
+				desc = "[desc] At least, it used to."
+				used = TRUE
+				update_icon()
+			else
+				to_chat(user, "<span class='warning'>You can not sharpen your claws any further!</span>")
 
 /obj/item/whetstone/super
 	name = "super whetstone block"

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -521,6 +521,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	sharp = TRUE
 	animation_type = ATTACK_EFFECT_CLAW
+	var/has_been_sharpened = FALSE
 
 /datum/unarmed_attack/bite
 	attack_verb = list("chomp")


### PR DESCRIPTION
**What does this PR do:**
Currently, certain species can use whetstones to infinitely sharpen their claws. This means that claws can literally become a one-hit-kill weapon. With this change, claws can only be sharpened once. To compensate, regular whetstones now add two damage instead of one and cult whetstones now add four damage instead of two (subject to change).

**Changelog:**
:cl: Markolie
balance: Claws can now only be sharpened using whetstones once.
/:cl:

