### PR TITLE
Gives dead minebots a sprite

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "mining_drone"
 	icon_living = "mining_drone"
+	icon_dead = "mining_drone"
 	status_flags = CANSTUN|CANWEAKEN|CANPUSH
 	mouse_opacity = MOUSE_OPACITY_ICON
 	faction = list("neutral")


### PR DESCRIPTION
**What does this PR do:**
Gives Mining Drones a dead icon, so they have a visible ghost.

Fixes #11878

**Changelog:**
:cl:
fix: Makes ghosts of Mining Drones visible
/:cl:

