### PR TITLE
Explorer suits now will properly hide tails

### DIFF
--- a/code/modules/mining/explorer_gear.dm
+++ b/code/modules/mining/explorer_gear.dm
@@ -13,6 +13,7 @@
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
 	allowed = list(/obj/item/flashlight, /obj/item/tank, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
 	resistance_flags = FIRE_PROOF
+	hide_tail_by_species = list("Vox" , "Vulpkanin" , "Unathi" , "Tajaran")
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi',


### PR DESCRIPTION
**What does this PR do:**
This PR will hide tales when wearing a explorer suit since theres a special sprite to indictate theres a tail

**Changelog:**
:cl: Improvedname
fix: Explorer suits now properly hide tails
/:cl:

