### PR TITLE
Helmets no longer protects from chance of bible mental damage

### DIFF
--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -67,7 +67,7 @@
 			to_chat(M, "<span class='warning'>May the power of [src.deity_name] compel you to be healed!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)
 		else
-			if(ishuman(M) && !istype(M:head, /obj/item/clothing/head/helmet))
+			if(ishuman(M))
 				M.adjustBrainLoss(10)
 				to_chat(M, "<span class='warning'>You feel dumber.</span>")
 			for(var/mob/O in viewers(M, null))


### PR DESCRIPTION
**What does this PR do:**
This changes so, regardless weather you are wearing a helmet or not, you cannot be protected from the chance of getting brain damage from being hit with a bible.

With a helmet, you have _zero_ chance of a negative outcome if you do not get healed, and a nearly limitless way of getting healed, regardless of how little it is, is not really good balance.

**Images of sprite/map changes (IF APPLICABLE):**
N/A.

**Changelog:**

:cl: Quantum-M
balance: Helmets no longer protect you from the mental damage chance Bibles have when applied to the head.
/:cl:

