### PR TITLE
Fixes Warning Spam for Mob Transitions and Roundstart Spawning

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -473,10 +473,10 @@ SUBSYSTEM_DEF(jobs)
 			T = S.loc
 
 		if(T)
-			H.loc = T
+			H.forceMove(T)
 			// Moving wheelchair if they have one
 			if(H.buckled && istype(H.buckled, /obj/structure/chair/wheelchair))
-				H.buckled.loc = H.loc
+				H.buckled.forceMove(H.loc)
 				H.buckled.dir = H.dir
 
 	if(job)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -91,17 +91,17 @@
 
 /turf/space/Entered(atom/movable/A as mob|obj, atom/OL, ignoreRest = 0)
 	..()
+	if((!(A) || !(src in A.locs)))
+		return
 
-	if(destination_z && A && (src in A.locs))
-		A.x = destination_x
-		A.y = destination_y
-		A.z = destination_z
+	if(destination_z && destination_x && destination_y)
+		A.forceMove(locate(destination_x, destination_y, destination_z))
 
 		if(isliving(A))
 			var/mob/living/L = A
 			if(L.pulling)
 				var/turf/T = get_step(L.loc,turn(A.dir, 180))
-				L.pulling.loc = T
+				L.pulling.forceMove(T)
 
 		//now we're on the new z_level, proceed the space drifting
 		sleep(0)//Let a diagonal move finish, if necessary

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -412,7 +412,7 @@
 		toggle_ai(AI_Z_OFF)
 		return
 
-	var/cheap_search = isturf(T) && !(T.z == 1) // The original check for SSmapping's station z level trait, unfortunately it isn't here.
+	var/cheap_search = isturf(T) && !is_station_level(T.z)
 	if(cheap_search)
 		tlist = ListTargetsLazy(T.z)
 	else


### PR DESCRIPTION
At round start, there's a ton of warnings generated when players are initially spawned in.

Likewise, when someone transitions from one z-level to another, it generates a warning.

These warnings need to stay in, but the cause of the current ones are due to setting `loc` directly as opposed to properly using `forceMove`.

There may be more, but these seems to be the ones that crop up a ton.

Also changes a hardcoded check to instead use a z-levels trait one.

:cl: Fox McCloud
fix: Fixes a few instances generating log spam relating to z-level tracking
/:cl: