### PR TITLE
Can't use cuffs with nodrops now

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -24,6 +24,10 @@
 	if(!istype(C))
 		return
 
+	if(flags & NODROP)
+		to_chat(user, "<span class='warning'>[src] is stuck to your hand!</span>")
+		return
+
 	if((CLUMSY in user.mutations) && prob(50) && (!ignoresClumsy))
 		to_chat(user, "<span class='warning'>Uh... how do those things work?!</span>")
 		apply_cuffs(user, user)


### PR DESCRIPTION
**What does this PR do:**
You now can't cuff somebody when the cuffs have the NODROP flag.

**Changelog:**
:cl:
fix: Can't use cuffs now while you have antidrop
/:cl:

