### PR TITLE
Glass shards can now cut cables.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -171,6 +171,13 @@ By design, d1 is the smallest direction and d2 is the highest
 		deconstruct()
 		return
 
+	else if(istype(W, /obj/item/shard))
+		if(shock(user, 50))
+			return
+		user.visible_message("[user] cuts the cable.", "<span class='notice'>You cut the cable.</span>")
+		investigate_log("was cut by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
+		deconstruct()
+		return
 
 	else if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/coil = W

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -174,10 +174,16 @@ By design, d1 is the smallest direction and d2 is the highest
 	else if(istype(W, /obj/item/shard))
 		if(shock(user, 50))
 			return
-		user.visible_message("[user] cuts the cable.", "<span class='notice'>You cut the cable.</span>")
-		investigate_log("was cut by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
-		deconstruct()
-		return
+		if(prob(30)) // Chance to destroy the cable
+			user.visible_message("[user] cuts the cable to pieces!", "<span class='notice'>You accidentally cut the cable to pieces!</span>")
+			investigate_log("was destroyed using a glass shard by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
+			Destroy()
+			return
+		else
+			user.visible_message("[user] cuts the cable.", "<span class='notice'>You cut the cable.</span>")
+			investigate_log("was cut by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
+			deconstruct()
+			return
 
 	else if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/coil = W


### PR DESCRIPTION
**What does this PR do:**
Allows glass shards to be used to cut wires. This is something to allow people with basically no items in their inventory to work towards getting a spear or cable cuffs by breaking windows and cutting wires. It should be possible. So here it is.

**Changelog:**
:cl: EmanTheAlmighty
add: Glass shards can now be used to cut wires, however, being an improvised tool, there's a chance the wire will be destroyed, becoming unusable.
/:cl: