### PR TITLE
Boo affects APCs (again) & no more infinite Boo

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -62,6 +62,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	var/charge_type = "recharge" //can be recharge or charges, see charge_max and charge_counter descriptions; can also be based on the holder's vars now, use "holder_var" for that
 
 	var/charge_max = 100 //recharge time in deciseconds if charge_type = "recharge" or starting charges if charge_type = "charges"
+	var/starts_charged = TRUE //Does this spell start ready to go?
 	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each decisecond if charge_type = "recharge" or -- each cast if charge_type = "charges"
 	var/still_recharging_msg = "<span class='notice'>The spell is still recharging.</span>"
 
@@ -193,9 +194,11 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 /obj/effect/proc_holder/spell/New()
 	..()
 	action = new(src)
-
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
-	charge_counter = charge_max
+	if(starts_charged)
+		charge_counter = charge_max
+	else
+		start_recharge()
 
 /obj/effect/proc_holder/spell/Destroy()
 	QDEL_NULL(action)
@@ -212,10 +215,14 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 /obj/effect/proc_holder/spell/proc/start_recharge()
 	if(action)
 		action.UpdateButtonIcon()
-	while(charge_counter < charge_max)
-		sleep(1)
-		charge_counter++
-	if(action)
+	addtimer(CALLBACK(src, .add_charge), 10)
+
+/obj/effect/proc_holder/spell/proc/add_charge()
+	charge_counter += 10
+	if(charge_counter < charge_max) //Needs to charge some more
+		addtimer(CALLBACK(src, .add_charge), 10)
+		return
+	if(action) //We got this far, it's charged
 		action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = 1, mob/user = usr) //if recharge is started is important for the trigger spells

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -215,14 +215,15 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 /obj/effect/proc_holder/spell/proc/start_recharge()
 	if(action)
 		action.UpdateButtonIcon()
-	addtimer(CALLBACK(src, .add_charge), 10)
+	START_PROCESSING(SSfastprocess, src)
 
-/obj/effect/proc_holder/spell/proc/add_charge()
-	charge_counter += 10
-	if(charge_counter < charge_max) //Needs to charge some more
-		addtimer(CALLBACK(src, .add_charge), 10)
+/obj/effect/proc_holder/spell/process()
+	charge_counter += 2
+	if(charge_counter < charge_max)
 		return
-	if(action) //We got this far, it's charged
+	STOP_PROCESSING(SSfastprocess, src)
+	charge_counter = charge_max
+	if(action)
 		action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = 1, mob/user = usr) //if recharge is started is important for the trigger spells

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -333,6 +333,9 @@
 	if(AM && isturf(AM.loc))
 		step(AM, turn(AM.dir, 180))
 
+/atom/proc/get_spooked()
+	return
+
 /atom/proc/add_hiddenprint(mob/living/M as mob)
 	if(isnull(M)) return
 	if(isnull(M.key)) return
@@ -651,7 +654,7 @@ var/list/blood_splatter_icons = list()
 			if(V.type == type)
 				V.reagents.add_reagent(vomit_reagent, 5)
 				return
-			
+
 		var/obj/effect/decal/cleanable/vomit/this = new type(src)
 
 		// Make toxins vomit look different

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -78,6 +78,9 @@
 	set_picture("ai_bsod")
 	..(severity)
 
+/obj/machinery/status_display/get_spooked()
+	spookymode = TRUE
+
 // set what is displayed
 /obj/machinery/status_display/proc/update()
 	if(friendc && !ignore_friendc)
@@ -226,6 +229,9 @@
 		return
 	set_picture("ai_bsod")
 	..(severity)
+
+/obj/machinery/ai_status_display/get_spooked()
+	spookymode = TRUE
 
 /obj/machinery/ai_status_display/proc/update()
 	if(mode==0) //Blank

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -282,6 +282,10 @@
 /turf/proc/Bless()
 	flags |= NOJAUNT
 
+/turf/get_spooked()
+	for(var/atom/movable/AM in contents)
+		AM.get_spooked()
+
 /turf/proc/burn_down()
 	return
 

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -17,6 +17,7 @@ GLOBAL_LIST_INIT(boo_phrases, list(
 
 	school = "transmutation"
 	charge_max = 600
+	starts_charged = FALSE
 	clothes_req = 0
 	stat_allowed = 1
 	invocation = ""

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -1,6 +1,4 @@
-
-
-var/global/list/boo_phrases=list(
+GLOBAL_LIST_INIT(boo_phrases, list(
 	"You feel a chill run down your spine.",
 	"You think you see a figure in your peripheral vision.",
 	"What was that?",
@@ -9,13 +7,13 @@ var/global/list/boo_phrases=list(
 	"Something doesn't feel right...",
 	"You feel a presence in the room.",
 	"It feels like someone's standing behind you.",
-)
+))
 
 /obj/effect/proc_holder/spell/aoe_turf/boo
 	name = "Boo!"
 	desc = "Fuck with the living."
 
-	ghost = 1
+	ghost = TRUE
 
 	school = "transmutation"
 	charge_max = 600
@@ -27,26 +25,4 @@ var/global/list/boo_phrases=list(
 
 /obj/effect/proc_holder/spell/aoe_turf/boo/cast(list/targets, mob/user = usr)
 	for(var/turf/T in targets)
-		for(var/atom/A in T.contents)
-
-			// Bug humans
-			if(ishuman(A))
-				var/mob/living/carbon/human/H = A
-				if(H && H.client)
-					to_chat(H, "<i>[pick(boo_phrases)]</i>")
-
-			// Flicker unblessed lights in range
-			if(istype(A,/obj/machinery/light))
-				var/obj/machinery/light/L = A
-				if(L)
-					L.flicker()
-
-			// OH GOD BLUE APC (single animation cycle)
-			if(istype(A, /obj/machinery/power/apc))
-				A:spookify()
-
-			if(istype(A, /obj/machinery/status_display))
-				A:spookymode=1
-
-			if(istype(A, /obj/machinery/ai_status_display))
-				A:spookymode=1
+		T.get_spooked()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1987,6 +1987,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		genemutcheck(src, block, null, MUTCHK_FORCED)
 	dna.UpdateSE()
 
+/mob/living/carbon/human/get_spooked()
+	to_chat(src, "<span class='whisper'>[pick(GLOB.boo_phrases)]</span>")
+
 /mob/living/carbon/human/extinguish_light()
 	// Parent function handles stuff the human may be holding
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -414,15 +414,17 @@
 			update_icon()
 			updating_icon = 0
 
-/obj/machinery/power/apc/get_spooked()
+/obj/machinery/power/apc/get_spooked(second_pass = FALSE)
 	if(opened || wiresexposed)
 		return
 	if(stat & (NOPOWER | BROKEN))
 		return
-	addtimer(CALLBACK(src, .proc/update_icon, TRUE), 10)
-	overlays.Cut()
-	flick("apcemag", src)
-
+	if(!second_pass) //The first time, we just cut overlays
+		addtimer(CALLBACK(src, .get_spooked, TRUE), 1)
+		cut_overlays()
+	else
+		flick("apcemag", src) //Second time we cause the APC to update its icon, then add a timer to update icon later
+		addtimer(CALLBACK(src, .proc/update_icon, TRUE), 10)
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 /obj/machinery/power/apc/attackby(obj/item/W, mob/living/user, params)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -232,6 +232,9 @@
 			on = FALSE
 	return
 
+/obj/machinery/light/get_spooked()
+	flicker()
+
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(var/trigger = TRUE)
 	switch(status)


### PR DESCRIPTION
This PR does the following:
- Fixes #11459 - to maintainers: I don't know if this is a fix per se, as the behaviour doesn't seem to have been in the code for quite a long time. If so, please let me know and I'll update the changelog and PR accordingly.
- Fixes #6939
- Also refactors boo code and spell recharging

:cl:
fix: Boo affects APCs again
fix: Boo no longer fully charges when you enter your corpse
/:cl: