### PR TITLE
Make the lighting plane master respect client color and other lighting fixes

### DIFF
--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -34,7 +34,7 @@
 /obj/screen/plane_master/game_world
 	name = "game world plane master"
 	plane = GAME_PLANE
-	appearance_flags = PLANE_MASTER //should use client color
+	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_OVERLAY
 
 /obj/screen/plane_master/game_world/backdrop(mob/mymob)
@@ -45,6 +45,7 @@
 /obj/screen/plane_master/lighting
 	name = "lighting plane master"
 	plane = LIGHTING_PLANE
+	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -14,7 +14,6 @@ var/global/list/image/splatter_cache = list()
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "mfloor1"
 	random_icon_states = list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")
-	appearance_flags = NO_CLIENT_COLOR
 	blood_DNA = list()
 	var/base_icon = 'icons/effects/blood.dmi'
 	var/blood_state = BLOOD_STATE_HUMAN
@@ -155,7 +154,6 @@ var/global/list/image/splatter_cache = list()
 	layer = TURF_LAYER
 	random_icon_states = null
 	blood_DNA = list()
-	appearance_flags = NO_CLIENT_COLOR
 	var/list/existing_dirs = list()
 
 /obj/effect/decal/cleanable/trail_holder/can_bloodcrawl_in()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -679,8 +679,8 @@
 			message += " (RESTRICTED)"
 		to_chat(world, "[message]")
 
-/client/proc/colour_transition(var/list/colour_to = null, var/time = 10) //Call this with no parameters to reset to default.
-	animate(src, color=colour_to, time=time, easing=SINE_EASING)
+/client/proc/colour_transition(list/colour_to = null, time = 10) //Call this with no parameters to reset to default.
+	animate(src, color = colour_to, time = time, easing = SINE_EASING)
 
 /client/proc/on_varedit()
 	var_edited = TRUE

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -247,16 +247,16 @@
 	desc = "Somehow these seem even more out-of-date than normal sunglasses."
 	actions_types = list(/datum/action/item_action/noir)
 
-/obj/item/clothing/glasses/sunglasses/noir/attack_self()
-	toggle_noir()
+/obj/item/clothing/glasses/sunglasses/noir/attack_self(mob/user)
+	toggle_noir(user)
 
 /obj/item/clothing/glasses/sunglasses/noir/item_action_slot_check(slot)
 	if(slot == slot_glasses)
 		return 1
 
-/obj/item/clothing/glasses/sunglasses/noir/proc/toggle_noir()
+/obj/item/clothing/glasses/sunglasses/noir/proc/toggle_noir(mob/user)
 	color_view = color_view ? null : MATRIX_GREYSCALE //Toggles between null and grayscale, with null being the default option.
-	usr.update_client_colour()
+	user.update_client_colour()
 
 /obj/item/clothing/glasses/sunglasses/yeah
 	name = "agreeable glasses"

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -207,19 +207,26 @@
 /datum/action/innate/minedrone/toggle_meson_vision
 	name = "Toggle Meson Vision"
 	button_icon_state = "meson"
+	var/sight_flags = SEE_TURFS
+	var/lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 
 /datum/action/innate/minedrone/toggle_meson_vision/Activate()
-	var/mob/living/simple_animal/hostile/mining_drone/user = owner
-	if(user.sight & SEE_TURFS)
-		user.sight &= ~SEE_TURFS
-		user.lighting_alpha = initial(user.lighting_alpha)
+	var/mob/living/user = owner
+	var/is_active = user.sight & SEE_TURFS
+
+	if(is_active)
+		UnregisterSignal(user, COMSIG_MOB_UPDATE_SIGHT)
+		user.update_sight()
 	else
-		user.sight |= SEE_TURFS
-		user.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+		RegisterSignal(user, COMSIG_MOB_UPDATE_SIGHT, .proc/update_user_sight)
+		user.update_sight()
 
-	user.sync_lighting_plane_alpha()
+	to_chat(user, "<span class='notice'>You toggle your meson vision [!is_active ? "on" : "off"].</span>")
 
-	to_chat(user, "<span class='notice'>You toggle your meson vision [(user.sight & SEE_TURFS) ? "on" : "off"].</span>")
+/datum/action/innate/minedrone/toggle_meson_vision/proc/update_user_sight(mob/living/user)
+	user.sight |= sight_flags
+	if(!isnull(lighting_alpha))
+		user.lighting_alpha = min(user.lighting_alpha, lighting_alpha)
 
 /datum/action/innate/minedrone/toggle_mode
 	name = "Toggle Mode"

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -619,12 +619,14 @@
 
 /datum/pai_software/flashlight/toggle(mob/living/silicon/pai/user)
 	var/atom/movable/actual_location = istype(user.loc, /obj/item/paicard) ? user.loc : user
-	if(user.flashlight_on)
+	if(!user.flashlight_on)
 		actual_location.set_light(2)
 		user.card.set_light(2)
-		return
-	actual_location.set_light(2)
-	user.card.set_light(0)
+	else
+		actual_location.set_light(0)
+		user.card.set_light(0)
+
+	user.flashlight_on = !user.flashlight_on
 
 /datum/pai_software/flashlight/is_active(mob/living/silicon/pai/user)
 	return user.flashlight_on


### PR DESCRIPTION
**What does this PR do:**
The lighting plane master currently doesn't respect the client color, which means that lighting is still colored for mobs with color blindness. This pull request makes the lighting plane master respect the client color.

With the new plane_master system, the noir sunglasses no longer display blood color. Sadly enough I don't see a way around this, aside from putting blood on their own plane which would be a bit overkill. As such, I've removed the NO_CLIENT_COLOR appearance flag from blood, as it doesn't do anything anymore. This wasn't a very good solution anyway, as I believe this also means that blood would still still be colored for color blind mobs with the old lighting system.

As a bonus, this also fixes pAI flashlights not working (which wasn't caused by the lighting update) and fixes minebot mesons not working either.

Fixes https://github.com/ParadiseSS13/Paradise/issues/11503.
Fixes https://github.com/ParadiseSS13/Paradise/issues/11531.

**Changelog:**
:cl: Markolie
fix: Lighting now respects color blindness again.
fix: pAI flashlights now work properly.
/:cl:

