### PR TITLE
Public Time & Security

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -369,7 +369,7 @@ var/world_topic_spam_protect_time = world.timeofday
 	if(config && config.server_tag_line)
 		s += "<br>[config.server_tag_line]"
 
-	s += "<br>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)], " + get_security_level()
+	s += "<br>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)], " + capitalize(get_security_level())
 
 	s += "<br>"
 	var/list/features = list()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -369,16 +369,13 @@ var/world_topic_spam_protect_time = world.timeofday
 	if(config && config.server_tag_line)
 		s += "<br>[config.server_tag_line]"
 
-	s += "<br>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)], " + capitalize(get_security_level())
+	if(SSticker && ROUND_TIME > 0)
+		s += "<br>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)], " + capitalize(get_security_level())
+	else
+		s += "<br><b>STARTING</b>"
 
 	s += "<br>"
 	var/list/features = list()
-
-	if(SSticker)
-		if(master_mode && master_mode != "secret")
-			features += master_mode
-	else
-		features += "<b>STARTING</b>"
 
 	if(!enter_allowed)
 		features += "closed"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -369,6 +369,8 @@ var/world_topic_spam_protect_time = world.timeofday
 	if(config && config.server_tag_line)
 		s += "<br>[config.server_tag_line]"
 
+	s += "<br>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)], " + get_security_level()
+
 	s += "<br>"
 	var/list/features = list()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -263,7 +263,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	..()
 	statpanel("Status")
 	if(client.statpanel == "Status")
-		show_stat_station_time()
 		show_stat_emergency_shuttle_eta()
 		stat(null, "Respawnability: [(src in GLOB.respawnable_list) ? "Yes" : "No"]")
 

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -95,7 +95,6 @@ I'm using this for Stat to give it a more nifty interface to work with
 	..()
 	if(has_synthetic_assistance())
 		statpanel("Status")
-		show_stat_station_time()
 		show_stat_emergency_shuttle_eta()
 
 		if(client.statpanel == "Status")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -162,8 +162,6 @@
 	stat(null, "Intent: [a_intent]")
 	stat(null, "Move Mode: [m_intent]")
 
-	show_stat_station_time()
-
 	show_stat_emergency_shuttle_eta()
 
 	if(client.statpanel == "Status")

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -156,7 +156,6 @@
 /mob/living/silicon/Stat()
 	..()
 	if(statpanel("Status"))
-		show_stat_station_time()
 		show_stat_emergency_shuttle_eta()
 		show_system_integrity()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -988,6 +988,9 @@ var/list/slot_equipment_priority = list( \
 
 	statpanel("Status") // Switch to the Status panel again, for the sake of the lazy Stat procs
 
+	if(client && client.statpanel == "Status" && SSticker)
+		show_stat_station_time()
+
 // this function displays the station time in the status panel
 /mob/proc/show_stat_station_time()
 	stat(null, "Round Time: [worldtime2text()]")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -136,8 +136,6 @@
 	..()
 
 	statpanel("Status")
-	if(client.statpanel == "Status" && SSticker)
-		show_stat_station_time()
 
 
 /mob/new_player/Topic(href, href_list[])


### PR DESCRIPTION
:cl: Kyep
add: Round time (h:mm) and station security level (green/red/blue/etc) are now visible on our server hub entry.
tweak: Round time is now visible to all player-controlled mobs in their status panel (including simple animals).
/:cl:

![time](https://user-images.githubusercontent.com/16434066/59179361-4a7f9d80-8b51-11e9-989f-a7710d1d1ad0.png)


Reasons:
- Helps people decide if they want to join the server or not (has the round just started, or about to end?)
- Makes our server hub entry more dynamic/informative, instead of always having the same text.
- Formatting omits 'h' 'm' and 'code' because its fairly obvious what they are, and because of the strict character limit of hub entries.