### PR TITLE
Blob split consciousness fix

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -126,7 +126,7 @@
 /obj/screen/blob/Split
 	icon_state = "ui_split"
 	name = "Split consciousness (100)"
-	desc = "Creates another Blob Overmind at the nearest node. One use only.<br>Offsprings are be unable to use this ability."
+	desc = "Creates another Blob Overmind at the targetted node. One use only.<br>Offsprings are unable to use this ability."
 
 /obj/screen/blob/Split/Click()
 	if(isovermind(usr))

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -126,7 +126,7 @@
 /obj/screen/blob/Split
 	icon_state = "ui_split"
 	name = "Split consciousness (100)"
-	desc = "Creates another Blob Overmind at the targetted node. One use only.<br>Offsprings are unable to use this ability."
+	desc = "Creates another Blob Overmind at the targeted node. One use only.<br>Offspring are unable to use this ability."
 
 /obj/screen/blob/Split/Click()
 	if(isovermind(usr))

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -105,7 +105,7 @@
 
 	spawn()
 		if(!new_overmind)
-			candidates = pollCandidates("Do you want to play as a blob?", ROLE_BLOB, 1)
+			candidates = pollCandidates("Do you want to play as a blob offspring?", ROLE_BLOB, 1)
 			if(candidates.len)
 				C = pick(candidates)
 		else

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -105,7 +105,11 @@
 
 	spawn()
 		if(!new_overmind)
-			candidates = pollCandidates("Do you want to play as a blob offspring?", ROLE_BLOB, 1)
+			if(is_offspring)
+				candidates = pollCandidates("Do you want to play as a blob offspring?", ROLE_BLOB, 1)
+			else
+				candidates = pollCandidates("Do you want to play as a blob?", ROLE_BLOB, 1)
+
 			if(candidates.len)
 				C = pick(candidates)
 		else
@@ -122,7 +126,6 @@
 			spawn(0)
 				if(is_offspring)
 					B.is_offspring = TRUE
-
 
 /obj/structure/blob/core/proc/lateblobtimer()
 	addtimer(CALLBACK(src, .proc/lateblobcheck), 50)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -367,10 +367,10 @@
 
 	var/obj/structure/blob/N = (locate(/obj/structure/blob) in T)
 	if(!N)
-		to_chat(src, "<span class='warning'>A node is required to birth your offspring..</span>")
+		to_chat(src, "<span class='warning'>A node is required to birth your offspring.</span>")
 		return
 	if(!istype(N, /obj/structure/blob/node))
-		to_chat(src, "<span class='warning'>A node is required to birth your offspring..</span>")
+		to_chat(src, "<span class='warning'>A node is required to birth your offspring.</span>")
 		return
 	if(!can_buy(100))
 		return

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -350,38 +350,38 @@
 			BS.Goto(pick(surrounding_turfs), BS.move_to_delay)
 	return
 
-
 /mob/camera/blob/verb/split_consciousness()
 	set category = "Blob"
 	set name = "Split consciousness (100) (One use)"
 	set desc = "Expend resources to attempt to produce another sentient overmind."
 
+	var/turf/T = get_turf(src)
+	if(!T)
+		return
 	if(split_used)
 		to_chat(src, "<span class='warning'>You have already produced an offspring.</span>")
 		return
 	if(is_offspring)
 		to_chat(src, "<span class='warning'>You cannot split as an offspring of another Blob.</span>")
 		return
-	if(!blob_nodes || !blob_nodes.len)
-		to_chat(src, "<span class='warning'>A node is required to birth your offspring...</span>")
-		return
-	var/obj/structure/blob/node/N = locate(/obj/structure/blob) in blob_nodes
-	if(!N)
-		to_chat(src, "<span class='warning'>A node is required to birth your offspring...</span>")
-		return
 
+	var/obj/structure/blob/N = (locate(/obj/structure/blob) in T)
+	if(!N)
+		to_chat(src, "<span class='warning'>A node is required to birth your offspring..</span>")
+		return
+	if(!istype(N, /obj/structure/blob/node))
+		to_chat(src, "<span class='warning'>A node is required to birth your offspring..</span>")
+		return
 	if(!can_buy(100))
 		return
 
 	split_used = TRUE
-
 	new /obj/structure/blob/core/ (get_turf(N), 200, null, blob_core.point_rate, "offspring")
 	qdel(N)
 
 	if(ticker && ticker.mode.name == "blob")
 		var/datum/game_mode/blob/BL = ticker.mode
 		BL.blobwincount += initial(BL.blobwincount)
-
 
 /mob/camera/blob/verb/blob_broadcast()
 	set category = "Blob"


### PR DESCRIPTION
**What does this PR do:**
Currently, Blob split counsciousness ability takes a nearest Blob node to turn into another sentient overmind. This causes issues when it selects node player did not intent to split into, and even completely bugs out with multiple Blob overminds, where it selects node another Blob overmind built across the map. This PR fixes that.

Blob split consciousness ability now requires you to directly target the node you want to turn into another sentient overmind instead of selecting a nearest one, which is also consistent with other Blob abilities.

Also fixes and improves some descriptions regarding Blob offspring.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Blob split consciousness ability now requires you to directly target a node you want to turn into another sentient overmind instead of selecting a nearest one
spellcheck: Fixed and improved some descriptions regarding Blob offspring
/:cl: