### PR TITLE
Allow admin access to airlock buttons

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -255,10 +255,15 @@
 		return
 	..()
 
+/obj/machinery/access_button/attack_ghost(mob/user)
+	if(user.can_advanced_admin_interact())
+		return attack_hand(user)
+
 /obj/machinery/access_button/attack_hand(mob/user)
 	add_fingerprint(usr)
-	if(!allowed(user))
-		to_chat(user, "<span class='warning'>Access Denied</span>")
+
+	if(!allowed(user) && !user.can_advanced_admin_interact())
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 
 	else if(radio_connection)
 		var/datum/signal/signal = new


### PR DESCRIPTION
**What does this PR do:**
Admins with advanced admin interaction toggled on can now interact with the small airlock buttons.

**Changelog:**
:cl: Markolie
tweak: Admins with advanced admin interaction toggled on can now interact with the small airlock buttons.
/:cl:

