### PR TITLE
The Sentience event will only produce one prompt per occurance of the event

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -6,22 +6,22 @@
 	event_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 
 /datum/event/blob/start()
-	processing = FALSE //so it won't fire again in next tick
-	var/turf/T = pick(blobstart)
-	if(!T)
-		return kill()
-	var/list/candidates = pollCandidates("Do you want to play as a blob infested mouse?", ROLE_BLOB, 1)
-	if(!candidates.len)
-		return kill()
-	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in GLOB.all_vent_pumps)
-		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
-			if(temp_vent.parent.other_atmosmch.len > 50)
-				vents += temp_vent
-	var/obj/vent = pick(vents)
-	var/mob/living/simple_animal/mouse/blobinfected/B = new(vent.loc)
-	var/mob/M = pick(candidates)
-	B.key = M.key
-	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
-	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B)
-	processing = TRUE // Let it naturally end, if it runs successfully
+	spawn()
+		var/turf/T = pick(blobstart)
+		if(!T)
+			return kill()
+		var/list/candidates = pollCandidates("Do you want to play as a blob infested mouse?", ROLE_BLOB, 1)
+		if(!candidates.len)
+			return kill()
+		var/list/vents = list()
+		for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in GLOB.all_vent_pumps)
+			if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
+				if(temp_vent.parent.other_atmosmch.len > 50)
+					vents += temp_vent
+		var/obj/vent = pick(vents)
+		var/mob/living/simple_animal/mouse/blobinfected/B = new(vent.loc)
+		var/mob/M = pick(candidates)
+		B.key = M.key
+		to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
+		notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B)
+

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -1,46 +1,46 @@
 /datum/event/sentience
 
 /datum/event/sentience/start()
-	var/ghostmsg = "Do you want to awaken as a sentient being?"
-	var/list/candidates = pollCandidates(ghostmsg, ROLE_SENTIENT, 1)
-	var/list/potential = list()
-	var/sentience_type = SENTIENCE_ORGANIC
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to awaken as a sentient being?", ROLE_SENTIENT, 1)
+		var/list/potential = list()
+		var/sentience_type = SENTIENCE_ORGANIC
 
-	for(var/mob/living/simple_animal/L in GLOB.living_mob_list)
-		var/turf/T = get_turf(L)
-		if (T.z != 1)
-			continue
-		if(!(L in GLOB.player_list) && !L.mind && (L.sentience_type == sentience_type))
-			potential += L
+		for(var/mob/living/simple_animal/L in GLOB.living_mob_list)
+			var/turf/T = get_turf(L)
+			if (T.z != 1)
+				continue
+			if(!(L in GLOB.player_list) && !L.mind && (L.sentience_type == sentience_type))
+				potential += L
 
-	if(!candidates.len || !potential.len) //if there are no players or simple animals to choose from, then end
-		return FALSE
+		if(!candidates.len || !potential.len) //if there are no players or simple animals to choose from, then end
+			return FALSE
 
-	var/mob/living/simple_animal/SA = pick(potential)
-	var/mob/SG = pick(candidates)
+		var/mob/living/simple_animal/SA = pick(potential)
+		var/mob/SG = pick(candidates)
 
-	var/sentience_report = "<font size=3><b>[command_name()] Medium-Priority Update</b></font>"
+		var/sentience_report = "<font size=3><b>[command_name()] Medium-Priority Update</b></font>"
 
-	var/data = pick("scans from our long-range sensors", "our sophisticated probabilistic models", "our omnipotence", "the communications traffic on your station", "energy emissions we detected", "\[REDACTED\]", "Steve")
-	var/pets = pick("animals", "pets", "simple animals", "lesser lifeforms", "\[REDACTED\]")
-	var/strength = pick("human", "skrell", "vox", "grey", "diona", "IPC", "tajaran", "vulpakanin", "kidan", "plasmaman", "drask",
-					 "slime", "monkey", "moderate", "lizard", "security", "command", "clown", "mime", "low", "very low", "greytide", "catgirl", "\[REDACTED\]")
+		var/data = pick("scans from our long-range sensors", "our sophisticated probabilistic models", "our omnipotence", "the communications traffic on your station", "energy emissions we detected", "\[REDACTED\]", "Steve")
+		var/pets = pick("animals", "pets", "simple animals", "lesser lifeforms", "\[REDACTED\]")
+		var/strength = pick("human", "skrell", "vox", "grey", "diona", "IPC", "tajaran", "vulpakanin", "kidan", "plasmaman", "drask",
+						"slime", "monkey", "moderate", "lizard", "security", "command", "clown", "mime", "low", "very low", "greytide", "catgirl", "\[REDACTED\]")
 
-	sentience_report += "<br><br>Based on [data], we believe that one of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
+		sentience_report += "<br><br>Based on [data], we believe that one of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
 
 
 
-	SA.key = SG.key
-	SA.universal_speak = 1
-	SA.sentience_act()
-	SA.can_collar = 1
-	SA.maxHealth = max(SA.maxHealth + 200)
-	SA.melee_damage_lower = max(SA.melee_damage_lower + 15)
-	SA.melee_damage_upper = max(SA.melee_damage_upper + 15)
-	SA.health = SA.maxHealth
-	SA.del_on_death = FALSE
-	greet_sentient(SA)
-	print_command_report(sentience_report, "[command_name()] Update")
+		SA.key = SG.key
+		SA.universal_speak = 1
+		SA.sentience_act()
+		SA.can_collar = 1
+		SA.maxHealth = max(SA.maxHealth + 200)
+		SA.melee_damage_lower = max(SA.melee_damage_lower + 15)
+		SA.melee_damage_upper = max(SA.melee_damage_upper + 15)
+		SA.health = SA.maxHealth
+		SA.del_on_death = FALSE
+		greet_sentient(SA)
+		print_command_report(sentience_report, "[command_name()] Update")
 
 /datum/event/sentience/proc/greet_sentient(var/mob/living/carbon/human/M)
 	to_chat(M, "<span class='userdanger'>Hello world!</span>")


### PR DESCRIPTION
**What does this PR do:**
The sentience event was firing every tick for the 30 second window that players could respond to the sentience even prompt, which made it send out 15 prompts. This should longer happen; there will be only one prompt sent out. 

The code for the sentience event is now brought in line with other events that would poll players such as traders, morphs, revenants, xenomorphs, and abductors. Additionally I gave the same tweak to the blob event code.

Fixes #11874

**Changelog:**
:cl:
tweak: Standardizes the sentience and blob event spawning code
fix: The sentience event will only produce one prompt per observer per occurrence of the event
/:cl: