### PR TITLE
Waddling component, clowns can now choose to waddle while they walk, penguins automatically waddle

### DIFF
--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -1,0 +1,15 @@
+/datum/component/waddling
+    dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+
+/datum/component/waddling/Initialize()
+    if(!isliving(parent))
+        return COMPONENT_INCOMPATIBLE
+    RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), .proc/Waddle)
+
+/datum/component/waddling/proc/Waddle()
+    var/mob/living/L = parent
+    if(L.incapacitated() || L.lying)
+        return
+    animate(L, pixel_z = 4, time = 0)
+    animate(pixel_z = 0, transform = turn(matrix(), pick(-12, 0, 12)), time=2)
+    animate(pixel_z = 0, transform = matrix(), time = 0)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -87,7 +87,7 @@ obj/item/clothing/shoes/magboots/syndie/advance //For the Syndicate Strike Team
 	if(!isliving(user))
 		return
 	if(user.get_active_hand() != src)
-		to_chat(user, "You must hold the [src] in your hand to do this.")
+		to_chat(user, "You must hold [src] in your hand to do this.")
 		return
 	if(!enabled_waddle)
 		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -71,6 +71,30 @@ obj/item/clothing/shoes/magboots/syndie/advance //For the Syndicate Strike Team
 	silence_steps = 1
 	shoe_sound = "clownstep"
 	origin_tech = "magnets=4;syndicate=2"
+	var/enabled_waddle = TRUE
+	var/datum/component/waddle
+
+/obj/item/clothing/shoes/magboots/clown/equipped(mob/user, slot)
+	. = ..()
+	if(slot == slot_shoes && enabled_waddle)
+		waddle = user.AddComponent(/datum/component/waddling)
+
+/obj/item/clothing/shoes/magboots/clown/dropped(mob/user)
+	. = ..()
+	QDEL_NULL(waddle)
+
+/obj/item/clothing/shoes/magboots/clown/CtrlClick(mob/living/user)
+	if(!isliving(user))
+		return
+	if(user.get_active_hand() != src)
+		to_chat(user, "You must hold the [src] in your hand to do this.")
+		return
+	if(!enabled_waddle)
+		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
+		enabled_waddle = TRUE
+	else
+		to_chat(user, "<span class='notice'>You switch on the waddle dampeners!</span>")
+		enabled_waddle = FALSE
 
 /obj/item/clothing/shoes/magboots/wizard //bundled with the wiz hardsuit
 	name = "boots of gripping"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -82,10 +82,10 @@
 		to_chat(user, "You must hold the [src] in your hand to do this.")
 		return
 	if(!enabled_waddle)
-		to_chat(user, "<span class='notice'>You switch on the waddle dampeners!</span>")
+		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
 		enabled_waddle = TRUE
 	else
-		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
+		to_chat(user, "<span class='notice'>You switch on the waddle dampeners!</span>")
 		enabled_waddle = FALSE
 
 /obj/item/clothing/shoes/clown_shoes/magical

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -63,6 +63,30 @@
 	item_color = "clown"
 	var/footstep = 1	//used for squeeks whilst walking
 	shoe_sound = "clownstep"
+	var/enabled_waddle = TRUE
+	var/datum/component/waddle
+
+/obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)
+	. = ..()
+	if(slot == slot_shoes && enabled_waddle)
+		user.AddComponent(/datum/component/waddling)
+
+/obj/item/clothing/shoes/clown_shoes/dropped(mob/user)
+	. = ..()
+	QDEL_NULL(waddle)
+
+/obj/item/clothing/shoes/clown_shoes/CtrlClick(mob/living/user)
+	if(!isliving(user))
+		return
+	if(user.get_active_hand() != src)
+		to_chat(user, "You must hold the [src] in your hand to do this.")
+		return
+	if(!enabled_waddle)
+		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
+		enabled_waddle = TRUE
+	else
+		to_chat(user, "<span class='notice'>You switch on the waddle dampeners!</span>")
+		enabled_waddle = FALSE
 
 /obj/item/clothing/shoes/clown_shoes/magical
 	name = "magical clown shoes"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -79,7 +79,7 @@
 	if(!isliving(user))
 		return
 	if(user.get_active_hand() != src)
-		to_chat(user, "You must hold the [src] in your hand to do this.")
+		to_chat(user, "You must hold [src] in your hand to do this.")
 		return
 	if(!enabled_waddle)
 		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -55,7 +55,7 @@
 		t_loc.MakeDry(TURF_WET_WATER)
 
 /obj/item/clothing/shoes/clown_shoes
-	desc = "The prankster's standard-issue clowning shoes. Damn they're huge!"
+	desc = "The prankster's standard-issue clowning shoes. Damn they're huge! Ctrl-click to toggle the waddle dampeners!"
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
@@ -69,7 +69,7 @@
 /obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)
 	. = ..()
 	if(slot == slot_shoes && enabled_waddle)
-		user.AddComponent(/datum/component/waddling)
+		waddle = user.AddComponent(/datum/component/waddling)
 
 /obj/item/clothing/shoes/clown_shoes/dropped(mob/user)
 	. = ..()
@@ -82,10 +82,10 @@
 		to_chat(user, "You must hold the [src] in your hand to do this.")
 		return
 	if(!enabled_waddle)
-		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
+		to_chat(user, "<span class='notice'>You switch on the waddle dampeners!</span>")
 		enabled_waddle = TRUE
 	else
-		to_chat(user, "<span class='notice'>You switch on the waddle dampeners!</span>")
+		to_chat(user, "<span class='notice'>You switch off the waddle dampeners!</span>")
 		enabled_waddle = FALSE
 
 /obj/item/clothing/shoes/clown_shoes/magical

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -16,6 +16,10 @@
 	turns_per_move = 10
 	icon = 'icons/mob/penguins.dmi'
 
+/mob/living/simple_animal/pet/penguin/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/waddling)
+
 /mob/living/simple_animal/pet/penguin/emperor
 	name = "Emperor penguin"
 	real_name = "penguin"

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -457,6 +457,7 @@
 			C.AdjustDizzy(volume)
 	C.AddComponent(/datum/component/jestosterone, mind_type)
 	C.AddComponent(/datum/component/squeak, null, null, null, null, null, TRUE)
+	C.AddComponent(/datum/component/waddling)
 
 /datum/reagent/jestosterone/on_mob_life(mob/living/carbon/M)
 	if(!istype(M))
@@ -493,8 +494,10 @@
 	..()
 	GET_COMPONENT_FROM(remove_fun, /datum/component/jestosterone, M)
 	GET_COMPONENT_FROM(squeaking, /datum/component/squeak, M)
+	GET_COMPONENT_FROM(waddling, /datum/component/waddling, M)
 	remove_fun.Destroy()
 	squeaking.Destroy()
+	waddling.Destroy()
 
 /datum/reagent/royal_bee_jelly
 	name = "royal bee jelly"

--- a/paradise.dme
+++ b/paradise.dme
@@ -278,6 +278,7 @@
 #include "code\datums\components\jestosterone.dm"
 #include "code\datums\components\material_container.dm"
 #include "code\datums\components\squeak.dm"
+#include "code\datums\components\waddling.dm"
 #include "code\datums\diseases\_disease.dm"
 #include "code\datums\diseases\_MobProcs.dm"
 #include "code\datums\diseases\anxiety.dm"


### PR DESCRIPTION
**What does this PR do:**
Port over TG's waddling component and allow clowns to pick whether or not they waddle while they walk

**Images of sprite/map changes (IF APPLICABLE):**
![ezgif com-gif-maker](https://user-images.githubusercontent.com/30060146/62028957-8927f080-b1af-11e9-9fa9-3ec70e3685b9.gif)


**Changelog:**
:cl:
add: TG waddle component, clowns can now optionally waddle, penguins always waddle. Ctrl Click clown shoes in hand to toggle waddling
/:cl:

