### PR TITLE
Fixes Toggles Not Saving Properly

### DIFF
--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -87,7 +87,7 @@
 					UI_style_alpha='[UI_style_alpha]',
 					be_role='[sanitizeSQL(list2params(be_special))]',
 					default_slot='[default_slot]',
-					toggles='[toggles]',
+					toggles='[num2text(toggles, 7)]',
 					atklog='[atklog]',
 					sound='[sound]',
 					randomslot='[randomslot]',


### PR DESCRIPTION
Fixes toggles not saving properly.

@Crazylemon64 and I were up for a while trying to fix this, testing it locally with my database--at first we were stumped, but @Crazylemon64 noted that the problem occurred when then were more than 6 digits. 

As it turns out, if scientific notation was needed to represent a digit, it would round this value, for the SQL table, thus causing the final value to be rounded *up* by 10. Internally, in game, this has no effect, and only becomes a problem once SQL is involved. This is avoided by using `num2text`.

Also discovered that BYOND's maximum bitvalue is...23. If you try to use 24, it'll fail. Which means, the maximum flags we can have is `8,388,608`, so we're getting close to bumping up against that, as is.

fixes: https://github.com/ParadiseSS13/Paradise/issues/11281

:cl: Crazylemon and Fox McCloud
fix: Fixes toggles not properly saving
/:cl: