### PR TITLE
Various borg fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -665,7 +665,7 @@ var/list/robot_verbs_default = list(
 				I.loc = src.loc
 				var/was_installed = C.installed
 				C.installed = 0
-				if(was_installed)
+				if(was_installed == 1)
 					C.uninstall()
 
 		else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -157,6 +157,7 @@ var/list/robot_verbs_default = list(
 		var/datum/robot_component/cell_component = components["power cell"]
 		cell_component.wrapped = cell
 		cell_component.installed = 1
+		cell_component.install()
 
 	diag_hud_set_borgcell()
 	scanner = new(src)
@@ -438,8 +439,10 @@ var/list/robot_verbs_default = list(
 	var/dat = "<HEAD><TITLE>[src.name] Self-Diagnosis Report</TITLE></HEAD><BODY>\n"
 	for(var/V in components)
 		var/datum/robot_component/C = components[V]
-		dat += "<b>[C.name]</b><br><table><tr><td>Brute Damage:</td><td>[C.brute_damage]</td></tr><tr><td>Electronics Damage:</td><td>[C.electronics_damage]</td></tr><tr><td>Powered:</td><td>[C.is_powered() ? "Yes" : "No"]</td></tr><tr><td>Toggled:</td><td>[ C.toggled ? "Yes" : "No"]</td></table><br>"
-
+		if(C.installed == 0)
+			dat += "<b>[C.name]</b><br>MISSING<br>"
+		else
+			dat += "<b>[C.name]</b>[C.installed == -1 ? "<br>DESTROYED" : ""]<br><table><tr><td>Brute Damage:</td><td>[C.brute_damage]</td></tr><tr><td>Electronics Damage:</td><td>[C.electronics_damage]</td></tr><tr><td>Powered:</td><td>[C.is_powered() ? "Yes" : "No"]</td></tr><tr><td>Toggled:</td><td>[ C.toggled ? "Yes" : "No"]</td></table><br>"
 	return dat
 
 /mob/living/silicon/robot/verb/self_diagnosis_verb()
@@ -591,6 +594,9 @@ var/list/robot_verbs_default = list(
 		if(!getBruteLoss())
 			to_chat(user, "<span class='notice'>Nothing to fix!</span>")
 			return
+		else if(!getBruteLoss(TRUE))
+			to_chat(user, "<span class='warning'>The damaged components are beyond saving!</span>")
+			return
 		var/obj/item/weldingtool/WT = W
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(WT.remove_fuel(0))
@@ -603,10 +609,13 @@ var/list/robot_verbs_default = list(
 			return
 
 
-	else if(istype(W, /obj/item/stack/cable_coil) && user.a_intent == INTENT_HELP && (wiresexposed || istype(src,/mob/living/silicon/robot/drone)))
+	else if(istype(W, /obj/item/stack/cable_coil) && user.a_intent == INTENT_HELP && (wiresexposed || istype(src, /mob/living/silicon/robot/drone)))
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(!getFireLoss())
 			to_chat(user, "<span class='notice'>Nothing to fix!</span>")
+			return
+		else if(!getFireLoss(TRUE))
+			to_chat(user, "<span class='warning'>The damaged components are beyond saving!</span>")
 			return
 		var/obj/item/stack/cable_coil/coil = W
 		adjustFireLoss(-30)
@@ -654,10 +663,10 @@ var/list/robot_verbs_default = list(
 					I.burn = C.electronics_damage
 
 				I.loc = src.loc
-
-				if(C.installed == 1)
-					C.uninstall()
+				var/was_installed = C.installed
 				C.installed = 0
+				if(was_installed)
+					C.uninstall()
 
 		else
 			if(locked)
@@ -1362,7 +1371,7 @@ var/list/robot_verbs_default = list(
 	..()
 	var/brute = 1000
 	var/burn = 1000
-	var/list/datum/robot_component/borked_parts = get_damaged_components(brute,burn,1)
+	var/list/datum/robot_component/borked_parts = get_damaged_components(TRUE, TRUE, TRUE, TRUE)
 	for(var/datum/robot_component/borked_part in borked_parts)
 		brute = borked_part.brute_damage
 		burn = borked_part.electronics_damage

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -8,18 +8,20 @@
 	handle_hud_icons_health()
 	diag_hud_set_health()
 
-/mob/living/silicon/robot/getBruteLoss()
+/mob/living/silicon/robot/getBruteLoss(repairable_only = FALSE)
 	var/amount = 0
 	for(var/V in components)
 		var/datum/robot_component/C = components[V]
-		if(C.installed != 0) amount += C.brute_damage
+		if(C.installed != 0 && (!repairable_only || C.installed != -1)) // Installed ones only and if repair only remove the borked ones
+			amount += C.brute_damage
 	return amount
 
-/mob/living/silicon/robot/getFireLoss()
+/mob/living/silicon/robot/getFireLoss(repairable_only = FALSE)
 	var/amount = 0
 	for(var/V in components)
 		var/datum/robot_component/C = components[V]
-		if(C.installed != 0) amount += C.electronics_damage
+		if(C.installed != 0 && (!repairable_only || C.installed != -1)) // Installed ones only and if repair only remove the borked ones
+			amount += C.electronics_damage
 	return amount
 
 /mob/living/silicon/robot/adjustBruteLoss(amount, updating_health = TRUE)
@@ -36,11 +38,19 @@
 		heal_overall_damage(0, -amount, updating_health)
 	return STATUS_UPDATE_HEALTH
 
-/mob/living/silicon/robot/proc/get_damaged_components(var/brute, var/burn, var/get_all)
+/mob/living/silicon/robot/proc/get_damaged_components(get_brute, get_burn, get_borked = FALSE, get_missing = FALSE)
 	var/list/datum/robot_component/parts = list()
 	for(var/V in components)
 		var/datum/robot_component/C = components[V]
-		if(C.installed == 1 || get_all) if((brute && C.brute_damage) || (burn && C.electronics_damage))
+		if((C.installed == 1 || (get_borked && C.installed == -1) || (get_missing && C.installed == 0)) && ((get_brute && C.brute_damage) || (get_burn && C.electronics_damage)))
+			parts += C
+	return parts
+
+/mob/living/silicon/robot/proc/get_missing_components()
+	var/list/datum/robot_component/parts = list()
+	for(var/V in components)
+		var/datum/robot_component/C = components[V]
+		if(C.installed == 0)
 			parts += C
 	return parts
 
@@ -48,41 +58,43 @@
 	var/list/rval = new
 	for(var/V in components)
 		var/datum/robot_component/C = components[V]
-		if(C.installed == 1) rval += C
+		if(C.installed == 1)
+			rval += C
 	return rval
 
 /mob/living/silicon/robot/proc/get_armour()
-
-	if(!components.len) return 0
+	if(!LAZYLEN(components))
+		return 0
 	var/datum/robot_component/C = components["armour"]
 	if(C && C.installed == 1)
 		return C
 	return 0
 
 /mob/living/silicon/robot/heal_organ_damage(brute, burn, updating_health = TRUE)
-	var/list/datum/robot_component/parts = get_damaged_components(brute,burn)
-	if(!parts.len)	return
+	var/list/datum/robot_component/parts = get_damaged_components(brute, burn)
+	if(!LAZYLEN(parts))	
+		return
 	var/datum/robot_component/picked = pick(parts)
-	picked.heal_damage(brute,burn, updating_health)
+	picked.heal_damage(brute, burn, updating_health)
 
 /mob/living/silicon/robot/take_organ_damage(brute = 0, burn = 0, updating_health = TRUE, sharp = 0, edge = 0)
 	var/list/components = get_damageable_components()
-	if(!components.len)
+	if(!LAZYLEN(components))
 		return
 
 	 //Combat shielding absorbs a percentage of damage directly into the cell.
 	var/obj/item/borg/combat/shield/shield
-	if(module_state_1 && istype(module_state_1,/obj/item/borg/combat/shield))
+	if(module_state_1 && istype(module_state_1, /obj/item/borg/combat/shield))
 		shield = module_state_1
-	else if(module_state_2 && istype(module_state_2,/obj/item/borg/combat/shield))
+	else if(module_state_2 && istype(module_state_2, /obj/item/borg/combat/shield))
 		shield = module_state_2
-	else if(module_state_3 && istype(module_state_3,/obj/item/borg/combat/shield))
+	else if(module_state_3 && istype(module_state_3, /obj/item/borg/combat/shield))
 		shield = module_state_3
 	if(shield)
 		//Shields absorb a certain percentage of damage based on their power setting.
-		var/absorb_brute = brute*shield.shield_level
-		var/absorb_burn = burn*shield.shield_level
-		var/cost = (absorb_brute+absorb_burn)*100
+		var/absorb_brute = brute * shield.shield_level
+		var/absorb_burn = burn * shield.shield_level
+		var/cost = (absorb_brute+absorb_burn) * 100
 
 		cell.charge -= cost
 		if(cell.charge <= 0)
@@ -102,9 +114,9 @@
 	C.take_damage(brute, burn, sharp, updating_health)
 
 /mob/living/silicon/robot/heal_overall_damage(var/brute, var/burn, updating_health = TRUE)
-	var/list/datum/robot_component/parts = get_damaged_components(brute,burn)
+	var/list/datum/robot_component/parts = get_damaged_components(brute, burn)
 
-	while(parts.len && (brute>0 || burn>0) )
+	while(LAZYLEN(parts) && (brute > 0 || burn > 0) )
 		var/datum/robot_component/picked = pick(parts)
 
 		var/brute_was = picked.brute_damage
@@ -112,8 +124,8 @@
 
 		picked.heal_damage(brute,burn, updating_health)
 
-		brute -= (brute_was-picked.brute_damage)
-		burn -= (burn_was-picked.electronics_damage)
+		brute -= (brute_was - picked.brute_damage)
+		burn -= (burn_was - picked.electronics_damage)
 
 		parts -= picked
 
@@ -126,17 +138,17 @@
 
 	 //Combat shielding absorbs a percentage of damage directly into the cell.
 	var/obj/item/borg/combat/shield/shield
-	if(module_state_1 && istype(module_state_1,/obj/item/borg/combat/shield))
+	if(module_state_1 && istype(module_state_1, /obj/item/borg/combat/shield))
 		shield = module_state_1
-	else if(module_state_2 && istype(module_state_2,/obj/item/borg/combat/shield))
+	else if(module_state_2 && istype(module_state_2, /obj/item/borg/combat/shield))
 		shield = module_state_2
-	else if(module_state_3 && istype(module_state_3,/obj/item/borg/combat/shield))
+	else if(module_state_3 && istype(module_state_3, /obj/item/borg/combat/shield))
 		shield = module_state_3
 	if(shield)
 		//Shields absorb a certain percentage of damage based on their power setting.
-		var/absorb_brute = brute*shield.shield_level
-		var/absorb_burn = burn*shield.shield_level
-		var/cost = (absorb_brute+absorb_burn)*100
+		var/absorb_brute = brute * shield.shield_level
+		var/absorb_burn = burn * shield.shield_level
+		var/cost = (absorb_brute+absorb_burn) * 100
 
 		cell.charge -= cost
 		if(cell.charge <= 0)
@@ -152,7 +164,7 @@
 		A.take_damage(brute, burn, sharp)
 		return
 
-	while(parts.len && (brute>0 || burn>0) )
+	while(LAZYLEN(parts) && (brute > 0 || burn > 0) )
 		var/datum/robot_component/picked = pick(parts)
 
 		var/brute_was = picked.brute_damage

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -46,7 +46,9 @@
 			user.put_in_active_hand(cell)
 			to_chat(user, "<span class='notice'>You remove \the [cell].</span>")
 			cell = null
-			update_stat()
+			var/datum/robot_component/C = components["power cell"]
+			C.installed = 0
+			C.uninstall()
 			diag_hud_set_borgcell()
 
 	if(!opened)


### PR DESCRIPTION
**What does this PR do:**
Fixes a few things:
1. You won't try to fix Destroyed components anymore. Meaning no wasted welding fuel or wires.
2. The borg health status will be updated properly when removing and adding components.
3. The borg analyser will now correctly show missing components. And won't show their damage if missing.
4. Cells now get counted as removed when they are removed
5. Self diagnostics now shows the destroyed and missing parts

And a few refactors due to it being shit old code.

**Changelog:**
:cl:
fix: Borgs health status now updates properly when removing and adding parts
fix: You won't try to fix destroyed components in borgs anymore. Which resulted to lost materials and no healing
fix: Borg analysers will now properly show missing components and won't show their damage if missing
tweak: Self diagnostics for borgs now also shows missing parts and destroyed ones
/:cl:

