### PR TITLE
Lets vamp and cling anti-stun powers remove sleep too

### DIFF
--- a/code/game/gamemodes/changeling/powers/epinephrine.dm
+++ b/code/game/gamemodes/changeling/powers/epinephrine.dm
@@ -14,6 +14,7 @@
 		to_chat(user, "<span class='notice'>We arise.</span>")
 	else
 		to_chat(user, "<span class='notice'>Adrenaline rushes through us.</span>")
+	user.SetSleeping(0)
 	user.stat = 0
 	user.SetParalysis(0)
 	user.SetStunned(0)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -156,6 +156,7 @@
 	user.SetWeakened(0)
 	user.SetStunned(0)
 	user.SetParalysis(0)
+	user.SetSleeping(0)
 	U.adjustStaminaLoss(-75)
 	to_chat(user, "<span class='notice'>You flush your system with clean blood and remove any incapacitating effects.</span>")
 	spawn(1)


### PR DESCRIPTION
**What does this PR do:**
This PR changes the vampire rejuvenate ability and the cling epinephrine power to also remove sleeping/wake you up if you're asleep. This means their anti-stun powers now work against abductor batons. It also has some uses against ether syringe guns and allow you to maybe escape from a surgery if you're fast in turning off internals. I guess it also means you can take actual naps without fearing for your life, if you want to use the sleep verb in dangerous places.

Mostly, I did this PR because I feel like those anti-stun powers are intended to be fairly thorough so having one kind of deliberating effect completely missed by it feels weird.

**Images of sprite/map changes (IF APPLICABLE):**


**Changelog:**
:cl:
tweak: Vampire rejuv wakes you up if you're asleep now
tweak: Cling epinephrine wakes you up if you're asleep now
/:cl:

