### PR TITLE
Cultists now get a new sacrifice target when the old one leaves the round via cryo

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -29,7 +29,7 @@ var/global/list/all_cults = list()
 	return 1
 
 /proc/is_sacrifice_target(datum/mind/mind)
-	if(istype(SSticker.mode.name, "cult"))
+	if(SSticker.mode.name == "cult")
 		var/datum/game_mode/cult/cult_mode = SSticker.mode
 		if(mind == cult_mode.sacrifice_target)
 			return 1

--- a/code/game/gamemodes/cult/cult_objectives.dm
+++ b/code/game/gamemodes/cult/cult_objectives.dm
@@ -163,6 +163,16 @@
 				possible_sac_targets += player.mind
 	return possible_sac_targets
 
+// Handles the updating of sacrifice objectives after the sacrifice target goes to cryo and ghosts
+/datum/game_mode/cult/proc/update_sac_objective(previous_target, previous_role)
+	for(var/datum/mind/cult_mind in cult)
+		if(cult_mind)
+			var/updated_memory = cult_mind.memory
+			updated_memory = replacetext("[cult_mind.memory]", "[previous_target]", "[sacrifice_target]")
+			updated_memory = replacetext("[updated_memory]", "[previous_role]", "[sacrifice_target.assigned_role]")
+			cult_mind.memory = updated_memory
+			
+
 /datum/game_mode/cult/proc/pick_objective()
 	var/list/possible_objectives = list()
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -371,6 +371,8 @@
 			for(var/datum/mind/H in SSticker.mode.cult)
 				if(H.current)
 					to_chat(H.current, "<span class='danger'>[SSticker.cultdat.entity_name]</span> murmurs, <span class='cultlarge'>[occupant] is beyond your reach. Sacrifice [cult_mode.sacrifice_target.current] instead...</span></span>")
+					H.current << 'sound/ambience/alarm4.ogg'
+			cult_mode.update_sac_objective(occupant.mind, occupant.mind.assigned_role)
 		else
 			cult_mode.bypass_phase()
 


### PR DESCRIPTION
**What does this PR do:**
The game will now properly reassign a cultist sacrifice target when the current one goes to cryo, and updates every cultists notes as well. Also, the game now plays the same alarm sound that other antags get when their assassinate targets go to cryo, allowing cultists to get better notification on their updated objectives

Fixes #11796

**Changelog:**
:cl: SteelSlayer
fix: When a cult sacrifice target leaves the round via cryo, the game will reassign a new target for them
add: Added an alarm sound that plays for cultists when their sacrifice target leave the round via cryo
add: When a cult sacrifice target leaves the round via cryo, the game will update every cultist's notes to reflect the change
/:cl: