### PR TITLE
AI can now change its intent

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -257,3 +257,9 @@
 	using = new /obj/screen/ai/add_multicam()
 	using.screen_loc = ui_ai_add_multicam
 	static_inventory += using
+
+//Intent
+	using = new /obj/screen/act_intent/robot/AI()
+	using.icon_state = mymob.a_intent
+	static_inventory += using
+	action_intent = using

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -95,6 +95,9 @@
 	icon = 'icons/mob/screen_robot.dmi'
 	screen_loc = ui_borg_intents
 
+/obj/screen/act_intent/robot/AI
+	screen_loc = "EAST-1:32,SOUTH:70"
+
 /obj/screen/mov_intent
 	name = "run/walk toggle"
 	icon_state = "running"

--- a/code/modules/keybindings/bindings_ai.dm
+++ b/code/modules/keybindings/bindings_ai.dm
@@ -1,0 +1,6 @@
+/mob/living/silicon/ai/key_down(_key, client/user)
+	switch(_key)
+		if("4")
+			a_intent_change(INTENT_HOTKEY_LEFT)
+			return
+	return ..()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -369,7 +369,7 @@ var/list/intents = list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
 			if(hud_used && hud_used.action_intent)
 				hud_used.action_intent.icon_state = "[a_intent]"
 
-		else if(isrobot(src) || islarva(src) || isanimal(src))
+		else if(isrobot(src) || islarva(src) || isanimal(src) || isAI(src))
 			switch(input)
 				if(INTENT_HELP)
 					a_intent = INTENT_HELP

--- a/paradise.dme
+++ b/paradise.dme
@@ -1590,6 +1590,7 @@
 #include "code\modules\hydroponics\grown\towercap.dm"
 #include "code\modules\karma\karma.dm"
 #include "code\modules\keybindings\bindings_admin.dm"
+#include "code\modules\keybindings\bindings_ai.dm"
 #include "code\modules\keybindings\bindings_atom.dm"
 #include "code\modules\keybindings\bindings_carbon.dm"
 #include "code\modules\keybindings\bindings_client.dm"


### PR DESCRIPTION
**What does this PR do:**
By pressing four or clicking on the on-screen object, the AI can now change its intent. This is only useful (for now) for when the AI is controlling a mech, as it can now punch people instead of pushing them.

**Images of sprite/map changes (IF APPLICABLE):**
![AIchange](https://user-images.githubusercontent.com/9964331/61128344-ed5d6b80-a4b1-11e9-8bf2-402744dd5e8c.PNG)

**Changelog:**
:cl: EmanTheAlmighty
add: The AI can now change its intent by clicking on the new on-screen button or pressing 4 to switch to help or harm.
/:cl: