### PR TITLE
Fixes throw_at runtime in vending machines

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -299,7 +299,7 @@
 		pulledby.stop_pulling()
 
 	// They are moving! Wouldn't it be cool if we calculated their momentum and added it to the throw?
-	if(thrower && thrower.last_move && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
+	if(thrower && istype(thrower) && thrower.last_move && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
 		var/user_momentum = thrower.movement_delay()
 		if(!user_momentum) // no movement_delay, this means they move once per byond tick, let's calculate from that instead
 			user_momentum = world.tick_lag

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -299,7 +299,7 @@
 		pulledby.stop_pulling()
 
 	// They are moving! Wouldn't it be cool if we calculated their momentum and added it to the throw?
-	if(thrower && istype(thrower) && thrower.last_move && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
+	if(thrower && thrower.last_move && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
 		var/user_momentum = thrower.movement_delay()
 		if(!user_momentum) // no movement_delay, this means they move once per byond tick, let's calculate from that instead
 			user_momentum = world.tick_lag

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -738,7 +738,7 @@
 		break
 	if(!throw_item)
 		return
-	throw_item.throw_at(target, 16, 3, src)
+	throw_item.throw_at(target, 16, 3)
 	visible_message("<span class='danger'>[src] launches [throw_item.name] at [target.name]!</span>")
 
 /*


### PR DESCRIPTION
:cl: Kyep
fix: unanchored vending machines will no longer generate a runtime error when throwing products at people.
/:cl:

