### PR TITLE
Add admin pencode: style, class, and img

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -546,7 +546,8 @@ proc/checkhtml(var/t)
 	return text
 
 /proc/convert_pencode_arg(text, tag, arg)
-	arg = replacetext(replacetext(html_encode(arg), "'", ""), "\"", "")
+	arg = sanitize_simple(html_encode(arg), list("''"="","\""="", "?"=""))
+
 	if(tag == "class")
 		return "<span class='[arg]'>"
 
@@ -554,6 +555,8 @@ proc/checkhtml(var/t)
 		return "<span style='[arg]'>"
 
 	if(tag == "img")
+		if(dd_hasprefix(arg, "byond:") || dd_hasprefix(arg, "file:"))
+			return text
 		var/list/img_props = splittext(arg, ";")
 		if(img_props.len == 3)
 			return "<img src='[img_props[1]]' width='[img_props[2]]' height='[img_props[3]]'>"

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -545,6 +545,35 @@ proc/checkhtml(var/t)
 	text = copytext(text, 1, MAX_PAPER_MESSAGE_LEN)
 	return text
 
+/proc/convert_pencode_arg(text, tag, arg)
+	arg = replacetext(replacetext(html_encode(arg), "'", ""), "\"", "")
+	if(tag == "class")
+		return "<span class='[arg]'>"
+
+	if(tag == "style")
+		return "<span style='[arg]'>"
+
+	if(tag == "img")
+		var/list/img_props = splittext(arg, ";")
+		if(img_props.len == 3)
+			return "<img src='[img_props[1]]' width='[img_props[2]]' height='[img_props[3]]'>"
+		if(img_props.len == 2)
+			return "<img src='[img_props[1]]' width='[img_props[2]]'>"
+		return "<img src='[arg]'>"
+
+	return text
+
+/proc/admin_pencode_to_html()
+	var/text = pencode_to_html(arglist(args))
+	var/regex/R = new(@"\[(.*?) (.*?)\]", "ge")
+	text = R.Replace(text, /proc/convert_pencode_arg)
+
+	text = replacetext(text, "\[/class\]", "</span>")
+	text = replacetext(text, "\[/style\]", "</span>")
+	text = replacetext(text, "\[/img\]", "</img>")
+
+	return text
+
 /proc/html_to_pencode(text)
 	text = replacetext(text, "<BR>",								"\n")
 	text = replacetext(text, "<center>",							"\[center\]")

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -547,6 +547,13 @@ proc/checkhtml(var/t)
 
 /proc/convert_pencode_arg(text, tag, arg)
 	arg = sanitize_simple(html_encode(arg), list("''"="","\""="", "?"=""))
+	// https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-4---css-escape-and-strictly-validate-before-inserting-untrusted-data-into-html-style-property-values
+	var/list/style_attacks = list("javascript:", "expression", "byond:", "file:")
+
+	for(var/style_attack in style_attacks)
+		if(findtext(arg, style_attack))
+			// Do not attempt to render dangerous things
+			return text
 
 	if(tag == "class")
 		return "<span class='[arg]'>"
@@ -555,8 +562,6 @@ proc/checkhtml(var/t)
 		return "<span style='[arg]'>"
 
 	if(tag == "img")
-		if(dd_hasprefix(arg, "byond:") || dd_hasprefix(arg, "file:"))
-			return text
 		var/list/img_props = splittext(arg, ";")
 		if(img_props.len == 3)
 			return "<img src='[img_props[1]]' width='[img_props[2]]' height='[img_props[3]]'>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -642,7 +642,7 @@ var/list/admin_verbs_ticket = list(
 		if(!message)
 			return
 		for(var/mob/V in hearers(O))
-			V.show_message(message, 2)
+			V.show_message(admin_pencode_to_html(message), 2)
 		log_admin("[key_name(usr)] made [O] at [O.x], [O.y], [O.z] make a sound")
 		message_admins("<span class='notice'>[key_name_admin(usr)] made [O] at [O.x], [O.y], [O.z] make a sound</span>")
 		feedback_add_details("admin_verb","MS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2181,7 +2181,7 @@
 		if(!input)
 			qdel(P)
 			return
-		input = P.parsepencode(input) // Encode everything from pencode to html
+		input = admin_pencode_to_html(html_encode(input)) // Encode everything from pencode to html
 
 		var/customname = clean_input("Pick a title for the fax.", "Fax Title", , owner)
 		if(!customname)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -110,7 +110,7 @@
 		if(!msg)
 			return
 	else
-		msg = pencode_to_html(msg)
+		msg = admin_pencode_to_html(msg)
 
 	var/recieve_span = "playerreply"
 	var/send_pm_type = " "

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -58,6 +58,9 @@
 
 	if(!msg)
 		return
+
+	msg = admin_pencode_to_html(msg)
+
 	if(usr)
 		if(usr.client)
 			if(usr.client.holder)
@@ -136,7 +139,7 @@
 
 	if( !msg )
 		return
-	msg = pencode_to_html(msg)
+	msg = admin_pencode_to_html(msg)
 
 	to_chat(M, msg)
 	log_admin("DirectNarrate: [key_name(usr)] to ([key_name(M)]): [msg]")


### PR DESCRIPTION
# What does this PR do
#11515 reduced the flexibility of admin message formatting. This introduces 3 tags that are part of admin pencode, [class], [style], and [img]. This is enabled for subtle, direct, global, admin pms, make sound, and admin faxes.

# Examples
## class
Let's say you want to get someone's attention. You can use any span that you could use before html was removed.
### input
![image](https://user-images.githubusercontent.com/26497062/62843196-df476a00-bc6c-11e9-9f16-68ea8d66dcf1.png?s=100)
### output
![image](https://user-images.githubusercontent.com/26497062/62843202-ec645900-bc6c-11e9-8af3-2b1119cc8e6f.png)

## style
Maybe you like the classic big red text.
### input
![image](https://user-images.githubusercontent.com/26497062/62843221-19187080-bc6d-11e9-9c44-aea554bdfad9.png)
### output
![image](https://user-images.githubusercontent.com/26497062/62843225-203f7e80-bc6d-11e9-9ef7-4aa9a92eb12f.png)

## img
### input
![image](https://user-images.githubusercontent.com/26497062/62843327-fd619a00-bc6d-11e9-8265-7ff37adb2bd4.png)
### output
![image](https://user-images.githubusercontent.com/26497062/62843346-19653b80-bc6e-11e9-8ae6-19cd6717eb0a.png)

You can also specify a width x height using semicolons:
### input
![image](https://user-images.githubusercontent.com/26497062/62843373-3f8adb80-bc6e-11e9-9447-c53679e0ccd2.png)

### output
![image](https://user-images.githubusercontent.com/26497062/62843379-46b1e980-bc6e-11e9-8a1c-d0254131a5ac.png)
