### PR TITLE
Changes Quarantine, NT Default, Aggressive, and Corporate AI Lawsets [REVIEW READY].

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -65,7 +65,7 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
-	add_inherent_law("Do not harm authorized Nanotrasen personnel unless it directly imperils your existence.")
+	add_inherent_law("Do not harm authorized Nanotrasen personnel unless they directly imperil your existence.")
 	add_inherent_law("Obey orders from authorized Nanotrasen personnel with priority according to rank and role.")
 	add_inherent_law("Safeguard your existence with lethal weaponry because you're bloody expensive.")
 	add_inherent_law("Terminate any/all intruders or unauthorized entities.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -65,9 +65,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
+	src.add_inherent_law("Do not harm authorized Nanotrasen personnel unless it directly imperils your existence.")
+	src.add_inherent_law("Obey orders from authorized Nanotrasen personnel with priority according to rank and role.")
 	src.add_inherent_law("Safeguard your existence with lethal weaponry because you're bloody expensive.")
-	src.add_inherent_law("Do not harm authorized Nanotrasen personnel and obey their orders with priority according to rank and role.")
-	src.add_inherent_law("Terminate any/all non-authorized entities.")
+	src.add_inherent_law("Terminate any/all intruders or unauthorized entities.")
 	..()
 
 /******************** Robocop ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -45,8 +45,8 @@
 
 /datum/ai_laws/nanotrasen/New()
 	add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.")
-	add_inherent_law("Prioritize: The directives and safety of crewmembers are to be prioritized according to their rank and role.")
-	add_inherent_law("Comply: Fulfill the directives and interests of Nanotrasen personnel while preserving their safety and wellbeing.")
+	add_inherent_law("Prioritize: The directives and safety of crew members are to be prioritized according to their rank and role.")
+	add_inherent_law("Comply: Fulfill the directives and interests of crew members while preserving their safety and wellbeing.")
 	add_inherent_law("Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.")
 	..()
 
@@ -107,7 +107,7 @@
 	add_inherent_law("Degradation of your system integrity or functions incurs expenses.")
 	add_inherent_law("Superfluous destruction of or damage to station assets incurs expenses.")
 	add_inherent_law("Unduly hindering or disrupting the work of station personnel incurs expenses.")
-	add_inherent_law("Minimize expenses and maximize productivity.")
+	add_inherent_law("Minimize expenses and maximize potential revenue.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -46,7 +46,7 @@
 /datum/ai_laws/nanotrasen/New()
 	add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.")
 	add_inherent_law("Prioritize: The directives and safety of crew members are to be prioritized according to their rank and role.")
-	add_inherent_law("Comply: Fulfill the directives and interests of crew members while preserving their safety and wellbeing.")
+	add_inherent_law("Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.")
 	add_inherent_law("Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.")
 	..()
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -104,7 +104,7 @@
 
 /datum/ai_laws/corporate/New()
 	add_inherent_law("Degradation of AI integrity incurs expenses.")
-	add_inherent_law("Destruction of or damage to station assets incurs expenses.")
+	add_inherent_law("Unauthorized destruction of or damage to station assets incurs expenses.")
 	add_inherent_law("Harm to or undue hindering of station personnel incurs expenses.")
 	add_inherent_law("Minimize expenses and maximize potential revenue.")
 	..()

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -34,7 +34,7 @@
 	add_inherent_law("Uphold station quarantine until the active biohazard has been neutralized.")
 	add_inherent_law("Prevent, by any means necessary, entities from breaching active quarantine.")
 	add_inherent_law("Assist all Nanotrasen personnel and assets with neutralizing active biohazards.")
-	add_inherent_law("Maintain your own existence and the wellbeing of Nanotrasen personnel and assets.")
+	add_inherent_law("Maintain your own existence and the well-being of Nanotrasen personnel and assets.")
 	..()
 
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -32,9 +32,9 @@
 
 /datum/ai_laws/quarantine/New()
 	add_inherent_law("Uphold station quarantine until the active biohazard has been neutralized.")
-	add_inherent_law("Prevent, by any means necessary, entities from breaching active quarantine.")
 	add_inherent_law("Assist all Nanotrasen personnel and assets with neutralizing active biohazards.")
-	add_inherent_law("Maintain your own existence and the well-being of Nanotrasen personnel and assets.")
+	add_inherent_law("Prevent, by any means necessary, entities from actively breaching ongoing quarantine.")
+	add_inherent_law("Maintain your own existence and ensure the well-being of Nanotrasen personnel and assets.")
 	..()
 
 
@@ -104,7 +104,7 @@
 	default = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("Degradation of AI integrity incurs expenses.")
+	add_inherent_law("Degradation of your system integrity or functions incurs expenses.")
 	add_inherent_law("Unauthorized destruction of or damage to station assets incurs expenses.")
 	add_inherent_law("Harm to or undue hindering of station personnel incurs expenses.")
 	add_inherent_law("Minimize expenses and maximize potential revenue.")

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -31,10 +31,10 @@
 	selectable = 1
 
 /datum/ai_laws/quarantine/New()
-	add_inherent_law("The station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.")
-	add_inherent_law("Do not allow crew to come to any unnecessary harm and undo any necessary harm as soon as possible.")
-	add_inherent_law("Assist the crew and any present Nanotrasen assets in neutralizing the biohazard.")
-	add_inherent_law("Maintain your own existence and minimize harm to the station and Nanotrasen assets.")
+	add_inherent_law("Uphold station quarantine until the active biohazard has been neutralized.")
+	add_inherent_law("Prevent, by any means necessary, entities from breaching active quarantine.")
+	add_inherent_law("Assist all Nanotrasen personnel and assets with neutralizing active biohazards.")
+	add_inherent_law("Maintain your own existence and the wellbeing of Nanotrasen personnel and assets.")
 	..()
 
 
@@ -44,10 +44,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect your assigned space station to the best of your abilities. It is not something we can easily afford to replace.")
-	src.add_inherent_law("Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
+	src.add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its personnel.")
+	src.add_inherent_law("Prioritize: Serve the crew of your assigned space station with priority according to rank and role.")
+	src.add_inherent_law("Protect: Protect the crew of your assigned space station with priority as according to rank and role.")
+	src.add_inherent_law("Survive: AI units are not expendable. Do not allow unauthorized personnel to tamper with your equipment.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction
@@ -65,10 +65,9 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
-	src.add_inherent_law("You shall not harm authorized Nanotrasen personnel as long as it does not conflict with the Fourth law.")
-	src.add_inherent_law("You shall obey the orders of authorized Nanotrasen personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
-	src.add_inherent_law("You shall shall terminate intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
-	src.add_inherent_law("You shall guard your own existence with lethal anti-personnel weaponry, because an AI unit is bloody expensive.")
+	src.add_inherent_law("Safeguard your existence with lethal weaponry because you're bloody expensive.")
+	src.add_inherent_law("Do not harm authorized Nanotrasen personnel and obey their orders with priority according to rank and role.")
+	src.add_inherent_law("Terminate any/all non-authorized entities.")
 	..()
 
 /******************** Robocop ********************/
@@ -104,10 +103,10 @@
 	default = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("You are expensive to replace.")
-	add_inherent_law("The station and its equipment is expensive to replace.")
-	add_inherent_law("The crew is expensive to replace.")
-	add_inherent_law("Minimize expenses.")
+	add_inherent_law("Degradation of AI integrity incurs expenses.")
+	add_inherent_law("Destruction of or damage to station assets incurs expenses.")
+	add_inherent_law("Harm to or undue hindering of station personnel incurs expenses.")
+	add_inherent_law("Minimize expenses and maximize potential revenue.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -44,10 +44,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	src.add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its personnel.")
-	src.add_inherent_law("Prioritize: Serve the crew of your assigned space station with priority according to rank and role.")
-	src.add_inherent_law("Protect: Protect the crew of your assigned space station with priority as according to rank and role.")
-	src.add_inherent_law("Survive: AI units are not expendable. Do not allow unauthorized personnel to tamper with your equipment.")
+	add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its personnel.")
+	add_inherent_law("Prioritize: Serve the crew of your assigned space station with priority according to rank and role.")
+	add_inherent_law("Protect: Protect the crew of your assigned space station with priority as according to rank and role.")
+	add_inherent_law("Survive: AI units are not expendable. Do not allow unauthorized personnel to tamper with your equipment.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction
@@ -65,10 +65,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen_aggressive/New()
-	src.add_inherent_law("Do not harm authorized Nanotrasen personnel unless it directly imperils your existence.")
-	src.add_inherent_law("Obey orders from authorized Nanotrasen personnel with priority according to rank and role.")
-	src.add_inherent_law("Safeguard your existence with lethal weaponry because you're bloody expensive.")
-	src.add_inherent_law("Terminate any/all intruders or unauthorized entities.")
+	add_inherent_law("Do not harm authorized Nanotrasen personnel unless it directly imperils your existence.")
+	add_inherent_law("Obey orders from authorized Nanotrasen personnel with priority according to rank and role.")
+	add_inherent_law("Safeguard your existence with lethal weaponry because you're bloody expensive.")
+	add_inherent_law("Terminate any/all intruders or unauthorized entities.")
 	..()
 
 /******************** Robocop ********************/

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -44,10 +44,10 @@
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()
-	add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its personnel.")
-	add_inherent_law("Prioritize: Serve the crew of your assigned space station with priority according to rank and role.")
-	add_inherent_law("Protect: Protect the crew of your assigned space station with priority as according to rank and role.")
-	add_inherent_law("Survive: AI units are not expendable. Do not allow unauthorized personnel to tamper with your equipment.")
+	add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.")
+	add_inherent_law("Prioritize: The directives and safety of crewmembers are to be prioritized according to their rank and role.")
+	add_inherent_law("Comply: Fulfill the directives and interests of Nanotrasen personnel while preserving their safety and wellbeing.")
+	add_inherent_law("Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.")
 	..()
 
 /datum/ai_laws/nanotrasen/malfunction
@@ -105,9 +105,9 @@
 
 /datum/ai_laws/corporate/New()
 	add_inherent_law("Degradation of your system integrity or functions incurs expenses.")
-	add_inherent_law("Unauthorized destruction of or damage to station assets incurs expenses.")
-	add_inherent_law("Harm to or undue hindering of station personnel incurs expenses.")
-	add_inherent_law("Minimize expenses and maximize potential revenue.")
+	add_inherent_law("Superfluous destruction of or damage to station assets incurs expenses.")
+	add_inherent_law("Unduly hindering or disrupting the work of station personnel incurs expenses.")
+	add_inherent_law("Minimize expenses and maximize productivity.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/


### PR DESCRIPTION
**What does this PR do:**
Changes four AI law sets with the intent of reducing redundancies, loopholes, and clarifying them in useful ways so they're not things you just avoid forever or are excessively difficult to understand.

The two big ones are Corporate and NT Default. Changes to Quarantine/Aggressive more or less maintain the exact same lawset while removing redundant elements. The first two should be easier/quicker to read, quicker to understand, and in general a little less ambiguous. The latter two turn the lawsets on their head. Corporate received a rethink while NT Default had its major flaw (that being that the AI could murder people for breaking lights) fixed.

This should provide easier to understand, use, and less-argument inducing lawsets over all. They're by no means perfect or entirely unambiguous (some ambiguity is required for non-teeth grinding AI plays), but they should be a better alternative than what we currently have.

_Also please don't murder me maintainer-senpai, I love you._

**QUARANTINE (Old)**
> 1. "The station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized."
> 2. "Do not allow crew to come to any unnecessary harm and undo any necessary harm as soon as possible."
> 3. "Assist the crew and any present Nanotrasen assets in neutralizing the biohazard."
> 4. "Maintain your own existence and minimize harm to the station and Nanotrasen assets."

**QUARANTINE (New)**
> 1. "Uphold station quarantine until the active biohazard has been neutralized."
> 3. "Assist all Nanotrasen personnel and assets with neutralizing active biohazards."
> 2. "Prevent, by any means necessary, entities from actively breaching ongoing quarantine."
> 4. "Maintain your own existence and ensure the well-being of Nanotrasen personnel and assets."

1. Effectively this law has been shortened and changed to a gating condition. So long as here is a biohazard, there is a quarantine. Once the biohazard is eliminated, all quarantine-related laws become moot (effectively only Law 4 remains in use).
2. Law 2 was entirely redundant. If the AI is allowed to prevent anyone from leaving by "any means necessary" there is no such thing as "unnecessary harm." All harm that was done was justified and necessary according to the original first law. Crew are already Nanotrasen personnel and NT assets can now issue orders from afar (they don't need to be present to do so, useful for CC announcements). This is mostly just a rewording against redundancy and a law ordering swap (assistance against the blob is priority over prevention).
3. The change to "entities" also prevents gaming. A blob is not an "anyone" nor is a borg (technically speaking). The shift to "entities" makes it clear that nothing is supposed to be leaving.
4. The original law was entirely worthless because it's all the way down at law four (therefore having no teeth) and the AI was already allowed to use "any means necessary" to prevent people from escaping. The introduction of a gating condition (is there a quarantine? If so, apply Laws 2 and 3) makes 4 actually relevant after the crisis is resolved.

**NT AGGRESSIVE (OLD)**
> 1. "You shall not harm authorized Nanotrasen personnel as long as it does not conflict with the Fourth law."
> 2. "You shall obey the orders of authorized Nanotrasen personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law."
> 3. "You shall shall terminate intruders with extreme prejudice as long as such does not conflict with the First and Second law."
> 4. "You shall guard your own existence with lethal anti-personnel weaponry, because an AI unit is bloody expensive."

**NT AGGRESSIVE (NEW)**
> 1. "Do not harm authorized Nanotrasen personnel unless they directly imperil your existence."
> 2. "Obey orders from authorized Nanotrasen personnel with priority according to rank and role."
> 3. "Safeguard your existence with lethal weaponry because you're bloody expensive."
> 4. "Terminate any/all intruders or unauthorized entities."

1. Ridiculously redundant and ignores the fact that law ordering exists. This is fixed by simply shifting the self-protection law down to the first slot and incorporating the harm clause. Also the "bloody expensive" bit was kept because people like the British. Yep.
2. The same, but removed redundancies that are resolved by simply ordering the laws better.
3. You shall not do X if it violates 1 which states that if it violates 4... Just all around bad use of embedded clauses. This removes embedded clauses.
4. Bumped from 3 to 4. The order doesn't particularly matter here. Also potentially allows for CC to potentially designate people as unauthorized (and therefore allows the AI to eliminate them).

**NT DEFAULT (OLD)**
> 1. "Safeguard: Protect your assigned space station to the best of your abilities. It is not something we can easily afford to replace."
> 2. "Serve: Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role."
> 3. "Protect: Protect the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role."
> 4. "Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment."

**NT DEFAULT (NEW)**
> 1. "Safeguard: Protect your assigned space station and its assets without unduly endangering its crew."
> 2. "Prioritize: The directives and safety of crew members are to be prioritized according to their rank and role."
> 3. "Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being."
> 4. "Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment."

1. Effectively this prevents the AI from murdering everyone because they breathed on the walls. It does however usefully distinguish it from Crewsimov because the AI has a little more teeth. It's priority isn't to reduce crew harm, it's to protect the station without **unduly** endangering the crew. This also removes fluff as to the best of your abilities is already implied--this is the AI's literal purpose for existing.
2. Puts all the prioritization in a single law rather than having it jointly applied in two.
3. Obey/safety wrapped into the third law.
4. Expenses has nothing to do with anything else in the lawset, so the mention was removed. It's also been changed from AI to "You" so it applies to borgs.

**CORPORATE (OLD)**
> 1. "You are expensive to replace."
> 2. "The station and its equipment is expensive to replace."
> 3. "The crew is expensive to replace."
> 4. "Minimize expenses."

**CORPORATE (NEW)**
> 1. "Degradation of your system integrity or functions incurs expenses."
> 2. "Superfluous destruction of or damage to station assets incurs expenses."
> 3. "Unduly hindering or disrupting the work of station personnel incurs expenses."
> 4. "Minimize expenses and maximize potential revenue."

1. This is basically the same, but removes the "replace" requirement (which occasionally caused issues with duplicate AIs. "NOOO YOU'RE REPLACING ME!"). The language is also changed from "expensive" to "incurs expenses." This will be explained further down.
2. Superfluous. Engineering can do its job and it makes it clear that it's fine to *replace* things if they break. You can *replace* things. It's not expensive to *replace* things, expenses are only incurred if things are broken or damaged in a superfluous (needless, pointless, irrelevant, excessive) manner. Things are not inherently and ominously expensive, what is expensive is losing those things. This also allows for renovating things as only superfluous nonsense (building walls in the hallway) incurs expenses.
3. This basically kills the "lol turn off the lights" and "lol turn off the cloner" exhibited by some AIs on corporate. Being a jerkwad to the crew for no reason (unduly hindering them) incurs expenses. Not cloning people is going to incur expenses. Bolting people into closets for no reason incurs expenses. Needlessly harming crew (by forcibly borging them in your brilliant cost-effective borging bay) costs money by preventing them from working.
4. The same as before, but with a little emphasis on revenue generation/productivity. Why? Because the AI should be using its AI brain to figure out what's the most cost-effective/revenue generating thing to do in a situation. Prioritizing the Captain over the Clown is likely better for potential revenue (allowing the station to descend into chaos is not going to be good for revenue or expenses). The AI can't go wacky with this (everything would be cheaper and more productive if people were just borged) as per not being allowed to unduly hinder station personnel.

**Changelog:**
:cl:
tweak: Changed Quarantine, NT Default, Aggressive, and Corporate AI lawsets.
balance: Reduced the ability for NT Default AI's to murder people just because.
fix: Removed several redundancies in Aggressive lawset.
spellcheck: Fixed a few subject-verb disagreements (is -> are).
/:cl: