### PR TITLE
Fix ghosts being asked the wrong nukie role

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -32,7 +32,7 @@
 		return FALSE
 	if(checking)
 		to_chat(user, "<span class='danger'>The device is already connecting to Syndicate command. Please wait.</span>")
-		return FALSE	
+		return FALSE
 	return TRUE
 
 /obj/item/antag_spawner/nuke_ops/attack_self(mob/user)
@@ -110,10 +110,10 @@
 
 	if(switch_roles_choice == "Syndicate Cyborg")
 		switch_roles = TRUE
-		rolename = "Syndicate [borg_to_spawn]"
+		rolename = initial(rolename)
 	else
 		switch_roles = FALSE
-		rolename = initial(rolename)
+		rolename = "Syndicate [borg_to_spawn]"
 
 	return TRUE
 

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -113,7 +113,7 @@
 		rolename = initial(rolename)
 	else
 		switch_roles = FALSE
-		rolename = "Syndicate [borg_to_spawn]"
+		rolename = "Syndicate [borg_to_spawn] Cyborg"
 
 	return TRUE
 


### PR DESCRIPTION
#11492 mixed up which players gets which role.
The role being selected is the role that the player using the spawner
will play, so the role that the ghost gets is the other one.

Also adds 'Cyborg' to the role name so it does not show up as just Syndicate Assault but as Syndicate Assault Cyborg
🆑
fix: Ghosts will no longer get the wrong role offered when a nukie
spawns a borg and will properly be informed whether they will spawn as a
nuke ops or a syndi cyborg.
/🆑