### PR TITLE
Rechargers now show their contents and charge status on examine

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -58,6 +58,10 @@
 		pulledby = null
 	return ..()
 
+//Returns an atom's power cell, if it has one. Overload for individual items.
+/atom/movable/proc/get_cell()
+	return
+
 /atom/movable/proc/start_pulling(atom/movable/AM, state, force = move_force, supress_message = FALSE)
 	if(QDELETED(AM))
 		return FALSE

--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -15,6 +15,10 @@
 	var/obj/item/defibrillator/defib //this mount's defibrillator
 	var/clamps_locked = FALSE //if true, and a defib is loaded, it can't be removed without unlocking the clamps
 
+/obj/machinery/defibrillator_mount/get_cell()
+	if(defib)
+		return defib.get_cell()
+
 /obj/machinery/defibrillator_mount/New(location, direction, building = 0)
 	..()
 
@@ -27,7 +31,6 @@
 	if(building)
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -30 : 30)
 		pixel_y = (dir & 3)? (dir == 1 ? -30 : 30) : 0
-
 
 /obj/machinery/defibrillator_mount/loaded/New() //loaded subtype for mapping use
 	..()

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -12,6 +12,8 @@
 	var/open = FALSE
 	var/brightness_on = 14
 
+/obj/machinery/floodlight/get_cell()
+	return cell
 
 /obj/machinery/floodlight/Initialize()
 	. = ..()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -8,6 +8,7 @@
 	idle_power_usage = 4
 	active_power_usage = 250
 	var/obj/item/charging = null
+	var/using_power = FALSE
 	var/list/allowed_devices = list(/obj/item/gun/energy, /obj/item/melee/baton, /obj/item/modular_computer, /obj/item/rcs, /obj/item/bodyanalyzer)
 	var/icon_state_off = "rechargeroff"
 	var/icon_state_charged = "recharger2"
@@ -81,22 +82,21 @@
 	if(stat & (NOPOWER|BROKEN) || !anchored)
 		return
 
-	var/using_power = 0
+	using_power = FALSE
 	if(charging)
 		if(istype(charging, /obj/item/gun/energy))
 			var/obj/item/gun/energy/E = charging
 			if(E.power_supply.charge < E.power_supply.maxcharge)
 				E.power_supply.give(E.power_supply.chargerate)
 				use_power(250)
-				using_power = 1
-
+				using_power = TRUE
 
 		if(istype(charging, /obj/item/melee/baton))
 			var/obj/item/melee/baton/B = charging
 			if(B.bcell)
 				if(B.bcell.give(B.bcell.chargerate))
 					use_power(200)
-					using_power = 1
+					using_power = TRUE
 
 		if(istype(charging, /obj/item/modular_computer))
 			var/obj/item/modular_computer/C = charging
@@ -107,21 +107,21 @@
 					if(B.battery.charge < B.battery.maxcharge)
 						B.battery.give(B.battery.chargerate)
 						use_power(200)
-						using_power = 1
+						using_power = TRUE
 
 		if(istype(charging, /obj/item/rcs))
 			var/obj/item/rcs/R = charging
 			if(R.rcell)
 				if(R.rcell.give(R.rcell.chargerate))
 					use_power(200)
-					using_power = 1
+					using_power = TRUE
 
 		if(istype(charging, /obj/item/bodyanalyzer))
 			var/obj/item/bodyanalyzer/B = charging
 			if(B.power_supply)
 				if(B.power_supply.give(B.power_supply.chargerate))
 					use_power(200)
-					using_power = 1
+					using_power = TRUE
 
 	update_icon(using_power)
 
@@ -141,7 +141,7 @@
 			B.bcell.charge = 0
 	..(severity)
 
-/obj/machinery/recharger/update_icon(using_power = 0)	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
+/obj/machinery/recharger/update_icon(using_power = FALSE)	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
 	if(stat & (NOPOWER|BROKEN) || !anchored)
 		icon_state = icon_state_off
 		return
@@ -152,6 +152,23 @@
 			icon_state = icon_state_charged
 		return
 	icon_state = icon_state_idle
+
+/obj/machinery/recharger/examine(mob/user)
+	..()
+	if(charging && (!in_range(user, src) && !issilicon(user) && !isobserver(user)))
+		to_chat(user, "<span class='warning'>You're too far away to examine [src]'s contents and display!</span>")
+		return
+
+	if(charging)
+		to_chat(user, "<span class='notice'>\The [src] contains:</span>")
+		to_chat(user, "<span class='notice'>- \A [charging].</span>")
+		if(!(stat & (NOPOWER|BROKEN)))
+			var/obj/item/stock_parts/cell/C = charging.get_cell()
+			to_chat(user, "<span class='notice'>The status display reads:<span>")
+			if(using_power)
+				to_chat(user, "<span class='notice'>- Recharging <b>[(C.chargerate/C.maxcharge)*100]%</b> cell charge per cycle.<span>")
+			if(charging)
+				to_chat(user, "<span class='notice'>- \The [charging]'s cell is at <b>[C.percent()]%</b>.<span>")
 
 // Atlantis: No need for that copy-pasta code, just use var to store icon_states instead.
 /obj/machinery/recharger/wallcharger

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -12,6 +12,9 @@
 	var/set_temperature = 50		// in celcius, add T0C for kelvin
 	var/heating_power = 40000
 
+/obj/machinery/space_heater/get_cell()
+	return cell
+
 /obj/machinery/space_heater/New()
 	..()
 	cell = new(src)
@@ -38,7 +41,6 @@
 		to_chat(user, "The power cell is [cell ? "installed" : "missing"].")
 	else
 		to_chat(user, "The charge meter reads [cell ? round(cell.percent(),1) : 0]%")
-
 
 /obj/machinery/space_heater/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -137,6 +137,10 @@
 ////////////////////////
 ////// Helpers /////////
 ////////////////////////
+
+/obj/mecha/get_cell()
+	return cell
+
 /obj/mecha/proc/add_airtank()
 	internal_tank = new /obj/machinery/portable_atmospherics/canister/air(src)
 	return internal_tank

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -591,6 +591,9 @@ REAGENT SCANNER
 	var/scan_time = 10 SECONDS //how long does it take to scan
 	var/scan_cd = 60 SECONDS //how long before we can scan again
 
+/obj/item/bodyanalyzer/get_cell()
+	return power_supply
+
 /obj/item/bodyanalyzer/advanced
 	cell_type = /obj/item/stock_parts/cell/upgraded/plus
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -23,6 +23,9 @@
 	var/obj/item/stock_parts/cell/high/bcell = null
 	var/combat = 0 //can we revive through space suits?
 
+/obj/item/defibrillator/get_cell()
+	return bcell
+
 /obj/item/defibrillator/New() //starts without a cell for rnd
 	..()
 	paddles = make_paddles()

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -20,6 +20,9 @@
 	user.visible_message("<span class='suicide'>[user] is putting the live [name] in [user.p_their()] mouth! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	return FIRELOSS
 
+/obj/item/melee/baton/get_cell()
+	return bcell
+
 /obj/item/melee/baton/New()
 	..()
 	update_icon()

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -64,13 +64,15 @@
 	item_state = "lgloves"
 	flags = NODROP
 
-
 /obj/item/clothing/gloves/color/yellow/stun
 	name = "stun gloves"
 	desc = "Horrendous and awful. It smells like cancer. The fact it has wires attached to it is incidental."
 	var/obj/item/stock_parts/cell/cell = null
 	var/stun_strength = 5
 	var/stun_cost = 2000
+
+/obj/item/clothing/gloves/color/yellow/stun/get_cell()
+	return cell
 
 /obj/item/clothing/gloves/color/yellow/stun/New()
 	..()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -97,6 +97,9 @@
 		to_chat(usr, "The maintenance panel is [open ? "open" : "closed"].")
 		to_chat(usr, "Hardsuit systems are [offline ? "<font color='red'>offline</font>" : "<font color='green'>online</font>"].")
 
+/obj/item/rig/get_cell()
+	return cell
+
 /obj/item/rig/New()
 	..()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -103,6 +103,9 @@ var/list/robot_verbs_default = list(
 	var/datum/action/item_action/toggle_research_scanner/scanner = null
 	var/list/module_actions = list()
 
+/mob/living/silicon/robot/get_cell()
+	return cell
+
 /mob/living/silicon/robot/New(loc,var/syndie = 0,var/unfinished = 0, var/alien = 0)
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -50,6 +50,9 @@
 	var/currentBloodColor = "#A10808"
 	var/currentDNA = null
 
+/mob/living/simple_animal/bot/mulebot/get_cell()
+	return cell
+
 /mob/living/simple_animal/bot/mulebot/New()
 	..()
 	wires = new /datum/wires/mulebot(src)

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -26,6 +26,10 @@
 		return battery_module.battery.give(amount)
 	return 0
 
+/obj/item/modular_computer/get_cell()
+	var/obj/item/computer_hardware/battery/battery_module = all_components[MC_CELL]
+	if(battery_module && battery_module.battery)
+		return battery_module.battery
 
 // Used in following function to reduce copypaste
 /obj/item/modular_computer/proc/power_failure()

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -8,6 +8,9 @@
 	var/obj/item/stock_parts/cell/battery = null
 	device_type = MC_CELL
 
+/obj/item/computer_hardware/battery/get_cell()
+	return battery
+
 /obj/item/computer_hardware/battery/New(loc, battery_type = null)
 	if(battery_type)
 		battery = new battery_type(src)

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -27,6 +27,9 @@ Contents:
 	var/obj/item/clothing/mask/gas/space_ninja/suitMask
 	var/mob/living/carbon/human/suitOccupant
 
+/obj/item/clothing/suit/space/space_ninja/get_cell()
+	return suitCell
+
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_suit_lock(mob/living/carbon/human/user)
 	if(!suitActive)
 		if(!istype(user.wear_suit, /obj/item/clothing/suit/space/space_ninja))

--- a/code/modules/ninja/suit/suit_attackby.dm
+++ b/code/modules/ninja/suit/suit_attackby.dm
@@ -1,5 +1,3 @@
-
-
 /obj/item/clothing/suit/space/space_ninja/attackby(obj/item/I, mob/U, params)
 	if(U==suitOccupant)//Safety, in case you try doing this without wearing the suit/being the person with the suit.
 		if(istype(I, /obj/item/stock_parts/cell))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -117,7 +117,6 @@
 	lighting = 0
 	operating = 0
 
-
 /obj/machinery/power/apc/noalarm
 	report_power_alarm = 0
 
@@ -132,6 +131,9 @@
 	flags = CONDUCT
 	usesound = 'sound/items/deconstruct.ogg'
 	toolspeed = 1
+
+/obj/machinery/power/apc/get_cell()
+	return cell
 
 /obj/machinery/power/apc/connect_to_network()
 	//Override because the APC does not directly connect to the network; it goes through a terminal.

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -19,6 +19,9 @@
 	var/ratingdesc = TRUE
 	var/grown_battery = FALSE // If it's a grown that acts as a battery, add a wire overlay to it.
 
+/obj/item/stock_parts/cell/get_cell()
+	return src
+
 /obj/item/stock_parts/cell/New()
 	..()
 	START_PROCESSING(SSobj, src)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -23,6 +23,9 @@
 	power_supply.use(round(power_supply.charge / severity))
 	update_icon()
 
+/obj/item/gun/energy/get_cell()
+	return power_supply
+
 /obj/item/gun/energy/New()
 	..()
 	if(cell_type)

--- a/code/modules/projectiles/guns/throw/crossbow.dm
+++ b/code/modules/projectiles/guns/throw/crossbow.dm
@@ -22,6 +22,9 @@
 	var/obj/item/stock_parts/cell/cell = null    // Used for firing superheated rods.
 	var/list/possible_tensions = list(XBOW_TENSION_20, XBOW_TENSION_40, XBOW_TENSION_60, XBOW_TENSION_80, XBOW_TENSION_FULL)
 
+/obj/item/gun/throw/crossbow/get_cell()
+	return cell
+
 /obj/item/gun/throw/crossbow/emp_act(severity)
 	if(cell && severity)
 		emp_act(severity)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -24,6 +24,9 @@
 	var/hack_message = "You disable the safety safeguards, enabling the \"Mad Scientist\" mode."
 	var/unhack_message = "You re-enable the safety safeguards, enabling the \"NT Standard\" mode."
 
+/obj/machinery/chem_dispenser/get_cell()
+	return cell
+
 /obj/machinery/chem_dispenser/New()
 	..()
 	component_parts = list()

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -92,6 +92,8 @@
 		has_paint = 1
 	update_icons()
 
+/obj/spacepod/get_cell()
+	return battery
 
 /obj/spacepod/New()
 	. = ..()

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -128,10 +128,12 @@
 	var/teleporting = 0
 	var/chargecost = 1000
 
+/obj/item/rcs/get_cell()
+	return rcell
+
 /obj/item/rcs/New()
 	..()
 	rcell = new(src)
-
 
 /obj/item/rcs/examine(mob/user)
 	..(user)


### PR DESCRIPTION
**What does this PR do:**
Upon examine, rechargers will now show what item do they hold, what is a charge rate for that item and what is a current charge of that item. You need to be next to the recharger to get that extra information on examine, unless you are a silicon.

**Images of sprite/map changes (IF APPLICABLE):**
![NewRecharger](https://user-images.githubusercontent.com/43862960/57973326-79b64b00-79a7-11e9-830d-073dfaff25fd.png)

Ported from /tg/station13:

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Rechargers now show their contents and charge status on close examine
/:cl: