### PR TITLE
Gives vampire thralls an objective listing their master's name

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -347,7 +347,14 @@
 	SSticker.mode.vampire_enthralled.Add(H.mind)
 	SSticker.mode.vampire_enthralled[H.mind] = user.mind
 	H.mind.special_role = SPECIAL_ROLE_VAMPIRE_THRALL
-	to_chat(H, "<span class='danger'>You have been Enthralled by [user]. Follow [user.p_their()] every command.</span>")
+
+	var/datum/objective/protect/serve_objective = new
+	serve_objective.owner = user.mind
+	serve_objective.target = H.mind
+	serve_objective.explanation_text = "You have been Enthralled by [user]. Follow [user.p_their()] every command."
+	H.mind.objectives += serve_objective
+
+	to_chat(H, "<span class='biggerdanger'>You have been Enthralled by [user]. Follow [user.p_their()] every command.</span>")
 	to_chat(user, "<span class='warning'>You have successfully Enthralled [H]. <i>If [H.p_they()] refuse[H.p_s()] to do as you say just adminhelp.</i></span>")
 	add_attack_logs(user, H, "Vampire-thralled")
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -356,6 +356,7 @@
 
 	to_chat(H, "<span class='biggerdanger'>You have been Enthralled by [user]. Follow [user.p_their()] every command.</span>")
 	to_chat(user, "<span class='warning'>You have successfully Enthralled [H]. <i>If [H.p_they()] refuse[H.p_s()] to do as you say just adminhelp.</i></span>")
+	H.Weaken(2)
 	add_attack_logs(user, H, "Vampire-thralled")
 
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -356,7 +356,7 @@
 
 	to_chat(H, "<span class='biggerdanger'>You have been Enthralled by [user]. Follow [user.p_their()] every command.</span>")
 	to_chat(user, "<span class='warning'>You have successfully Enthralled [H]. <i>If [H.p_they()] refuse[H.p_s()] to do as you say just adminhelp.</i></span>")
-	H.Weaken(2)
+	H.Stun(2)
 	add_attack_logs(user, H, "Vampire-thralled")
 
 


### PR DESCRIPTION
**What does this PR do:**
Makes it easier for vampire thralls too see who their master is

Fixes #11802

![thrallobj](https://user-images.githubusercontent.com/42044220/61329098-8100a600-a7ea-11e9-8a26-dd90d7588dfe.jpg)
![enthrallwarning](https://user-images.githubusercontent.com/42044220/61329114-8958e100-a7ea-11e9-8f06-6e784aed3765.jpg)


**Changelog:**
:cl:
add: Gives vampire thralls an objective, which can be viewed in their notes
tweak: Increases the size of the enthralling message seen by newly created vampire thralls
tweak: Vampire thralls are now stunned briefly (about 3 seconds) upon being enthralled
/:cl:
