### PR TITLE
Removes telescience boards from RnD

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -332,16 +332,6 @@
 	build_path = /obj/item/circuitboard/comm_traffic
 	category = list("Computer Boards")
 
-/datum/design/telesci_console
-	name = "Console Board (Telepad Control Console)"
-	desc = "Allows for the construction of circuit boards used to build a telescience console."
-	id = "telesci_console"
-	req_tech = list("programming" = 3, "bluespace" = 3, "plasmatech" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000)
-	build_path = /obj/item/circuitboard/telesci_console
-	category = list("Computer Boards")
-
 /datum/design/teleconsole
 	name = "Console Board (Teleporter Console)"
 	desc = "Allows for the construction of circuit boards used to build a teleporter control console."

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -72,16 +72,6 @@
 	build_path = /obj/item/circuitboard/quantumpad
 	category = list ("Teleportation Machinery")
 
-/datum/design/telepad
-	name = "Machine Board (Telepad Board)"
-	desc = "Allows for the construction of circuit boards used to build a Telepad."
-	id = "telepad"
-	req_tech = list("programming" = 4, "bluespace" = 5, "plasmatech" = 4, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000)
-	build_path = /obj/item/circuitboard/telesci_pad
-	category = list ("Teleportation Machinery")
-
 /datum/design/teleport_hub
 	name = "Machine Board (Teleportation Hub)"
 	desc = "Allows for the construction of circuit boards used to build a Teleportation Hub."


### PR DESCRIPTION
**What does this PR do:**
This removes the telescience boards from being able to be printed from RnD. **_HOWEVER_**, the boards still exists in game, and can only be currently acquired via admin magic.

Relevant thread: https://nanotrasen.se/forum/topic/15744-remove-telescience/

As pointed out in the thread, telescience in itself can be rather powerful, and abusable at that too.

People can just keep a note as to where things are (which is just extremely cheesey, like how are you supposed to know the **_exact_** coordinates to that one tool box out in space? ),and then edit their calculations to whatever needs to be used in science, along with using external programs instead of doing the math themselves.

Not only that, it has been pointed out that telescience has gone through several revisions, and it still has issues.

It could be argued that telescience is beneficial, but to what extent? It _could_ be used to save crewmembers, but compared to it's other uses, such as sending a bomb over to a location without a warning, having things stolen through thin air without someone realizing, or sending a crewmember/dead body to a seperate z-level with a very low chance of being found shows that it has more negative use over positive.

And while we are _not_ /tg/, I like to point out that tg, a _lowRP_ server that tends to be known for it's powergaming playerbase, even considered telescience to be a issue.

**Images of sprite/map changes (IF APPLICABLE):**
N/A.

**Changelog:**

:cl: Quantum-M
del: RnD is no longer able to print out any telescience boards.
/:cl:

