### PR TITLE
Splits vampire rejuvenate stun canceling and healing into 2 abilities

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -213,7 +213,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		/obj/effect/proc_holder/spell/vampire/targetted/disease = 150,
 		/obj/effect/proc_holder/spell/vampire/bats = 200,
 		/obj/effect/proc_holder/spell/vampire/self/screech = 200,
-		/datum/vampire_passive/regen = 200,
+		/obj/effect/proc_holder/spell/vampire/self/vitalise = 200,
 		/obj/effect/proc_holder/spell/vampire/shadowstep = 250,
 		/obj/effect/proc_holder/spell/vampire/self/jaunt = 300,
 		/obj/effect/proc_holder/spell/vampire/targetted/enthrall = 300,

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -159,14 +159,25 @@
 	user.SetSleeping(0)
 	U.adjustStaminaLoss(-75)
 	to_chat(user, "<span class='notice'>You flush your system with clean blood and remove any incapacitating effects.</span>")
-	spawn(1)
-		if(usr.mind.vampire.get_ability(/datum/vampire_passive/regen))
-			for(var/i = 1 to 5)
-				U.adjustBruteLoss(-2)
-				U.adjustOxyLoss(-5)
-				U.adjustToxLoss(-2)
-				U.adjustFireLoss(-2)
-				sleep(35)
+
+/obj/effect/proc_holder/spell/vampire/self/vitalise
+	name = "Vitalise (20)"
+	desc= "Flush your system with spare blood to heal yourself."
+	action_icon_state = "fleshmend"
+	charge_max = 200
+	stat_allowed = 1
+	required_blood = 20
+
+/obj/effect/proc_holder/spell/vampire/self/vitalise/cast(list/targets, mob/user = usr)
+	var/mob/living/U = user
+
+	to_chat(user, "<span class='notice'>You flush your system with clean blood and heal your wounds.</span>")
+	for(var/i = 1 to 5)
+		U.adjustBruteLoss(-2)
+		U.adjustOxyLoss(-5)
+		U.adjustToxLoss(-2)
+		U.adjustFireLoss(-2)
+		sleep(25)
 
 /obj/effect/proc_holder/spell/vampire/targetted/hypnotise
 	name = "Hypnotise (20)"
@@ -525,9 +536,6 @@
 		user.forceMove(picked)
 		spawn(10)
 			qdel(animation)
-
-/datum/vampire_passive/regen
-	gain_desc = "Your rejuvination abilities have improved and will now heal you over time when used."
 
 /datum/vampire_passive/vision
 	gain_desc = "Your vampiric vision has improved."

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -163,6 +163,7 @@
 /obj/effect/proc_holder/spell/vampire/self/vitalise
 	name = "Vitalise (20)"
 	desc= "Flush your system with spare blood to heal yourself."
+	gain_desc = "You have gained the Vitalise ability, at the cost of stored blood you can heal damge you've sustained."
 	action_icon_state = "fleshmend"
 	charge_max = 200
 	stat_allowed = 1
@@ -170,14 +171,23 @@
 
 /obj/effect/proc_holder/spell/vampire/self/vitalise/cast(list/targets, mob/user = usr)
 	var/mob/living/U = user
-
-	to_chat(user, "<span class='notice'>You flush your system with clean blood and heal your wounds.</span>")
-	for(var/i = 1 to 5)
-		U.adjustBruteLoss(-2)
-		U.adjustOxyLoss(-5)
-		U.adjustToxLoss(-2)
-		U.adjustFireLoss(-2)
-		sleep(25)
+	var/healing_power = 40
+	var/healing_ticks = 5
+	var/missing_health = U.getBruteLoss() + U.getToxLoss() + U.getFireLoss()
+	if (missing_health > 0)
+		var/brute_loss_percentage = U.getBruteLoss() / missing_health
+		var/tox_loss_percentage = U.getToxLoss() / missing_health
+		var/fire_loss_percentage = U.getFireLoss() / missing_health
+		to_chat(user, "<span class='notice'>You flush your system with clean blood and heal your wounds.</span>")
+		for(var/i = 1 to healing_ticks)
+			U.adjustBruteLoss(-brute_loss_percentage * healing_power / healing_ticks)
+			U.adjustOxyLoss(-5)
+			U.adjustToxLoss(-tox_loss_percentage * healing_power / healing_ticks)
+			U.adjustFireLoss(-fire_loss_percentage * healing_power / healing_ticks)
+			sleep(25)
+	else
+		revert_cast(user)
+		to_chat(user, "<span class='notice'>You have no wounds to heal!</span>")
 
 /obj/effect/proc_holder/spell/vampire/targetted/hypnotise
 	name = "Hypnotise (20)"


### PR DESCRIPTION
**What does this PR do:**
Instead of having the rejuvenate ability heal you once you reach 200 passive blood, you now unlock an ability called Vitalise that heals you slightly faster and for more damage for 20 active blood.

The reason I think this is a good idea is that vampires already have several powerful ways to get out of a fight, and with rejuvenate healing a respectable amount of all standard damage types for free, damage you dealt to the vamp has almost no chance of actually sticking. Especially now that bone breaking is far less common, vampires can shrug off lasers and bullets far more often than they should. Now, they will have to weigh the cost of that heal against alternatives such as stealing medicine or using that blood to get away from fights in the first place. My idea of a vampire was that they are very powerful, as long as they can afford to pay the upkeep for that power.

**Changelog:**
:cl:
add: Vampires now unlock an active healing ability called "Vitalise" at 200 passive blood
del: Vampires no longer heal passively as part of the "Rejuvenate" ability once they reach 200 passive blood.
/:cl:

