### PR TITLE
Fixes shuttles leaving behind their propulsion

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -80,7 +80,7 @@
 	icon_state = "burst_r";
 	tag = "icon-burst_r (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aal" = (
 /turf/simulated/shuttle/wall{
@@ -128,7 +128,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aar" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -136,7 +136,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aas" = (
 /turf/simulated/shuttle/floor{
@@ -260,7 +260,7 @@
 	icon_state = "burst_l";
 	tag = "icon-burst_l (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aaK" = (
 /obj/structure/window/full/shuttle{
@@ -1021,7 +1021,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "acx" = (
 /obj/structure/closet/syndicate/suits,
@@ -1048,7 +1048,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/administration)
 "acB" = (
 /turf/space,
@@ -1795,7 +1795,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/arrival/station)
 "aef" = (
 /obj/machinery/door/airlock/external{
@@ -2782,7 +2782,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "afW" = (
 /obj/structure/computerframe,
@@ -2921,7 +2921,7 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/arrival/station)
 "agl" = (
 /turf/space,
@@ -2998,18 +2998,18 @@
 	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "ags" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "agt" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion_r";
 	icon_state = "propulsion_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "agu" = (
 /obj/structure/table,
@@ -4162,7 +4162,7 @@
 	dir = 8;
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/specops)
 "aja" = (
 /turf/simulated/shuttle/wall{
@@ -4316,7 +4316,7 @@
 	dir = 8;
 	icon_state = "propulsion"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/specops)
 "ajq" = (
 /obj/structure/window/reinforced{
@@ -5098,7 +5098,7 @@
 	dir = 8;
 	icon_state = "burst_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/specops)
 "akU" = (
 /obj/machinery/door/airlock/external{
@@ -6301,7 +6301,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/vox)
 "anE" = (
 /obj/structure/rack,
@@ -6633,7 +6633,7 @@
 	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/vox)
 "aol" = (
 /obj/structure/rack,
@@ -6889,7 +6889,7 @@
 	icon_state = "propulsion_l";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "aoP" = (
 /obj/docking_port/stationary{
@@ -7279,7 +7279,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "apC" = (
 /turf/space,
@@ -19711,7 +19711,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "aMp" = (
 /turf/space,
@@ -20353,18 +20353,18 @@
 	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "aNA" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "aNB" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-burst_r";
 	icon_state = "burst_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "aNC" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -33123,7 +33123,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/mining)
 "bjX" = (
 /obj/structure/ore_box,
@@ -34129,7 +34129,7 @@
 /area/shuttle/mining)
 "blQ" = (
 /obj/structure/shuttle/engine/propulsion/burst,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/mining)
 "blR" = (
 /turf/space,
@@ -42844,7 +42844,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/siberia)
 "bAM" = (
 /obj/structure/cable{
@@ -44196,7 +44196,7 @@
 /area/shuttle/siberia)
 "bCG" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/siberia)
 "bCH" = (
 /turf/space,
@@ -115065,7 +115065,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "dYf" = (
 /obj/structure/window/reinforced,
@@ -115074,7 +115074,7 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "dYg" = (
 /obj/structure/bed/roller,
@@ -115548,7 +115548,7 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "dYY" = (
 /turf/simulated/shuttle/wall{
@@ -115735,7 +115735,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "dZs" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -115743,7 +115743,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "dZt" = (
 /turf/space,
@@ -115758,7 +115758,7 @@
 	icon_state = "propulsion_l";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "dZv" = (
 /turf/simulated/shuttle/wall{
@@ -115773,7 +115773,7 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "dZx" = (
 /obj/effect/decal/remains/human,

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -921,7 +921,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "abR" = (
 /obj/structure/computerframe,
@@ -1030,18 +1030,18 @@
 	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "acc" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "acd" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion_r";
 	icon_state = "propulsion_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "ace" = (
 /obj/structure/cable,
@@ -5910,7 +5910,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/vox)
 "akr" = (
 /obj/machinery/door/firedoor,
@@ -6466,7 +6466,7 @@
 	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/vox)
 "alm" = (
 /obj/structure/closet/l3closet/security,

--- a/_maps/map_files/MetaStation/z2.dmm
+++ b/_maps/map_files/MetaStation/z2.dmm
@@ -3754,7 +3754,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
-/turf/space/transit,
+/turf/simulated/shuttle/plating,
 /area/wizard_station)
 "kr" = (
 /obj/structure/flora/tree/pine,
@@ -3769,7 +3769,7 @@
 	icon_state = "heater";
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/wizard_station)
 "kt" = (
 /obj/structure/flora/grass/brown,
@@ -4627,14 +4627,14 @@
 	dir = 4;
 	icon_state = "propulsion"
 	},
-/turf/space/transit,
+/turf/simulated/shuttle/plating,
 /area/wizard_station)
 "mP" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/wizard_station)
 "mQ" = (
 /obj/machinery/light{
@@ -5975,7 +5975,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/wizard_station)
 "tq" = (
 /obj/structure/rack,
@@ -6049,7 +6049,7 @@
 /area/centcom/holding)
 "tP" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/space)
 "tQ" = (
 /turf/unsimulated/beach/coastline,

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
@@ -63,7 +63,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/unpowered)
 "m" = (
 /obj/item/shard,

--- a/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -27,7 +27,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered)
 "f" = (
 /obj/structure/window/reinforced{
@@ -38,7 +38,7 @@
 	icon_state = "heater";
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered)
 "g" = (
 /obj/structure/table/wood,

--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -240,7 +240,7 @@
 /area/ruin/powered)
 "R" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered)
 
 (1,1,1) = {"

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -498,7 +498,7 @@
 /area/ruin/unpowered)
 "bG" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/unpowered)
 "bH" = (
 /turf/simulated/wall/mineral/titanium,

--- a/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
+++ b/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
@@ -1499,10 +1499,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel/airless{
-	tag = "icon-engine";
-	icon_state = "engine"
-	},
+/turf/simulated/shuttle/plating,
 /area/awaymission/BMPship/Aft)
 "ec" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -1510,7 +1507,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/BMPship/Aft)
 "ed" = (
 /obj/item/multitool,

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -8170,7 +8170,7 @@
 	icon_state = "burst_r";
 	tag = "icon-burst_r (WEST)"
 	},
-/turf/simulated/floor/plating/airless/asteroid,
+/turf/simulated/shuttle/plating,
 /area/awaycontent/a1{
 	has_gravity = 1;
 	name = "MO19 Arrivals"
@@ -8233,9 +8233,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless{
-	name = "plating"
-	},
+/turf/simulated/shuttle/plating,
 /area/awaycontent/a1{
 	has_gravity = 1;
 	name = "MO19 Arrivals"
@@ -8467,7 +8465,7 @@
 	icon_state = "burst_l";
 	tag = "icon-burst_l (WEST)"
 	},
-/turf/simulated/floor/plating/airless/asteroid,
+/turf/simulated/shuttle/plating,
 /area/awaycontent/a1{
 	has_gravity = 1;
 	name = "MO19 Arrivals"

--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -26,7 +26,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate2)
 "af" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -55,7 +55,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate2)
 "aj" = (
 /turf/simulated/shuttle/floor{
@@ -147,7 +147,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate3)
 "ax" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -155,7 +155,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate3)
 "ay" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -163,7 +163,7 @@
 	icon_state = "propulsion_l";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate3)
 "az" = (
 /turf/space,
@@ -191,7 +191,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate3)
 "aD" = (
 /turf/simulated/shuttle/floor{
@@ -282,7 +282,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate1)
 "aQ" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -290,7 +290,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate1)
 "aR" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -298,7 +298,7 @@
 	icon_state = "propulsion_l";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate1)
 "aS" = (
 /turf/space,
@@ -329,7 +329,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate1)
 "aX" = (
 /obj/structure/window/reinforced,
@@ -1927,6 +1927,17 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
+"gm" = (
+/obj/structure/shuttle/engine/heater{
+	tag = "icon-heater (WEST)";
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/cruiser)
 "gn" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/ammo_casing/a357,
@@ -2090,7 +2101,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate4)
 "gO" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -2162,7 +2173,7 @@
 /area/awaymission/spacebattle/syndicate7)
 "gY" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate4)
 "gZ" = (
 /obj/item/pickaxe,
@@ -2221,15 +2232,15 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate7)
 "hh" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (WEST)";
-	icon_state = "propulsion_r";
-	dir = 8
+	dir = 4;
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate7)
 "hi" = (
 /obj/structure/largecrate,
@@ -2286,14 +2297,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/spacebattle/syndicate7)
-"hq" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (WEST)";
-	icon_state = "propulsion_l";
-	dir = 8
-	},
-/turf/space,
 /area/awaymission/spacebattle/syndicate7)
 "hr" = (
 /obj/structure/largecrate,
@@ -2604,14 +2607,6 @@
 /mob/living/simple_animal/hostile/syndicate/ranged,
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
-"io" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_r (EAST)";
-	icon_state = "burst_r";
-	dir = 4
-	},
-/turf/space,
-/area/awaymission/spacebattle/cruiser)
 "ip" = (
 /obj/effect/mob_spawn/human/engineer{
 	name = "Mercutio"
@@ -2745,11 +2740,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/space)
 "iK" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/space)
 "iL" = (
 /obj/machinery/door/airlock/external,
@@ -2775,11 +2770,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate5)
 "iP" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate5)
 "iQ" = (
 /turf/space,
@@ -2850,11 +2845,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate6)
 "jb" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/spacebattle/syndicate6)
 "jc" = (
 /turf/simulated/floor/plating/airless/asteroid,
@@ -2872,6 +2867,78 @@
 /obj/machinery/door/airlock/plasma,
 /turf/simulated/wall/mineral/plasma,
 /area/awaymission/spacebattle/secret)
+"nG" = (
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	tag = "icon-heater (NORTH)";
+	icon_state = "heater";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/cruiser)
+"qC" = (
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	tag = "icon-heater (NORTH)";
+	icon_state = "heater";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/cruiser)
+"zS" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l (WEST)"
+	},
+/turf/simulated/shuttle/plating,
+/area/space)
+"Jj" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion_l (NORTH)";
+	icon_state = "propulsion_l";
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/syndicate2)
+"Jw" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion_r (NORTH)";
+	icon_state = "propulsion_r";
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/syndicate2)
+"JS" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion_l (NORTH)";
+	icon_state = "propulsion_l";
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/cruiser)
+"JW" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion_r (NORTH)";
+	icon_state = "propulsion_r";
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/cruiser)
+"YV" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "burst_r";
+	tag = "icon-burst_r (EAST)"
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/spacebattle/cruiser)
 
 (1,1,1) = {"
 aa
@@ -21516,15 +21583,15 @@ ab
 ab
 ab
 bP
-bU
-cc
-cc
-cc
-cc
-cc
-cc
-cc
-io
+YV
+YV
+YV
+YV
+YV
+YV
+YV
+YV
+YV
 dq
 ab
 ab
@@ -21773,15 +21840,15 @@ ab
 ab
 ab
 bS
-bV
-bV
-bV
-bV
-bV
-bV
-bV
-bV
-bV
+gm
+gm
+gm
+gm
+gm
+gm
+gm
+gm
+gm
 bQ
 ab
 ab
@@ -36817,7 +36884,7 @@ ab
 ab
 ab
 ab
-ad
+Jw
 ai
 aj
 aj
@@ -40158,7 +40225,7 @@ ab
 ab
 ab
 ab
-af
+Jj
 ai
 aj
 aj
@@ -45948,7 +46015,7 @@ ab
 ab
 ab
 ab
-iq
+zS
 iv
 iv
 iv
@@ -51555,8 +51622,8 @@ ab
 ab
 ab
 ab
-bF
-bK
+JW
+nG
 bN
 bN
 bN
@@ -52326,8 +52393,8 @@ ab
 ab
 ab
 ab
-bH
-bM
+JS
+qC
 bO
 bO
 bO
@@ -64175,12 +64242,12 @@ ab
 ab
 gM
 hh
-hq
+hh
 hz
 ab
 gM
 hh
-hq
+hh
 hz
 ab
 ab

--- a/_maps/map_files/RandomZLevels/spacehotel.dmm
+++ b/_maps/map_files/RandomZLevels/spacehotel.dmm
@@ -4712,14 +4712,14 @@
 	icon_state = "heater";
 	dir = 4
 	},
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission)
 "kV" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
 	icon_state = "propulsion"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission)
 "kW" = (
 /turf/simulated/shuttle/wall{
@@ -4740,7 +4740,7 @@
 	dir = 4;
 	icon_state = "propulsion"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/space)
 "la" = (
 /obj/structure/chair{

--- a/_maps/map_files/RandomZLevels/stationCollision.dmm
+++ b/_maps/map_files/RandomZLevels/stationCollision.dmm
@@ -173,11 +173,11 @@
 /area/awaymission/northblock)
 "aI" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l (EAST)";
+	dir = 8;
 	icon_state = "burst_l";
-	dir = 4
+	tag = "icon-burst_l (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/syndishuttle)
 "aJ" = (
 /turf/simulated/floor/plating/airless,
@@ -197,14 +197,6 @@
 /obj/machinery/mecha_part_fabricator/robot,
 /turf/simulated/floor/plasteel,
 /area/awaymission/northblock)
-"aO" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (EAST)";
-	icon_state = "propulsion_r";
-	dir = 4
-	},
-/turf/space,
-/area/awaymission/syndishuttle)
 "aP" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (WEST)";
@@ -278,16 +270,6 @@
 	icon_state = "floorscorched2"
 	},
 /area/awaymission/northblock)
-"bd" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l (EAST)";
-	icon_state = "burst_l";
-	dir = 4
-	},
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/awaymission/syndishuttle)
 "be" = (
 /obj/structure/shuttle/engine/heater,
 /turf/simulated/shuttle/plating,
@@ -349,16 +331,6 @@
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/northblock)
-"bo" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (EAST)";
-	icon_state = "propulsion";
-	dir = 4
-	},
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/awaymission/syndishuttle)
 "bp" = (
 /obj/structure/shuttle/engine/router,
 /turf/simulated/shuttle/plating,
@@ -554,16 +526,6 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/grass,
 /area/awaymission/research)
-"bU" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_r (EAST)";
-	icon_state = "burst_r";
-	dir = 4
-	},
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/awaymission/syndishuttle)
 "bV" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
@@ -775,11 +737,11 @@
 /area/awaymission/research)
 "cy" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (EAST)";
-	icon_state = "propulsion";
-	dir = 4
+	dir = 8;
+	icon_state = "burst_l";
+	tag = "icon-burst_l (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/research)
 "cz" = (
 /obj/structure/shuttle/engine/heater{
@@ -794,7 +756,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/research)
 "cA" = (
 /turf/simulated/floor/plasteel{
@@ -807,14 +769,6 @@
 	icon_state = "dark"
 	},
 /area/awaymission/research)
-"cC" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (EAST)";
-	icon_state = "propulsion_l";
-	dir = 4
-	},
-/turf/space,
-/area/awaymission/syndishuttle)
 "cD" = (
 /turf/simulated/floor/plating/airless,
 /turf/simulated/shuttle/wall{
@@ -885,7 +839,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/research)
 "cL" = (
 /obj/effect/decal/remains/human{
@@ -1763,7 +1717,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/research)
 "eI" = (
 /obj/structure/window/reinforced{
@@ -3581,14 +3535,14 @@
 	icon_state = "propulsion_r"
 	},
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/arrivalblock)
 "je" = (
 /turf/space,
 /area/awaymission/arrivalblock)
 "jf" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/arrivalblock)
 "jg" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -3604,7 +3558,7 @@
 	icon_state = "propulsion_l"
 	},
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/arrivalblock)
 "jh" = (
 /obj/structure/cable{
@@ -4038,7 +3992,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/awaymission/arrivalblock)
 "km" = (
 /obj/structure/window/reinforced,
@@ -4138,7 +4092,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/arrivalblock)
 "kB" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -4147,7 +4101,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/awaymission/arrivalblock)
 "kC" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -4737,11 +4691,11 @@ aa
 aa
 aC
 aC
-bd
-bo
-bo
-bo
-bU
+aI
+aI
+aI
+aI
+aI
 aC
 aC
 aa
@@ -5461,7 +5415,7 @@ aa
 aa
 aC
 aI
-aO
+aI
 aC
 er
 eK
@@ -5469,7 +5423,7 @@ eK
 ff
 ff
 aC
-cC
+aI
 aK
 aC
 af
@@ -5535,7 +5489,7 @@ eK
 eX
 eX
 aC
-aP
+bq
 aJ
 af
 aj

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -84,7 +84,7 @@
 	icon_state = "burst_r";
 	tag = "icon-burst_r (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aam" = (
 /turf/simulated/shuttle/wall{
@@ -129,7 +129,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aas" = (
 /obj/structure/shuttle/engine/heater{
@@ -140,7 +140,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aat" = (
 /turf/simulated/shuttle/floor{
@@ -270,7 +270,7 @@
 	icon_state = "burst_l";
 	tag = "icon-burst_l (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/abandoned)
 "aaM" = (
 /turf/simulated/shuttle/floor{
@@ -3970,7 +3970,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "ahz" = (
 /obj/structure/computerframe,
@@ -4125,18 +4125,18 @@
 	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "ahO" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "ahP" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion_r";
 	icon_state = "propulsion_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
 "ahQ" = (
 /obj/machinery/alarm{
@@ -5582,7 +5582,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/vox)
 "ajZ" = (
 /obj/structure/rack,
@@ -5833,7 +5833,7 @@
 	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/vox)
 "akq" = (
 /obj/structure/rack,
@@ -9292,7 +9292,7 @@
 	dir = 8;
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/trade/sol)
 "aqg" = (
 /obj/machinery/light/spot{
@@ -9825,7 +9825,7 @@
 	dir = 8;
 	icon_state = "propulsion"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/trade/sol)
 "are" = (
 /obj/machinery/door/poddoor{
@@ -10418,7 +10418,7 @@
 	dir = 8;
 	icon_state = "burst_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/trade/sol)
 "arW" = (
 /obj/structure/chair{
@@ -13480,7 +13480,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "awq" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -13488,7 +13488,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "awr" = (
 /turf/space,
@@ -13503,7 +13503,7 @@
 	icon_state = "propulsion_l";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "awt" = (
 /turf/space,
@@ -13518,7 +13518,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "awv" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -13526,7 +13526,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "aww" = (
 /turf/space,
@@ -13541,7 +13541,7 @@
 	icon_state = "propulsion_l";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "awy" = (
 /obj/machinery/mineral/labor_claim_console{
@@ -13937,7 +13937,7 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "axk" = (
 /turf/simulated/shuttle/wall{
@@ -13952,7 +13952,7 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "axm" = (
 /obj/structure/chair{
@@ -15266,7 +15266,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/siberia)
 "azl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -15845,7 +15845,7 @@
 /area/shuttle/siberia)
 "aAk" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/siberia)
 "aAl" = (
 /obj/machinery/door/airlock/external{
@@ -27276,7 +27276,7 @@
 	dir = 4;
 	icon_state = "burst_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/arrival/station)
 "aXo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -28162,7 +28162,7 @@
 	dir = 4;
 	icon_state = "propulsion"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/arrival/station)
 "aYU" = (
 /obj/structure/grille,
@@ -28177,7 +28177,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/arrival/station)
 "aYW" = (
 /obj/structure/cable{
@@ -31158,7 +31158,7 @@
 	dir = 4;
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/arrival/station)
 "bez" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -42691,7 +42691,7 @@
 	dir = 8;
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/specops)
 "bAR" = (
 /turf/simulated/shuttle/wall{
@@ -43235,7 +43235,7 @@
 	dir = 8;
 	icon_state = "propulsion"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/specops)
 "bCb" = (
 /turf/simulated/shuttle/floor{
@@ -45680,7 +45680,7 @@
 	dir = 8;
 	icon_state = "burst_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/specops)
 "bGQ" = (
 /obj/machinery/mineral/stacking_unit_console{
@@ -46512,7 +46512,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bIv" = (
 /obj/structure/table,
@@ -46552,7 +46552,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bIy" = (
 /obj/item/radio/intercom{
@@ -47566,7 +47566,7 @@
 /area/maintenance/asmaint2)
 "bKm" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bKn" = (
 /obj/machinery/shower{
@@ -55155,7 +55155,7 @@
 	icon_state = "propulsion_l";
 	tag = "icon-propulsion_l (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/administration)
 "bWP" = (
 /obj/machinery/door/airlock/external{
@@ -56137,7 +56137,7 @@
 	icon_state = "propulsion_r";
 	tag = "icon-propulsion_r (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/administration)
 "bYv" = (
 /turf/space,
@@ -59551,7 +59551,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "cdv" = (
 /turf/space,
@@ -60302,21 +60302,21 @@
 /area/shuttle/administration)
 "ceU" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "ceV" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "ceW" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-burst_r";
 	icon_state = "burst_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "ceX" = (
 /turf/space,
@@ -65216,7 +65216,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/mining)
 "cnj" = (
 /obj/structure/ore_box,
@@ -66158,7 +66158,7 @@
 /area/blueshield)
 "coN" = (
 /obj/structure/shuttle/engine/propulsion/burst,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/mining)
 "coO" = (
 /turf/space,
@@ -90899,12 +90899,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dgD" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	tag = "icon-propulsion (EAST)";
-	icon_state = "propulsion";
-	dir = 4
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l (EAST)"
 	},
+/turf/simulated/shuttle/plating,
 /area/shuttle/constructionsite)
 "dgE" = (
 /obj/machinery/power/grounding_rod{

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -7143,7 +7143,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/centcom/evac)
 "rK" = (
 /turf/unsimulated/wall/splashscreen,
@@ -7154,7 +7154,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/centcom/evac)
 "rM" = (
 /turf/simulated/shuttle/wall{
@@ -7169,7 +7169,7 @@
 	icon_state = "propulsion_l";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/centcom/evac)
 "rO" = (
 /obj/docking_port/stationary{
@@ -7207,7 +7207,7 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/centcom/evac)
 "rS" = (
 /turf/simulated/shuttle/wall{

--- a/_maps/map_files/cyberiad/z3.dmm
+++ b/_maps/map_files/cyberiad/z3.dmm
@@ -425,14 +425,14 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/freegolem)
 "aW" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
+	dir = 4;
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/freegolem)
 "aX" = (
 /obj/machinery/light/small,

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -5391,7 +5391,7 @@
 	icon_state = "propulsion_r";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/space)
 "lu" = (
 /turf/space,
@@ -5414,7 +5414,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/space)
 "lx" = (
 /turf/space,
@@ -5839,7 +5839,7 @@
 	icon_state = "burst_r";
 	tag = "icon-burst_r (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/space)
 "mG" = (
 /obj/structure/shuttle/engine/heater{
@@ -5850,7 +5850,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/space)
 "mH" = (
 /turf/simulated/mineral,
@@ -6004,7 +6004,7 @@
 	icon_state = "propulsion_l";
 	tag = "icon-propulsion_l (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/space)
 "nf" = (
 /obj/effect/spawner/random_spawners/syndicate/trap/mine,
@@ -6092,7 +6092,7 @@
 	icon_state = "propulsion_l";
 	tag = "icon-propulsion_l (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/space)
 "nr" = (
 /obj/effect/decal/warning_stripes/red,

--- a/_maps/map_files/shuttles/cargo_base.dmm
+++ b/_maps/map_files/shuttles/cargo_base.dmm
@@ -159,7 +159,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "u" = (
 /turf/space,
@@ -177,18 +177,18 @@
 	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "x" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "y" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-burst_r";
 	icon_state = "burst_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 
 (1,1,1) = {"

--- a/_maps/map_files/shuttles/emergency_bar.dmm
+++ b/_maps/map_files/shuttles/emergency_bar.dmm
@@ -642,7 +642,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bH" = (
 /turf/simulated/shuttle/wall{
@@ -661,7 +661,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bK" = (
 /turf/space,
@@ -672,7 +672,7 @@
 /area/shuttle/escape)
 "bL" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"

--- a/_maps/map_files/shuttles/emergency_clown.dmm
+++ b/_maps/map_files/shuttles/emergency_clown.dmm
@@ -505,7 +505,7 @@
 /obj/structure/window/reinforced,
 /obj/item/stack/sheet/mineral/bananium,
 /obj/item/bikehorn/rubberducky,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bp" = (
 /turf/simulated/shuttle/wall{
@@ -527,7 +527,7 @@
 /obj/structure/window/reinforced,
 /obj/item/stack/sheet/mineral/bananium,
 /obj/item/bikehorn/rubberducky,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bs" = (
 /turf/space,
@@ -538,7 +538,7 @@
 /area/shuttle/escape)
 "bt" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"

--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -162,7 +162,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "A" = (
 /turf/simulated/shuttle/wall{
@@ -175,14 +175,14 @@
 	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "C" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion_r";
 	icon_state = "propulsion_r"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "D" = (
 /turf/simulated/shuttle/wall{

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -543,7 +543,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bs" = (
 /turf/simulated/shuttle/wall{
@@ -562,7 +562,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bv" = (
 /turf/space,
@@ -573,7 +573,7 @@
 /area/shuttle/escape)
 "bw" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"

--- a/_maps/map_files/shuttles/emergency_dept.dmm
+++ b/_maps/map_files/shuttles/emergency_dept.dmm
@@ -743,14 +743,14 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bR" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bS" = (
 /turf/space,
@@ -761,7 +761,7 @@
 /area/shuttle/escape)
 "bT" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bU" = (
 /turf/space,

--- a/_maps/map_files/shuttles/emergency_mil.dmm
+++ b/_maps/map_files/shuttles/emergency_mil.dmm
@@ -559,14 +559,14 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bv" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bw" = (
 /turf/space,
@@ -577,7 +577,7 @@
 /area/shuttle/escape)
 "bx" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "by" = (
 /turf/simulated/floor/plating/airless,

--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -410,7 +410,7 @@
 	},
 /obj/structure/shuttle/engine/heater,
 /obj/structure/cult/forge,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bi" = (
 /obj/structure/shuttle/engine/heater,
@@ -418,11 +418,11 @@
 	dir = 1
 	},
 /obj/structure/cult/forge,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bj" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"

--- a/_maps/map_files/shuttles/emergency_old.dmm
+++ b/_maps/map_files/shuttles/emergency_old.dmm
@@ -472,7 +472,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bk" = (
 /turf/simulated/shuttle/wall{
@@ -485,7 +485,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bn" = (
 /turf/space,
@@ -496,7 +496,7 @@
 /area/shuttle/escape)
 "bo" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"

--- a/_maps/map_files/templates/medium_shuttle1.dmm
+++ b/_maps/map_files/templates/medium_shuttle1.dmm
@@ -8,7 +8,7 @@
 	icon_state = "burst_l";
 	tag = "icon-burst_l (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -23,7 +23,7 @@
 	icon_state = "rwindow";
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -218,7 +218,7 @@
 	icon_state = "burst_r";
 	tag = "icon-burst_r (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})

--- a/_maps/map_files/templates/medium_shuttle2.dmm
+++ b/_maps/map_files/templates/medium_shuttle2.dmm
@@ -8,7 +8,7 @@
 	icon_state = "burst_l";
 	tag = "icon-burst_l (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -23,7 +23,7 @@
 	icon_state = "rwindow";
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -52,7 +52,7 @@
 	icon_state = "burst_r";
 	tag = "icon-burst_r (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})

--- a/_maps/map_files/templates/medium_shuttle3.dmm
+++ b/_maps/map_files/templates/medium_shuttle3.dmm
@@ -8,7 +8,7 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -26,7 +26,7 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -103,7 +103,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -113,7 +113,7 @@
 	icon_state = "heater";
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -129,7 +129,7 @@
 	icon_state = "heater";
 	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -139,7 +139,7 @@
 	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
@@ -262,13 +262,13 @@
 	})
 "F" = (
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})
 "G" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered{
 	name = "Shuttle"
 	})

--- a/_maps/map_files/templates/small_shuttle_1.dmm
+++ b/_maps/map_files/templates/small_shuttle_1.dmm
@@ -46,11 +46,11 @@
 /area/ruin/powered)
 "j" = (
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered)
 "k" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered)
 "l" = (
 /turf/simulated/shuttle/wall{
@@ -75,7 +75,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_l"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered)
 "p" = (
 /turf/simulated/shuttle/wall{
@@ -124,7 +124,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_r"
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/shuttle/plating,
 /area/ruin/powered)
 
 (1,1,1) = {"


### PR DESCRIPTION
**What does this PR do:**
A lot of shuttles were leaving behind their propulsion when jumping, because the propulsion had no turfs underneath it. I've gone through all the maps to make sure all propulsions are facing the right way and that they all have shuttle plating underneath them. I've also made sure existing propulsions and heaters with plating use /turf/simulated/shuttle/plating: they shouldn't use airless plating as that causes issues when they land on non-space. This doesn't really affect anything though, as heaters and engines are dense and don't let atmos pass through.

**Changelog:**
:cl: Markolie
fix: Shuttles no longer leave behind their propulsion.
/:cl:

