### PR TITLE
Alien Queens are now slightly faster.

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -4,6 +4,7 @@
 	maxHealth = 100
 	health = 100
 	icon_state = "aliend_s"
+	desc = "A strange alien. This one seems to be less adept at fighting."
 
 /mob/living/carbon/alien/humanoid/drone/New()
 	create_reagents(100)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -4,6 +4,7 @@
 	maxHealth = 125
 	health = 125
 	icon_state = "alienh_s"
+	desc = "A strange alien. This one seems to be able to move really quickly."
 
 /mob/living/carbon/alien/humanoid/hunter/New()
 	create_reagents(100)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -4,6 +4,7 @@
 	maxHealth = 150
 	health = 150
 	icon_state = "aliens_s"
+	desc = "A strange alien. This one has two green glowing sacs on its crest."
 
 /mob/living/carbon/alien/humanoid/sentinel/large
 	name = "alien praetorian"

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -8,6 +8,7 @@
 	heal_rate = 5
 	large = 1
 	ventcrawler = 0
+	desc = "A bulky alien. This one seems to be a jack of all trades, its only drawback being its size."
 
 /mob/living/carbon/alien/humanoid/queen/New()
 	create_reagents(100)
@@ -30,7 +31,7 @@
 
 /mob/living/carbon/alien/humanoid/queen/movement_delay()
 	. = ..()
-	. += 3
+	. += 2
 
 /mob/living/carbon/alien/humanoid/queen/handle_regular_hud_updates()
 	..() //-Yvarov

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/alien/larva
 	name = "alien larva"
+	desc = "A small snake-like creature. It's covered in blood..."
 	real_name = "alien larva"
 	icon_state = "larva0"
 	pass_flags = PASSTABLE | PASSMOB

--- a/code/modules/mob/living/carbon/alien/larva/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/larva/update_icons.dm
@@ -7,8 +7,10 @@
 	var/state = 0
 	if(amount_grown > 150)
 		state = 2
+		desc = "A snake-like creature."
 	else if(amount_grown > 50)
 		state = 1
+		desc = "A small snake-like creature."
 
 	if(stat == DEAD)
 		icon_state = "larva[state]_dead"


### PR DESCRIPTION
**What does this PR do:**
Alien Queens now move slightly faster than before.
Also added descriptions to every alien.

The reason for the buff is that, they are REALLY, really too slow. They can't protect themselves at all. They "can" shoot at people with their neurotoxin, but by the time they get to the downed person, either they have gotten up or somebody dragged them away. If they had way more health and looked bigger, then this speed could be justified, but as of now they are the same size as the other xenos and are inexplicably slow. 
The QUEEN of xenomorphs should be more dangerous.

Old compared to new:
https://gfycat.com/bleakquerulouslice

**Changelog:**
:cl: EmanTheAlmighty
tweak: Alien Queens are now slightly faster.
add: Added new descriptions to every xenomorph.
/:cl: