### PR TITLE
Changelings can now survive decapitation

### DIFF
--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -375,6 +375,11 @@ var/list/sting_paths
 			path.on_purchase(src)
 
 	var/mob/living/carbon/C = src		//only carbons have dna now, so we have to typecaste
+	if(istype(C))
+		var/obj/item/organ/internal/brain/B = C.get_int_organ(/obj/item/organ/internal/brain)
+		if(B)
+			B.vital = FALSE
+			B.decoy_override = TRUE	
 	mind.changeling.absorbed_dna |= C.dna.Clone()
 	mind.changeling.trim_dna()
 	return 1

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -31,6 +31,9 @@
 		H.dna.species.create_organs(H)
 		// Now that recreating all organs is necessary, the rest of this organ stuff probably
 		//  isn't, but I don't want to remove it, just in case.
+		var/obj/item/organ/internal/brain/B = user.get_int_organ(/obj/item/organ/internal/brain)
+		B.vital = FALSE
+		B.decoy_override = TRUE
 		for(var/organ_name in H.bodyparts_by_name)
 			var/obj/item/organ/external/O = H.bodyparts_by_name[organ_name]
 			if(!O)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -328,6 +328,10 @@
 
 	if(incapacitated())
 		return
+		
+	if (!head)
+		to_chat(src, "They have no head to infest!")
+		return
 
 	to_chat(src, "You slither up [M] and begin probing at [M.p_their()] ear canal...")
 

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -330,7 +330,7 @@
 		return
 		
 	if (!head)
-		to_chat(src, "They have no head to infest!")
+		to_chat(src, "[M.p_they(TRUE)] [M.p_have()] no head to infest!")
 		return
 
 	to_chat(src, "You slither up [M] and begin probing at [M.p_their()] ear canal...")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -657,7 +657,7 @@ About the new airlock wires panel:
 				var/obj/item/organ/external/affecting = H.get_organ("head")
 				H.Stun(5)
 				H.Weaken(5)
-				if(affecting.receive_damage(10, 0))
+				if(affecting && affecting.receive_damage(10, 0))
 					H.UpdateDamageIcon()
 			else
 				visible_message("<span class='warning'>[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet.</span>")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -509,7 +509,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 				if(M.stat != 2)
 					to_chat(M, "<span class='danger'>You go blind!</span>")
 		var/obj/item/organ/external/affecting = H.get_organ("head")
-		if(affecting.receive_damage(7))
+		if(affecting && affecting.receive_damage(7))
 			H.UpdateDamageIcon()
 	else
 		M.take_organ_damage(7)

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -18,6 +18,7 @@
 	hidden_pain = TRUE //the brain has no pain receptors, and brain damage is meant to be a stealthy damage type.
 	var/mmi_icon = 'icons/obj/assemblies.dmi'
 	var/mmi_icon_state = "mmi_full"
+	var/decoy_override = FALSE	//if it's a fake brain with no brainmob assigned. Feedback messages will be faked as if it does have a brainmob. See changelings & dullahans.
 
 /obj/item/organ/internal/brain/xeno
 	name = "xenomorph brain"
@@ -34,6 +35,10 @@
 			brainmob.client.screen.len = null //clear the hud
 
 /obj/item/organ/internal/brain/proc/transfer_identity(var/mob/living/carbon/H)
+	if(brainmob || decoy_override)
+		return
+	if(!H.mind)
+		return
 	brainmob = new(src)
 	if(isnull(dna)) // someone didn't set this right...
 		log_runtime(EXCEPTION("[src] at [loc] did not contain a dna datum at time of removal."), src)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -32,7 +32,7 @@
 			if(dna.species && amount > 0)
 				amount = amount * dna.species.brain_mod
 			sponge.damage = Clamp(sponge.damage + amount, 0, 120)
-			if(sponge.damage >= 120)
+			if(sponge.damage >= 120 && sponge.vital)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
 				death()
 	if(updating)
@@ -49,7 +49,7 @@
 			if(dna.species && amount > 0)
 				amount = amount * dna.species.brain_mod
 			sponge.damage = Clamp(amount, 0, 120)
-			if(sponge.damage >= 120)
+			if(sponge.damage >= 120 && sponge.vital)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
 				death()
 	if(updating)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -805,8 +805,8 @@
 			gloves.germ_level += 1
 
 		handle_organs()
-
-		if(getBrainLoss() >= 120 || (health + (getOxyLoss() / 2)) <= -500)
+		var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
+		if((getBrainLoss() >= 120 && B.vital) || (health + (getOxyLoss() / 2)) <= -500)
 			death()
 			return
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -806,6 +806,8 @@
 
 		handle_organs()
 		var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
+		if (!B)
+			return
 		if((getBrainLoss() >= 120 && B.vital) || (health + (getOxyLoss() / 2)) <= -500)
 			death()
 			return


### PR DESCRIPTION
**What does this PR do:**
This PR makes it possible to make organs vestigial and unneccessary, changelings are the only things in our codebase that have vestigial brains but its very easy to configure it now. Changelings no longer die from brain damage, though they are still affected by it because it's hilarious watching a headless changeling ram into an airlock and scream funny things

![image](https://user-images.githubusercontent.com/30060146/57885927-11763680-77fa-11e9-830b-5a9f138aa7cd.png)


**Changelog:**
:cl:
add: Changelings no longer die from being decapitated
/:cl:

