### PR TITLE
Fixed a bug that prevented Catwalks and Lattice from returning materials

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -39,8 +39,7 @@
 		return T.attackby(C, user) //hand this off to the turf instead (for building plating, catwalks, etc)
 
 /obj/structure/lattice/deconstruct(disassembled = TRUE)
-	if(!can_deconstruct)
-		new /obj/item/stack/rods(get_turf(src), number_of_rods)
+	new /obj/item/stack/rods(get_turf(src), number_of_rods)
 	qdel(src)
 
 /obj/structure/lattice/blob_act()


### PR DESCRIPTION
**What does this PR do:**
Fixes #11775

**Changelog:**
fix: Fixed a bug that caused Catwalks and Lattice to not return metal rods when cut.
/:cl:

