### PR TITLE
Adds AntagHUD to everyone at the round end

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -508,6 +508,12 @@ var/round_start_time = 0
 	//Ask the event manager to print round end information
 	event_manager.RoundEnd()
 
+	// Add AntagHUD to everyone, see who was really evil the whole time!
+	for(var/datum/atom_hud/antag/H in huds)
+		for(var/m in GLOB.player_list)
+			var/mob/M = m
+			H.add_hud_to(M)
+
 	return 1
 
 /datum/controller/gameticker/proc/HasRoundStarted()


### PR DESCRIPTION
**What does this PR do:**
Once the round ends and antagonists are publicly declared, everyone will receive AntagHUD to see with their own eyes who was the the bad guy all along. You do not get to know anything extra, as all antagonists are showed in the chat by that time, but this is better if you just want to know if your shady coworker next to you was antagonist all along, and do not want to search in that sometimes lengthy antagonist list incase he was.

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Added AntagHUD to everyone at the round end
/:cl: