### PR TITLE
Uplink Items are now chosen based on the type of uplink.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
-/proc/get_uplink_items(var/job = null)
+/proc/get_uplink_items(var/datum/game_mode/gamemode = null, var/job = null)
 	var/list/uplink_items = list()
 	var/list/sales_items = list()
 	var/newreference = 1
@@ -12,10 +12,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			var/datum/uplink_item/I = new path
 			if(!I.item)
 				continue
-			if(I.gamemodes.len && SSticker && !(SSticker.mode.type in I.gamemodes))
-				continue
-			if(I.excludefrom.len && SSticker && (SSticker.mode.type in I.excludefrom))
-				continue
+			if(I.include_modes.len)
+				if(!gamemode && SSticker.mode && !(SSticker.mode.type in I.include_modes))
+					continue
+				if(gamemode && !(gamemode in I.include_modes))
+					continue
+			if(I.exclude_modes.len)
+				if(!gamemode && SSticker.mode && (SSticker.mode.type in I.exclude_modes))
+					continue
+				if(gamemode && (gamemode in I.exclude_modes))
+					continue
 			if(I.last)
 				last += I
 				continue
@@ -75,8 +81,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/cost = 0
 	var/last = 0 // Appear last
 	var/abstract = 0
-	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
-	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
+	var/list/include_modes = list() // Game modes to allow this item in.
+	var/list/exclude_modes = list() // Game modes to disallow this item from.
 	var/list/job = null
 	var/surplus = 100 //Chance of being included in the surplus crate (when pick() selects it)
 	var/cant_discount = FALSE
@@ -163,7 +169,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/jobspecific
 	category = "Job Specific Tools"
 	cant_discount = TRUE
-	excludefrom = list(/datum/game_mode/nuclear) // Stops the job specific category appearing for nukies
+	exclude_modes = list(/datum/game_mode/nuclear) // Stops the job specific category appearing for nukies
 
 //Clown
 /datum/uplink_item/jobspecific/clowngrenade
@@ -432,7 +438,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "PP"
 	item = /obj/item/pen/poison
 	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian")
 
 
@@ -462,7 +468,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun that fires .45 rounds with a 20-round magazine and is compatible with suppressors."
 	item = /obj/item/gun/projectile/automatic/c20r
 	cost = 14
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 40
 
 /datum/uplink_item/dangerous/carbine
@@ -471,7 +477,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "AR"
 	item = /obj/item/gun/projectile/automatic/m90
 	cost = 18
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 50
 
 /datum/uplink_item/dangerous/machinegun
@@ -480,7 +486,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "LMG"
 	item = /obj/item/gun/projectile/automatic/l6_saw
 	cost = 40
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/dangerous/rapid
@@ -497,7 +503,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	cost = 16
 	surplus = 25
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/sniper_compact //For when you really really hate that one guy.
 	name = "Compact Sniper Rifle"
@@ -507,7 +513,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 16
 	surplus = 0
 	cant_discount = TRUE
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/crossbow
 	name = "Energy Crossbow"
@@ -515,7 +521,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "EC"
 	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
 	cost = 12
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 	surplus = 50
 
 /datum/uplink_item/dangerous/flamethrower
@@ -524,7 +530,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FT"
 	item = /obj/item/flamethrower/full/tank
 	cost = 8
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 40
 
 /datum/uplink_item/dangerous/sword
@@ -563,7 +569,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/support
 	category = "Support and Mechanized Exosuits"
 	surplus = 0
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/support/gygax
 	name = "Gygax Exosuit"
@@ -624,7 +630,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FSMG"
 	item = /obj/item/gun/projectile/automatic/c20r/toy
 	cost = 5
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/dangerous/foammachinegun
@@ -633,7 +639,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FLMG"
 	item = /obj/item/gun/projectile/automatic/l6_saw/toy
 	cost = 10
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/dangerous/guardian
@@ -641,7 +647,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an organic host as a home base and source of fuel. \
 			The holoparasites are unable to incoporate themselves to changeling and vampire agents."
 	item = /obj/item/storage/box/syndie_kit/guardian
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 	cost = 12
 	refund_path = /obj/item/guardiancreator/tech/choose
 	refundable = TRUE
@@ -687,7 +693,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12BSG"
 	item = /obj/item/ammo_box/magazine/m12g
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bullbuck
 	name = "Bulldog - 12g Buckshot Magazine"
@@ -695,7 +701,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12BS"
 	item = /obj/item/ammo_box/magazine/m12g/buckshot
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bullstun
 	name = "Bulldog - 12g Stun Slug Magazine"
@@ -703,7 +709,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12SS"
 	item = /obj/item/ammo_box/magazine/m12g/stun
 	cost = 3
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bulldragon
 	name = "Bulldog - 12g Dragon's Breath Magazine"
@@ -711,7 +717,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12DB"
 	item = /obj/item/ammo_box/magazine/m12g/dragon
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bulldog_ammobag
 	name = "Bulldog - 12g Ammo Duffel Bag"
@@ -719,7 +725,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "12ADB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgun
 	cost = 12 // normally 18
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/smg
 	name = "C-20r - .45 Magazine"
@@ -727,7 +733,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "45"
 	item = /obj/item/ammo_box/magazine/smgm45
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/smg_ammobag
 	name = "C-20r - .45 Ammo Duffel Bag"
@@ -735,7 +741,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "45ADB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/smg
 	cost = 14 // normally 20
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/carbine
 	name = "Carbine - 5.56 Toploader Magazine"
@@ -743,7 +749,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "556"
 	item = /obj/item/ammo_box/magazine/m556
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/a40mm
 	name = "Carbine - 40mm Grenade Ammo Box"
@@ -751,7 +757,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "40MM"
 	item = /obj/item/ammo_box/a40mm
 	cost = 4
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/machinegun
 	name = "L6 SAW - 5.56x45mm Box Magazine"
@@ -759,12 +765,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "762"
 	item = /obj/item/ammo_box/magazine/mm556x45
 	cost = 12
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/ammo/sniper
 	cost = 4
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/sniper/basic
 	name = "Sniper - .50 Magazine"
@@ -800,7 +806,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BTS"
 	item = /obj/item/storage/box/syndie_kit/bioterror
 	cost = 5
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/toydarts
 	name = "Box of Riot Darts"
@@ -808,7 +814,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "FOAM"
 	item = /obj/item/ammo_box/foambox/riot
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/ammo/revolver
@@ -839,7 +845,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SCS"
 	item = /obj/item/sleeping_carp_scroll
 	cost = 17
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 	refundable = TRUE
 	cant_discount = TRUE
 
@@ -848,7 +854,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. Does not restrict weapon usage, but cannot be used alongside Gloves of the North Star."
 	reference = "CQC"
 	item = /obj/item/CQC_manual
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	cost = 13
 	surplus = 0
 
@@ -882,7 +888,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SP"
 	item = /obj/item/pen/sleepy
 	cost = 8
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/foampistol
 	name = "Toy Gun (with Stun Darts)"
@@ -907,7 +913,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/syringe/syndicate
 	cost = 4
 	surplus = 50
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/RSG
 	name = "Rapid Syringe Gun"
@@ -915,7 +921,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "RSG"
 	item = /obj/item/gun/syringe/rapidsyringe
 	cost = 4
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/silencer
 	name = "Universal Suppressor"
@@ -958,7 +964,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/backpack/duffel/syndie/c4
 	cost = 8 //20% discount!
 	cant_discount = TRUE
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/breaching_charge
 	name = "Composition X-4"
@@ -966,7 +972,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "X4"
 	item = /obj/item/grenade/plastic/x4
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/x4bag
 	name = "Bag of X-4 explosives"
@@ -977,7 +983,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/backpack/duffel/syndie/x4
 	cost = 4
 	cant_discount = TRUE
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
@@ -1017,7 +1023,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/belt/grenade/full
 	cost = 30
 	surplus = 0
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/manhacks
 	name = "Viscerator Delivery Grenade"
@@ -1025,7 +1031,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "VDG"
 	item = /obj/item/grenade/spawnergrenade/manhacks
 	cost = 6
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 35
 
 /datum/uplink_item/explosives/saringrenades
@@ -1034,7 +1040,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "TGG"
 	item = /obj/item/storage/box/syndie_kit/sarin
 	cost = 12
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/explosives/atmosn2ogrenades
@@ -1091,13 +1097,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "NSSS"
 	item = /obj/item/clothing/shoes/chameleon/noslip
 	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	reference = "TNSSS"
 	cost = 4 //but they aren't
-	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	exclude_modes = list()
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/chamsechud
 	name = "Chameleon Security HUD"
@@ -1119,7 +1125,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SBM"
 	item = /obj/item/storage/belt/military/traitor
 	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/frame
 	name = "F.R.A.M.E. PDA Cartridge"
@@ -1207,7 +1213,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "HBIK"
 	item = /obj/item/storage/backpack/clown/syndie
 	cost = 6
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 // DEVICE AND TOOLS
@@ -1257,7 +1263,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "DRL"
 	item = /obj/item/thermal_drill
 	cost = 3
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/diamond_drill
 	name = "Diamond Tipped Thermal Safe Drill"
@@ -1265,7 +1271,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "DDRL"
 	item = /obj/item/thermal_drill/diamond_drill
 	cost = 1
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/medkit
 	name = "Syndicate Combat Medic Kit"
@@ -1274,7 +1280,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SCMK"
 	item = /obj/item/storage/firstaid/tactical
 	cost = 7
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
@@ -1300,7 +1306,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BRHS"
 	item = /obj/item/storage/box/syndie_kit/hardsuit
 	cost = 8
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/suits/hardsuit/elite
 	name = "Elite Syndicate Hardsuit"
@@ -1308,8 +1314,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/elite_hardsuit
 	cost = 8
 	reference = "ESHS"
-	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	exclude_modes = list()
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/suits/hardsuit/shielded
 	name = "Shielded Hardsuit"
@@ -1317,8 +1323,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/shielded_hardsuit
 	cost = 30
 	reference = "SHS"
-	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	exclude_modes = list()
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/binary
 	name = "Binary Translator Key"
@@ -1350,7 +1356,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BRMB"
 	item = /obj/item/clothing/shoes/magboots/syndie
 	cost = 3
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/magboots/advance
 	name = "Advanced Blood-Red Magboots"
@@ -1358,8 +1364,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "ABRMB"
 	item = /obj/item/clothing/shoes/magboots/syndie/advance
 	cost = 3
-	excludefrom = list()
-	gamemodes = list(/datum/game_mode/nuclear)
+	exclude_modes = list()
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
@@ -1388,7 +1394,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SD"
 	item = /obj/item/syndicatedetonator
 	cost = 3
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/advpinpointer
 	name = "Advanced Pinpointer"
@@ -1417,7 +1423,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/circuitboard/teleporter
 	reference = "TP"
 	cost = 20
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/device_tools/assault_pod
@@ -1426,7 +1432,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/assault_pod
 	reference = "APT"
 	cost = 25
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
 /datum/uplink_item/device_tools/shield
@@ -1435,7 +1441,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/shield/energy
 	reference = "ESD"
 	cost = 16
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 	surplus = 20
 
 /datum/uplink_item/device_tools/medgun
@@ -1444,7 +1450,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/medbeam
 	reference = "MBG"
 	cost = 15
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 
 // IMPLANTS
@@ -1496,13 +1502,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "MBI"
 	item = /obj/item/implanter/explosive
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 // Cybernetics
 /datum/uplink_item/cyber_implants
 	category = "Cybernetic Implants"
 	surplus = 0
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/cyber_implants/spawn_item(turf/loc, obj/item/uplink/U)
 	if(item)
@@ -1563,7 +1569,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SPC"
 	item = /obj/item/toy/cards/deck/syndicate
 	cost = 1
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 	surplus = 40
 
 /datum/uplink_item/badass/syndiecash
@@ -1580,7 +1586,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "PBAG"
 	item = /obj/item/storage/bag/plasticbag
 	cost = 1
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/badass/balloon
 	name = "For showing that you are The Boss"
@@ -1596,7 +1602,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "HAB"
 	item = /obj/item/implanter/explosive_macro
 	cost = 20
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC
 	category = "Bundles and Telecrystals"
@@ -1610,7 +1616,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "BULB"
 	item = /obj/item/storage/backpack/duffel/syndie/bulldogbundle
 	cost = 9 // normally 12
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/c20r
 	name = "C-20r Bundle"
@@ -1618,7 +1624,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "C20B"
 	item = /obj/item/storage/backpack/duffel/syndie/c20rbundle
 	cost = 14 // normally 17
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/cyber_implants
 	name = "Cybernetic Implants Bundle"
@@ -1627,7 +1633,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CIB"
 	item = /obj/item/storage/box/cyber_implants/bundle
 	cost = 40
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/medical
 	name = "Medical Bundle"
@@ -1636,7 +1642,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "MEDB"
 	item = /obj/item/storage/backpack/duffel/syndie/med/medicalbundle
 	cost = 15 // normally 20
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/sniper
 	name = "Sniper bundle"
@@ -1646,7 +1652,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SNPB"
 	item = /obj/item/storage/briefcase/sniperbundle
 	cost = 18 // normally 23
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/badass
 	name = "Syndicate Bundle"
@@ -1654,7 +1660,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SYB"
 	item = /obj/item/storage/box/syndicate
 	cost = 20
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/surplus_crate
 	name = "Syndicate Surplus Crate"
@@ -1662,7 +1668,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SYSC"
 	cost = 20
 	item = /obj/item/storage/box/syndicate
-	excludefrom = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear)
 	var/crate_value = 50
 
 /datum/uplink_item/bundles_TC/surplus_crate/super
@@ -1730,4 +1736,4 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "RTCB"
 	item = /obj/item/stack/telecrystal/fifty
 	cost = 50
-	gamemodes = list(/datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
-/proc/get_uplink_items(var/datum/game_mode/gamemode = null, var/job = null)
+/proc/get_uplink_items(datum/game_mode/gamemode = null, job = null)
 	var/list/uplink_items = list()
 	var/list/sales_items = list()
 	var/newreference = 1

--- a/code/game/jobs/job/syndicate.dm
+++ b/code/game/jobs/job/syndicate.dm
@@ -49,7 +49,10 @@
 
 	var/obj/item/implant/uplink/admin/U = new /obj/item/implant/uplink/admin(H)
 	U.implant(H)
-	U.hidden_uplink.uses = 500
+	U.hidden_uplink.uses = 350
+	var/obj/item/implant/uplink/admin/nuclear/N = new /obj/item/implant/uplink/admin/nuclear(H)
+	N.implant(H)
+	N.hidden_uplink.uses = 350
 	H.faction += "syndicate"
 	var/datum/atom_hud/antag/opshud = huds[ANTAG_HUD_OPS]
 	opshud.join_hud(H.mind.current)

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -17,6 +17,7 @@ var/list/world_uplinks = list()
 	var/list/nanoui_items	// List of items for NanoUI use
 	var/nanoui_menu = 0		// The current menu we are in
 	var/list/nanoui_data = new // Additional data for NanoUI use
+	var/gamemode
 
 	var/purchase_log = ""
 	var/uplink_owner = null//text-only
@@ -24,7 +25,10 @@ var/list/world_uplinks = list()
 
 	var/job = null
 	var/temp_category
-	var/uplink_type = "traitor"
+
+/obj/item/uplink/proc/set_gamemode(_gamemode)
+	gamemode = _gamemode
+	uplink_items = get_uplink_items(gamemode)
 
 /obj/item/uplink/nano_host()
 	return loc
@@ -33,7 +37,7 @@ var/list/world_uplinks = list()
 	..()
 	welcome = SSticker.mode.uplink_welcome
 	uses = SSticker.mode.uplink_uses
-	uplink_items = get_uplink_items()
+	uplink_items = get_uplink_items(gamemode)
 
 	world_uplinks += src
 
@@ -326,7 +330,7 @@ var/list/world_uplinks = list()
 /obj/item/radio/uplink/nuclear/New()
 	..()
 	if(hidden_uplink)
-		hidden_uplink.uplink_type = "nuclear"
+		hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
 	GLOB.nuclear_uplink_list += src
 
 /obj/item/radio/uplink/nuclear/Destroy()
@@ -336,7 +340,7 @@ var/list/world_uplinks = list()
 /obj/item/radio/uplink/sst/New()
 	..()
 	if(hidden_uplink)
-		hidden_uplink.uplink_type = "sst"
+		hidden_uplink.gamemode = "sst"
 
 /obj/item/multitool/uplink/New()
 	hidden_uplink = new(src)

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -13,12 +13,12 @@
 /obj/item/implant/uplink/sit/New()
 	..()
 	if(hidden_uplink)
-		hidden_uplink.uplink_type = "sit"
+		hidden_uplink.gamemode = "sit"
 
 /obj/item/implant/uplink/admin/New()
 	..()
 	if(hidden_uplink)
-		hidden_uplink.uplink_type = "admin"
+		hidden_uplink.gamemode = "admin"
 
 /obj/item/implant/uplink/implant(mob/source)
 	var/obj/item/implant/imp_e = locate(src.type) in source

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -18,7 +18,12 @@
 /obj/item/implant/uplink/admin/New()
 	..()
 	if(hidden_uplink)
-		hidden_uplink.gamemode = "admin"
+		hidden_uplink.set_gamemode(/datum/game_mode/traitor)
+
+/obj/item/implant/uplink/admin/nuclear/New()
+	..()
+	if(hidden_uplink)
+		hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
 
 /obj/item/implant/uplink/implant(mob/source)
 	var/obj/item/implant/imp_e = locate(src.type) in source


### PR DESCRIPTION
**What does this PR do:**
Uplink items are now chosen based on the type of uplink. If you have a traitor uplink, it will give you access to normal traitor equipment. If you have a nuclear uplink, it will give you access to nuclear equipment. The uplinks can be spawned in any gamemode and have the correct items.
Did not come up with the solution myself, had to look at TG's code since their system for loading uplink items was already fixed.

**Changelog:**
:cl: EmanTheAlmighty
tweak: Uplinks no longer check what the current gamemode is to pick what items you can buy, they now check the type of uplink.
/:cl: