### PR TITLE
Copied the 'space-immunity' property from Vox to IPCs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -17,6 +17,14 @@
 	eyes = "blank_eyes"
 	brute_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
 	burn_mod = 2.28  // So they take 50% extra damage from brute/burn overall
+
+	warning_low_pressure = 50 // Copied Straight from the Vox
+	hazard_low_pressure = 0
+
+	cold_level_1 = 80 // Copied Straight from the Vox
+	cold_level_2 = 50
+	cold_level_3 = 0
+
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."


### PR DESCRIPTION
**What does this PR do:**
This PR makes IPC's space-proof. I believe IPC's should not be vulnerable to space. Not only does it not make any sense in the lore, it would make for an effective and appropriate buff to IPCs. The races that operate under New Crit have 2 to 3 times the effective health of an IPC. Rather than try to fix the lack of durability that is iconic to IPCs I purpose that IPCs should instead be buffed to become space-proof. I believe this would not effect the overall balance of combat and antagonists, but rather serve as another utility for IPCs, a utility that fits well with the overall high amount of conveniences IPC already trades for the ease at which they die.

**Changelog:**
:cl:
tweak: Copied the 'space-immunity' property from Vox to IPCs
/:cl:

I even wrote an entire essay on why I think this change would be appropriate on the Paradise Forums.
https://nanotrasen.se/forum/topic/16212-giving-ipcs-space-immunity/
