### PR TITLE
Automatically offload ore to orebox when pulling one

### DIFF
--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -50,6 +50,12 @@
 				break
 	if(OB && istype(F, /turf/simulated/floor/plating/asteroid))
 		F.attackby(OB, AM)
+		// Then, if the user is dragging an ore box, empty the satchel
+		// into the box.
+		var/mob/living/L = AM
+		if(istype(L.pulling, /obj/structure/ore_box))
+			var/obj/structure/ore_box/box = L.pulling
+			box.attackby(OB, AM)
 	return ..()
 
 /obj/item/stack/ore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)


### PR DESCRIPTION
**What does this PR do:**
Pretty self-explanatory, you now put ores in the orebox you're pulling, https://github.com/tgstation/tgstation/pull/22228

**Changelog:**
:cl:
add: Automatically offload ore you're carrying to an orebox you're dragging
/:cl:

