### PR TITLE
Fix windoor click opening

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -214,7 +214,7 @@
 		return attack_hand(user)
 
 /obj/machinery/door/window/attack_hand(mob/user)
-	return bumpopen(user)
+	return try_to_activate_door(user)
 
 /obj/machinery/door/window/emag_act(mob/user, obj/weapon)
 	if(!operating && density && !emagged)
@@ -228,7 +228,6 @@
 		return 1
 
 /obj/machinery/door/window/attackby(obj/item/I, mob/living/user, params)
-
 	//If it's in the process of opening/closing, ignore the click
 	if(operating)
 		return


### PR DESCRIPTION
**What does this PR do:**
Fixes https://github.com/ParadiseSS13/Paradise/issues/11487: clicking on windoors will now prevent them from auto-closing again.

**Changelog:**
:cl: Markolie
fix: Resolved an issue where clicking on a windoor would no longer prevent it from auto-closing.
/:cl:

