### PR TITLE
Fixes weird identity problems

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -601,28 +601,29 @@ proc/get_all_job_icons() //For all existing HUD icons
 	return GLOB.joblist + list("Prisoner")
 
 /obj/proc/GetJobName() //Used in secHUD icon generation
-	var/obj/item/card/id/I
+	var/assignmentName = "Unknown"
+	var/rankName = "Unknown"
 	if(istype(src, /obj/item/pda))
 		var/obj/item/pda/P = src
-		I = P.id
+		assignmentName = P.ownjob
+		rankName = P.ownrank
 	else if(istype(src, /obj/item/card/id))
-		I = src
+		var/obj/item/card/id/I = src
+		assignmentName = I.assignment
+		rankName = I.rank
+		
 
-	if(I)
-		var/job_icons = get_all_job_icons()
-		var/centcom = get_all_centcom_jobs()
+	var/job_icons = get_all_job_icons()
+	var/centcom = get_all_centcom_jobs()
 
-		if(I.assignment	in centcom) //Return with the NT logo if it is a Centcom job
-			return "Centcom"
-		if(I.rank in centcom)
-			return "Centcom"
+	if(assignmentName in centcom) //Return with the NT logo if it is a Centcom job
+		return "Centcom"
+	if(rankName in centcom)
+		return "Centcom"
 
-		if(I.assignment	in job_icons) //Check if the job has a hud icon
-			return I.assignment
-		if(I.rank in job_icons)
-			return I.rank
-
-	else
-		return
-
+	if(assignmentName	in job_icons) //Check if the job has a hud icon
+		return assignmentName
+	if(rankName in job_icons)
+		return rankName
+	
 	return "Unknown" //Return unknown if none of the above apply

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -553,9 +553,7 @@ Class Procs:
 			threatcount += 2
 
 	if(check_records || check_arrest)
-		var/perpname = perp.name
-		if(id)
-			perpname = id.registered_name
+		var/perpname = perp.get_visible_name(TRUE)
 
 		var/datum/data/record/R = find_security_record("name", perpname)
 		if(check_records && !R)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -338,17 +338,8 @@
 		msg += "[p_they(TRUE)] [p_are()] mostly dessicated now, with only bones remaining of what used to be a person.\n"
 
 	if(hasHUD(user,"security"))
-		var/perpname = "wot"
+		var/perpname = get_visible_name(TRUE)
 		var/criminal = "None"
-
-		if(wear_id)
-			var/obj/item/card/id/I = wear_id.GetID()
-			if(I)
-				perpname = I.registered_name
-			else
-				perpname = name
-		else
-			perpname = name
 
 		if(perpname)
 			for(var/datum/data/record/E in data_core.general)
@@ -361,17 +352,8 @@
 			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=[UID()];secrecord=`'>\[View\]</a>  <a href='?src=[UID()];secrecordadd=`'>\[Add comment\]</a>\n"
 
 	if(hasHUD(user,"medical"))
-		var/perpname = "wot"
+		var/perpname = get_visible_name(TRUE)
 		var/medical = "None"
-
-		if(wear_id)
-			if(istype(wear_id,/obj/item/card/id))
-				perpname = wear_id:registered_name
-			else if(istype(wear_id,/obj/item/pda))
-				var/obj/item/pda/tempPda = wear_id
-				perpname = tempPda.owner
-		else
-			perpname = src.name
 
 		for(var/datum/data/record/E in data_core.general)
 			if(E.fields["name"] == perpname)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -713,17 +713,9 @@
 			if(usr.incapacitated())
 				return
 			var/found_record = 0
-			var/perpname = "wot"
-			if(wear_id)
-				var/obj/item/card/id/I = wear_id.GetID()
-				if(I)
-					perpname = I.registered_name
-				else
-					perpname = name
-			else
-				perpname = name
+			var/perpname = get_visible_name(TRUE)
 
-			if(perpname)
+			if(perpname != "Unknown")
 				for(var/datum/data/record/E in data_core.general)
 					if(E.fields["name"] == perpname)
 						for(var/datum/data/record/R in data_core.security)
@@ -760,17 +752,9 @@
 		if(hasHUD(usr,"security"))
 			if(usr.incapacitated())
 				return
-			var/perpname = "wot"
+			var/perpname = get_visible_name(TRUE)
 			var/read = 0
 
-			if(wear_id)
-				if(istype(wear_id,/obj/item/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/pda))
-					var/obj/item/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in data_core.security)
@@ -792,24 +776,16 @@
 		if(hasHUD(usr,"security"))
 			if(usr.incapacitated())
 				return
-			var/perpname = "wot"
+			var/perpname = get_visible_name(TRUE)
 			var/read = 0
 
-			if(wear_id)
-				if(istype(wear_id,/obj/item/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/pda))
-					var/obj/item/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in data_core.security)
 						if(R.fields["id"] == E.fields["id"])
 							if(hasHUD(usr,"security"))
 								read = 1
-								if(length(R.fields["comments"]))
+								if(LAZYLEN(R.fields["comments"]))
 									for(var/c in R.fields["comments"])
 										to_chat(usr, c)
 								else
@@ -823,15 +799,8 @@
 		if(hasHUD(usr,"security"))
 			if(usr.incapacitated())
 				return
-			var/perpname = "wot"
-			if(wear_id)
-				if(istype(wear_id,/obj/item/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/pda))
-					var/obj/item/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
+			var/perpname = get_visible_name(TRUE)
+
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in data_core.security)
@@ -854,17 +823,8 @@
 		if(hasHUD(usr,"medical"))
 			if(usr.incapacitated())
 				return
-			var/perpname = "wot"
 			var/modified = 0
-
-			if(wear_id)
-				if(istype(wear_id,/obj/item/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/pda))
-					var/obj/item/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
+			var/perpname = get_visible_name(TRUE)
 
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
@@ -889,17 +849,9 @@
 		if(hasHUD(usr,"medical"))
 			if(usr.incapacitated())
 				return
-			var/perpname = "wot"
 			var/read = 0
-
-			if(wear_id)
-				if(istype(wear_id,/obj/item/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/pda))
-					var/obj/item/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
+			var/perpname = get_visible_name(TRUE)
+			
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in data_core.medical)
@@ -922,24 +874,16 @@
 		if(hasHUD(usr,"medical"))
 			if(usr.incapacitated())
 				return
-			var/perpname = "wot"
+			var/perpname = get_visible_name(TRUE)
 			var/read = 0
 
-			if(wear_id)
-				if(istype(wear_id,/obj/item/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/pda))
-					var/obj/item/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in data_core.medical)
 						if(R.fields["id"] == E.fields["id"])
 							if(hasHUD(usr,"medical"))
 								read = 1
-								if(length(R.fields["comments"]))
+								if(LAZYLEN(R.fields["comments"]))
 									for(var/c in R.fields["comments"])
 										to_chat(usr, c)
 								else
@@ -953,15 +897,7 @@
 		if(hasHUD(usr,"medical"))
 			if(usr.incapacitated())
 				return
-			var/perpname = "wot"
-			if(wear_id)
-				if(istype(wear_id,/obj/item/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/pda))
-					var/obj/item/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
+			var/perpname = get_visible_name(TRUE)
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in data_core.medical)
@@ -976,6 +912,9 @@
 								if(isrobot(usr))
 									var/mob/living/silicon/robot/U = usr
 									R.fields["comments"] += "Made by [U.name] ([U.modtype] [U.braintype]) on [current_date_string] [station_time_timestamp()]<BR>[t1]"
+								if(isAI(usr))
+									var/mob/living/silicon/ai/U = usr
+									R.fields["comments"] += "Made by [U.name] (artificial intelligence) on [current_date_string] [station_time_timestamp()]<BR>[t1]"
 
 	if(href_list["lookitem"])
 		var/obj/item/I = locate(href_list["lookitem"])
@@ -1602,7 +1541,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	//Check for arrest warrant
 	if(judgebot.check_records)
-		var/perpname = get_face_name(get_id_name())
+		var/perpname = get_visible_name(TRUE)
 		var/datum/data/record/R = find_record("name", perpname, data_core.security)
 		if(R && R.fields["criminal"])
 			switch(R.fields["criminal"])


### PR DESCRIPTION
**What does this PR do:**
Fixes a few things
1. Beepsky now will respect your identity like expected. He no longer will look right through your disguise and check your face even if disguised.
2. Fixed the medical and security logs using the old and insufficient way to get the identity. 
3. Fixed PDA's not giving you a job icon when put in the ID slot

Fixes #10567

**Changelog:**
:cl:
fix: Beepsky will now respect your disguise again. No more looking right through that gasmask
fix: Medical and security HUDs now use the correct way to identify somebody. They will see the same as you do on your screen.
fix: You will now get a job icon in the sec HUD when you use your PDA as ID. It'll use the PDA's assigned job.
/:cl:

