### PR TITLE
Adds examine tooltips

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -100,6 +100,10 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	var/trip_walksafe = TRUE
 	var/trip_tiles = 0
 
+	//Tooltip vars
+	var/in_inventory = FALSE //is this item equipped into an inventory slot or hand of a mob?
+	var/tip_timer = 0
+
 /obj/item/New()
 	..()
 	for(var/path in actions_types)
@@ -340,11 +344,13 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 		A.Remove(user)
 	if(flags & DROPDEL)
 		qdel(src)
+	in_inventory = FALSE
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
 	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
+	in_inventory = TRUE
 	return TRUE
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
@@ -374,6 +380,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 		var/datum/action/A = X
 		if(item_action_slot_check(slot, user)) //some items only give their actions buttons when in a specific slot.
 			A.Grant(user)
+	in_inventory = TRUE
 
 /obj/item/proc/item_action_slot_check(slot, mob/user)
 	return 1
@@ -532,6 +539,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	if(callback) //call the original callback
 		. = callback.Invoke()
 	throw_speed = initial(throw_speed) //explosions change this.
+	in_inventory = FALSE
 
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill
@@ -579,3 +587,16 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 /obj/item/attack_hulk(mob/living/carbon/human/user)
 	return FALSE
+
+/obj/item/proc/openTip(location, control, params, user)
+	openToolTip(user, src, params, title = name, content = "[desc]", theme = "")
+
+/obj/item/MouseEntered(location, control, params)
+	if(in_inventory)
+		var/timedelay = 5
+		var/user = usr
+		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
+
+/obj/item/MouseExited()
+	deltimer(tip_timer) //delete any in-progress timer if the mouse is moved off the item before it finishes
+	closeToolTip(usr)


### PR DESCRIPTION
**What does this PR do:**
This PR adds examine tooltips. Hover any equipped or hold item for a little while, and it will display the item description as a tooltip. Example images below.

**Images of sprite/map changes (IF APPLICABLE):**
![EX1](https://user-images.githubusercontent.com/43862960/56762065-3cdba780-679f-11e9-8fc4-858966f0b670.png)
![EX2](https://user-images.githubusercontent.com/43862960/56762067-3d743e00-679f-11e9-954f-b7fa66ba2abc.png)
![EX3](https://user-images.githubusercontent.com/43862960/56762068-3ea56b00-679f-11e9-9d87-6ca2d5bcd1ed.png)

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Added examine toolptips. Hover over any equipped or hold item for a little while and it will display the item description as a tooltip.
/:cl: