### PR TITLE
When using the signal emote, you now need to raise at least 1 finger

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -671,9 +671,9 @@
 			if(!restrained())
 				var/t1 = round(text2num(param))
 				if(isnum(t1))
-					if(t1 <= 5 && (!r_hand || !l_hand))
+					if(t1 <= 5 && t1 >= 1 && (!r_hand || !l_hand))
 						message = "<B>[src]</B> raises [t1] finger\s."
-					else if(t1 <= 10 && (!r_hand && !l_hand))
+					else if(t1 <= 10 && t1 >= 1 && (!r_hand && !l_hand))
 						message = "<B>[src]</B> raises [t1] finger\s."
 			m_type = 1
 


### PR DESCRIPTION
**What does this PR do:**
Fixes #11680 
You now need to raise between 1 to 10 fingers when using the signal emote, rather than the -infinity to 10.

**Changelog:**
:cl:
fix: It is no longer possible to raise zero to -infinity fingers using the *signal emote
/:cl:

