### PR TITLE
Removes the verb interface to SDQL2

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -15,12 +15,14 @@
 
 */
 
-/client/proc/SDQL2_query(query_text as message)
+/client/proc/SDQL2_query()
 	set category = "Debug"
 
 	if(!check_rights(R_PROCCALL))  //Shouldn't happen... but just to be safe.
 		message_admins("<span class='danger'>ERROR: Non-admin [key_name_admin(usr)] attempted to execute a SDQL query!</span>")
 		log_admin("Non-admin [key_name(usr)] attempted to execute a SDQL query!")
+
+	var/query_text = input("SDQL2 query") as message
 
 	if(!query_text || length(query_text) < 1)
 		return


### PR DESCRIPTION
**What does this PR do:**
SDQL2 can be invoked via macro, but certain scenarios make this a vulnerable convenience. This PR removes the macro interface for SDQL2, but otherwise it should function identically.

**Changelog:**
:cl:Crazylemon
del: SDQL2 no longer allows a macro argument
/:cl:

