### PR TITLE
Makes the crit cure texts clearer

### DIFF
--- a/code/datums/diseases/critical.dm
+++ b/code/datums/diseases/critical.dm
@@ -19,7 +19,7 @@
 	spread_text = "The patient is in shock"
 	max_stages = 3
 	spread_flags = SPECIAL
-	cure_text = "Saline Solution"
+	cure_text = "Saline-Glucose Solution"
 	cures = list("salglu_solution")
 	cure_chance = 10
 	viable_mobtypes = list(/mob/living/carbon/human)
@@ -80,7 +80,7 @@
 	spread_text = "The patient is having a cardiac emergency"
 	max_stages = 3
 	spread_flags = SPECIAL
-	cure_text = "Cardiac Stimulants"
+	cure_text = "Atropine or Epinephrine"
 	cures = list("atropine", "epinephrine")
 	cure_chance = 10
 	needs_all_cures = FALSE


### PR DESCRIPTION
**What does this PR do:**
Changes the cure text from Shock and for Cardiac Failure to be more clear.

**Changelog:**
:cl:
tweak: Cure text for Shock and Cardiac failure are more clear now
/:cl:

