### PR TITLE
Re-add ghost space transitions, add ghost-z level tracking

### DIFF
--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -6,12 +6,14 @@ SUBSYSTEM_DEF(mobs)
 
 	var/list/currentrun = list()
 	var/static/list/clients_by_zlevel[][]
+	var/static/list/dead_players_by_zlevel[][] = list(list()) // Needs to support zlevel 1 here, MaxZChanged only happens when z2 is created and new_players can login before that.
 
 /datum/controller/subsystem/mobs/stat_entry()
 	..("P:[GLOB.mob_list.len]")
 
 /datum/controller/subsystem/mobs/Initialize(start_timeofday)
 	clients_by_zlevel = new /list(world.maxz,0)
+	dead_players_by_zlevel = new /list(world.maxz,0)
 	return ..()
 
 /datum/controller/subsystem/mobs/fire(resumed = 0)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -252,3 +252,8 @@
 
 /turf/space/proc/remove_transitions()
 	destination_z = initial(destination_z)
+
+/turf/space/attack_ghost(mob/dead/observer/user)
+	if(destination_z)
+		var/turf/T = locate(destination_x, destination_y, destination_z)
+		user.forceMove(T)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -1,4 +1,33 @@
+/mob/dead/Login()
+	. = ..()
+	var/turf/T = get_turf(src)
+	if (isturf(T))
+		update_z(T.z)
+
+/mob/dead/Logout()
+	update_z(null)
+	return ..()
+
 /mob/dead/forceMove(atom/destination)
+	var/turf/old_turf = get_turf(src)
+	var/turf/new_turf = get_turf(destination)
+	if (old_turf?.z != new_turf?.z)
+		onTransitZ(old_turf?.z, new_turf?.z)
 	var/oldloc = loc
 	loc = destination
 	Moved(oldloc, NONE, TRUE)
+
+/mob/dead/onTransitZ(old_z,new_z)
+	..()
+	update_z(new_z)
+
+/mob/dead/proc/update_z(new_z) // 1+ to register, null to unregister
+	if (registered_z != new_z)
+		if (registered_z)
+			SSmobs.dead_players_by_zlevel[registered_z] -= src
+		if (client)
+			if (new_z)
+				SSmobs.dead_players_by_zlevel[new_z] += src
+			registered_z = new_z
+		else
+			registered_z = null


### PR DESCRIPTION
**What does this PR do:**
This pull request does two things. Firstly, it re-adds ghost transitions. Because of the way ghost movement was changed a while back, this now requires you to click on the edge of space (which is how /tg/ does it as well).

Secondly, this adds z-level registering/tracking for ghosts like we currently do for living mobs (ported from /tg/). We don't really need this right now, but I added it as I initially thought it would fix the transition issue before I found out /tg/ handles it by clicking now. It's not a bad idea to have this in anyway.

Fixes https://github.com/ParadiseSS13/Paradise/issues/11509.

**Changelog:**
:cl: Markolie
fix: Ghosts can now transition through space again. This is now done by clicking on the edge of space.
/:cl:

