### PR TITLE
Fixes speed and normal process switching being broken

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -148,8 +148,8 @@ Class Procs:
 	if(!speed_process)
 		return
 	speed_process = FALSE
-	START_PROCESSING(SSmachines, src)
 	STOP_PROCESSING(SSfastprocess, src)
+	START_PROCESSING(SSmachines, src)
 
 /obj/machinery/Destroy()
 	if(myArea)


### PR DESCRIPTION
**What does this PR do:**
Switching from a speed process to a normal process is currently broken - this PR fixes that.
Fixes #11595

:cl:
fix: Fixes conveyor belts not moving items spawned via an autolathe. (And other possible behaviours when machines switch between speed and normal processes)
/:cl: