### PR TITLE
Lavaland changes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -168,6 +168,7 @@
 #define isskeleton(A) (is_species(A, /datum/species/skeleton))
 #define ishumanbasic(A) (is_species(A, /datum/species/human))
 #define isunathi(A) (is_species(A, /datum/species/unathi))
+#define isashwalker(A) (is_species(A, /datum/species/unathi/ashwalker))
 #define istajaran(A) (is_species(A, /datum/species/tajaran))
 #define isvulpkanin(A) (is_species(A, /datum/species/vulpkanin))
 #define isskrell(A) (is_species(A, /datum/species/skrell))

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -48,6 +48,14 @@
 	setDir(angle2dir(rotation + dir2angle(dir)))
 	queue_smooth(src)
 
+/turf/simulated/mineral/attack_hand(mob/living/carbon/human/M)
+	if(isashwalker(M)) // Ash walkers can dig without a pickaxe
+		to_chat(M, "<span class='notice'>You start digging into the rock...</span>")
+		playsound(src, 'sound/effects/break_stone.ogg', 50, 1)
+		if(do_after(M, 80, target = src)) // But it takes longer
+			to_chat(M, "<span class='notice'>You tunnel into the rock.</span>")
+			gets_drilled()
+
 /turf/simulated/mineral/attackby(var/obj/item/pickaxe/P as obj, mob/user as mob, params)
 	if(!user.IsAdvancedToolUser())
 		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -110,10 +110,12 @@
 	name_plural = "Ash Walkers"
 
 	blurb = "These reptillian creatures appear to be related to the Unathi, but seem significantly less evolved. \
-	They roam the wastes of Lavaland, worshipping a dead city and capturing unsuspecting miners." 
+	They roam the wastes of Lavaland, worshipping a dead city and capturing unsuspecting miners."
 
 	language = "Sinta'unathi"
 	default_language = "Sinta'unathi"
 
-	slowdown = -0.80
+	slowdown = -0.90
 	species_traits = list(NO_BREATHE, NOGUNS)
+	brute_mod = 0.8
+	burn_mod = 0.8

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -247,6 +247,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	check_friendly_fire = TRUE //you're supposed to protect the resource swarmers, you poop
 	retreat_distance = 3
 	minimum_distance = 3
+	speed = 1
 
 /mob/living/simple_animal/hostile/swarmer/ai/ranged_combat/Aggro()
 	..()
@@ -260,6 +261,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	health = 60
 	maxHealth = 60
 	ranged = FALSE
+	speed = 1
 
 /mob/living/simple_animal/hostile/swarmer/ai/melee_combat/Aggro()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
@@ -35,11 +35,12 @@
 /obj/item/projectile/temp/basilisk
 	name = "freezing blast"
 	icon_state = "ice_2"
-	damage = 0
+	damage = 3
 	damage_type = BURN
-	nodamage = 1
+	nodamage = 0
 	flag = "energy"
-	temperature = 50
+	temperature = 225
+	speed = 1.6
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(var/new_target)
 	if(..()) //we have a target
@@ -68,8 +69,8 @@
 	icon_dead = "watcher_dead"
 	pixel_x = -10
 	throw_message = "bounces harmlessly off of"
-	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_lower = 8
+	melee_damage_upper = 13
 	attacktext = "impales"
 	a_intent = INTENT_HARM
 	speak_emote = list("telepathically cries")
@@ -118,7 +119,7 @@
 /obj/item/projectile/temp/basilisk/magmawing
 	name = "scorching blast"
 	icon_state = "lava"
-	damage = 5
+	damage = 10
 	damage_type = BURN
 	nodamage = FALSE
 	temperature = 500 //Heats you up!
@@ -132,9 +133,10 @@
 			L.IgniteMob()
 
 /obj/item/projectile/temp/basilisk/icewing
-	damage = 5
+	damage = 7
 	damage_type = BURN
 	nodamage = FALSE
+	temperature = 50 // Actual freeze beam
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril
 	fromtendril = TRUE


### PR DESCRIPTION
**What does this PR do:**
Changes a few things in lavaland.
Ash walkers are now slightly slower but more durable in terms of brute and burn damage.
Ash walkers can now dig rocks without a pickaxe, however, it takes longer.
Melee and ranged swarmers are now slightly slower so they don't chase you around with nothing you can do about it.
Watchers reworked to be less tedious to fight with melee weapons.

These are all changes I have decided to make after playing for some time as an ash walker in lavaland. They'll not only make the whole experience a bit more fun, but also change the walkers to act more like tough lavaland mobs, which can take quite a beating and tunnel around without the need of any tools, rather than just being fast unathis with a different name.

Specifics:
Ash Walkers can now be defined with "isashwalker" for future ash walker only things.
Ash walkers' slowdown changed to -0.90 from -0.80, making them slower.
Ash walkers now have a brute and burn modifiers of 0.8, making them more resistant to those damage types.
Ranged and melee swarmers now have a speed of 1, from 0, making them slower.
Watchers now have a lower damage of 8, and a higher damage of 13, from both of them being 15.
Watcher projectile changes:
Speed was set to 1.6 from 1.0, making it a bit slower and easier to dodge.
Now deals 3 burn damage per hit.
Temperature changed to 225 from 50, making it have less of a freezing effect on its victim.
Magmawing projectile deals 10 burn damage from 5, icewing deals 7 burn damage from 5.

**Changelog:**
:cl:
add: Ash walkers can now dig into rocks without pickaxes at the cost of taking longer to do so.
tweak: Ash walkers have been slowed down, however they are still faster than normal humans.
tweak: Ash walkers can now sustain more brute and burn damage.
tweak: Ranged and melee swarmers are now slower.
balance: Rebalanced watchers to be slightly less tedious to fight without ranged weapons.
/:cl: