### PR TITLE
Fix mice going unconscious randomly

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -57,7 +57,7 @@
 
 /mob/living/simple_animal/mouse/Life()
 	..()
-	if(prob(0.5))
+	if(prob(0.5) && !ckey)
 		stat = UNCONSCIOUS
 		icon_state = "mouse_[mouse_color]_sleep"
 		wander = 0


### PR DESCRIPTION
**What does this PR do:**
Small fix that stops mice with ckeys from going unconscious


**Changelog:**
:cl:
fix: player-controlled mice no longer randomly go unconscious
:cl:

