### PR TITLE
Minor SSicons tweaks.

### DIFF
--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -28,5 +28,21 @@ SUBSYSTEM_DEF(icon_smooth)
 			continue
 		smooth_icon(A)
 		CHECK_TICK
-
+	// Smooth those atoms
+	var/s_watch = start_watch()
+	log_startup_progress("Smoothing atoms...")
+	for(var/turf/T in world)
+		if(T.smooth)
+			queue_smooth(T)
+		for(var/A in T)
+			var/atom/AA = A
+			if(AA.smooth)
+				queue_smooth(AA)
+	log_startup_progress("Smoothed atoms in [stop_watch(s_watch)]s.")
+	// Reticulate those splines, baby!
+	var/r_watch = start_watch()
+	log_startup_progress("Reticulating splines...")
+	for(var/turf/simulated/mineral/M in GLOB.mineral_turfs)
+		M.add_edges()
+	log_startup_progress("Splines reticulated in [stop_watch(r_watch)]s.")
 	return ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -54,19 +54,6 @@
 	if (opacity)
 		has_opaque_atom = TRUE
 
-/hook/startup/proc/smooth_world()
-	var/watch = start_watch()
-	log_startup_progress("Smoothing atoms...")
-	for(var/turf/T in world)
-		if(T.smooth)
-			queue_smooth(T)
-		for(var/A in T)
-			var/atom/AA = A
-			if(AA.smooth)
-				queue_smooth(AA)
-	log_startup_progress(" Smoothed atoms in [stop_watch(watch)]s.")
-	return 1
-
 /turf/Destroy()
 // Adds the adjacent turfs to the current atmos processing
 	if(SSair)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -76,14 +76,6 @@ var/global/list/rockTurfEdgeCache = list(
 /turf/simulated/mineral/proc/Spread(var/turf/T)
 	new src.type(T)
 
-/hook/startup/proc/add_mineral_edges()
-	var/watch = start_watch()
-	log_startup_progress("Reticulating splines...")
-	for(var/turf/simulated/mineral/M in GLOB.mineral_turfs)
-		M.add_edges()
-	log_startup_progress(" Splines reticulated in [stop_watch(watch)]s.")
-	return 1
-
 /turf/simulated/mineral/proc/add_edges()
 	var/turf/T
 	if((istype(get_step(src, NORTH), /turf/simulated/floor)) || (istype(get_step(src, NORTH), /turf/space)))


### PR DESCRIPTION
**What does this PR do:**
This PR kills some `/hook/startup` that smooths icons out, and moves it to the `Initialize()` for `SSicons`. This is part of the hook killing, but is also needed for map rotation, as what is the point of smoothing the world if there is no world?

**Changelog:**
:cl:
tweak: Icons smooth in a different place in startup
/:cl:

