### PR TITLE
Add the NO_MACHINES tag to ashwalkers

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -147,4 +147,4 @@
 #define RESISTCOLD		17
 #define NO_EXAMINE		18
 #define CAN_WINGDINGS	19
-#define TRIBAL			20
+#define NO_MACHINES		20

--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -147,3 +147,4 @@
 #define RESISTCOLD		17
 #define NO_EXAMINE		18
 #define CAN_WINGDINGS	19
+#define TRIBAL			20

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -351,15 +351,11 @@ Class Procs:
 	if(user.incapacitated())
 		return TRUE
 
-	if(!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+	if(!user.can_use_machinery())
 		return TRUE
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(TRIBAL in H.dna.species.species_traits)
-			to_chat(user, "<span class='warning'>You can't figure out how to use [src].</span>")
-			return TRUE
 		if(H.getBrainLoss() >= 60)
 			visible_message("<span class='warning'>[H] stares cluelessly at [src] and drools.</span>")
 			return TRUE

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -357,6 +357,9 @@ Class Procs:
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
+		if(TRIBAL in H.dna.species.species_traits)
+			to_chat(user, "<span class='warning'>You can't figure out how to use [src].</span>")
+			return TRUE
 		if(H.getBrainLoss() >= 60)
 			visible_message("<span class='warning'>[H] stares cluelessly at [src] and drools.</span>")
 			return TRUE

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -176,12 +176,8 @@
 	interact(user)
 
 /obj/machinery/syndicatebomb/attack_hand(mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(TRIBAL in H.dna.species.species_traits)
-			to_chat(user, "<span class='warning'>You can't figure out how to use [src].</span>")
-			return TRUE
-	interact(user)
+	if(user.can_use_machinery())
+		interact(user)
 
 /obj/machinery/syndicatebomb/attack_ai()
 	return

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -176,6 +176,11 @@
 	interact(user)
 
 /obj/machinery/syndicatebomb/attack_hand(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(TRIBAL in H.dna.species.species_traits)
+			to_chat(user, "<span class='warning'>You can't figure out how to use [src].</span>")
+			return TRUE
 	interact(user)
 
 /obj/machinery/syndicatebomb/attack_ai()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1122,11 +1122,8 @@
 		return
 	if(user != M)
 		return
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(TRIBAL in H.dna.species.species_traits)
-			to_chat(user, "<span class='warning'>You can't figure out how to enter [src].</span>")
-			return
+	if(!user.can_use_machinery())
+		return
 	log_message("[user] tries to move in.")
 	if(occupant)
 		to_chat(user, "<span class='warning'>The [src] is already occupied!</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1122,6 +1122,11 @@
 		return
 	if(user != M)
 		return
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(TRIBAL in H.dna.species.species_traits)
+			to_chat(user, "<span class='warning'>You can't figure out how to enter [src].</span>")
+			return
 	log_message("[user] tries to move in.")
 	if(occupant)
 		to_chat(user, "<span class='warning'>The [src] is already occupied!</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2020,10 +2020,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		visible_message("<span class='danger'>[src] is engulfed in shadows and fades into the darkness.</span>", "<span class='danger'>A sense of dread washes over you as you suddenly dim dark.</span>")
 
 /mob/living/carbon/human/can_use_machinery()
-	if(!IsAdvancedToolUser())
-		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return FALSE
 	if(NO_MACHINES in dna.species.species_traits)
 		to_chat(src, "<span class='warning'>You can't figure out how to do this!</span>")
 		return FALSE
-	return TRUE
+	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1823,6 +1823,10 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return 0
 
+	if(TRIBAL in dna.species.species_traits)
+		to_chat(src, "<span class='warning'>You can't figure out how to use this weapon!</span>")
+		return 0
+
 	if(martial_art && martial_art.no_guns) //great dishonor to famiry
 		to_chat(src, "<span class='warning'>[martial_art.no_guns_message]</span>")
 		return 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1823,10 +1823,6 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return 0
 
-	if(TRIBAL in dna.species.species_traits)
-		to_chat(src, "<span class='warning'>You can't figure out how to use this weapon!</span>")
-		return 0
-
 	if(martial_art && martial_art.no_guns) //great dishonor to famiry
 		to_chat(src, "<span class='warning'>[martial_art.no_guns_message]</span>")
 		return 0
@@ -2004,6 +2000,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 /mob/living/carbon/human/fakefireextinguish()
 	overlays_standing[FIRE_LAYER] = null
 	update_icons()
+
 /mob/living/carbon/human/proc/cleanSE()	//remove all disabilities/powers
 	for(var/block = 1; block <= DNA_SE_LENGTH; block++)
 		dna.SetSEState(block, FALSE, TRUE)
@@ -2021,3 +2018,12 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	if(O && O.glowing)
 		O.toggle_biolum(TRUE)
 		visible_message("<span class='danger'>[src] is engulfed in shadows and fades into the darkness.</span>", "<span class='danger'>A sense of dread washes over you as you suddenly dim dark.</span>")
+
+/mob/living/carbon/human/can_use_machinery()
+	if(!IsAdvancedToolUser())
+		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return FALSE
+	if(NO_MACHINES in dna.species.species_traits)
+		to_chat(src, "<span class='warning'>You can't figure out how to do this!</span>")
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -116,4 +116,4 @@
 	default_language = "Sinta'unathi"
 
 	slowdown = -0.80
-	species_traits = list(NO_BREATHE, TRIBAL)
+	species_traits = list(NO_BREATHE, NOGUNS, NO_MACHINES)

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -110,10 +110,10 @@
 	name_plural = "Ash Walkers"
 
 	blurb = "These reptillian creatures appear to be related to the Unathi, but seem significantly less evolved. \
-	They roam the wastes of Lavaland, worshipping a dead city and capturing unsuspecting miners." 
+	They roam the wastes of Lavaland, worshipping a dead city and capturing unsuspecting miners."
 
 	language = "Sinta'unathi"
 	default_language = "Sinta'unathi"
 
 	slowdown = -0.80
-	species_traits = list(NO_BREATHE, NOGUNS)
+	species_traits = list(NO_BREATHE, TRIBAL)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -693,7 +693,7 @@ var/list/slot_equipment_priority = list( \
 
 	msg = copytext(msg, 1, MAX_MESSAGE_LEN)
 	msg = sanitize_simple(html_encode(msg), list("\n" = "<BR>"))
-	
+
 	var/combined = length(memory + msg)
 	if(mind && (combined < MAX_PAPER_MESSAGE_LEN))
 		mind.store_memory(msg)
@@ -1386,3 +1386,6 @@ var/list/slot_equipment_priority = list( \
 				suffix = "_8"
 
 		S.icon_state = "[initial(S.icon_state)][suffix]"
+
+/mob/proc/can_use_machinery()
+	return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1388,4 +1388,7 @@ var/list/slot_equipment_priority = list( \
 		S.icon_state = "[initial(S.icon_state)][suffix]"
 
 /mob/proc/can_use_machinery()
-	return FALSE
+	if(!IsAdvancedToolUser())
+		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return FALSE
+	return TRUE

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -761,9 +761,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/spacepod_equipment/SPE, v
 	if(!ishuman(user))
 		return FALSE
 
-	var/mob/living/carbon/human/H = user
-	if(TRIBAL in H.dna.species.species_traits)
-		to_chat(user, "<span class='warning'>You can't figure out how to enter [src].</span>")
+	if(!user.can_use_machinery())
 		return FALSE
 
 	if(fukkendisk)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -741,34 +741,39 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/spacepod_equipment/SPE, v
 
 /obj/spacepod/proc/enter_pod(mob/user)
 	if(usr.stat != CONSCIOUS)
-		return 0
+		return FALSE
 
 	if(equipment_system.lock_system && !unlocked)
 		to_chat(user, "<span class='warning'>[src]'s doors are locked!</span>")
-		return 0
+		return FALSE
 
 	if(get_dist(src, user) > 2 || get_dist(usr, user) > 1)
 		to_chat(usr, "They are too far away to put inside")
-		return 0
+		return FALSE
 
 	if(!istype(user))
-		return 0
+		return FALSE
 
 	var/fukkendisk = user.GetTypeInAllContents(/obj/item/disk/nuclear)
 
 	if(user.incapacitated()) //are you cuffed, dying, lying, stunned or other
-		return 0
+		return FALSE
 	if(!ishuman(user))
-		return 0
+		return FALSE
+
+	var/mob/living/carbon/human/H = user
+	if(TRIBAL in H.dna.species.species_traits)
+		to_chat(user, "<span class='warning'>You can't figure out how to enter [src].</span>")
+		return FALSE
 
 	if(fukkendisk)
 		to_chat(user, "<span class='danger'><B>The nuke-disk is locking the door every time you try to open it. You get the feeling that it doesn't want to go into the spacepod.</b></span>")
-		return 0
+		return FALSE
 
 	for(var/mob/living/carbon/slime/S in range(1,usr))
 		if(S.Victim == user)
 			to_chat(user, "You're too busy getting your life sucked out of you.")
-			return 0
+			return FALSE
 
 	move_inside(user)
 


### PR DESCRIPTION
This PR adds a new tag, NO_MACHINES, to ashwalkers. This tag prevents them from using most machinery/computers (basically everything you can find on lavaland aside from airlocks and airlock controllers), and entering mechs/space pods.

This PR solves : 

1. ashwalkers invading/visiting the station. they need assistance, either from crewmembers or admins, to do so now.
2. ashwalkers blowing up the syndi base easy peasy by deconstructing the outside wall and triggering the base's self destruct. the base's self destruct really should also check for a syndicate ID before triggering but thats outside the scope of this PR.
3. ashwalkers stealing miner mechs who were too dumb dumb to DNA lock it, cavelizards shouldnt be able to pilot mechs

this PR also adds a new mob proc, can_use_machines(), which checks for the tag and if youre an advanced tool user.

:cl:
tweak: Ashwalkers can no longer operate most machinery, computers, mechs, space pods, and shuttles.
/:cl: