### PR TITLE
Tags for inits

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -143,9 +143,13 @@
 /**
  * Standardized method for tracking startup times.
  */
-/proc/log_startup_progress(var/message)
-	to_chat(world, "<span class='danger'>[message]</span>")
-	log_world(message)
+/proc/log_startup_progress(var/message, var/tag)
+	if(tag)
+		to_chat(world, "<span class='danger'><small>\[[tag]\]</small> [message]</span>")
+		log_world("\[[tag]\] [message]")
+	else
+		to_chat(world, "<span class='danger'>[message]</span>")
+		log_world(message)
 
 // A logging proc that only outputs after setup is done, to
 // help devs test initialization stuff that happens a lot

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -97,9 +97,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	sortTim(subsystems, /proc/cmp_subsystem_init)
 	reverseRange(subsystems)
 	for(var/datum/controller/subsystem/ss in subsystems)
-		log_world("Shutting down [ss.name] subsystem...")
+		log_world("\[MC\] Shutting down [ss.name] subsystem...")
 		ss.Shutdown()
-	log_world("Shutdown complete")
+	log_world("\[MC\] Shutdown complete")
 
 // Returns 1 if we created a new mc, 0 if we couldn't due to a recent restart,
 //	-1 if we encountered a runtime trying to recreate it
@@ -149,7 +149,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				msg = "The [BadBoy.name] subsystem seems to be destabilizing the MC and will be offlined."
 				BadBoy.flags |= SS_NO_FIRE
 		if(msg)
-			to_chat(GLOB.admins, "<span class='boldannounce'>[msg]</span>")
+			to_chat(GLOB.admins, "<span class='boldannounce'><small>\[MC\]</small> [msg]</span>")
 			log_world(msg)
 
 	if(istype(Master.subsystems))
@@ -159,7 +159,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		current_runlevel = Master.current_runlevel
 		StartProcessing(10)
 	else
-		to_chat(world, "<span class='boldannounce'>The Master Controller is having some issues, we will need to re-initialize EVERYTHING</span>")
+		to_chat(world, "<span class='boldannounce'><small>\[MC\]</small> The Master Controller is having some issues, we will need to re-initialize EVERYTHING</span>")
 		Initialize(20, TRUE)
 
 
@@ -174,7 +174,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	if(init_sss)
 		init_subtypes(/datum/controller/subsystem, subsystems)
 
-	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
+	log_startup_progress("Initializing subsystems...", "MC")
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, /proc/cmp_subsystem_init)
@@ -190,9 +190,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	current_ticklimit = TICK_LIMIT_RUNNING
 	var/time = (REALTIMEOFDAY - start_timeofday) / 10
 
-	var/msg = "Initializations complete within [time] second[time == 1 ? "" : "s"]!"
-	to_chat(world, "<span class='boldannounce'>[msg]</span>")
-	log_world(msg)
+	log_startup_progress("Initializations complete within [time] second[time == 1 ? "" : "s"]!", "MC")
 
 	if(config.developer_express_start & SSticker.current_state == GAME_STATE_PREGAME)
 		SSticker.current_state = GAME_STATE_SETTING_UP

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -160,9 +160,7 @@
 /datum/controller/subsystem/Initialize(start_timeofday)
 	initialized = TRUE
 	var/time = (REALTIMEOFDAY - start_timeofday) / 10
-	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!"
-	to_chat(world, "<span class='boldannounce'>[msg]</span>")
-	log_world(msg)
+	log_startup_progress("Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!", "MC")
 	return time
 
 //hook for printing stats to the "MC" statuspanel for admins to see performance and related stats etc.

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -320,9 +320,9 @@ SUBSYSTEM_DEF(air)
 
 /datum/controller/subsystem/air/proc/setup_atmos_machinery(var/list/machines_to_init)
 	var/watch = start_watch()
-	log_startup_progress("Initializing atmospherics machinery...")
+	log_startup_progress("Initializing atmospherics machinery...", "Air")
 	var/count = _setup_atmos_machinery(machines_to_init)
-	log_startup_progress("	Initialized [count] atmospherics machines in [stop_watch(watch)]s.")
+	log_startup_progress("Initialized [count] atmospherics machines in [stop_watch(watch)]s.", "Air")
 
 // this underscored variant is so that we can have a means of late initing
 // atmos machinery without a loud announcement to the world
@@ -344,9 +344,9 @@ SUBSYSTEM_DEF(air)
 //	pipenet can be built.
 /datum/controller/subsystem/air/proc/setup_pipenets(var/list/pipes)
 	var/watch = start_watch()
-	log_startup_progress("Initializing pipe networks...")
+	log_startup_progress("Initializing pipe networks...", "Air")
 	var/count = _setup_pipenets(pipes)
-	log_startup_progress("	Initialized [count] pipenets in [stop_watch(watch)]s.")
+	log_startup_progress("Initialized [count] pipenets in [stop_watch(watch)]s.", "Air")
 
 // An underscored wrapper that exists for the same reason
 // the machine init wrapper does

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(atoms)
 
 	var/watch = start_watch()
 	if(noisy)
-		log_startup_progress("Initializing atoms...")
+		log_startup_progress("Initializing atoms...", "Atoms")
 	else
 		log_debug("Initializing atoms...")
 	var/count
@@ -54,7 +54,7 @@ SUBSYSTEM_DEF(atoms)
 				CHECK_TICK
 
 	if(noisy)
-		log_startup_progress("	Initialized [count] atoms in [stop_watch(watch)]s")
+		log_startup_progress("Initialized [count] atoms in [stop_watch(watch)]s", "Atoms")
 	else
 		log_debug("	Initialized [count] atoms in [stop_watch(watch)]s")
 	pass(count)
@@ -64,14 +64,14 @@ SUBSYSTEM_DEF(atoms)
 	if(late_loaders.len)
 		watch = start_watch()
 		if(noisy)
-			log_startup_progress("Late-initializing atoms...")
+			log_startup_progress("Late-initializing atoms...", "Atoms")
 		else
 			log_debug("Late-initializing atoms...")
 		for(var/I in late_loaders)
 			var/atom/A = I
 			A.LateInitialize()
 		if(noisy)
-			log_startup_progress("	Late initialized [late_loaders.len] atoms in [stop_watch(watch)]s")
+			log_startup_progress("Late initialized [late_loaders.len] atoms in [stop_watch(watch)]s", "Atoms")
 		else
 			log_debug("	Late initialized [late_loaders.len] atoms in [stop_watch(watch)]s")
 		late_loaders.Cut()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -12,9 +12,9 @@ SUBSYSTEM_DEF(mapping)
 	// Seed space ruins
 	if(!config.disable_space_ruins)
 		var/timer = start_watch()
-		log_startup_progress("Creating random space levels...")
+		log_startup_progress("Creating random space levels...", "Mapping")
 		seedRuins(level_name_to_num(EMPTY_AREA), rand(0, 3), /area/space, space_ruins_templates)
-		log_startup_progress("Loaded random space levels in [stop_watch(timer)]s.")
+		log_startup_progress("Loaded random space levels in [stop_watch(timer)]s.", "Mapping")
 
 		// load in extra levels of space ruins
 

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -47,7 +47,7 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 
 	if(potentialRandomZlevels && potentialRandomZlevels.len)
 		var/watch = start_watch()
-		log_startup_progress("Loading away mission...")
+		log_startup_progress("Loading away mission...", "Mapping")
 
 		var/map = pick(potentialRandomZlevels)
 		var/file = file(map)
@@ -57,17 +57,17 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 			maploader.load_map(file, z_offset = zlev)
 			late_setup_level(block(locate(1, 1, zlev), locate(world.maxx, world.maxy, zlev)))
 			space_manager.remove_dirt(zlev)
-			log_world("  Away mission loaded: [map]")
+			log_world("\[Mapping\] Away mission loaded: [map]")
 
 		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 			if(L.name != "awaystart")
 				continue
 			awaydestinations.Add(L)
 
-		log_startup_progress("  Away mission loaded in [stop_watch(watch)]s.")
+		log_startup_progress("Away mission loaded in [stop_watch(watch)]s.", "Mapping")
 
 	else
-		log_startup_progress("  No away missions found.")
+		log_startup_progress("No away missions found.", "Mapping")
 		return
 
 
@@ -77,18 +77,18 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 
 	if(potentialRandomZlevels && potentialRandomZlevels.len)
 		var/watch = start_watch()
-		log_startup_progress("Loading away missions...")
+		log_startup_progress("Loading away missions...", "Mapping")
 
 		for(var/map in potentialRandomZlevels)
 			var/file = file(map)
 			if(isfile(file))
-				log_startup_progress("Loading away mission: [map]")
+				log_startup_progress("Loading away mission: [map]", "Mapping")
 				var/zlev = space_manager.add_new_zlevel()
 				space_manager.add_dirt(zlev)
 				maploader.load_map(file, z_offset = zlev)
 				late_setup_level(block(locate(1, 1, zlev), locate(world.maxx, world.maxy, zlev)))
 				space_manager.remove_dirt(zlev)
-				log_world("  Away mission loaded: [map]")
+				log_world("\[Mapping\] Away mission loaded: [map]")
 
 			//map_transition_config.Add(AWAY_MISSION_LIST)
 
@@ -97,11 +97,11 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 					continue
 				awaydestinations.Add(L)
 
-			log_startup_progress("  Away mission loaded in [stop_watch(watch)]s.")
+			log_startup_progress(" Away mission loaded in [stop_watch(watch)]s.", "Mapping")
 			watch = start_watch()
 
 	else
-		log_startup_progress("  No away missions found.")
+		log_startup_progress("No away missions found.", "Mapping")
 		return
 
 /proc/generateMapList(filename)
@@ -169,7 +169,7 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 			if(!valid)
 				continue
 
-			log_world("  Ruin \"[ruin.name]\" loaded in [stop_watch(watch)]s at ([T.x], [T.y], [T.z]).")
+			log_world("\[Mapping\] Ruin \"[ruin.name]\" loaded in [stop_watch(watch)]s at ([T.x], [T.y], [T.z]).")
 
 			var/obj/effect/ruin_loader/R = new /obj/effect/ruin_loader(T)
 			R.Load(ruins,ruin)
@@ -180,7 +180,7 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 
 
 	if(initialbudget == budget) //Kill me
-		log_world("  No ruins loaded.")
+		log_world("\[Mapping\] No ruins loaded.")
 
 
 /obj/effect/ruin_loader


### PR DESCRIPTION
**What does this PR do:**
This PR adds in tags for inits, shown in-world and within the daemon. The purpose of this is to tie init messages to the subsystem they are from, just for ease of debugging and eyes. Completely unnecessary feature but I think its cool

**Images of sprite/map changes:**
Chat:
![image](https://user-images.githubusercontent.com/25063394/58387650-25941200-800a-11e9-89a1-914c23862326.png)

Daemon:
![image](https://user-images.githubusercontent.com/25063394/58387651-2e84e380-800a-11e9-8671-6c60811953a4.png)

**Changelog:**
:cl:
add: Initialisation messages are now tagged
/:cl:

I would expand this to other things, but I cant really think what to expand it to