### PR TITLE
Add Jaws of Life to Paramedic locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -142,3 +142,4 @@
 	new /obj/item/clothing/suit/storage/paramedic(src)
 	new /obj/item/tank/emergency_oxygen/engi(src)
 	new /obj/item/tank/emergency_oxygen/engi(src)
+	new /obj/item/crowbar/power(src)


### PR DESCRIPTION
**What does this PR do:**
Adds the Jaws of Life to the Paramedic locker to allow for quick entry in emergencies where every second counts

credit to Mischievous#3759 for the idea

if merged, Space Law should have an exception for Paramedics responding to medical emergencies.

:cl:
add: Paramedic's Locker now has the Jaws of Life
/ :cl: