### PR TITLE
Remove non-manifest names from the code phrases

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -161,12 +161,8 @@ var/syndicate_code_response//Code response for traitors.
 			if(1)//1 and 2 can only be selected once each to prevent more than two specific names/places/etc.
 				switch(rand(1,2))//Mainly to add more options later.
 					if(1)
-						if(names.len&&prob(70))
+						if(names.len)
 							code_phrase += pick(names)
-						else
-							code_phrase += pick(pick(GLOB.first_names_male,GLOB.first_names_female))
-							code_phrase += " "
-							code_phrase += pick(GLOB.last_names)
 					if(2)
 						code_phrase += pick(GLOB.joblist)//Returns a job.
 				safety -= 1


### PR DESCRIPTION
**What does this PR do:**
Only names on the manifest can be given to syndicate agents as codephrases, this is intended to be a QoL because if you're given a code-word with a random-generated name its very hard to spin it into a conversation. It's somewhat easier to do so with names on the manifest

**Changelog:**
:cl:
add: Only names from the manifest will be used for syndicate code phrases
del: randomly generated people names from syndicate code phrases
/:cl:

