### PR TITLE
Fixes unnecessary pAI warning for admins

### DIFF
--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -57,12 +57,6 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			usr << browse(null, "window=findPai")
 
 
-	if(candidate)
-		if(candidate.key && usr.key && candidate.key != usr.key)
-			message_admins("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr are different mobs)")
-			log_debug("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr are different mobs)")
-			return
-
 	if("signup" in href_list)
 		var/mob/dead/observer/O = locate(href_list["signup"])
 		if(!O)
@@ -75,6 +69,11 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 		recruitWindow(O)
 		return
 
+	if(candidate)
+		if(candidate.key && usr.key && candidate.key != usr.key)
+			message_admins("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr are different mobs)")
+			log_debug("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr are different mobs)")
+			return
 
 	if(href_list["new"])
 		var/option = href_list["option"]


### PR DESCRIPTION
In https://github.com/ParadiseSS13/Paradise/pull/10445 I added a warning message for admins when certain kinds of hrefs were used.
Unfortunately due to a bug, the warning is being sent to admins whenever anyone signs up to play a pAI.
This PR alters the logic so that the warning is no longer sent in that case.

Due to the complexity of how pAIs work, the fact _I have limited ability to test this myself_ (it requires multiple people) and the fact it changes something related to security, I am requesting careful review of the logic by whichever maint reviews this.

:cl: Kyep
fix: Fixed an error message being inappropriately generated for admins when someone signs up as a pAI.
/:cl:

