### PR TITLE
Update issue templates to latest version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Issue Description**:
+
+**What did you expect to happen**: 
+
+**What happened instead**:
+
+**Why is this bad/What are the consequences:**
+
+**Steps to reproduce the problem**:
+
+**When did the problem start happening**:
+
+**Extra information**:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,17 +6,18 @@ labels: ''
 assignees: ''
 
 ---
-
+<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable -->
 **Issue Description**:
-
+<!---What is the problem?-->
 **What did you expect to happen**: 
-
+<!--Why do you think this is an issue?-->
 **What happened instead**:
-
+<!--How is what happened different from what you expected?-->
 **Why is this bad/What are the consequences**:
-
+<!--Why do you think this is an important issue?-->
 **Steps to reproduce the problem**:
-
+<!--The most important section. Review everything you did leading up to causing the issue.-->
 **When did the problem start happening**:
-
+<!--If your report is about something that used to work but no longer does, when was the last time you remember it working?-->
 **Extra information**:
+<!--Anything else you can tell us.-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ assignees: ''
 
 **What happened instead**:
 
-**Why is this bad/What are the consequences:**
+**Why is this bad/What are the consequences**:
 
 **Steps to reproduce the problem**:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please place all features requests here: https://nanotrasen.se/forum/60-suggestions/


### PR DESCRIPTION
**What does this PR do:**
Cleans up the issue template and moves it to the latest version, I thought the extra text after each field was just confusing and might cause people to include unneccessary information and just repeat themselves

**Changelog:**
:cl:
tweak: Update issue templates to latest version and clean up the current template
/:cl:

