### PR TITLE
Donksoft Sniper Rifle now available in STORE! - The Punisher!

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1031,6 +1031,7 @@
 	contraband = list(/obj/item/gun/projectile/shotgun/toy/crossbow= 10,   //Congrats, you unlocked the +18 setting!
 					  /obj/item/gun/projectile/automatic/c20r/toy/riot = 10,
 					  /obj/item/gun/projectile/automatic/l6_saw/toy/riot = 10,
+  					  /obj/item/gun/projectile/automatic/sniper_rifle/toy = 10,
 					  /obj/item/ammo_box/foambox/riot = 20,
 					  /obj/item/toy/katana = 10,
 					  /obj/item/twohanded/dualsaber/toy = 5,

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -242,7 +242,8 @@
 				/obj/item/gun/projectile/automatic/toy/pistol/enforcer = 50,
 				/obj/item/gun/projectile/shotgun/toy = 50,
 				/obj/item/gun/projectile/shotgun/toy/crossbow = 50,
-				/obj/item/gun/projectile/shotgun/toy/tommygun = 50
+				/obj/item/gun/projectile/shotgun/toy/tommygun = 50,
+				/obj/item/gun/projectile/automatic/sniper_rifle/toy = 50
 				)
 
 


### PR DESCRIPTION
### Donksoft is pleased to announce our new product, the Donksoft Sniper Rifle is now available in various Stores!!!!!

![image](https://i.imgur.com/PJ3XY9j.png)
### With our matte plastic color coating it looks and feels just like the real deal! 

You can load it up with either our new Foam Force Sniper Darts, or the Donksoft Riot Control Sniper Foam Darts! 

Just load the magazine, and off you go! Nothing will stand in your way - not even your **Neighbour's cat**! Just look through our patented scope (no lenses included!) and shoot away.

### BUY TODAY AND RECEIVE A FREE MAGAZINE PRELOADED WITH OUR FINEST RIOT FOAM DARTS FOR FREE! CALL 555-2391-112 OR YOUR TRUSTED LOCAL RETAILER.

<br>
<br>
<br>

This PR adds the Donksoft Sniper Rifle into the spawnpool of the trader event, so it can be acquired in game. 
:cl:
add: Added the Donksoft sniper into the Trader spawnpool.
/:cl:

