### PR TITLE
Department Medals

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -116,15 +116,10 @@
 
 /obj/item/storage/lockbox/medal/New()
 	..()
-	new /obj/item/clothing/accessory/medal/gold/heroism(src)
-	new /obj/item/clothing/accessory/medal/silver/security(src)
-	new /obj/item/clothing/accessory/medal/silver/valor(src)
-	new /obj/item/clothing/accessory/medal/nobel_science(src)
-	new /obj/item/clothing/accessory/medal/bronze_heart(src)
-	new /obj/item/clothing/accessory/medal/conduct(src)
-	new /obj/item/clothing/accessory/medal/conduct(src)
-	new /obj/item/clothing/accessory/medal/conduct(src)
 	new /obj/item/clothing/accessory/medal/gold/captain(src)
+	new /obj/item/clothing/accessory/medal/silver/leadership(src)
+	new /obj/item/clothing/accessory/medal/silver/valor(src)
+	new /obj/item/clothing/accessory/medal/heart(src)
 
 /obj/item/storage/lockbox/t4
 	name = "lockbox (T4)"

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -38,6 +38,7 @@
 	new /obj/item/rpd(src)
 	new /obj/item/reagent_containers/food/drinks/mug/ce(src)
 	new /obj/item/organ/internal/cyberimp/eyes/meson(src)
+	new /obj/item/clothing/accessory/medal/engineering(src)
 
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -193,6 +193,7 @@
 	new /obj/item/organ/internal/cyberimp/eyes/hud/medical(src)
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/reagent_containers/food/drinks/mug/cmo(src)
+	new /obj/item/clothing/accessory/medal/medical(src)
 
 
 /obj/structure/closet/secure_closet/animal

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -77,7 +77,7 @@
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/reagent_containers/food/drinks/mug/rd(src)
 	new /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic(src)
-
+	new /obj/item/clothing/accessory/medal/science(src)
 
 /obj/structure/closet/secure_closet/research_reagents
 	name = "research chemical storage closet"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -60,7 +60,7 @@
 	new /obj/item/clothing/accessory/petcollar(src)
 	new /obj/item/door_remote/civillian(src)
 	new /obj/item/reagent_containers/food/drinks/mug/hop(src)
-
+	new /obj/item/clothing/accessory/medal/service(src)
 
 /obj/structure/closet/secure_closet/hop2
 	name = "head of personnel's attire"
@@ -128,7 +128,7 @@
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/reagent_containers/food/drinks/mug/hos(src)
 	new /obj/item/organ/internal/cyberimp/eyes/hud/security(src)
-
+	new /obj/item/clothing/accessory/medal/security(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "warden's locker"
@@ -465,3 +465,4 @@
 	new /obj/item/gavelblock(src)
 	new /obj/item/gavelhammer(src)
 	new /obj/item/clothing/head/justice_wig(src)
+	new /obj/item/clothing/accessory/medal/legal(src)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -182,34 +182,7 @@
 	materials = list(MAT_METAL=1000)
 	burn_state = FIRE_PROOF
 
-/obj/item/clothing/accessory/medal/conduct
-	name = "distinguished conduct medal"
-	desc = "A bronze medal awarded for distinguished conduct. Whilst a great honor, this is the most basic award given by Nanotrasen. It is often awarded by a captain to a member of his crew."
-
-/obj/item/clothing/accessory/medal/bronze_heart
-	name = "bronze heart medal"
-	desc = "A bronze heart-shaped medal awarded for sacrifice. It is often awarded posthumously or for severe injury in the line of duty."
-	icon_state = "bronze_heart"
-
-/obj/item/clothing/accessory/medal/nobel_science
-	name = "nobel sciences award"
-	desc = "A bronze medal which represents significant contributions to the field of science or engineering."
-
-/obj/item/clothing/accessory/medal/silver
-	name = "silver medal"
-	desc = "A silver medal."
-	icon_state = "silver"
-	item_color = "silver"
-	materials = list(MAT_SILVER=1000)
-
-/obj/item/clothing/accessory/medal/silver/valor
-	name = "medal of valor"
-	desc = "A silver medal awarded for acts of exceptional valor."
-
-/obj/item/clothing/accessory/medal/silver/security
-	name = "robust security award"
-	desc = "An award for distinguished combat and sacrifice in defence of Nanotrasen's commercial interests. Often awarded to security staff."
-
+// GOLD (awarded by centcom)
 /obj/item/clothing/accessory/medal/gold
 	name = "gold medal"
 	desc = "A prestigious golden medal."
@@ -223,7 +196,61 @@
 
 /obj/item/clothing/accessory/medal/gold/heroism
 	name = "medal of exceptional heroism"
-	desc = "An extremely rare golden medal awarded only by CentComm. To recieve such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but commanders."
+	desc = "An extremely rare golden medal awarded only by CentComm. To recieve such a medal is the highest honor and as such, very few exist."
+
+// SILVER (awarded by Captain)
+
+/obj/item/clothing/accessory/medal/silver
+	name = "silver medal"
+	desc = "A silver medal."
+	icon_state = "silver"
+	item_color = "silver"
+	materials = list(MAT_SILVER=1000)
+
+/obj/item/clothing/accessory/medal/silver/valor
+	name = "medal of valor"
+	desc = "An award issued by Captains to crew members whose exceptional performance and service to the station has been commended by the station's top leadership."
+
+/obj/item/clothing/accessory/medal/silver/leadership
+	name = "medal of command"
+	desc = "An award issued by Captains to heads of department who do an excellent job managing their department. Made of pure silver."
+
+
+// BRONZE (awarded by heads of department, except for the bronze heart)
+
+
+
+/obj/item/clothing/accessory/medal/security
+	name = "robust security medal"
+	desc = "An award issued by the HoS to security staff who excel at upholding the law."
+
+/obj/item/clothing/accessory/medal/science
+	name = "smart science medal"
+	desc = "An award issued by the RD to science staff who advance the frontiers of knowledge."
+
+/obj/item/clothing/accessory/medal/engineering
+	name = "excellent engineering medal"
+	desc = "An award issued by the CE to engineering staff whose dedication keep the station running at its best."
+
+/obj/item/clothing/accessory/medal/service
+	name = "superior service medal"
+	desc = "An award issued by the HoP to service staff who go above and beyond."
+
+/obj/item/clothing/accessory/medal/medical
+	name = "magnificient medical medal"
+	desc = "An award issued by the CMO to medical staff who excel at saving lives."
+
+/obj/item/clothing/accessory/medal/legal
+	name = "meritous legal medal"
+	desc = "An award issued by the Magistrate to legal staff who uphold the rule of law."
+
+/obj/item/clothing/accessory/medal/heart
+	name = "bronze heart medal"
+	desc = "A rarely-awarded medal for those who sacrifice themselves in the line of duty to save their fellow crew."
+	icon_state = "bronze_heart"
+
+
+
 
 /*
 	Holobadges are worn on the belt or neck, and can be used to show that the holder is an authorized


### PR DESCRIPTION
With this PR:

1. Each department head (CE/CMO/RD/HoS/HoP/Magi/Captain) gets a department-specific medal, typically in their locker at shift start, which is intended to be awarded to someone in their department for doing a good job that shift. For example, the CE gets an excellent engineering medal, the HoP gets a superior service medal, the HoS gets a robust security medal, etc.
2. The Captain also gets some special medals, the bronze heart (for sacrifice in the line of duty), the medal of valor (for amazing stuff as a regular crew member) and the medal of command (for exceptional performance as a head of department). The Captain does NOT get the department-specific medals anymore - since handing those out is now the job of the relevant heads.
3. Medals in general are standardized. Bronze medals are awarded by department heads to crew in that department. Silver medals are awarded by the Captain, typically to heads, though sometimes a crew member may earn one through acts of awesomeness. Gold medals are awarded only by CentCom, and include the (antag objective) medal of captaincy and the even rarer medal of exceptional heroism (something admins can bestow during events). Medals are typically stored in head of department lockers, but the Captain's medal set is still stored in their lockbox.

Why?
1. To add a carrot that encourages people to RP (do their job).
2. To add ways of recognizing some areas which are currently not recognized (service medal, legal medal, medal for leadership as member of command, etc)
3. To create a framework for later on when I might later make these medals 'awardable' in a tracked way, and make them show up at round end, similar to how CM does it.

:cl: Kyep
tweak: Heads of department may now issue department-specific medals to members of their department.
/:cl:

