### PR TITLE
Adds Server Time to MC Tab for Admins

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1001,6 +1001,8 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/show_stat_station_time()
 	stat(null, "Round Time: [worldtime2text()]")
 	stat(null, "Station Time: [station_time_timestamp()]")
+	if(client.holder && (client.holder.rights & R_ADMIN))
+		stat(null, "Server Time: [time_stamp()]")
 
 // this function displays the shuttles ETA in the status panel if the shuttle has been called
 /mob/proc/show_stat_emergency_shuttle_eta()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -981,6 +981,7 @@ var/list/slot_equipment_priority = list( \
 			stat("CPU:", "[world.cpu]")
 			stat("Instances:", "[num2text(world.contents.len, 10)]")
 			GLOB.stat_entry()
+			stat("Server Time:", time_stamp())
 			stat(null)
 			if(Master)
 				Master.stat_entry()
@@ -1001,8 +1002,6 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/show_stat_station_time()
 	stat(null, "Round Time: [worldtime2text()]")
 	stat(null, "Station Time: [station_time_timestamp()]")
-	if(client.holder && (client.holder.rights & R_ADMIN))
-		stat(null, "Server Time: [time_stamp()]")
 
 // this function displays the shuttles ETA in the status panel if the shuttle has been called
 /mob/proc/show_stat_emergency_shuttle_eta()


### PR DESCRIPTION
This just adds the ability for admins only to see the server time itself, the same time that get set to logs, to allow an easier time of comparing current time to when logs were generated, so an admin can know how long ago something occurred, such as attack logs, admin logs, tickets, etc. This is for administrative use only, and only shows up for admins.

How it looks: https://i.imgur.com/sx7QU63.png

Edit: Moved Server Time Stamp to the MC Tab, just below the Globals info.

:cl:Twinmold
Add: Adds Server Time to the Status Tab for Admins.
/:cl: