### PR TITLE
Changeling Swap Forms fix

### DIFF
--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -21,6 +21,9 @@
 	if(!istype(target) || issmall(target) || NO_DNA in target.dna.species.species_traits)
 		to_chat(user, "<span class='warning'>[target] is not compatible with this ability.</span>")
 		return
+	if(target.mind.changeling)
+		to_chat(user, "<span class='warning'>We are unable to swap forms with another changeling!</span>")
+		return
 	return 1
 
 /datum/action/changeling/swap_form/sting_action(var/mob/living/carbon/user)


### PR DESCRIPTION
**What does this PR do:**
As a changeling, you are now unable to swap forms with another changeling. This caused myriad of issues, from removing changeling status completely to gaining duplicit or wrong abilities on a changeling.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
fix: You are now unable to swap forms with another changeling
/:cl: