### PR TITLE
Circuit Boards now show their required components on examine

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -56,6 +56,17 @@
 /obj/item/circuitboard/machine
 	board_type = "machine"
 
+/obj/item/circuitboard/examine(mob/user)
+	..()
+	if(LAZYLEN(req_components))
+		var/list/nice_list = list()
+		for(var/B in req_components)
+			var/atom/A = B
+			if(!ispath(A))
+				continue
+			nice_list += list("[req_components[A]] [initial(A.name)]")
+		to_chat(user,"<span class='notice'>Required components: [english_list(nice_list)].</span>")
+
 /obj/item/circuitboard/message_monitor
 	name = "Circuit board (Message Monitor)"
 	build_path = /obj/machinery/computer/message_monitor


### PR DESCRIPTION
**What does this PR do:**
All machinery circuit boards will now show their required components on examine. This will be especially useful to a new players, who do not know which components will they need in their future machinery constructions. 

Ported from /tg/station13.

Tested locally without any issue.

**Images of sprite/map changes (IF APPLICABLE):**
![BoardsExamine](https://user-images.githubusercontent.com/43862960/56671740-70da9e00-66b5-11e9-9208-f764e0e0146c.png)

**Changelog:**
:cl: Arkatos
add: Circuit Boards now show their required components on examine
/:cl: