### PR TITLE
Adds Eyewear Adjustment: Wearing Over/Under Masks

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -208,33 +208,34 @@
 #define MFOAM_IRON 		2
 
 //Human Overlays Indexes/////////
-#define BODY_LAYER				37
-#define MUTANTRACE_LAYER		36
-#define TAIL_UNDERLIMBS_LAYER	35	//Tail split-rendering.
-#define LIMBS_LAYER				34
-#define INTORGAN_LAYER			33
-#define MARKINGS_LAYER			32
-#define UNDERWEAR_LAYER			31
-#define MUTATIONS_LAYER			30
-#define H_DAMAGE_LAYER			29
-#define UNIFORM_LAYER			28
-#define ID_LAYER				27
-#define SHOES_LAYER				26
-#define GLOVES_LAYER			25
-#define EARS_LAYER				24
-#define SUIT_LAYER				23
-#define BELT_LAYER				22	//Possible make this an overlay of somethign required to wear a belt?
-#define SUIT_STORE_LAYER		21
-#define BACK_LAYER				20
-#define HEAD_ACCESSORY_LAYER	19
-#define FHAIR_LAYER				18
-#define GLASSES_LAYER			17
-#define HAIR_LAYER				16	//TODO: make part of head layer?
-#define HEAD_ACC_OVER_LAYER		15	//Select-layer rendering.
-#define FHAIR_OVER_LAYER		14	//Select-layer rendering.
-#define GLASSES_OVER_LAYER		13	//Select-layer rendering.
-#define TAIL_LAYER				12	//bs12 specific. this hack is probably gonna come back to haunt me
-#define FACEMASK_LAYER			11
+#define BODY_LAYER				38
+#define MUTANTRACE_LAYER		37
+#define TAIL_UNDERLIMBS_LAYER	36	//Tail split-rendering.
+#define LIMBS_LAYER				35
+#define INTORGAN_LAYER			34
+#define MARKINGS_LAYER			33
+#define UNDERWEAR_LAYER			32
+#define MUTATIONS_LAYER			31
+#define H_DAMAGE_LAYER			30
+#define UNIFORM_LAYER			29
+#define ID_LAYER				28
+#define SHOES_LAYER				27
+#define GLOVES_LAYER			26
+#define EARS_LAYER				25
+#define SUIT_LAYER				24
+#define BELT_LAYER				23	//Possible make this an overlay of somethign required to wear a belt?
+#define SUIT_STORE_LAYER		22
+#define BACK_LAYER				21
+#define HEAD_ACCESSORY_LAYER	20
+#define FHAIR_LAYER				19
+#define GLASSES_LAYER			18
+#define HAIR_LAYER				17	//TODO: make part of head layer?
+#define HEAD_ACC_OVER_LAYER		16	//Select-layer rendering.
+#define FHAIR_OVER_LAYER		15	//Select-layer rendering.
+#define GLASSES_OVER_LAYER		14	//Select-layer rendering.
+#define TAIL_LAYER				13	//bs12 specific. this hack is probably gonna come back to haunt me
+#define FACEMASK_LAYER			12
+#define OVER_MASK_LAYER			11	//Select-layer rendering.
 #define HEAD_LAYER				10
 #define COLLAR_LAYER			9
 #define HANDCUFF_LAYER			8
@@ -245,7 +246,7 @@
 #define FIRE_LAYER				3	//If you're on fire
 #define MISC_LAYER				2
 #define FROZEN_LAYER			1
-#define TOTAL_LAYERS			37
+#define TOTAL_LAYERS			38
 
 ///Access Region Codes///
 #define REGION_ALL			0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -159,6 +159,7 @@
 	var/list/color_view = null//overrides client.color while worn
 	var/prescription = 0
 	var/prescription_upgradable = 0
+	var/over_mask = FALSE //Whether or not the eyewear is rendered above the mask. Purely cosmetic.
 	strip_delay = 20			//	   but seperated to allow items to protect but not impair vision, like space helmets
 	put_on_delay = 25
 	burn_state = FIRE_PROOF
@@ -173,6 +174,28 @@ SEE_PIXELS// if an object is located on an unlit area, but some of its pixels ar
 BLIND     // can't see anything
 */
 
+/obj/item/clothing/glasses/verb/adjust_eyewear() //Adjust eyewear to be worn above or below the mask.
+	set name = "Adjust Eyewear"
+	set category = "Object"
+	set desc = "Adjust your eyewear to be worn over or under a mask."
+	set src in usr
+
+	var/mob/living/carbon/human/user = usr
+	if(!istype(user))
+		return
+	if(user.incapacitated()) //Dead spessmen adjust no glasses. Resting/buckled ones do, though
+		return
+
+	var/action_fluff = "You adjust \the [src]"
+	if(user.glasses == src)
+		if(!user.canUnEquip(src))
+			to_chat(usr, "[src] is stuck to you!")
+			return
+		if(attack_hand(user)) //Remove the glasses for this action. Prevents logic-defying instances where glasses phase through your mask as it ascends/descends to another plane of existence.
+			action_fluff = "You remove \the [src] and adjust it"
+
+	over_mask = !over_mask
+	to_chat(user, "<span class='notice'>[action_fluff] to be worn [over_mask ? "over" : "under"] a mask.</span>")
 
 //Gloves
 /obj/item/clothing/gloves

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -659,6 +659,7 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/update_inv_glasses(var/update_icons=1)
 	remove_overlay(GLASSES_LAYER)
 	remove_overlay(GLASSES_OVER_LAYER)
+	remove_overlay(OVER_MASK_LAYER)
 
 	if(client && hud_used)
 		var/obj/screen/inventory/inv = hud_used.inv_slots[slot_glasses]
@@ -681,7 +682,12 @@ var/global/list/damage_icon_parts = list()
 			new_glasses = mutable_appearance('icons/mob/eyes.dmi', "[glasses.icon_state]", layer = -GLASSES_LAYER)
 
 		var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_full_list[head_organ.h_style]
-		if(hair_style && hair_style.glasses_over) //Select which layer to use based on the properties of the hair style. Hair styles with hair that don't overhang the arms of the glasses should have glasses_over set to a positive value.
+		var/obj/item/clothing/glasses/G = glasses
+		if(istype(G) && G.over_mask) //If the user's used the 'wear over mask' verb on the glasses.
+			new_glasses.layer = -OVER_MASK_LAYER
+			overlays_standing[OVER_MASK_LAYER] = new_glasses
+			apply_overlay(OVER_MASK_LAYER)
+		else if(hair_style && hair_style.glasses_over) //Select which layer to use based on the properties of the hair style. Hair styles with hair that don't overhang the arms of the glasses should have glasses_over set to a positive value.
 			new_glasses.layer = -GLASSES_OVER_LAYER
 			overlays_standing[GLASSES_OVER_LAYER] = new_glasses
 			apply_overlay(GLASSES_OVER_LAYER)


### PR DESCRIPTION
**What does this PR do:**
Adds a verb to eyewear that'll let you adjust them to be worn above or below a mask. Purely cosmetic.
Certain articles of clothing look better adorning masks rather than hiding behind them and this gives you the freedom to make that choice.

**Images of sprite/map changes (IF APPLICABLE):**
See demo [here](https://anonfile.com/5dy5Tek1n5). Real OGs be remembering where this was recorded at

**Changelog:**
:cl:
add: Adds a verb to eyewear you can use to adjust them so they appear above or below masks. Discover interesting combinations and enjoy a cool look.
/:cl:

Someday I'm going to have to consider a better way of handling the 'above x' layers.
