### PR TITLE
Idle warning component for NetraKyram

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -94,6 +94,12 @@
 	#define COMPONENT_NO_MOUSEDROP 1
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"			//from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 
+// /client signals
+#define COMSIG_CLIENT_MOVE "client_move"						//from base of client/Move: (atom/newloc, direct)
+
+// /datum/mind
+#define COMSIG_MIND_TRANSFER_TO "mind_transfer_to"				//from base of datum/mind/transfer_to: (mob/living/new_character)
+
 // /area signals
 #define COMSIG_AREA_ENTERED "area_entered" 						//from base of area/Entered(): (atom/movable/M)
 #define COMSIG_AREA_EXITED "area_exited" 							//from base of area/Exited(): (atom/movable/M)
@@ -142,6 +148,8 @@
 #define COMSIG_LIVING_EXTINGUISHED "living_extinguished"		//from base of mob/living/ExtinguishMob() (/mob/living)
 #define COMSIG_LIVING_ELECTROCUTE_ACT "living_electrocute_act"		//from base of mob/living/electrocute_act(): (shock_damage)
 #define COMSIG_LIVING_MINOR_SHOCK "living_minor_shock"			//sent by stuff like stunbatons and tasers: ()
+#define COMSIG_LIVING_LIFE "living_life"						//from base of mob/living/Life: (seconds, times_fired)
+
 
 //ALL OF THESE DO NOT TAKE INTO ACCOUNT WHETHER AMOUNT IS 0 OR LOWER AND ARE SENT REGARDLESS!
 #define COMSIG_LIVING_STATUS_STUN "living_stun"					//from base of mob/living/Stun() (amount, update, ignore)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -43,6 +43,7 @@
 	Note that this proc can be overridden, and is in the case of screen objects.
 */
 /atom/Click(location,control,params)
+	SEND_SIGNAL(usr, COMSIG_CLICK, location, control, params, src)
 	usr.ClickOn(src, params)
 /atom/DblClick(location,control,params)
 	usr.DblClickOn(src,params)

--- a/code/datums/components/idle_warning.dm
+++ b/code/datums/components/idle_warning.dm
@@ -1,0 +1,56 @@
+/datum/component/idle_warning
+    var/last_action_timer // Last time stamp of which the user did something
+    var/ahelp_text // Text to send to the admins if the person goes AFK
+    var/time // Time it takes to be AFK to send an ahelp
+    var/warning_given = FALSE
+
+/datum/component/idle_warning/Initialize(ahelp_message_text, send_time)
+    var/mob/living/M = parent
+    if(!istype(M) || !M.mind) //Something went wrong
+        return COMPONENT_INCOMPATIBLE
+    ahelp_text = ahelp_message_text
+    time = send_time
+    RegisterSignal(M, COMSIG_CLICK, .proc/activity)
+    RegisterSignal(M, COMSIG_LIVING_LIFE, .proc/life)
+    RegisterSignal(M, COMSIG_CLIENT_MOVE, .proc/activity)
+    RegisterSignal(M.mind, COMSIG_MIND_TRANSFER_TO, .proc/transfer_mind)
+    last_action_timer = start_watch() // Reset the timer
+    addtimer(CALLBACK(GLOBAL_PROC, .proc/StartUpWarning, M, time), 30)
+
+/datum/component/idle_warning/PostTransfer()
+    return 0
+
+/datum/component/idle_warning/proc/StartUpWarning(mob/M, time)
+    to_chat(M, "<span class='warning'>Idle Warning component loaded in. Timer before sending an ahelp is set to [time] seconds. Clicking ingame and moving around will reset the timer.</span>")
+
+/datum/component/idle_warning/proc/activity()
+    var/cur_time = start_watch()
+    if(cur_time < last_action_timer)
+        var/mob/living/M = parent
+        sendMorAhelp(M.client, "(Automated message from the idle_warning component): The user returned to the game", "Adminhelp")
+    last_action_timer = cur_time // Reset the timer
+    warning_given = FALSE
+
+/datum/component/idle_warning/proc/life()
+    var/mob/living/M = parent
+    if(!istype(M))
+        return
+    if(M.stat == DEAD || !M.mind || M.player_ghosted || M.get_ghost(TRUE))
+        last_action_timer = start_watch()
+        return
+    var/d = stop_watch(last_action_timer)
+    if(d >= time)
+        sendMorAhelp(M.client, "(Automated message from the idle_warning component): [ahelp_text]", "Adminhelp")
+        last_action_timer = INFINITY // Only send once
+    else if(!warning_given && d >= 0.8 * time)
+        warning_given = TRUE
+        to_chat(parent, "<span class='danger'>You've been AFK for [d] seconds. After [time] seconds the system will send an Ahelp. Please move or click somewhere on the screen</span>")
+        parent << 'sound/effects/adminhelp.ogg'
+        window_flash(M.client)
+
+/datum/component/idle_warning/proc/transfer_mind(datum/mind/mind, mob/new_mob)
+    UnregisterSignal(parent, list(COMSIG_CLICK, COMSIG_LIVING_LIFE, COMSIG_CLIENT_MOVE))
+    RegisterSignal(new_mob, COMSIG_CLICK, .proc/activity)
+    RegisterSignal(new_mob, COMSIG_LIVING_LIFE, .proc/life)
+    RegisterSignal(new_mob, COMSIG_CLIENT_MOVE, .proc/activity)
+    new_mob.TakeComponent(src)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -99,6 +99,7 @@
 	if(!istype(new_character))
 		log_runtime(EXCEPTION("transfer_to(): Some idiot has tried to transfer_to() a non mob/living mob."), src)
 	if(current)					//remove ourself from our old body's mind variable
+		SEND_SIGNAL(src, COMSIG_MIND_TRANSFER_TO, new_character)
 		current.mind = null
 		leave_all_huds() //leave all the huds in the old body, so it won't get huds if somebody else enters it
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -2,6 +2,8 @@
 	set invisibility = 0
 	set background = BACKGROUND_ENABLED
 
+	SEND_SIGNAL(src, COMSIG_LIVING_LIFE, seconds, times_fired)
+
 	if(notransform)
 		return FALSE
 	if(!loc)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -163,6 +163,8 @@
 	if(mob.notransform)
 		return 0 //This is sota the goto stop mobs from moving var
 
+	SEND_SIGNAL(mob, COMSIG_CLIENT_MOVE, n, direct)
+
 	if(mob.control_object)
 		return Move_object(direct)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -555,6 +555,8 @@
 			new_character.rename_self("mime")
 		mind.original = new_character
 		mind.transfer_to(new_character)					//won't transfer key since the mind is not active
+		if(key == "NetraKyram") // TODO make this modular using the DB
+			new_character.AddComponent(/datum/component/idle_warning, "This player has narcolepsy and might have fallen asleep due to it. This is a medical condition that they cannot control. They request that you cryo them.", 600)
 
 
 	new_character.key = key		//Manually transfer the key to log them in

--- a/paradise.dme
+++ b/paradise.dme
@@ -272,6 +272,7 @@
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\decal.dm"
 #include "code\datums\components\ducttape.dm"
+#include "code\datums\components\idle_warning.dm"
 #include "code\datums\components\jestosterone.dm"
 #include "code\datums\components\material_container.dm"
 #include "code\datums\components\squeak.dm"


### PR DESCRIPTION
**What does this PR do:**
This component is made for people with medical conditions like narcolepsy. They can suddenly due to the condition not play the game without them being able to prevent it or see it coming.
The component will send an ahelp after a given time saying a custom text.
This component won't affect others who don't require it. It is coded to be the least amount of snowflake.

Currently I've only implemented this for NetraKyram. The next step would be to make this modular using the DB.

Why? So people with medical conditions can still play the game like normal.

**Changelog:**
:cl:
add: Added an Idle warning component. See the PR for more info.
/:cl:

