### PR TITLE
Lighting fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -629,6 +629,8 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	return has_organ[organ_slot]
 
 /datum/species/proc/update_sight(mob/living/carbon/human/H)
+	H.sight = initial(H.sight)
+
 	var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)
 	if(eyes)
 		H.sight |= eyes.vision_flags
@@ -636,7 +638,6 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 		H.see_invisible = eyes.see_invisible
 		H.lighting_alpha = eyes.lighting_alpha
 	else
-		H.sight = initial(H.sight)
 		H.see_in_dark = initial(H.see_in_dark)
 		H.see_invisible = initial(H.see_invisible)
 		H.lighting_alpha = initial(H.lighting_alpha)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -211,7 +211,7 @@
 	sight |= SEE_TURFS
 	sight |= SEE_MOBS
 	sight |= SEE_OBJS
-	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_OBSERVER
 	sync_lighting_plane_alpha()

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -14,6 +14,8 @@
 		loc = locate(1,1,1)
 	lastarea = loc
 
+	client.screen = list() // Remove HUD items just in case.
+	client.images = list()
 	if(!hud_used)
 		create_mob_hud()
 	if(hud_used)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -14,18 +14,13 @@
 		loc = locate(1,1,1)
 	lastarea = loc
 
+	if(!hud_used)
+		create_mob_hud()
+	if(hud_used)
+		hud_used.show_hud(hud_used.hud_version)
+
 	sight |= SEE_TURFS
 	GLOB.player_list |= src
-
-/*
-	var/list/watch_locations = list()
-	for(var/obj/effect/landmark/landmark in GLOB.landmarks_list)
-		if(landmark.tag == "landmark*new_player")
-			watch_locations += landmark.loc
-
-	if(watch_locations.len>0)
-		loc = pick(watch_locations)
-*/
 
 	callHook("mob_login", list("client" = client, "mob" = src))
 


### PR DESCRIPTION
This pull request fixes an issue where a mob's sight wouldn't update properly (causing issues with revivals and glasses not being reset), fixes an issue with the lobby being bright white when being sent back to lobby and an issue where ambient occlusion wouldn't update properly in the lobby.

Fixes https://github.com/ParadiseSS13/Paradise/issues/11488.

**Changelog:**
:cl: Markolie
fix: Fixed an issue where a mob's sight wouldn't update properly in certain cases, such as being revived.
fix: Resolved an issue where the lobby would be bright white when being sent back.
fix: Resolved an issue where the ambient occlusion preference wouldn't update properly in the lobby.
/:cl:

