### PR TITLE
Remove an admin message when drones join

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -248,9 +248,9 @@
 	death()
 
 /mob/living/silicon/robot/drone/proc/full_law_reset()
-	clear_supplied_laws()
-	clear_inherent_laws()
-	clear_ion_laws()
+	clear_supplied_laws(TRUE)
+	clear_inherent_laws(TRUE)
+	clear_ion_laws(TRUE)
 	laws = new /datum/ai_laws/drone
 
 //Reboot procs.


### PR DESCRIPTION
**What does this PR do:**
This pull request removes a useless message that would be sent to admins whenever a drone joins the round.

**Changelog:**
:cl: Markolie
fix: Removed a useless message that would be sent to admins whenever a drone joins the round.
/:cl:

