### PR TITLE
Add links to ping and open conversation in window for PMs

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -161,7 +161,9 @@
 	var/emoji_msg = "<span class='emoji_enabled'>[msg]</span>"
 	recieve_message = "<span class='[recieve_span]'>[type] from-<b>[recieve_pm_type][C.holder ? key_name(src, TRUE, type) : key_name_hidden(src, TRUE, type)]</b>: [emoji_msg]</span>"
 	to_chat(C, recieve_message)
-	to_chat(src, "<span class='pmsend'>[send_pm_type][type] to-<b>[holder ? key_name(C, TRUE, type) : key_name_hidden(C, TRUE, type)]</b>: [emoji_msg]</span>")
+	var/ping_link = check_rights(R_ADMIN, 0, mob) ? "(<a href='?src=[pm_tracker.UID()];ping=[C.key]'>PING</a>)" : ""
+	var/window_link = "(<a href='?src=[pm_tracker.UID()];newtitle=[C.key]'>WINDOW</a>)"
+	to_chat(src, "<span class='pmsend'>[send_pm_type][type] to-<b>[holder ? key_name(C, TRUE, type) : key_name_hidden(C, TRUE, type)]</b>: [emoji_msg]</span> [ping_link] [window_link]")
 
 	/*if(holder && !C.holder)
 		C.last_pm_recieved = world.time
@@ -380,7 +382,6 @@
 			window_flash(C)
 			C.pm_tracker.show_ui(C.mob)
 			to_chat(usr, "<span class='notice'>Forced open [C]'s messages window.</span>")
-		show_ui(usr)
 		return
 
 	if(href_list["reply"])


### PR DESCRIPTION
**What does this PR do:**
Adds a PING link for admins when they send a PM that allows them to more easily ping a user who hasn't noticed the message, and a WINDOW link for all users that allows them to open up the conversation in the messages window.

![image](https://user-images.githubusercontent.com/26497062/62919356-45102080-bd57-11e9-8748-d3f36f87651c.png)

**Changelog:**
:cl:
tweak: message window links added to PM send receipt
/:cl:
