### PR TITLE
Diagonal Movement tweaks

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -35,7 +35,8 @@ SUBSYSTEM_DEF(input)
 			"O" = "ooc",
 			"T" = "say",
 			"M" = "me",
-			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
+			"F3" = "say",
+			"Back" = "\".winset \\\"input.focus=true input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 			),
@@ -43,13 +44,15 @@ SUBSYSTEM_DEF(input)
 			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
 			"Ctrl+T" = "say",
 			"Ctrl+O" = "ooc",
+			"F3" = "say",
 			),
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
 			"T" = "say",
 			"M" = "me",
-			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
+			"F3" = "say",
+			"Back" = "\".winset \\\"input.focus=true input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 			),

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -186,6 +186,3 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 			send2irc(source, "[msg] - All admins AFK ([admin_number_afk]/[admin_number_total]) or skipped ([admin_number_ignored]/[admin_number_total])")
 	return admin_number_present
 	
-/client/proc/get_adminhelp()
-	var/msg = input(src, "Please describe your problem concisely and an admin will help as soon as they're able.", "Adminhelp contents") as text|null
-	adminhelp(msg)

--- a/code/modules/keybindings/bindings_admin.dm
+++ b/code/modules/keybindings/bindings_admin.dm
@@ -1,22 +1,19 @@
 /datum/admins/key_down(_key, client/user)
 	switch(_key)
-		if("F3")
+		if("F5")
 			user.get_admin_say()
 			return
-		if("F5")
+		if("F6")
 			user.admin_ghost()
 			return
-		if("F6")
+		if("F7")
 			player_panel_new()
 			return
-		if("F7")
-			user.togglebuildmodeself()
-			return
 		if("F8")
-			if(user.keys_held["Ctrl"])
-				user.stealth()
-			else
-				user.invisimin()
+			user.cmd_admin_pm_panel()
+			return
+		if("F9")
+			user.stealth()
 			return
 		if("F10")
 			user.get_dead_say()

--- a/code/modules/keybindings/bindings_carbon.dm
+++ b/code/modules/keybindings/bindings_carbon.dm
@@ -1,18 +1,20 @@
 /mob/living/carbon/key_down(_key, client/user)
-	switch(_key)
-		if("R", "Southwest") // Southwest is End
-			toggle_throw_mode()
-			return
-		if("1")
-			a_intent_change("help")
-			return
-		if("2")
-			a_intent_change("disarm")
-			return
-		if("3")
-			a_intent_change("grab")
-			return
-		if("4")
-			a_intent_change("harm")
-			return
+	user.keys_held[_key] = world.time
+	if(!user.keys_held["Shift"])
+		switch(_key)
+			if("R", "Southwest") // Southwest is End
+				toggle_throw_mode()
+				return	
+			if("1")
+				a_intent_change("help")
+				return
+			if("2")
+				a_intent_change("disarm")
+				return
+			if("3")
+				a_intent_change("grab")
+				return
+			if("4")
+				a_intent_change("harm")
+				return
 	return ..()

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -20,7 +20,10 @@
 				adminhelp()
 			return
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
-			winset(src, null, "command=.screenshot [!keys_held["shift"] ? "auto" : ""]")
+			ooc()
+			return
+		if("F4")
+			mob.me_verb()
 			return
 		if("F12") // Toggles minimal HUD
 			mob.button_pressed_F12()

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -17,7 +17,7 @@
 			if(keys_held["Ctrl"] && keys_held["Shift"]) // Is this command ever used?
 				winset(src, null, "command=.options")
 			else
-				get_adminhelp()
+				adminhelp()
 			return
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
 			winset(src, null, "command=.screenshot [!keys_held["shift"] ? "auto" : ""]")

--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -93,7 +93,20 @@
 			if("Numpad3")
 				user.body_l_leg()
 				return
-
+	else
+		switch(_key)
+			if("Numpad1")
+				a_intent_change("help")
+				return
+			if("Numpad2")
+				a_intent_change("disarm")
+				return
+			if("Numpad3")
+				a_intent_change("grab")
+				return
+			if("Numpad4")
+				a_intent_change("harm")
+				return
 	if(client.keys_held["Ctrl"] && client.prefs.toggles & AZERTY)
 		switch(SSinput.alt_movement_keys[_key])
 			if(NORTH)

--- a/code/modules/keybindings/bindings_robot.dm
+++ b/code/modules/keybindings/bindings_robot.dm
@@ -6,6 +6,9 @@
 		if("4")
 			a_intent_change(INTENT_HOTKEY_LEFT)
 			return
+		if("X")
+			cycle_modules()
+			return
 		if("Q")
 			uneq_active()
 			return

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -103,12 +103,11 @@
 
 	var/adminhotkeys = {"<font color='purple'>
 Admin:
-\tF3 = asay
-\tF5 = Aghost (admin-ghost)
-\tF6 = player-panel
-\tF7 = Buildmode
-\tF8 = Invisimin
-\tCtrl+F8 = Stealthmin
+\tF5 = Asay
+\tF6 = Admin Ghost
+\tF7 = Player Panel
+\tF8 = Admin PM
+\tF9 = Invisimin
 
 Admin ghost:
 \tCtrl+Click = Player Panel


### PR DESCRIPTION
**What does this PR do:**
A few tweaks after getting some feedback after the testmerge, Nothing high priority

**Changelog:**
:cl:
tweak: Borgs can now cycle modules with X again
tweak: Ahelp message is less confusing
tweak: F2 (say) F3(ooc) F4(me) buttons have been restored
tweak:when numpad targetting is off you can use numpad 1-4 to change intents
tweak:pressing shift before any of the intent buttons doesn't change intents(for people with shift+1-4 macros)
tweak:backspace now sets the focus to the chat bar
/:cl:

fixes #11839 fixes #11838 