### PR TITLE
More turf fixes

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -21229,10 +21229,8 @@
 	tag = ""
 	},
 /obj/machinery/igniter{
-	icon_state = "igniter0";
 	id = "Incinerator";
-	luminosity = 2;
-	on = 0
+	luminosity = 2
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -73649,10 +73649,8 @@
 /area/medical/reception)
 "cuQ" = (
 /obj/machinery/igniter{
-	icon_state = "igniter0";
 	id = "Turbine_igniter";
-	luminosity = 2;
-	on = 0
+	luminosity = 2
 	},
 /obj/structure/cable{
 	d1 = 1;

--- a/_maps/map_files/MetaStation/z2.dmm
+++ b/_maps/map_files/MetaStation/z2.dmm
@@ -1498,7 +1498,7 @@
 /turf/unsimulated/wall,
 /area/tdome/arena_source)
 "eb" = (
-/obj/machinery/igniter,
+/obj/machinery/igniter/on,
 /turf/simulated/floor/plasteel,
 /area/tdome/arena_source)
 "ec" = (
@@ -5805,7 +5805,7 @@
 /turf/unsimulated/wall,
 /area/tdome/arena)
 "qu" = (
-/obj/machinery/igniter,
+/obj/machinery/igniter/on,
 /turf/simulated/floor/plasteel,
 /area/tdome/arena)
 "qv" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -686,17 +686,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/igniter{
-	id = "syndicate_base_incinerator"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
-"bg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/glass{
 	frequency = 1449;
 	id_tag = "syndicate_base_incinerator_interior";
@@ -712,28 +701,30 @@
 	pixel_y = 0;
 	req_access_txt = "150"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/insulated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"bh" = (
+"bg" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/engine/insulated,
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"bh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/insulated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bi" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/binary/pump/on{
-	target_pressure = 4500
+/obj/machinery/atmospherics/binary/pump{
+	name = "Incinerator Input"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/insulated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bj" = (
 /obj/structure/cable{
@@ -756,7 +747,7 @@
 	pixel_y = 0;
 	req_access_txt = "150"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/insulated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bk" = (
 /obj/structure/rack,
@@ -1012,7 +1003,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold4w/visible/supply,
+/obj/machinery/atmospherics/pipe/manifold/visible/supply,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bH" = (
@@ -1057,27 +1048,25 @@
 "bM" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small,
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/welding,
-/obj/item/weldingtool/largetank,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Plasma to Incinerator"
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bN" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10;
 	level = 2
 	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/clothing/head/welding,
+/obj/item/weldingtool/largetank,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bO" = (
@@ -1107,6 +1096,9 @@
 /obj/structure/window/plastitanium,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"bQ" = (
+/turf/simulated/floor/engine/insulated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "bR" = (
 /obj/machinery/optable,
@@ -1361,6 +1353,60 @@
 	oxygen = 0;
 	toxins = 70000
 	},
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"cp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/igniter{
+	id = "syndicate_base_incinerator"
+	},
+/turf/simulated/floor/engine/insulated,
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"cq" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1;
+	id = "syndie_lavaland_inc_in"
+	},
+/obj/structure/sign/vacuum/external{
+	pixel_y = -32
+	},
+/turf/simulated/floor/engine/insulated,
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"cr" = (
+/obj/machinery/door/poddoor{
+	id_tag = "lavalandsyndi_incineratorinput"
+	},
+/turf/simulated/floor/engine/insulated,
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"cs" = (
+/obj/structure/cable,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/compressor{
+	comp_id = "syndie_lavaland_incineratorturbine";
+	dir = 1;
+	luminosity = 2
+	},
+/turf/simulated/floor/engine/insulated,
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"ct" = (
+/obj/structure/cable,
+/obj/machinery/power/turbine{
+	dir = 2;
+	luminosity = 2
+	},
+/turf/simulated/floor/engine/insulated,
+/area/ruin/unpowered/syndicate_lava_base/engineering)
+"cu" = (
+/obj/machinery/door/poddoor{
+	id_tag = "lavalandsyndi_incineratoroutput"
+	},
+/turf/simulated/floor/engine/insulated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "cA" = (
 /obj/structure/table/reinforced,
@@ -2872,12 +2918,6 @@
 "gj" = (
 /turf/simulated/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/virology)
-"gn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4395,6 +4435,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "ju" = (
@@ -5020,9 +5061,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "ky" = (
@@ -5040,9 +5078,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "kz" = (
@@ -5057,8 +5092,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/visible/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "kB" = (
@@ -5215,12 +5252,6 @@
 /obj/structure/sign/redcross,
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"kU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5755,13 +5786,11 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mj" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "O2 to Incinerator";
-	target_pressure = 4500
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "O2 to Incinerator"
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mn" = (
@@ -6619,17 +6648,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white/side,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"oe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/binary/dp_vent_pump/high_volume/on{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oh" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -6771,50 +6789,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"oz" = (
-/turf/simulated/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
-"oB" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1;
-	id = "syndie_lavaland_inc_in"
-	},
-/obj/structure/sign/vacuum/external{
-	pixel_y = -32
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
-"oE" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/compressor{
-	comp_id = "syndie_lavaland_incineratorturbine";
-	dir = 1;
-	luminosity = 2
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oF" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"oG" = (
-/obj/structure/cable,
-/obj/machinery/power/turbine{
-	dir = 2;
-	luminosity = 2
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
-"oH" = (
-/obj/machinery/door/poddoor{
-	id_tag = "lavalandsyndi_incineratorinput"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oP" = (
 /obj/structure/sign/chemistry,
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
@@ -6831,16 +6809,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"tW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
-"uB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6892,12 +6860,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"IJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "Lg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -6909,22 +6871,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Qt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
-"RE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "RI" = (
 /turf/simulated/wall/mineral/plastitanium/coated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "RV" = (
 /obj/structure/sign/fire,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "Tp" = (
@@ -6945,12 +6896,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Wv" = (
-/obj/machinery/door/poddoor{
-	id_tag = "lavalandsyndi_incineratoroutput"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 
 (1,1,1) = {"
 aa
@@ -8682,15 +8627,15 @@ jt
 jF
 jT
 ju
-gn
-IJ
-IJ
-IJ
-kU
-IJ
-IJ
-IJ
-uB
+ju
+ju
+ju
+ju
+Au
+ju
+ju
+RI
+RI
 RI
 RI
 RI
@@ -8739,10 +8684,10 @@ lL
 mg
 mF
 nc
-ju
-bh
 RI
-oz
+bg
+RI
+bQ
 RI
 RI
 nf
@@ -8789,13 +8734,13 @@ lM
 mh
 mG
 nd
-bg
-oe
-bj
 bf
-oE
-oG
-Wv
+bh
+bj
+cp
+cs
+ct
+cu
 ab
 ab
 ab
@@ -8839,10 +8784,10 @@ bF
 ca
 bL
 bO
-Qt
+yd
 bi
 yd
-oB
+cq
 RI
 RI
 nf
@@ -8889,10 +8834,10 @@ bG
 mj
 bM
 RV
-tW
-RE
 RI
-oH
+RI
+RI
+cr
 nf
 ab
 ab
@@ -9038,9 +8983,9 @@ Au
 kD
 bB
 ju
-RI
-RI
-RI
+ju
+ju
+ju
 RI
 ab
 ab

--- a/_maps/map_files/RandomZLevels/academy.dmm
+++ b/_maps/map_files/RandomZLevels/academy.dmm
@@ -1365,7 +1365,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/academy/classrooms)
 "dZ" = (
-/obj/machinery/igniter,
+/obj/machinery/igniter/on,
 /turf/simulated/floor/plating,
 /area/awaymission/academy/classrooms)
 "ea" = (
@@ -3718,7 +3718,7 @@
 /turf/space,
 /area/space/nearstation)
 "jz" = (
-/obj/machinery/igniter,
+/obj/machinery/igniter/on,
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
 "jA" = (

--- a/_maps/map_files/RandomZLevels/centcomAway.dmm
+++ b/_maps/map_files/RandomZLevels/centcomAway.dmm
@@ -5193,7 +5193,7 @@
 	},
 /area/awaymission/centcomAway/general)
 "mE" = (
-/obj/machinery/igniter,
+/obj/machinery/igniter/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "floor"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -74238,9 +74238,7 @@
 /area/toxins/test_area)
 "cCw" = (
 /obj/machinery/igniter{
-	icon_state = "igniter0";
-	id = "Incinerator";
-	on = 0
+	id = "Incinerator"
 	},
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/incinerator)
@@ -93941,9 +93939,7 @@
 	tag = ""
 	},
 /obj/machinery/igniter{
-	icon_state = "igniter0";
-	id = "gasturbine";
-	on = 0
+	id = "gasturbine"
 	},
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/turbine)

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -3499,7 +3499,7 @@
 /turf/unsimulated/wall,
 /area/tdome/arena)
 "jb" = (
-/obj/machinery/igniter,
+/obj/machinery/igniter/on,
 /turf/simulated/floor/plasteel,
 /area/tdome/arena)
 "jc" = (
@@ -4426,7 +4426,7 @@
 /turf/unsimulated/wall,
 /area/tdome/arena_source)
 "lD" = (
-/obj/machinery/igniter,
+/obj/machinery/igniter/on,
 /turf/simulated/floor/plasteel,
 /area/tdome/arena_source)
 "lE" = (

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -6,11 +6,14 @@
 	plane = FLOOR_PLANE
 	armor = list(melee = 50, bullet = 30, laser = 70, energy = 50, bomb = 20, bio = 0, rad = 0)
 	var/id = null
-	var/on = 1.0
-	anchored = 1.0
+	var/on = FALSE
+	anchored = TRUE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
+
+/obj/machinery/igniter/on
+	on = TRUE
 
 /obj/machinery/igniter/attack_ai(mob/user as mob)
 	return src.attack_hand(user)
@@ -51,8 +54,8 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "migniter"
 	var/id = null
-	var/disable = 0
-	var/last_spark = 0
+	var/disable = FALSE
+	var/last_spark = FALSE
 	var/base_state = "migniter"
 	anchored = 1
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -116,7 +116,7 @@
 				if(TURF_WET_PERMAFROST) // Permafrost
 					M.slip("the frosted floor", 0, 5, tilesSlipped = 1, walkSafely = 0, slipAny = 1)
 
-/turf/simulated/ChangeTurf(var/path)
+/turf/simulated/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
 	. = ..()
 	queue_smooth_neighbors(src)
 


### PR DESCRIPTION
**What does this PR do:**
This pull request:
- Fixes missing parameters on a ChangeTurf call.
- Makes it so incinerators now start off by default and adds a custom /on type (like other atmos-related machinery). All incinerators that started on in the past use the new on type.
- For the final time, fixes the incinerator (thanks for the help, @Allfd).

No changelog, as I don't think there's much point.
