### PR TITLE
Changeling fix bundle

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -906,9 +906,11 @@
 				if(src in SSticker.mode.changelings)
 					SSticker.mode.changelings -= src
 					special_role = null
-					current.remove_changeling_powers()
+					if(changeling)
+						current.remove_changeling_powers()
+						qdel(changeling)
+						changeling = null
 					SSticker.mode.update_change_icons_removed(src)
-					if(changeling)	qdel(changeling)
 					to_chat(current, "<FONT color='red' size = 3><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</B></FONT>")
 					log_admin("[key_name(usr)] has de-changelinged [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has de-changelinged [key_name_admin(current)]")

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -167,6 +167,8 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 			if("holdervar")
 				adjust_var(user, holder_var_type, holder_var_amount)
 
+	if(action)
+		action.UpdateButtonIcon()
 	return 1
 
 /obj/effect/proc_holder/spell/proc/invocation(mob/user = usr) //spelling the spell out and setting it on recharge/reducing charges amount
@@ -235,6 +237,8 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	else
 		cast(targets, user = user)
 	after_cast(targets)
+	if(action)
+		action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/proc/before_cast(list/targets)
 	if(overlay)
@@ -291,8 +295,8 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 			charge_counter++
 		if("holdervar")
 			adjust_var(user, holder_var_type, -holder_var_amount)
-
-	return
+	if(action)
+		action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/proc/updateButtonIcon()
 	if(action)

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -8,18 +8,25 @@
 	button_icon_state = "augmented_eyesight"
 	chemical_cost = 0
 	dna_cost = 2 //Would be 1 without thermal vision
+	active = FALSE
 
-/datum/action/changeling/augmented_eyesight/sting_action(mob/living/carbon/human/user)
+/datum/action/changeling/augmented_eyesight/on_purchase(mob/user) //The ability starts inactive, so we should be protected from flashes.
+	..()
+	var/obj/item/organ/internal/cyberimp/eyes/O = new /obj/item/organ/internal/cyberimp/eyes/shield/ling()
+	O.insert(user)
+	active = FALSE
+
+/datum/action/changeling/augmented_eyesight/sting_action(mob/living/carbon/user)
 	if(!istype(user))
 		return
-	if(user.get_int_organ(/obj/item/organ/internal/cyberimp/eyes/thermals/ling))
-		var/obj/item/organ/internal/cyberimp/eyes/O = new /obj/item/organ/internal/cyberimp/eyes/shield/ling()
-		O.insert(user)
-
-	else
+	if(!active)
 		var/obj/item/organ/internal/cyberimp/eyes/O = new /obj/item/organ/internal/cyberimp/eyes/thermals/ling()
 		O.insert(user)
-
+		active = TRUE
+	else
+		var/obj/item/organ/internal/cyberimp/eyes/O = new /obj/item/organ/internal/cyberimp/eyes/shield/ling()
+		O.insert(user)
+		active = FALSE
 	return 1
 
 /datum/action/changeling/augmented_eyesight/Remove(mob/user)
@@ -49,7 +56,6 @@
 	var/obj/S = ..()
 	S.reagents.add_reagent("oculine", 15)
 	return S
-
 
 /obj/item/organ/internal/cyberimp/eyes/thermals/ling
 	name = "heat receptors"

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -44,7 +44,7 @@
 	var/lingpowers = list()
 	for(var/power in changeling.purchasedpowers)
 		lingpowers += power
-	
+
 	changeling.absorbed_dna -= changeling.find_dna(user.dna)
 	changeling.protected_dna -= changeling.find_dna(user.dna)
 	changeling.absorbedcount -= 1
@@ -66,6 +66,7 @@
 
 	for(var/power in lingpowers)
 		var/datum/action/changeling/S = power
+		target.mind.changeling.purchasedpowers += S
 		if(istype(S) && S.needs_button)
 			S.Grant(target)
 


### PR DESCRIPTION
**What does this PR do:**
This PR contains tweaks and fixes for changelings, with a general improvements for all action buttons.

1) Upon purchasing Augmented Eyesight changeling ability, changeling immediately receives passive version of the ability instead of having to toggle it once to "start" it up.
2) Changelings in the lesser form can now toggle Augmented Eyesight ability, so they dont get stuck with it.
3) Changelings are now removed properly via Traitor Panel.
4) Changelings do not get their action buttons bugged when using Swap Forms ability now.
5) Action buttons should update their cooldown statuses more reliably.

Should fix #11558

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Upon purchasing Augmented Eyesight changeling ability, changeling immediately receives passive version of the ability
tweak: Changelings in the lesser form can now toggle Augmented Eyesight ability
fix: Changelings are now removed properly via Traitor Panel
fix: Changelings do not get their action buttons bugged when using Swap Forms ability now
fix: Action buttons should update their cooldown statuses more reliably
/:cl: