### PR TITLE
Dismembering now uses health of the limb instead of damage of the weapon!

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -459,8 +459,8 @@
 			organData["germ_level"] = I.germ_level
 			organData["damage"] = I.damage
 			organData["maxHealth"] = I.max_damage
-			organData["bruised"] = I.min_bruised_damage
-			organData["broken"] = I.min_broken_damage
+			organData["bruised"] = I.min_broken_damage
+			organData["broken"] = I.min_bruised_damage
 			organData["robotic"] = I.is_robotic()
 			organData["dead"] = (I.status & ORGAN_DEAD)
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -459,8 +459,8 @@
 			organData["germ_level"] = I.germ_level
 			organData["damage"] = I.damage
 			organData["maxHealth"] = I.max_damage
-			organData["bruised"] = I.min_broken_damage
-			organData["broken"] = I.min_bruised_damage
+			organData["bruised"] = I.min_bruised_damage
+			organData["broken"] = I.min_broken_damage
 			organData["robotic"] = I.is_robotic()
 			organData["dead"] = (I.status & ORGAN_DEAD)
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -228,7 +228,7 @@
 	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
-		if(!cannot_amputate && brute_dam >= min_broken_damage)
+		if(!cannot_amputate && brute_dam >= max_damage)
 			if(prob(brute_dam / 2)) // the probability of dismembering is now dependent on the damage of the limb
 				if(sharp)
 					droplimb(0, DROPLIMB_SHARP)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -228,8 +228,8 @@
 	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
-		if(!cannot_amputate && (brute_dam) >= (max_damage))
-			if(prob(brute_dam)) // the probability of dismembering is now dependent on the damage of the limb
+		if(!cannot_amputate && brute_dam >= min_broken_damage)
+			if(prob(brute_dam / 2)) // the probability of dismembering is now dependent on the damage of the limb
 				if(sharp)
 					droplimb(0, DROPLIMB_SHARP)
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -229,7 +229,7 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
 		if(!cannot_amputate && brute_dam >= max_damage)
-			if(prob(brute_dam / 2)) // the probability of dismembering is now dependent on the damage of the limb
+			if(prob(brute_dam / 5)) // the probability of dismembering is now dependent on the damage of the limb
 				if(sharp)
 					droplimb(0, DROPLIMB_SHARP)
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -229,7 +229,7 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
 		if(!cannot_amputate && (brute_dam) >= (max_damage))
-			if(prob(brute / 2))
+			if(prob(brute_dam)) // the probability of dismembering is now dependent on the damage of the limb
 				if(sharp)
 					droplimb(0, DROPLIMB_SHARP)
 


### PR DESCRIPTION
**What does this PR do:**
Prior to this PR, the probability of you dismembering a limb that reached max damage(head's maximum damage is 75) was the damage of the weapon divided by 2, this means a fireaxe had a 12% chance of dismembering the head even after it reached 75 damage. This change makes it so it bases the chance off the damage of the organ divided by 5 this means that a fully damaged head has a 15% chance of dismembering per swing. Though do note that it makes it slightly harder to dismember hands and feet at max damage(these have a 6% chance at max damage) and arms and legs(these have a 10% chance at max damage).
**Changelog:**
:cl:
add: Dismembering uses the health of the limb instead of the damage of the weapon
/:cl:

