### PR TITLE
Fix conflicting traitor objectives

### DIFF
--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -6,6 +6,7 @@
 #define TARGET_INVALID_UNREACHABLE	5
 #define TARGET_INVALID_GOLEM		6
 #define TARGET_INVALID_EVENT		7
+#define TARGET_INVALID_IS_TARGET	8
 
 //gamemode istype helpers
 #define GAMEMODE_IS_BLOB		(SSticker && istype(SSticker.mode, /datum/game_mode/blob))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -42,6 +42,7 @@
 	var/list/kills = list()
 	var/list/datum/objective/objectives = list()
 	var/list/datum/objective/special_verbs = list()
+	var/list/targets = list()
 
 	var/has_been_rev = 0//Tracks if this mind has been a rev or not
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -25,6 +25,8 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 /datum/objective/proc/is_invalid_target(datum/mind/possible_target)
 	if(possible_target == owner)
 		return TARGET_INVALID_IS_OWNER
+	if(possible_target in owner.targets)
+		return TARGET_INVALID_IS_TARGET
 	if(!ishuman(possible_target.current))
 		return TARGET_INVALID_NOT_HUMAN
 	if(!possible_target.current.stat == DEAD)
@@ -51,7 +53,6 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 
 	if(possible_targets.len > 0)
 		target = pick(possible_targets)
-
 
 /datum/objective/assassinate
 	martyr_compatible = 1
@@ -361,9 +362,12 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 		var/datum/theft_objective/O = new thefttype
 		if(owner.assigned_role in O.protected_jobs)
 			continue
+		if(O in owner.targets)
+			continue
 		if(O.flags & 2)
 			continue
-		steal_target=O
+		steal_target = O
+
 		explanation_text = "Steal [steal_target]. One was last seen in [get_location()]. "
 		if(islist(O.protected_jobs) && O.protected_jobs.len)
 			explanation_text += "It may also be in the possession of the [jointext(O.protected_jobs, ", ")]."

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -110,7 +110,7 @@
 		var/is_hijacker = prob(10)
 		var/martyr_chance = prob(20)
 		var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
-		if(!exchange_blue && traitors.len >= 8 && !locate(/datum/objective/steal/exchange) in traitor.objectives) 	//Set up an exchange if there are enough traitors
+		if(!exchange_blue && traitors.len >= 8) 	//Set up an exchange if there are enough traitors
 			if(!exchange_red)
 				exchange_red = traitor
 			else

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -87,6 +87,7 @@
 					yandere_one.owner = traitor
 					traitor.objectives += yandere_one
 					yandere_one.find_target()
+					traitor.targets += yandere_one.target
 					objective_count++
 					var/datum/objective/maroon/yandere_two = new
 					yandere_two.owner = traitor
@@ -99,6 +100,7 @@
 			kill_objective.owner = traitor
 			kill_objective.find_target()
 			traitor.objectives += kill_objective
+			traitor.targets += kill_objective.target
 
 		var/datum/objective/survive/survive_objective = new
 		survive_objective.owner = traitor
@@ -108,7 +110,7 @@
 		var/is_hijacker = prob(10)
 		var/martyr_chance = prob(20)
 		var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
-		if(!exchange_blue && traitors.len >= 8) 	//Set up an exchange if there are enough traitors
+		if(!exchange_blue && traitors.len >= 8 && !locate(/datum/objective/steal/exchange) in traitor.objectives) 	//Set up an exchange if there are enough traitors
 			if(!exchange_red)
 				exchange_red = traitor
 			else
@@ -124,26 +126,31 @@
 					destroy_objective.owner = traitor
 					destroy_objective.find_target()
 					traitor.objectives += destroy_objective
+					traitor.targets += destroy_objective.target
 				else if(prob(5))
 					var/datum/objective/debrain/debrain_objective = new
 					debrain_objective.owner = traitor
 					debrain_objective.find_target()
 					traitor.objectives += debrain_objective
+					traitor.targets += debrain_objective.target
 				else if(prob(30))
 					var/datum/objective/maroon/maroon_objective = new
 					maroon_objective.owner = traitor
 					maroon_objective.find_target()
 					traitor.objectives += maroon_objective
+					traitor.targets += maroon_objective.target
 				else
 					var/datum/objective/assassinate/kill_objective = new
 					kill_objective.owner = traitor
 					kill_objective.find_target()
 					traitor.objectives += kill_objective
+					traitor.targets += kill_objective.target
 			else
 				var/datum/objective/steal/steal_objective = new
 				steal_objective.owner = traitor
 				steal_objective.find_target()
 				traitor.objectives += steal_objective
+				traitor.targets += steal_objective.steal_target
 
 		if(is_hijacker && objective_count <= config.traitor_objectives_amount) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount
 			if(!(locate(/datum/objective/hijack) in traitor.objectives))


### PR DESCRIPTION
This PR changes objective code to check that you are not targeting someone who's already a target for that traitor, avoiding situations where you have to protect and assassinate the same person.

~~There's still a bug where somebody with a steal objective (or other martyr incompatible objs) can apparently get the Die a glorious death obj when they are not meant to, the check is apparently buggy. I cant figure out why and its hard to test it for stuff like this on a private server, I've never seen it on live.~~

There might also be a bug where somebody can get both sets of documents at once, although looking at the code I am not sure how that happens and I havent seen it happen myself.

Once this PR is merged the config should be set back to two objectives per traitor

:cl:
fix: Fix some cases of traitors getting conflicting objectives, such as assassinating and protecting the same target.
/:cl: