### PR TITLE
Input subsystem now checks client list for nulls before running keyloop

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -115,6 +115,8 @@ SUBSYSTEM_DEF(input)
 
 /datum/controller/subsystem/input/fire()
 	var/list/clients = GLOB.clients // Let's sing the list cache song
+	if(listclearnulls(clients)) // clear nulls before we run keyloop
+		log_world("Found a null in clients list!")
 	for(var/i in 1 to clients.len)
 		var/client/C = clients[i]
 		C.keyLoop()

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -117,6 +117,5 @@ SUBSYSTEM_DEF(input)
 	var/list/clients = GLOB.clients // Let's sing the list cache song
 	if(listclearnulls(clients)) // clear nulls before we run keyloop
 		log_world("Found a null in clients list!")
-	for(var/i in 1 to clients.len)
-		var/client/C = clients[i]
+	for(var/client/C in clients)
 		C.keyLoop()

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -117,5 +117,6 @@ SUBSYSTEM_DEF(input)
 	var/list/clients = GLOB.clients // Let's sing the list cache song
 	if(listclearnulls(clients)) // clear nulls before we run keyloop
 		log_world("Found a null in clients list!")
-	for(var/client/C in clients)
+	for(var/i in 1 to clients.len)
+		var/client/C = clients[i]
 		C.keyLoop()


### PR DESCRIPTION
**What does this PR do:**
Fixes #11849 This isn't the most graceful way, if an maintainer can help me figure out a better way to check the list for nulls instead of running it everytime input fires that would be appreciated.


**Changelog:**
:cl:
fix: fixes the runtime caused by running keyloop for clients
/:cl:

