### PR TITLE
Hierophant layer fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -498,6 +498,7 @@ Difficulty: Hard
 	name = "vortex blast"
 	luminosity = 1
 	desc = "Get out of the way!"
+	layer = BELOW_OBJ_LAYER
 	duration = 9
 	var/damage = 10 //how much damage do we do?
 	var/list/hit_things = list() //we hit these already, ignore them

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -496,9 +496,9 @@ Difficulty: Hard
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "hierophant_blast"
 	name = "vortex blast"
+	layer = 3.9 // between LYING_MOB_LAYER and ABOVE_MOB_LAYER
 	luminosity = 1
 	desc = "Get out of the way!"
-	layer = BELOW_OBJ_LAYER
 	duration = 9
 	var/damage = 10 //how much damage do we do?
 	var/list/hit_things = list() //we hit these already, ignore them


### PR DESCRIPTION
**What does this PR do:**
Adjusts the effect layer for the Hierophant blast to always be between a laying mob and a further above mob in order to make sure the effect doesn't ever apply over the mob. This is not really a fix, merely a bandaid for an issue that supposedly happens, but is hard to reproduce.

Fixes #11947

**Changelog:**
:cl: kazboo
fix: adjusts the hierophant blast layer to make for it to always be below the effect. this should be the case already due to mouse_opacity, though for some unknown reason, it just doesn't work sometimes, so this should fix it.
/:cl:

