### PR TITLE
[WIP]More spread out symptoms and even more experimentation (Viro rework 2)

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -18,7 +18,10 @@
 		return FALSE
 
 	if(istype(D, /datum/disease/advance) && count_by_type(viruses, /datum/disease/advance) > 0)
-		return FALSE
+		var/datum/disease/advance/A = D
+		for(var/datum/disease/advance/A_existing in viruses)
+			if(A_existing.HasSymptom(new /datum/symptom/heal/metabolism) || A_existing.totalResistance() > A.totalStageSpeed()) // Gotta beat that resistance by 1
+				return FALSE
 
 	if(!(type in D.viable_mobtypes))
 		return -1 //for stupid fucking monkies
@@ -33,6 +36,10 @@
 
 
 /mob/proc/AddDisease(datum/disease/D)
+	if(istype(D, /datum/disease/advance))
+		for(var/datum/disease/advance/A in viruses)
+			A.cure(FALSE) //Remove the old advanced virus, not immune
+	
 	var/datum/disease/DD = new D.type(1, D, 0)
 	viruses += DD
 	DD.affected_mob = src

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -38,7 +38,7 @@ var/list/advance_cures = 	list(
 	var/list/symptoms = list() // The symptoms of the disease.
 	var/id = ""
 	var/processing = 0
-
+	var/hatched = FALSE // If the virus can be used to create more virus cultures, will activate at 3th stage. If there are more than 5 symptoms it will require a host with a soul attached to it.
 /*
 
 	OLD PROCS
@@ -55,6 +55,7 @@ var/list/advance_cures = 	list(
 		if(!D || !D.symptoms || !D.symptoms.len)
 			symptoms = GenerateSymptoms(0, 2)
 		else
+			hatched = D.hatched
 			for(var/datum/symptom/S in D.symptoms)
 				symptoms += new S.type
 
@@ -71,6 +72,9 @@ var/list/advance_cures = 	list(
 // Randomly pick a symptom to activate.
 /datum/disease/advance/stage_act()
 	..()
+	if(!hatched && stage >= 3)
+		hatched = LAZYLEN(symptoms) > 5 ? ishuman(affected_mob) && affected_mob.mind : TRUE // Ready for production
+
 	if(symptoms && symptoms.len)
 
 		if(!processing)

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -24,26 +24,25 @@ BONUS
 	level = 4
 	severity = 1
 
-/datum/symptom/beard/Activate(datum/disease/advance/A)
+/datum/symptom/beard/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		if(istype(M, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/external/head/head_organ = H.get_organ("head")
-			switch(A.stage)
-				if(1, 2)
-					to_chat(H, "<span class='warning'>Your chin itches.</span>")
-					if(head_organ.f_style == "Shaved")
-						head_organ.f_style = "Jensen Beard"
-						H.update_fhair()
-				if(3, 4)
-					to_chat(H, "<span class='warning'>You feel tough.</span>")
-					if(!(head_organ.f_style == "Dwarf Beard") && !(head_organ.f_style == "Very Long Beard") && !(head_organ.f_style == "Full Beard"))
-						head_organ.f_style = "Full Beard"
-						H.update_fhair()
-				else
-					to_chat(H, "<span class='warning'>You feel manly!</span>")
-					if(!(head_organ.f_style == "Dwarf Beard") && !(head_organ.f_style == "Very Long Beard"))
-						head_organ.f_style = pick("Dwarf Beard", "Very Long Beard")
-						H.update_fhair()
+	var/mob/living/M = A.affected_mob
+	if(istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
+		switch(A.stage)
+			if(1, 2)
+				to_chat(H, "<span class='warning'>Your chin itches.</span>")
+				if(head_organ.f_style == "Shaved")
+					head_organ.f_style = "Jensen Beard"
+					H.update_fhair()
+			if(3, 4)
+				to_chat(H, "<span class='warning'>You feel tough.</span>")
+				if(!(head_organ.f_style == "Dwarf Beard") && !(head_organ.f_style == "Very Long Beard") && !(head_organ.f_style == "Full Beard"))
+					head_organ.f_style = "Full Beard"
+					H.update_fhair()
+			else
+				to_chat(H, "<span class='warning'>You feel manly!</span>")
+				if(!(head_organ.f_style == "Dwarf Beard") && !(head_organ.f_style == "Very Long Beard"))
+					head_organ.f_style = pick("Dwarf Beard", "Very Long Beard")
+					H.update_fhair()

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -25,8 +25,8 @@ BONUS
 	severity = 1
 
 /datum/symptom/beard/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
@@ -47,4 +47,3 @@ BONUS
 					if(!(head_organ.f_style == "Dwarf Beard") && !(head_organ.f_style == "Very Long Beard"))
 						head_organ.f_style = pick("Dwarf Beard", "Very Long Beard")
 						H.update_fhair()
-	return

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 3
 
 /datum/symptom/choking/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2)
@@ -40,7 +40,6 @@ Bonus
 				to_chat(M, "<span class='userdanger'>[pick("You're choking!", "You can't breathe!")]</span>")
 				Choke(M, A)
 				M.emote("gasp")
-	return
 
 /datum/symptom/choking/proc/Choke_stage_3_4(mob/living/M, datum/disease/advance/A)
 	var/get_damage = sqrtor0(21+A.totalStageSpeed()*0.5)+sqrtor0(16+A.totalStealth())

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -25,21 +25,20 @@ Bonus
 	level = 3
 	severity = 3
 
-/datum/symptom/choking/Activate(datum/disease/advance/A)
+/datum/symptom/choking/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(1, 2)
-				to_chat(M, "<span class='warning'>[pick("You're having difficulty breathing.", "Your breathing becomes heavy.")]</span>")
-			if(3, 4)
-				to_chat(M, "<span class='warning'><b>[pick("Your windpipe feels like a straw.", "Your breathing becomes tremendously difficult.")]</span>")
-				Choke_stage_3_4(M, A)
-				M.emote("gasp")
-			else
-				to_chat(M, "<span class='userdanger'>[pick("You're choking!", "You can't breathe!")]</span>")
-				Choke(M, A)
-				M.emote("gasp")
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(1, 2)
+			to_chat(M, "<span class='warning'>[pick("You're having difficulty breathing.", "Your breathing becomes heavy.")]</span>")
+		if(3, 4)
+			to_chat(M, "<span class='warning'><b>[pick("Your windpipe feels like a straw.", "Your breathing becomes tremendously difficult.")]</span>")
+			Choke_stage_3_4(M, A)
+			M.emote("gasp")
+		else
+			to_chat(M, "<span class='userdanger'>[pick("You're choking!", "You can't breathe!")]</span>")
+			Choke(M, A)
+			M.emote("gasp")
 
 /datum/symptom/choking/proc/Choke_stage_3_4(mob/living/M, datum/disease/advance/A)
 	var/get_damage = sqrtor0(21+A.totalStageSpeed()*0.5)+sqrtor0(16+A.totalStealth())

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -27,8 +27,8 @@ Bonus
 
 
 /datum/symptom/confusion/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/carbon/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3, 4)
@@ -36,5 +36,3 @@ Bonus
 			else
 				to_chat(M, "<span class='userdanger'>You can't think straight!</span>")
 				M.AdjustConfused(8, bound_lower = 0, bound_upper = 100)
-
-	return

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -26,13 +26,12 @@ Bonus
 	severity = 2
 
 
-/datum/symptom/confusion/Activate(datum/disease/advance/A)
+/datum/symptom/confusion/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/carbon/M = A.affected_mob
-		switch(A.stage)
-			if(1, 2, 3, 4)
-				to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your mind blanks for a moment.")]</span>")
-			else
-				to_chat(M, "<span class='userdanger'>You can't think straight!</span>")
-				M.AdjustConfused(8, bound_lower = 0, bound_upper = 100)
+	var/mob/living/carbon/M = A.affected_mob
+	switch(A.stage)
+		if(1, 2, 3, 4)
+			to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your mind blanks for a moment.")]</span>")
+		else
+			to_chat(M, "<span class='userdanger'>You can't think straight!</span>")
+			M.AdjustConfused(8, bound_lower = 0, bound_upper = 100)

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -1
 	stage_speed = -3
 	transmittable = 0
-	level = 4
+	level = 5
 	severity = 2
 
 

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -26,8 +26,8 @@ BONUS
 	severity = 1
 
 /datum/symptom/cough/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3)
@@ -37,4 +37,3 @@ BONUS
 				var/obj/item/I = M.get_active_hand()
 				if(I && I.w_class == 1)
 					M.drop_item()
-	return

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -25,15 +25,14 @@ BONUS
 	level = 1
 	severity = 1
 
-/datum/symptom/cough/Activate(datum/disease/advance/A)
+/datum/symptom/cough/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(1, 2, 3)
-				to_chat(M, "<span notice='warning'>[pick("You swallow excess mucus.", "You lightly cough.")]</span>")
-			else
-				M.emote("cough")
-				var/obj/item/I = M.get_active_hand()
-				if(I && I.w_class == 1)
-					M.drop_item()
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(1, 2, 3)
+			to_chat(M, "<span notice='warning'>[pick("You swallow excess mucus.", "You lightly cough.")]</span>")
+		else
+			M.emote("cough")
+			var/obj/item/I = M.get_active_hand()
+			if(I && I.w_class == 1)
+				M.drop_item()

--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -23,15 +23,15 @@ Bonus
 	stage_speed = -4
 	transmittable = -2
 	level = 4
+	activation_delay = 4
 
 /datum/symptom/damage_converter/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB * 10))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(4, 5)
 				Convert(M)
-	return
 
 /datum/symptom/damage_converter/proc/Convert(mob/living/M)
 

--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -25,13 +25,12 @@ Bonus
 	level = 4
 	activation_delay = 4
 
-/datum/symptom/damage_converter/Activate(datum/disease/advance/A)
+/datum/symptom/damage_converter/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(4, 5)
-				Convert(M)
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(4, 5)
+			Convert(M)
 
 /datum/symptom/damage_converter/proc/Convert(mob/living/M)
 

--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -4
 	stage_speed = -4
 	transmittable = -2
-	level = 4
+	level = 6
 	activation_delay = 4
 
 /datum/symptom/damage_converter/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 3
 
 /datum/symptom/deafness/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(3, 4)
@@ -40,4 +40,3 @@ Bonus
 						if(M)
 							to_chat(M, "<span class='warning'>The ringing in your ears fades...</span>")
 							M.CureDeaf()
-	return

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -25,18 +25,17 @@ Bonus
 	level = 4
 	severity = 3
 
-/datum/symptom/deafness/Activate(datum/disease/advance/A)
+/datum/symptom/deafness/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(3, 4)
-				to_chat(M, "<span class='warning'>[pick("You hear a ringing in your ear.", "Your ears pop.")]</span>")
-			if(5)
-				if(!(M.disabilities & DEAF))
-					to_chat(M, "<span class='userdanger'>Your ears pop and begin ringing loudly!</span>")
-					M.BecomeDeaf()
-					spawn(200)
-						if(M)
-							to_chat(M, "<span class='warning'>The ringing in your ears fades...</span>")
-							M.CureDeaf()
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(3, 4)
+			to_chat(M, "<span class='warning'>[pick("You hear a ringing in your ear.", "Your ears pop.")]</span>")
+		if(5)
+			if(!(M.disabilities & DEAF))
+				to_chat(M, "<span class='userdanger'>Your ears pop and begin ringing loudly!</span>")
+				M.BecomeDeaf()
+				spawn(200)
+					if(M)
+						to_chat(M, "<span class='warning'>The ringing in your ears fades...</span>")
+						M.CureDeaf()

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -2
 	stage_speed = -1
 	transmittable = -3
-	level = 4
+	level = 5
 	severity = 3
 
 /datum/symptom/deafness/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -25,13 +25,12 @@ Bonus
 	level = 4
 	severity = 2
 
-/datum/symptom/dizzy/Activate(datum/disease/advance/A)
+/datum/symptom/dizzy/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(1, 2, 3, 4)
-				to_chat(M, "<span class='warning'>[pick("You feel dizzy.", "Your head spins.")]</span>")
-			else
-				to_chat(M, "<span class='userdanger'>A wave of dizziness washes over you!</span>")
-				M.Dizzy(5)
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(1, 2, 3, 4)
+			to_chat(M, "<span class='warning'>[pick("You feel dizzy.", "Your head spins.")]</span>")
+		else
+			to_chat(M, "<span class='userdanger'>A wave of dizziness washes over you!</span>")
+			M.Dizzy(5)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -2
 	stage_speed = -3
 	transmittable = -1
-	level = 4
+	level = 5
 	severity = 2
 
 /datum/symptom/dizzy/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 2
 
 /datum/symptom/dizzy/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3, 4)
@@ -35,4 +35,3 @@ Bonus
 			else
 				to_chat(M, "<span class='userdanger'>A wave of dizziness washes over you!</span>")
 				M.Dizzy(5)
-	return

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -26,14 +26,12 @@ Bonus
 	severity = 2
 
 /datum/symptom/fever/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/carbon/M = A.affected_mob
 		to_chat(M, "<span class='warning'>[pick("You feel hot.", "You feel like you're burning.")]</span>")
 		if(M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT)
 			Heat(M, A)
-
-	return
 
 /datum/symptom/fever/proc/Heat(mob/living/M, datum/disease/advance/A)
 	var/get_heat = (sqrtor0(21+A.totalTransmittable()*2))+(sqrtor0(20+A.totalStageSpeed()*3))

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -25,13 +25,12 @@ Bonus
 	level = 2
 	severity = 2
 
-/datum/symptom/fever/Activate(datum/disease/advance/A)
+/datum/symptom/fever/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/carbon/M = A.affected_mob
-		to_chat(M, "<span class='warning'>[pick("You feel hot.", "You feel like you're burning.")]</span>")
-		if(M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT)
-			Heat(M, A)
+	var/mob/living/carbon/M = A.affected_mob
+	to_chat(M, "<span class='warning'>[pick("You feel hot.", "You feel like you're burning.")]</span>")
+	if(M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT)
+		Heat(M, A)
 
 /datum/symptom/fever/proc/Heat(mob/living/M, datum/disease/advance/A)
 	var/get_heat = (sqrtor0(21+A.totalTransmittable()*2))+(sqrtor0(20+A.totalStageSpeed()*3))

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -25,23 +25,22 @@ Bonus
 	level = 6
 	severity = 5
 
-/datum/symptom/fire/Activate(datum/disease/advance/A)
+/datum/symptom/fire/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(3)
-				to_chat(M, "<span class='warning'>[pick("You feel hot.", "You hear a crackling noise.", "You smell smoke.")]</span>")
-			if(4)
-				Firestacks_stage_4(M, A)
-				M.IgniteMob()
-				to_chat(M, "<span class='userdanger'>Your skin bursts into flames!</span>")
-				M.emote("scream")
-			if(5)
-				Firestacks_stage_5(M, A)
-				M.IgniteMob()
-				to_chat(M, "<span class='userdanger'>Your skin erupts into an inferno!</span>")
-				M.emote("scream")
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(3)
+			to_chat(M, "<span class='warning'>[pick("You feel hot.", "You hear a crackling noise.", "You smell smoke.")]</span>")
+		if(4)
+			Firestacks_stage_4(M, A)
+			M.IgniteMob()
+			to_chat(M, "<span class='userdanger'>Your skin bursts into flames!</span>")
+			M.emote("scream")
+		if(5)
+			Firestacks_stage_5(M, A)
+			M.IgniteMob()
+			to_chat(M, "<span class='userdanger'>Your skin erupts into an inferno!</span>")
+			M.emote("scream")
 
 /datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
 	var/get_stacks = max((sqrtor0(20 + A.totalStageSpeed() * 2)) - (sqrtor0(16 + A.totalStealth())), 1)

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 5
 
 /datum/symptom/fire/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(3)
@@ -42,7 +42,6 @@ Bonus
 				M.IgniteMob()
 				to_chat(M, "<span class='userdanger'>Your skin erupts into an inferno!</span>")
 				M.emote("scream")
-	return
 
 /datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
 	var/get_stacks = max((sqrtor0(20 + A.totalStageSpeed() * 2)) - (sqrtor0(16 + A.totalStealth())), 1)

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -4
 	stage_speed = -4
 	transmittable = -4
-	level = 6
+	level = 7
 	severity = 5
 
 /datum/symptom/fire/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -25,16 +25,15 @@ Bonus
 	level = 6
 	severity = 5
 
-/datum/symptom/flesh_eating/Activate(datum/disease/advance/A)
+/datum/symptom/flesh_eating/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(2,3)
-				to_chat(M, "<span class='warning'>[pick("You feel a sudden pain across your body.", "Drops of blood appear suddenly on your skin.")]</span>")
-			if(4,5)
-				to_chat(M, "<span class='userdanger'>[pick("You cringe as a violent pain takes over your body.", "It feels like your body is eating itself inside out.", "IT HURTS.")]</span>")
-				Flesheat(M, A)
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(2,3)
+			to_chat(M, "<span class='warning'>[pick("You feel a sudden pain across your body.", "Drops of blood appear suddenly on your skin.")]</span>")
+		if(4,5)
+			to_chat(M, "<span class='userdanger'>[pick("You cringe as a violent pain takes over your body.", "It feels like your body is eating itself inside out.", "IT HURTS.")]</span>")
+			Flesheat(M, A)
 
 /datum/symptom/flesh_eating/proc/Flesheat(mob/living/M, datum/disease/advance/A)
 	var/get_damage = ((sqrtor0(16-A.totalStealth()))*5)

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -4
 	stage_speed = 0
 	transmittable = -4
-	level = 6
+	level = 8
 	severity = 5
 
 /datum/symptom/flesh_eating/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 5
 
 /datum/symptom/flesh_eating/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(2,3)
@@ -35,7 +35,6 @@ Bonus
 			if(4,5)
 				to_chat(M, "<span class='userdanger'>[pick("You cringe as a violent pain takes over your body.", "It feels like your body is eating itself inside out.", "IT HURTS.")]</span>")
 				Flesheat(M, A)
-	return
 
 /datum/symptom/flesh_eating/proc/Flesheat(mob/living/M, datum/disease/advance/A)
 	var/get_damage = ((sqrtor0(16-A.totalStealth()))*5)

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -26,10 +26,11 @@ Bonus
 	severity = 3
 	var/list/possible_mutations
 	var/archived_dna = null
+	activation_delay = 7
 
 /datum/symptom/genetic_mutation/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB * 5)) // 15% chance
+	. = ..()
+	if(.)
 		var/mob/living/carbon/M = A.affected_mob
 		if(!M.has_dna())
 			return
@@ -38,7 +39,6 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("Your skin feels itchy.", "You feel light headed.")]</span>")
 				M.dna.remove_mutation_group(possible_mutations)
 				randmut(M, possible_mutations)
-	return
 
 // Archive their DNA before they were infected.
 /datum/symptom/genetic_mutation/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -28,17 +28,16 @@ Bonus
 	var/archived_dna = null
 	activation_delay = 7
 
-/datum/symptom/genetic_mutation/Activate(datum/disease/advance/A)
+/datum/symptom/genetic_mutation/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/carbon/M = A.affected_mob
-		if(!M.has_dna())
-			return
-		switch(A.stage)
-			if(4, 5)
-				to_chat(M, "<span class='warning'>[pick("Your skin feels itchy.", "You feel light headed.")]</span>")
-				M.dna.remove_mutation_group(possible_mutations)
-				randmut(M, possible_mutations)
+	var/mob/living/carbon/M = A.affected_mob
+	if(!M.has_dna())
+		return
+	switch(A.stage)
+		if(4, 5)
+			to_chat(M, "<span class='warning'>[pick("Your skin feels itchy.", "You feel light headed.")]</span>")
+			M.dna.remove_mutation_group(possible_mutations)
+			randmut(M, possible_mutations)
 
 // Archive their DNA before they were infected.
 /datum/symptom/genetic_mutation/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -25,15 +25,14 @@ Bonus
 	level = 5
 	severity = 3
 
-/datum/symptom/hallucigen/Activate(datum/disease/advance/A)
+/datum/symptom/hallucigen/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/carbon/M = A.affected_mob
-		switch(A.stage)
-			if(1, 2)
-				to_chat(M, "<span class='warning'>[pick("Something appears in your peripheral vision, then winks out.", "You hear a faint whispher with no source.", "Your head aches.")]</span>")
-			if(3, 4)
-				to_chat(M, "<span class='warning'><b>[pick("Something is following you.", "You are being watched.", "You hear a whisper in your ear.", "Thumping footsteps slam toward you from nowhere.")]</b></span>")
-			else
-				to_chat(M, "<span class='userdanger'>[pick("Oh, your head...", "Your head pounds.", "They're everywhere! Run!", "Something in the shadows...")]</span>")
-				M.AdjustHallucinate(5)
+	var/mob/living/carbon/M = A.affected_mob
+	switch(A.stage)
+		if(1, 2)
+			to_chat(M, "<span class='warning'>[pick("Something appears in your peripheral vision, then winks out.", "You hear a faint whispher with no source.", "Your head aches.")]</span>")
+		if(3, 4)
+			to_chat(M, "<span class='warning'><b>[pick("Something is following you.", "You are being watched.", "You hear a whisper in your ear.", "Thumping footsteps slam toward you from nowhere.")]</b></span>")
+		else
+			to_chat(M, "<span class='userdanger'>[pick("Oh, your head...", "Your head pounds.", "They're everywhere! Run!", "Something in the shadows...")]</span>")
+			M.AdjustHallucinate(5)

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -3
 	stage_speed = -3
 	transmittable = -1
-	level = 5
+	level = 6
 	severity = 3
 
 /datum/symptom/hallucigen/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 3
 
 /datum/symptom/hallucigen/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/carbon/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2)
@@ -37,5 +37,3 @@ Bonus
 			else
 				to_chat(M, "<span class='userdanger'>[pick("Oh, your head...", "Your head pounds.", "They're everywhere! Run!", "Something in the shadows...")]</span>")
 				M.AdjustHallucinate(5)
-
-	return

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -26,8 +26,7 @@ BONUS
 	level = 1
 	severity = 1
 
-/datum/symptom/headache/Activate(datum/disease/advance/A)
+/datum/symptom/headache/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your head starts pounding.")]</span>")
+	var/mob/living/M = A.affected_mob
+	to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your head starts pounding.")]</span>")

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -27,8 +27,7 @@ BONUS
 	severity = 1
 
 /datum/symptom/headache/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your head starts pounding.")]</span>")
-	return

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -25,13 +25,12 @@ Bonus
 	level = 6
 	activation_delay = 4
 
-/datum/symptom/heal/Activate(datum/disease/advance/A)
+/datum/symptom/heal/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(4, 5)
-				Heal(M, A)
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(4, 5)
+			Heal(M, A)
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
 	var/get_damage = (sqrtor0(20+A.totalStageSpeed())*(1+rand()))

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -4
 	stage_speed = -4
 	transmittable = -4
-	level = 6
+	level = 8
 	activation_delay = 4
 
 /datum/symptom/heal/DoEffect(datum/disease/advance/A)
@@ -61,7 +61,7 @@ Bonus
 	resistance = -1
 	stage_speed = -1
 	transmittable = -4
-	level = 3
+	level = 4
 	var/list/cured_diseases = list()
 
 /datum/symptom/heal/metabolism/Heal(mob/living/M, datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -23,15 +23,15 @@ Bonus
 	stage_speed = -4
 	transmittable = -4
 	level = 6
+	activation_delay = 4
 
 /datum/symptom/heal/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB * 10))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(4, 5)
 				Heal(M, A)
-	return
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
 	var/get_damage = (sqrtor0(20+A.totalStageSpeed())*(1+rand()))

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -27,8 +27,7 @@ BONUS
 	severity = 1
 
 /datum/symptom/itching/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		to_chat(M, "<span class='warning'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")
-	return

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -26,8 +26,7 @@ BONUS
 	level = 1
 	severity = 1
 
-/datum/symptom/itching/Activate(datum/disease/advance/A)
+/datum/symptom/itching/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		to_chat(M, "<span class='warning'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")
+	var/mob/living/M = A.affected_mob
+	to_chat(M, "<span class='warning'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -3
 	stage_speed = -3
 	transmittable = -4
-	level = 6
+	level = 7
 	activation_delay = 7
 
 /datum/symptom/oxygen/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -23,7 +23,7 @@ Bonus
 	stage_speed = -3
 	transmittable = -4
 	level = 6
-	activation_delay = 6
+	activation_delay = 7
 
 /datum/symptom/oxygen/DoEffect(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -25,15 +25,14 @@ Bonus
 	level = 6
 	activation_delay = 6
 
-/datum/symptom/oxygen/Activate(datum/disease/advance/A)
+/datum/symptom/oxygen/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(4, 5)
-				if(M.reagents.get_reagent_amount("salbutamol") < 20)
-					M.reagents.add_reagent("salbutamol", 20)
-			else
-				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-					to_chat(M, "<span class='notice'>[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]</span>")
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(4, 5)
+			if(M.reagents.get_reagent_amount("salbutamol") < 20)
+				M.reagents.add_reagent("salbutamol", 20)
+		else
+			if(prob(SYMPTOM_ACTIVATION_PROB * 5))
+				to_chat(M, "<span class='notice'>[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]</span>")
 	

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -23,10 +23,11 @@ Bonus
 	stage_speed = -3
 	transmittable = -4
 	level = 6
+	activation_delay = 6
 
 /datum/symptom/oxygen/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB * 5))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(4, 5)
@@ -35,4 +36,4 @@ Bonus
 			else
 				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
 					to_chat(M, "<span class='notice'>[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]</span>")
-	return
+	

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -25,25 +25,24 @@ Bonus
 	severity = 0
 	activation_delay = 11
 
-/datum/symptom/mind_restoration/Activate(datum/disease/advance/A)
+/datum/symptom/mind_restoration/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		var/datum/reagents/RD = M.reagents
+	var/mob/living/M = A.affected_mob
+	var/datum/reagents/RD = M.reagents
 
-		if(A.stage >= 3)
-			M.AdjustSlur(-2)
-			M.AdjustDrunk(-4)
-			M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3, 0, 1)
-		if(A.stage >= 4)
-			M.AdjustDrowsy(-2)
-			if(RD.has_reagent("lsd"))
-				RD.remove_reagent("lsd", 5)
-			if(RD.has_reagent("histamine"))
-				RD.remove_reagent("histamine", 5)
-			M.AdjustHallucinate(-10)
-		if(A.stage >= 5)
-			RD.check_and_add("mannitol", 10, 10)
+	if(A.stage >= 3)
+		M.AdjustSlur(-2)
+		M.AdjustDrunk(-4)
+		M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3, 0, 1)
+	if(A.stage >= 4)
+		M.AdjustDrowsy(-2)
+		if(RD.has_reagent("lsd"))
+			RD.remove_reagent("lsd", 5)
+		if(RD.has_reagent("histamine"))
+			RD.remove_reagent("histamine", 5)
+		M.AdjustHallucinate(-10)
+	if(A.stage >= 5)
+		RD.check_and_add("mannitol", 10, 10)
 
 /datum/symptom/sensory_restoration
 	name = "Sensory Restoration"
@@ -52,15 +51,14 @@ Bonus
 	stage_speed = -2
 	transmittable = -4
 	level = 4
+	activation_delay = 7
 
-/datum/symptom/sensory_restoration/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
-			if(4, 5)
-				if(M.reagents.get_reagent_amount("oculine") < 20)
-					M.reagents.add_reagent("oculine", 20)
-			else
-				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-					to_chat(M, "<span class='notice'>[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your ears feel great.","Your healing feels more acute.")]</span>")
+/datum/symptom/sensory_restoration/DoEffect(datum/disease/advance/A)
+	. = ..()
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(4, 5)
+			if(M.reagents.get_reagent_amount("oculine") < 20)
+				M.reagents.add_reagent("oculine", 20)
+		else
+			to_chat(M, "<span class='notice'>[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your ears feel great.","Your healing feels more acute.")]</span>")

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -23,10 +23,11 @@ Bonus
 	transmittable = -3
 	level = 5
 	severity = 0
+	activation_delay = 11
 
 /datum/symptom/mind_restoration/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB * 3))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		var/datum/reagents/RD = M.reagents
 

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -21,7 +21,7 @@ Bonus
 	resistance = -4
 	stage_speed = -4
 	transmittable = -3
-	level = 5
+	level = 6
 	severity = 0
 	activation_delay = 11
 
@@ -50,7 +50,7 @@ Bonus
 	resistance = -3
 	stage_speed = -2
 	transmittable = -4
-	level = 4
+	level = 5
 	activation_delay = 7
 
 /datum/symptom/sensory_restoration/DoEffect(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -25,8 +25,8 @@ BONUS
 	severity = 1
 
 /datum/symptom/shedding/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		to_chat(M, "<span class='warning'>[pick("Your scalp itches.", "Your skin feels flakey.")]</span>")
 		if(istype(M, /mob/living/carbon/human))
@@ -47,4 +47,3 @@ BONUS
 							head_organ.h_style = "Bald"
 							H.update_hair()
 							H.update_fhair()
-	return

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -24,26 +24,25 @@ BONUS
 	level = 4
 	severity = 1
 
-/datum/symptom/shedding/Activate(datum/disease/advance/A)
+/datum/symptom/shedding/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/M = A.affected_mob
-		to_chat(M, "<span class='warning'>[pick("Your scalp itches.", "Your skin feels flakey.")]</span>")
-		if(istype(M, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/external/head/head_organ = H.get_organ("head")
-			switch(A.stage)
-				if(3, 4)
-					if(!(head_organ.h_style == "Bald") && !(head_organ.h_style == "Balding Hair"))
-						to_chat(H, "<span class='warning'>Your hair starts to fall out in clumps...</span>")
-						spawn(50)
-							head_organ.h_style = "Balding Hair"
-							H.update_hair()
-				if(5)
-					if(!(head_organ.f_style == "Shaved") || !(head_organ.h_style == "Bald"))
-						to_chat(H, "<span class='warning'>Your hair starts to fall out in clumps...</span>")
-						spawn(50)
-							head_organ.f_style = "Shaved"
-							head_organ.h_style = "Bald"
-							H.update_hair()
-							H.update_fhair()
+	var/mob/living/M = A.affected_mob
+	to_chat(M, "<span class='warning'>[pick("Your scalp itches.", "Your skin feels flakey.")]</span>")
+	if(istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
+		switch(A.stage)
+			if(3, 4)
+				if(!(head_organ.h_style == "Bald") && !(head_organ.h_style == "Balding Hair"))
+					to_chat(H, "<span class='warning'>Your hair starts to fall out in clumps...</span>")
+					spawn(50)
+						head_organ.h_style = "Balding Hair"
+						H.update_hair()
+			if(5)
+				if(!(head_organ.f_style == "Shaved") || !(head_organ.h_style == "Bald"))
+					to_chat(H, "<span class='warning'>Your hair starts to fall out in clumps...</span>")
+					spawn(50)
+						head_organ.f_style = "Shaved"
+						head_organ.h_style = "Bald"
+						H.update_hair()
+						H.update_fhair()

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -25,13 +25,12 @@ Bonus
 	level = 2
 	severity = 2
 
-/datum/symptom/shivering/Activate(datum/disease/advance/A)
+/datum/symptom/shivering/DoEffect(datum/disease/advance/A)
 	. = ..()
-	if(.)
-		var/mob/living/carbon/M = A.affected_mob
-		to_chat(M, "<span class='warning'>[pick("You feel cold.", "You start shivering.")]</span>")
-		if(M.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
-			Chill(M, A)
+	var/mob/living/carbon/M = A.affected_mob
+	to_chat(M, "<span class='warning'>[pick("You feel cold.", "You start shivering.")]</span>")
+	if(M.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
+		Chill(M, A)
 
 /datum/symptom/shivering/proc/Chill(mob/living/M, datum/disease/advance/A)
 	var/get_cold = (sqrtor0(16+A.totalStealth()*2))+(sqrtor0(21+A.totalResistance()*2))

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -26,13 +26,12 @@ Bonus
 	severity = 2
 
 /datum/symptom/shivering/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/carbon/M = A.affected_mob
 		to_chat(M, "<span class='warning'>[pick("You feel cold.", "You start shivering.")]</span>")
 		if(M.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 			Chill(M, A)
-	return
 
 /datum/symptom/shivering/proc/Chill(mob/living/M, datum/disease/advance/A)
 	var/get_cold = (sqrtor0(16+A.totalStealth()*2))+(sqrtor0(21+A.totalResistance()*2))

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -25,8 +25,8 @@ BONUS
 	severity = 1
 
 /datum/symptom/vitiligo/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
@@ -38,9 +38,6 @@ BONUS
 					H.update_body(0)
 				else
 					H.visible_message("<span class='warning'>[H] looks a bit pale...</span>", "<span class='notice'>Your skin suddenly appears lighter...</span>")
-
-	return
-
 
 /*
 //////////////////////////////////////
@@ -69,8 +66,8 @@ BONUS
 	severity = 1
 
 /datum/symptom/revitiligo/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
@@ -82,5 +79,3 @@ BONUS
 					H.update_body(0)
 				else
 					H.visible_message("<span class='warning'>[H] looks a bit dark...</span>", "<span class='notice'>Your skin suddenly appears darker...</span>")
-
-	return

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -27,8 +27,8 @@ Bonus
 	severity = 1
 
 /datum/symptom/sneeze/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3)
@@ -36,4 +36,3 @@ Bonus
 			else
 				M.emote("sneeze")
 				A.spread(5)
-	return

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -36,7 +36,7 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 3
 	return
 
 /datum/symptom/proc/Activate(datum/disease/advance/A)
-	activation_delay -= max(A.totalStageSpeed(), 1)
+	activation_delay -= max(1 + 0.5 * A.totalStageSpeed(), 1)
 	if(activation_delay <= 0)
 		activation_delay = initial(activation_delay)
 		activation_delay += rand(-0.5 * activation_delay, 0.5 * activation_delay) // Bit of randomness

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -17,6 +17,7 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 3
 	var/severity = 0
 	// The hash tag for our diseases, we will add it up with our other symptoms to get a unique id! ID MUST BE UNIQUE!!!
 	var/id = ""
+	var/activation_delay = 33 //How long it takes before the symptom activates again. Based on stage speed 100/SYMPTOM_ACTIVATION_PROB (3)
 
 /datum/symptom/New()
 	var/list/S = list_symptoms
@@ -35,5 +36,10 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 3
 	return
 
 /datum/symptom/proc/Activate(datum/disease/advance/A)
-	return
+	activation_delay -= max(A.totalStageSpeed(), 1)
+	if(activation_delay <= 0)
+		activation_delay = initial(activation_delay)
+		activation_delay += rand(-0.5 * activation_delay, 0.5 * activation_delay) // Bit of randomness
+		return TRUE
+	return FALSE
 

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -40,6 +40,9 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 3
 	if(activation_delay <= 0)
 		activation_delay = initial(activation_delay)
 		activation_delay += rand(-0.5 * activation_delay, 0.5 * activation_delay) // Bit of randomness
+		DoEffect(A)
 		return TRUE
 	return FALSE
 
+/datum/symptom/proc/DoEffect(datum/disease/advance/A)
+	return

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -22,8 +22,8 @@ BONUS
 	level = 3
 
 /datum/symptom/viraladaptation/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1)
@@ -55,8 +55,8 @@ BONUS
 	level = 3
 
 /datum/symptom/viraladaptation/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -4
 	stage_speed = -4
 	transmittable = -3
-	level = 5
+	level = 6
 	severity = 4
 
 /datum/symptom/visionloss/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 4
 
 /datum/symptom/visionloss/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/carbon/M = A.affected_mob
 		var/obj/item/organ/internal/eyes/eyes = M.get_int_organ(/obj/item/organ/internal/eyes)
 		if(!eyes) //NO EYES, NO PROBLEM! Rip out your eyes today to prevent future blindness!

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -22,7 +22,7 @@ Bonus
 	resistance = -3
 	stage_speed = -3
 	transmittable = -1
-	level = 6
+	level = 7
 	severity = 2
 
 /datum/symptom/voice_change/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -26,9 +26,8 @@ Bonus
 	severity = 2
 
 /datum/symptom/voice_change/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
-
+	. = ..()
+	if(.)
 		var/mob/living/carbon/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3, 4)
@@ -37,8 +36,6 @@ Bonus
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
 					H.SetSpecialVoice(H.dna.species.get_random_name(H.gender))
-
-	return
 
 /datum/symptom/voice_change/End(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -70,7 +70,7 @@ Bonus
 	resistance = -1
 	stage_speed = -1
 	transmittable = 1
-	level = 4
+	level = 5
 	severity = 5
 
 /datum/symptom/vomit/blood/Vomit(mob/living/carbon/M)

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -28,18 +28,17 @@ Bonus
 	transmittable = 1
 	level = 3
 	severity = 4
+	activation_delay = 67
 
 /datum/symptom/vomit/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB / 2))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3, 4)
 				to_chat(M, "<span class='warning'>[pick("You feel nauseous.", "You feel like you're going to throw up!")]</span>")
 			else
 				Vomit(M)
-
-	return
 
 /datum/symptom/vomit/proc/Vomit(mob/living/carbon/M)
 	M.vomit(20)

--- a/code/datums/diseases/advance/symptoms/weakness.dm
+++ b/code/datums/diseases/advance/symptoms/weakness.dm
@@ -26,8 +26,8 @@ Bonus
 	severity = 3
 
 /datum/symptom/weakness/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2)
@@ -41,4 +41,4 @@ Bonus
 				if(M.getStaminaLoss() > 60 && !M.stat)
 					M.visible_message("<span class='warning'>[M] faints!</span>", "<span class='userdanger'>You swoon and faint...</span>")
 					M.AdjustSleeping(5)
-	return
+

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -27,8 +27,8 @@ Bonus
 	severity = 1
 
 /datum/symptom/weight_loss/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(1, 2, 3, 4)

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -22,7 +22,7 @@ BONUS
 	resistance = 4
 	stage_speed = 4
 	transmittable = -4
-	level = 5
+	level = 7
 	activation_delay = 17
 
 /datum/symptom/youth/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -23,10 +23,11 @@ BONUS
 	stage_speed = 4
 	transmittable = -4
 	level = 5
+	activation_delay = 17
 
 /datum/symptom/youth/Activate(datum/disease/advance/A)
-	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB * 2))
+	. = ..()
+	if(.)
 		var/mob/living/M = A.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
@@ -51,5 +52,3 @@ BONUS
 					if(H.age > 21)
 						H.age = 21
 						to_chat(H, "<span class='notice'>You feel like you can take on the world!</span>")
-
-	return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -187,7 +187,7 @@ REAGENT SCANNER
 	for(var/thing in H.viruses)
 		var/datum/disease/D = thing
 		if(!(D.visibility_flags & HIDDEN_SCANNER))
-			user.show_message("<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text]</span>")
+			user.show_message("<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.stage >= 3 ? D.name : "Unknown"].\nType: [D.stage >= 2 ? D.spread_text : "Unknown"].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.stage >= 4 ? D.cure_text : "Unknown"]</span>")
 	if(H.undergoing_cardiac_arrest())
 		var/obj/item/organ/internal/heart/heart = H.get_int_organ(/obj/item/organ/internal/heart)
 		if(heart && !(heart.status & ORGAN_DEAD))

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -281,10 +281,15 @@
 						var/datum/disease/D = thing
 						i++
 						if(!(D.visibility_flags & HIDDEN_PANDEMIC))
-
+							var/hatched = TRUE
+							var/list/unhatched_symptoms = list()
+							var/list/unhatched_symptom_possilities = list()
 							if(istype(D, /datum/disease/advance))
 
 								var/datum/disease/advance/A = D
+								hatched = A.hatched // Only show stats when the virus has reached stage 3
+								unhatched_symptoms = A.unhatched_symptoms
+								unhatched_symptom_possilities = A.unhatched_symptom_possilities
 								D = archive_diseases[A.GetDiseaseID()]
 								if(D)
 									if(D.name == "Unknown")
@@ -298,16 +303,25 @@
 							dat += "<b>Disease Agent:</b> [D?"[D.agent] - <A href='?src=[UID()];create_virus_culture=[i]'>Create virus culture bottle</A>":"none"]<BR>"
 							dat += "<b>Common name:</b> [(D.name||"none")]<BR>"
 							dat += "<b>Description: </b> [(D.desc||"none")]<BR>"
-							dat += "<b>Spread:</b> [(D.spread_text||"none")]<BR>"
-							dat += "<b>Possible cure:</b> [(D.cure_text||"none")]<BR><BR>"
+							dat += "<b>Spread:</b> [hatched ? (D.spread_text||"none") : "Unknown"]<BR>"
+							dat += "<b>Possible cure:</b> [hatched ? (D.cure_text||"none") : "Unknown"]<BR><BR>"
 
 							if(istype(D, /datum/disease/advance))
 								var/datum/disease/advance/A = D
 								dat += "<b>Symptoms:</b> "
 								var/english_symptoms = list()
 								for(var/datum/symptom/S in A.symptoms)
-									english_symptoms += S.name
+									if(!(S.name in unhatched_symptoms)) // Skip the unknown ones
+										english_symptoms += S.name
 								dat += english_list(english_symptoms)
+								english_symptoms = list()
+								if(LAZYLEN(unhatched_symptoms))
+									for(var/symptomName in unhatched_symptoms)
+										var/list/possibilities = list(symptomName)
+										possibilities += unhatched_symptom_possilities[symptomName]
+										english_symptoms += "(" + english_list(shuffle(possibilities), "nothing", " or ") + ")" // Create an entry (possible symptoms)
+									dat += "<BR><b>Unhatched Symptoms:</b> " + english_list(english_symptoms)
+
 
 						else
 							dat += "No detectable virus in the sample."

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -119,7 +119,7 @@
 			if(istype(D, /datum/disease/advance))
 				var/datum/disease/advance/A = D
 				if(!A.hatched)
-					temp_html = "The virus is not able to be copied yet. Let it grow in a test subject first."
+					temp_html = "The virus is not able to be copied yet. Let it evolve in a test subject first."
 					updateUsrDialog()
 					return
 			var/type = GetVirusTypeByIndex(text2num(href_list["create_virus_culture"]))//the path is received as string - converting
@@ -183,7 +183,7 @@
 			var/datum/disease/advance/A = archive_diseases[id]
 			A.AssignName(new_name)
 			for(var/datum/disease/advance/AD in GLOB.active_diseases)
-				AD.Refresh()
+				AD.Refresh(FALSE, FALSE)
 		updateUsrDialog()
 	else if(href_list["print_form"])
 		var/datum/disease/D = GetVirusByIndex(text2num(href_list["print_form"]))

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -104,8 +104,16 @@
 		return
 	else if(href_list["create_virus_culture"])
 		if(!wait)
+			var/i = text2num(href_list["create_virus_culture"])
+			var/datum/disease/D = GetVirusByIndex(i)
+			if(istype(D, /datum/disease/advance))
+				var/datum/disease/advance/A = D
+				if(!A.hatched)
+					temp_html = "The virus is not able to be copied yet. Let it grow in a test subject first."
+					updateUsrDialog()
+					return
 			var/type = GetVirusTypeByIndex(text2num(href_list["create_virus_culture"]))//the path is received as string - converting
-			var/datum/disease/D = null
+			D = null
 			if(!ispath(type))
 				D = GetVirusByIndex(text2num(href_list["create_virus_culture"]))
 				var/datum/disease/advance/A = archive_diseases[D.GetDiseaseID()]

--- a/code/modules/reagents/chemistry/reagents/disease.dm
+++ b/code/modules/reagents/chemistry/reagents/disease.dm
@@ -198,3 +198,18 @@
 	name = "weakened virus plasma"
 	id = "weakplasmavirusfood"
 	color = "#CEC3C6" // rgb: 206,195,198
+
+/datum/reagent/uranium/uraniumvirusfood
+	name = "decaying uranium gel"
+	id = "uraniumvirusfood"
+	color = "#67ADBA" // rgb: 103,173,186
+
+/datum/reagent/uranium/uraniumvirusfood/unstable
+	name = "unstable uranium gel"
+	id = "uraniumplasmavirusfood_unstable"
+	color = "#2FF2CB" // rgb: 47,242,203
+
+/datum/reagent/uranium/uraniumvirusfood/stable
+	name = "stable uranium gel"
+	id = "uraniumplasmavirusfood_stable"
+	color = "#04506C" // rgb: 4,80,108

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -391,6 +391,30 @@
 	required_reagents = list("salglu_solution" = 1, "mutagenvirusfood" = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/virus_food_uranium
+	name = "Decaying uranium gel"
+	id = "uraniumvirusfood"
+	result = "uraniumvirusfood"
+	required_reagents = list("uranium" = 1, "virusfood" = 1)
+
+/datum/chemical_reaction/virus_food_uranium_plasma
+	name = "Unstable uranium gel"
+	id = "uraniumvirusfood_plasma"
+	result = "uraniumplasmavirusfood_unstable"
+	required_reagents = list("uranium" = 5, "plasmavirusfood" = 1)
+
+/datum/chemical_reaction/virus_food_uranium_plasma_gold
+	name = "Stable uranium gel"
+	id = "uraniumvirusfood_gold"
+	result = "uraniumplasmavirusfood_stable"
+	required_reagents = list("uranium" = 10, "gold" = 10, "plasma" = 1)
+
+/datum/chemical_reaction/virus_food_uranium_plasma_silver
+	name = "Stable uranium gel"
+	id = "uraniumvirusfood_silver"
+	result = "uraniumplasmavirusfood_stable"
+	required_reagents = list("uranium" = 10, "silver" = 10, "plasma" = 1)
+
 /datum/chemical_reaction/mix_virus
 	name = "Mix Virus"
 	id = "mixvirus"
@@ -462,6 +486,27 @@
 	required_reagents = list("diphenhydraminevirusfood" = 1)
 	level_min = 1
 	level_max = 1
+
+/datum/chemical_reaction/mix_virus/mix_virus_10
+	name = "Mix Virus 10"
+	id = "mixvirus10"
+	required_reagents = list("uraniumvirusfood" = 1)
+	level_min = 6
+	level_max = 7
+
+/datum/chemical_reaction/mix_virus/mix_virus_11
+	name = "Mix Virus 11"
+	id = "mixvirus11"
+	required_reagents = list("uraniumplasmavirusfood_unstable" = 1)
+	level_min = 7
+	level_max = 7
+
+/datum/chemical_reaction/mix_virus/mix_virus_12
+	name = "Mix Virus 12"
+	id = "mixvirus12"
+	required_reagents = list("uraniumplasmavirusfood_stable" = 1)
+	level_min = 8
+	level_max = 8
 
 /datum/chemical_reaction/mix_virus/rem_virus
 	name = "Devolve Virus"


### PR DESCRIPTION
**What does this PR do:**
This PR is branched of the first PR #11220 

Adds 3 new reagents for creating virus symptoms (from /TG/).
1. Decaying uranium gel level 6-7
2. Unstable uranium gel level 7
3. Stable uranium gel level 8

These new levels are used to spread out the symptoms a bit better. Making certain symptoms harder to get but reducing the RNG to get a certain level symptom in the process. (Do give feedback please)
![image](https://user-images.githubusercontent.com/15887760/57988790-777ceb00-7a92-11e9-9cd3-edf9f046f7de.png)



Symptoms now don't instantly show up on the pandemic when generated. You first have to get a virus in a humanoid to stage 3.
Before doing that it'll give a set of 2 random symptoms and the real one as possibilities.
The PANDEMIC will not show the cure and spread. They will be hidden till stage 3 was hit before hand. This is done to prevent calculating which symptom is actually added.
![image](https://user-images.githubusercontent.com/15887760/57988634-e8230800-7a90-11e9-95cb-6eaeaede2118.png)

WIP due to the fact that I'm still missing 1 idea which I wanted to implement in this PR.
That the PANDEMIC can recreate known symptoms. See the forum post for more details.
And I need feedback on the changes thus far.

Link to the forum thread:
https://nanotrasen.se/forum/topic/15561-virology-rework-need-feedback/

**Changelog:**
:cl:
add: Decaying/unstable/stable uranium gel for virology. Level 6-7, 7 and 8 respectively 
balance: The PANDEMIC won't show the cure and spread of a virus till it's hatched in a humanoid. Till it reaches stage 3.
balance: Virus symptoms will not be known till the virus is hatched in a humanoid. Till it reaches stage 3. If not yet reached it'll display a random set of symptoms and the actual one.
balance: Virus symptoms are spread out over 8 levels now
/:cl:

