### PR TITLE
Small Ghost teleport verb refactor

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -397,13 +397,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, "Not when you're not dead!")
 		return
 
-	usr.verbs -= /mob/dead/observer/proc/dead_tele
-	spawn(30)
-		usr.verbs += /mob/dead/observer/proc/dead_tele
-
 	var/area/A  = input("Area to jump to", "BOOYEA") as null|anything in ghostteleportlocs
 	var/area/thearea = ghostteleportlocs[A]
-	if(!thearea)	return
+	
+	if(!thearea)
+		return
 
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
@@ -411,6 +409,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	if(!L || !L.len)
 		to_chat(usr, "<span class='warning'>No area available.</span>")
+		return
 
 	usr.forceMove(pick(L))
 	following = null


### PR DESCRIPTION
**What does this PR do:**
Small refactor of the Ghost teleport verb. Ghost teleport was changed with the Ghost HUD, but I forgot to clean this up. In short, when ghost teleport verb is used, the verb disappears for 3 seconds, and then is added back in to the ghost. That is no longer needed in any way, and it's only annoying. This PR cleans that up.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
fix: Ghost teleport verb will no locker flicker when used
/:cl: