### PR TITLE
cursed heart fix

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -36,7 +36,7 @@
 		if(8)
 			new /obj/item/organ/internal/brain/xeno(src)
 		if(9)
-			new /obj/item/organ/internal/heart/cursed(src)
+			new /obj/item/organ/internal/heart/cursed/wizard(src)
 		if(10)
 			new /obj/item/ship_in_a_bottle(src)
 		if(11)


### PR DESCRIPTION
**What does this PR do:**
The cursed heart you got from necropolis chests before was the incorrect type, this fixes that. Thanks Denthamos for pointing this out.

:cl: CornMyCob
fix: The cursed heart you get from necropolis chests is now the one that heals you.
/:cl:

