### PR TITLE
Adds hidden fingerprint to remote door uses

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -50,6 +50,7 @@
 		to_chat(user, "<span class='danger'>[D]'s ID scan is disabled!</span>")
 		return
 	if(D.check_access(src.ID))
+		D.add_hiddenprint(user)
 		switch(mode)
 			if(WAND_OPEN)
 				if(D.density)


### PR DESCRIPTION
**What does this PR do:**
Shows who opened a door with a door remote for admins
🆑 
fix: Door remotes now add to admin-only hidden fingerprint list
/ 🆑 