### PR TITLE
Clarify nuclear operative/syndicate cyborg switch acceptance message

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -18,6 +18,7 @@
 	icon_state = "locator"
 	var/borg_to_spawn
 	var/checking = FALSE
+	var/rolename = "Syndicate Operative"
 
 /obj/item/antag_spawner/nuke_ops/proc/before_candidate_search(user)
 	return TRUE
@@ -45,7 +46,7 @@
 	checking = TRUE
 
 	to_chat(user, "<span class='notice'>You activate [src] and wait for confirmation.</span>")
-	var/list/nuke_candidates = pollCandidates("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg" : "operative"]?", ROLE_OPERATIVE, TRUE, 150)
+	var/list/nuke_candidates = pollCandidates("Do you want to play as a [rolename]?", ROLE_OPERATIVE, TRUE, 150)
 	if(LAZYLEN(nuke_candidates))
 		checking = FALSE
 		if(QDELETED(src) || !check_usability(user))
@@ -109,8 +110,10 @@
 
 	if(switch_roles_choice == "Syndicate Cyborg")
 		switch_roles = TRUE
+		rolename = "Syndicate [borg_to_spawn]"
 	else
 		switch_roles = FALSE
+		rolename = initial(rolename)
 
 	return TRUE
 


### PR DESCRIPTION
**What does this PR do:**
This pull request makes sure ghosts are aware they'll be playing as a Syndicate operative, if the user of the borg spawner chooses to play as the borg instead.

**Changelog:**
:cl: Markolie
fix: When a nuclear operative chooses to play as the borg instead of operative using the cyborg teleporter, ghosts will now be informed of this in their acceptance message.
/:cl:

