### PR TITLE
Working with stacks QoL update

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -54,7 +54,7 @@
 			to_chat(user, "There are [amount] [singular_name]\s in the stack.")
 		else
 			to_chat(user, "There are [amount] [name]\s in the stack.")
-		to_chat(user,"<span class='notice'>Ctrl-Shift-click to take a custom amount.</span>")
+		to_chat(user,"<span class='notice'>Alt-click to take a custom amount.</span>")
 
 /obj/item/stack/proc/add(newamount)
 	amount += newamount
@@ -263,7 +263,7 @@
 	else
 		..()
 
-/obj/item/stack/CtrlShiftClick(mob/living/user)
+/obj/item/stack/AltClick(mob/living/user)
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -276,7 +276,7 @@
 	//get amount from user
 	var/min = 0
 	var/max = get_amount()
-	var/stackmaterial = round(input(user, "How many sheets do you wish to take out of this stack? (Maximum: [max])") as num)
+	var/stackmaterial = round(input(user, "How many sheets do you wish to take out of this stack? (Maximum: [max])") as null|num)
 	if(stackmaterial == null || stackmaterial <= min || stackmaterial > get_amount())
 		return
 	change_stack(user,stackmaterial)


### PR DESCRIPTION
**What does this PR do:**
This PR consists of two changes, improving working with stacks behaviour:

1) Added cancel button to transfer amount from stack menu incase you change your mind about transferring any amount from stack. Example image below.

2) Alt-click is a new shortcut to take a custom amount from stack instead of Ctrl-Shift-click, which is rather clumsy to use.

Ported from /tg/station13.

Tested locally without any issue.

**Images of sprite/map changes (IF APPLICABLE):**
![CancelStack](https://user-images.githubusercontent.com/43862960/56469719-8e053780-643d-11e9-8c53-7ab67ef66526.png)

**Changelog:**
:cl: Arkatos
add: Added cancel button to transfer amount from stack menu
tweak: Alt-click is a new shortcut to take a custom amount from stack
/:cl: