### PR TITLE
resupport old hotkey mode

### DIFF
--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -43,4 +43,4 @@
 			var/key = macro_set[k]
 			var/command = macro_set[key]
 			winset(src, "[setname]-\ref[key]", "parent=[setname];name=[key];command=[command]")
-	winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED] mainwindow.macro=default")
+	winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED] mainwindow.macro=old_default")


### PR DESCRIPTION
**What does this PR do:**
closes #11866 Brings back old hotkey mode as the default, hotkey mode users have to press tab as they did before

**Changelog:**
:cl:
add: Restore hotkey mode
/:cl:

