### PR TITLE
pAI admin message fix

### DIFF
--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -55,7 +55,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 
 			pai_candidates -= candidate
 			usr << browse(null, "window=findPai")
-
+		return
 
 	if("signup" in href_list)
 		var/mob/dead/observer/O = locate(href_list["signup"])
@@ -70,7 +70,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 		return
 
 	if(candidate)
-		if(candidate.key && usr.key && lowertext(candidate.key) != lowertext(usr.key))
+		if(candidate.key && usr.key && candidate.key != usr.key)
 			message_admins("Warning: possible href exploit by [key_name_admin(usr)] (paiController/Topic, candidate and usr have different keys)")
 			log_debug("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr have different keys)")
 			return

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -28,7 +28,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 
 	if(candidate)
 		if(!istype(candidate))
-			message_admins("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate is not a pAI)")
+			message_admins("Warning: possible href exploit by [key_name_admin(usr)] (paiController/Topic, candidate is not a pAI)")
 			log_debug("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate is not a pAI)")
 			return
 
@@ -70,9 +70,9 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 		return
 
 	if(candidate)
-		if(candidate.key && usr.key && candidate.key != usr.key)
-			message_admins("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr are different mobs)")
-			log_debug("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr are different mobs)")
+		if(candidate.key && usr.key && lowertext(candidate.key) != lowertext(usr.key))
+			message_admins("Warning: possible href exploit by [key_name_admin(usr)] (paiController/Topic, candidate and usr have different keys)")
+			log_debug("Warning: possible href exploit by [key_name(usr)] (paiController/Topic, candidate and usr have different keys)")
 			return
 
 	if(href_list["new"])


### PR DESCRIPTION
**What does this PR do:**
This pull request fixes an issue where admins would receive a message whenever someone joined up as a pAI. 

**Changelog:**
:cl: Markolie
fix: Fixed an issue where admins would receive a message whenever someone joined up as a pAI.
/:cl: