### PR TITLE
Re-applies the steel_rain runtime fix

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -714,6 +714,8 @@
 		possible_destinations = C.possible_destinations
 		shuttleId = C.shuttleId
 
+/obj/machinery/computer/shuttle/Initialize(mapload)
+	. = ..()
 	connect()
 
 /obj/machinery/computer/shuttle/proc/connect()


### PR DESCRIPTION
**What does this PR do:**
This re-applies the steel_rain runtime fix, which was accidentally reverted in the hospital ship pull request.

**Changelog:**
:cl: Markolie
fix: The steel_rain runtime fix has been re-applied.
/:cl:

