### PR TITLE
Steal objective and Adv Pinpointer no longer target items in Centcom Z level.

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -165,7 +165,10 @@
 					var/targetitem = input("Select item to search for.", "Item Mode Select","") as null|anything in item_names
 					if(!targetitem)
 						return
-					target = locate(item_paths[targetitem])
+					var/list/obj/item/target_candidates = get_all_of_type(item_paths[targetitem], subtypes = TRUE)
+						for(var/obj/item/candidate in target_candidates)
+							if(!is_admin_level(candidate.loc.z))
+								target = candidate
 					if(!target)
 						to_chat(usr, "<span class='warning'>Failed to locate [targetitem]!</span>")
 						return

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -344,11 +344,14 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 	var/theft_area
 
 /datum/objective/steal/proc/get_location()
-    if(steal_target.location_override)
-        return steal_target.location_override
-    var/obj/item/T = locate(steal_target.typepath)
-    theft_area = get_area(T.loc)
-    return "[theft_area]"
+	if(steal_target.location_override)
+		return steal_target.location_override
+	var/list/obj/item/steal_candidates = get_all_of_type(steal_target.typepath, subtypes = TRUE)
+	for(var/obj/item/candidate in steal_candidates)
+		if(!is_admin_level(candidate.loc.z))
+			theft_area = get_area(candidate.loc)
+			return "[theft_area]"
+	return "an unknown area"
 
 /datum/objective/steal/find_target()
 	var/loop=50


### PR DESCRIPTION
**What does this PR do:**
Fixes #11010
Fixes #11560
Fixes #11579 

**Changelog:**
:cl: uc_guy
fix: Theft objective locations hints now ignore the Centcomm Z level. 
fix: Adv. Pinpointer no longer targets items in Centcom Z level. 
/:cl:

