### PR TITLE
IRC's and the like now get checked to be revived when their vital organs are in

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -41,6 +41,8 @@
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.Grant(M)
+	if(vital)
+		M.update_stat("Vital organ inserted")
 
 // Removes the given organ from its owner.
 // Returns the removed object, which is usually just itself


### PR DESCRIPTION
**What does this PR do:**
Organs will now prompt a update_stat. Meaning that IRCs and the like now get revived when possible when you put their battery and brain in.

Fixes: #11379

**Changelog:**
:cl:
fix: Organs will now prompt a update_stat. Meaning that IRCs and the like now get revived when possible when you put their battery and brain in
/:cl:

