### PR TITLE
Remove traces of the Mask of Nar'Sie

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1019,16 +1019,6 @@
 			return
 		holder.Topic(href, list("makeai"=href_list["makeai"]))
 
-	else if(href_list["makemask"])
-		if(!check_rights(R_SPAWN)) return
-		var/mob/currentMob = locateUID(href_list["makemask"])
-		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")	return
-		if(!currentMob)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-		holder.Topic(href, list("makemask"=href_list["makemask"]))
-
-
 	else if(href_list["setspecies"])
 		if(!check_rights(R_SPAWN))	return
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -167,7 +167,6 @@ var/global/nologevent = 0
 				body += "<B>Is an AI</B> "
 			else if(ishuman(M))
 				body += {"<A href='?_src_=holder;makeai=[M.UID()]'>Make AI</A> |
-					<A href='?_src_=holder;makemask=[M.UID()]'>Make Mask</A> |
 					<A href='?_src_=holder;makerobot=[M.UID()]'>Make Robot</A> |
 					<A href='?_src_=holder;makealien=[M.UID()]'>Make Alien</A> |
 					<A href='?_src_=holder;makeslime=[M.UID()]'>Make Slime</A> |

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1935,7 +1935,6 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	. += "---"
 	.["Set Species"] = "?_src_=vars;setspecies=[UID()]"
 	.["Make AI"] = "?_src_=vars;makeai=[UID()]"
-	.["Make Mask of Nar'sie"] = "?_src_=vars;makemask=[UID()]"
 	.["Make cyborg"] = "?_src_=vars;makerobot=[UID()]"
 	.["Make monkey"] = "?_src_=vars;makemonkey=[UID()]"
 	.["Make alien"] = "?_src_=vars;makealien=[UID()]"


### PR DESCRIPTION
**What does this PR do:**
Removes the final traces of the Mask of Nar'Sie. Seeing it in the view variables screen triggered my oldcult PTSD.

**Changelog:**
:cl: Markolie
del: The Mask of Nar'Sie transformation buttons have been removed, as the mask was removed a long time ago.
/:cl:

