### PR TITLE
Gives lavaland syndie base a fax (+some small other changes)

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -6067,6 +6067,13 @@
 /obj/structure/sign/fire,
 /turf/simulated/wall/mineral/plastitanium/coated,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
+"ng" = (
+/obj/structure/table,
+/obj/machinery/photocopier/faxmachine/longrange/syndie{
+	department = "Syndicate Bioweapon Research Outpost"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nh" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -6827,10 +6834,6 @@
 "Au" = (
 /turf/simulated/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Bj" = (
-/obj/machinery/porta_turret/syndicate,
-/turf/simulated/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
 "BF" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -6873,13 +6876,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Ln" = (
-/obj/structure/table,
-/obj/machinery/photocopier/faxmachine/longrange/syndie{
-	department = "Syndicate Bioweapon Research Outpost"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7347,7 +7343,7 @@ ab
 ab
 ab
 mp
-Ln
+ng
 nk
 nI
 oi
@@ -8835,7 +8831,7 @@ hV
 ha
 ha
 ha
-Bj
+ha
 ha
 ju
 jJ

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1611,15 +1611,6 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/radio/headset/syndicate/alt{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/radio/headset/syndicate/alt,
-/obj/item/radio/headset/syndicate/alt{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
@@ -3538,6 +3529,10 @@
 /obj/machinery/alarm/syndicate{
 	pixel_y = 24
 	},
+/obj/item/radio/headset/syndicate/alt{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hN" = (
@@ -3562,6 +3557,10 @@
 /obj/item/ammo_box/magazine/m10mm,
 /obj/machinery/alarm/syndicate{
 	pixel_y = 24
+	},
+/obj/item/radio/headset/syndicate/alt{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -4480,6 +4479,10 @@
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
+/obj/item/radio/headset/syndicate/alt{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jB" = (
@@ -6824,6 +6827,10 @@
 "Au" = (
 /turf/simulated/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
+"Bj" = (
+/obj/machinery/porta_turret/syndicate,
+/turf/simulated/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered/syndicate_lava_base/main)
 "BF" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -6866,6 +6873,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
+"Ln" = (
+/obj/structure/table,
+/obj/machinery/photocopier/faxmachine/longrange/syndie{
+	department = "Syndicate Bioweapon Research Outpost"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7333,7 +7347,7 @@ ab
 ab
 ab
 mp
-mP
+Ln
 nk
 nI
 oi
@@ -8821,7 +8835,7 @@ hV
 ha
 ha
 ha
-ha
+Bj
 ha
 ju
 jJ

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -201,6 +201,9 @@
 		return FALSE
 	if(!Adjacent(user))
 		return FALSE
+	if(!allowed(user))
+		to_chat(user, "<span class='warning'>Access denied!</span>")
+		return FALSE
 	return TRUE
 
 /obj/machinery/syndicatebomb/proc/activate()
@@ -273,6 +276,7 @@
 /obj/machinery/syndicatebomb/self_destruct
 	name = "self destruct device"
 	desc = "Do not taunt. Warranty invalid if exposed to high temperature. Not suitable for agents under 3 years of age."
+	req_access = list(access_syndicate)
 	payload = /obj/item/bombcore/large
 	can_unanchor = FALSE
 	var/explosive_wall_group = EXPLOSIVE_WALL_GROUP_SYNDICATE_BASE // If set, this bomb will also cause explosive walls in the same group to explode

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2158,7 +2158,7 @@
 		var/obj/item/paper/P = new /obj/item/paper(null) //hopefully the null loc won't cause trouble for us
 
 		if(!fax)
-			var/list/departmentoptions = alldepartments + "All Departments"
+			var/list/departmentoptions = alldepartments + hidden_departments + "All Departments"
 			destination = input(usr, "To which department?", "Choose a department", "") as null|anything in departmentoptions
 			if(!destination)
 				qdel(P)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -11,6 +11,7 @@ var/global/list/fax_blacklist = list()
 	icon_state = "fax"
 	insert_anim = "faxsend"
 	var/fax_network = "Local Fax Network"
+	var/syndie_restricted = FALSE //is it a syndicate base fax restricted from contacting NT assets?
 
 	var/long_range_enabled = 0 // Can we send messages off the station?
 	req_one_access = list(access_lawyer, access_heads, access_armory)
@@ -47,6 +48,7 @@ var/global/list/fax_blacklist = list()
 /obj/machinery/photocopier/faxmachine/longrange/syndie
 	name = "syndicate long range fax machine"
 	emagged = TRUE
+	syndie_restricted = TRUE
 	req_one_access = list(access_syndicate)
 	//No point setting fax network, being emagged overrides that anyway.
 
@@ -167,6 +169,13 @@ var/global/list/fax_blacklist = list()
 			if(emagged)
 				combineddepartments += hidden_admin_departments.Copy()
 				combineddepartments += hidden_departments.Copy()
+
+			if(syndie_restricted)
+				combineddepartments = hidden_admin_departments.Copy()
+				combineddepartments += hidden_departments.Copy()
+				for(var/obj/machinery/photocopier/faxmachine/F in allfaxes)
+					if(F.emagged)//we can contact emagged faxes on the station
+						combineddepartments |= F.department
 
 			destination = input(usr, "To which department?", "Choose a department", "") as null|anything in combineddepartments
 			if(!destination)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -2,6 +2,7 @@ var/list/obj/machinery/photocopier/faxmachine/allfaxes = list()
 var/list/admin_departments = list("Central Command")
 var/list/hidden_admin_departments = list("Syndicate")
 var/list/alldepartments = list()
+var/list/hidden_departments = list()
 var/global/list/fax_blacklist = list()
 
 /obj/machinery/photocopier/faxmachine
@@ -35,13 +36,23 @@ var/global/list/fax_blacklist = list()
 
 /obj/machinery/photocopier/faxmachine/proc/update_network()
 	if(department != "Unknown")
-		if(!(("[department]" in alldepartments) || ("[department]" in admin_departments) || ("[department]" in hidden_admin_departments)))
+		if(!(("[department]" in alldepartments) || ("[department]" in hidden_departments) || ("[department]" in admin_departments) || ("[department]" in hidden_admin_departments)))
 			alldepartments |= department
 
 /obj/machinery/photocopier/faxmachine/longrange
 	name = "long range fax machine"
 	fax_network = "Central Command Quantum Entanglement Network"
 	long_range_enabled = 1
+
+/obj/machinery/photocopier/faxmachine/longrange/syndie
+	name = "syndicate long range fax machine"
+	emagged = TRUE
+	req_one_access = list(access_syndicate)
+	//No point setting fax network, being emagged overrides that anyway.
+
+/obj/machinery/photocopier/faxmachine/longrange/syndie/update_network()
+	if(department != "Unknown")
+		hidden_departments |= department
 
 /obj/machinery/photocopier/faxmachine/attack_hand(mob/user)
 	ui_interact(user)
@@ -119,7 +130,7 @@ var/global/list/fax_blacklist = list()
 			if((destination in admin_departments) || (destination in hidden_admin_departments))
 				send_admin_fax(usr, destination)
 			else
-				sendfax(destination,usr)
+				sendfax(destination, usr)
 
 			if(sendcooldown)
 				spawn(sendcooldown) // cooldown time
@@ -155,6 +166,7 @@ var/global/list/fax_blacklist = list()
 
 			if(emagged)
 				combineddepartments += hidden_admin_departments.Copy()
+				combineddepartments += hidden_departments.Copy()
 
 			destination = input(usr, "To which department?", "Choose a department", "") as null|anything in combineddepartments
 			if(!destination)


### PR DESCRIPTION
**What does this PR do:**
This PR contains 3 changes to the lavaland base:

1. This PR gives the syndicate comms agent an emagged, long-range fax machine. The primary purpose is to communicate with the syndicate itself, so this should help with events, or letting the admins know the base is getting looted and they should blow it up or whatever. ~~The fax can also be used to send faxes to the station in an attempt to sow further chaos and misinformation, though the lack of stamps should make those fakes not too convincing, so no faking CC communication unless they get visited by a traitor with a chameleon stamp.~~

Changed so the fax can't be used to fax the station, expect for emagged faxes.

Fax code has been adjusted so **only** emagged faxes see the lavaland base as a possible fax destination. This keeps station crew from faxing the outpost or knowing there is a base because it shows up in the list.

2. The syndicate headsets have been moved from the equipment room to the dorm rooms where syndies wake up. Grabbing a headset is a thing you very likely want to do so you can communicate with your buddies anyway. There are now 4 headsets instead of 3.

3. Syndicate access is now required to trigger the self destruction device, this means you have to at least kill one syndie before blowing it all up instead of just quietly sneaking in and out.


**Images of sprite/map changes (IF APPLICABLE):**
![lavaland1](https://user-images.githubusercontent.com/32099540/59032311-46f4c980-8866-11e9-97f0-f52ceaa53644.PNG)
(dead skrell not included)

**Changelog:**
:cl:
add: syndicate fax machine to lavaland syndie base.
tweak: syndicate lavaland base self destruct now requires syndie access.
tweak: moved headsets in lavaland syndie base.
/:cl:

