### PR TITLE
Moves a global var around

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -87,3 +87,5 @@ var/copier_items_printed_logged = FALSE
 
 
 GLOBAL_VAR(map_name) // Self explanatory
+
+var/global/datum/datacore/data_core = null // Station datacore, manifest, etc

--- a/code/_globalvars/station.dm
+++ b/code/_globalvars/station.dm
@@ -1,2 +1,0 @@
-// TODO: Move this to be not in its own fucking file all alone on its own
-var/global/datum/datacore/data_core = null

--- a/paradise.dme
+++ b/paradise.dme
@@ -103,7 +103,6 @@
 #include "code\_globalvars\logging.dm"
 #include "code\_globalvars\mapping.dm"
 #include "code\_globalvars\misc.dm"
-#include "code\_globalvars\station.dm"
 #include "code\_globalvars\unused.dm"
 #include "code\_globalvars\lists\flavor_misc.dm"
 #include "code\_globalvars\lists\fortunes.dm"


### PR DESCRIPTION
**What does this PR do:**
This moves the datacore def to another file so its not all on its own. I tried to make it a proper var with `GLOBAL_VAR_INIT` but I couldnt make it work. If anyone has suggestions I am open

**Changelog:**
:cl: AffectedArc07
tweak: Moved a global define
/:cl:

