### PR TITLE
Improves unspawnable ERT alert

### DIFF
--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -90,22 +90,13 @@ var/ert_request_answered = FALSE
 		return 0
 
 	var/index = 1
-	var/ert_spawn_seconds = 120
-	spawn(ert_spawn_seconds * 10) // to account for spawn() using deciseconds
-		var/list/unspawnable_ert = list()
-		for(var/mob/M in response_team_members)
-			if(M)
-				unspawnable_ert |= M
-		if(unspawnable_ert.len)
-			message_admins("ERT SPAWN: The following ERT members could not be spawned within [ert_spawn_seconds] seconds:")
-			for(var/mob/M in unspawnable_ert)
-				message_admins("- Unspawned ERT: [ADMIN_FULLMONTY(M)]")
 	for(var/mob/M in response_team_members)
 		if(index > emergencyresponseteamspawn.len)
 			index = 1
 
 		if(!M || !M.client)
 			continue
+		log_debug("Spawning as ERT: [M.ckey] ([M])")
 		var/client/C = M.client
 		var/mob/living/new_commando = C.create_response_team(emergencyresponseteamspawn[index])
 		if(!M || !new_commando)


### PR DESCRIPTION
Currently, during ERT spawning, the code is meant to inform admins about any ERT members who could not be spawned within 120 seconds. The intention was to alert admins if someone is dithering on the choose gender/role popup and thus preventing the rest of their team from spawning.

Unfortunately, due to a bug, it seems to always list the entire ERT (spawned or not) in this list, making the list effectively useless. The code quality is also not great, it takes a lot of lines to accomplish this simple task, and it uses spawn().

This PR changes the way the notice works, so that, as each ERT member is being spawned, a debug log is generated in the format:
"Spawning as ERT: [M.ckey] ([M])"

This is shorter, neater, avoids the use of spawn(), and now enables admins to properly find out who is delaying the spawning process if they need to. All they have to do is look for the last "Spawning as ERT" line in the log - its that person. 

:cl: Kyep
refactor: improved the logging shown to admins when players are spawning as ERT.
/:cl:

