### PR TITLE
The Empty beaker button from the pandemic now also ejects

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -135,12 +135,11 @@
 		return
 	else if(href_list["empty_beaker"])
 		beaker.reagents.clear_reagents()
+		eject_beaker()
 		updateUsrDialog()
 		return
 	else if(href_list["eject"])
-		beaker:loc = loc
-		beaker = null
-		icon_state = "mixer0"
+		eject_beaker()
 		updateUsrDialog()
 		return
 	else if(href_list["clear"])
@@ -172,6 +171,11 @@
 		return
 
 	add_fingerprint(usr)
+
+/obj/machinery/computer/pandemic/proc/eject_beaker()
+	beaker.forceMove(loc)
+	beaker = null
+	icon_state = "mixer0"
 
 //Prints a nice virus release form. Props to Urbanliner for the layout
 /obj/machinery/computer/pandemic/proc/print_form(var/datum/disease/advance/D, mob/living/user)
@@ -308,7 +312,7 @@
 					dat += "nothing<BR>"
 			else
 				dat += "nothing<BR>"
-		dat += "<BR><A href='?src=[UID()];eject=1'>Eject beaker</A>[((R.total_volume&&R.reagent_list.len) ? "-- <A href='?src=[UID()];empty_beaker=1'>Empty beaker</A>":"")]<BR>"
+		dat += "<BR><A href='?src=[UID()];eject=1'>Eject beaker</A>[((R.total_volume&&R.reagent_list.len) ? "-- <A href='?src=[UID()];empty_beaker=1'>Empty beaker and Eject</A>":"")]<BR>"
 		dat += "<A href='?src=[user.UID()];mach_close=pandemic'>Close</A>"
 
 	var/datum/browser/popup = new(user, "pandemic", name, 575, 400)

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -312,7 +312,7 @@
 					dat += "nothing<BR>"
 			else
 				dat += "nothing<BR>"
-		dat += "<BR><A href='?src=[UID()];eject=1'>Eject beaker</A>[((R.total_volume&&R.reagent_list.len) ? "-- <A href='?src=[UID()];empty_beaker=1'>Empty beaker and Eject</A>":"")]<BR>"
+		dat += "<BR><A href='?src=[UID()];eject=1'>Eject beaker</A>[((R.total_volume&&R.reagent_list.len) ? "-- <A href='?src=[UID()];empty_beaker=1'>Empty and eject beaker</A>":"")]<BR>"
 		dat += "<A href='?src=[user.UID()];mach_close=pandemic'>Close</A>"
 
 	var/datum/browser/popup = new(user, "pandemic", name, 575, 400)


### PR DESCRIPTION
**What does this PR do:**
The PANDEMIC Empty button is now replaced with Empty and eject beaker.

**Changelog:**
:cl:
tweak: Empty beaker button from the PANDEMIC is now replaced with Empty and eject beaker
/:cl:

