### PR TITLE
Lets you teleport to z levels 9-12

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(mapping)
 
 		var/num_extra_space = rand(config.extra_space_ruin_levels_min, config.extra_space_ruin_levels_max)
 		for(var/i = 1, i <= num_extra_space, i++)
-			var/zlev = space_manager.add_new_zlevel("[EMPTY_AREA] #[i]", linkage = CROSSLINKED)
+			var/zlev = space_manager.add_new_zlevel("[EMPTY_AREA] #[i]", linkage = CROSSLINKED, traits = list(REACHABLE))
 			seedRuins(list(zlev), rand(0, 3), /area/space, space_ruins_templates)
 
 	// Setup the Z-level linkage


### PR DESCRIPTION
**What does this PR do:**
This PR fixes #11563
It sets the reachable trait on those additional z levels and removes the trait blocking teleportation.
There's no real reason those levels of random, mostly empty space shouldn't be reachable via teleportation. This also allows cult teleport runes to go there and back. Note that I believe telescience is hardcoded to only go to certain z levels, so this won't affect that.

**Changelog:**
:cl:
tweak: cult teleport runes and similar powers now work on z levels 9-12
/:cl:

