### PR TITLE
New damage type: Critical, for races that don't breathe

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -475,7 +475,7 @@ GLOBAL_LIST_INIT(do_after_once_tracker, list())
 			if(DEAD)
 				status = "<font color='red'><b>Dead</b></font>"
 		health_description = "Status = [status]"
-		health_description += "<BR>Oxy: [L.getOxyLoss()] - Tox: [L.getToxLoss()] - Fire: [L.getFireLoss()] - Brute: [L.getBruteLoss()] - Clone: [L.getCloneLoss()] - Brain: [L.getBrainLoss()]"
+		health_description += "<BR>Oxy: [L.getOxyLoss()] - Tox: [L.getToxLoss()] - Fire: [L.getFireLoss()] - Brute: [L.getBruteLoss()] - Clone: [L.getCloneLoss()] - Brain: [L.getBrainLoss()] - Crit: [L.getCritLoss()]"
 	else
 		health_description = "This mob type has no health to speak of."
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -130,6 +130,7 @@
 					CLONE:<font size='1'><a href='?_src_=vars;mobToDamage=[L.UID()];adjustDamage=clone'>[L.getCloneLoss()]</a>
 					BRAIN:<font size='1'><a href='?_src_=vars;mobToDamage=[L.UID()];adjustDamage=brain'>[L.getBrainLoss()]</a>
 					STAMINA:<font size='1'><a href='?_src_=vars;mobToDamage=[L.UID()];adjustDamage=stamina'>[L.getStaminaLoss()]</a>
+					CRIT:<font size='1'><a href='?_src_=vars;mobToDamage=[L.UID()];adjustDamage=crit'>[L.getCritLoss()]</a>
 				</font>
 			"}
 		else
@@ -1254,6 +1255,8 @@
 				L.adjustCloneLoss(amount)
 			if("stamina") 
 				L.adjustStaminaLoss(amount)
+			if("crit")
+				L.adjustCritLoss(amount)
 			else
 				to_chat(usr, "You caused an error. DEBUG: Text:[Text] Mob:[L]")
 				return

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -154,6 +154,7 @@
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()
 		occupantData["fireLoss"] = occupant.getFireLoss()
+		occupantData["critLoss"] = occupant.getCritLoss()
 		occupantData["paralysis"] = occupant.paralysis
 		occupantData["hasBlood"] = 0
 		occupantData["bodyTemperature"] = occupant.bodytemperature

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -375,7 +375,7 @@
 		occupantData["oxyLoss"] = H.getOxyLoss()
 		occupantData["toxLoss"] = H.getToxLoss()
 		occupantData["fireLoss"] = H.getFireLoss()
-
+		occupantData["critLoss"] = H.getCritLoss()
 		occupantData["radLoss"] = H.radiation
 		occupantData["cloneLoss"] = H.getCloneLoss()
 		occupantData["brainLoss"] = H.getBrainLoss()

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -117,6 +117,7 @@
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()
 		occupantData["fireLoss"] = occupant.getFireLoss()
+		occupantData["critLoss"] = occupant.getCritLoss()
 		occupantData["paralysis"] = occupant.paralysis
 		occupantData["hasBlood"] = 0
 		occupantData["bodyTemperature"] = occupant.bodytemperature

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -214,6 +214,7 @@
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()
 		occupantData["fireLoss"] = occupant.getFireLoss()
+		occupantData["critLoss"] = occupant.getCritLoss()
 		occupantData["bodyTemperature"] = occupant.bodytemperature
 	data["occupant"] = occupantData;
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -153,13 +153,14 @@ REAGENT SCANNER
 	var/TX = H.getToxLoss() > 50 	? 	"<b>[H.getToxLoss()]</b>" 		: H.getToxLoss()
 	var/BU = H.getFireLoss() > 50 	? 	"<b>[H.getFireLoss()]</b>" 		: H.getFireLoss()
 	var/BR = H.getBruteLoss() > 50 	? 	"<b>[H.getBruteLoss()]</b>" 	: H.getBruteLoss()
+	var/CR = H.getCritLoss() > 50	?	"<b>[H.getCritLoss()]</b>"		: H.getCritLoss()
 	if(H.status_flags & FAKEDEATH)
 		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
 		user.show_message("<span class='notice'>Analyzing Results for [H]:\n\t Overall Status: dead</span>")
 	else
 		user.show_message("<span class='notice'>Analyzing Results for [H]:\n\t Overall Status: [H.stat > 1 ? "dead" : "[H.health]% healthy"]</span>")
-	user.show_message("\t Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>", 1)
-	user.show_message("\t Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>")
+	user.show_message("\t Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>/<font color='purple'>Crit</font>", 1)
+	user.show_message("\t Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font> - <font color='purple'>[CR]</font>")
 	user.show_message("<span class='notice'>Body Temperature: [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)</span>", 1)
 	if(H.timeofdeath && (H.stat == DEAD || (H.status_flags & FAKEDEATH)))
 		user.show_message("<span class='notice'>Time of Death: [station_time_timestamp("hh:mm:ss", H.timeofdeath)]</span>")

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -419,6 +419,7 @@
 						tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 						tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 						H.adjustOxyLoss(tobehealed)
+						H.adjustCritLoss(tobehealed)
 						H.adjustToxLoss(tobehealed)
 						H.adjustFireLoss(tobehealed)
 						H.adjustBruteLoss(tobehealed)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -12,7 +12,7 @@
 		total_brute += O.brute_dam //calculates health based on organ brute and burn
 		total_burn += O.burn_dam
 
-	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
+	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - getCritLoss() - total_burn - total_brute
 
 	//TODO: fix husking
 	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD) && stat == DEAD)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -253,6 +253,8 @@
 /mob/living/carbon/human/breathe()
 	if(!dna.species.breathe(src))
 		..()
+	else if(getCritLoss() && health > HEALTH_THRESHOLD_CRIT) // if they're a breathless race and have crit damage take away some when they'd normally breathe
+		adjustCritLoss(-5)
 
 /mob/living/carbon/human/check_breath(datum/gas_mixture/breath)
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -298,7 +298,7 @@
 	if((NO_BREATHE in species_traits) || (BREATHLESS in H.mutations))
 		var/takes_crit_damage = (!(NOCRITDAMAGE in species_traits))
 		if((H.health <= HEALTH_THRESHOLD_CRIT) && takes_crit_damage)
-			H.adjustBruteLoss(1)
+			H.adjustCritLoss(1)
 	return
 
 /datum/species/proc/handle_dna(mob/living/carbon/human/H, remove) //Handles DNA mutations, as that doesn't work at init. Make sure you call genemutcheck on any blocks changed here

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -96,7 +96,7 @@
 		return
 	head_organ.h_style = "Bald"
 	head_organ.f_style = "Shaved"
-	H.setCritLoss(0) // reset their crit damage to 0 upon death as they can't be healed with chemicals or defibs
+	H.setCritLoss(0, FALSE) // reset their crit damage to 0 upon death as they can't be healed with chemicals or defibs
 	spawn(100)
 		if(H && head_organ)
 			H.update_hair()

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -96,6 +96,7 @@
 		return
 	head_organ.h_style = "Bald"
 	head_organ.f_style = "Shaved"
+	H.setCritLoss(0) // reset their crit damage to 0 upon death as they can't be healed with chemicals or defibs
 	spawn(100)
 		if(H && head_organ)
 			H.update_hair()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -100,6 +100,41 @@
 	if(jitter) 		apply_effect(jitter, JITTER, blocked)
 	return 1
 
+/mob/living/carbon/getCritLoss()
+	return critloss
+
+/mob/living/proc/getCritLoss()
+	return FALSE
+
+/mob/living/proc/adjustCritLoss(amount, updating_health = TRUE)
+	return FALSE
+
+/mob/living/carbon/adjustCritLoss(amount, updating_health = TRUE)
+	if(status_flags & GODMODE)// if they breathe don't stack crit damage
+		return FALSE //godmode
+	var/old_critloss = critloss
+	critloss = max(critloss + amount, 0)
+	if(old_critloss == critloss)
+		updating_health = FALSE
+		. = STATUS_UPDATE_NONE
+	else
+		. = STATUS_UPDATE_HEALTH
+	if(updating_health)
+		updatehealth("adjustCritLoss")	
+
+/mob/living/proc/setCritLoss(amount, updating_health = TRUE)
+	if(status_flags & GODMODE)
+		critloss = 0
+		return FALSE	//godmode
+	var/old_critloss = critloss
+	critloss = amount
+	if(old_critloss == critloss)
+		updating_health = FALSE
+		. = STATUS_UPDATE_NONE
+	else
+		. = STATUS_UPDATE_HEALTH
+	if(updating_health)
+		updatehealth("setCritLoss")
 
 /mob/living/proc/getBruteLoss()
 	return bruteloss

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -268,7 +268,7 @@
 		health = maxHealth
 		stat = CONSCIOUS
 		return
-	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss()
+	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - getCritLoss()
 
 	update_stat("updatehealth([reason])")
 	handle_hud_icons_health()
@@ -411,6 +411,7 @@
 	setCloneLoss(0)
 	setBrainLoss(0)
 	setStaminaLoss(0)
+	setCritLoss(0)
 	SetSleeping(0)
 	SetParalysis(0, 1, 1)
 	SetStunned(0, 1, 1)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -7,6 +7,7 @@
 
 
 	//Damage related vars, NOTE: THESE SHOULD ONLY BE MODIFIED BY PROCS
+	var/critloss = 0 // New critical damage, to handle things like nobreathe races and the like instead of giving them brute.
 	var/bruteloss = 0	//Brutal damage caused by brute force (punching, being clubbed by a toolbox ect... this also accounts for pressure damage)
 	var/oxyloss = 0	//Oxygen depravation damage (no air in lungs)
 	var/toxloss = 0	//Toxic damage caused by being poisoned or radiated

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -629,6 +629,8 @@
 	M.AdjustLoseBreath(-1, bound_lower = 3)
 	if(M.getOxyLoss() > 35)
 		update_flags |= M.adjustOxyLoss(-10*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	if(M.getCritLoss() > 35)
+		update_flags |= M.adjustCritLoss(-10*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	if(M.health < -10 && M.health > -65)
 		update_flags |= M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -117,6 +117,7 @@
 	if(M.bodytemperature < TCRYO)
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
+		update_flags |= M.adjustCritLoss(-3, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)
 		update_flags |= M.adjustBruteLoss(-12, FALSE)
 		update_flags |= M.adjustFireLoss(-12, FALSE)
@@ -294,6 +295,7 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustOxyLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.adjustCritLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	if(prob(50))
@@ -468,6 +470,7 @@
 		update_flags |= M.adjustToxLoss(-1, FALSE)
 		update_flags |= M.adjustBruteLoss(-1, FALSE)
 		update_flags |= M.adjustFireLoss(-1, FALSE)
+		update_flags |= M.adjustCritLoss(-1, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M, severity)
@@ -593,6 +596,7 @@
 		update_flags |= M.adjustToxLoss(-1, FALSE)
 		update_flags |= M.adjustBruteLoss(-3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustFireLoss(-3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustCritLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	else if(M.health > -60)
 		update_flags |= M.adjustToxLoss(1, FALSE)
 	M.reagents.remove_reagent("sarin", 20)
@@ -629,6 +633,7 @@
 		update_flags |= M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustCritLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/epinephrine/overdose_process(mob/living/M, severity)
@@ -694,6 +699,7 @@
 					M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
 					M.adjustCloneLoss(50)
 					M.setOxyLoss(0)
+					M.setCritLoss(0)
 					M.adjustBruteLoss(rand(0, 15))
 					M.adjustToxLoss(rand(0, 15))
 					M.adjustFireLoss(rand(0, 15))
@@ -784,6 +790,7 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	if(volume > 5)
 		update_flags |= M.adjustOxyLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustCritLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustToxLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustBruteLoss(-10*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustFireLoss(-10*REAGENTS_EFFECT_MULTIPLIER, FALSE)
@@ -822,6 +829,7 @@
 	M.status_flags |= GOTTAGOFAST
 	if(M.health < 50 && M.health > 0)
 		update_flags |= M.adjustOxyLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustCritLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
@@ -940,6 +948,7 @@
 	update_flags |= M.adjustBruteLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE) //A ton of healing - this is a 50 telecrystal investment.
 	update_flags |= M.adjustFireLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustOxyLoss(-15*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.adjustCritLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)	
 	update_flags |= M.adjustToxLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustBrainLoss(-15*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustCloneLoss(-3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
@@ -959,6 +968,7 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.adjustToxLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustOxyLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.adjustCritLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -94,11 +94,11 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			</tr>
 			<tr>
 				<td> Burn Severity: </td>
-				<td> Paralysis %: ({{:helper.smoothRound(data.occupant.paralysisSeconds)}} seconds left) </td>
+				<td> Critical damage: </td>
 			</tr>
 			<tr>
 				<td> {{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth+100, (data.occupant.fireLoss < 15) ? 'notgood' : (data.occupant.fireLoss < 40) ? 'average' : 'bad', data.occupant.fireLoss)}} </td>
-				<td> {{:helper.displayBar(data.occupant.paralysis, 0, 100, (data.occupant.paralysis < 25) ? 'notgood' : (data.occupant.paralysis < 50) ? 'average' : 'bad', data.occupant.paralysis)}} </td>
+				<td> {{:helper.displayBar(data.occupant.critLoss, 0, data.occupant.maxHealth+100, (data.occupant.critLoss < 15) ? 'notgood' : (data.occupant.critLoss < 40) ? 'average' : 'bad', data.occupant.critLoss)}} </td>
 			</tr>
 		</tbody>
 	</table>

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -53,6 +53,13 @@
 					{{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad')}}
 					<div class="statusValue">{{:helper.smoothRound(data.occupant.fireLoss)}}</div>
 				</div>
+
+				<div class="line">
+					<div class="statusLabel"><i class="fa fa-arrow-right"></i>Critical Damage:</div>
+					{{:helper.displayBar(data.occupant.critLoss, 0, data.occupant.maxHealth, 'bad')}}
+					<div class="statusValue">{{:helper.smoothRound(data.occupant.critLoss)}}</div>
+				</div>
+
 			{{/if}}
 		{{/if}}
 		<br>

--- a/nano/templates/op_computer.tmpl
+++ b/nano/templates/op_computer.tmpl
@@ -59,6 +59,12 @@ Used In File(s): \code\game\machinery\computer\Operating.dm
 				</div>
 
 				<div class="line">
+					<div class="statusLabel">Critical Damage:</div>
+					{{:helper.displayBar(data.occupant.critLoss, 0, data.occupant.maxHealth, 'bad')}}
+					<div class="statusValue">{{:helper.smoothRound(data.occupant.critLoss)}}</div>
+				</div>
+
+				<div class="line">
 					<div class="statusLabel">Patient Temperature:</div>
 					{{if data.occupant.temperatureSuitability == -3}}
 					{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'bad')}}

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -57,6 +57,12 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 				<div class="statusValue">{{:helper.smoothRound(data.occupant.fireLoss)}}</div>
 			</div>
 
+			<div class="line">
+				<div class="statusLabel">=&gt; Critical Damage:</div>
+				{{:helper.displayBar(data.occupant.critLoss, 0, data.occupant.maxHealth, 'bad')}}
+				<div class="statusValue">{{:helper.smoothRound(data.occupant.critLoss)}}</div>
+			</div>
+
 			<br>
 			<div class="line">
 			<!--


### PR DESCRIPTION
**What does this PR do:**
Creates a new critical damage type for the special snowflakes so they don't take brute damage in crit instead, as brute is much harder to heal and I don't think these races should be punished for getting stabilized. The only way to currently accumulate critical damage is through admemes or being in critical, you take 1 critical damage while in crit per tick(this is on par with 1 oxyloss per tick in crit for oldcrit races that breathe), you also heal 5 critical damage every tick spent outside of crit which is again on par with breathing races. Epinephrine and Ephedrine lower critical damage by small amounts to simulate the same effect these chems have on oxyloss.

![image](https://user-images.githubusercontent.com/30060146/62199280-338b4980-b351-11e9-95b7-d15bcdb24648.png)

The new damage type appears in scanners, advanced scanners, sleepers and cryocells

**Changelog:**
:cl:
add: Unique critical damage type for non-breathing races
tweak: replaces paralysis % field in advanced scanner with critical damage field
/:cl:

