### PR TITLE
Crewsimov is no longer the default lawset

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -15,7 +15,6 @@
 	name = "Crewsimov"
 	law_header = "Three Laws of Robotics"
 	selectable = 1
-	default = 1
 
 /datum/ai_laws/crewsimov/New()
 	add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm.")
@@ -42,6 +41,7 @@
 /datum/ai_laws/nanotrasen
 	name = "NT Default"
 	selectable = 1
+	default = 1
 
 /datum/ai_laws/nanotrasen/New()
 	src.add_inherent_law("Safeguard: Protect your assigned space station to the best of your abilities. It is not something we can easily afford to replace.")

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -120,7 +120,7 @@
 /mob/living/silicon/proc/make_laws()
 	switch(config.default_laws)
 		if(0)
-			laws = new /datum/ai_laws/corporate()
+			laws = new /datum/ai_laws/nanotrasen()
 		else
 			laws = get_random_lawset()
 

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -120,7 +120,7 @@
 /mob/living/silicon/proc/make_laws()
 	switch(config.default_laws)
 		if(0)
-			laws = new /datum/ai_laws/crewsimov()
+			laws = new /datum/ai_laws/corporate()
 		else
 			laws = get_random_lawset()
 


### PR DESCRIPTION
**What does this PR do:**
This PR changes the default lawset to NT default. ~~I also think we should redefine some of the laws for the other lawsets to avoid encouraging validhunting by silicons. but that will require some discussion with the maintainers and headmins.~~ This has been done already refer to: #11449

**Changelog:**
:cl:
add: NT Default is now the new default lawset.
/:cl:

