### PR TITLE
Switches some misplaced returns to continues

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1005,12 +1005,12 @@
 		if(prob(2))
 			var/obj/item/clothing/mask/M = H.wear_mask
 			if(M && (M.flags_cover & MASKCOVERSMOUTH))
-				return
+				continue
 			if(NO_BREATHE in H.dna.species.species_traits)
-				return //no puking if you can't smell!
+				continue //no puking if you can't smell!
 			// Humans can lack a mind datum, y'know
 			if(H.mind && (H.mind.assigned_role == "Detective" || H.mind.assigned_role == "Coroner"))
-				return //too cool for puke
+				continue //too cool for puke
 			to_chat(H, "<span class='warning'>You smell something foul...</span>")
 			H.fakevomit()
 


### PR DESCRIPTION
**What does this PR do:**
In humans' life.dm, there's a for(human) loop that, upon meeting a coroner or someone with a mask, returns. This means that any other humans near them don't smell the body because someone else wasn't supposed to smell it.


**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
*Remove this line, and appropriate fields from the changelog*
:cl:
fix: you can smell dead bodies, even if someone else shouldn't
/:cl:

