### PR TITLE
Smartfridge gets smarter

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -595,3 +595,11 @@ Class Procs:
 		emp_act(EMP_LIGHT)
 	else
 		ex_act(EXPLODE_HEAVY)
+
+/obj/machinery/proc/adjust_item_drop_location(atom/movable/AM)	// Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8
+	var/md5 = md5(AM.name)										// Oh, and it's deterministic too. A specific item will always drop from the same slot.
+	for (var/i in 1 to 32)
+		. += hex2num(md5[i])
+	. = . % 9
+	AM.pixel_x = -8 + ((.%3)*8)
+	AM.pixel_y = -8 + (round( . / 3)*8)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -373,6 +373,7 @@
 			for(var/obj/O in contents)
 				if(O.name == K)
 					O.forceMove(loc)
+					adjust_item_drop_location(O)
 					update_icon()
 					i--
 					if(i <= 0)


### PR DESCRIPTION
**What does this PR do:**
This PR adds a new system for outputting contents of smartfridges, comparison images below. Instead of being one bulky pile, smartfridges will now try to output their contents in a systematic grid.

**Images of sprite/map changes (IF APPLICABLE):**
**OLD**
![OLD](https://user-images.githubusercontent.com/43862960/57234348-af127e80-7020-11e9-919c-f43b849746b1.png)
**NEW**
![NewFridge](https://user-images.githubusercontent.com/43862960/57234359-b33e9c00-7020-11e9-91c7-705414948f63.png)

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Added new system for outputting contents of smartfridges
/:cl: