### PR TITLE
Adds an option to grant Martial Arts via Var menu

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -635,7 +635,7 @@
 			var/datum/martial_art/M = i
 			artnames[initial(M.name)] = M
 
-		var/result = input(usr, "Choose the martial art to teach","JUDO CHOP") as null|anything in artnames
+		var/result = input(usr, "Choose the martial art to teach", "JUDO CHOP") as null|anything in artnames
 		if(!usr)
 			return
 		if(QDELETED(C))

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -621,6 +621,33 @@
 		src.give_spell(M)
 		href_list["datumrefresh"] = href_list["give_spell"]
 
+	else if(href_list["givemartialart"])
+		if(!check_rights(R_SERVER|R_EVENT))	return
+
+		var/mob/living/carbon/C = locateUID(href_list["givemartialart"])
+		if(!istype(C))
+			to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
+			return
+
+		var/list/artpaths = subtypesof(/datum/martial_art)
+		var/list/artnames = list()
+		for(var/i in artpaths)
+			var/datum/martial_art/M = i
+			artnames[initial(M.name)] = M
+
+		var/result = input(usr, "Choose the martial art to teach","JUDO CHOP") as null|anything in artnames
+		if(!usr)
+			return
+		if(QDELETED(C))
+			to_chat(usr, "Mob doesn't exist anymore")
+			return
+
+		if(result)
+			var/chosenart = artnames[result]
+			var/datum/martial_art/MA = new chosenart
+			MA.teach(C)
+
+		href_list["datumrefresh"] = href_list["givemartialart"]
 
 	else if(href_list["give_disease"])
 		if(!check_rights(R_SERVER|R_EVENT))	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1299,6 +1299,7 @@ var/list/slot_equipment_priority = list( \
 	.["Show player panel"] = "?_src_=vars;mob_player_panel=[UID()]"
 
 	.["Give Spell"] = "?_src_=vars;give_spell=[UID()]"
+	.["Give Martial Art"] = "?_src_=vars;givemartialart=[UID()]"
 	.["Give Disease"] = "?_src_=vars;give_disease=[UID()]"
 	.["Toggle Godmode"] = "?_src_=vars;godmode=[UID()]"
 	.["Toggle Build Mode"] = "?_src_=vars;build_mode=[UID()]"


### PR DESCRIPTION
**What does this PR do:**
This PR adds an option to grant any possible Martial Art via administrative Variable menu. Could come very handy in custom events. Keep in mind that it will only work on mob/carbons.

Ported from /tg/station13.

Tested locally without any issue.

**Images of sprite/map changes (IF APPLICABLE):**
![MartialArtVar](https://user-images.githubusercontent.com/43862960/56429727-3db69a00-62c4-11e9-895b-ee634a47ae1a.png)

**Changelog:**
:cl: Arkatos
add: Added an option to grant Martial Arts via administrative Var menu
/:cl: