### PR TITLE
Makes space/starlight actually scary for vamps

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -402,7 +402,14 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 
 		if(T.density)
 			return
-	vamp_burn(1)
+	if(bloodusable >= 10)	//burn through your blood to tank the light for a little while
+		to_chat(owner, "<span class='warning'>The starlight saps your strength!</span>")
+		bloodusable -= 10
+		vamp_burn(10)
+	else		//You're in trouble, get out of the sun NOW
+		to_chat(owner, "<span class='userdanger'>Your body is turning to ash, get out of the light now!</span>")
+		owner.adjustCloneLoss(10)	//I'm melting!
+		vamp_burn(85)
 
 /datum/vampire/proc/handle_vampire()
 	if(owner.hud_used)
@@ -419,7 +426,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	if(istype(owner.loc, /turf/space))
 		check_sun()
 	if(istype(owner.loc.loc, /area/chapel) && !get_ability(/datum/vampire_passive/full))
-		vamp_burn(0)
+		vamp_burn(7)
 	nullified = max(0, nullified - 1)
 
 /datum/vampire/proc/handle_vampire_cloak()
@@ -442,8 +449,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	else
 		owner.alpha = round((255 * 0.80))
 
-/datum/vampire/proc/vamp_burn(severe_burn)
-	var/burn_chance = severe_burn ? 35 : 8
+/datum/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.health >= 50)
 		switch(owner.health)
 			if(75 to 100)


### PR DESCRIPTION
**What does this PR do:**
One of the vampire's major weakness is supposed to be starlight (cause it's from suns), which means certain spots in space. The wiki, in fact, says:

> DON'T STEP FOOT ANYWHERE NEAR SPACE. Space operates much the same as the chapel, and will cause you to spontaneously combust and subsequently die even if you've reached final form.

On the other hand, vampires currently...really don't have any reason to be afraid of space/light, it is pretty laughable at the moment. The main reason is that once you're at 50% health or lower, it gives you burn stacks instead of damage, and fire immediately goes out if you're in space. Also, fire immunity is fairly easy to get, just nab an atmos hardsuit or similar.

Vamps misting into space are an annoyance, on top of subverting this supposed weakness, so I decided to make space a real pain for vampires to be in.

**Vampires now lose 10 usable blood** for every tick (ie 2 seconds) they spend exposed to starlight, on top of a chance for very minor burn damage/fire stacks as before.
If a vampire ever runs out of usable blood while in space though, he's in **real** trouble. He has a very high chance for the usual fire damage, but they also suffer **10 clone damage** as their body gets destroyed by the sun. This is primarily to be a sticky kind of damage, one not easily healed with some patches on the run, or with a healing virus.

If it's too controversial, I suppose just adding more fire damage manually would also work.

Sidenote, refactored how the vamp_burn proc works slightly to be more flexible with its argument.

**Changelog:**
:cl:
balance: Vampires exposed to starlight now lose blood, if out of blood they suffer very nasty clone damage.
/:cl:

