### PR TITLE
Upon transforming into a slime/shadow person, your HUD is reset.

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -201,6 +201,8 @@
 				var/mob/living/carbon/human/human = affected_mob
 				if(!isslimeperson(human))
 					human.set_species(/datum/species/slime)
+					human.hud_used = new /datum/hud/human(human, ui_style2icon(human.client.prefs.UI_style), human.client.prefs.UI_style_color, human.client.prefs.UI_style_alpha)
+					human.hud_used.show_hud(human.hud_used.hud_version)
 
 /datum/disease/transformation/corgi
 	name = "The Barkening"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -70,6 +70,8 @@
 			to_chat(M, "<span class='danger'>Your body reacts violently to light.</span> <span class='notice'>However, it naturally heals in darkness.</span>")
 			to_chat(M, "<span class='danger'>Aside from your new traits, you are mentally unchanged and retain your prior obligations.</span>")
 			human.set_species(/datum/species/shadow)
+			human.hud_used = new /datum/hud/human(human, ui_style2icon(human.client.prefs.UI_style), human.client.prefs.UI_style_color, human.client.prefs.UI_style_alpha)
+			human.hud_used.show_hud(human.hud_used.hud_version)
 	return ..()
 
 /datum/reagent/aslimetoxin


### PR DESCRIPTION
**What does this PR do:**
Upon transforming into a shadow / slime person, your HUD is reset. This is only useful for those cases where you're (for some reason) a monkey, and you start one of those transformations.

**Changelog:**
:cl: EmanTheAlmighty
tweak: Transforming into a shadow person or slime person as a monkey will now change your HUD to be the human one.
/:cl: