### PR TITLE
fixed typo in sst console

### DIFF
--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -42,7 +42,7 @@
 	..()
 
 /obj/machinery/computer/shuttle/sst
-	name = "Syndicate Strike Time Shuttle Console"
+	name = "Syndicate Strike Team Shuttle Console"
 	desc = "Used to call and send the SST shuttle."
 	icon_keyboard = "syndie_key"
 	icon_screen = "syndishuttle"


### PR DESCRIPTION
**What does this PR do:**
fixes a typo, because why not. Console is now properly named.
syndicate strike time -> syndicate strike team

**Changelog:**
:cl:
fix: typo on sst shuttle console
/:cl:

