### PR TITLE
Fix extra newline after field, borked autogenerated papers, and disable gfm

### DIFF
--- a/html/browser/marked.js
+++ b/html/browser/marked.js
@@ -15,7 +15,7 @@ function parse(node) {
     return;
   }
 
-  node.innerHTML = marked(node.innerHTML.replace(/<br>/gi, '\n'), { breaks: true, gfm: false });
+  node.innerHTML = marked(node.innerHTML.replace(/<br>/gi, '\n').replace(/\t/gi, ''), { breaks: true, gfm: false });
 }
 
 window.onload = function() {

--- a/html/browser/marked.js
+++ b/html/browser/marked.js
@@ -11,16 +11,26 @@ function parse(node) {
     parse(node.childNodes[i]);
   }
 
-  if(!node.innerHTML) {
+  if (!node.innerHTML || node.tagName === 'A') {
     return;
   }
-  node.innerHTML = marked(node.innerHTML.replace(/<br>/gi, '\n'), { breaks: true });
+
+  node.innerHTML = marked(node.innerHTML.replace(/<br>/gi, '\n'), { breaks: true, gfm: false });
 }
 
-function main() {
+window.onload = function() {
+  var para = marked.Renderer.prototype.paragraph;
+  var field = '<span class="paper_field">';
+  marked.Renderer.prototype.paragraph = function(text) {
+    if (text.slice(0, field.length) === field ||
+        text.slice(0, 2) === '<a'||
+        text.slice(0, 5) === '<font' && text.indexOf('<a') >= 0) {
+      return text;
+    }
+    return para(text);
+  };
+
   if ($('#markdown')) {
     parse($('#markdown'));
   }
 }
-
-window.onload = main;


### PR DESCRIPTION
**What does this PR do:**
Fixes #11811
Fixes #11869

Disabling Github Markdown to fix some issues where it would randomly think things were code blocks. GFM features aren't really needed, anyways.

Fixed autogenerated papers being interpreted as code blocks.

**Changelog:**
:cl: Tayyyyyyy
fix: Fix extra newline after field and disable Github Flavored Markdown in papers (normal markdown still works)
fix: autogenerated papers no longer appear as HTML code
/:cl:

