### PR TITLE
Fixed Emergency NanoMed Vendors to no longer require a medical ID to access.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1131,7 +1131,6 @@
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?"
 	icon_state = "wallmed"
 	icon_deny = "wallmed-deny"
-	req_access = list(access_medical)
 	density = FALSE //It is wall-mounted, and thus, not dense. --Superxpdude
 	products = list(/obj/item/stack/medical/bruise_pack = 2, /obj/item/stack/medical/ointment = 2, /obj/item/reagent_containers/hypospray/autoinjector = 4, /obj/item/healthanalyzer = 1)
 	contraband = list(/obj/item/reagent_containers/syringe/charcoal = 4, /obj/item/reagent_containers/syringe/antiviral = 4, /obj/item/reagent_containers/food/pill/tox = 1)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1141,7 +1141,6 @@
 	desc = "Wall-mounted Medical Equipment dispenser."
 	icon_state = "wallmed"
 	icon_deny = "wallmed-deny"
-	req_access = list(access_medical)
 	density = FALSE //It is wall-mounted, and thus, not dense. --Superxpdude
 	products = list(/obj/item/reagent_containers/hypospray/autoinjector = 5, /obj/item/reagent_containers/syringe/charcoal = 3, /obj/item/stack/medical/bruise_pack = 3,
 					/obj/item/stack/medical/ointment = 3, /obj/item/healthanalyzer = 3)


### PR DESCRIPTION
**What does this PR do:**
Fixes #11755
The Emergency NanoMed Vendors found all over station could only be accessed with a Medical ID. Funnily enough this included the one in the Nukies Shuttle, meaning Nukies couldn't even use their own Emergency Vendor.  This PR removes the offending line that made these machines so stingy with their life saving goods.

**Changelog:**
:cl:
fix: Issue where Emergency NanoMed Vendors required Medical ID to Access.
/:cl:

