### PR TITLE
Fixes Ghosts Drifting

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -226,6 +226,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			P.despawn_occupant()
 	return
 
+// Ghosts have no momentum, being massless ectoplasm
+/mob/dead/observer/Process_Spacemove(movement_dir)
+	return 1
+
 /mob/dead/observer/Move(NewLoc, direct)
 	following = null
 	setDir(direct)


### PR DESCRIPTION
When movement was altered for observers, so they couldn't trigger `Crossed`, it unintentionally allowed them to drift.

While hilarious, this really isn't something we want 😛 

:cl: Fox McCloud
fix: Fixes drifting ghosts
/:cl: