### PR TITLE
Slime People can regrow limbs while both legs are missing. Reworks how the game treats legless people

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -71,8 +71,7 @@
 			if(!(NO_PAIN in dna.species.species_traits))
 				emote("scream")
 			custom_emote(1, "collapses!")
-		Weaken(5) //can't emote while weakened, apparently. Weakness kept here just to make the player collapse
-		SetWeakened(0) // Being weakened constantly is replaced by the legless status, so we dont need weakness
+		update_canmove()
 
 
 /mob/living/carbon/human/proc/handle_grasp()

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -59,9 +59,16 @@
 	if(stance_damage < 0)
 		stance_damage = 0
 
+	if(stance_damage <= 6)
+		legless = 0
+
 	// standing is poor
 	if(stance_damage >= 8)
+		if(legless)
+			SetWeakened(0)
+			return
 		if(!(lying || resting))
+			legless = TRUE
 			if(!(NO_PAIN in dna.species.species_traits))
 				emote("scream")
 			custom_emote(1, "collapses!")

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -60,19 +60,19 @@
 		stance_damage = 0
 
 	if(stance_damage <= 6)
-		legless = 0
+		legless = FALSE
 
 	// standing is poor
 	if(stance_damage >= 8)
 		if(legless)
-			SetWeakened(0)
 			return
 		if(!(lying || resting))
 			legless = TRUE
 			if(!(NO_PAIN in dna.species.species_traits))
 				emote("scream")
 			custom_emote(1, "collapses!")
-		Weaken(5) //can't emote while weakened, apparently.
+		Weaken(5) //can't emote while weakened, apparently. Weakness kept here just to make the player collapse
+		SetWeakened(0) // Being weakened constantly is replaced by the legless status, so we dont need weakness
 
 
 /mob/living/carbon/human/proc/handle_grasp()

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -136,7 +136,7 @@
 
 	H.visible_message("<span class='notice'>[H] begins to hold still and concentrate on [H.p_their()] missing [limb_select]...</span>", "<span class='notice'>You begin to focus on regrowing your missing [limb_select]... (This will take [round(SLIMEPERSON_REGROWTHDELAY/10)] seconds, and you must hold still.)</span>")
 	if(do_after(H, SLIMEPERSON_REGROWTHDELAY, needhand = 0, target = H))
-		if(H.incapacitated())
+		if(H.incapacitated(ignore_lying = TRUE))
 			to_chat(H, "<span class='warning'>You cannot regenerate missing limbs in your current state.</span>")
 			return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -415,7 +415,6 @@
 	SetParalysis(0, 1, 1)
 	SetStunned(0, 1, 1)
 	SetWeakened(0, 1, 1)
-	legless = 0
 	SetSlowed(0)
 	SetLoseBreath(0)
 	SetDizzy(0)
@@ -468,6 +467,7 @@
 			human_mob.remove_all_embedded_objects()
 
 	restore_all_organs()
+	NotLegless()
 	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
 		update_revive()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -415,6 +415,7 @@
 	SetParalysis(0, 1, 1)
 	SetStunned(0, 1, 1)
 	SetWeakened(0, 1, 1)
+	legless = 0
 	SetSlowed(0)
 	SetLoseBreath(0)
 	SetDizzy(0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -467,7 +467,7 @@
 			human_mob.remove_all_embedded_objects()
 
 	restore_all_organs()
-	NotLegless()
+	legless = FALSE
 	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
 		update_revive()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -99,6 +99,7 @@
 
 	// Booleans
 	var/resting = FALSE
+	var/legless = FALSE
 
 	/*
 	STATUS EFFECTS
@@ -156,6 +157,22 @@
 	flying = FALSE
 	if(val_change)
 		update_animations()
+
+// LEGLESS
+
+/mob/living/proc/IsLegless(updating = 1)
+	var/val_change = !legless
+	legless = TRUE
+
+	if(updating && val_change)
+		update_canmove()
+
+/mob/living/proc/NotLegless(updating = 1)
+	var/val_change = !!legless
+	legless = FALSE
+
+	if(updating && val_change)
+		update_canmove()
 
 
 // SCALAR STATUS EFFECTS

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -158,22 +158,6 @@
 	if(val_change)
 		update_animations()
 
-// LEGLESS
-
-/mob/living/proc/IsLegless(updating = 1)
-	var/val_change = !legless
-	legless = TRUE
-
-	if(updating && val_change)
-		update_canmove()
-
-/mob/living/proc/NotLegless(updating = 1)
-	var/val_change = !!legless
-	legless = FALSE
-
-	if(updating && val_change)
-		update_canmove()
-
 
 // SCALAR STATUS EFFECTS
 

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -62,7 +62,7 @@
 
 // Whether the mob is capable of standing or not
 /mob/living/proc/can_stand()
-	return !(weakened || paralysis || stat || (status_flags & FAKEDEATH))
+	return !(weakened || legless || paralysis || stat || (status_flags & FAKEDEATH))
 
 // Whether the mob is capable of actions or not
 /mob/living/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE, ignore_lying = FALSE)
@@ -78,7 +78,7 @@
 /mob/living/update_canmove(delay_action_updates = 0)
 	var/fall_over = !can_stand()
 	var/buckle_lying = !(buckled && !buckled.buckle_lying)
-	if(fall_over || resting || stunned)
+	if(fall_over || legless || resting || stunned)
 		drop_r_hand()
 		drop_l_hand()
 	else
@@ -89,7 +89,7 @@
 	else if((fall_over || resting) && !lying)
 		fall(fall_over)
 
-	canmove = !(fall_over || resting || stunned || buckled)
+	canmove = !(fall_over || legless || resting || stunned || buckled)
 	density = !lying
 	if(lying)
 		if(layer == initial(layer))


### PR DESCRIPTION
**What does this PR do:**
Adds a new status labeled "legless". When people missing both their legs fall over, legless is set to True. The person is no longer spammed with weakness forever. Having weakness or not didn't seem to matter to me, as the person couldn't move, get up, or interact with anything anyway. In that regard nothing has changed, legless people will still fall over and cannot move or do anything.

This allows Slime People who are missing both legs to regrow their limbs, regardless if they're buckled into something or not.

I tested this on my local server by amputating legs through surgery, hacking legs off with a weapon or using admin proc calls to delete the legs. Everything was working as intended in all those instances.

Fixes #10066
Fixes #11200

**Changelog:**
:cl:
add: Added the "legless" status effect to mobs who have both legs and both feet missing
add: Admin Rejuvenate sets legless to False, allowing people to move properly again
fix: Slime People can now regrow their limbs while missing both legs and/or resting
del: People missing both legs no longer receive weakness constantly
/:cl:
