### PR TITLE
Crit change proposal

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -86,6 +86,17 @@
 	if(amount > 0)
 		if(dna.species)
 			amount = amount * dna.species.brute_mod
+		if(!check_death_method() && amount > 10)//for newcrit races only, and only for bigger hits
+			switch(health)//bad things happen, depending on how hurt you are.
+				if(-INFINITY to -300)//really massive damage
+					src.set_heartattack(TRUE)
+				if(-299 to -200)
+					var/datum/disease/D = new /datum/disease/critical/heart_failure
+					ForceContractDisease(D)
+				if(-199 to -100)
+					var/datum/disease/D = new /datum/disease/critical/shock
+					ForceContractDisease(D)
+
 		take_overall_damage(amount, 0, updating_health, used_weapon = damage_source)
 	else
 		heal_overall_damage(-amount, 0, updating_health, FALSE, robotic)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -89,7 +89,7 @@
 		if(!check_death_method() && amount > 10)//for newcrit races only, and only for bigger hits
 			switch(health)//bad things happen, depending on how hurt you are.
 				if(-INFINITY to -300)//really massive damage
-					src.set_heartattack(TRUE)
+					set_heartattack(TRUE)
 				if(-299 to -200)
 					var/datum/disease/D = new /datum/disease/critical/heart_failure
 					ForceContractDisease(D)


### PR DESCRIPTION
**What does this PR do:**
Despite newcrit being in for quite a while, I keep seeing complaints about it. Not so much from medbay players anymore, but from antags that say people in combat just don't die/go down. First, the reasons for newcrit in the first place were:

> Current crit isn't particularly engaging; you inject a single medicine (epinephrine) then slap on a few patches/throw them into cryo and they're good to go in about 30-120 seconds (or a bit longer if they need surgery).

>Likewise, for the player, your experience is largely “hit black screen and stare at it until dead”.

It talks about the experience after combat or whatever else hurt you into crit, mostly focused on medbay treating you. My changes leave the medbay part of this the same. What they do, however, is make repeatedly taking damage have a bigger impact in the following way:

At certain health thresholds, taking another _large_ amount of brute damage is guaranteed to progress you along the newcrit path of death (ie shock, cardiac failure, heart attack). For reference, the **current crit** system works like this, each tick:

- 0 to -50 health, 3% chance to go into shock.
- -50 to -80 health, 10% chance of shock and ~5% chance of cardiac failure(scaling from 4 to 6.4 with damage)
- -80 to -100 health, 4% chance of cardiac failure and paralysis (sidenote, lol chance going down)
- below -100 health, 20+% chance of cardiac failure, 10+% chance of heart attack. Chances scale with damage, up to 100% at -500 for cardiac failure and -1000 for heart attacks
- Below -100 health, you have a chance to die based on damage total (with brain damage weighted really high)


This PR modifies this the following way. All these checks are only performed when you are taking 11+ brute damage in one hit. This means they do not ever apply to being treated in medbay or otherwise saved from danger. They only apply when someone is actively attacking you with a deadly weapon (or you're getting doorcrushed or something).

- -100 health, you are guaranteed to enter shock.
- -200 health, you are guaranteed to suffer cardiac failure
- -300 health, you are guaranteed a heart attack.


You note those are very conservative numbers. You are very likely to already be in shock at -100 health. In fact, -100 is where you start rolling against death chance each tick. But it means that we hopefully have no more 'I wailed on him with my desword for forever and he just wouldn't die', rare as it may be. You hitting him with the desword will now guarantee shock, failure and heart attack if done long enough. Consider it a hedge against bad(or too good, depending on your POV) RNG

FAQ (or what I anticipate to be):
_Why only brute, not burn damage?_
Mostly because most really lethal weapons deal brute damage. I also consider it a way to emphasise projectile guns over laser guns in lethality. Stretchkins and revolvers are supposed to be more deadly than eguns, making up for it with lack of recharging. I can change it to also apply to burn though, if desired.

_Making medbay's job harder, AGAIN????_
Once a patient is in medbay, these changes make no difference. They apply only when taking big brute damage hits once already in crit range. Very likely, any patient being dragged to medbay from the battlefield would have already entered failure/shock just from the normal chance to do so before arriving.

**Changelog:**
:cl:
tweak: Taking brute damage while heavily wounded now has thresholds to guarantee shock/cardiac failure/heart attacks
/:cl:

