### PR TITLE
Action Button QoL improvements

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -17,6 +17,7 @@
 //Hide/Show Action Buttons ... Button
 /obj/screen/movable/action_button/hide_toggle
 	name = "Hide Buttons"
+	desc = "Shift-click any button to reset its position. Alt-click to reset all buttons to their default positions."
 	icon = 'icons/mob/actions/actions.dmi'
 	icon_state = "bg_default"
 	var/hidden = 0
@@ -24,8 +25,18 @@
 /obj/screen/movable/action_button/hide_toggle/Click(location,control,params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
-		moved = 0
-		return 1
+		moved = FALSE
+		usr.update_action_buttons(TRUE)
+		return TRUE
+	if(modifiers["alt"])
+		for(var/V in usr.actions)
+			var/datum/action/A = V
+			var/obj/screen/movable/action_button/B = A.button
+			B.moved = FALSE
+		moved = FALSE
+		usr.update_action_buttons(TRUE)
+		to_chat(usr, "<span class='notice'>Action button positions have been reset.</span>")
+		return TRUE
 	usr.hud_used.action_buttons_hidden = !usr.hud_used.action_buttons_hidden
 
 	hidden = usr.hud_used.action_buttons_hidden
@@ -36,6 +47,15 @@
 	UpdateIcon()
 	usr.update_action_buttons()
 
+/obj/screen/movable/action_button/hide_toggle/AltClick(mob/user)
+	for(var/V in user.actions)
+		var/datum/action/A = V
+		var/obj/screen/movable/action_button/B = A.button
+		B.moved = FALSE
+	if(moved)
+		moved = FALSE
+	user.update_action_buttons(TRUE)
+	to_chat(user, "<span class='notice'>Action button positions have been reset.</span>")
 
 /obj/screen/movable/action_button/hide_toggle/proc/InitialiseIcon(mob/living/user)
 	if(isalien(user))


### PR DESCRIPTION
**What does this PR do:**
As you might know, you can click-drag any action button to set its position anywhere you like on your screen, sometimes it may even happen on accident if you are not careful. Getting them back exactly where they were originally is almost.. impossible. This PR fixes that issue.

You can now shift-click any action button to reset it's position. Alt-click will reset all action buttons to their default positions. I have added description to the Hide Button to reflect that, example image below.

**Images of sprite/map changes (IF APPLICABLE):**
![ActionButtons](https://user-images.githubusercontent.com/43862960/56685794-0afd0f00-66d3-11e9-95ba-84f28f8bf229.png)

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: You can now shift-click any action button to reset it's position. Alt-click will reset all action buttons to their default positions.
/:cl: