### PR TITLE
Fixes the advanced pinpointer crashing the server

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -168,7 +168,7 @@
 					
 					var/list/target_candidates = get_all_of_type(item_paths[targetitem], subtypes = TRUE)
 					for(var/obj/item/candidate in target_candidates)
-						if(!is_admin_level(candidate.loc.z))
+						if(!is_admin_level((get_turf(candidate)).z))
 							target = candidate
 							break
 					

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -165,10 +165,13 @@
 					var/targetitem = input("Select item to search for.", "Item Mode Select","") as null|anything in item_names
 					if(!targetitem)
 						return
-					var/list/obj/item/target_candidates = get_all_of_type(item_paths[targetitem], subtypes = TRUE)
-						for(var/obj/item/candidate in target_candidates)
-							if(!is_admin_level(candidate.loc.z))
-								target = candidate
+					
+					var/list/target_candidates = get_all_of_type(item_paths[targetitem], subtypes = TRUE)
+					for(var/obj/item/candidate in target_candidates)
+						if(!is_admin_level(candidate.loc.z))
+							target = candidate
+							break
+					
 					if(!target)
 						to_chat(usr, "<span class='warning'>Failed to locate [targetitem]!</span>")
 						return


### PR DESCRIPTION
**What does this PR do:**
Stops the advanced pinpointer from crashing the server

Fixes: #11883

**Changelog:**
:cl:
fix: The syndicate can't use meta warfare no more. Advanced pinpointers no longer crash the server
/:cl:

