### PR TITLE
Port Polaris Eye Adjustment to Dark

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -189,6 +189,7 @@
 	if(!client)	return 0
 
 	handle_vision()
+	handle_darksight() //Adjust transparency of darksight overlay relative to turf luminosity.
 	handle_hud_icons()
 
 	return 1
@@ -205,6 +206,25 @@
 	else
 		if(!remote_view && !client.adminobs)
 			reset_perspective(null)
+
+/* Adjust eyes to the dark by manipulating opacity of the darksight overlay. The darker an turf is the more your eyes will adjust and the better you'll be able to see.
+The darksight overlay starts fully opaque and becomes more transparent relative to the luminosity of the owner's turf. Full darksightedness is achieved in total darkness.
+This is a port from Polaris minus alpha scaling (caps transparency of the darksight overlay relative to darksight level, 1-8) since we have specific overlays for that value. */
+/mob/living/proc/handle_darksight()
+	var/obj/screen/fullscreen/see_through_darkness/S = screens["see_through_darkness"]
+	if(!S)
+		return
+	var/current = S.alpha / 255		//Our current adjustedness.
+	var/brightness = 0.0 			//We'll assume it's superdark if we can't find something else..
+	if(isturf(loc))
+		var/turf/T = loc			//Will be true 99% of the time, thus avoiding the whole elif chain.
+		brightness = T.get_lumcount()
+	var/darkness = 1 - brightness	//Silly, I know, but 'alpha' and 'darkness' go the same direction on a number line.
+	var/distance = abs(current - darkness) //Used for how long to animate for.
+	if(distance < 0.01)				//We're already all set.
+		return
+
+	animate(S, alpha = (darkness * 255), time = (distance * 10 SECONDS)) //Vite in umbra!
 
 // Gives a mob the vision of being dead
 /mob/living/proc/grant_death_vision()


### PR DESCRIPTION
Split off of PR #11484 for further discussion & adjustment.

**What does this PR do:**
This is a slightly simplified port of [Polaris' take](https://github.com/PolarisSS13/Polaris/pull/4626) on eyes adjusting to the dark.
I left out the alpha scaling since we have specific overlays for each level of darksight. 'Alpha scaling' is a rough term I'm using to try and describe capping transparency of one overlay to emulate the various levels of darksight.

This does NOT reduce how much you see in the dark when comparing fully adjusted eyes to the live server before this PR - so when fully adjusted, your eyes will see the exact same as they do on the live server when you dive into a dark maintenance tunnel.

Darkness will be opaque when you're in a well lit area and will become transparent in relation to the darkness of the tile you're on. The darker the area, the more of more you will see in the dark (up to your full darksight potential, being vision of the number of tiles in one direction your darksight level is as the transparency of the darksight overlay permits).

Before this PR you could walk into darkness from a maximally bright room and see as far as you can with no period of adaptation required. Now you walk into darkness and your eyes adjust over a few seconds until you see as far as you possibly can (same as before, just takes time to get there).

Mesons and other nightvision goggles are unaffected because they ignore the overlay and this is an overlay-based effect. How far you see with mesons is how far things are actually rendered on screen full stop which is determined by a mob's darksight/see in dark.

**Images of sprite/map changes (IF APPLICABLE):**
_[Here](https://anonfile.com/a6Dc24k4n0/para_ss13_new_darksight_eyes_adjusting_no_alpha_scaling_mp4) is a preview of eyes adjusting to the dark with >=8,7,6,5,4,3,<=2 darksight._ (Uploaded to different file hosting service due to size)

**Changelog:**
:cl:
add: The vision of living creatures now takes a few seconds to adjust to the dark and how well you see in the dark is relative to how dark the current turf is.
/:cl:

