### PR TITLE
Slightly easier Sling glare targetting

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -24,8 +24,35 @@
 	panel = "Shadowling Abilities"
 	charge_max = 300
 	clothes_req = 0
+	range = 10	//has no effect beyond this range, so setting this makes invalid/useless targets not show up in popup
 	action_icon_state = "glare"
-	humans_only = 1
+	humans_only = 1	//useless since we override chose_targets, but might be used for other code later??? Might remove, idk
+
+/obj/effect/proc_holder/spell/targeted/glare/choose_targets(mob/user)
+	var/list/possible_targets = list()
+	for(var/mob/living/carbon/human/target in view_or_range(range, user, "view"))
+		if(target.stat)
+			continue
+		if(is_shadow_or_thrall(target))
+			continue
+		possible_targets += target
+	var/mob/living/carbon/human/M
+	var/list/targets = list()
+	if(possible_targets.len == 1)//no choice involved
+		targets = possible_targets
+	else
+		M = input("Choose the target for the spell.", "Targeting") as mob in possible_targets
+		if(M in view_or_range(range, user, "view"))
+			targets += M
+
+	
+	if(!targets.len) //doesn't waste the spell
+		revert_cast(user)
+		return
+
+	perform(targets, user = user)
+	return
+	
 
 /obj/effect/proc_holder/spell/targeted/glare/cast(list/targets, mob/user = usr)
 	for(var/mob/living/carbon/human/target in targets)


### PR DESCRIPTION
**What does this PR do:**
This PR changes the targetting code for Sling glare slightly, so that the popup list _only shows targets you can actually glare_. In other words, thralls and other shadowlings are no longer listed as possible targets (you couldn't actually glare them anyway, selecting them just got you an error message). It also excludes unconscious and dead mobs, who also can't be glared. This hopefully reduces the amount of times where you actually have to use the awful popup menu and can instead just glare instantly cause there's only one target on screen.

You can argue this is a buff, but imo it just makes the power slightly less of a pain to use.


As for the code...I tried to think of more oop ways to do it by still using the parent or whatever, but couldn't find one that didn't refactor spell/targeted code. Ideally, you'd want more control on the spell level on what counts as a valid target instead of just the binary human_only which really feels like a hack, but I didn't feel like rewriting all that.
And it seemed like other spells with special target choice just override chose_targets too, so I went with that myself.

**Changelog:**
:cl:
tweak: Sling glare popup no longer lists invalid targets for glaring
/:cl:

