### PR TITLE
Disallows Vampires from acquiring power from ckeyless humanized monkeys

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -297,23 +297,23 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			to_chat(owner, "<span class='warning'>They've got no blood left to give.</span>")
 			break
 		if(H.stat < DEAD)
-			if(!issmall(H) || H.ckey)
+			if(H.ckey || H.player_ghosted) //Requires ckey regardless if monkey or humanoid, or the body has been ghosted before it died
 				blood = min(20, H.blood_volume)	// if they have less than 20 blood, give them the remnant else they get 20 blood
 				bloodtotal += blood / 2	//divide by 2 to counted the double suction since removing cloneloss -Melandor0
 				bloodusable += blood / 2
 		else
-			if(!issmall(H) || H.ckey)
+			if(H.ckey || H.player_ghosted)
 				blood = min(5, H.blood_volume)	// The dead only give 5 blood
 				bloodtotal += blood
 		if(old_bloodtotal != bloodtotal)
-			if(!issmall(H) || H.ckey) // not small OR has a ckey, monkeys with ckeys can be sucked, humanized monkeys can be sucked monkeys without ckeys cannot be sucked
+			if(H.ckey || H.player_ghosted) // Requires ckey regardless if monkey or human, and has not ghosted, otherwise no power
 				to_chat(owner, "<span class='notice'><b>You have accumulated [bloodtotal] [bloodtotal > 1 ? "units" : "unit"] of blood[bloodusable != old_bloodusable ? ", and have [bloodusable] left to use" : ""].</b></span>")
 		check_vampire_upgrade()
 		H.blood_volume = max(H.blood_volume - 25, 0)
 		if(ishuman(owner))
 			var/mob/living/carbon/human/V = owner
-			if(issmall(H) && !H.ckey)
-				to_chat(V, "<span class='notice'><b>Feeding on [H] reduces your hunger, but you get no usable blood from it.</b></span>")
+			if(!H.ckey && !H.player_ghosted)//Only runs if there is no ckey and the body has not being ghosted while alive
+				to_chat(V, "<span class='notice'><b>Feeding on [H] reduces your thirst, but you get no usable blood from them.</b></span>")
 				V.nutrition = min(NUTRITION_LEVEL_WELL_FED, V.nutrition + 5)
 			else
 				V.nutrition = min(NUTRITION_LEVEL_WELL_FED, V.nutrition + (blood / 2))


### PR DESCRIPTION
**What does this PR do:**
What this does is that it disallows players from acquiring vampire powers from ckeyless humanoid monkeys (they can still replenish their thirst however on them). They will now have to hunt down and get a character that has a ckey, or had at some point (if they ghosted while alive).

My reasoning is that vampires should not get easily powered up within ten - fifteen minutes into the shift without any risk, they should be interacting with other character/capturing them to get their powers.

Some arguments that I have seen against this is that: Vampires are the weakest round start antag and this will hinder them.
> My argument to that is that only a few roles (geneticist, science, CMO, RD) are able to get a monkey _**AND**_ be capable to make them into a human. This change largely affects _these_ roles, as the other roles have to go through some effort to either get a monkey and/or the way to humanize them.

**NOTE! I have tested this, but request at least one test merge just in case I missed something by accident.**

**Images of sprite/map changes (IF APPLICABLE):**
N/A.

**Changelog:**

:cl: Quantum-M
tweak: Minor grammar edits to the text that tells you that your thirst is dealt with but no blood power is given.
balance: Vampires are no longer able to drink get power from ckeyless humanoid monkeys, they will now need to hunt down actual characters with ckey to get power.
/:cl:

