### PR TITLE
Admin created cultists can now properly summon their Gods.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -18,6 +18,7 @@
 		However if you want that mind to have any special properties like being a traitor etc you will have to do that
 		yourself.
 */
+#define SUMMON_POSSIBILITIES 3
 
 /datum/mind
 	var/key
@@ -823,6 +824,11 @@
 					to_chat(current, "<span class='cultitalic'>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve [ticker.cultdat.entity_title2] above all else. Bring It back.</span>")
 					log_admin("[key_name(usr)] has culted [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has culted [key_name_admin(current)]")
+					if(!summon_spots.len)
+						while(summon_spots.len < SUMMON_POSSIBILITIES)
+							var/area/summon = pick(return_sorted_areas() - summon_spots)
+							if(summon && is_station_level(summon.z) && summon.valid_territory)
+								summon_spots += summon
 			if("tome")
 				var/mob/living/carbon/human/H = current
 				if(istype(H))

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -177,6 +177,11 @@ client/proc/one_click_antag()
 			H = pick(candidates)
 			ticker.mode.add_cultist(H.mind)
 			candidates.Remove(H)
+			if(!summon_spots.len)
+				while(summon_spots.len < SUMMON_POSSIBILITIES)
+					var/area/summon = pick(return_sorted_areas() - summon_spots)
+					if(summon && is_station_level(summon.z) && summon.valid_territory)
+						summon_spots += summon
 
 		return 1
 	return 0


### PR DESCRIPTION
**What does this PR do:**
Upon being made a cultist through admin means, the "summon spots" will now be generated, even if the game mode isn't cult. This allows admin created cultists to actually reach their goal of summoning their god, if it is what the admins told them to do.

**Changelog:**
:cl: EmanTheAlmighty
tweak: Admin made cultists can now properly summon their Gods if the gamemode wasn't initially Cult.
/:cl: