### PR TITLE
Allows you to easily replace tanks in canisters & pumps

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -371,7 +371,15 @@ update_flag
 
 	SSnanoui.update_uis(src) // Update all NanoUIs attached to src
 
-
+/obj/machinery/portable_atmospherics/canister/replace_tank(mob/living/user, close_valve)
+	. = ..()
+	if(.)
+		if(close_valve)
+			valve_open = FALSE
+			update_icon()
+			investigate_log("Valve was <b>closed</b> by [key_name(user)].<br>", "atmos")
+		else if(valve_open && holding)
+			investigate_log("[key_name(user)] started a transfer into [holding].<br>", "atmos")
 
 /obj/machinery/portable_atmospherics/canister/attack_ai(var/mob/user as mob)
 	src.add_hiddenprint(user)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -114,6 +114,8 @@
 /obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/tank))
 		if(!(stat & BROKEN))
+			if((W.flags & NODROP) || (flags & NODROP))
+				return
 			var/obj/item/tank/T = W
 			user.drop_item()
 			if(src.holding)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -114,7 +114,7 @@
 /obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/tank))
 		if(!(stat & BROKEN))
-			if((W.flags & NODROP) || (flags & NODROP))
+			if(!user.drop_item())
 				return
 			var/obj/item/tank/T = W
 			user.drop_item()

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -95,6 +95,16 @@
 /obj/machinery/portable_atmospherics/pump/return_air()
 	return air_contents
 
+/obj/machinery/portable_atmospherics/pump/replace_tank(mob/living/user, close_valve)
+	. = ..()
+	if(.)
+		if(close_valve)
+			if(on)
+				on = FALSE
+				update_icon()
+		else if(on && holding && direction_out)
+			investigate_log("[key_name(user)] started a transfer into [holding].<br>", "atmos")
+
 /obj/machinery/portable_atmospherics/pump/attack_ai(var/mob/user as mob)
 	src.add_hiddenprint(user)
 	return src.attack_hand(user)
@@ -139,10 +149,14 @@
 
 	if(href_list["power"])
 		on = !on
+		if(on && direction_out)
+			investigate_log("[key_name(usr)] started a transfer into [holding].<br>", "atmos")
 		update_icon()
 
 	if(href_list["direction"])
 		direction_out = !direction_out
+		if(on && holding)
+			investigate_log("[key_name(usr)] started a transfer into [holding].<br>", "atmos")
 
 	if(href_list["remove_tank"])
 		if(holding)


### PR DESCRIPTION
**What does this PR do:**
This PR consists of two changes regardings tanks, canisters and pumps:

1) You can now alt-click any canister or gas pump to close the valve and remove the tank inside. Tank will be put in your hand, if able.

2) You can now hotswap tanks in a canister or gas pump by clicking it with a new tank. This is absolutely seemless and allows you to quickly fill large amount of tanks without going through repetetive motion of  inserting a tank into a canister, opening the valve, closing the valve, ejecting the tank and repeating it.

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: You can now hotswap tanks in a canister or gas pump by clicking it with a new tank!
add: You can now also close a canister's valve and remove the tank inside it by alt-clicking it.
/:cl: