### PR TITLE
Examine tooltips tweaks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -593,7 +593,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 /obj/item/MouseEntered(location, control, params)
 	if(in_inventory)
-		var/timedelay = 5
+		var/timedelay = 7
 		var/user = usr
 		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -593,7 +593,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 /obj/item/MouseEntered(location, control, params)
 	if(in_inventory)
-		var/timedelay = 7
+		var/timedelay = 8
 		var/user = usr
 		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -312,7 +312,9 @@
 		if(usr.s_active)
 			usr.s_active.show_to(usr)
 	W.mouse_opacity = MOUSE_OPACITY_OPAQUE //So you can click on the area around the item to equip it, instead of having to pixel hunt
+	W.in_inventory = TRUE
 	update_icon()
+	W.in_inventory = TRUE
 	return 1
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -314,7 +314,6 @@
 	W.mouse_opacity = MOUSE_OPACITY_OPAQUE //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	W.in_inventory = TRUE
 	update_icon()
-	W.in_inventory = TRUE
 	return 1
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target


### PR DESCRIPTION
**What does this PR do:**
This PR consists of 2 changes regarding examine tooltips:
1) Delay before tooltip is shown increased slightly to prevent showing while doing common actions with the item.
2) Fixed a bug where examine tooltip was not showing properly on items in storage, such as backpack.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Examine tooltip delay increased slightly
fix: Examine tooltips now work properly on items in storage
/:cl: