### PR TITLE
Water turf runtime fix

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -23,12 +23,11 @@
 /turf/simulated/proc/burn_tile()
 	return
 
-/turf/simulated/proc/water_act(volume, temperature, source)
+/turf/simulated/water_act(volume, temperature, source)
+	. = ..()
+	
 	if(volume >= 3)
 		MakeSlippery()
-
-	for(var/mob/living/carbon/slime/M in src)
-		M.apply_water()
 
 	var/hotspot = (locate(/obj/effect/hotspot) in src)
 	if(hotspot)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -509,3 +509,7 @@
 
 /turf/AllowDrop()
 	return TRUE
+
+/turf/proc/water_act(volume, temperature, source)
+	for(var/mob/living/carbon/slime/M in src)
+		M.apply_water()


### PR DESCRIPTION
**What does this PR do:**
Fixed a runtime with water_act on turfs. Slimes now also properly take water damage in space and on unsimulated turfs as a result of this.

**Changelog:**
:cl: Markolie
fix: Fixed an issue where slimes wouldn't take damage from water in space.
/:cl:

