### PR TITLE
Makes Cybernetic Bundles a Nukie-only item again

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1627,7 +1627,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CIB"
 	item = /obj/item/storage/box/cyber_implants/bundle
 	cost = 40
-	
+	gamemodes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/bundles_TC/medical
 	name = "Medical Bundle"
 	desc = "The support specialist: Aid your fellow operatives with this medical bundle. Contains a tactical medkit, \


### PR DESCRIPTION
**What does this PR do:**
Regular Traitors can purchase the cybernetic implant bundle that's meant to be for nuke ops teams. While it costs more TC than they start with and is unlikely to cause serious issues if someone does buy it, it should probably be reverted back to being a nukie-only item given it's really only useful for them.

**Changelog:**
:cl:
fix: The cybernetic implant bundle can no longer be bought by traitors.
/:cl:

