### PR TITLE
Pill Bottles are now printable in the Autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -447,6 +447,14 @@
 	build_path = /obj/item/healthanalyzer
 	category = list("initial", "Medical")
 
+/datum/design/pillbottle
+	name = "Pill Bottle"
+	id = "pillbottle"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 80, MAT_GLASS = 20)
+	build_path = /obj/item/storage/pill_bottle
+	category = list("initial", "Medical")
+
 /datum/design/beanbag_slug
 	name = "Beanbag Slug"
 	id = "beanbag_slug"


### PR DESCRIPTION
**What does this PR do:**
This PR allows pill bottles to be printed in the Autolathe. You can find them in the Medical section, and each costs 80 metal and 20 glass to print. This should solve issues when chemistry/science runs out of their allocated pill bottles.

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Pill Bottles are now printable in the Autolathe. You can find them in the Medical section, and each costs 80 metal and 20 glass to print.
/:cl: