### PR TITLE
Makes secborgs unpickable

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -106,7 +106,7 @@
 	name = "robotic VTEC Module"
 	desc = "Used to kick in a robot's VTEC systems, increasing their speed."
 	icon_state = "cyborg_upgrade2"
-	require_module = 1
+	require_module = TRUE
 	origin_tech = "engineering=4;materials=5;programming=4"
 
 /obj/item/borg/upgrade/vtec/action(var/mob/living/silicon/robot/R)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -282,7 +282,7 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/proc/pick_module()
 	if(module)
 		return
-	var/list/modules = list("Standard", "Engineering", "Medical", "Miner", "Janitor", "Service", "Security")
+	var/list/modules = list("Standard", "Engineering", "Medical", "Miner", "Janitor", "Service")
 	if(islist(force_modules) && force_modules.len)
 		modules = force_modules.Copy()
 	if(security_level == (SEC_LEVEL_GAMMA || SEC_LEVEL_EPSILON) || crisis)
@@ -344,18 +344,6 @@ var/list/robot_verbs_default = list(
 			module_sprites["Standard"] = "Standard-Medi"
 			module_sprites["Noble-MED"] = "Noble-MED"
 			module_sprites["Cricket"] = "Cricket-MEDI"
-			status_flags &= ~CANPUSH
-
-		if("Security")
-			module = new /obj/item/robot_module/security(src)
-			module.channels = list("Security" = 1)
-			module_sprites["Basic"] = "secborg"
-			module_sprites["Red Knight"] = "Security"
-			module_sprites["Black Knight"] = "securityrobot"
-			module_sprites["Bloodhound"] = "bloodhound"
-			module_sprites["Standard"] = "Standard-Secy"
-			module_sprites["Noble-SEC"] = "Noble-SEC"
-			module_sprites["Cricket"] = "Cricket-SEC"
 			status_flags &= ~CANPUSH
 
 		if("Engineering")

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1051,16 +1051,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_disablercooler
-	name = "Cyborg Upgrade Module (Rapid Disabler Cooling)"
-	id = "borg_upgrade_disablercooler"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/disablercooler
-	req_tech = list("combat" = 5, "powerstorage" = 4, "engineering" = 4)
-	materials = list(MAT_METAL=80000 , MAT_GLASS=6000 , MAT_GOLD= 2000, MAT_DIAMOND = 500)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 /datum/design/borg_upgrade_diamonddrill
 	name = "Cyborg Upgrade (Diamond Drill)"
 	id = "borg_upgrade_diamonddrill"


### PR DESCRIPTION
**What does this PR do:**
Please see https://github.com/ParadiseSS13/Paradise/pull/11433 for an alternative to this pull request. This pull request makes the security module unpickable.

Security borgs are incredibly powerful. They're effectively security officers that can not be stunned and can not be disarmed. Their only effective counters are EMP's and flashes: both specialized tools that aren't readily available to all roles. 

Security borgs can not be countered properly by antagonists. Traitors must either be in possession of a flash or EMP, which they generally have to spend valuable telecrystals on. Did you spend 17 telecrystals on sleeping carp? Tough luck if a borg comes running. Changelings better have purchased that EMP screech if the borgs come busting down the airlocks. Shadowlings, abductors, vampires are straight out of luck unless they're carrying a flash.

These days, science can complete their research by the thirty minute mark. That means a load of posibrains, who are more than eager to play as a security borg. Around the fifteen minute mark you can usually pick up a VTEC upgrade and be speedier than Sonic.

Security borgs can instantly lock down everything around you, locking you inside. They can also instantly let security officers straight into areas they'd otherwise be unable to enter. Plus, if you partner up a security officer and security borg, what's going to stop them? You'll have to flash AND stun at the same time.

Sadly enough, many security borgs on Paradise also do not care much for their lawset. Even on Crewsimov or Corporate they will focus on one thing: making sure those darn antags do not get their greentext. This validhunty behaviour from silicons on the server has been an issue for forever.

When is the last time you had a meaningful roleplaying experience with a security borg? I can't remember any. 

A strong argument in favour of security borgs is that they are of significant help to the security team. That is true, but I think these days it's not that necessary. Security tends to be in control most of the time even when dealing with many traitors, and security ERT's aren't anywhere near as common as they used to be. 

I strongly believe, and I know others do too, that security borgs do not contribute anything to the station except for validhunting. And if you want to validhunt, security borgs are arguably the very best choice. Antagonists on the station already have a hard enough time with the current population. Plus, I do not believe that security borgs add anything meaningful in terms of roleplaying.

**Changelog:**
:cl: Markolie
balance: The security module can no longer be picked by cyborgs.
/:cl:

