### PR TITLE
Blindfolds are now craftable from 3 cloth

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -214,6 +214,8 @@ var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 	null, \
 	new/datum/stack_recipe("fingerless gloves", /obj/item/clothing/gloves/fingerless, 1), \
 	new/datum/stack_recipe("black gloves", /obj/item/clothing/gloves/color/black, 3), \
+	null, \
+	new/datum/stack_recipe("blindfold", /obj/item/clothing/glasses/sunglasses/blindfold, 3), \
 	)
 
 /obj/item/stack/sheet/cloth


### PR DESCRIPTION
**What does this PR do:**
Makes blindfolds craftable from 3 cloth

**Changelog:**
:cl:
add: Blindfolds are now craftable from 3 cloth. For those vampire prisoners you want to keep in check
/:cl:

