### PR TITLE
Vampire Tweaks

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -183,10 +183,8 @@
 				to_chat(target, "<span class='notice'>[user]'s feeble gaze is ineffective.</span>")
 			else
 				to_chat(user, "<span class='warning'>Your piercing gaze knocks out [target].</span>")
-				to_chat(target, "<span class='warning'>You find yourself unable to move and barely able to speak.</span>")
-				target.Weaken(10)
-				target.Stun(10)
-				target.stuttering = 10
+				to_chat(target, "<span class='warning'>You begin to notice your consciousness fading</span>")
+				target.AdjustSleeping(10)
 		else
 			revert_cast(usr)
 			to_chat(usr, "<span class='warning'>You broke your gaze.</span>")
@@ -216,6 +214,10 @@
 	stat_allowed = 1
 
 /obj/effect/proc_holder/spell/vampire/mob_aoe/glare/cast(list/targets, mob/user = usr)
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		revert_cast(user)
+		return 0
 	user.visible_message("<span class='warning'>[user]'s eyes emit a blinding flash!</span>")
 	if(istype(user:glasses, /obj/item/clothing/glasses/sunglasses/blindfold))
 		to_chat(user, "<span class='warning'>You're blindfolded!</span>")
@@ -266,10 +268,9 @@
 		if(!affects(C))
 			continue
 		to_chat(C, "<span class='warning'><font size='3'><b>You hear a ear piercing shriek and your senses dull!</font></b></span>")
-		C.Weaken(4)
 		C.MinimumDeafTicks(20)
 		C.Stuttering(20)
-		C.Stun(4)
+		C.AdjustConfused(20)
 		C.Jitter(150)
 	for(var/obj/structure/window/W in view(4))
 		W.deconstruct(FALSE)
@@ -413,9 +414,16 @@
 	centcom_cancast = 0
 	var/jaunt_duration = 50 //in deciseconds
 
-/obj/effect/proc_holder/spell/vampire/self/jaunt/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/vampire/self/jaunt/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(user.buckled)
 		user.buckled.unbuckle_mob()
+	if(user.handcuffed)
+		var/obj/O = user.get_item_by_slot(slot_handcuffed)
+		if(!istype(O))
+			return FALSE
+		user.unEquip(O)
+		O.forceMove(get_turf(user))
+		visible_message("<span class= 'warning'>You hear a CLANG as the handcuffs fall to the ground</span>")
 	spawn(0)
 		var/mob/living/U = user
 		var/originalloc = get_turf(user.loc)
@@ -502,7 +510,7 @@
 
 	perform(turfs, user = user)
 
-/obj/effect/proc_holder/spell/vampire/shadowstep/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/vampire/shadowstep/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(usr.buckled)
 		user.buckled.unbuckle_mob()
 	spawn(0)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -214,10 +214,6 @@
 	stat_allowed = 1
 
 /obj/effect/proc_holder/spell/vampire/mob_aoe/glare/cast(list/targets, mob/user = usr)
-	if(user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		revert_cast(user)
-		return 0
 	user.visible_message("<span class='warning'>[user]'s eyes emit a blinding flash!</span>")
 	if(istype(user:glasses, /obj/item/clothing/glasses/sunglasses/blindfold))
 		to_chat(user, "<span class='warning'>You're blindfolded!</span>")

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -413,13 +413,6 @@
 /obj/effect/proc_holder/spell/vampire/self/jaunt/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(user.buckled)
 		user.buckled.unbuckle_mob()
-	if(user.handcuffed)
-		var/obj/O = user.get_item_by_slot(slot_handcuffed)
-		if(!istype(O))
-			return FALSE
-		user.unEquip(O)
-		O.forceMove(get_turf(user))
-		visible_message("<span class= 'warning'>You hear a CLANG as the handcuffs fall to the ground</span>")
 	spawn(0)
 		var/mob/living/U = user
 		var/originalloc = get_turf(user.loc)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -344,6 +344,9 @@
 		if(issmall(target) && !target.ckey) //Monkeyized humans are okay, humanized monkeys are okay, NPC monkeys are not.
 			to_chat(user, "<span class='warning'>Blood from a monkey is useless!</span>")
 			return
+		if(!target.ckey)
+			to_chat(user, "<span class='warning'>Blood from a monkey is useless!</span>")
+			return
 		//we're good to suck the blood, blaah
 		user.mind.vampire.handle_bloodsucking(target)
 		add_attack_logs(user, target, "vampirebit")


### PR DESCRIPTION
**What does this PR do:**
A few vampire balance tweaks, vampire screech now inflicts confusion instead of stunning everyone in range the idea here is to keep it as a last resort tool to get away but make the power more of a defensive power. Also hypnotize puts targets to sleep instead of just being a longer stun

**Changelog:**
:cl:
tweak: Vampire screech now confuses everyone in the area instead of stunning them
tweak: Hypnotize actually puts targets to sleep now
tweak: Can no longer drain humanized monkeys
/:cl:

