### PR TITLE
Improves Hub Listing

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -3,7 +3,7 @@ var/datum/configuration/config = null
 var/host = null
 var/join_motd = null
 GLOBAL_VAR(join_tos)
-var/game_version = "Custom ParaCode"
+var/game_version = "ParaCode"
 var/changelog_hash = md5('html/changelog.html') //used to check if the CL changed
 var/game_year = (text2num(time2text(world.realtime, "YYYY")) + 544)
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -1,5 +1,7 @@
 /datum/configuration
 	var/server_name = null				// server name (for world name / status)
+	var/server_tag_line = null			// server tagline (for showing on hub entry)
+	var/server_extra_features = null		// server-specific extra features (for hub entry)
 	var/server_suffix = 0				// generate numeric suffix based on server port
 
 	var/minimum_client_build = 1421		// Build 1421 due to the middle mouse button exploit
@@ -53,7 +55,6 @@
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
 	var/allow_ai = 1					// allow ai job
-	var/hostedby = null
 	var/respawn = 0
 	var/guest_jobban = 1
 	var/usewhitelist = 0
@@ -213,7 +214,7 @@
 
 	// Automatic localhost admin disable
 	var/disable_localhost_admin = 0
-	
+
 	//Start now warning
 	var/start_now_confirmation = 0
 
@@ -358,10 +359,10 @@
 
 				if("no_dead_vote")
 					config.vote_no_dead = 1
-					
+
 				if("vote_autotransfer_initial")
 					config.vote_autotransfer_initial = text2num(value)
-					
+
 				if("vote_autotransfer_interval")
 					config.vote_autotransfer_interval = text2num(value)
 
@@ -386,6 +387,12 @@
 				if("servername")
 					config.server_name = value
 
+				if("server_tag_line")
+					config.server_tag_line = value
+
+				if("server_extra_features")
+					config.server_extra_features = value
+
 				if("serversuffix")
 					config.server_suffix = 1
 
@@ -394,9 +401,6 @@
 
 				if("nudge_script_path")
 					config.nudge_script_path = value
-
-				if("hostedby")
-					config.hostedby = value
 
 				if("server")
 					config.server = value
@@ -645,7 +649,7 @@
 
 				if("disable_karma")
 					config.disable_karma = 1
-					
+
 				if("start_now_confirmation")
 					config.start_now_confirmation = 1
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -386,19 +386,13 @@ var/world_topic_spam_protect_time = world.timeofday
 		s += "<b>[config.server_name]</b> &#8212; "
 	s += "<b>[station_name()]</b> "
 	if(config && config.githuburl)
-		s+= "(<a href=\"[config.githuburl]\">[game_version]</a>)"
+		s+= "([game_version])"
 
 	if(config && config.server_tag_line)
 		s += "<br>[config.server_tag_line]"
 
 	s += "<br>"
 	var/list/features = list()
-
-	var/n = GLOB.clients.len
-	if(n > 1)
-		features += "~[n] players"
-	else if(n > 0)
-		features += "~[n] player"
 
 	if(ticker)
 		if(master_mode && master_mode != "secret")
@@ -415,13 +409,6 @@ var/world_topic_spam_protect_time = world.timeofday
 	if(config && config.allow_vote_mode)
 		features += "vote"
 
-	if(config && config.allow_ai)
-		features += "AI allowed"
-
-	if(config && config.forumurl)
-		features += "<a href=\"[config.forumurl]\">Forum</a>"
-	if(config && config.discordurl)
-		features += "<a href=\"[config.discordurl]\">Discord</a>"
 	if(config && config.wikiurl)
 		features += "<a href=\"[config.wikiurl]\">Wiki</a>"
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -374,26 +374,34 @@ var/world_topic_spam_protect_time = world.timeofday
 	// apply some settings from config..
 
 /world/proc/update_status()
+	status = get_status_text()
+
+/proc/get_world_status_text()
+	return world.get_status_text()
+
+/world/proc/get_status_text()
 	var/s = ""
 
 	if(config && config.server_name)
 		s += "<b>[config.server_name]</b> &#8212; "
+	s += "<b>[station_name()]</b> "
+	if(config && config.githuburl)
+		s+= "(<a href=\"[config.githuburl]\">[game_version]</a>)"
 
-	s += "<b>[station_name()]</b>";
-	s += " ("
-	s += "<a href=\"http://nanotrasen.se\">" //Change this to wherever you want the hub to link to.
-	s += "[game_version]"
-	s += "</a>"
-	s += ")"
-	s += "<br>The Perfect Mix of RP & Action<br>"
+	if(config && config.server_tag_line)
+		s += "<br>[config.server_tag_line]"
 
-
-
-
+	s += "<br>"
 	var/list/features = list()
 
+	var/n = GLOB.clients.len
+	if(n > 1)
+		features += "~[n] players"
+	else if(n > 0)
+		features += "~[n] player"
+
 	if(ticker)
-		if(master_mode)
+		if(master_mode && master_mode != "secret")
 			features += master_mode
 	else
 		features += "<b>STARTING</b>"
@@ -401,7 +409,8 @@ var/world_topic_spam_protect_time = world.timeofday
 	if(!enter_allowed)
 		features += "closed"
 
-	features += abandon_allowed ? "respawn" : "no respawn"
+	if(config && config.server_extra_features)
+		features += config.server_extra_features
 
 	if(config && config.allow_vote_mode)
 		features += "vote"
@@ -409,31 +418,20 @@ var/world_topic_spam_protect_time = world.timeofday
 	if(config && config.allow_ai)
 		features += "AI allowed"
 
-	var/n = 0
-	for(var/mob/M in GLOB.player_list)
-		if(M.client)
-			n++
+	if(config && config.forumurl)
+		features += "<a href=\"[config.forumurl]\">Forum</a>"
+	if(config && config.discordurl)
+		features += "<a href=\"[config.discordurl]\">Discord</a>"
+	if(config && config.wikiurl)
+		features += "<a href=\"[config.wikiurl]\">Wiki</a>"
 
-	if(n > 1)
-		features += "~[n] players"
-	else if(n > 0)
-		features += "~[n] player"
-
-	/*
-	is there a reason for this? the byond site shows 'hosted by X' when there is a proper host already.
-	if(host)
-		features += "hosted by <b>[host]</b>"
-	*/
-
-//	if(!host && config && config.hostedby)
-//		features += "hosted by <b>[config.hostedby]</b>"
+	if(abandon_allowed)
+		features += "respawn"
 
 	if(features)
-		s += ": [jointext(features, ", ")]"
+		s += "[jointext(features, ", ")]"
 
-	/* does this help? I do not know */
-	if(src.status != s)
-		src.status = s
+	return s
 
 #define FAILED_DB_CONNECTION_CUTOFF 5
 var/failed_db_connections = 0

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -1,6 +1,12 @@
 ## Server name: This appears at the top of the screen in-game. In this case it will read "spacestation13: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'spacestation13' with the name of your choice
 # SERVERNAME spacestation13
 
+## Server tagline: This appears on the hub entry.
+# SERVER_TAG_LINE The Perfect Mix of RP & Action
+
+## Server extra features: This appears in the feature list on the hub entry.
+# SERVER_EXTRA_FEATURES fun
+
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -2,7 +2,7 @@
 # SERVERNAME spacestation13
 
 ## Server tagline: This appears on the hub entry.
-# SERVER_TAG_LINE The Perfect Mix of RP & Action
+# SERVER_EXTRA_FEATURES medium RP, varied species/jobs/modes
 
 ## Server extra features: This appears in the feature list on the hub entry.
 # SERVER_EXTRA_FEATURES fun

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -2,10 +2,10 @@
 # SERVERNAME spacestation13
 
 ## Server tagline: This appears on the hub entry.
-# SERVER_EXTRA_FEATURES medium RP, varied species/jobs/modes
+#SERVER_TAG_LINE The Perfect Mix of RP & Action
 
 ## Server extra features: This appears in the feature list on the hub entry.
-# SERVER_EXTRA_FEATURES fun
+#SERVER_EXTRA_FEATURES medium RP, varied species/jobs/modes
 
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM


### PR DESCRIPTION
General changes to our hub entry:
- Hardcoding is replaced by config options
- Obsolete stuff is removed
- Useful new stuff is added

Details:
- Removed the "HostedBy" config setting, as it was unused
- Changed the "Custom Paracode" hardlink to nanotrasen.se into just "Paracode" that isn't a link. (save character count)
- Changed "The Perfect Mix of RP & Action" server tagline into a config option. Downstream server "[ES]Hispania" will probably appreciate the ability to set their own tagline.
- Removed listing of the game mode when the game mode is "secret", as that does not convey any information. Also removed the automatic adding of player count and "allow AI" to the feature list, seeing as the hub already lists the former (listing it twice is redundant) and the latter can be put in the extra features list config option if we want.
- Removed the ":" in front of the feature/status line. It served no purpose.
- Added wiki link. Decided not to add forums/discord due to reasons of space saving (255 char limit) and also worries about trolls in discord / forum not being used much except for ban appeals.
- Added an "extra features" config option that can be used to add text to the features line.


OLD example of hub entry:

![hub_old](https://user-images.githubusercontent.com/16434066/56935412-674f9c80-6ae0-11e9-87f3-6b98a1d679b4.PNG)

NEW example of hub entry:

![hub_withplayers](https://user-images.githubusercontent.com/16434066/56935411-64ed4280-6ae0-11e9-97d8-d741644ccbe7.PNG)
Note: pretty much everything in this example is a config option, so the exact text is easy to change. This screenshot mostly serves to show that it does work as-written, and how it looks with suggested options.

:cl: Kyep
tweak: Refactored and improved our entry on the server hub.
/:cl: