### PR TITLE
Reduce Say/Emote Chat Spam

### DIFF
--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -2,18 +2,18 @@
 /client/verb/toggle_ghost_ears()
 	set name = "Show/Hide GhostEars"
 	set category = "Preferences"
-	set desc = ".Toggle Between seeing all mob speech, and only speech of nearby mobs"
+	set desc = ".Toggle between seeing all player mob speech, and only speech of nearby mobs"
 	prefs.toggles ^= CHAT_GHOSTEARS
-	to_chat(src, "As a ghost, you will now [(prefs.toggles & CHAT_GHOSTEARS) ? "see all speech in the world" : "only see speech from nearby mobs"].")
+	to_chat(src, "As a ghost, you will now [(prefs.toggles & CHAT_GHOSTEARS) ? "see all player speech in the world" : "only see speech from nearby mobs"].")
 	prefs.save_preferences(src)
 	feedback_add_details("admin_verb","TGE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/toggle_ghost_sight()
 	set name = "Show/Hide GhostSight"
 	set category = "Preferences"
-	set desc = ".Toggle Between seeing all mob emotes, and only emotes of nearby mobs"
+	set desc = ".Toggle between seeing all player mob emotes, and only emotes of nearby mobs"
 	prefs.toggles ^= CHAT_GHOSTSIGHT
-	to_chat(src, "As a ghost, you will now [(prefs.toggles & CHAT_GHOSTSIGHT) ? "see all emotes in the world" : "only see emotes from nearby mobs"].")
+	to_chat(src, "As a ghost, you will now [(prefs.toggles & CHAT_GHOSTSIGHT) ? "see all player emotes in the world" : "only see emotes from nearby mobs"].")
 	prefs.save_preferences(src)
 	feedback_add_details("admin_verb","TGS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -61,15 +61,16 @@
  //Hearing gasp and such every five seconds is not good emotes were not global for a reason.
  // Maybe some people are okay with that.
 
-		for(var/mob/M in GLOB.player_list)
-			if(!M.client)
-				continue //skip monkeys and leavers
-			if(istype(M, /mob/new_player))
-				continue
-			if(findtext(message," snores.")) //Because we have so many sleeping people.
-				break
-			if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
-				M.show_message(message)
+		if(client)
+			for(var/mob/M in GLOB.player_list)
+				if(!M.client)
+					continue //skip monkeys and leavers
+				if(istype(M, /mob/new_player))
+					continue
+				if(findtext(message," snores.")) //Because we have so many sleeping people.
+					break
+				if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
+					M.show_message(message)
 
 
 		// Type 1 (Visual) emotes are sent to anyone in view of the item

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -930,11 +930,12 @@
  //Hearing gasp and such every five seconds is not good emotes were not global for a reason.
  // Maybe some people are okay with that.
 
-		for(var/mob/M in GLOB.dead_mob_list)
-			if(!M.client || istype(M, /mob/new_player))
-				continue //skip monkeys, leavers and new players
-			if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
-				M.show_message(message)
+		if(client)
+			for(var/mob/M in GLOB.dead_mob_list)
+				if(!M.client || istype(M, /mob/new_player))
+					continue //skip monkeys, leavers and new players
+				if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
+					M.show_message(message)
 
 		switch(m_type)
 			if(1)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -290,12 +290,13 @@ proc/get_radio_key_from_channel(var/channel)
 	if(act && type && message) //parent call
 		log_emote(message, src)
 
-		for(var/mob/M in GLOB.dead_mob_list)
-			if(!M.client || istype(M, /mob/new_player))
-				continue //skip monkeys, leavers and new players //who the hell knows why new players are in the dead mob list
+		if(client)
+			for(var/mob/M in GLOB.dead_mob_list)
+				if(!M.client || istype(M, /mob/new_player))
+					continue //skip monkeys, leavers and new players //who the hell knows why new players are in the dead mob list
 
-			if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
-				M.show_message(message)
+				if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
+					M.show_message(message)
 
 		switch(type)
 			if(1) //Visible
@@ -392,11 +393,12 @@ proc/get_radio_key_from_channel(var/channel)
 			hearturfs += get_turf(L)
 
 	//ghosts
-	for(var/mob/M in GLOB.dead_mob_list)	//does this include players who joined as observers as well?
-		if(!M.client)
-			continue
-		if(M.stat == DEAD && M.client && M.get_preference(CHAT_GHOSTEARS))
-			listening |= M
+	if(client)
+		for(var/mob/M in GLOB.dead_mob_list)	//does this include players who joined as observers as well?
+			if(!M.client)
+				continue
+			if(M.stat == DEAD && M.client && M.get_preference(CHAT_GHOSTEARS))
+				listening |= M
 
 	// This, in tandem with "hearturfs", lets nested mobs hear whispers that are in range
 	// Grifted from saycode above.


### PR DESCRIPTION
:cl: Kyep
tweak: GhostSight and GhostEars no longer show you speech/emotes from far away NPCs. This prevents ghosts (especially admins) from being spammed so hard by NPCs (e.g: monkeys dying in xenobio) that they have to turn off ghostears/ghostsight entirely.
/:cl:

The sort of thing that this is designed to stop:
Unknown gasps!
Unknown collapses!
Unknown gasps!x3
Unknown moans!
Unknown gasps!
...etc.