### PR TITLE
The Foodening (Adjusts nutriment factors)

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -233,7 +233,7 @@
 	desc = "Made in Space Switzerland."
 	icon_state = "hot_coco"
 	item_state = "coffee"
-	list_reagents = list("chocolate" = 30)
+	list_reagents = list("hot_coco" = 30)
 
 /obj/item/reagent_containers/food/drinks/weightloss
 	name = "Weight-Loss Shake"

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -257,7 +257,7 @@
 	name = "Hot Chocolate"
 	id = "hot_coco"
 	description = "Made with love! And coco beans."
-	nutriment_factor = 3 * REAGENTS_METABOLISM
+	nutriment_factor = 0.5 * REAGENTS_METABOLISM
 	color = "#403010" // rgb: 64, 48, 16
 	adj_temp_hot = 5
 	drink_icon = "hot_coco"

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -257,7 +257,7 @@
 	name = "Hot Chocolate"
 	id = "hot_coco"
 	description = "Made with love! And coco beans."
-	nutriment_factor = 0.5 * REAGENTS_METABOLISM
+	nutriment_factor = 0
 	color = "#403010" // rgb: 64, 48, 16
 	adj_temp_hot = 5
 	drink_icon = "hot_coco"

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -523,7 +523,7 @@
 	id = "chocolate"
 	description = "Chocolate is a delightful product derived from the seeds of the theobroma cacao tree."
 	reagent_state = LIQUID
-	nutriment_factor = 5 * REAGENTS_METABOLISM		//same as pure cocoa powder, because it makes no sense that chocolate won't fill you up and make you fat
+	nutriment_factor = 0	//chocolate decays into sugar which provides its own nutrition
 	color = "#2E2418"
 	drink_icon = "chocolateglass"
 	drink_name = "Glass of chocolate"

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -64,15 +64,15 @@
 /datum/reagent/consumable/vitamin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(50))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustBruteLoss(-2, FALSE)
+		update_flags |= M.adjustFireLoss(-2, FALSE)
 	if(M.satiety < 600)
 		M.satiety += 30
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!(NO_BLOOD in H.dna.species.species_traits))//do not restore blood on things with no blood by nature.
 			if(H.blood_volume < BLOOD_VOLUME_NORMAL)
-				H.blood_volume += 0.5
+				H.blood_volume += 1
 	return ..() | update_flags
 
 /datum/reagent/consumable/sugar

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -579,7 +579,7 @@
 	reagent_state = LIQUID
 	color = "#B4B400"
 	metabolization_rate = 0.2
-	nutriment_factor = 2
+	nutriment_factor = 0.5
 	taste_message = "broth"
 
 /datum/reagent/consumable/cheese

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -42,6 +42,7 @@
 	id = "protein"
 	description = "Various essential proteins and fats commonly found in animal flesh and blood."
 	diet_flags = DIET_CARN | DIET_OMNI
+	nutriment_factor = 20 * REAGENTS_METABOLISM
 	taste_message = "meat"
 
 /datum/reagent/consumable/nutriment/plantmatter		// Plant-based biomatter, digestable by herbivores and omnivores, worthless to carnivores
@@ -49,6 +50,7 @@
 	id = "plantmatter"
 	description = "Vitamin-rich fibers and natural sugars commonly found in fresh produce."
 	diet_flags = DIET_HERB | DIET_OMNI
+	nutriment_factor = 18 * REAGENTS_METABOLISM
 	taste_message = "vegetables"
 
 /datum/reagent/consumable/vitamin


### PR DESCRIPTION
**What does this PR do:**
_**It's not even real chicken anyways.**_

**The Controversial:**
Hot Coco nutriment factor 3 -> 0 (full base nutriment reduction. Coco decays into sugar which provides its own nutrition. Hot Chocolate has been changed to use hot_coco as well).
Chicken Soup nutriment factor 2 -> 0.5 (75% reduction)

Why? The convenience of these items is so high due to their values (1 cup from nothing to full) that they disincentive people from ever engaging with other food sources (even other vending machine items). Ideally they could have a junkiness factor like other vending machine food, but this is not viable due to them being reagents. While they can still be abused (simply drink more), they are less convenient insofar as the metabolic rates are already relatively low (you will need to wait longer to get your bang for your buck whereas other foods satiate quicker).

**The (Hopefully) Uncontroversial:**
Protein (found in products containing meat) provides a greater satiety over nutriment (15 -> 20)
Plantmatter (found in products containing plants) provides a greater satiety over nutriment (15 -> 18)

Why? Both of these are more commonly found in chef's food. While chef's food already has higher nutritional values (and also contains vitamins which heal damage and restore blood), this is further weighting to the efficacy of the chef's food. There are also some types of junkfood that got a buff due to this (pistachios, jerky).

**The Potentially Controversial:**
Vitamins (found only in chef's food) have had their healing effects doubled. There is a 50% chance per tick of metabolism for vitamins to heal 1 brute/burn damage and restore 0.5 blood. This has been doubled to 2/2 brute/burn and 1 blood (the chance remains the same).

**The Goal**
We have awful chefs/botanists quite frequently. While a lot of this can be attributed to it being a starter role, I think a fair amount is that these roles are also easily made irrelevant through more reliable mechanisms (vending machines). There is no pressure for anyone in these positions to do their job nor any reason for the HoP to fire them (unless they're being borderline griefy). By making them have the ability to offer out-and-out superior options for satiety and clawing back some other convenient sources, there should be a natural predilection for people to scrutinize players in these roles more frequently.

This should, in turn, lead to more people using the chef and thereby increase the general quality of chefs as demand rises.

**Changelog:**
:cl:
tweak: Hot Chocolate/Hot Coco contains no base nutriment, only the nutrition from sugar decay.
Hot Chocolate changed to use hot_coco reagent, not pure liquid chocolate.
Chicken Soup 75% less effective.
Protein 33% more effective.
Plant Matter 20% more effective.
Vitamins 100% more effective.
/:cl:

