### PR TITLE
Stops HoPs from opening Clown Slots

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -44,7 +44,8 @@ var/time_last_changed_position = 0
 		/datum/job/brigdoc,
 		/datum/job/mechanic,
 		/datum/job/barber,
-		/datum/job/chaplain
+		/datum/job/chaplain,
+		/datum/job/clown
 	)
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players


### PR DESCRIPTION
**What does this PR do:**
Opening clown slots is considered self antagging, so this just stops clowns from having their slots opened in the first place. 

I see more people get banned for this than legitimate uses such as antags opening clown slots which is important because things should not be based around outliers to the norm.

In the event of clown death someone can fax CC to get a new Clown from Clown Planet

**Changelog:**
🆑 
tweak: HoP can no longer increase Clown Slots. Central Command can call Clown Planet and open another Clown slot in the event that the Clown dies and needs to be replaced.
/ 🆑 