### PR TITLE
Better adminhelp take ticket color

### DIFF
--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -404,5 +404,8 @@ UI STUFF
 
 /datum/controller/subsystem/tickets/proc/takeTicket(var/index)
 	if(assignStaffToTicket(usr.client, index))
-		message_staff("<span class='admin_channel'>[usr.client] / ([usr]) has taken [ticket_name] number [index]</span>", TRUE)
+		if(span_text == "<span class='mentorhelp'>")
+			message_staff("[span_text][usr.client] / ([usr]) has taken [ticket_name] number [index]</span>")
+		else
+			message_staff("<span class='admin_channel'>[usr.client] / ([usr]) has taken [ticket_name] number [index]</span>", TRUE)
 		to_chat_safe(returnClient(index), "[span_text]Your [ticket_name] is being handled by [usr.client].</span>")

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -404,6 +404,5 @@ UI STUFF
 
 /datum/controller/subsystem/tickets/proc/takeTicket(var/index)
 	if(assignStaffToTicket(usr.client, index))
-		span_text = "<span class='adminchannel'>"
-		message_staff("[span_text][usr.client] / ([usr]) has taken [ticket_name] number [index]</span>", TRUE)
+		message_staff("<span class='admin_channel'>[usr.client] / ([usr]) has taken [ticket_name] number [index]</span>", TRUE)
 		to_chat_safe(returnClient(index), "[span_text]Your [ticket_name] is being handled by [usr.client].</span>")

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -335,8 +335,8 @@ UI STUFF
 	return TRUE
 
 //Sends a message to the designated staff
-/datum/controller/subsystem/tickets/proc/message_staff(var/msg)
-	message_adminTicket(msg)
+/datum/controller/subsystem/tickets/proc/message_staff(var/msg, var/alt = FALSE)
+	message_adminTicket(msg, alt)
 
 /datum/controller/subsystem/tickets/Topic(href, href_list)
 
@@ -404,5 +404,6 @@ UI STUFF
 
 /datum/controller/subsystem/tickets/proc/takeTicket(var/index)
 	if(assignStaffToTicket(usr.client, index))
-		message_staff("[span_text][usr.client] / ([usr]) has taken [ticket_name] number [index]</span>")
+		span_text = "<span class='adminchannel'>"
+		message_staff("[span_text][usr.client] / ([usr]) has taken [ticket_name] number [index]</span>", TRUE)
 		to_chat_safe(returnClient(index), "[span_text]Your [ticket_name] is being handled by [usr.client].</span>")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -21,8 +21,11 @@ var/global/nologevent = 0
 					to_chat(C, msg)
 
 
-/proc/message_adminTicket(var/msg)
-	msg = "<span class='adminticket'><span class='prefix'>ADMIN TICKET:</span> [msg]</span>"
+/proc/message_adminTicket(var/msg, var/alt = FALSE)
+	if(alt)
+		msg = "<span class=admin_channel>ADMIN TICKET: [msg]</span>"
+	else
+		msg = "<span class=adminticket><span class='prefix'>ADMIN TICKET:</span> [msg]</span>"
 	for(var/client/C in GLOB.admins)
 		if(R_ADMIN & C.holder.rights)
 			if(C.prefs && !(C.prefs.toggles & CHAT_NO_TICKETLOGS))


### PR DESCRIPTION
**What does this PR do:**
Changes green to Asay pink and makes it easier for admins to see that someone has taken a ticket. Everything else is still green, just not take ticket.

**Images of sprite/map changes (IF APPLICABLE):**

![](https://i.imgur.com/4ywlxVB.png)

(the pink)

**Changelog:**
:cl:
tweak: Changed admin take ticket color from neon green to Asay pink
/ :cl:
