### PR TITLE
Nerf syndicate space suit armor values

### DIFF
--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -1,11 +1,10 @@
 //Regular syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate
 	name = "red space helmet"
-	desc = "Top secret Spess Helmet."
 	icon_state = "syndicate"
 	item_state = "syndicate"
 	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
-	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
+	armor = list(melee = 20, bullet = 25, laser = 15, energy = 15, bomb = 30, bio = 30, rad = 30)
 
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"
@@ -14,7 +13,7 @@
 	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/saber,/obj/item/restraints/handcuffs,/obj/item/tank)
-	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
+	armor = list(melee = 20, bullet = 25, laser = 15, energy = 15, bomb = 30, bio = 30, rad = 30)
 
 
 //Green syndicate space suit


### PR DESCRIPTION
The syndicate space suit has insanely high armor values : 

armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)

This is essentially the same values as the syndicate hardsuit : 

 armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)

Considering the syndicate hardsuit costs 8 TC to the space suit's 4 TC, AND it marks you as valid compared to the space suit being entirely legal, this does not seem right, the space suit is way too good of an armor piece all around. 

I have cut the values for melee, bullet, and laser resistances on the spacesuit in half. This should hopefully make the hardsuit more attractive and have it see more use for traitors.

Also fixes a redudant description value.

Changelog:
:cl: 
balance: Lowered the melee, bullet, and laser resistances of the syndicate spacesuit in half
/:cl: