### PR TITLE
New Emote: Unathi Forked Tongue Flick

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -94,8 +94,8 @@
 			else								//Everyone else fails, skip the emote attempt
 				return
 
-		if("hiss", "hisses")
-			if(isunathi(src)) //Only Unathi can hiss.
+		if("hiss", "hisses", "flick", "flicks")
+			if(isunathi(src)) //Only Unathi can hiss and flick their tongue.
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
 			else								//Everyone else fails, skip the emote attempt
 				return
@@ -219,6 +219,10 @@
 			else
 				message = "<B>[src]</B> makes a weak hissing noise."
 				m_type = 2
+
+		if("flick", "flicks")
+			message = "<B>[src]</B> flicks [p_their()] forked tongue in the air."
+			m_type = 1
 
 		if("quill", "quills")
 			var/M = handle_emote_param(param)
@@ -910,7 +914,7 @@
 				if("Kidan")
 					emotelist += "\nKidan specific emotes :- click(s), clack(s)"
 				if("Unathi")
-					emotelist += "\nUnathi specific emotes :- hiss(es)"
+					emotelist += "\nUnathi specific emotes :- hiss(es), flick(s)"
 				if("Vulpkanin")
 					emotelist += "\nVulpkanin specific emotes :- growl(s)-none/mob, howl(s)-none/mob"
 				if("Vox")


### PR DESCRIPTION
**What does this PR do:**
Gives a new emote to solely unathi, where they can flick their tongue (as supported by current Unathi lore).

To use it:

1. Be a Unathi.
2. Use the emote *flick or *flicks
3. ???
4. Moghes Profit.

**Images of sprite/map changes (IF APPLICABLE):**
![image](https://user-images.githubusercontent.com/32376559/62345265-8d515800-b4a6-11e9-8704-dacd845309cd.png)


**Changelog:**

:cl:Quantum-M
add: New Emote for Unathi, use *flick or *flicks for them to flick their forked tongue.
/:cl:

