### PR TITLE
Netherworld portal fix and butler pick time increase

### DIFF
--- a/code/modules/awaymissions/mission_code/academy.dm
+++ b/code/modules/awaymissions/mission_code/academy.dm
@@ -193,7 +193,7 @@
 			servant_mind.objectives += O
 			servant_mind.transfer_to(H)
 
-			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as the servant of [user.real_name]?", ROLE_WIZARD, poll_time = 50)
+			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as the servant of [user.real_name]?", ROLE_WIZARD, poll_time = 300)
 			if(LAZYLEN(candidates))
 				var/mob/dead/observer/C = pick(candidates)
 				message_admins("[ADMIN_LOOKUPFLW(C)] was spawned as Dice Servant")

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -69,6 +69,7 @@
 	desc = null //see examine()
 	icon_state = "nether"
 	health = 50
+	maxHealth = 50
 	spawn_time = 600 //1 minute
 	max_mobs = 15
 	icon = 'icons/mob/nest.dmi'
@@ -76,9 +77,9 @@
 	mob_types = list(/mob/living/simple_animal/hostile/netherworld/migo, /mob/living/simple_animal/hostile/netherworld, /mob/living/simple_animal/hostile/netherworld/blankbody)
 	faction = list("nether")
 
-/mob/living/simple_animal/hostile/spawner/nether/Initialize()
-	.=..()
-	START_PROCESSING(SSprocessing, src)
+/mob/living/simple_animal/hostile/spawner/nether/death()
+	. = ..()
+	qdel(src)
 
 /mob/living/simple_animal/hostile/spawner/nether/examine(mob/user)
 	..()
@@ -96,7 +97,8 @@
 							"<span class='userdanger'>Touching the portal, you are quickly pulled through into a world of unimaginable horror!</span>")
 		contents.Add(user)
 
-/mob/living/simple_animal/hostile/spawner/nether/process()
+/mob/living/simple_animal/hostile/spawner/nether/Life()
+	. = ..()
 	for(var/mob/living/M in contents)
 		if(M)
 			playsound(src, 'sound/magic/demon_consume.ogg', 50, 1)


### PR DESCRIPTION
**What does this PR do:**
See the changelog.

**Changelog:**
:cl: Markolie
tweak: Players now have thirty seconds instead of just five seconds to select if they want to be somebody's butler through a die of fate roll.
fix: The Netherworld portal is now properly destroyed upon being killed. In addition, its max health is now equal to its starting health.
/:cl:

