### PR TITLE
Decreases log spam

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -49,10 +49,8 @@
 	if(!can_see(A))
 		if(isturf(A)) //On unmodified clients clicking the static overlay clicks the turf underneath
 			return // So there's no point messaging admins
-		message_admins("[key_name_admin(src)] might be running a modified client! (failed can_see on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
 		var/message = "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A]([COORD(pixel_turf)]))"
 		log_admin(message)
-		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)]))")
 
 
 	var/turf_visible


### PR DESCRIPTION
**What does this PR do:**
Removes a warning that appears pretty much multiple times every round, making it have no weight and useless. It will still log just not message the admins, so if someone needs to be investigated for this it is still possible.

**Changelog:**
:cl:
del: In game admin log of AI modified client removed
/ 🆑 