### PR TITLE
Prevents turret covers from being moved by atmos

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -977,6 +977,7 @@ var/list/turret_icons
 
 /atom/movable/porta_turret_cover
 	icon = 'icons/obj/turrets.dmi'
+	anchored = TRUE
 
 // Syndicate turrets
 /obj/machinery/porta_turret/syndicate


### PR DESCRIPTION
**What does this PR do:**
Makes turret cover overlays anchored so they don't get moved by fastmos and smack into you when you try and get the ai or anything like that. Previously, if you breached the AI sat and tried to do hit and run on the turrets, fastmos would move the turret cover as it plays the opening animation.


**Changelog:**
:cl:
fix: opening turret covers now stay on top of their turret.
/:cl:

