### PR TITLE
Allows player controlled mice to suicide

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -232,7 +232,7 @@
 
 /mob/living/simple_animal/mouse/verb/suicide()
 	set hidden = 1
-	if(stat == 2)
+	if(stat == DEAD)
 		to_chat(src, "You're already dead!")
 		return
 	if(suiciding)
@@ -242,6 +242,6 @@
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")
-		suiciding = 1
+		suiciding = TRUE
 		visible_message("<span class='danger'>[src] is playing dead permanently! It looks like [p_theyre()] trying to commit suicide.</span>")
 		adjustOxyLoss(max(100 - getBruteLoss(100), 0))

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -243,5 +243,5 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
-		to_chat(viewers(src), "<span class='danger'>[src] is playing dead permanently! It looks like [p_theyre()] trying to commit suicide.</span>")
+		visible_message("<span class='danger'>[src] is playing dead permanently! It looks like [p_theyre()] trying to commit suicide.</span>")
 		adjustOxyLoss(max(100 - getBruteLoss(100), 0))

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -229,3 +229,19 @@
 		setCloneLoss(100, FALSE)
 
 		updatehealth()
+
+/mob/living/simple_animal/mouse/verb/suicide()
+	set hidden = 1
+	if(stat == 2)
+		to_chat(src, "You're already dead!")
+		return
+	if(suiciding)
+		to_chat(src, "You're already committing suicide! Be patient!")
+		return
+
+	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+
+	if(confirm == "Yes")
+		suiciding = 1
+		to_chat(viewers(src), "<span class='danger'>[src] is playing dead permanently! It looks like [p_theyre()] trying to commit suicide.</span>")
+		adjustOxyLoss(max(100 - getBruteLoss(100), 0))


### PR DESCRIPTION
**What does this PR do:**
Allows player controlled mice to use the suicide verb. Handy for if you spawn as a mouse in an area you cannot get out of (cough solar vents), and don't want to get stuck ghosting while alive. Tested to work.

**Changelog:**
:cl:
add: Mouse suicide
/:cl:

