### PR TITLE
Giant spider updates (spontaneous player control!)

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -128,6 +128,7 @@
 	anchored = 0
 	layer = 2.75
 	health = 3
+	var/eventspiderling = FALSE // Spawned by the random event? If TRUE, said spiderling cannot be considered to become randomly sentient.
 	var/amount_grown = 0
 	var/grow_as = null
 	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
@@ -227,7 +228,7 @@
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(loc)
 			S.faction = faction.Copy()
 			S.master_commander = master_commander
-			if(player_spiders && !selecting_player) // If the spider who laid the eggs was a player
+			if((prob(15)) && player_spiders && !selecting_player && !eventspiderling) // If the spider who laid the eggs was a player, slightly better chance.
 				selecting_player = 1
 				spawn()
 					var/list/candidates = pollCandidates("Do you want to play as a giant spider?", ROLE_GSPIDER, 1, 150)
@@ -240,7 +241,7 @@
 								to_chat(S, "<span class='biggerdanger'>You are a giant spider who is loyal to [S.master_commander], obey [S.master_commander]'s every order and assist [S.master_commander.p_them()] in completing [S.master_commander.p_their()] goals at any cost.</span>")
 							else // Born from a sentient spider who isn't loyal to anybody, do the thing giant spiders do.
 								to_chat(S, "<span class='biggerdanger'>You are a smart giant spider! Use your sentiency to your advantage, and help the spiders take over!</span>")
-			else if((prob(10)) && !selecting_player && !player_spiders) // If the spider who laid the eggs was a NPC there's a 10% one of the spiderlings will become sentient.
+			else if((prob(10)) && !selecting_player && !player_spiders && !eventspiderling) // If the spider who laid the eggs was a NPC there's a 10% one of the spiderlings will become sentient.
 				selecting_player = 1
 				spawn()
 					var/list/candidates = pollCandidates("Do you want to play as a giant spider?", ROLE_GSPIDER, 1, 150)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -227,17 +227,29 @@
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(loc)
 			S.faction = faction.Copy()
 			S.master_commander = master_commander
-			if(player_spiders && !selecting_player)
+			if(player_spiders && !selecting_player) // If the spider who laid the eggs was a player
 				selecting_player = 1
 				spawn()
-					var/list/candidates = pollCandidates("Do you want to play as a spider?", ROLE_GSPIDER, 1)
+					var/list/candidates = pollCandidates("Do you want to play as a giant spider?", ROLE_GSPIDER, 1, 150)
 
 					if(candidates.len)
 						var/mob/C = pick(candidates)
 						if(C)
 							S.key = C.key
-							if(S.master_commander)
-								to_chat(S, "<span class='biggerdanger'>You are a spider who is loyal to [S.master_commander], obey [S.master_commander]'s every order and assist [S.master_commander.p_them()] in completing [S.master_commander.p_their()] goals at any cost.</span>")
+							if(S.master_commander) // Born from a servant sentient spider, gotta follow the commander's orders.
+								to_chat(S, "<span class='biggerdanger'>You are a giant spider who is loyal to [S.master_commander], obey [S.master_commander]'s every order and assist [S.master_commander.p_them()] in completing [S.master_commander.p_their()] goals at any cost.</span>")
+							else // Born from a sentient spider who isn't loyal to anybody, do the thing giant spiders do.
+								to_chat(S, "<span class='biggerdanger'>You are a smart giant spider! Use your sentiency to your advantage, and help the spiders take over!</span>")
+			else if((prob(10)) && !selecting_player && !player_spiders) // If the spider who laid the eggs was a NPC there's a 10% one of the spiderlings will become sentient.
+				selecting_player = 1
+				spawn()
+					var/list/candidates = pollCandidates("Do you want to play as a giant spider?", ROLE_GSPIDER, 1, 150)
+
+					if(candidates.len)
+						var/mob/C = pick(candidates)
+						if(C)
+							S.key = C.key
+							to_chat(S, "<span class='biggerdanger'>You are a smart giant spider! Use your sentiency to your advantage, and help the spiders take over!</span>")
 			qdel(src)
 
 /obj/effect/decal/cleanable/spiderling_remains

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -23,6 +23,7 @@
 	while((spawncount >= 1) && vents.len)
 		var/obj/vent = pick(vents)
 		var/obj/structure/spider/spiderling/S = new(vent.loc)
+		S.eventspiderling = TRUE
 		if(prob(66))
 			S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 		vents -= vent

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -47,6 +47,12 @@
 		if(C.can_inject(null, 0, inject_target, 0))
 			C.reagents.add_reagent("spidertoxin", venom_per_bite)
 
+/mob/living/simple_animal/hostile/poison/giant_spider/New()
+	..()
+	spawn(1)
+	if(!faction.len)
+		faction = list("spiders")
+
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 	desc = "Furry and black, it makes you shudder to look at it. This one has brilliant green eyes."
@@ -55,8 +61,8 @@
 	icon_dead = "nurse_dead"
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/spidermeat = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8, /obj/item/reagent_containers/food/snacks/spidereggs = 4)
 
-	maxHealth = 40
-	health = 40
+	maxHealth = 50
+	health = 50
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	venom_per_bite = 30
@@ -69,8 +75,8 @@
 	icon_state = "hunter"
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
-	maxHealth = 120
-	health = 120
+	maxHealth = 140
+	health = 140
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	venom_per_bite = 10
@@ -144,6 +150,9 @@
 	set category = "Spider"
 	set desc = "Spread a sticky web to slow down prey."
 
+	if(stat == DEAD)
+		return
+
 	var/T = src.loc
 
 	if(busy != SPINNING_WEB)
@@ -161,6 +170,9 @@
 	set name = "Wrap"
 	set category = "Spider"
 	set desc = "Wrap up prey to feast upon and objects for safe keeping."
+
+	if(stat == DEAD)
+		return
 
 	if(!cocoon_target)
 		var/list/choices = list()
@@ -217,6 +229,9 @@
 	set name = "Lay Eggs"
 	set category = "Spider"
 	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
+
+	if(stat == DEAD)
+		return
 
 	var/obj/structure/spider/eggcluster/E = locate() in get_turf(src)
 	if(E)


### PR DESCRIPTION
**What does this PR do:**
Giant spider spiderlings now have a 10% chance of growing up sentient. This will, on rare occasions, give ghosts the ability to play as said lucky spider, which means that they can live a bit longer than normal spiders and "lead" them, causing more damage than usual.
Player controlled giant nurse spiders will create spiderlings that have a 15% chance.

Green giant spiders now have 50 health from 40, and hunters have 140 health from 120.

Fixed giant spiders occasionally growing up without a faction.

Fixed nurse spiders being able to use abilities while dead.

**Changelog:**
:cl: EmanTheAlmighty
add: Giant spider spiderlings (not including the ones spawned from the random event) now have a 10% chance of growing up sentient, subsequently becoming more dangerous. Better not let it happen!
tweak: Nurse and hunter giant spiders now have slightly more health.
del: Player controlled spiders are no longer guaranteed to make more sentient spiders.
fix: Fixed nurse giant spiders being able to use abilities while dead.
fix: Giant spiders who grow up without a specific faction will automatically join the spiders' faction. This fixes changeling spiderlings growing up only to then attack and kill each other.
/:cl: