### PR TITLE
Action Buttons - Lockdown

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -24,7 +24,7 @@
 //Hide/Show Action Buttons ... Button
 /obj/screen/movable/action_button/hide_toggle
 	name = "Hide Buttons"
-	desc = "Shift-click any button to reset its position, and Control-click it to unlock/lock its position in place. Alt-click this button to reset all buttons to their default positions."
+	desc = "Shift-click any button to reset its position, and Control-click it to lock/unlock its position. Alt-click this button to reset all buttons to their default positions."
 	icon = 'icons/mob/actions/actions.dmi'
 	icon_state = "bg_default"
 	var/hidden = 0

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -1,4 +1,3 @@
-
 /obj/screen/movable/action_button
 	var/datum/action/linked_action
 	screen_loc = null
@@ -6,18 +5,26 @@
 /obj/screen/movable/action_button/Click(location,control,params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
-		moved = 0
+		if(locked)
+			to_chat(usr, "<span class='warning'>Action button \"[name]\" is locked, unlock it first.</span>")
+			return TRUE
+		moved = FALSE
 		usr.update_action_buttons() //redraw buttons that are no longer considered "moved"
-		return 1
-	if(usr.next_move >= world.time) // Is this needed ?
+		return TRUE
+	if(modifiers["ctrl"])
+		locked = !locked
+		to_chat(usr, "<span class='notice'>Action button \"[name]\" [locked ? "" : "un"]locked.</span>")
+		return TRUE
+	if(usr.next_click > world.time)
 		return
+	usr.next_click = world.time + 1
 	linked_action.Trigger()
-	return 1
+	return TRUE
 
 //Hide/Show Action Buttons ... Button
 /obj/screen/movable/action_button/hide_toggle
 	name = "Hide Buttons"
-	desc = "Shift-click any button to reset its position. Alt-click to reset all buttons to their default positions."
+	desc = "Shift-click any button to reset its position, and Control-click it to unlock/lock its position in place. Alt-click this button to reset all buttons to their default positions."
 	icon = 'icons/mob/actions/actions.dmi'
 	icon_state = "bg_default"
 	var/hidden = 0
@@ -25,8 +32,15 @@
 /obj/screen/movable/action_button/hide_toggle/Click(location,control,params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
+		if(locked)
+			to_chat(usr, "<span class='warning'>Action button \"[name]\" is locked, unlock it first.</span>")
+			return TRUE
 		moved = FALSE
 		usr.update_action_buttons(TRUE)
+		return TRUE
+	if(modifiers["ctrl"])
+		locked = !locked
+		to_chat(usr, "<span class='notice'>Action button \"[name]\" [locked ? "" : "un"]locked.</span>")
 		return TRUE
 	if(modifiers["alt"])
 		for(var/V in usr.actions)
@@ -69,14 +83,12 @@
 	var/image/img = image(icon, src, hidden ? "show" : "hide")
 	overlays += img
 
-
 /obj/screen/movable/action_button/MouseEntered(location,control,params)
 	openToolTip(usr,src,params,title = name,content = desc)
 
 
 /obj/screen/movable/action_button/MouseExited()
 	closeToolTip(usr)
-
 
 /mob/proc/update_action_buttons_icon()
 	for(var/X in actions)
@@ -120,7 +132,6 @@
 		hud_used.hide_actions_toggle.screen_loc = hud_used.hide_actions_toggle.moved
 	if(reload_screen)
 		client.screen += hud_used.hide_actions_toggle
-
 
 
 #define AB_MAX_COLUMNS 10

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -11,6 +11,7 @@
 /obj/screen/movable
 	var/snap2grid = FALSE
 	var/moved = FALSE
+	var/locked = TRUE
 	var/x_off = -16
 	var/y_off = -16
 
@@ -20,8 +21,10 @@
 /obj/screen/movable/snap
 	snap2grid = TRUE
 
-
 /obj/screen/movable/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+	if(locked) //no! I am locked! begone!
+		return
+
 	var/list/PM = params2list(params)
 
 	//No screen-loc information? abort.
@@ -47,7 +50,6 @@
 
 	moved = screen_loc
 
-
 //Debug procs
 /client/proc/test_movable_UI()
 	set category = "Debug"
@@ -66,7 +68,6 @@
 	M.screen_loc = screen_l
 
 	screen += M
-
 
 /client/proc/test_snap_UI()
 	set category = "Debug"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -43,6 +43,7 @@
 	M.actions += src
 	if(M.client)
 		M.client.screen += button
+		button.locked = TRUE
 	M.update_action_buttons()
 
 /datum/action/proc/Remove(mob/M)
@@ -52,6 +53,7 @@
 	if(M.client)
 		M.client.screen -= button
 	button.moved = FALSE //so the button appears in its normal position when given to another owner.
+	button.locked = FALSE
 	M.actions -= src
 	M.update_action_buttons()
 


### PR DESCRIPTION
**What does this PR do:**
This PR adds a new feature to all action buttons - lockdown!

All action buttons are now locked in their place by default, unable to be moved via mouse drag. You can lock/unlock any button you wish via ctrl-click on the button.

This way, everyone wins - those who dont want to be bothered by moving action buttons no longer have to reset them everytime they move them on accident. And those who want to create their own custom HUD are now more empowered than ever before - they can rearrange action buttons anywhere they wish, and lock them in that place to prevent moving them on accident.

Also contains minor refactors regarding action buttons.

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: You can ctrl-click any action button to lock/unlock its position
tweak: All actions buttons now start with their position locked
/:cl: