### PR TITLE
Fixes bugs/exploits related to SMES. Reorganizes parts of the SMES file

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -179,7 +179,7 @@
 				return 
 		
 		to_chat(user, "<span class='notice'>You start adding cable to the [src].</span>")
-		playsound(src.loc, C.usesound, 50, 1)
+		playsound(loc, C.usesound, 50, 1)
 
 		if(do_after(user, 50, target = src))
 			if(!terminal && panel_open)


### PR DESCRIPTION
**What does this PR do:**
Fixes #11848

**Changelog:**
:cl:
fix: You can no longer spam dismantle a SMES terminal and get 10 cable for every progress bar
fix: The game will properly remove 10 cable from your stack after building a SMES terminal, instead of removing 0
add: A cable adding sound gets played when you add wires to create a terminal for a SMES
/:cl: