### PR TITLE
Miner starter kits you can order from cargo will no longer include a ID that grants miner/cargo access, only the concription kits from mining vendor

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1366,7 +1366,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	name = "Shaft Miner Starter Kit"
 	cost = 30
 	access = access_qm
-	contains = list(/obj/item/storage/backpack/duffel/mining_conscript)
+	contains = list(/obj/item/storage/backpack/duffel/mining_conscript/noid)
 	containertype = /obj/structure/closet/crate/secure
 	containername = "shaft miner starter kit"
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -357,6 +357,21 @@
 	new /obj/item/ammo_box/magazine/m12g/buckshot(src)
 	new /obj/item/ammo_box/magazine/m12g/dragon(src)
 
+/obj/item/storage/backpack/duffel/mining_conscript/noid
+	name = "mining conscription kit"
+	desc = "A kit containing everything a crewmember needs to support a shaft miner in the field."
+
+/obj/item/storage/backpack/duffel/mining_conscript/noid/New()
+	..()
+	new /obj/item/pickaxe(src)
+	new /obj/item/clothing/glasses/meson(src)
+	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
+	new /obj/item/storage/bag/ore(src)
+	new /obj/item/clothing/under/rank/miner/lavaland(src)
+	new /obj/item/encryptionkey/headset_cargo(src)
+	new /obj/item/clothing/mask/gas(src)
+
+
 /obj/item/storage/backpack/duffel/syndie/ammo/smg
 	desc = "A large duffel bag, packed to the brim with C-20r magazines."
 


### PR DESCRIPTION
**What does this PR do:**
What this pr does is removing the miner access ID from the miner starter crate you can order from cargo. since some things should go trough HOP or lavaland mining team,

Mining can still get a conscription kit with ID from the vendor
Or you can get the access from the HOP

but why you may ask?
Well if you have a ordered a shaft miner kit for whatever reason, it basically grants you free cargo/mining access with a emagg or somoene who is clueless about the contents and open it.
and usually who wants to be a shaft miner goes to hop to for a job change anyways so usually the ID in the crate ends up being pointless

**Changelog:**
:cl: Improvedname
tweak: Cargo miner starter kit crate will no longer include a ID
/:cl:

