### PR TITLE
Prevents Future SSTicker from Runtiming

### DIFF
--- a/code/datums/cache/cache.dm
+++ b/code/datums/cache/cache.dm
@@ -1,6 +1,6 @@
 /datum/cache_entry
 	var/timestamp
-	var/data
-	
+	var/list/data = list()
+
 /datum/repository
 	var/cache_data


### PR DESCRIPTION
SSTicker seems to be fine, except for a problem with air alarms runtiming, as the assumption is `data` for `/datum/cache_entry` is a list, and not just a totally null variable.

This doesn't change the functionality of anything and shouldn't cause problems; `data` in this context is *always* utilized as a list, anyway

:cl: Fox McCloud
fix: Future proofs the coming Ticker subsystem
/:cl: