### PR TITLE
AZERTY keybind hotfix

### DIFF
--- a/code/modules/keybindings/bindings_robot.dm
+++ b/code/modules/keybindings/bindings_robot.dm
@@ -10,6 +10,11 @@
 			cycle_modules()
 			return
 		if("Q")
-			uneq_active()
-			return
+			if(!(client.prefs.toggles & AZERTY))
+				uneq_active()
+				return
+		if("A")
+			if(client.prefs.toggles & AZERTY)
+				uneq_active()
+				return
 	return ..()


### PR DESCRIPTION
**What does this PR do:**
Fix an issue where Q on azerty mode as a cyborg caused you to unequip your module.

**Changelog:**
:cl:
fix: Q no longer drops items as a cyborg on AZERTY mode
/:cl:

