### PR TITLE
Add scrolling to messages window, bug fix

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -308,16 +308,25 @@
 		dat += "<a class='[class]' href='?src=[UID()];newtitle=[title]'>[label]</a>"
 
 	var/datum/pm_convo/convo = pms[current_title]
+	var/datum/browser/popup = new(user, window_id, "Messages", 1000, 600, src)
 	if(convo)
+		popup.add_head_content(@{"<script type='text/javascript'>
+			window.onload = function () {
+				var msgs = document.getElementById('msgs');
+				msgs.scrollTop = msgs.scrollHeight;
+			}
+			</script>"})
 		convo.read = TRUE
 		dat += "<h2>[check_rights(R_ADMIN, FALSE, user) ? fancy_title(current_title) : current_title]</h2>"
 		dat += "<h4>"
-		dat += "<table style='width:950px; border: 3px solid;'>"
+		dat += "<div id='msgs' style='width:950px; border: 3px solid; overflow-y: scroll; height: 350px;'>"
+		dat += "<table>"
 
 		for(var/message in convo.messages)
 			dat += "<tr><td>[message]</td></tr>"
 
 		dat += "</table>"
+		dat += "</div>"
 		if(convo.typing)
 			dat += "<i><span class='typing'>[current_title] is typing</span></i>"
 		dat += "<br>"
@@ -327,7 +336,6 @@
 		if(check_rights(R_ADMIN, FALSE, user))
 			dat += "<a href='?src=[UID()];ping=[current_title]'>Ping</a>"
 
-	var/datum/browser/popup = new(user, window_id, "Messages", 1000, 600, src)
 	popup.set_content(dat)
 	popup.open()
 	open = TRUE

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -279,6 +279,9 @@
 /datum/pm_tracker/proc/add_message(client/title, client/sender, message, mob/user)
 	if(!pms[title.key])
 		pms[title.key] = new /datum/pm_convo(title)
+	else if(!pms[title.key].client)
+		// If they DCed earlier, we need to add the client reference back
+		pms[title.key].client = title
 	pms[title.key].add(sender, message)
 
 	if(!open)
@@ -341,10 +344,17 @@
 	open = TRUE
 
 /datum/pm_tracker/proc/fancy_title(title)
-	var/client/C = pms[title].client
+	var/client/C = pms[title].client || update_client(title)
 	if(!C)
 		return "[title] (Disconnected)"
 	return "[key_name(C, FALSE)] ([ADMIN_QUE(C.mob,"?")]) ([ADMIN_PP(C.mob,"PP")]) ([ADMIN_VV(C.mob,"VV")]) ([ADMIN_SM(C.mob,"SM")]) ([admin_jump_link(C.mob)]) (<A HREF='?_src_=holder;check_antagonist=1'>CA</A>)"
+
+/datum/pm_tracker/proc/update_client(title)
+	var/client/C = GLOB.directory[ckey(title)]
+	if(C)
+		pms[title].client = C
+		return C
+	return null
 
 /datum/pm_tracker/Topic(href, href_list)
 	if(href_list["archive"])


### PR DESCRIPTION
**What does this PR do:**
Just a small tweak to make long conversations easier on the UI.

![image](https://user-images.githubusercontent.com/26497062/58657250-b8ff6880-82d2-11e9-9102-1d67004ba7bd.png)

**Changelog:**
:cl:
tweak: PMs window scrollable
fix: Fix a bug where a player who reconnects is still shown as disconnected
/:cl:

