### PR TITLE
Gamma borgs are now reset when security level is dropped below Gamma

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -31,31 +31,9 @@
 	if(..())
 		return
 
-	R.notify_ai(2)
+	R.reset_module()
 
-	R.uneq_all()
-	R.sight_mode = null
-	R.hands.icon_state = "nomod"
-	R.icon_state = "robot"
-	R.module.remove_subsystems_and_actions(R)
-	QDEL_NULL(R.module)
-
-	R.camera.network.Remove(list("Engineering", "Medical", "Mining Outpost"))
-	R.rename_character(R.real_name, R.get_default_name("Default"))
-	R.languages = list()
-	R.speech_synthesizer_langs = list()
-
-	R.update_icons()
-	R.update_headlamp()
-
-	R.speed = 0 // Remove upgrades.
-	R.ionpulse = 0
-	R.magpulse = 0
-	R.add_language("Robot Talk", 1)
-
-	R.status_flags |= CANPUSH
-
-	return 1
+	return TRUE
 
 /obj/item/borg/upgrade/rename
 	name = "cyborg reclassification board"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -287,7 +287,7 @@ var/list/robot_verbs_default = list(
 	if(islist(force_modules) && force_modules.len)
 		modules = force_modules.Copy()
 	if(security_level == (SEC_LEVEL_GAMMA || SEC_LEVEL_EPSILON) || crisis)
-		to_chat(src, "<span class='warning'>Crisis mode active. Combat module available.</span>")
+		to_chat(src, "<span class='warning'>Crisis mode active. The combat module is now available.</span>")
 		modules += "Combat"
 	if(mmi != null && mmi.alien)
 		modules = list("Hunter")
@@ -414,6 +414,31 @@ var/list/robot_verbs_default = list(
 	if(!static_radio_channels)
 		radio.config(module.channels)
 	notify_ai(2)
+
+/mob/living/silicon/robot/proc/reset_module()
+	notify_ai(2)
+
+	uneq_all()
+	sight_mode = null
+	hands.icon_state = "nomod"
+	icon_state = "robot"
+	module.remove_subsystems_and_actions(src)
+	QDEL_NULL(module)
+
+	camera.network.Remove(list("Engineering", "Medical", "Mining Outpost"))
+	rename_character(real_name, get_default_name("Default"))
+	languages = list()
+	speech_synthesizer_langs = list()
+
+	update_icons()
+	update_headlamp()
+
+	speed = 0 // Remove upgrades.
+	ionpulse = FALSE
+	magpulse = FALSE
+	add_language("Robot Talk", 1)
+
+	status_flags |= CANPUSH
 
 //for borg hotkeys, here module refers to borg inv slot, not core module
 /mob/living/silicon/robot/verb/cmd_toggle_module(module as num)

--- a/code/modules/security_levels/security levels.dm
+++ b/code/modules/security_levels/security levels.dm
@@ -31,6 +31,15 @@
 			// Mark down this time to prevent shuttle cheese
 			SSshuttle.emergency_sec_level_time = world.time
 
+		// Reset gamma borgs if the new security level is lower than Gamma.
+		if(level < SEC_LEVEL_GAMMA)
+			for(var/M in GLOB.silicon_mob_list)
+				if(isrobot(M))
+					var/mob/living/silicon/robot/R = M
+					if(istype(R.module, /obj/item/robot_module/combat))
+						R.reset_module()
+						to_chat(R, "<span class='warning'>Crisis mode deactivated. The combat module is no longer available and your module has been reset.</span>")
+
 		switch(level)
 			if(SEC_LEVEL_GREEN)
 				security_announcement_down.Announce("All threats to the station have passed. All weapons need to be holstered and privacy laws are once again fully enforced.","Attention! Security level lowered to green.")
@@ -176,15 +185,3 @@
 			return SEC_LEVEL_EPSILON
 		if("delta")
 			return SEC_LEVEL_DELTA
-
-
-/*DEBUG
-/mob/verb/set_thing0()
-	set_security_level(0)
-/mob/verb/set_thing1()
-	set_security_level(1)
-/mob/verb/set_thing2()
-	set_security_level(2)
-/mob/verb/set_thing3()
-	set_security_level(3)
-*/

--- a/code/modules/security_levels/security levels.dm
+++ b/code/modules/security_levels/security levels.dm
@@ -36,7 +36,7 @@
 			for(var/M in GLOB.silicon_mob_list)
 				if(isrobot(M))
 					var/mob/living/silicon/robot/R = M
-					if(istype(R.module, /obj/item/robot_module/combat))
+					if(istype(R.module, /obj/item/robot_module/combat) && !R.crisis)
 						R.reset_module()
 						to_chat(R, "<span class='warning'>Crisis mode deactivated. The combat module is no longer available and your module has been reset.</span>")
 


### PR DESCRIPTION
**What does this PR do:**
If the security levels drops below Gamma, all Gamma borgs (with the combat module) will now be reset. Epsilon and Delta are both higher level than Gamma, and as such will not reset Gamma borgs. Borgs with their crisis mode manually enabled will not be reset.

Gamma borgs are incredibly powerful. When the threat to the station is contained, they no longer have a need for their combat module. 

**Changelog:**
:cl: Markolie
balance: When the alert level drops below Gamma, Gamma borgs will now be reset.
/:cl:

