### PR TITLE
ChangeTurf icon fix

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -120,13 +120,22 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 /turf/simulated/floor/proc/make_plating()
 	return ChangeTurf(/turf/simulated/floor/plating)
 
-/turf/simulated/floor/ChangeTurf(turf/simulated/floor/T, defer_change = FALSE, ignore_air = FALSE)
-	if(!istype(src,/turf/simulated/floor)) 
+/turf/simulated/floor/ChangeTurf(turf/simulated/floor/T, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
+	if(!istype(src, /turf/simulated/floor)) 
 		return ..() //fucking turfs switch the fucking src of the fucking running procs
-	if(!ispath(T,/turf/simulated/floor)) 
+	if(!ispath(T, /turf/simulated/floor)) 
 		return ..()
+		
+	var/old_icon = icon_regular_floor
+	var/old_plating = icon_plating
+	var/old_dir = dir
 
 	var/turf/simulated/floor/W = ..()
+
+	if(keep_icon)
+		W.icon_regular_floor = old_icon
+		W.icon_plating = old_plating
+		W.dir = old_dir
 
 	W.update_icon()
 	return W

--- a/code/game/turfs/simulated/floor/asteroid.dm
+++ b/code/game/turfs/simulated/floor/asteroid.dm
@@ -72,7 +72,10 @@
 		var/obj/item/stack/tile/Z = W
 		if(!Z.use(1))
 			return
-		ChangeTurf(Z.turf_type)
+		if(istype(Z, /obj/item/stack/tile/plasteel)) // Turn asteroid floors into plating by default
+			ChangeTurf(/turf/simulated/floor/plating, keep_icon = FALSE)
+		else
+			ChangeTurf(Z.turf_type, keep_icon = FALSE)
 		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 
 /turf/simulated/floor/plating/asteroid/gets_drilled()

--- a/code/game/turfs/simulated/floor/mineral.dm
+++ b/code/game/turfs/simulated/floor/mineral.dm
@@ -254,3 +254,6 @@
 
 /turf/simulated/floor/plating/abductor2/burn_tile()
 	return //unburnable
+
+/turf/simulated/floor/plating/abductor2/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
+	return

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -287,12 +287,3 @@
 /turf/simulated/floor/plating/abductor/New()
 	..()
 	icon_state = "alienpod[rand(1,9)]"
-
-/turf/simulated/floor/plating/abductor/break_tile()
-	return //unbreakable
-
-/turf/simulated/floor/plating/abductor/burn_tile()
-	return //unburnable
-
-/turf/simulated/floor/plating/abductor/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
-	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -180,11 +180,11 @@
 	if(L)
 		qdel(L)
 
-/turf/proc/TerraformTurf(path, defer_change = FALSE, ignore_air = FALSE)
-	return ChangeTurf(path, defer_change, ignore_air)
+/turf/proc/TerraformTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
+	return ChangeTurf(path, defer_change, keep_icon, ignore_air)
 
 //Creates a new turf
-/turf/proc/ChangeTurf(path, defer_change = FALSE, ignore_air = FALSE)
+/turf/proc/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
 	if(!path)
 		return
 	if(!use_preloader && path == type) // Don't no-op if the map loader requires it to be reconstructed

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -321,7 +321,7 @@ var/global/dmm_suite/preloader/_preloader = new
 	var/turf/T = locate(x,y,z)
 	if(T)
 		if(ispath(path, /turf))
-			T.ChangeTurf(path, TRUE)
+			T.ChangeTurf(path, defer_change = TRUE, keep_icon = FALSE)
 			instance = T
 		else if(ispath(path, /area))
 


### PR DESCRIPTION
**What does this PR do:**
Follow up to https://github.com/ParadiseSS13/Paradise/pull/11643: turns out the keep_icon was used to retain unique floor icons when floors were crowbarred and replaced. Ideally we want to get rid of this (which we can with the new turf_decals), but then all maps will need to be converted first.

Also moves the abductor plating checks to the proper plating.