### PR TITLE
Fix quotes not working in announcements

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -613,7 +613,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What's the message?") as message|null
 	if(!input)
 		return
-	input = html_encode(input)
 
 	switch(alert("Should this be announced to the general population?",,"Yes","No", "Cancel"))
 		if("Yes")


### PR DESCRIPTION
**What does this PR do:**
Turns out html_encoding something twice messes up quotes. Removed an extra html_encode.

If there are any other quotes being messed up, please comment!

