### PR TITLE
Reinforcement number fix

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -62,7 +62,7 @@
 /obj/item/antag_spawner/nuke_ops/spawn_antag(client/C, turf/T, kind, datum/mind/user)
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(T)
 
-	var/agent_number = LAZYLEN(ticker.mode.syndicates)
+	var/agent_number = LAZYLEN(ticker.mode.syndicates) - 1
 	M.real_name = "[syndicate_name()] Operative #[agent_number]"
 
 	set_syndicate_values(C, M)


### PR DESCRIPTION
**What does this PR do:**
This pull request reduces the agent number of nuclear operative reinforcement spawns by one. Right now, they spawn as [Company] Operative #6 when there's five operatives. However, the first non-boss operative is actually #1, meaning #5 is missing.

**Changelog:**
:cl: Markolie
fix: Nuclear Operative reinforcements now spawn with a properly counted agent designation.
/:cl:

