### PR TITLE
Make the traitor reviver implant EMP-proof

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1544,10 +1544,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 12
 
 /datum/uplink_item/cyber_implants/reviver
-	name = "Reviver Implant"
-	desc = "This implant will attempt to revive you if you lose consciousness. Comes with an automated implanting tool."
+	name = "Hardened Reviver Implant"
+	desc = "This implant will attempt to revive you if you lose consciousness. It is invulnerable to EMPs. Comes with an automated implanting tool."
 	reference = "CIR"
-	item = /obj/item/organ/internal/cyberimp/chest/reviver
+	item = /obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	cost = 8
 
 // POINTLESS BADASSERY

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -256,8 +256,15 @@
 	origin_tech = "materials=5;programming=4;biotech=4"
 	slot = "heartdrive"
 	var/revive_cost = 0
-	var/reviving = 0
+	var/reviving = FALSE
 	var/cooldown = 0
+
+/obj/item/organ/internal/cyberimp/chest/reviver/hardened
+	name = "Hardened reviver implant"
+	emp_proof = TRUE
+
+/obj/item/organ/internal/cyberimp/chest/reviver/hardened/Initialize(mapload)
+	desc += " The implant has been hardened. It is invulnerable to EMPs."
 
 /obj/item/organ/internal/cyberimp/chest/reviver/on_life()
 	if(reviving)
@@ -320,7 +327,7 @@
 /obj/item/storage/box/cyber_implants/bundle
 	name = "boxed cybernetic implants"
 	var/list/boxed = list(/obj/item/organ/internal/cyberimp/eyes/xray,/obj/item/organ/internal/cyberimp/eyes/thermals,
-						/obj/item/organ/internal/cyberimp/brain/anti_stun, /obj/item/organ/internal/cyberimp/chest/reviver)
+						/obj/item/organ/internal/cyberimp/brain/anti_stun, /obj/item/organ/internal/cyberimp/chest/reviver/hardened)
 	var/amount = 5
 
 /obj/item/storage/box/cyber_implants/bundle/New()

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -264,6 +264,7 @@
 	emp_proof = TRUE
 
 /obj/item/organ/internal/cyberimp/chest/reviver/hardened/Initialize(mapload)
+	. = ..()
 	desc += " The implant has been hardened. It is invulnerable to EMPs."
 
 /obj/item/organ/internal/cyberimp/chest/reviver/on_life()


### PR DESCRIPTION
**What does this PR do:**
This pull request makes the reviver implant that traitors and nuke ops can buy (separately or through the cyber implant bundle) invulnerable to EMPs. The one obtainable through research is still vulnerable. 

It's much too dangerous to ever use this implant as nuke ops as getting hit by an EMP means an instant heart attack. Occasionally fluke ops even friendly fire their own ion gun, killing a fellow operative with a reviver implant.

**Changelog:**
:cl: Markolie
balance: The reviver implant in the uplink and cyber implant bundle is now invulnerable to EMPs.
/:cl:

