### PR TITLE
Newcrit users in hard crit no longer interrupts hijack

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -182,6 +182,8 @@
 					continue
 				if(ishuman(player)) //hostages allowed on the shuttle, check for restraints
 					var/mob/living/carbon/human/H = player
+					if(!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD) //new crit users who are in hard crit are considered dead
+						continue
 					if(H.handcuffed) //cuffs
 						continue
 					if(H.wear_suit && H.wear_suit.breakouttime) //straight jacket


### PR DESCRIPTION
This PR adds a check to the hijack proc, which now checks for new crit users, if they have less than -100 health (200 total damage) they are considered dead and will not stop the hijack.

This is because a newcrit user can take a very long time to actually die even if you are actively whacking them with a dual esword, which can prevent an hijack attempt and is pretty dumb.

🆑
tweak: New crit species with below -100 health will be considered dead for hijack purposes, and will not interrupt a shuttle hijack attempt.
/🆑