### PR TITLE
Allows pod pilots to start with security armbands

### DIFF
--- a/code/modules/client/preference/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference/loadout/loadout_accessories.dm
@@ -166,7 +166,7 @@
 /datum/gear/accessory/armband_sec
 	display_name = " armband, security"
 	path = /obj/item/clothing/accessory/armband/sec
-	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer", "Brig Physician")
+	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer", "Brig Physician", "Security Pod Pilot")
 
 /datum/gear/accessory/armband_cargo
 	display_name = "cargo armband"


### PR DESCRIPTION
**What does this PR do:**
Adds Security Pod Pilots to the allowed roles list for the loadout security armband.
Fixes #11716 

**Changelog:**
:cl:
fix: Sec pod pilots can now spawn with the loadout security armbands
/:cl:

