### PR TITLE
Ghost vision lighting fix

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -720,7 +720,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/proc/updateghostimages()
 	if(!client)
 		return
-	if(!ghostvision)
+	if(seedarkness || !ghostvision)
 		client.images -= ghost_images
 	else
 		//add images for the 60inv things ghosts can normally see when darkness is enabled so they can see them now


### PR DESCRIPTION
**What does this PR do:**
This PR contains a fix for ghost vision, where as a ghost, you saw some other ghosts as too bright and with an extra ghost icon layering under them. Example images below.

**Images of sprite/map changes (IF APPLICABLE):**
**BEFORE FIX:**
![ghostsbefore](https://user-images.githubusercontent.com/43862960/57985925-214a8080-7a6f-11e9-8dcd-aab8df724540.png)
**AFTER FIX:**
![ghostsfixed](https://user-images.githubusercontent.com/43862960/57985932-260f3480-7a6f-11e9-9d0c-2cc5e92fc3bf.png)

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
fix: Fixed a case where ghosts had an extra ghost icon visible on them
fix: Fixed a case where some ghosts were too bright
/:cl: