### PR TITLE
bring invismin back to F9

### DIFF
--- a/code/modules/keybindings/bindings_admin.dm
+++ b/code/modules/keybindings/bindings_admin.dm
@@ -13,7 +13,7 @@
 			user.cmd_admin_pm_panel()
 			return
 		if("F9")
-			user.stealth()
+			user.invisimin()
 			return
 		if("F10")
 			user.get_dead_say()


### PR DESCRIPTION
**What does this PR do:**
I apparently didn't know the difference between stealthmin and invismin. Nice. I brought invismin back now

**Changelog:**
:cl:
add: Added invismin macro back to F9
del: stealthmin macro removed from F9
/:cl:

