### PR TITLE
gives event-spawned xeno larva  a growth boost

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -26,6 +26,7 @@
 			if(C)
 				GLOB.respawnable_list -= C.client
 				var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
+				new_xeno.amount_grown += (0.75 * new_xeno.max_grown)	//event spawned larva start off almost ready to evolve.
 				new_xeno.key = C.key
 				if(SSticker && SSticker.mode)
 					SSticker.mode.xenos += new_xeno.mind


### PR DESCRIPTION
**What does this PR do:**
TLDR: the larvas spawned by a xeno event now start 3/4 grown up already, so they can evolve without as much needless waiting around.

We all know how the typical Xeno event goes, somewhat like this:

1. event fires and two larva are spawned in. They hide, hopefully crew doesn't spot them already at this point.
2. Wait for larva to mature, nothing really happens in this stage, larvas look for turbine or similar abandoned location.
3. larvas evolve, one hopefully goes drone to become queen. Hunter can go out and start capturing hosts for later.
4. wait for drone to become queen.
5. queen lays eggs.
6. wait for eggs to hatch
7. facehugger people
8. wait for larvas to chestburst
9. wait for second larva generation to grow up
10. Oh wait, round end vote happened and escape shuttle arrives before you can do anything, crew didn't bother fighting you anyway and just went to escape. Yay quarantine? 

There is a long, _long_ windup time until xenos get going. By the time the first second generation hunter is created, the shuttle's already been called, since round extension votes never go through anyway. Now, you can argue this is also a balance question, and xenos can really get out of hand, so I am not interested in speeding up the xeno lifecycle in general.

However, I want xeno investations to not get totally trivialised by the round end all the time. One method to do that would have been to make the event fire earlier, but that has large knock-on effects I wished to avoid. Instead, I focused on one of the most boring parts of the xeno infestation:

Waiting for the initial larva to grow up. There really isn't anything to do during this part, either for the crew or the xenos. The xeno hide in vents, the crew is unaware of their presence. Now, in theory the larva could go out biting people to speed up their grow but that's basically suicide, and risking one of the two only xenos that are needed to get the infestation going is very unwise.

For that reason, the larvas are now created with 150/200 evolution progress. By the time they've found a good place to nest up, they should generally be ready to evolve now.  This means the action should start a few minutes sooner, meaning it has more of a chance to play out before shift end evacuation.

**Changelog:**
:cl:
tweak: midround event spawned xeno larva now need less time to grow up and evolve.
/:cl:

