### PR TITLE
Adds cancel button to Wizard teleportation scrolls

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -47,7 +47,11 @@
 
 	var/A
 
-	A = input(user, "Area to jump to", "BOOYEA", A) in teleportlocs
+	A = input(user, "Area to jump to", "BOOYEA", A) as null|anything in teleportlocs
+
+	if(!A)
+		return
+	
 	var/area/thearea = teleportlocs[A]
 
 	if(user.stat || user.restrained())


### PR DESCRIPTION
**What does this PR do:**
This PR adds cancel button to the Wizard teleportation scrolls, so Wizards can easily get rid of the teleportation menu pop-up if they have changed their mind about teleporting.

Tested locally without any issue.

**Images of sprite/map changes (IF APPLICABLE):**
![ScrollCancel](https://user-images.githubusercontent.com/43862960/56427890-c7af3480-62bd-11e9-9ace-31ce6b36c755.png)

**Changelog:**
:cl: Arkatos
add: Added cancel button to Wizard teleportation scrolls
/:cl: