### PR TITLE
Improve water handling for slimes, Grey mask/head water protection tweak

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -405,3 +405,6 @@
 
 // Cult summon possibilities
 #define SUMMON_POSSIBILITIES 3
+
+// Water temperature
+#define COLD_WATER_TEMPERATURE 283.15 // 10 degrees celsius

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -79,7 +79,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 		reagents.reaction(A)
 	if(istype(A,/atom/movable))
 		var/atom/movable/AM = A
-		AM.water_act(life, 310.15, src)
+		AM.water_act(life, COLD_WATER_TEMPERATURE, src)
 	return ..()
 
 

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -21,7 +21,7 @@
 		reagents.reaction(A)
 	if(istype(A,/atom/movable))
 		var/atom/movable/AM = A
-		AM.water_act(life, 310.15, src)
+		AM.water_act(life, COLD_WATER_TEMPERATURE, src)
 	return ..()
 
 /////////////////////////////////////////////

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -600,7 +600,7 @@
 				wateract = (W.wash(user, src))
 				busy = 0
 				if(wateract)
-					W.water_act(20, 310.15, src)
+					W.water_act(20, COLD_WATER_TEMPERATURE, src)
 			if("Disconnect")
 				user.visible_message("<span class='notice'>[user] starts disconnecting [src].</span>", "<span class='notice'>You begin disconnecting [src]...</span>")
 				if(do_after(user, 40 * O.toolspeed, target = src))
@@ -633,7 +633,7 @@
 	wateract = (O.wash(user, src))
 	busy = 0
 	if(wateract)
-		O.water_act(20, 310.15, src)
+		O.water_act(20, COLD_WATER_TEMPERATURE, src)
 
 /obj/structure/sink/update_icon()
 	..()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -27,9 +27,6 @@
 	if(volume >= 3)
 		MakeSlippery()
 
-	for(var/mob/living/carbon/slime/M in src)
-		M.apply_water()
-
 	var/hotspot = (locate(/obj/effect/hotspot) in src)
 	if(hotspot)
 		var/datum/gas_mixture/lowertemp = remove_air(air.total_moles())

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -16,7 +16,7 @@
 
 /mob/living/carbon/water_act(volume, temperature, source, method = TOUCH)
 	. = ..()
-	if(volume > 10) //anything over 10 volume will make the mob wetter.
+	if(volume > 10) // Anything over 10 volume will make the mob wetter.
 		wetlevel = min(wetlevel + 1,5)
 
 /mob/living/carbon/attackby(obj/item/I, mob/user, params)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -719,8 +719,8 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	H.sync_lighting_plane_alpha()
 
 /datum/species/proc/water_act(mob/living/carbon/human/M, volume, temperature, source, method = TOUCH)
-	if(abs(temperature - M.bodytemperature) > 10) //If our water and mob temperature varies by more than 10K, cool or/ heat them appropriately
-		M.bodytemperature = (temperature + M.bodytemperature) * 0.5 //Approximation for gradual heating or cooling
+	if(abs(temperature - M.bodytemperature) > 10) // If our water and mob temperature varies by more than 10K, cool or/ heat them appropriately.
+		M.bodytemperature = (temperature + M.bodytemperature) * 0.5 // Approximation for gradual heating or cooling.
 
 /datum/species/proc/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H) //return TRUE if hit, FALSE if stopped/reflected/etc
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -40,15 +40,15 @@
 	. = ..()
 
 	if(method == TOUCH)
+		if(H.wear_mask)
+			to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
+			return
+
+		if(H.head)
+			to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
+			return
+
 		if(volume > 25)
-			if(H.wear_mask)
-				to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
-				return
-
-			if(H.head)
-				to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid!</span>")
-				return
-
 			if(prob(75))
 				H.take_organ_damage(5, 10)
 				H.emote("scream")
@@ -65,9 +65,6 @@
 			H.adjustFireLoss(min(max(4, (volume - 10) * 2), 20))
 			H.emote("scream")
 			to_chat(H, "<span class='warning'>The water stings[volume < 10 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
-		if(volume >= 10)
-			H.adjustFireLoss(min(max(4, (volume - 10) * 2), 20))
-			H.emote("scream")
 
 /datum/species/grey/after_equip_job(datum/job/J, mob/living/carbon/human/H)
 	var/translator_pref = H.client.prefs.speciesprefs

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -472,13 +472,15 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 /mob/living/carbon/slime/toggle_throw_mode()
 	return
 
-/mob/living/carbon/slime/proc/apply_water()
-	adjustToxLoss(rand(15,20))
-	if(!client)
-		if(Target) // Like cats
-			Target = null
-			++Discipline
-	return
+/mob/living/carbon/slime/water_act(volume, temperature, source, method = TOUCH)
+	. = ..()
+
+	var/water_damage = rand(10, 15) * volume
+	adjustToxLoss(water_damage)
+
+	if(!client && Target && volume >= 3)
+		Target = null
+		++Discipline
 
 /mob/living/carbon/slime/can_use_vents()
 	if(Victim)


### PR DESCRIPTION
**What does this PR do:**
This pull request changes two water related things:

1. Water handling for slimes of the Xenobiology variety now uses the water_act system instead of relying on the turf propagating water to slimes. As a result, slimes are now affected by most sources of water. Fire extinguisher damage is roughly equal. Showers and pools effectively one-shot them.
2. Previously, if water touched a Gray wearing a mask or hat it wouldn't affect them if the volume was over 25. If it was below that, it'd still damage them. As far as I can tell, this was caused by faulty logic in the head/mask checking. It also made very little sense. Wearing a mask or hat now fully protects Gray from water damaging them.
3. Water from sinks and water effects is now 10°C (cold sink water temperature) instead of body temperature.

**Changelog:**
:cl: Markolie
balance: Slimes (of the Xenobiology variety) are now affected by regular sources of water.
balance: If a Gray is wearing a hat/mask and water touches them, it will no longer affect them. Previously, it'd still affect them in volumes less than 25.
balance: Water coming from sinks and certain water effects is now 10°C instead of body temperature.
/:cl:

