### PR TITLE
Adds multicolor pens to the Internal Affairs Office

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -9787,6 +9787,7 @@
 	pixel_y = 2
 	},
 /obj/item/stamp/law,
+/obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
 	tag = "icon-cult";
 	icon_state = "cult";


### PR DESCRIPTION
**What does this PR do:**
Adds multicolor pens to the IAA Office, as the previous version of the office had them, but it seems it was accidentally left out in the brig remap.

Two of them have been added to the respective desks.

**Images of sprite/map changes (IF APPLICABLE):**
![image](https://user-images.githubusercontent.com/32376559/56703385-71773280-66bd-11e9-861c-d5286cf28da8.png)
_Pens under those folders and such in the squares, original black pens on the paper bins left, as what kind of bureaucrat will give their fancy pen to some random weirdo complaining about something?_

**Changelog:**

:cl: Quantum-M
add: Two multicolor pens to the Internal Affairs Office
/:cl:

