### PR TITLE
Absolutely No Clothes

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -2055,12 +2055,7 @@
 	},
 /area/wizard_station)
 "fr" = (
-/obj/structure/closet{
-	icon_closed = "cabinet_closed";
-	icon_opened = "cabinet_open";
-	icon_state = "cabinet_closed"
-	},
-/obj/item/storage/backpack/satchel,
+/obj/structure/dresser,
 /turf/unsimulated/floor{
 	dir = 9;
 	icon_state = "carpetside"
@@ -2160,6 +2155,7 @@
 /obj/effect/landmark{
 	name = "Teleport-Scroll"
 	},
+/obj/item/storage/backpack/satchel,
 /turf/unsimulated/floor{
 	dir = 6;
 	icon_state = "carpetside"

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -73,6 +73,10 @@
 	name = "No Clothes"
 	desc = "This always-on spell allows you to cast magic without your garments."
 
+/obj/effect/proc_holder/spell/absolutelynoclothes
+	name = "Absolutely No Clothes"
+	desc = "This variant of the No Clothes spell allows you to cast any spell but requires you to be naked. Belts, headsets and backpacks are fine. So is underwear, if you insist on it..."
+
 /obj/effect/proc_holder/spell/targeted/genetic/mutate
 	name = "Mutate"
 	desc = "This spell causes you to turn into a hulk and gain laser vision for a short while."

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -100,6 +100,13 @@
 	log_name = "NC"
 	category = "Defensive"
 
+/datum/spellbook_entry/absolutelynoclothes
+	name = "Absolutely No Clothes"
+	spell_type = /obj/effect/proc_holder/spell/absolutelynoclothes
+	log_name = "ANC"
+	category = "Defensive"
+	cost = 0
+
 /datum/spellbook_entry/fireball
 	name = "Fireball"
 	spell_type = /obj/effect/proc_holder/spell/fireball


### PR DESCRIPTION
This PR adds the Absolutely No Clothes spell to the wizard spellbook for 0 spellpoints.

"This variant of the No Clothes spell allows you to cast any spell but requires you to be naked. Belts, headsets and backpacks are fine. So is underwear, if you insist on it..."

Pros : 
- You can cast any spell while you are naked, bypassing clothes requirements for free.
- Memes
- Stealth? Maybe? Kind of?

Cons : 
- You lose out on the significant armor provided by wizard robes.
- You cannot use pockets, suit storage, or ID slots.
- You cannot wear any clothing and cast spells, this includes useful items such as internals mask, space suits, magboots. sechuds, etc. Wearing any clothing will block ALL spells, including the ones that do not require wizard robes by default.

This PR also changes the cabinet-style locker in the wizard bedroom to a clothes drawer so that the wizard can ~~get out of that jabroni outfit~~ change their underwear/tshirt/socks as they prefer. The leather satchel inside was moved to the bedroom table.

🆑
add: Added the 'Absolutely No Clothes' spell to wizard spellbooks for 0 points. Lets wizard cast any spells but forces them to wear no clothing to do so.
tweak: Changed the cabinet in the wizard bedroom to a clothes drawer, moved the leather satchel inside to the bedroom table.
/🆑
