### PR TITLE
Fix autocomplete input mishandling single quotes

### DIFF
--- a/code/datums/helper_datums/input.dm
+++ b/code/datums/helper_datums/input.dm
@@ -141,6 +141,11 @@
 	..()
 	popup.add_script("autocomplete.js", 'html/browser/autocomplete.js')
 
+	for(var/i=1, i <= choices.len, i++)
+		var/C = choices[choices[i]]
+		choices[i] = url_encode(choices[i], TRUE)
+		choices[choices[i]] = C
+
 /datum/async_input/autocomplete/render_prompt()
 	return "<label for='input'>[prompt]</label>"
 
@@ -162,6 +167,8 @@
 		// Entering an invalid choice is the same as canceling
 		if(href_list["submit"] in choices)
 			result = href_list["submit"]
+		else if(url_encode(href_list["submit"], TRUE) in choices)
+			result = url_encode(href_list["submit"], TRUE)
 		close()
 		return
 

--- a/html/browser/autocomplete.js
+++ b/html/browser/autocomplete.js
@@ -15,14 +15,6 @@ function updateTopic() {
   submitButton.setAttribute('href', hrefList.join(';'));
 }
 
-function clean(name) {
-  // \improper shows up as 2 characters outside of ascii range
-  if (name.charCodeAt(0) > 127) {
-    return name.slice(2);
-  }
-  return name;
-}
-
 function setElements() {
   input = $('#input');
   submitButton = $('#submit-button');
@@ -35,7 +27,7 @@ function setElements() {
 
   for (var i = 0; i < choices.options.length; i++) {
     var name = choices.options[i].value;
-    var cleaned = clean(name);
+    var cleaned = decodeURI(name);
     optionsMap[cleaned] = name;
     choices.options[i].value = cleaned;
   }


### PR DESCRIPTION
**What does this PR do:**
Fixes #11803

Credit to the peeps on that issue for pinpointing the problem.

**Changelog:**
:cl: Tayyyyyyy
fix: autocomplete input mishandling single quotes (you can teleport to Wizard's den now)
/:cl:

