### PR TITLE
Randomized ERT priority + drag and drop role selection

### DIFF
--- a/code/datums/helper_datums/input.dm
+++ b/code/datums/helper_datums/input.dm
@@ -100,15 +100,20 @@
 	height = 400
 	immediate_submit = TRUE
 
+/datum/async_input/ranked/New()
+	..()
+	popup.add_script("rankedInput.js", 'html/browser/rankedInput.js')
+	popup.add_head_content("<title>Drag and drop or use the buttons to reorder</title>")
+
 /datum/async_input/ranked/render_choices()
 	var/dat = "<div>"
-	dat += "<table style='margin: auto; text-align: left;'>"
+	dat += "<table id='choices' uid=[UID()] style='margin: auto; text-align: left;'>"
 	for(var/i = 1, i <= choices.len, i++)
 		var/choice = choices[i]
 		dat += "<tr>"
 		dat += "<td>[button("+", i != 1 ? "upvote=[i]" : "", , i == 1)]</td>"
 		dat += "<td>[button("-", i != choices.len ? "downvote=[i]" : "", , i == choices.len)]</td>"
-		dat += "<td>[i]. [choice]</td>"
+		dat += "<td style='cursor: move;' index='[i]'  ondrop='drop(event)' ondragover='allowDrop(event)' draggable='true' ondragstart='drag(event)'>[i]. [choice]</td>"
 		dat += "</tr>"
 	dat += "</table>"
 	dat += "</div>"
@@ -128,6 +133,15 @@
 	if(href_list["downvote"])
 		var/index = text2num(href_list["downvote"])
 		choices.Swap(index, index + 1)
+		show()
+		return
+
+	if(href_list["cut"] && href_list["insert"])
+		var/cut = text2num(href_list["cut"])
+		var/insert = text2num(href_list["insert"])
+		var/choice = choices[cut]
+		choices.Cut(cut, cut + 1)
+		choices.Insert(insert, choice)
 		show()
 		return
 

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -95,8 +95,8 @@ var/ert_request_answered = FALSE
 	for(var/datum/async_input/A in ert_gender_prefs)
 		A.close()
 	for(var/mob/M in response_team_members)
-		ert_role_prefs.Add(input_ranked_async(M, "Please order ERT roles from most to least preferred (15 seconds):", active_team.get_slot_list()))
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/dispatch_response_team, response_team_members, ert_gender_prefs, ert_role_prefs), 150)
+		ert_role_prefs.Add(input_ranked_async(M, "Please order ERT roles from most to least preferred (20 seconds):", active_team.get_slot_list()))
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/dispatch_response_team, response_team_members, ert_gender_prefs, ert_role_prefs), 200)
 
 /proc/dispatch_response_team(list/response_team_members, list/ert_gender_prefs, list/ert_role_prefs)
 	var/spawn_index = 1

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -63,7 +63,7 @@ var/ert_request_answered = FALSE
 	active_team.setSlots(commander_slots, security_slots, medical_slots, engineering_slots, janitor_slots, paranormal_slots, cyborg_slots)
 
 	send_emergency_team = TRUE
-	var/list/ert_candidates = pollCandidates("Join the Emergency Response Team?",, responseteam_age, 600, 1, role_playtime_requirements[ROLE_ERT])
+	var/list/ert_candidates = shuffle(pollCandidates("Join the Emergency Response Team?",, responseteam_age, 600, 1, role_playtime_requirements[ROLE_ERT]))
 	if(!ert_candidates.len)
 		active_team.cannot_send_team()
 		send_emergency_team = FALSE

--- a/html/browser/rankedInput.js
+++ b/html/browser/rankedInput.js
@@ -1,0 +1,26 @@
+var uid;
+
+function allowDrop(ev) {
+  ev.preventDefault();
+}
+
+function drag(ev) {
+  var index = ev.target.getAttribute('index');
+  if (index) {
+    ev.dataTransfer.setData('text', index);
+  }
+}
+
+function drop(ev) {
+  ev.preventDefault();
+  var data = ev.dataTransfer.getData('text');
+  if (data && ev.target.getAttribute('index')) {
+    window.location = '?src=' + uid + ';' + 'cut=' + data + ';' + 'insert=' + ev.target.getAttribute('index');
+  }
+}
+
+function setUid() {
+  uid = document.getElementById('choices').getAttribute('uid');
+}
+
+window.onload = setUid;


### PR DESCRIPTION
**What does this PR do:**
- ERT priority randomized instead of by who picked "yes" first. We can do this now since AFK people are skipped anyway, so there's no need to prioritize people who are more "active". Also gives people the full minute to think about whether they want to join the ERT instead of making a snap decision
- Drag and drop support for role selection to make things less awkward
- 20 seconds to select a role instead of 15 seconds to make things less rushed (the dialog in the image below)

**Images**
![dragndrop](https://user-images.githubusercontent.com/26497062/60845636-ce996500-a191-11e9-940a-67864436abe0.gif) (gif made before the change to 20 seconds)

**Changelog:**
:cl: Tayyyyyyy
tweak: Whether you join the ERT is no longer determined by how fast you click "yes" on the prompt.
tweak: Drag and drop support and 20 seconds to pick ERT role instead of 15
/:cl:

