### PR TITLE
Fixes earmuffs not protecting from vampire screeches

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -261,8 +261,10 @@
 	for(var/mob/living/carbon/C in hearers(4))
 		if(C == user)
 			continue
-		if(ishuman(C) && (C:l_ear || C:r_ear) && istype((C:l_ear || C:r_ear), /obj/item/clothing/ears/earmuffs))
-			continue
+		if(ishuman(C))
+			var/mob/living/carbon/human/H = C
+			if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
+				continue
 		if(!affects(C))
 			continue
 		to_chat(C, "<span class='warning'><font size='3'><b>You hear a ear piercing shriek and your senses dull!</font></b></span>")


### PR DESCRIPTION
**What does this PR do:**
Fixes a bug where earmuffs wouldn't protect you from vampire screeches if you were wearing earmuffs in your right ear slot while wearing something else in your left ear slot.

**Changelog:**
:cl:
fix: Earmuffs now properly protect you from vampire screeches no matter what you are wearing on your other ear
/:cl:

