### PR TITLE
Puts beakers in your hand upon eject from chemistry machines

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -184,6 +184,8 @@
 	if(href_list["ejectBeaker"])
 		if(beaker)
 			beaker.forceMove(loc)
+			if(Adjacent(usr) && !issilicon(usr))
+				usr.put_in_hands(beaker)
 			beaker = null
 			overlays.Cut()
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -38,9 +38,11 @@
 	if(state_change)
 		SSnanoui.update_uis(src)
 
-/obj/machinery/chem_heater/proc/eject_beaker()
+/obj/machinery/chem_heater/proc/eject_beaker(mob/user)
 	if(beaker)
 		beaker.forceMove(get_turf(src))
+		if(Adjacent(user) && !issilicon(user))
+			user.put_in_hands(beaker)
 		beaker = null
 		icon_state = "mixer0b"
 		on = FALSE
@@ -118,7 +120,7 @@
 		. = 1
 
 	if(href_list["eject_beaker"])
-		eject_beaker()
+		eject_beaker(usr)
 		. = 0 //updated in eject_beaker() already
 
 /obj/machinery/chem_heater/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -229,6 +229,8 @@
 		else if(href_list["eject"])
 			if(beaker)
 				beaker.forceMove(get_turf(src))
+				if(Adjacent(usr) && !issilicon(usr))
+					usr.put_in_hands(beaker)
 				beaker = null
 				reagents.clear_reagents()
 				update_icon()


### PR DESCRIPTION
**What does this PR do:**
Upon ejecting beakers from chemistry machines, that is Chem Dispenser, Chem Master and Chem Heater, the beaker is put directly into your hand, if able.

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Puts beakers in your hand upon eject from chemistry machines
/:cl: