### PR TITLE
Dropped anti drop items now lose the antidrop status if not initialized with it

### DIFF
--- a/code/datums/spells/horsemask.dm
+++ b/code/datums/spells/horsemask.dm
@@ -36,7 +36,7 @@
 		return
 
 	var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
-	magichead.flags |= NODROP		//curses!
+	magichead.flags |= NODROP | DROPDEL	//curses!
 	magichead.flags_inv = null	//so you can still see their face
 	magichead.voicechange = 1	//NEEEEIIGHH
 	target.visible_message(	"<span class='danger'>[target]'s face  lights up in fire, and after the event a horse's head takes its place!</span>", \

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -48,10 +48,6 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
-/obj/item/clothing/suit/armor/abductor/vest/dropped()
-	. = ..()
-	flags &= ~NODROP
-
 /obj/item/clothing/suit/armor/abductor/vest/item_action_slot_check(slot, mob/user)
 	if(slot == slot_wear_suit) //we only give the mob the ability to activate the vest if he's actually wearing it.
 		return 1

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -48,6 +48,10 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
+/obj/item/clothing/suit/armor/abductor/vest/dropped()
+	. = ..()
+	flags &= ~NODROP
+
 /obj/item/clothing/suit/armor/abductor/vest/item_action_slot_check(slot, mob/user)
 	if(slot == slot_wear_suit) //we only give the mob the ability to activate the vest if he's actually wearing it.
 		return 1

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -863,7 +863,7 @@
 	if(istype(user, /mob/living/carbon/human))
 		to_chat(user, "<font size='15' color='red'><b>HOR-SIE HAS RISEN</b></font>")
 		var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
-		magichead.flags |= NODROP		//curses!
+		magichead.flags |= NODROP | DROPDEL	//curses!
 		magichead.flags_inv = null	//so you can still see their face
 		magichead.voicechange = 1	//NEEEEIIGHH
 		if(!user.unEquip(user.wear_mask))

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -141,7 +141,7 @@
 		new /obj/effect/hallucination/delusion(victim.loc, victim, force_kind = "demon", duration = duration, skip_nearby = 0)
 
 	var/obj/item/twohanded/required/chainsaw/doomslayer/chainsaw = new(victim.loc)
-	chainsaw.flags |= NODROP
+	chainsaw.flags |= NODROP | DROPDEL
 	victim.drop_l_hand()
 	victim.drop_r_hand()
 	victim.put_in_hands(chainsaw)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -347,6 +347,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 		A.Remove(user)
 	if(flags & DROPDEL)
 		qdel(src)
+	if((flags & NODROP) && !(initial(flags) & NODROP)) //Remove NODROP is dropped
+		flags &= ~NODROP
 	in_inventory = FALSE
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1930,7 +1930,7 @@
 				evilcookie.reagents.add_reagent("mutagen", 10)
 				evilcookie.desc = "It has a faint green glow."
 				evilcookie.bitesize = 100
-				evilcookie.flags = NODROP
+				evilcookie.flags = NODROP | DROPDEL
 				H.drop_l_hand()
 				H.equip_to_slot_or_del(evilcookie, slot_l_hand)
 				logmsg = "a mutagen cookie."
@@ -1939,7 +1939,7 @@
 				evilcookie.reagents.add_reagent("hell_water", 25)
 				evilcookie.desc = "Sulphur-flavored."
 				evilcookie.bitesize = 100
-				evilcookie.flags = NODROP
+				evilcookie.flags = NODROP | DROPDEL
 				H.drop_l_hand()
 				H.equip_to_slot_or_del(evilcookie, slot_l_hand)
 				logmsg = "a hellwater cookie."

--- a/code/modules/ninja/suit/gloves.dm
+++ b/code/modules/ninja/suit/gloves.dm
@@ -12,7 +12,3 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	transfer_prints = FALSE
-
-/obj/item/clothing/gloves/space_ninja/dropped()
-	. = ..()
-	flags &= ~NODROP

--- a/code/modules/ninja/suit/gloves.dm
+++ b/code/modules/ninja/suit/gloves.dm
@@ -12,3 +12,7 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	transfer_prints = FALSE
+
+/obj/item/clothing/gloves/space_ninja/dropped()
+	. = ..()
+	flags &= ~NODROP

--- a/code/modules/ninja/suit/head.dm
+++ b/code/modules/ninja/suit/head.dm
@@ -8,7 +8,3 @@
 	armor = list(melee = 60, bullet = 60, laser = 45, energy = 15, bomb = 30, bio = 30, rad = 25)
 	unacidable = 1
 	blockTracking = 1
-	
-/obj/item/clothing/head/helmet/space/space_ninja/dropped()
-	. = ..()
-	flags &= ~NODROP 

--- a/code/modules/ninja/suit/head.dm
+++ b/code/modules/ninja/suit/head.dm
@@ -8,3 +8,7 @@
 	armor = list(melee = 60, bullet = 60, laser = 45, energy = 15, bomb = 30, bio = 30, rad = 25)
 	unacidable = 1
 	blockTracking = 1
+	
+/obj/item/clothing/head/helmet/space/space_ninja/dropped()
+	. = ..()
+	flags &= ~NODROP 

--- a/code/modules/ninja/suit/mask.dm
+++ b/code/modules/ninja/suit/mask.dm
@@ -29,7 +29,3 @@ Contents:
 /obj/item/clothing/mask/gas/space_ninja/Destroy()
 	QDEL_NULL(voice_changer)
 	return ..()
-	
-/obj/item/clothing/mask/gas/voice/space_ninja/dropped()
-	. = ..()
-	flags &= ~NODROP 

--- a/code/modules/ninja/suit/mask.dm
+++ b/code/modules/ninja/suit/mask.dm
@@ -29,3 +29,7 @@ Contents:
 /obj/item/clothing/mask/gas/space_ninja/Destroy()
 	QDEL_NULL(voice_changer)
 	return ..()
+	
+/obj/item/clothing/mask/gas/voice/space_ninja/dropped()
+	. = ..()
+	flags &= ~NODROP 

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -10,8 +10,3 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
-	
-/obj/item/clothing/shoes/space_ninja/dropped()
-	. = ..()
-	flags &= ~NODROP 
-	

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -10,3 +10,8 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
+	
+/obj/item/clothing/shoes/space_ninja/dropped()
+	. = ..()
+	flags &= ~NODROP 
+	

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -87,3 +87,7 @@ Contents:
 		suitOccupant = null
 
 		return 1
+		
+/obj/item/clothing/suit/space/space_ninja/dropped()
+	. = ..()
+	flags &= ~NODROP 

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -87,7 +87,3 @@ Contents:
 		suitOccupant = null
 
 		return 1
-		
-/obj/item/clothing/suit/space/space_ninja/dropped()
-	. = ..()
-	flags &= ~NODROP 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -85,7 +85,7 @@
 
 	holder = item
 
-	holder.flags |= NODROP
+	holder.flags |= NODROP | DROPDEL
 	holder.unacidable = 1
 	holder.slot_flags = null
 	holder.w_class = WEIGHT_CLASS_HUGE


### PR DESCRIPTION
What does this PR do:
If an item magically drops (or drops due to surgery) while it has nodrop it'll now get nodrop removed from it's flags if the item didn't have it when it was created.
There might be a few items that implement antidrop weirdly but those are usually admin spawned stuf.

Fixes: #7300

Remake of #11212 Git fucked up so yeah

Changelog:
🆑
fix: Items with NODROP that are dropped now lose the flag if they didn't get created with it
/🆑