### PR TITLE
Blobbernaut major changes (player control!)

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -49,8 +49,8 @@
 
 /obj/screen/blob/Blobbernaut
 	icon_state = "ui_blobbernaut"
-	name = "Produce Blobbernaut (40)"
-	desc = "Produces a strong, intelligent blobbernaut from a factory blob for 40 resources.<br>The factory blob will be destroyed in the process."
+	name = "Produce Blobbernaut (60)"
+	desc = "Produces a strong, intelligent blobbernaut from a factory blob for 60 resources.<br>The factory blob will be destroyed in the process."
 
 /obj/screen/blob/Blobbernaut/Click()
 	if(isovermind(usr))

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -49,8 +49,8 @@
 
 /obj/screen/blob/Blobbernaut
 	icon_state = "ui_blobbernaut"
-	name = "Produce Blobbernaut (20)"
-	desc = "Produces a strong, but dumb blobbernaut from a factory blob for 20 resources.<br>The factory blob will be destroyed in the process."
+	name = "Produce Blobbernaut (40)"
+	desc = "Produces a strong, intelligent blobbernaut from a factory blob for 40 resources.<br>The factory blob will be destroyed in the process."
 
 /obj/screen/blob/Blobbernaut/Click()
 	if(isovermind(usr))

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -184,8 +184,8 @@
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life(seconds, times_fired)
 	if(stat != DEAD && (getBruteLoss() || getFireLoss())) // Heal on blob structures
 		if (locate(/obj/structure/blob) in get_turf(src))
-			adjustBruteLoss(-0.5)
-			adjustFireLoss(-0.5)
+			adjustBruteLoss(-0.25)
+			adjustFireLoss(-0.25)
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()
 	return

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -183,9 +183,12 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life(seconds, times_fired)
 	if(stat != DEAD && (getBruteLoss() || getFireLoss())) // Heal on blob structures
-		if (locate(/obj/structure/blob) in get_turf(src))
+		if(locate(/obj/structure/blob) in get_turf(src))
 			adjustBruteLoss(-0.25)
 			adjustFireLoss(-0.25)
+		else
+			adjustBruteLoss(0.2) // If you are at full health, you won't lose health. You'll need it. However the moment anybody sneezes on you, the decaying will begin.
+			adjustFireLoss(0.2)
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()
 	return

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -163,10 +163,10 @@
 	icon_state = "blobbernaut"
 	icon_living = "blobbernaut"
 	icon_dead = "blobbernaut_dead"
-	health = 240
-	maxHealth = 240
-	melee_damage_lower = 20
-	melee_damage_upper = 20
+	health = 200
+	maxHealth = 200
+	melee_damage_lower = 10
+	melee_damage_upper = 15
 	obj_damage = 60
 	attacktext = "hits"
 	attack_sound = 'sound/effects/blobattack.ogg'
@@ -175,14 +175,25 @@
 	maxbodytemp = 360
 	force_threshold = 10
 	mob_size = MOB_SIZE_LARGE
-	environment_smash = ENVIRONMENT_SMASH_RWALLS
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
 	pressure_resistance = 100    //100 kPa difference required to push
 	throw_pressure_limit = 120  //120 kPa difference required to throw
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 
+/mob/living/simple_animal/hostile/blob/blobbernaut/Life(seconds, times_fired)
+	if(stat != DEAD && (getBruteLoss() || getFireLoss())) // Heal on blob structures
+		if (locate(/obj/structure/blob) in get_turf(src))
+			adjustBruteLoss(-0.5)
+			adjustFireLoss(-0.5)
+
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()
 	return
+
+/mob/living/simple_animal/hostile/blob/blobbernaut/New()
+	..()
+	if(name == "blobbernaut")
+		name = text("blobbernaut ([rand(1, 1000)])")
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/death(gibbed)
 	// Only execute the below if we successfully died
@@ -190,3 +201,19 @@
 	if(!.)
 		return FALSE
 	flick("blobbernaut_death", src)
+
+/mob/living/simple_animal/hostile/blob/blobbernaut/verb/communicate_overmind()
+	set category = "Blobbernaut"
+	set name = "Blob Telepathy"
+	set desc = "Send a message to the Overmind"
+
+	if(stat != DEAD)
+		blob_talk()
+
+/mob/living/simple_animal/hostile/blob/blobbernaut/proc/blob_talk()
+	var/message = input(src, "Announce to the overmind", "Blob Telepathy")
+	var/rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]([overmind])</span> <span class='message'>states, \"[message]\"</span></span></i></font>"
+	if(message)
+		for(var/mob/M in GLOB.mob_list)
+			if(isovermind(M) || isobserver(M) || istype((M), /mob/living/simple_animal/hostile/blob/blobbernaut))
+				M.show_message(rendered, 2)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -84,7 +84,7 @@
 	var/rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]([blob_reagent_datum.name])</span> <span class='message'>[verb] \"[message]\"</span></span></i></font>"
 
 	for(var/mob/M in GLOB.mob_list)
-		if(isovermind(M) || isobserver(M))
+		if(isovermind(M) || isobserver(M) || istype((M), /mob/living/simple_animal/hostile/blob/blobbernaut))
 			M.show_message(rendered, 2)
 
 /mob/camera/blob/emote(act, m_type = 1, message = null, force)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -234,7 +234,7 @@
 	blobber.overmind = src
 	blob_mobs.Add(blobber)
 	spawn()
-		var/list/candidates = pollCandidates("Do you want to play as a blobbernaut?", ROLE_BLOB, 1)
+		var/list/candidates = pollCandidates("Do you want to play as a blobbernaut?", ROLE_BLOB, 1, 150)
 		if(candidates.len)
 			var/mob/C = pick(candidates)
 			if(C)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -207,7 +207,7 @@
 
 /mob/camera/blob/verb/create_blobbernaut()
 	set category = "Blob"
-	set name = "Create Blobbernaut (20)"
+	set name = "Create Blobbernaut (40)"
 	set desc = "Create a powerful blob-being, a Blobbernaut"
 
 	var/turf/T = get_turf(src)
@@ -224,7 +224,7 @@
 		to_chat(src, "Unable to use this blob, find a factory blob.")
 		return
 
-	if(!can_buy(20))
+	if(!can_buy(40))
 		return
 
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
@@ -233,6 +233,13 @@
 	blobber.color = blob_reagent_datum.complementary_color
 	blobber.overmind = src
 	blob_mobs.Add(blobber)
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to play as a blobbernaut?", ROLE_BLOB, 1)
+		if(candidates.len)
+			var/mob/C = pick(candidates)
+			if(C)
+				blobber.key = C.key
+				to_chat(blobber, "<span class='biggerdanger'>You are a blobbernaut! You must assist all blob lifeforms in their mission to consume everything!</span>")
 	return
 
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -240,6 +240,7 @@
 			if(C)
 				blobber.key = C.key
 				to_chat(blobber, "<span class='biggerdanger'>You are a blobbernaut! You must assist all blob lifeforms in their mission to consume everything!</span>")
+				to_chat(blobber, "<span class='danger'>You heal while standing on blob structures, however you will decay slowly if you are damaged outside of the blob.</span>")
 	return
 
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -207,7 +207,7 @@
 
 /mob/camera/blob/verb/create_blobbernaut()
 	set category = "Blob"
-	set name = "Create Blobbernaut (40)"
+	set name = "Create Blobbernaut (60)"
 	set desc = "Create a powerful blob-being, a Blobbernaut"
 
 	var/turf/T = get_turf(src)
@@ -224,7 +224,7 @@
 		to_chat(src, "Unable to use this blob, find a factory blob.")
 		return
 
-	if(!can_buy(40))
+	if(!can_buy(60))
 		return
 
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))


### PR DESCRIPTION
**What does this PR do:**
Blobbernauts can now be controlled by players through a prompt which appears when they are spawned by blobs.
Blobbernauts have been nerfed, they now have less health, deal less damage and cannot break walls anymore.
Blobbernauts now regenerate health overtime when standing on blob structures.
Blobbernauts will start losing health overtime if they are not standing on blob structures and they are not at full health.
Blobbernauts and blobs can now communicate with each other.
Blob's "Produce Blobbernaut" ability has been made more expensive to use, now costing 60 resources instead of 20.

Blobbernauts are now smart "minions" the blobs can rely on. They are best used defensively as they can regenerate health when they're on blob structures, but they can still be used to do other strategic things, such as moving out in groups and attacking some specific department, or killing unsuspecting people and dragging them back to the blob to be zombified, etc. 

Specifics:
Blobbernauts now have 200 health down from 240.
They now deal 10 lower/15 higher damage down from 20/20.
Their environment smash has been set to "SMASH_STRUCTURES" from "SMASH_RWALLS" which is the same as blob spores now.
They now heal by 0.25 HP every tick if they are standing on blob structures.
They now lose health by 0.2 HP every tick if they are not standing on blob structures and they are not at max health. (Until you lose a bit of health, your integrity will remain the same no matter where you are)
They now have a random ID next to their name which can go from 0 to 1000, this is the same system used by monkeys, aliens, etc to help identify them.
They now have a verb which lets them type what they want to say in the blob chat. Said message will reach blobs and blobbernauts alike. Blobs' overmind chat has also been changed to send the messages to blobbernauts too.

**Changelog:**
:cl: EmanTheAlmighty
add: Blobbernauts can now be controlled by players through a prompt which appears when they are spawned by blobs.
add: Blobbernauts and blobs can now communicate with each other.
add: Blobbernauts now regenerate health overtime when standing on blob structures.
add: Blobbernauts will slowly lose health if they are not standing on blob structures while not at full health.
balance: Blobbernauts have been nerfed, they now have less health, deal less damage and cannot break walls anymore.
balance: Blob's "Produce Blobbernaut" ability has been made more expensive to use, now costing 60 resources instead of 20.
/:cl: