### PR TITLE
Gave Cyborgs with 0 battery left the ability to succumb.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -244,7 +244,7 @@
 
 /mob/living/verb/succumb()
 	set hidden = 1
-	if(InCritical() || LowBattery())
+	if(CanSuccumb())
 		create_attack_log("[src] has ["succumbed to death"] with [round(health, 0.1)] points of health!")
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		// super check for weird mobs, including ones that adjust hp
@@ -256,6 +256,9 @@
 		death()
 		to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
 
+/mob/living/proc/CanSuccumb()
+	return InCritical()
+	
 /mob/living/proc/InCritical()
 	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)
 	

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -244,7 +244,7 @@
 
 /mob/living/verb/succumb()
 	set hidden = 1
-	if(CanSuccumb())
+	if(InCritical())
 		create_attack_log("[src] has ["succumbed to death"] with [round(health, 0.1)] points of health!")
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		// super check for weird mobs, including ones that adjust hp
@@ -256,8 +256,6 @@
 		death()
 		to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
 
-/mob/living/proc/CanSuccumb()
-	return InCritical()
 	
 /mob/living/proc/InCritical()
 	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -260,7 +260,7 @@
 	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)
 	
 /mob/living/proc/LowBattery()
-    if (isrobot(usr))
+    if(isrobot(usr))
         var/mob/living/silicon/robot/R = usr
         return (R.low_power_mode)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -259,10 +259,6 @@
 /mob/living/proc/InCritical()
 	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)
 	
-/mob/living/proc/LowBattery()
-    if(isrobot(usr))
-        var/mob/living/silicon/robot/R = usr
-        return (R.low_power_mode)
 
 /mob/living/ex_act(severity)
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -244,7 +244,7 @@
 
 /mob/living/verb/succumb()
 	set hidden = 1
-	if(InCritical())
+	if(InCritical() || LowBattery())
 		create_attack_log("[src] has ["succumbed to death"] with [round(health, 0.1)] points of health!")
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		// super check for weird mobs, including ones that adjust hp
@@ -258,6 +258,11 @@
 
 /mob/living/proc/InCritical()
 	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)
+	
+/mob/living/proc/LowBattery()
+    if (isrobot(usr))
+        var/mob/living/silicon/robot/R = usr
+        return (R.low_power_mode)
 
 /mob/living/ex_act(severity)
 	..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -576,6 +576,8 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/restrained()
 	return 0
 
+/mob/living/silicon/robot/CanSuccumb()
+	return low_power_mode
 
 /mob/living/silicon/robot/ex_act(severity)
 	switch(severity)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -576,7 +576,7 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/restrained()
 	return 0
 
-/mob/living/silicon/robot/CanSuccumb()
+/mob/living/silicon/robot/InCritical()
 	return low_power_mode
 
 /mob/living/silicon/robot/ex_act(severity)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -339,7 +339,3 @@
 /mob/living/silicon/can_hear()
 	. = TRUE
 
-/mob/living/proc/LowBattery()
-    if(isrobot(usr))
-        var/mob/living/silicon/robot/R = usr
-        return (R.low_power_mode)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -338,3 +338,8 @@
 /////////////////////////////////// EAR DAMAGE ////////////////////////////////////
 /mob/living/silicon/can_hear()
 	. = TRUE
+
+/mob/living/proc/LowBattery()
+    if(isrobot(usr))
+        var/mob/living/silicon/robot/R = usr
+        return (R.low_power_mode)


### PR DESCRIPTION
**What does this PR do:**
Fixes #11743 

More specifically, this expands the 'succumb' verb that lets a regular crew member in critical condition to 'give up on life and die' meaning they ghost without penalty. They can still be revived, and still take other ghost roles. Currently, Cyborgs have no such alternative and can easily be put into 'Cyborg hell', as Issue #11743 puts it, and not have a way out that doesn't permanently remove you from the round. (Ghosting)

This PR expands the succumb verb to include Cyborgs on 'low_charge' which can either happen from a drained battery, or having one's power cell removed. This let's cyborg players stuck in 'cyborg hell' leave without permanent consequence.

This solution isn't the most elegant. The succumb verb does cause the user to take damage until they reach the point of death, which is normal looking for someone in critical condition, but really weird to see a full health, 0 battery cyborg suddenly take massive damage. 

However, I would argue that considering the situation of 'cyborg hell' is fairly rare, and the succumb verb rarely used to begin with, an elaborate substitute specifically for cyborgs would be too much effort for such a niche issue, and a lightweight change like this will be enough to satisfy players needs in this situation.

**Changelog:**
:cl:
add: Added the ability for cyborgs with zero battery to use the 'succumb' verb.
/:cl:

