### PR TITLE
Dice will now roll when thrown

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -112,10 +112,9 @@
 /obj/item/dice/attack_self(mob/user as mob)
 	diceroll(user)
 
-/obj/item/dice/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
-	if(!..())
-		return
-	diceroll(thrower)
+/obj/item/dice/throw_impact(atom/target)
+	diceroll(thrownby)
+	. = ..()
 
 /obj/item/dice/proc/diceroll(mob/user)
 	result = rand(1, sides)


### PR DESCRIPTION
**What does this PR do:**
All Dices, when thrown, will now roll for their number. Buffs Dungeons & Dragons roleplay on our server.

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Dice will now roll when thrown
/:cl: