### PR TITLE
Removes space lube

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -635,7 +635,7 @@
 //////////////////////////////
 
 //Ultra-Lube: Meth
-/datum/reagent/lube/ultra
+/datum/reagent/ultralube
 	name = "Ultra-Lube"
 	id = "ultralube"
 	description = "Ultra-Lube is an enhanced lubricant which induces effect similar to Methamphetamine in synthetic users by drastically reducing internal friction and increasing cooling capabilities."

--- a/code/modules/reagents/chemistry/recipes/drinks.dm
+++ b/code/modules/reagents/chemistry/recipes/drinks.dm
@@ -718,7 +718,7 @@
 	name = "Synthanol"
 	id = "synthanol"
 	result = "synthanol"
-	required_reagents = list("lube" = 1, "plasma" = 1, "fuel" = 1)
+	required_reagents = list("water" = 1, "silicon" = 1, "oxygen" = 1, "plasma" = 1, "fuel" = 1)
 	result_amount = 3
 	mix_message = "The chemicals mix to create shiny, blue substance."
 	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -99,11 +99,11 @@
 	result_amount = 3
 	mix_message = "The mixture turns a rather unassuming color and settles."
 
-/datum/chemical_reaction/lube/ultra
+/datum/chemical_reaction/ultralube
 	name = "Ultra-Lube"
 	id = "ultralube"
 	result = "ultralube"
-	required_reagents = list("lube" = 2, "formaldehyde" = 1, "cryostylane" = 1)
+	required_reagents = list("water" = 1, "silicon" = 1, "oxygen" = 1, "formaldehyde" = 1, "cryostylane" = 1)
 	result_amount = 2
 	mix_message = "The mixture darkens and appears to partially vaporize into a chilling aerosol."
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -106,14 +106,6 @@
 	P.amount = 10
 	P.forceMove(get_turf(holder.my_atom))
 
-/datum/chemical_reaction/lube
-	name = "Space Lube"
-	id = "lube"
-	result = "lube"
-	required_reagents = list("water" = 1, "silicon" = 1, "oxygen" = 1)
-	result_amount = 3
-	mix_message = "The substance turns a striking cyan and becomes oily."
-
 /datum/chemical_reaction/holy_water
 	name = "Holy Water"
 	id = "holywater"
@@ -284,7 +276,7 @@
 	name = "Jestosterone"
 	id = "jestosterone"
 	result = "jestosterone"
-	required_reagents = list("blood" = 1, "sodiumchloride" = 1, "banana" = 1, "lube" = 1, "space_drugs" = 1) //Or one freshly-squeezed clown
+	required_reagents = list("blood" = 1, "sodiumchloride" = 1, "banana" = 1, "water" = 1, "silicon" = 1, "oxygen" = 1, "space_drugs" = 1) //Or one freshly-squeezed clown
 	min_temp = T0C + 100
 	result_amount = 5
 	mix_message = "The substance quickly shifts colour, cycling from red, to yellow, to green, to blue, and finally settles at a vibrant fuchsia."


### PR DESCRIPTION
**What does this PR do:**
am ded pls nerf.
Removes space lube reaction, cannot be made from chem dispenser but can still be found through other methods(admemery or whatever the heck), ultra lube no longer lubes tiles when you spill it on stuff it only serves as a IPC meth now. All other reactions that need space lube(jesterone and the rest) now use the three ingredients that used to be used to make lube(water silicon and oxygen)

**Changelog:**
:cl:
del: Space lube
/:cl:

