### PR TITLE
Patreon Upgrade

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -318,10 +318,8 @@
 #define SHELTER_DEPLOY_BAD_AREA "bad area"
 #define SHELTER_DEPLOY_ANCHORED_OBJECTS "anchored objects"
 
-// Client donator levels
-#define DONATOR_LEVEL_NONE 0
-#define DONATOR_LEVEL_ONE 1
-#define DONATOR_LEVEL_TWO 2
+// Maximum donation level
+#define DONATOR_LEVEL_MAX 4
 
 // The cooldown on OOC messages such as OOC, LOOC, praying and adminhelps
 #define OOC_COOLDOWN 5

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -11,7 +11,7 @@ var/global/admin_ooc_colour = "#b82e00"
 /client/verb/ooc(msg = "" as text)
 	set name = "OOC"
 	set category = "OOC"
-	
+
 	if(!mob)
 		return
 	if(IsGuestKey(key))
@@ -28,10 +28,10 @@ var/global/admin_ooc_colour = "#b82e00"
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return
-	
+
 	if(!msg)
 		msg = typing_input(src.mob, "", "ooc \"text\"")
-		
+
 	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
 	if(!msg)
 		return
@@ -76,7 +76,7 @@ var/global/admin_ooc_colour = "#b82e00"
 					var/icon/byond = icon('icons/member_content.dmi', "blag")
 					display_name = "[bicon(byond)][display_name]"
 
-			if(donator_level >= DONATOR_LEVEL_ONE)
+			if(donator_level > 0)
 				if((prefs.toggles & DONATOR_PUBLIC))
 					var/icon/donator = icon('icons/ooc_tag_16x.dmi', "donator")
 					display_name = "[bicon(donator)][display_name]"

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -81,7 +81,7 @@
 	var/datum/chatOutput/chatOutput
 
 	// Donator stuff.
-	var/donator_level = DONATOR_LEVEL_NONE
+	var/donator_level = 0
 
 	// If set to true, this client can interact with atoms such as buttons and doors on top of regular machinery interaction
 	var/advanced_admin_interaction = FALSE

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -326,8 +326,6 @@
 		GLOB.admins += src
 		holder.owner = src
 
-	donator_check()
-
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)
 	prefs = preferences_datums[ckey]
 	if(!prefs)
@@ -340,12 +338,6 @@
 
 	spawn() // Goonchat does some non-instant checks in start()
 		chatOutput.start()
-
-	if(custom_event_msg && custom_event_msg != "")
-		to_chat(src, "<h1 class='alert'>Custom Event</h1>")
-		to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
-		to_chat(src, "<span class='alert'>[html_encode(custom_event_msg)]</span>")
-		to_chat(src, "<br>")
 
 	if( (world.address == address || !address) && !host )
 		host = key
@@ -374,6 +366,7 @@
 			to_chat(src, message)
 		clientmessages.Remove(ckey)
 
+	donator_check()
 
 	send_resources()
 
@@ -397,6 +390,12 @@
 		void = new()
 
 	screen += void
+
+	if(custom_event_msg && custom_event_msg != "")
+		to_chat(src, "<h1 class='alert'>Custom Event</h1>")
+		to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
+		to_chat(src, "<span class='alert'>[html_encode(custom_event_msg)]</span>")
+		to_chat(src, "<br>")
 
 	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
 		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
@@ -429,13 +428,17 @@
 	if(!dbcon.IsConnected())
 		return
 
+	if(check_rights(R_ADMIN, 0, mob)) // Yes, the mob is required, regardless of other examples in this file, it won't work otherwise
+		donator_level = DONATOR_LEVEL_MAX
+		return
+
 	//Donator stuff.
 	var/DBQuery/query_donor_select = dbcon.NewQuery("SELECT ckey, tier, active FROM `[format_table_name("donators")]` WHERE ckey = '[ckey]'")
 	query_donor_select.Execute()
 	while(query_donor_select.NextRow())
 		if(!text2num(query_donor_select.item[3]))
 			// Inactive donator.
-			donator_level = DONATOR_LEVEL_NONE
+			donator_level = 0
 			return
 		donator_level = text2num(query_donor_select.item[2])
 		break

--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -4,7 +4,6 @@ var/list/gear_datums = list()
 /datum/loadout_category
 	var/category = ""
 	var/list/gear = list()
-	var/donor_only = FALSE
 
 /datum/loadout_category/New(cat)
 	category = cat
@@ -34,8 +33,6 @@ var/list/gear_datums = list()
 		if(!loadout_categories[use_category])
 			loadout_categories[use_category] = new /datum/loadout_category(use_category)
 		var/datum/loadout_category/LC = loadout_categories[use_category]
-		if(initial(G.donor_only))
-			LC.donor_only = TRUE
 		gear_datums[use_name] = new geartype
 		LC.gear[use_name] = gear_datums[use_name]
 
@@ -57,7 +54,7 @@ var/list/gear_datums = list()
 	var/list/gear_tweaks = list() //List of datums which will alter the item after it has been spawned.
 	var/subtype_path = /datum/gear //for skipping organizational subtypes (optional)
 	var/subtype_cost_overlap = TRUE //if subtypes can take points at the same time
-	var/donor_only = FALSE // if it's only available to donors
+	var/donator_tier = 0
 
 /datum/gear/New()
 	..()

--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -1,5 +1,5 @@
 /datum/gear/donor
-	donor_only = TRUE
+	donator_tier = 2
 	sort_category = "Donor"
 	subtype_path = /datum/gear/donor
 
@@ -77,6 +77,26 @@
 	display_name = "Guy Fawkes mask"
 	path = /obj/item/clothing/mask/fawkes
 
-/datum/gear/donor/noble_clothes
-	display_name = "Noble Clothes"
-	path = /obj/item/clothing/under/noble_clothes
+/datum/gear/donor/id_decal_silver
+	display_name = "Silver ID Decal"
+	path = /obj/item/id_decal/silver
+	donator_tier = 3
+	cost = 2
+
+/datum/gear/donor/id_decal_prisoner
+	display_name = "Prisoner ID Decal"
+	path = /obj/item/id_decal/prisoner
+	donator_tier = 3
+	cost = 2
+
+/datum/gear/donor/id_decal_emag
+	display_name = "Emag ID Decal"
+	path = /obj/item/id_decal/emag
+	donator_tier = 3
+	cost = 2
+
+/datum/gear/donor/id_decal_gold
+	display_name = "Gold ID Decal"
+	path = /obj/item/id_decal/gold
+	donator_tier = 4
+	cost = 4


### PR DESCRIPTION
Changes to the Patron/Donor system:
- All players can now see the patreon/donor category, and its items, in the loadout section of preferences. Picking any of these items still requires you to be a donor of the appropriate tier.
- Refactors the donation system to be more flexible.
- Adds support for a third tier of donations ($15/mo), to replace the (now removed) fluff item tier. This tier gets silver/prisoner/emag ID decals as additional loadout item unlocks. These are just decals that change the appearance of your ID. They do NOT grant any additional access.
- Adds support for a 4th tier of donations ($20/mo), to supplement the 'emoji tier' we currently use. I'd like to move us towards offering cosmetic rewards in-game, rather than just discord stuff. With these changes, it should be easy for us to add additional patreon loadout items in future for other tiers, if we want to. Right now, this tier only gets one unlock: the gold ID decal. Like the other ID decals, it changes your ID's appearance, but does NOT grant any additional access. Since there are only a few players at this donation tier, it should be pretty rare to see this used. It is also already available as an arcade prize.
- Admins always count as max tier donors, so they can experiment with the system and its items. Also because I plan to start granting in-game patreon status based on linked forum accounts - and there's a technical issue with how linking works which makes it disadvantageous to admins.
- Moves the "custom event info" to be displayed AFTER the MOTD when you connect. This way, when admins are running a custom event, and you late join, you will actually notice! Instead of it being pushed off your screen by the MOTD before you even notice it was there.

:cl: Kyep
add: Added new bonus loadout items for higher-tier patrons. Also gave admins access to patron items, and ensured that during custom events, you see the custom event announcement when you connect.
/:cl:

