### PR TITLE
Makes active internals visible in pockets

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -414,8 +414,22 @@
 			if(has_breathable_mask && istype(belt, /obj/item/tank))
 				dat += "&nbsp;<A href='?src=[UID()];internal=[slot_belt]'>[internal ? "Disable Internals" : "Set Internals"]</A>"
 			dat += "</td></tr>"
-			dat += "<tr><td>&nbsp;&#8627;<B>Pockets:</B></td><td><A href='?src=[UID()];pockets=left'>[(l_store && !(l_store.flags&ABSTRACT)) ? "Left (Full)" : "<font color=grey>Left (Empty)</font>"]</A>"
-			dat += "&nbsp;<A href='?src=[UID()];pockets=right'>[(r_store && !(r_store.flags&ABSTRACT)) ? "Right (Full)" : "<font color=grey>Right (Empty)</font>"]</A></td></tr>"
+			// Pockets
+			dat += "<tr><td>&nbsp;&#8627;<B>Pockets:</B></td><td><A href='?src=[UID()];pockets=left'>"
+			if(l_store && internal && l_store == internal)
+				dat += "[l_store]"
+			else if(l_store && !(l_store.flags&ABSTRACT))
+				dat += "Left (Full)"
+			else
+				dat += "<font color=grey>Left (Empty)</font>"
+			dat += "</A>&nbsp;<A href='?src=[UID()];pockets=right'>"
+			if(r_store && internal && r_store == internal)
+				dat += "[r_store]"
+			else if(r_store && !(r_store.flags&ABSTRACT))
+				dat += "Right (Full)"
+			else
+				dat += "<font color=grey>Right (Empty)</font>"
+			dat += "</A></td></tr>"
 			dat += "<tr><td>&nbsp;&#8627;<B>ID:</B></td><td><A href='?src=[UID()];item=[slot_wear_id]'>[(wear_id && !(wear_id.flags&ABSTRACT)) ? wear_id : "<font color=grey>Empty</font>"]</A></td></tr>"
 			dat += "<tr><td>&nbsp;&#8627;<B>PDA:</B></td><td><A href='?src=[UID()];item=[slot_wear_pda]'>[(wear_pda && !(wear_pda.flags&ABSTRACT)) ? wear_pda : "<font color=grey>Empty</font>"]</A></td></tr>"
 


### PR DESCRIPTION
Currently, when you examine someone else's inventory, you can only see if their pockets are 'full' or 'empty'.

With this PR, if you examine the inventory of someone with active internals, you will be able to see exactly what that active internals tank is in their pocket - without removing it.
This only applies to the exact item they're currently using for internal air supply. The one with presumably air cables reaching out of their pocket and up to their breath mask. No other items are revealed.

Example:
![oxytank](https://user-images.githubusercontent.com/16434066/56883947-ba314180-6a57-11e9-828f-2aabf99c9cf5.PNG)

:cl: Kyep
tweak: You can now identify when someone is using internals from a tank in their pocket, without having to remove the tank.
/:cl:

