### PR TITLE
Show Admin Notes verb

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -504,6 +504,7 @@ CREATE TABLE `notes` (
   `last_editor` varchar(32),
   `edits` text,
   `server` varchar(50) NOT NULL,
+  `secret` tinyint(1) NOT NULL DEFAULT  '1',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/paradise_schema_prefixed.sql
+++ b/SQL/paradise_schema_prefixed.sql
@@ -503,6 +503,7 @@ CREATE TABLE `SS13_notes` (
   `last_editor` varchar(32),
   `edits` text,
   `server` varchar(50) NOT NULL,
+  `secret` tinyint(1) NOT NULL DEFAULT  '1',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/updates/8-9.sql
+++ b/SQL/updates/8-9.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `feedback`.`notes` ADD COLUMN `secret` TINYINT(1) NOT NULL DEFAULT '1'  AFTER `server`

--- a/SQL/updates/8-9.sql
+++ b/SQL/updates/8-9.sql
@@ -1,1 +1,2 @@
-ALTER TABLE `feedback`.`notes` ADD COLUMN `secret` TINYINT(1) NOT NULL DEFAULT '1'  AFTER `server`
+# Add secret column to notes to allow for admins to hide and show admin remarks to players
+ALTER TABLE `notes` ADD COLUMN `secret` TINYINT(1) NOT NULL DEFAULT '1'  AFTER `server`

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -315,7 +315,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 8
+#define SQL_VERSION 9
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -1,4 +1,4 @@
-/proc/add_note(target_ckey, notetext, timestamp, adminckey, logged = 1, server, checkrights = 1)
+/proc/add_note(target_ckey, notetext, timestamp, adminckey, logged = 1, secret, server, checkrights = 1)
 	if(checkrights && !check_rights(R_ADMIN|R_MOD))
 		return
 	if(!dbcon.IsConnected())
@@ -38,7 +38,15 @@
 		if(config && config.server_name)
 			server = config.server_name
 	server = sanitizeSQL(server)
-	var/DBQuery/query_noteadd = dbcon.NewQuery("INSERT INTO [format_table_name("notes")] (ckey, timestamp, notetext, adminckey, server) VALUES ('[target_sql_ckey]', '[timestamp]', '[notetext]', '[admin_sql_ckey]', '[server]')")
+	if(isnull(secret))
+		switch(alert("Hide note from being viewed by players?", "Secret Note?","Yes","No","Cancel"))
+			if("Yes")
+				secret = 1
+			if("No")
+				secret = 0
+			else
+				return
+	var/DBQuery/query_noteadd = dbcon.NewQuery("INSERT INTO [format_table_name("notes")] (ckey, timestamp, notetext, adminckey, server, secret) VALUES ('[target_sql_ckey]', '[timestamp]', '[notetext]', '[admin_sql_ckey]', '[server]', '[secret]')")
 	if(!query_noteadd.Execute())
 		var/err = query_noteadd.ErrorMsg()
 		log_game("SQL ERROR adding new note to table. Error : \[[err]\]\n")
@@ -48,6 +56,33 @@
 		message_admins("[key_name_admin(usr)] has added a note to [target_ckey]:<br>[notetext]")
 		show_note(target_ckey)
 
+/proc/toggle_note_secrecy(note_id)
+	if(!dbcon.IsConnected())
+		usr << "<span class='danger'>Failed to establish database connection.</span>"
+		return
+	if(!note_id)
+		return
+	note_id = text2num(note_id)
+	var/DBQuery/query_find_note_secret = dbcon.NewQuery("SELECT ckey, adminckey, secret FROM [format_table_name("notes")] WHERE id = [note_id]")
+	if(!query_find_note_secret.Execute())
+		var/err = query_find_note_secret.ErrorMsg()
+		log_game("SQL ERROR obtaining ckey, adminckey, secret from notes table. Error : \[[err]\]\n")
+		return
+	if(query_find_note_secret.NextRow())
+		var/target_ckey = query_find_note_secret.item[1]
+		var/adminckey = query_find_note_secret.item[2]
+		var/secret = text2num(query_find_note_secret.item[3])
+		var/sql_ckey = sanitizeSQL(usr.ckey)
+		var/edit_text = "Made [secret ? "not secret" : "secret"] by [sql_ckey] on [SQLtime()]<hr>"
+		var/DBQuery/query_update_note = dbcon.NewQuery("UPDATE [format_table_name("notes")] SET secret = NOT secret, last_editor = '[sql_ckey]', edits = CONCAT(IFNULL(edits,''),'[edit_text]') WHERE id = [note_id]")
+		if(!query_update_note.Execute())
+			var/err = query_update_note.ErrorMsg()
+			log_game("SQL ERROR toggling note secrecy. Error : \[[err]\]\n")
+			return
+		log_admin("[key_name(usr)] has toggled [target_ckey]'s note made by [adminckey] to [secret ? "not secret" : "secret"]")
+		message_admins("[key_name_admin(usr)] has toggled [target_ckey]'s note made by [adminckey] to [secret ? "not secret" : "secret"]")
+		show_note(target_ckey)
+		
 /proc/remove_note(note_id)
 	if(!check_rights(R_ADMIN|R_MOD))
 		return
@@ -114,8 +149,6 @@
 		show_note(target_ckey)
 
 /proc/show_note(target_ckey, index, linkless = 0)
-	if(!check_rights(R_ADMIN|R_MOD))
-		return
 	var/output
 	var/navbar
 	var/ruler
@@ -131,7 +164,7 @@
 		output = navbar
 	if(target_ckey)
 		var/target_sql_ckey = ckey(target_ckey)
-		var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT id, timestamp, notetext, adminckey, last_editor, server FROM [format_table_name("notes")] WHERE ckey = '[target_sql_ckey]' ORDER BY timestamp")
+		var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT id, secret, timestamp, notetext, adminckey, last_editor, server FROM [format_table_name("notes")] WHERE ckey = '[target_sql_ckey]' ORDER BY timestamp")
 		if(!query_get_notes.Execute())
 			var/err = query_get_notes.ErrorMsg()
 			log_game("SQL ERROR obtaining ckey, notetext, adminckey, last_editor, server from notes table. Error : \[[err]\]\n")
@@ -142,14 +175,17 @@
 		output += ruler
 		while(query_get_notes.NextRow())
 			var/id = query_get_notes.item[1]
-			var/timestamp = query_get_notes.item[2]
-			var/notetext = query_get_notes.item[3]
-			var/adminckey = query_get_notes.item[4]
-			var/last_editor = query_get_notes.item[5]
-			var/server = query_get_notes.item[6]
+			var/secret = text2num(query_get_notes.item[2])
+			if(linkless && secret)
+				continue
+			var/timestamp = query_get_notes.item[3]
+			var/notetext = query_get_notes.item[4]
+			var/adminckey = query_get_notes.item[5]
+			var/last_editor = query_get_notes.item[6]
+			var/server = query_get_notes.item[7]
 			output += "<b>[timestamp] | [server] | [adminckey]</b>"
 			if(!linkless)
-				output += " <a href='?_src_=holder;removenote=[id]'>\[Remove Note\]</a> <a href='?_src_=holder;editnote=[id]'>\[Edit Note\]</a>"
+				output += " <a href='?_src_=holder;removenote=[id]'>\[Remove Note\]</a> <a href='?_src_=holder;secretnote=[id]'>[secret ? "<b>\[Secret\]</b>" : "\[Not Secret\]"]</a> <a href='?_src_=holder;editnote=[id]'>\[Edit Note\]</a>"
 				if(last_editor)
 					output += " <font size='2'>Last edit by [last_editor] <a href='?_src_=holder;noteedits=[id]'>(Click here to see edit log)</a></font>"
 			output += "<br>[notetext]<hr style='background:#000000; border:0; height:1px'>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -170,14 +170,13 @@
 
 		DB_ban_record(bantype, playermob, banduration, banreason, banjob, null, banckey, banip, bancid )
 		if(BANTYPE_PERMA)
-			add_note(banckey, "Permanently Banned - [banreason]", null, usr.ckey, 0)
+			add_note(banckey, "Permanently Banned - [banreason]", null, usr.ckey, 0, 0)
 		else if(BANTYPE_TEMP)
-			add_note(banckey, "Banned for [banduration] minutes - [banreason]", null, usr.ckey, 0)
+			add_note(banckey, "Banned for [banduration] minutes - [banreason]", null, usr.ckey, 0, 0)
 		else if(BANTYPE_JOB_PERMA)
-			add_note(banckey, "Banned from [banjob] - [banreason]", null, usr.ckey, 0)
+			add_note(banckey, "Banned from [banjob] - [banreason]", null, usr.ckey, 0, 0)
 		else
-			add_note(banckey, "[banreason]", null, usr.ckey, 0)
-
+			add_note(banckey, "[banreason]", null, usr.ckey, 0, 0)
 
 	else if(href_list["editrights"])
 		if(!check_rights(R_PERMISSIONS))
@@ -476,7 +475,7 @@
 				feedback_inc("ban_appearance",1)
 				DB_ban_record(BANTYPE_APPEARANCE, M, -1, reason)
 				appearance_fullban(M, "[reason]; By [usr.ckey] on [time2text(world.realtime)]")
-				add_note(M.ckey, "Appearance banned - [reason]", null, usr.ckey, 0)
+				add_note(M.ckey, "Appearance banned - [reason]", null, usr.ckey, 0, 0)
 				message_admins("<span class='notice'>[key_name_admin(usr)] appearance banned [key_name_admin(M)]</span>", 1)
 				to_chat(M, "<span class='warning'><BIG><B>You have been appearance banned by [usr.client.ckey].</B></BIG></span>")
 				to_chat(M, "<span class='danger'>The reason is: [reason]</span>")
@@ -843,7 +842,7 @@
 							msg = job
 						else
 							msg += ", [job]"
-					add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
+					add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0, 0)
 					message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg] for [mins] minutes</span>", 1)
 					to_chat(M, "<span class='warning'><BIG><B>You have been jobbanned by [usr.client.ckey] from: [msg].</B></BIG></span>")
 					to_chat(M, "<span class='danger'>The reason is: [reason]</span>")
@@ -864,7 +863,7 @@
 							jobban_fullban(M, job, "[reason]; By [usr.ckey] on [time2text(world.realtime)]")
 							if(!msg)	msg = job
 							else		msg += ", [job]"
-						add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
+						add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0, 0)
 						message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg]</span>", 1)
 						to_chat(M, "<span class='warning'><BIG><B>You have been jobbanned by [usr.client.ckey] from: [msg].</B></BIG></span>")
 						to_chat(M, "<span class='danger'>The reason is: [reason]</span>")
@@ -923,6 +922,11 @@
 
 	else if(href_list["addnoteempty"])
 		add_note()
+
+
+	else if(href_list["secretnote"])
+		var/note_id = href_list["secretnote"]
+		toggle_note_secrecy(note_id)
 
 	else if(href_list["removenote"])
 		var/note_id = href_list["removenote"]

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -883,4 +883,11 @@
 	to_chat(src, "Interacting with SSD players is against server rules unless you've ahelped first for permission. If you have, <a href='byond://?src=[UID()];ssdwarning=accepted'>confirm that</A> and proceed.")
 	return TRUE
 
+/client/verb/show_notes()
+	set name = "Show Admin Notes"
+	set category = "OOC"
+	set desc = "View the notes that admins have written about you"
+
+	show_note(ckey, null, 1)
+
 #undef SSD_WARNING_TIMER

--- a/config/example/dbconfig.txt
+++ b/config/example/dbconfig.txt
@@ -9,7 +9,7 @@
 ## This value must be set to the version of the paradise schema in use.
 ## If this value does not match, the SQL database will not be loaded and an error will be generated.
 ## Roundstart will be delayed.
-DB_VERSION 8
+DB_VERSION 9
 
 ## Server the MySQL database can be found at.
 # Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.


### PR DESCRIPTION
**What does this PR do:**
Create the proposal outlined in kyet's post here: https://nanotrasen.se/forum/topic/16668-admin-note-policy-and-transparency/?do=findComment&comment=132993

All notes are invisible by default, admins can choose whether or not a note should be kept secret upon applying their notes. Admins can also choose to hide and reveal notes as they please with a new button in the note managing window.

Credit to TG for some portion of their code as reference.

**Images:**
Upon adding a note, admins will get this popup:
![image](https://user-images.githubusercontent.com/30060146/62756204-e7bd5c00-ba44-11e9-99be-65cdcfcb197d.png)

Note panel:
![image](https://user-images.githubusercontent.com/30060146/62756217-f441b480-ba44-11e9-84fa-652189c4f524.png)

What the player sees:
![image](https://user-images.githubusercontent.com/30060146/62756240-00c60d00-ba45-11e9-99d7-8ac3e2aa9c92.png)

New verb in the OOC tab:
![image](https://user-images.githubusercontent.com/30060146/62756440-c4df7780-ba45-11e9-94d7-eb48e62fc478.png)


This PR requires an SQL update.
**Changelog:**
:cl:
add: Players can now see their notes using the show admin notes verb in the OOC tab, all notes are secret by default but can be made visible to players by admins. When a new note is issued the admin issuing said note is able to decide whether or not the note should be hidden.
/:cl:

