### PR TITLE
Toggling hardhat light on/off now correctly updates wearer's sprite

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -16,25 +16,39 @@
 		"Grey" = 'icons/mob/species/grey/head.dmi'
 	)
 
-/obj/item/clothing/head/hardhat/attack_self(mob/user)
+/obj/item/clothing/head/hardhat/attack_self(mob/living/user)
+	toggle_helmet_light(user)
+
+/obj/item/clothing/head/hardhat/proc/toggle_helmet_light(mob/living/user)
 	on = !on
+	if(on)
+		turn_on(user)
+	else
+		turn_off(user)
+	update_icon()
+
+/obj/item/clothing/head/hardhat/update_icon()
 	icon_state = "hardhat[on]_[item_color]"
 	item_state = "hardhat[on]_[item_color]"
-	if(on)
-		set_light(brightness_on)
-	else
-		set_light(0)
-
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		H.update_inv_head()
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
+	..()
 
-/obj/item/clothing/head/hardhat/extinguish_light()
+/obj/item/clothing/head/hardhat/proc/turn_on(mob/user)
+	set_light(brightness_on)
+
+/obj/item/clothing/head/hardhat/proc/turn_off(mob/user)
+	set_light(0)
+
+/obj/item/clothing/head/hardhat/extinguish_light(mob/living/user)
 	if(on)
 		on = FALSE
-		set_light(0)
-		icon_state = "hardhat0_[item_color]"
-		item_state = "hardhat0_[item_color]"
+		turn_off(user)
+		update_icon()
 		visible_message("<span class='danger'>[src]'s light fades and turns off.</span>")
 
 /obj/item/clothing/head/hardhat/orange


### PR DESCRIPTION
**What does this PR do:**
Currently, toggling any hardhat's light on/off while wearing said hat does not update wearer's sprite correctly. This PR fixes that.

Also refactors hardhat code quite a bit.

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
fix: Toggling hardhat light on/off now correctly updates wearer's sprite
/:cl: