### PR TITLE
Fix golem getting selected as auto traitors

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -96,7 +96,7 @@
 			for(var/obj/item/implant/mindshield/I in H.contents)
 				if(I && I.implanted)
 					possible_traitors -= player
-			if(isgolem(H))
+			if(!H.job) //Golems, special events stuff, etc.
 				possible_traitors -= player
 		//message_admins("Live Players: [playercount]")
 		//message_admins("Live Traitors: [traitorcount]")

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -96,7 +96,8 @@
 			for(var/obj/item/implant/mindshield/I in H.contents)
 				if(I && I.implanted)
 					possible_traitors -= player
-
+			if(isgolem(H))
+				possible_traitors -= player
 		//message_admins("Live Players: [playercount]")
 		//message_admins("Live Traitors: [traitorcount]")
 //		message_admins("Potential Traitors:")

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -607,7 +607,6 @@
 	..()
 	last_banana = world.time
 	last_honk = world.time
-	H.job = "Clown"
 	H.mutations.Add(COMIC)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/food/drinks/bottle/bottleofbanana(H), slot_r_store)
 	H.equip_to_slot_or_del(new /obj/item/bikehorn(H), slot_l_store)
@@ -682,7 +681,6 @@
 
 /datum/species/golem/tranquillite/on_species_gain(mob/living/carbon/human/H)
 	..()
-	H.job = "Mime"
 	H.equip_to_slot_or_del(new 	/obj/item/clothing/head/beret(H), slot_head)
 	H.equip_to_slot_or_del(new 	/obj/item/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_r_store)
 	H.equip_to_slot_or_del(new 	/obj/item/cane(H), slot_l_hand)

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -178,7 +178,7 @@
 
 /datum/reagent/consumable/drink/banana/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if((ishuman(M) && M.job in list("Clown") ) || issmall(M))
+	if((ishuman(M) && COMIC in M.mutations) || issmall(M))
 		update_flags |= M.adjustBruteLoss(-1, FALSE)
 		update_flags |= M.adjustFireLoss(-1, FALSE)
 	return ..() | update_flags
@@ -194,7 +194,7 @@
 
 /datum/reagent/consumable/drink/nothing/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(ishuman(M) && M.job in list("Mime"))
+	if(ishuman(M) && M.mind && M.mind.miming)
 		update_flags |= M.adjustBruteLoss(-1, FALSE)
 		update_flags |= M.adjustFireLoss(-1, FALSE)
 	return ..() | update_flags
@@ -402,7 +402,7 @@
 
 /datum/reagent/consumable/drink/bananahonk/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if((ishuman(M) && M.job in list("Clown") ) || issmall(M))
+	if((ishuman(M) && COMIC in M.mutations) || issmall(M))
 		update_flags |= M.adjustBruteLoss(-1, FALSE)
 		update_flags |= M.adjustFireLoss(-1, FALSE)
 	return ..() | update_flags


### PR DESCRIPTION
This prevents both free golems and xenobio golems, aswell as other event style characters, from being selected as auto traitors by checking the job var.

This also changes banana juice, banana honk and Nothing to check for the COMIC mutation/an active vow of silence

Fixes #11408 

🆑
fix: The Syndicate will no longer hire golems as agents.
tweak: Banana juice and Banana honk will now heal everyone with the Comic Sans mutation instead of checking for the clown job
tweak: Nothing will now check if the player has an active vow of silence instead of checking for the mime job
/🆑