### PR TITLE
Admins can now see the mhelp tickets

### DIFF
--- a/code/controllers/subsystem/tickets/mentor_tickets.dm
+++ b/code/controllers/subsystem/tickets/mentor_tickets.dm
@@ -9,7 +9,7 @@ GLOBAL_REAL(SSmentor_tickets, /datum/controller/subsystem/tickets/mentor_tickets
 	ticket_system_name = "Mentor Tickets"
 	ticket_name = "Mentor Ticket"
 	span_text = "<span class='mentorhelp'>"
-	close_rights = R_MENTOR
+	close_rights = R_MENTOR | R_ADMIN
 
 /datum/controller/subsystem/tickets/mentor_tickets/message_staff(var/msg)
 	message_mentorTicket(msg)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -224,6 +224,8 @@ var/list/admin_verbs_snpc = list(
 var/list/admin_verbs_ticket = list(
 	/client/proc/openAdminTicketUI,
 	/client/proc/toggleticketlogs,
+	/client/proc/openMentorTicketUI,
+	/client/proc/toggleMentorTicketLogs,
 	/client/proc/resolveAllAdminTickets,
 	/client/proc/resolveAllMentorTickets
 )
@@ -944,10 +946,10 @@ var/list/admin_verbs_ticket = list(
 		to_chat(usr, "You now will get admin log messages.")
 
 /client/proc/toggleMentorTicketLogs()
-	set name = "Toggle Mentor Ticket Messgaes"
+	set name = "Toggle Mentor Ticket Messages"
 	set category = "Preferences"
 
-	if(!check_rights(R_MENTOR))
+	if(!check_rights(R_MENTOR|R_ADMIN))
 		return
 
 	prefs.toggles ^= CHAT_NO_MENTORTICKETLOGS

--- a/code/modules/admin/tickets/mentorticketsverbs.dm
+++ b/code/modules/admin/tickets/mentorticketsverbs.dm
@@ -5,7 +5,7 @@
 	set name = "Open Mentor Ticket Interface"
 	set category = "Admin"
 
-	if(!holder || !check_rights(R_MENTOR))
+	if(!holder || !check_rights(R_MENTOR|R_ADMIN))
 		return
 
 	SSmentor_tickets.showUI(usr)


### PR DESCRIPTION
**What does this PR do:**
Fixes: #11322
And fixes a small typo

**Changelog:**
:cl:
fix: Admins can now use all mhelp related things again
spellcheck: Fixed the toggle mentor ticket messages text
/:cl:

