### PR TITLE
Fix typo in scanner code

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -459,8 +459,8 @@
 			organData["germ_level"] = I.germ_level
 			organData["damage"] = I.damage
 			organData["maxHealth"] = I.max_damage
-			organData["bruised"] = I.min_broken_damage
-			organData["broken"] = I.min_bruised_damage
+			organData["bruised"] = I.min_bruised_damage
+			organData["broken"] = I.min_broken_damage
 			organData["robotic"] = I.is_robotic()
 			organData["dead"] = (I.status & ORGAN_DEAD)
 


### PR DESCRIPTION
**What does this PR do:**
There was a typo the line for broken and bruised organdata was switched this fixes it
**Changelog:**
:cl:
fix: t-t-t-typo!
/:cl:

