### PR TITLE
Adds error message when trying to join with no free job slots

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -464,8 +464,7 @@
 				dat += " [a.title]. </font><br>"
 
 
-	dat += "Choose from the following open positions:<br><br>"
-
+	var/num_jobs_available = 0
 	var/list/activePlayers = list()
 	var/list/categorizedJobs = list(
 		"Command" = list(jobs = list(), titles = command_positions, color = "#aac1ee"),
@@ -480,6 +479,7 @@
 		)
 	for(var/datum/job/job in SSjobs.occupations)
 		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client))
+			num_jobs_available++
 			activePlayers[job] = 0
 			var/categorized = 0
 			// Only players with the job assigned and AFK for less than 10 minutes count as active
@@ -502,23 +502,27 @@
 			if(!categorized)
 				categorizedJobs["Miscellaneous"]["jobs"] += job
 
-	dat += "<table><tr><td valign='top'>"
-	for(var/jobcat in categorizedJobs)
-		if(categorizedJobs[jobcat]["colBreak"])
-			dat += "</td><td valign='top'>"
-		if(length(categorizedJobs[jobcat]["jobs"]) < 1)
-			continue
-		var/color = categorizedJobs[jobcat]["color"]
-		dat += "<fieldset style='border: 2px solid [color]; display: inline'>"
-		dat += "<legend align='center' style='color: [color]'>[jobcat]</legend>"
-		for(var/datum/job/job in categorizedJobs[jobcat]["jobs"])
-			if(job in SSjobs.prioritized_jobs)
-				dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'><font color='lime'><B>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</B></font></a><br>"
-			else
-				dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</a><br>"
-		dat += "</fieldset><br>"
+	if(num_jobs_available)
+		dat += "Choose from the following open positions:<br><br>"
+		dat += "<table><tr><td valign='top'>"
+		for(var/jobcat in categorizedJobs)
+			if(categorizedJobs[jobcat]["colBreak"])
+				dat += "</td><td valign='top'>"
+			if(length(categorizedJobs[jobcat]["jobs"]) < 1)
+				continue
+			var/color = categorizedJobs[jobcat]["color"]
+			dat += "<fieldset style='border: 2px solid [color]; display: inline'>"
+			dat += "<legend align='center' style='color: [color]'>[jobcat]</legend>"
+			for(var/datum/job/job in categorizedJobs[jobcat]["jobs"])
+				if(job in SSjobs.prioritized_jobs)
+					dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'><font color='lime'><B>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</B></font></a><br>"
+				else
+					dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</a><br>"
+			dat += "</fieldset><br>"
 
-	dat += "</td></tr></table></center>"
+		dat += "</td></tr></table></center>"
+	else
+		dat += "<br><br><center>Unfortunately, there are no job slots free currently.<BR>Wait a few minutes, then try again.<BR>Or, try observing the round.</center>"
 	// Removing the old window method but leaving it here for reference
 //		src << browse(dat, "window=latechoices;size=300x640;can_close=1")
 	// Added the new browser window method


### PR DESCRIPTION
:cl:
add: Trying to latejoin a round with no open job slots now results in an informative error message, rather than broken-looking blank window.
/:cl:

![no_free_job_slots](https://user-images.githubusercontent.com/16434066/56798668-c4a8cc80-6806-11e9-8179-69e40852700f.PNG)