### PR TITLE
Fixes bug that deletes stuff in blocked trunks

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -692,11 +692,9 @@
 // pipe is deleted
 // ensure if holder is present, it is expelled
 /obj/structure/disposalpipe/Destroy()
-	var/obj/structure/disposalholder/H = locate() in src
-	if(H)
-		// holder was present
+	for(var/obj/structure/disposalholder/H in contents)
 		H.active = 0
-		var/turf/T = src.loc
+		var/turf/T = loc
 		if(T.density)
 			// deleting pipe is inside a dense turf (wall)
 			// this is unlikely, but just dump out everything into the turf in case
@@ -709,8 +707,7 @@
 			return
 
 		// otherwise, do normal expel from turf
-		if(H)
-			expel(H, T, 0)
+		expel(H, T, 0)
 	return ..()
 
 /obj/structure/disposalpipe/singularity_pull(S, current_size)


### PR DESCRIPTION
Previously, destroying a disposals pipe would only eject the *first* disposals holder it found, ignoring all others. Turns out if you send an item into a blocked disposals trunk, the two holders don't merge, so deleting such a trunk will just erase everything inside the pipe past the first disposalsholder.

:cl:
fix: Destroying a disposals trunk should no longer occasionally delete things held inside it.
/:cl: