### PR TITLE
Adds Pig Crate to Cargo

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1073,6 +1073,12 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/closet/critter/cow
 	containername = "cow crate"
 
+/datum/supply_packs/organic/pig
+	name = "Pig Crate"
+	cost = 25
+	containertype = /obj/structure/closet/critter/pig
+	containername = "pig crate"
+
 /datum/supply_packs/organic/goat
 	name = "Goat Crate"
 	cost = 25

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -44,6 +44,10 @@
 	name = "cow crate"
 	content_mob = /mob/living/simple_animal/cow
 
+/obj/structure/closet/critter/pig
+	name = "pig crate"
+	content_mob = /mob/living/simple_animal/pig
+
 /obj/structure/closet/critter/goat
 	name = "goat crate"
 	content_mob = /mob/living/simple_animal/hostile/retaliate/goat


### PR DESCRIPTION
**What does this PR do:**
There is a distinct lack of pigs on the station. This crate keeps in line with ordering animals to turn into tasty tasty food and adds in the pig for 25 cargo points. No longer will chefs be in tears that they can have turkey but not a pig.

**Changelog:**
:cl:
add: You can now order a Pig Crate from Cargo for 25 points.
/:cl:

