### PR TITLE
You cannot combine eswords anymore, but you can buy them from your uplink now

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -534,6 +534,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/melee/energy/sword/saber
 	cost = 8
 
+/datum/uplink_item/dangerous/dsword
+	name = "double-bladed energy sword"
+	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be pocketed when inactive. Activating it produces a loud, distinctive noise, this one is doubled side and can reflect all energy projectiles"
+	reference = "DES"
+	item = /obj/item/twohanded/dualsaber
+	cost = 16
+
 /datum/uplink_item/dangerous/powerfist
 	name = "Power Fist"
 	desc = "The power-fist is a metal gauntlet with a built-in piston-ram powered by an external gas supply.\
@@ -1627,7 +1634,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CIB"
 	item = /obj/item/storage/box/cyber_implants/bundle
 	cost = 40
-	
+
 /datum/uplink_item/bundles_TC/medical
 	name = "Medical Bundle"
 	desc = "The support specialist: Aid your fellow operatives with this medical bundle. Contains a tactical medkit, \

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -175,23 +175,7 @@
 
 /obj/item/melee/energy/sword/saber/attackby(obj/item/W, mob/living/user, params)
 	..()
-	if(istype(W, /obj/item/melee/energy/sword/saber))
-		if(W == src)
-			to_chat(user, "<span class='notice'>You try to attach the end of the energy sword to... itself. You're not very smart, are you?</span>")
-			if(ishuman(user))
-				user.adjustBrainLoss(10)
-		else
-			to_chat(user, "<span class='notice'>You attach the ends of the two energy swords, making a single double-bladed weapon! You're cool.</span>")
-			var/obj/item/twohanded/dualsaber/newSaber = new /obj/item/twohanded/dualsaber(user.loc)
-			if(src.hacked) // That's right, we'll only check the "original" esword.
-				newSaber.hacked = 1
-				newSaber.item_color = "rainbow"
-			user.unEquip(W)
-			user.unEquip(src)
-			qdel(W)
-			qdel(src)
-			user.put_in_hands(newSaber)
-	else if(istype(W, /obj/item/multitool))
+	if(istype(W, /obj/item/multitool))
 		if(hacked == 0)
 			hacked = 1
 			item_color = "rainbow"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -94,8 +94,7 @@
 			return
 
 		if("darklord") // 22TC + two 0TC
-			new /obj/item/melee/energy/sword/saber/red(src) // 8TC
-			new /obj/item/melee/energy/sword/saber/red(src) // 8TC
+			new /obj/item/twohanded/dualsaber/red(src) // 16TC
 			new /obj/item/dnainjector/telemut/darkbundle(src) // 0TC
 			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src) // 0TC
 			new /obj/item/card/id/syndicate(src) // 2TC
@@ -108,7 +107,7 @@
 			new /obj/item/gun/projectile/automatic/sniper_rifle/syndicate/penetrator(src) // 16TC
 			new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src) // 5TC
 			new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src) // 3TC
-			new /obj/item/clothing/glasses/thermal/syndi/sunglasses(src) // 6TC 
+			new /obj/item/clothing/glasses/thermal/syndi/sunglasses(src) // 6TC
 			new /obj/item/clothing/gloves/combat(src) // 0 TC
 			new /obj/item/clothing/under/suit_jacket/really_black(src) // 0 TC
 			new /obj/item/clothing/suit/storage/lawyer/blackjacket/armored(src) // 0TC


### PR DESCRIPTION
**What does this PR do:**
This pr makes it so you can't combine two eswords for a dsword anymore.
But you can still buy one for 16 TC from you uplink.

The flexibility is really a issue because if you have two eswords found or not. you basically have a shield that deflects all energy projectiles

**Changelog:**
:cl: Improvedname
tweak: You can't combine eswords anymore, but you can buy them from your uplink for tc.
/:cl:

