### PR TITLE
Fixes some issues with cryopod

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -231,7 +231,6 @@
 		/obj/item/reagent_containers/hypospray/CMO,
 		/obj/item/clothing/accessory/medal/gold/captain,
 		/obj/item/clothing/gloves/color/black/krav_maga/sec,
-		/obj/item/storage/internal,
 		/obj/item/spacepod_key,
 		/obj/item/nullrod,
 		/obj/item/key

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -233,7 +233,8 @@
 		/obj/item/clothing/gloves/color/black/krav_maga/sec,
 		/obj/item/storage/internal,
 		/obj/item/spacepod_key,
-		/obj/item/nullrod
+		/obj/item/nullrod,
+		/obj/item/key
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (


### PR DESCRIPTION
**What does this PR do:**
Fixes the cryopod removing ambulance, secway keys. Space pod keys were already in the list so that part was fine. It also fixes the cryopod recovering the headpocket item. I am not sure why it was in the preserved items list in the first place and removing it from there didn't change anything other than fixing it being recovered.
Fixes #11021 
Fixes #7892

**Changelog:**
:cl:
fix: Fixes cryopod removing ambulance, secway keys
fix: Fixes cryopod recovering the invisible headpocket item
/:cl:

