### PR TITLE
Singularity and tesla can no longer be thrown

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -437,3 +437,6 @@
 	explosion(src.loc,(dist),(dist*2),(dist*4))
 	qdel(src)
 	return(gain)
+
+/obj/singularity/throw_at()
+	return FALSE


### PR DESCRIPTION
**What does this PR do:**
You could throw the engine outside of the containment using build mode prior to this PR this fixes that by making them unthrowable at all

**Changelog:**
:cl:
fix: Engine can no longer be thrown
/:cl:

