### PR TITLE
Fire extinguisher cabinet QoL update

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -43,7 +43,6 @@
 	playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 	opened = !opened
 	update_icon()
-	return
 
 /obj/structure/extinguisher_cabinet/Destroy()
 	QDEL_NULL(has_extinguisher)
@@ -54,6 +53,8 @@
 		return
 	if(istype(O, /obj/item/extinguisher))
 		if(!has_extinguisher && opened)
+			if((O.flags & NODROP) || (flags & NODROP))
+				return
 			user.drop_item(O)
 			contents += O
 			has_extinguisher = O

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -28,6 +28,23 @@
 		else
 			has_extinguisher = new/obj/item/extinguisher
 
+/obj/structure/extinguisher_cabinet/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>Alt-click to [opened ? "close":"open"] it.</span>")
+
+/obj/structure/extinguisher_cabinet/AltClick(mob/living/user)
+	if(!istype(user) || user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user))
+		return
+	if(!iscarbon(usr))
+		return
+	playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
+	opened = !opened
+	update_icon()
+	return
+
 /obj/structure/extinguisher_cabinet/Destroy()
 	QDEL_NULL(has_extinguisher)
 	return ..()
@@ -40,8 +57,11 @@
 			user.drop_item(O)
 			contents += O
 			has_extinguisher = O
+			update_icon()
 			to_chat(user, "<span class='notice'>You place [O] in [src].</span>")
+			return TRUE
 		else
+			playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 			opened = !opened
 	else if(istype(O, /obj/item/weldingtool))
 		if(has_extinguisher)
@@ -65,6 +85,7 @@
 			new material_drop(T)
 			qdel(src)
 	else
+		playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 		opened = !opened
 	update_icon()
 
@@ -81,21 +102,27 @@
 			to_chat(user, "<span class='notice'>You try to move your [temp.name], but cannot!")
 			return
 	if(has_extinguisher)
+		if(icon_state == "extinguisher_closed")
+			playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 		user.put_in_hands(has_extinguisher)
 		to_chat(user, "<span class='notice'>You take [has_extinguisher] from [src].</span>")
 		has_extinguisher = null
 		opened = 1
 	else
+		playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 		opened = !opened
 	update_icon()
 
 /obj/structure/extinguisher_cabinet/attack_tk(mob/user)
 	if(has_extinguisher)
+		if(icon_state == "extinguisher_closed")
+			playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 		has_extinguisher.loc = loc
 		to_chat(user, "<span class='notice'>You telekinetically remove [has_extinguisher] from [src].</span>")
 		has_extinguisher = null
 		opened = 1
 	else
+		playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 		opened = !opened
 	update_icon()
 

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -53,7 +53,7 @@
 		return
 	if(istype(O, /obj/item/extinguisher))
 		if(!has_extinguisher && opened)
-			if((O.flags & NODROP) || (flags & NODROP))
+			if(!user.drop_item())
 				return
 			user.drop_item(O)
 			contents += O


### PR DESCRIPTION
**What does this PR do:**
This PR consists of 4 parts, improving fire extinguisher cabinets:

1) Added alt-click as a shortcut for opening and closing fire extinguisher cabinets. This allows you to close fire extinguisher cabinet even when it contains fire extinguisher.
2) Bug fix - When you put fire extinguisher back inside the fire extinguisher cabinet, the cabinet sprite does not update it's sprite correctly to reflect that it contains fire extinguisher. This PR fixes that.
3) Bug fix - When you put fire extinguisher into fire extinguisher cabinet with a safety off, it sprays water everywhere. This PR fixes that.
4) Added sound for opening and closing fire extinguisher cabinets, sample below

[Sound](https://raw.githubusercontent.com/ParadiseSS13/Paradise/master/sound/machines/click.ogg)

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Alt-click now opens and closes fire extinguisher cabinet
fix: Fire extinguisher cabinet now properly updates it's sprite correctly when putting fire extinquisher inside the cabinet
fix: Fire extinguisher no longer sprays when put into fire extinguisher cabinet with a safety off
soundadd: Added sound for opening and closing fire extinguisher cabinet
/:cl: