### PR TITLE
Fixes the tape gag still being there. Invinsible

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -99,12 +99,14 @@
 		)
 
 /obj/item/clothing/mask/muzzle/tapegag/dropped(mob/user)
-	var/obj/item/trash/tapetrash/TT = new(drop_location(src))
+	var/obj/item/trash/tapetrash/TT = new
 	transfer_fingerprints_to(TT)
 	user.transfer_fingerprints_to(TT)
+	user.put_in_active_hand(TT)
 	playsound(src, 'sound/items/poster_ripped.ogg', 40, 1)
 	..()
 	user.emote("scream")
+	qdel(src)
 
 /obj/item/clothing/mask/muzzle/safety
 	name = "safety muzzle"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -104,9 +104,8 @@
 	user.transfer_fingerprints_to(TT)
 	user.put_in_active_hand(TT)
 	playsound(src, 'sound/items/poster_ripped.ogg', 40, 1)
-	..()
 	user.emote("scream")
-	qdel(src)
+	..()
 
 /obj/item/clothing/mask/muzzle/safety
 	name = "safety muzzle"


### PR DESCRIPTION
**What does this PR do:**
Forces the trash into your hand when you remove the ducttape gag. Forcing your active hand to be cleared of the qdelled ducttape gag. 

Fixes: #9743
Fixes: #11272

**Changelog:**
:cl:
fix: Ducttape gags can now be removed properly without spawning an invisible one in your hands
/:cl:

