### PR TITLE
An end to the war

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -221,6 +221,9 @@
 	//Start now warning
 	var/start_now_confirmation = 0
 
+	// Disable picking of secborgs
+	var/allow_secborg = 0
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -736,6 +739,8 @@
 					config.randomize_shift_time = TRUE
 				if("enable_night_shifts")
 					config.enable_night_shifts = TRUE
+				if("allow_secborg")
+					config.allow_secborg = TRUE
 				else
 					log_config("Unknown setting in configuration: '[name]'")
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -283,7 +283,9 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/proc/pick_module()
 	if(module)
 		return
-	var/list/modules = list("Standard", "Engineering", "Medical", "Miner", "Janitor", "Service", "Security")
+	var/list/modules = list("Standard", "Engineering", "Medical", "Miner", "Janitor", "Service")
+	if(config.allow_secborg)
+		modules += "Security"
 	if(islist(force_modules) && force_modules.len)
 		modules = force_modules.Copy()
 	if(security_level == (SEC_LEVEL_GAMMA || SEC_LEVEL_EPSILON) || crisis)

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -66,3 +66,6 @@ RANDOMIZE_SHIFT_TIME
 
 ## Enable Nightshift - Causes the station to go into "night mode" from 19:30 to 07:30. Best used with RANDOMIZED_SHIFT_TIME.
 ENABLE_NIGHT_SHIFTS
+
+## Security borg module, Uncomment to enable
+#ALLOW_SECBORG


### PR DESCRIPTION
**What does this PR do:**
This PR makes a config option to enable or disable secborgs. This way the server staff can trial having them in and out to see if it makes a noticeable difference on gameplay.

**THIS IS IN NOT A REMOVAL, PUT DOWN YOUR PITCHFORKS**

**Changelog:**
:cl: AffectedArc07
add: Secborgs are now a config option
/:cl:

