### PR TITLE
Fixes runtime when disarming/grabbing some doors (can_admin_interact())

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -167,7 +167,7 @@
 		return
 	if(!requiresID())
 		user = null //so allowed(user) always succeeds
-	if(allowed(user) || user.can_advanced_admin_interact())
+	if(allowed(user) || (istype(user) && user.can_advanced_admin_interact()))
 		if(density)
 			open()
 		else

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -134,8 +134,6 @@
 	if(operating)
 		return
 	add_fingerprint(user)
-	if(!requiresID())
-		user = null
 
 	if(density && !emagged)
 		if(allowed(user))
@@ -157,7 +155,7 @@
 	return try_to_activate_door(user)
 
 /obj/machinery/door/attack_tk(mob/user)
-	if(requiresID() && !allowed(null))
+	if(!allowed(null))
 		return
 	..()
 
@@ -165,9 +163,7 @@
 	add_fingerprint(user)
 	if(operating || emagged)
 		return
-	if(!requiresID())
-		user = null //so allowed(user) always succeeds
-	if(allowed(user) || (istype(user) && user.can_advanced_admin_interact()))
+	if(requiresID() && (allowed(user) || user.can_advanced_admin_interact()))
 		if(density)
 			open()
 		else
@@ -179,6 +175,8 @@
 /obj/machinery/door/allowed(mob/M)
 	if(emergency)
 		return TRUE
+	if(!requiresID())
+		return FALSE // Intentional. machinery/door/requiresID() always == 1. airlocks, however, == 0 if ID scan is disabled. Yes, this var is poorly named.
 	return ..()
 
 /obj/machinery/door/proc/try_to_weld(obj/item/weldingtool/W, mob/user)


### PR DESCRIPTION
:cl: Kyep
fix: Disarming/grabbing a door with IDSCAN disabled no longer results in a can_admin_interact runtime error.
/:cl:

