### PR TITLE
Fix X-Ray on death for simple mobs

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1242,13 +1242,28 @@
 			return
 
 		switch(Text)
-			if("brute")	L.adjustBruteLoss(amount, robotic=1)
-			if("fire")	L.adjustFireLoss(amount, robotic=1)
-			if("toxin")	L.adjustToxLoss(amount)
-			if("oxygen")L.adjustOxyLoss(amount)
-			if("brain")	L.adjustBrainLoss(amount)
-			if("clone")	L.adjustCloneLoss(amount)
-			if("stamina") L.adjustStaminaLoss(amount)
+			if("brute")
+				if(ishuman(L))
+					var/mob/living/carbon/human/H = L	
+					H.adjustBruteLoss(amount, robotic = TRUE)
+				else
+					L.adjustBruteLoss(amount)
+			if("fire")	
+				if(ishuman(L))
+					var/mob/living/carbon/human/H = L	
+					H.adjustFireLoss(amount, robotic = TRUE)
+				else
+					L.adjustFireLoss(amount)
+			if("toxin")	
+				L.adjustToxLoss(amount)
+			if("oxygen")
+				L.adjustOxyLoss(amount)
+			if("brain")	
+				L.adjustBrainLoss(amount)
+			if("clone")	
+				L.adjustCloneLoss(amount)
+			if("stamina") 
+				L.adjustStaminaLoss(amount)
 			else
 				to_chat(usr, "You caused an error. DEBUG: Text:[Text] Mob:[L]")
 				return

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -277,6 +277,7 @@ Des: Removes all infected images from the alien.
 		grant_death_vision()
 		return
 
+	see_invisible = initial(see_invisible)
 	sight = SEE_MOBS
 	if(nightvision)
 		see_in_dark = 8

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1139,6 +1139,8 @@ so that different stomachs can handle things in different ways VB*/
 		grant_death_vision()
 		return
 
+	see_invisible = initial(see_invisible)
+	see_in_dark = initial(see_in_dark)
 	sight = initial(sight)
 	lighting_alpha = initial(lighting_alpha)
 	

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1039,13 +1039,3 @@
 			update_transform()
 		if("lighting_alpha")
 			sync_lighting_plane_alpha()
-
-/mob/living/update_sight()
-	if(!client)
-		return
-
-	if(stat == DEAD)
-		grant_death_vision()
-		return
-
-	. = ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1303,8 +1303,8 @@ var/list/ai_verbs_default = list(
 
 	see_invisible = initial(see_invisible)
 	see_in_dark = initial(see_in_dark)
-	lighting_alpha = initial(lighting_alpha)
 	sight = initial(sight)
+	lighting_alpha = initial(lighting_alpha)
 
 	if(aiRestorePowerRoutine)
 		sight = sight &~ SEE_TURFS

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -610,3 +610,32 @@
 	if(AIStatus == AI_Z_OFF)
 		SSidlenpcpool.idle_mobs_by_zlevel[old_z] -= src
 		toggle_ai(initial(AIStatus)) 
+
+// Simple animals will not be given night vision upon death, as that would result in issues when they are revived.
+/mob/living/simple_animal/grant_death_vision()
+	sight |= SEE_TURFS
+	sight |= SEE_MOBS
+	sight |= SEE_OBJS
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_OBSERVER
+	sync_lighting_plane_alpha()
+
+/mob/living/simple_animal/update_sight()
+	if(!client)
+		return
+
+	if(stat == DEAD)
+		grant_death_vision()
+		return
+
+	see_invisible = initial(see_invisible)
+	see_in_dark = initial(see_in_dark)
+	sight = initial(sight)
+
+	if(client.eye != src)
+		var/atom/A = client.eye
+		if(A.update_remote_sight(src)) //returns 1 if we override all other sight updates.
+			return
+
+	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
+	sync_lighting_plane_alpha()


### PR DESCRIPTION
**What does this PR do:**
This pull request fixes dead simple mobs retaining their X-Ray upon being revived. It also fixes an issue where you couldn't apply brute/fire damage to non-humans through View Variables.

Fixes https://github.com/ParadiseSS13/Paradise/issues/11500.

**Changelog:**
:cl: Markolie
fix: Simple mobs no longer retain their X-Ray upon being revived.
fix: Applying brute/fire damage through the View Variables menu for non-humans has been fixed.
/:cl:

