### PR TITLE
Changeling critical hotfix

### DIFF
--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -422,9 +422,3 @@ var/list/sting_paths
 		if(power.name == P.name)
 			return 1
 	return 0
-
-/datum/changeling/proc/regain_powers() //for when action buttons are lost and need to be regained, such as when the mind enters a new mob
-	for(var/power in purchasedpowers)
-		var/datum/action/changeling/S = power
-		if(istype(S) && S.needs_button)
-			S.Grant(src)

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -422,3 +422,9 @@ var/list/sting_paths
 		if(power.name == P.name)
 			return 1
 	return 0
+
+/datum/changeling/proc/regain_powers() //for when action buttons are lost and need to be regained, such as when the mind enters a new mob
+	for(var/power in purchasedpowers)
+		var/datum/action/changeling/S = power
+		if(istype(S) && S.needs_button)
+			S.Grant(src)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -18,6 +18,10 @@
 	if(ranged_ability)
 		ranged_ability.add_ranged_ability(src, "<span class='notice'>You currently have <b>[ranged_ability]</b> active!</span>")
 
+	var/datum/changeling/changeling = mind.has_antag_datum(/datum/changeling)
+	if(changeling)
+		changeling.regain_powers()
+
 	//Should update regardless of if we can ventcrawl, since we can end up in pipes in other ways.
 	update_pipe_vision()
 

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -18,9 +18,13 @@
 	if(ranged_ability)
 		ranged_ability.add_ranged_ability(src, "<span class='notice'>You currently have <b>[ranged_ability]</b> active!</span>")
 
-	var/datum/changeling/changeling = mind.has_antag_datum(/datum/changeling)
+	//for when action buttons are lost and need to be regained, such as when the mind enters a new mob
+	var/datum/changeling/changeling = usr.mind.changeling
 	if(changeling)
-		changeling.regain_powers()
+		for(var/power in changeling.purchasedpowers)
+			var/datum/action/changeling/S = power
+			if(istype(S) && S.needs_button)
+				S.Grant(src)
 
 	//Should update regardless of if we can ventcrawl, since we can end up in pipes in other ways.
 	update_pipe_vision()


### PR DESCRIPTION
**What does this PR do:**
New minds entering a changeling body should now correctly receive changeling action buttons. Also fixes changeling gamemode, or any other mode where there is more than 1 changeling. Previously, only one changeling received their action buttons and the rest got nothing.

Fixes #11583

**Changeling gamemode is not playable without this fix, please review and merge as soon as possible.**

Ported from /tg/station13.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
fix: Changelings should now correctly receive their action buttons
fix: Changelings now do not steal action buttons from other changelings
/:cl: