### PR TITLE
Fixes item_attack runtime when punching windoor

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -24,7 +24,7 @@
 	return FALSE
 
 /obj/attackby(obj/item/I, mob/living/user, params)
-	return ..() || (can_be_hit && I.attack_obj(src, user))
+	return ..() || (can_be_hit && istype(I) && I.attack_obj(src, user))
 
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -24,7 +24,7 @@
 	return FALSE
 
 /obj/attackby(obj/item/I, mob/living/user, params)
-	return ..() || (can_be_hit && istype(I) && I.attack_obj(src, user))
+	return ..() || (can_be_hit && I.attack_obj(src, user))
 
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -87,10 +87,7 @@
 	if(operating || !density)
 		return
 	add_fingerprint(user)
-	if(!requiresID())
-		user = null
-
-	if(allowed(user))
+	if(!requiresID() || allowed(user))
 		open_and_close()
 	else
 		do_animate("deny")
@@ -217,7 +214,7 @@
 		return attack_hand(user)
 
 /obj/machinery/door/window/attack_hand(mob/user)
-	return attackby(user, user)
+	return bumpopen(user)
 
 /obj/machinery/door/window/emag_act(mob/user, obj/weapon)
 	if(!operating && density && !emagged)


### PR DESCRIPTION
:cl: Kyep
fix: punching a windoor no longer generates a runtime error.
/:cl:

