### PR TITLE
Add debugging night vision glasses for Reyblood

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -177,6 +177,15 @@
 	flags = NODROP
 	flags_cover = null
 
+/obj/item/clothing/glasses/material/lighting
+	name = "Neutron Goggles"
+	desc = "These odd glasses use a form of neutron-based imaging to completely negate the effects of light and darkness."
+	origin_tech = null
+	vision_flags = 0
+
+	flags = NODROP
+	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+
 /obj/item/clothing/glasses/regular
 	name = "prescription glasses"
 	desc = "Made by Nerd. Co."

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1786,3 +1786,17 @@
 	item_color = "voxbodysuit"
 	body_parts_covered = HEAD|UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	species_fit = list("Vox")
+
+/obj/item/clothing/glasses/night/fluff/reyblood //Reyblood: All characters
+	name = "Custom Night Vision Goggles"
+	desc = "These customized night vision goggles completely remove all darkness."
+	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+
+	var/limited_to_ckey = "reyblood"
+
+/obj/item/clothing/glasses/night/fluff/reyblood/mob_can_equip(mob/user, slot)
+	. = ..()
+
+	if(. && user.ckey != limited_to_ckey)
+		to_chat(user, "<span class='warning'>These glasses can only be used by [limited_to_ckey], as they are not able to play the game with lighting enabled due to hardware limitations.")
+		. = FALSE

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1786,17 +1786,3 @@
 	item_color = "voxbodysuit"
 	body_parts_covered = HEAD|UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	species_fit = list("Vox")
-
-/obj/item/clothing/glasses/night/fluff/reyblood //Reyblood: All characters
-	name = "Custom Night Vision Goggles"
-	desc = "These customized night vision goggles completely remove all darkness."
-	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-
-	var/limited_to_ckey = "reyblood"
-
-/obj/item/clothing/glasses/night/fluff/reyblood/mob_can_equip(mob/user, slot)
-	. = ..()
-
-	if(. && user.ckey != limited_to_ckey)
-		to_chat(user, "<span class='warning'>These glasses can only be used by [limited_to_ckey], as they are not able to play the game with lighting enabled due to hardware limitations.")
-		. = FALSE


### PR DESCRIPTION
*This pull request should be merged after https://github.com/ParadiseSS13/Paradise/pull/11357 and is still pending head admin approval.*

**What does this PR do:**
One of our players, Reyblood, is unable to play the game with the new lighting system. They are using a laptop from 2002, and rely on the integrated graphics of their CPU to play the game. The new lighting system is too heavy on said CPU. 

As such, pending headmin approval, this pull request adds a pair of NODROP debugging night vision glasses to the game that completely remove lighting (like X-Ray does, without the actual X-Ray). They can also be used by coders for debugging.

I realize that this may not be entirely balanced, but I think this player being able to play the game is more important. They have volunteered for a blanket antag ban, but I personally do not believe that is necessary.

This is what they see with the new system: https://prnt.sc/nkvpka