### PR TITLE
Lowers throwforce of drinking cartons

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -256,6 +256,7 @@
 	desc = "Full of vitamins and deliciousness!"
 	icon_state = "orangejuice"
 	item_state = "carton"
+	throwforce = 0
 	isGlass = 0
 	list_reagents = list("orangejuice" = 100)
 
@@ -264,6 +265,7 @@
 	desc = "It's cream. Made from milk. What else did you think you'd find in there?"
 	icon_state = "cream"
 	item_state = "carton"
+	throwforce = 0
 	isGlass = 0
 	list_reagents = list("cream" = 100)
 
@@ -272,6 +274,7 @@
 	desc = "Well, at least it LOOKS like tomato juice. You can't tell with all that redness."
 	icon_state = "tomatojuice"
 	item_state = "carton"
+	throwforce = 0
 	isGlass = 0
 	list_reagents = list("tomatojuice" = 100)
 
@@ -280,6 +283,7 @@
 	desc = "Sweet-sour goodness."
 	icon_state = "limejuice"
 	item_state = "carton"
+	throwforce = 0
 	isGlass = 0
 	list_reagents = list("limejuice" = 100)
 
@@ -288,6 +292,7 @@
 	desc = "Soothing milk."
 	icon_state = "milk"
 	item_state = "carton"
+	throwforce = 0
 	isGlass = 0
 	list_reagents = list("milk" = 100)
 


### PR DESCRIPTION
**What does this PR do:**
Lowers the throwforce of drinking cartons from the bottle default of 15 to 0, as them hitting that hard, while humorous, makes little sense.

**Changelog:**

:cl:
tweak: Lowers throwforce of drinking cartons from 15 to 0
/:cl:

