### PR TITLE
Fix typing indicators not showing

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -33,25 +33,22 @@ SUBSYSTEM_DEF(input)
 		"default" = list(
 			"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = "say",
-			"M" = "me",
-			"F3" = "say",
+			"T" = ".say",
+			"M" = ".me",
 			"Back" = "\".winset \\\"input.focus=true input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 			),
 		"old_default" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
-			"Ctrl+T" = "say",
+			"Ctrl+T" = ".say",
 			"Ctrl+O" = "ooc",
-			"F3" = "say",
 			),
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = "say",
-			"M" = "me",
-			"F3" = "say",
+			"T" = ".say",
+			"M" = ".me",
 			"Back" = "\".winset \\\"input.focus=true input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -22,8 +22,11 @@
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
 			ooc()
 			return
+		if("F3")
+			mob.say_wrapper()
+			return
 		if("F4")
-			mob.me_verb()
+			mob.me_wrapper()
 			return
 		if("F12") // Toggles minimal HUD
 			mob.button_pressed_F12()


### PR DESCRIPTION
**What does this PR do:**
There was an regression with diagonal movement where typing indicators would no longer show up on characters that had them enabled, this fixes them by using the correct wrappers for the me and say verbs

**Changelog:**
:cl:
fix: typing indicators show up again
/:cl:

