### PR TITLE
Terror Spider Intent Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -202,7 +202,7 @@ var/global/list/ts_spiderling_list = list()
 		var/obj/machinery/door/airlock/A = target
 		if(A.density)
 			try_open_airlock(A)
-	else if(isliving(target))
+	else if(isliving(target) && (!client || a_intent == INTENT_HARM))
 		var/mob/living/G = target
 		if(issilicon(G))
 			G.attack_animal(src)


### PR DESCRIPTION
:cl: Kyep
fix: Terror Spiders no longer trigger their special attack when nuzzling someone on help intent.
/:cl:

Applies the same fix from https://github.com/ParadiseSS13/Paradise/pull/10432 to Terror Spiders.