### PR TITLE
Make it easier to slide into DMs

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -253,15 +253,20 @@
 	var/list/messages = list()
 	var/archived = FALSE
 	var/client/client
+	var/read = FALSE
 
 /datum/pm_convo/New(var/client/C)
 	client = C
 
+/datum/pm_convo/proc/add(var/client/sender, var/message)
+	messages.Add("[sender]: [message]")
+	archived = FALSE
+	read = FALSE
+
 /datum/pm_tracker/proc/add_message(var/client/title, var/client/sender, var/message, mob/user)
 	if(!pms[title.key])
 		pms[title.key] = new /datum/pm_convo(title)
-	pms[title.key].messages.Add("[sender]: [message]")
-	pms[title.key].archived = FALSE
+	pms[title.key].add(sender, message)
 
 	if(!open)
 		// The next time the window's opened, it'll be open to the most recent message
@@ -283,9 +288,12 @@
 		var/label = "[title]"
 		if(title == current_title)
 			label = "<b>[label]</b>"
+		else if(!pms[title].read)
+			label = "<i>*[label]</i>"
 		dat += "<a href='?src=[UID()];newtitle=[title]'>[label]</a>"
 
 	if(pms[current_title])
+		pms[current_title].read = TRUE
 		dat += "<h2>[check_rights(R_ADMIN, FALSE, user) ? fancy_title(current_title) : current_title]</h2>"
 		dat += "<h4>"
 		dat += "<table style='width:950px; border: 3px solid;'>"

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -319,7 +319,7 @@
 
 		dat += "</table>"
 		if(convo.typing)
-			dat += "<i>[current_title] is typing...</i>"
+			dat += "<i><span class='typing'>[current_title] is typing</span></i>"
 		dat += "<br>"
 		dat += "</h4>"
 		dat += "<a href='?src=[UID()];reply=[current_title]'>Reply</a>"

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -273,13 +273,15 @@
 		dat += "<a href='?src=[UID()];newtitle=[title]'>[label]</a>"
 
 	dat += "<h2>[current_title]</h2>"
-
+	dat += "<h4>"
 	dat += "<table style='width:950px; border: 3px solid;'>"
 
 	for(var/message in pms[current_title])
 		dat += "<tr><td>[message]</td></tr>"
 
-	dat += "</table><br><br>"
+	dat += "</table>"
+	dat += "<br>"
+	dat += "</h4>"
 	dat += "<a href='?src=[UID()];reply=[current_title]'>Reply</a>"
 
 	var/datum/browser/popup = new(user, window_id, "Messages", 1000, 600, src)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -244,7 +244,7 @@
 	set category = "OOC"
 	pm_tracker.show_ui(usr)
 
-/client/proc/set_typing(client/target, var/value)
+/client/proc/set_typing(client/target, value)
 	if(!target)
 		return
 	var/datum/pm_convo/convo = target.pm_tracker.pms[key]
@@ -268,15 +268,15 @@
 	var/read = FALSE
 	var/typing = FALSE
 
-/datum/pm_convo/New(var/client/C)
+/datum/pm_convo/New(client/C)
 	client = C
 
-/datum/pm_convo/proc/add(client/sender, var/message)
+/datum/pm_convo/proc/add(client/sender, message)
 	messages.Add("[sender]: [message]")
 	archived = FALSE
 	read = FALSE
 
-/datum/pm_tracker/proc/add_message(client/title, client/sender, var/message, mob/user)
+/datum/pm_tracker/proc/add_message(client/title, client/sender, message, mob/user)
 	if(!pms[title.key])
 		pms[title.key] = new /datum/pm_convo(title)
 	pms[title.key].add(sender, message)
@@ -332,7 +332,7 @@
 	popup.open()
 	open = TRUE
 
-/datum/pm_tracker/proc/fancy_title(var/title)
+/datum/pm_tracker/proc/fancy_title(title)
 	var/client/C = pms[title].client
 	if(!C)
 		return "[title] (Disconnected)"

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -308,6 +308,8 @@
 		dat += "</h4>"
 		dat += "<a href='?src=[UID()];reply=[current_title]'>Reply</a>"
 		dat += "<a href='?src=[UID()];archive=[current_title]'>[pms[current_title].archived ? "Unarchive" : "Archive"]</a>"
+		if(check_rights(R_ADMIN, FALSE, user))
+			dat += "<a href='?src=[UID()];ping=[current_title]'>Ping</a>"
 
 	var/datum/browser/popup = new(user, window_id, "Messages", 1000, 600, src)
 	popup.set_content(dat)
@@ -332,6 +334,16 @@
 
 	if(href_list["newtitle"])
 		current_title = href_list["newtitle"]
+		show_ui(usr)
+		return
+
+	if(href_list["ping"])
+		var/client/C = pms[href_list["ping"]].client
+		if(C)
+			C.pm_tracker.current_title = usr.key
+			window_flash(C)
+			C.pm_tracker.show_ui(C.mob)
+			to_chat(usr, "<span class='notice'>Forced open [C]'s messages window.</span>")
 		show_ui(usr)
 		return
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -286,11 +286,13 @@
 		if(pms[title].archived && !show_archived)
 			continue
 		var/label = "[title]"
+		var/class = ""
 		if(title == current_title)
 			label = "<b>[label]</b>"
+			class = "linkOn"
 		else if(!pms[title].read)
 			label = "<i>*[label]</i>"
-		dat += "<a href='?src=[UID()];newtitle=[title]'>[label]</a>"
+		dat += "<a class='[class]' href='?src=[UID()];newtitle=[title]'>[label]</a>"
 
 	if(pms[current_title])
 		pms[current_title].read = TRUE

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -7,6 +7,7 @@
 	var/last_message	= "" //contains the last message sent by this client - used to protect against copy-paste spamming.
 	var/last_message_count = 0 //contains a number of how many times a message identical to last_message was sent.
 	var/last_message_time = 0 //holds the last time (based on world.time) a message was sent
+	var/datum/pm_tracker/pm_tracker = new()
 
 		/////////
 		//OTHER//

--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -346,3 +346,19 @@ div.notice
 	width: 64px;
 	height:64px;
 }
+
+.typing:after
+{
+	overflow: hidden;
+	display: inline-block;
+	vertical-align: bottom;
+	animation: ellipsis steps(4,end) 900ms infinite;
+	content: "\2026";
+	width: 0px;
+}
+
+@keyframes ellipsis {
+	to {
+		width: 1.25em;
+	}
+}

--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -357,8 +357,10 @@ div.notice
 	width: 0px;
 }
 
-@keyframes ellipsis {
-	to {
+@keyframes ellipsis
+{
+	to
+	{
 		width: 1.25em;
 	}
 }


### PR DESCRIPTION
**What does this PR do:**
It can be tricky to keep track of PM conversations and reply to them when there's a lot of stuff going into chat, when handling an incident involving multiple players, or when you need to go investigate stuff. This adds a window that keeps track of all of your PM conversations and allows you to reply to a conversation.

- Auto updates when receiving/sending new messages if it's open, but doesn't pop up or anything if you don't have it open
- Opens to your most recent conversation when you open the window.
- You can archive conversations to clear up your window.
- It adds a verb in the OOC tab so players can use this as well.
- Also allows for easier copy pasting of conversations for notes and stuff.
- Admins get the buttons.
- Unread indicator for new messages in other tabs (italics + *)
- Can be extended to things like asay
- Admins can use the ping button to force open a user's messages window to the conversation with that admin
- Typing indicator (works whether the other person is using the messages window or not)

![window5](https://user-images.githubusercontent.com/26497062/57339675-68d42280-70e7-11e9-9c12-41397c9911ef.png)

Updated interface with ping button:
![image](https://user-images.githubusercontent.com/26497062/57392817-9fa54980-7176-11e9-9752-5e7de2736827.png)

Typing indicator:
![typing](https://user-images.githubusercontent.com/26497062/57404222-4fd37c00-7190-11e9-8d35-61034450ab03.gif)


**Changelog:**
:cl: Tayyyyyyy
add: Messages window (My PMs in OOC tab)
/:cl: