### PR TITLE
Craftable Patch Pack

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -240,6 +240,7 @@ var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 var/global/list/datum/stack_recipe/cardboard_recipes = list (
 	new /datum/stack_recipe("box", /obj/item/storage/box),
 	new /datum/stack_recipe("large box", /obj/item/storage/box/large, 4),
+	new /datum/stack_recipe("patch pack", /obj/item/storage/pill_bottle/patch_pack, 2),
 	new /datum/stack_recipe("light tubes", /obj/item/storage/box/lights/tubes),
 	new /datum/stack_recipe("light bulbs", /obj/item/storage/box/lights/bulbs),
 	new /datum/stack_recipe("mouse traps", /obj/item/storage/box/mousetraps),


### PR DESCRIPTION
**What does this PR do:**
Patch Pack is now craftable with a cardboard. You need 2 cardboard sheets to be able to craft one Patch Pack. You can order cardboard from Cargo, make it in a Biogenerator, or salvage some from boxes.

Tested locally without any issue.

**Images of sprite/map changes (IF APPLICABLE):**
![pack](https://user-images.githubusercontent.com/43862960/56982339-6458b880-6b81-11e9-9f0b-2d5b9816d780.png)

**Changelog:**
:cl: Arkatos
add: Patch Pack is now craftable with a cardboard, costs 2 cardboard sheets.
/:cl: