### PR TITLE
Fixes runtime in job_exp.dm

### DIFF
--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -257,7 +257,12 @@ var/global/list/role_playtime_requirements = list(
 			play_records[rtype] = text2num(read_records[rtype])
 		else
 			play_records[rtype] = 0
-	var/myrole = mob.mind.playtime_role ? mob.mind.playtime_role : mob.mind.assigned_role
+	var/myrole
+	if(mob.mind)
+		if(mob.mind.playtime_role)
+			myrole = mob.mind.playtime_role
+		else if(mob.mind.assigned_role)
+			myrole = mob.mind.assigned_role
 	if(mob.stat == CONSCIOUS && myrole)
 		play_records[EXP_TYPE_LIVING] += minutes
 		if(announce_changes)


### PR DESCRIPTION
job_exp.dm#260 currently makes the incorrect assumption that all player mobs have minds.
While this is almost always true, players who observe the game without ever being a living player don't have minds, and cause this proc to runtime.
This PR fixes solves the runtime.
:cl:Kyep
fix: Fixed a runtime in job_exp.dm
/:cl:

