### PR TITLE
Adds shortcuts for handling pumps, volume pumps, filters, and mixers + Ability to rename them with a pen

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -36,13 +36,11 @@ Thus, the two variables affect pump operation are set in New():
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AICtrlClick()
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AltClick(mob/living/user)
@@ -53,14 +51,22 @@ Thus, the two variables affect pump operation are set in New():
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	target_pressure = MAX_OUTPUT_PRESSURE
-	update_icon()
+	set_max()
 	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AIAltClick()
-	target_pressure = MAX_OUTPUT_PRESSURE
-	update_icon()
+	set_max()
 	return ..()
+
+/obj/machinery/atmospherics/binary/pump/proc/toggle()
+	if(powered())
+		on = !on
+		update_icon()
+
+/obj/machinery/atmospherics/binary/pump/proc/set_max()
+	if(powered())
+		target_pressure = MAX_OUTPUT_PRESSURE
+		update_icon()
 
 /obj/machinery/atmospherics/binary/pump/Destroy()
 	if(radio_controller)
@@ -237,7 +243,15 @@ Thus, the two variables affect pump operation are set in New():
 		update_icon()
 
 /obj/machinery/atmospherics/binary/pump/attackby(obj/item/W, mob/user, params)
-	if(!istype(W, /obj/item/wrench))
+	if(istype(W, /obj/item/pen))
+		var/t = copytext(stripped_input(user, "Enter the name for the pump.", "Rename", name), 1, MAX_NAME_LEN)
+		if(!t)
+			return
+		if(!in_range(src, usr) && loc != usr)
+			return
+		name = t
+		return
+	else if(!istype(W, /obj/item/wrench))
 		return ..()
 	if(!(stat & NOPOWER) && on)
 		to_chat(user, "<span class='alert'>You cannot unwrench this [src], turn it off first.</span>")

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -28,6 +28,40 @@ Thus, the two variables affect pump operation are set in New():
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
+/obj/machinery/atmospherics/binary/pump/CtrlClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/binary/pump/AICtrlClick()
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/binary/pump/AltClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	target_pressure = MAX_OUTPUT_PRESSURE
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/binary/pump/AIAltClick()
+	target_pressure = MAX_OUTPUT_PRESSURE
+	update_icon()
+	return ..()
+
 /obj/machinery/atmospherics/binary/pump/Destroy()
 	if(radio_controller)
 		radio_controller.remove_object(src, frequency)

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -29,6 +29,7 @@ Thus, the two variables affect pump operation are set in New():
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/atmospherics/binary/pump/CtrlClick(mob/living/user)
+	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -37,7 +38,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/binary/pump/AICtrlClick()
 	toggle()
@@ -52,7 +53,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/binary/pump/AIAltClick()
 	set_max()

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -29,7 +29,6 @@ Thus, the two variables affect pump operation are set in New():
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/atmospherics/binary/pump/CtrlClick(mob/living/user)
-	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -38,7 +37,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return
+	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AICtrlClick()
 	toggle()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -29,6 +29,7 @@ Thus, the two variables affect pump operation are set in New():
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/atmospherics/binary/volume_pump/CtrlClick(mob/living/user)
+ 	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -37,7 +38,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/binary/volume_pump/AICtrlClick()
 	toggle()
@@ -52,7 +53,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/binary/volume_pump/AIAltClick()
 	set_max()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -29,7 +29,6 @@ Thus, the two variables affect pump operation are set in New():
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/atmospherics/binary/volume_pump/CtrlClick(mob/living/user)
- 	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -38,7 +37,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return
+	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AICtrlClick()
 	toggle()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -36,13 +36,11 @@ Thus, the two variables affect pump operation are set in New():
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AICtrlClick()
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AltClick(mob/living/user)
@@ -53,14 +51,22 @@ Thus, the two variables affect pump operation are set in New():
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	transfer_rate = MAX_TRANSFER_RATE
-	update_icon()
+	set_max()
 	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AIAltClick()
-	transfer_rate = MAX_TRANSFER_RATE
-	update_icon()
+	set_max()
 	return ..()
+
+/obj/machinery/atmospherics/binary/volume_pump/proc/toggle()
+	if(powered())
+		on = !on
+		update_icon()
+
+/obj/machinery/atmospherics/binary/volume_pump/proc/set_max()
+	if(powered())
+		transfer_rate = MAX_TRANSFER_RATE
+		update_icon()
 
 /obj/machinery/atmospherics/binary/volume_pump/Destroy()
 	if(radio_controller)
@@ -233,7 +239,15 @@ Thus, the two variables affect pump operation are set in New():
 		update_icon()
 
 /obj/machinery/atmospherics/binary/volume_pump/attackby(obj/item/W, mob/user, params)
-	if(!istype(W, /obj/item/wrench))
+	if(istype(W, /obj/item/pen))
+		var/t = copytext(stripped_input(user, "Enter the name for the volume pump.", "Rename", name), 1, MAX_NAME_LEN)
+		if(!t)
+			return
+		if(!in_range(src, usr) && loc != usr)
+			return
+		name = t
+		return
+	else if(!istype(W, /obj/item/wrench))
 		return ..()
 	if(!(stat & NOPOWER) && on)
 		to_chat(user, "<span class='alert'>You cannot unwrench this [src], turn it off first.</span>")

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -28,6 +28,40 @@ Thus, the two variables affect pump operation are set in New():
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
+/obj/machinery/atmospherics/binary/volume_pump/CtrlClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/binary/volume_pump/AICtrlClick()
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/binary/volume_pump/AltClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	transfer_rate = MAX_TRANSFER_RATE
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/binary/volume_pump/AIAltClick()
+	transfer_rate = MAX_TRANSFER_RATE
+	update_icon()
+	return ..()
+
 /obj/machinery/atmospherics/binary/volume_pump/Destroy()
 	if(radio_controller)
 		radio_controller.remove_object(src, frequency)

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -23,6 +23,7 @@ Filter types:
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/atmospherics/trinary/filter/CtrlClick(mob/living/user)
+ 	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -31,7 +32,7 @@ Filter types:
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/trinary/filter/AICtrlClick()
 	toggle()
@@ -46,7 +47,7 @@ Filter types:
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/trinary/filter/AIAltClick()
 	set_max()

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -30,13 +30,11 @@ Filter types:
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AICtrlClick()
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AltClick(mob/living/user)
@@ -47,14 +45,22 @@ Filter types:
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	target_pressure = MAX_OUTPUT_PRESSURE
-	update_icon()
+	set_max()
 	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AIAltClick()
-	target_pressure = MAX_OUTPUT_PRESSURE
-	update_icon()
+	set_max()
 	return ..()
+
+/obj/machinery/atmospherics/trinary/filter/proc/toggle()
+	if(powered())
+		on = !on
+		update_icon()
+
+/obj/machinery/atmospherics/trinary/filter/proc/set_max()
+	if(powered())
+		target_pressure = MAX_OUTPUT_PRESSURE
+		update_icon()
 
 /obj/machinery/atmospherics/trinary/filter/Destroy()
 	if(radio_controller)
@@ -245,3 +251,15 @@ Filter types:
 
 	update_icon()
 	SSnanoui.update_uis(src)
+
+/obj/machinery/atmospherics/trinary/filter/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/pen))
+		var/t = copytext(stripped_input(user, "Enter the name for the filter.", "Rename", name), 1, MAX_NAME_LEN)
+		if(!t)
+			return
+		if(!in_range(src, usr) && loc != usr)
+			return
+		name = t
+		return
+	else
+		return ..()

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -22,6 +22,39 @@ Filter types:
 	var/frequency = 0
 	var/datum/radio_frequency/radio_connection
 
+/obj/machinery/atmospherics/trinary/filter/CtrlClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/trinary/filter/AICtrlClick()
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/trinary/filter/AltClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	target_pressure = MAX_OUTPUT_PRESSURE
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/trinary/filter/AIAltClick()
+	target_pressure = MAX_OUTPUT_PRESSURE
+	update_icon()
+	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/Destroy()
 	if(radio_controller)

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -23,7 +23,6 @@ Filter types:
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/atmospherics/trinary/filter/CtrlClick(mob/living/user)
- 	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -32,7 +31,7 @@ Filter types:
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return
+	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AICtrlClick()
 	toggle()

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -12,6 +12,40 @@
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
+/obj/machinery/atmospherics/trinary/mixer/CtrlClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/trinary/mixer/AICtrlClick()
+	on = !on
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/trinary/mixer/AltClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user) && !issilicon(usr))
+		return
+	if(!ishuman(usr) && !issilicon(usr))
+		return
+	target_pressure = MAX_OUTPUT_PRESSURE
+	update_icon()
+	return ..()
+
+/obj/machinery/atmospherics/trinary/mixer/AIAltClick()
+	target_pressure = MAX_OUTPUT_PRESSURE
+	update_icon()
+	return ..()
+
 /obj/machinery/atmospherics/trinary/mixer/flipped
 	icon_state = "mmap"
 	flipped = 1

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -13,7 +13,6 @@
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
 /obj/machinery/atmospherics/trinary/mixer/CtrlClick(mob/living/user)
- 	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -22,7 +21,7 @@
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return
+	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AICtrlClick()
 	toggle()

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -20,13 +20,11 @@
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AICtrlClick()
-	on = !on
-	update_icon()
+	toggle()
 	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AltClick(mob/living/user)
@@ -37,18 +35,26 @@
 		return
 	if(!ishuman(usr) && !issilicon(usr))
 		return
-	target_pressure = MAX_OUTPUT_PRESSURE
-	update_icon()
+	set_max()
 	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AIAltClick()
-	target_pressure = MAX_OUTPUT_PRESSURE
-	update_icon()
+	set_max()
 	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/flipped
 	icon_state = "mmap"
 	flipped = 1
+
+/obj/machinery/atmospherics/trinary/mixer/proc/toggle()
+	if(powered())
+		on = !on
+		update_icon()
+
+/obj/machinery/atmospherics/trinary/mixer/proc/set_max()
+	if(powered())
+		target_pressure = MAX_OUTPUT_PRESSURE
+		update_icon()
 
 /obj/machinery/atmospherics/trinary/mixer/update_icon(safety = 0)
 	if(flipped)
@@ -211,3 +217,15 @@
 
 	update_icon()
 	SSnanoui.update_uis(src)
+
+/obj/machinery/atmospherics/trinary/mixer/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/pen))
+		var/t = copytext(stripped_input(user, "Enter the name for the mixer.", "Rename", name), 1, MAX_NAME_LEN)
+		if(!t)
+			return
+		if(!in_range(src, usr) && loc != usr)
+			return
+		name = t
+		return
+	else
+		return ..()

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -13,6 +13,7 @@
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
 /obj/machinery/atmospherics/trinary/mixer/CtrlClick(mob/living/user)
+ 	..()
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
@@ -21,7 +22,7 @@
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	toggle()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/trinary/mixer/AICtrlClick()
 	toggle()
@@ -36,7 +37,7 @@
 	if(!ishuman(usr) && !issilicon(usr))
 		return
 	set_max()
-	return ..()
+	return
 
 /obj/machinery/atmospherics/trinary/mixer/AIAltClick()
 	set_max()


### PR DESCRIPTION
**What does this PR do:**
This PR adds two shortcuts for atmospherics devices, that is pumps, volume pumps, filters, and mixers. Shortcuts are as follows:
1) Click-click will turn these devices on/off
2) Alt-click will set their output to maximum

Unless you are a Silicon, you need to be next to the device to successfully use the shortcut. Silicons can use them at range.

Partial port from /tg/station13.

Tested locally without any issue.

EDIT: As requested, I have also added ability to rename these devices with a pen. Example:
![RenamePump](https://user-images.githubusercontent.com/43862960/56473462-f79c3a80-646b-11e9-8180-a2cd27cbfe37.png)

**Changelog:**
:cl: Arkatos
add: Added shortcuts for handling pumps, volume pumps, filters, and mixers. Ctrl-click these devices to turn them on/off and Alt-click them to set their output to maximum.
add: Added ability to rename pumps, volume pumps, filters and mixers with a pen.
/:cl: