### PR TITLE
Added warnings to the medbeam gun re: stream-crossing

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1351,7 +1351,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/medgun
 	name = "Medbeam Gun"
-	desc = "Medical Beam Gun, useful in prolonged firefights. DO NOT CROSS THE BEAMS. Crossing the beams or attaching two beams to one target will have explosive consequences."
+	desc = "Medical Beam Gun, useful in prolonged firefights. DO NOT CROSS THE BEAMS. Crossing beams with another medbeam or attaching two beams to one target will have explosive consequences."
 	item = /obj/item/gun/medbeam
 	reference = "MBG"
 	cost = 15

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1351,7 +1351,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/medgun
 	name = "Medbeam Gun"
-	desc = "Medical Beam Gun, useful in prolonged firefights."
+	desc = "Medical Beam Gun, useful in prolonged firefights. DO NOT CROSS THE BEAMS. Crossing the beams or attaching two beams to one target will have explosive consequences."
 	item = /obj/item/gun/medbeam
 	reference = "MBG"
 	cost = 15

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/medbeam
 	name = "Medical Beamgun"
-	desc = "Delivers medical nanites in a focused beam."
+	desc = "Delivers volatile medical nanites in a focused beam. Don't cross the beams!"
 	icon = 'icons/obj/chronos.dmi'
 	icon_state = "chronogun"
 	item_state = "chronogun"
@@ -92,6 +92,7 @@
 				return 0
 		for(var/obj/effect/ebeam/medical/B in turf)// Don't cross the str-beams!
 			if(B.owner != current_beam)
+				turf.visible_message("<span class='boldwarning'>The medbeams cross and EXPLODE!</span>")
 				explosion(B.loc,0,3,5,8)
 				qdel(dummy)
 				return 0


### PR DESCRIPTION
**What does this PR do:**
Adds several warnings to the medbeam gun in its description, both on examine and in the uplink.
Also throws a message to everyone who can see medbeams cross and explode when the aforementioned medbeams cross and explode,
Now you can yell at people to read the warning on the gun!

**Images of sprite/map changes (IF APPLICABLE):**
![image](https://user-images.githubusercontent.com/6721066/58933334-e154f000-8734-11e9-830c-8f7a2c1bfaad.png)


**Changelog:**
:cl:
tweak: Added explosion warnings to medbeams, because medbeams can cause explosions. DON'T CROSS THE BEAMS!
/:cl:

