### PR TITLE
Adds tips to certain things + general fixes that for issues I across

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -79,10 +79,10 @@ var/bomb_set
 	
 	if(istype(O, /obj/item/disk/nuclear))
 		if(extended)
-			if(O.flags & NODROP)
+			if(!user.unEquip(O))
 				to_chat(user, "<span class='notice'>\The [O] is stuck to your hand!</span>")
-			usr.drop_item()
-			O.loc = src
+				return
+			O.forceMove(src)
 			auth = O
 			add_fingerprint(user)
 			return attack_hand(user)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -85,8 +85,7 @@ var/bomb_set
 			O.forceMove(src)
 			auth = O
 			add_fingerprint(user)
-			attack_hand(user)
-			return
+			return attack_hand(user)
 		else
 			to_chat(user, "<span class='notice'>You need to deploy \the [src] first. Right click on the sprite, select 'Make Deployable' then click on \the [src] with an empty hand.</span>")
 			return

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -76,14 +76,18 @@ var/bomb_set
 
 	if(panel_open && (istype(O, /obj/item/multitool) || istype(O, /obj/item/wirecutters)))
 		return attack_hand(user)
-
-	if(extended)
-		if(istype(O, /obj/item/disk/nuclear))
+	
+	if(istype(O, /obj/item/disk/nuclear))
+		if(extended)
+			if(O.flags & NODROP)
+				to_chat(user, "<span class='notice'>\The [O] is stuck to your hand!</span>")
 			usr.drop_item()
 			O.loc = src
 			auth = O
 			add_fingerprint(user)
 			return attack_hand(user)
+		else
+			to_chat(user, "<span class='notice'>You need to deploy \the [src] first. Right click on the sprite, select 'Make Deployable' then click on \the [src] with an empty hand.</span>")
 
 	if(anchored)
 		switch(removal_stage)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -79,7 +79,7 @@ var/bomb_set
 	
 	if(istype(O, /obj/item/disk/nuclear))
 		if(extended)
-			if(!user.unEquip(O))
+			if(!user.drop_item())
 				to_chat(user, "<span class='notice'>\The [O] is stuck to your hand!</span>")
 				return
 			O.forceMove(src)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -85,7 +85,8 @@ var/bomb_set
 			O.forceMove(src)
 			auth = O
 			add_fingerprint(user)
-			return attack_hand(user)
+			attack_hand(user)
+			return
 		else
 			to_chat(user, "<span class='notice'>You need to deploy \the [src] first. Right click on the sprite, select 'Make Deployable' then click on \the [src] with an empty hand.</span>")
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -516,6 +516,7 @@ About the new airlock wires panel:
 		else
 			to_chat(user, "There's a [note.name] pinned to the front...")
 			note.examine(user)
+			to_chat(user, "<span class='notice'>Use an empty hand on the airlock on grab mode to remove [note.name].</span>")
 
 	if(panel_open)
 		switch(security_level)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -45,7 +45,7 @@
 
 /obj/item/defibrillator/examine(mob/user)
 	..(user)
-	to_chat(user,"<span class='notice'>Ctrl-click to remove the paddles from the defibrillator.")
+	to_chat(user, "<span class='notice'>Ctrl-click to remove the paddles from the defibrillator.</span>")
 
 /obj/item/defibrillator/proc/update_power()
 	if(bcell)

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -55,15 +55,14 @@
 		if(!fireaxe)
 			var/obj/item/twohanded/fireaxe/F = O
 			if(F.wielded)
-				to_chat(user, "<span class='warning'>Unwield the axe first.</span>")
+				to_chat(user, "<span class='warning'>Unwield \the [F] first.</span>")
 				return
-			if(!user.canUnEquip(F, FALSE))
-				to_chat(user, "<span class='warning'>\The [src] stays stuck to your hands!</span>")
+			if(!user.unEquip(F, FALSE))
+				to_chat(user, "<span class='warning'>\The [F] stays stuck to your hands!</span>")
 				return
 			fireaxe = F
-			user.drop_item(F)
 			contents += F
-			to_chat(user, "<span class='notice'>You place the fire axe back in the [name].</span>")
+			to_chat(user, "<span class='notice'>You place \the [F] back in the [name].</span>")
 			update_icon()
 		else
 			if(smashed)
@@ -103,8 +102,9 @@
 	if(localopened)
 		if(fireaxe)
 			user.put_in_hands(fireaxe)
+			to_chat(user, "<span class='notice'>You take \the [fireaxe] from the [src].</span>")
 			fireaxe = null
-			to_chat(user, "<span class='notice'>You take the fire axe from the [name].</span>")
+			
 			add_fingerprint(user)
 			update_icon()
 		else
@@ -127,7 +127,7 @@
 /obj/structure/closet/fireaxecabinet/attack_tk(mob/user as mob)
 	if(localopened && fireaxe)
 		fireaxe.forceMove(loc)
-		to_chat(user, "<span class='notice'>You telekinetically remove the fire axe.</span>")
+		to_chat(user, "<span class='notice'>You telekinetically remove \the [fireaxe].</span>")
 		fireaxe = null
 		update_icon()
 		return
@@ -157,12 +157,12 @@
 	if(localopened)
 		if(fireaxe)
 			usr.put_in_hands(fireaxe)
+			to_chat(usr, "<span class='notice'>You take \the [fireaxe] from the [src].</span>")
 			fireaxe = null
-			to_chat(usr, "<span class='notice'>You take the Fire axe from the [name].</span>")
 		else
-			to_chat(usr, "<span class='notice'>The [name] is empty.</span>")
+			to_chat(usr, "<span class='notice'>The [src] is empty.</span>")
 	else
-		to_chat(usr, "<span class='notice'>The [name] is closed.</span>")
+		to_chat(usr, "<span class='notice'>The [src] is closed.</span>")
 	update_icon()
 
 /obj/structure/closet/fireaxecabinet/attack_ai(mob/user as mob)

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -6,203 +6,194 @@
 	icon_state = "fireaxe1000"
 	icon_closed = "fireaxe1000"
 	icon_opened = "fireaxe1100"
-	anchored = 1
-	density = 0
+	anchored = TRUE
+	density = FALSE
 	armor = list(melee = 50, bullet = 50, laser = 50, energy = 100, bomb = 10, bio = 100, rad = 100)
-	var/localopened = 0 //Setting this to keep it from behaviouring like a normal closet and obstructing movement in the map. -Agouri
-	opened = 1
-	var/hitstaken = 0
-	locked = 1
-	var/smashed = 0
+	var/localopened = FALSE //Setting this to keep it from behaviouring like a normal closet and obstructing movement in the map. -Agouri
+	opened = TRUE
+	var/hitstaken = FALSE
+	locked = TRUE
+	var/smashed = FALSE
 
-	attackby(var/obj/item/O as obj, var/mob/living/user as mob)  //Marker -Agouri
-		//..() //That's very useful, Erro
+/obj/structure/closet/fireaxecabinet/examine(mob/user)
+	. = ..()
+	to_chat(user, "<span class='notice'>Use a multitool to lock/unlock it.</span>")
 
-		var/hasaxe = 0       //gonna come in handy later~
-		if(fireaxe)
-			hasaxe = 1
-
-		if(isrobot(user) || src.locked)
-			if(istype(O, /obj/item/multitool))
-				to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
-				playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
-				if(do_after(user, 20 * O.toolspeed, target = src))
-					src.locked = 0
-					to_chat(user, "<span class = 'caution'> You disable the locking modules.</span>")
-					update_icon()
-				return
-			else if(istype(O, /obj/item))
-				user.changeNext_move(CLICK_CD_MELEE)
-				var/obj/item/W = O
-				if(src.smashed || src.localopened)
-					if(localopened)
-						localopened = 0
-						icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
-						spawn(10) update_icon()
-					return
-				else
-					user.do_attack_animation(src)
-					playsound(user, 'sound/effects/Glasshit.ogg', 100, 1) //We don't want this playing every time
-				if(W.force < 15)
-					to_chat(user, "<span class='notice'>The cabinet's protective glass glances off the hit.</span>")
-				else
-					src.hitstaken++
-					if(src.hitstaken == 4)
-						playsound(user, 'sound/effects/glassbr3.ogg', 100, 1) //Break cabinet, receive goodies. Cabinet's fucked for life after that.
-						src.smashed = 1
-						src.locked = 0
-						src.localopened = 1
+/obj/structure/closet/fireaxecabinet/attackby(var/obj/item/O as obj, var/mob/living/user as mob)  //Marker -Agouri
+	if(isrobot(user) || locked)
+		if(istype(O, /obj/item/multitool))
+			to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
+			playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
+			if(do_after(user, 20 * O.toolspeed, target = src))
+				locked = FALSE
+				to_chat(user, "<span class = 'caution'> You disable the locking modules.</span>")
 				update_icon()
 			return
-		if(istype(O, /obj/item/twohanded/fireaxe) && src.localopened)
-			if(!fireaxe)
-				if(O:wielded)
-					to_chat(user, "<span class='warning'>Unwield the axe first.</span>")
-					return
-				fireaxe = O
-				user.drop_item(O)
-				src.contents += O
-				to_chat(user, "<span class='notice'>You place the fire axe back in the [src.name].</span>")
-				update_icon()
-			else
-				if(src.smashed)
-					return
-				else
-					localopened = !localopened
-					if(localopened)
-						icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
-						spawn(10) update_icon()
-					else
-						icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
-						spawn(10) update_icon()
-		else
-			if(src.smashed)
-				return
-			if(istype(O, /obj/item/multitool))
+		else if(istype(O, /obj/item))
+			user.changeNext_move(CLICK_CD_MELEE)
+			var/obj/item/W = O
+			if(smashed || localopened)
 				if(localopened)
-					localopened = 0
-					icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
-					spawn(10) update_icon()
-					return
-				else
-					to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
-					sleep(50)
-					src.locked = 1
-					to_chat(user, "<span class='notice'>You re-enable the locking modules.</span>")
-					playsound(user, 'sound/machines/lockenable.ogg', 50, 1)
-					if(do_after(user, 20 * O.toolspeed, target = src))
-						src.locked = 1
-						to_chat(user, "<span class = 'caution'> You re-enable the locking modules.</span>")
-					return
+					localopened = FALSE
+					update_icon_closing()
+				return
+			else
+				user.do_attack_animation(src)
+				playsound(user, 'sound/effects/Glasshit.ogg', 100, 1) //We don't want this playing every time
+			if(W.force < 15)
+				to_chat(user, "<span class='notice'>The cabinet's protective glass glances off the hit.</span>")
+			else
+				hitstaken++
+				if(hitstaken == 4)
+					playsound(user, 'sound/effects/glassbr3.ogg', 100, 1) //Break cabinet, receive goodies. Cabinet's fucked for life after that.
+					smashed = TRUE
+					locked = FALSE
+					localopened = TRUE
+			update_icon()
+		return
+	if(istype(O, /obj/item/twohanded/fireaxe) && localopened)
+		if(!fireaxe)
+			var/obj/item/twohanded/fireaxe/F = O
+			if(F.wielded)
+				to_chat(user, "<span class='warning'>Unwield the axe first.</span>")
+				return
+			if(!user.canUnEquip(F, FALSE))
+				to_chat(user, "<span class='warning'>\The [src] stays stuck to your hands!</span>")
+				return
+			fireaxe = F
+			user.drop_item(F)
+			contents += F
+			to_chat(user, "<span class='notice'>You place the fire axe back in the [name].</span>")
+			update_icon()
+		else
+			if(smashed)
+				return
 			else
 				localopened = !localopened
 				if(localopened)
-					icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
-					spawn(10) update_icon()
+					update_icon_opening()
 				else
-					icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
-					spawn(10) update_icon()
-
-
-
-
-	attack_hand(mob/user as mob)
-
-		var/hasaxe = 0
-		if(fireaxe)
-			hasaxe = 1
-
-		if(src.locked)
-			to_chat(user, "<span class='warning'>The cabinet won't budge!</span>")
+					update_icon_closing()
+	else
+		if(smashed)
 			return
-		if(localopened)
-			if(fireaxe)
-				user.put_in_hands(fireaxe)
-				fireaxe = null
-				to_chat(user, "<span class='notice'>You take the fire axe from the [name].</span>")
-				src.add_fingerprint(user)
-				update_icon()
-			else
-				if(src.smashed)
-					return
-				else
-					localopened = !localopened
-					if(localopened)
-						src.icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
-						spawn(10) update_icon()
-					else
-						src.icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
-						spawn(10) update_icon()
-
-		else
-			localopened = !localopened //I'm pretty sure we don't need an if(src.smashed) in here. In case I'm wrong and it fucks up teh cabinet, **MARKER**. -Agouri
+		if(istype(O, /obj/item/multitool))
 			if(localopened)
-				src.icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
-				spawn(10) update_icon()
+				localopened = FALSE
+				update_icon_closing()
+				return
 			else
-				src.icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
-				spawn(10) update_icon()
-
-	attack_tk(mob/user as mob)
-		if(localopened && fireaxe)
-			fireaxe.forceMove(loc)
-			to_chat(user, "<span class='notice'>You telekinetically remove the fire axe.</span>")
-			fireaxe = null
-			update_icon()
-			return
-		attack_hand(user)
-
-	verb/toggle_openness() //nice name, huh? HUH?! -Erro //YEAH -Agouri
-		set name = "Open/Close"
-		set category = "Object"
-
-		if(isrobot(usr) || src.locked || src.smashed)
-			if(src.locked)
-				to_chat(usr, "<span class='warning'>The cabinet won't budge!</span>")
-			else if(src.smashed)
-				to_chat(usr, "<span class='notice'>The protective glass is broken!</span>")
-			return
-
-		localopened = !localopened
-		update_icon()
-
-	verb/remove_fire_axe()
-		set name = "Remove Fire Axe"
-		set category = "Object"
-
-		if(isrobot(usr))
-			return
-
-		if(localopened)
-			if(fireaxe)
-				usr.put_in_hands(fireaxe)
-				fireaxe = null
-				to_chat(usr, "<span class='notice'>You take the Fire axe from the [name].</span>")
-			else
-				to_chat(usr, "<span class='notice'>The [src.name] is empty.</span>")
+				to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
+				playsound(user, 'sound/machines/lockenable.ogg', 50, 1)
+				if(do_after(user, 20 * O.toolspeed, target = src))
+					locked = TRUE
+					to_chat(user, "<span class = 'caution'> You re-enable the locking modules.</span>")
+				return
 		else
-			to_chat(usr, "<span class='notice'>The [src.name] is closed.</span>")
-		update_icon()
-
-	attack_ai(mob/user as mob)
-		if(src.smashed)
-			to_chat(user, "<span class='warning'>The security of the cabinet is compromised.</span>")
-			return
-		else
-			locked = !locked
-			if(locked)
-				to_chat(user, "<span class='warning'>Cabinet locked.</span>")
+			localopened = !localopened
+			if(localopened)
+				update_icon_opening()
 			else
-				to_chat(user, "<span class='notice'>Cabinet unlocked.</span>")
+				update_icon_closing()
 
-	update_icon() //Template: fireaxe[has fireaxe][is opened][hits taken][is smashed]. If you want the opening or closing animations, add "opening" or "closing" right after the numbers
-		var/hasaxe = 0
+/obj/structure/closet/fireaxecabinet/attack_hand(mob/user as mob)
+	if(locked)
+		to_chat(user, "<span class='warning'>The cabinet won't budge!</span>")
+		return
+	if(localopened)
 		if(fireaxe)
-			hasaxe = 1
-		icon_state = text("fireaxe[][][][]",hasaxe,src.localopened,src.hitstaken,src.smashed)
+			user.put_in_hands(fireaxe)
+			fireaxe = null
+			to_chat(user, "<span class='notice'>You take the fire axe from the [name].</span>")
+			add_fingerprint(user)
+			update_icon()
+		else
+			if(smashed)
+				return
+			else
+				localopened = !localopened
+				if(localopened)
+					update_icon_opening()
+				else
+					update_icon_closing()
 
-	open()
+	else
+		localopened = !localopened //I'm pretty sure we don't need an if(smashed) in here. In case I'm wrong and it fucks up teh cabinet, **MARKER**. -Agouri
+		if(localopened)
+			update_icon_opening()
+		else
+			update_icon_closing()
+
+/obj/structure/closet/fireaxecabinet/attack_tk(mob/user as mob)
+	if(localopened && fireaxe)
+		fireaxe.forceMove(loc)
+		to_chat(user, "<span class='notice'>You telekinetically remove the fire axe.</span>")
+		fireaxe = null
+		update_icon()
+		return
+	attack_hand(user)
+
+/obj/structure/closet/fireaxecabinet/verb/toggle_openness() //nice name, huh? HUH?! -Erro //YEAH -Agouri
+	set name = "Open/Close"
+	set category = "Object"
+
+	if(isrobot(usr) || locked || smashed)
+		if(locked)
+			to_chat(usr, "<span class='warning'>The cabinet won't budge!</span>")
+		else if(smashed)
+			to_chat(usr, "<span class='notice'>The protective glass is broken!</span>")
 		return
 
-	close()
+	localopened = !localopened
+	update_icon()
+
+/obj/structure/closet/fireaxecabinet/verb/remove_fire_axe()
+	set name = "Remove Fire Axe"
+	set category = "Object"
+
+	if(isrobot(usr))
 		return
+
+	if(localopened)
+		if(fireaxe)
+			usr.put_in_hands(fireaxe)
+			fireaxe = null
+			to_chat(usr, "<span class='notice'>You take the Fire axe from the [name].</span>")
+		else
+			to_chat(usr, "<span class='notice'>The [name] is empty.</span>")
+	else
+		to_chat(usr, "<span class='notice'>The [name] is closed.</span>")
+	update_icon()
+
+/obj/structure/closet/fireaxecabinet/attack_ai(mob/user as mob)
+	if(smashed)
+		to_chat(user, "<span class='warning'>The security of the cabinet is compromised.</span>")
+		return
+	else
+		locked = !locked
+		if(locked)
+			to_chat(user, "<span class='warning'>Cabinet locked.</span>")
+		else
+			to_chat(user, "<span class='notice'>Cabinet unlocked.</span>")
+
+/obj/structure/closet/fireaxecabinet/proc/update_icon_opening()
+	var/hasaxe = fireaxe != null
+	icon_state = "fireaxe[hasaxe][localopened][hitstaken][smashed]opening"
+	spawn(10) 
+		update_icon()
+
+/obj/structure/closet/fireaxecabinet/proc/update_icon_closing()
+	var/hasaxe = fireaxe != null
+	icon_state = "fireaxe[hasaxe][localopened][hitstaken][smashed]closing"
+	spawn(10) 
+		update_icon()
+
+/obj/structure/closet/fireaxecabinet/update_icon() //Template: fireaxe[has fireaxe][is opened][hits taken][is smashed]. If you want the opening or closing animations, add "opening" or "closing" right after the numbers
+	var/hasaxe = fireaxe != null
+	icon_state = "fireaxe[hasaxe][localopened][hitstaken][smashed]"
+
+/obj/structure/closet/fireaxecabinet/open()
+	return
+
+/obj/structure/closet/fireaxecabinet/close()
+	return

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -102,6 +102,10 @@
 	anchored = FALSE
 	throw_pressure_limit = INFINITY //Throwing an ambulance trolley can kill the process scheduler.
 
+/obj/structure/bed/amb_trolley/examine(mob/user)
+	. = ..()
+	to_chat(user, "<span class='notice'>Drag \the [src]'s sprite over the ambulance to (de)attach it.</span>")
+
 /obj/structure/bed/amb_trolley/MouseDrop(obj/over_object as obj)
 	..()
 	if(istype(over_object, /obj/vehicle/ambulance))

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -104,7 +104,7 @@
 
 /obj/structure/bed/amb_trolley/examine(mob/user)
 	. = ..()
-	to_chat(user, "<span class='notice'>Drag \the [src]'s sprite over the ambulance to (de)attach it.</span>")
+	to_chat(user, "<span class='notice'>Drag [src]'s sprite over the ambulance to (de)attach it.</span>")
 
 /obj/structure/bed/amb_trolley/MouseDrop(obj/over_object as obj)
 	..()


### PR DESCRIPTION
**What does this PR do:**
Adds help text for the following things:
1. The ambulance trolley, how to attach it.
2. The nuke, how to deploy it.
3. A fire axe cabinet, how to unlock/lock it.
4. Notes on airlocks, how to remove them

Also fixes the following bugs:
1. can't arm a nuke now with antidrop on
2. Weirdness while locking the fire axe cabinet
3. Can't put a nodrop fire axe in a fire axe cabinet now.

Refactored:
1. The fire axe cabinet code

No longer WIP due to me focusing on the psionic antag now.

**Changelog:**
:cl:
add: Adds tip text to the examine text of the ambulance trolley about how to attach it
add: Adds tip text to the nuke when trying to use the NAD before deploying it
add: Adds tip text to the fire axe cabinet about how to lock/unlock it
add: Adds tip text to airlocks if they have a note on them about how to remove the note
fix: Can't put the NAD in the nuke now when it has the NODROP flag
fix: Locking a fire axe cabinet is less weird now. No odd 5 seconds sleep
fix: Can't put a nodrop fire axe in fire axe cabinets now. Duping them
/:cl:

