### PR TITLE
Survival pod storage wrench fix

### DIFF
--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -238,6 +238,9 @@
 /obj/machinery/smartfridge/survival_pod/accept_check(obj/item/O)
 	return isitem(O)
 
+/obj/machinery/smartfridge/survival_pod/default_unfasten_wrench()
+	return FALSE
+
 /obj/machinery/smartfridge/survival_pod/empty
 	name = "dusty survival pod storage"
 	desc = "A heated storage unit. This one's seen better days."


### PR DESCRIPTION
**What does this PR do:**
Fixes https://github.com/ParadiseSS13/Paradise/issues/11799.

**Changelog:**
:cl: Markolie
fix: It is no longer possible to unanchor the surivval pod storage units.
/:cl:

