### PR TITLE
Removes pipe dispensers from atmospherics

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -27867,11 +27867,6 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"bat" = (
-/obj/machinery/pipedispenser,
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "bau" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
@@ -28740,11 +28735,6 @@
 "bbT" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"bbU" = (
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bbV" = (
@@ -142588,9 +142578,9 @@ aUd
 aVM
 aXq
 aYI
-bat
-bbU
-bat
+bhp
+bhp
+bhp
 beO
 aXn
 bhk

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -61914,7 +61914,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
-/obj/machinery/pipedispenser/disposal,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -62864,7 +62863,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cdq" = (
-/obj/machinery/pipedispenser,
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/atmos)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -22927,6 +22927,9 @@
 /turf/simulated/wall,
 /area/maintenance/fpmaint2)
 "aPd" = (
+/obj/machinery/light_switch{
+	pixel_y = 27
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -74735,6 +74738,10 @@
 /obj/machinery/light_switch{
 	pixel_y = 27
 	},
+/obj/machinery/alarm{
+	frequency = 1439;
+	pixel_y = 23
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -81707,12 +81714,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"cPR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cPS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
@@ -81824,14 +81825,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"cQd" = (
-/obj/machinery/alarm{
-	frequency = 1439;
-	pixel_y = 23
-	},
-/obj/machinery/pipedispenser,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cQe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4;
@@ -82241,10 +82234,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"cQQ" = (
-/obj/machinery/pipedispenser/disposal,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "cQR" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -83066,10 +83055,6 @@
 	},
 /area/toxins/xenobiology)
 "cSd" = (
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"cSe" = (
-/obj/structure/closet/wardrobe/atmospherics_yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cSf" = (
@@ -86427,7 +86412,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXP" = (
@@ -96313,19 +96297,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/item/pipe_painter,
-/obj/item/pipe_painter,
+/obj/structure/closet/wardrobe/atmospherics_yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dtk" = (
@@ -96550,6 +96522,14 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"lLC" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "mMw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -96677,6 +96657,17 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/constructionsite)
+"wOS" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pipe_painter,
+/obj/item/pipe_painter,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/turf/simulated/floor/plasteel,
+/area/atmos)
 "wVD" = (
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
@@ -129032,7 +129023,7 @@ cSd
 cOF
 cTk
 dfF
-dtn
+wOS
 dcq
 dcq
 dcq
@@ -129289,8 +129280,8 @@ cSd
 cSd
 cWT
 cXQ
-dtn
-dtn
+cSd
+lLC
 cXO
 dbK
 dct
@@ -129798,7 +129789,7 @@ cGK
 cDi
 cSd
 cSd
-cPR
+cPT
 cQS
 cEr
 cTq
@@ -130052,10 +130043,10 @@ cJc
 cJN
 csK
 cZS
-cQd
-cQQ
-cSe
-cPT
+dtn
+dtn
+dtn
+dtn
 cFG
 cVJ
 cWO


### PR DESCRIPTION
**What does this PR do:**
Removes pipe dispensers from atmospherics. It ONLY removes the ones in atmos, and keeps them elsewhere (e.g. engineering secure storage, engineering outpost, construction site). Farewell, you have been a right pain in the ass to use

**Why?**
Because virtually nobody uses these any more and they are a faff to get rid of.

**Images of sprite/map changes (IF APPLICABLE):**
Box:
![image](https://user-images.githubusercontent.com/18459142/59556413-10335780-8fba-11e9-962f-24d7710c2b8e.png) to ![image](https://user-images.githubusercontent.com/18459142/59641375-33e0d400-9159-11e9-877d-2a84293f056f.png)


Meta:
![image](https://user-images.githubusercontent.com/18459142/59556400-e5490380-8fb9-11e9-9564-0bdc0822ee7a.png) to ![image](https://user-images.githubusercontent.com/18459142/59556397-dbbf9b80-8fb9-11e9-8809-af74a6d4b3e3.png)

Delta:
![image](https://user-images.githubusercontent.com/18459142/59556386-c21e5400-8fb9-11e9-9224-662dbbc8230d.png) to ![image](https://user-images.githubusercontent.com/18459142/59556393-cfd3d980-8fb9-11e9-852c-e8f92d1f31fd.png)

:cl:
del: Removes the big pipe dispensers from atmospherics, you can still find them elsewhere.
/:cl: