### PR TITLE
False wall secure fix, add extra step to plating deconstruction

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -97,12 +97,9 @@
 	else
 		icon_state = "fwall_open"
 
-/obj/structure/falsewall/proc/ChangeToWall(delete = 1)
+/obj/structure/falsewall/proc/ChangeToWall(delete = TRUE)
 	var/turf/T = get_turf(src)
-	if(!walltype || walltype == "metal")
-		T.ChangeTurf(/turf/simulated/wall)
-	else
-		T.ChangeTurf(text2path("/turf/simulated/wall/mineral/[walltype]"))
+	T.ChangeTurf(walltype)
 	if(delete)
 		qdel(src)
 	return T

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -7,6 +7,8 @@
 	broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	burnt_states = list("floorscorched1", "floorscorched2")
 
+	var/plating_unscrewed = FALSE 
+
 	footstep_sounds = list(
 	"human" = list('sound/effects/footstep/plating_human.ogg'),
 	"xeno"  = list('sound/effects/footstep/plating_xeno.ogg')
@@ -30,6 +32,12 @@
 		return
 	if(!broken && !burnt)
 		icon_state = icon_plating //Because asteroids are 'platings' too.
+
+/turf/simulated/floor/plating/examine(mob/user)
+	. = ..()
+
+	if(plating_unscrewed)
+		to_chat(user, "<span class='warning'>It has been unfastened.</span>")
 
 /turf/simulated/floor/plating/attackby(obj/item/C, mob/user, params)
 	if(..())
@@ -64,7 +72,16 @@
 			to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welder to fix the damage.</span>")
 		return TRUE
 
-	else if(iswelder(C))
+	else if(isscrewdriver(C))
+		var/obj/item/screwdriver/screwdriver = C
+		to_chat(user, "<span class='notice'>You start [plating_unscrewed ? "fastening" : "unfastening"] [src].</span>")
+		playsound(src, screwdriver.usesound, 50, 1)
+		if(do_after(user, 20 * screwdriver.toolspeed, target = src) && screwdriver)
+			to_chat(user, "<span class='notice'>You [plating_unscrewed ? "fasten" : "unfasten"] [src].</span>")
+			plating_unscrewed = !plating_unscrewed
+		return TRUE
+
+	else if(iswelder(C) && plating_unscrewed)
 		var/obj/item/weldingtool/welder = C
 		if(welder.isOn())
 			if(!welder.remove_fuel(0, user))

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -7,7 +7,7 @@
 	broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	burnt_states = list("floorscorched1", "floorscorched2")
 
-	var/plating_unscrewed = FALSE 
+	var/unfastened = FALSE 
 
 	footstep_sounds = list(
 	"human" = list('sound/effects/footstep/plating_human.ogg'),
@@ -36,7 +36,7 @@
 /turf/simulated/floor/plating/examine(mob/user)
 	. = ..()
 
-	if(plating_unscrewed)
+	if(unfastened)
 		to_chat(user, "<span class='warning'>It has been unfastened.</span>")
 
 /turf/simulated/floor/plating/attackby(obj/item/C, mob/user, params)
@@ -74,14 +74,14 @@
 
 	else if(isscrewdriver(C))
 		var/obj/item/screwdriver/screwdriver = C
-		to_chat(user, "<span class='notice'>You start [plating_unscrewed ? "fastening" : "unfastening"] [src].</span>")
+		to_chat(user, "<span class='notice'>You start [unfastened ? "fastening" : "unfastening"] [src].</span>")
 		playsound(src, screwdriver.usesound, 50, 1)
 		if(do_after(user, 20 * screwdriver.toolspeed, target = src) && screwdriver)
-			to_chat(user, "<span class='notice'>You [plating_unscrewed ? "fasten" : "unfasten"] [src].</span>")
-			plating_unscrewed = !plating_unscrewed
+			to_chat(user, "<span class='notice'>You [unfastened ? "fasten" : "unfasten"] [src].</span>")
+			unfastened = !unfastened
 		return TRUE
 
-	else if(iswelder(C) && plating_unscrewed)
+	else if(iswelder(C) && unfastened)
 		var/obj/item/weldingtool/welder = C
 		if(welder.isOn())
 			if(!welder.remove_fuel(0, user))


### PR DESCRIPTION
**What does this PR do:**
Fixes https://github.com/ParadiseSS13/Paradise/issues/12001.
Fixes https://github.com/ParadiseSS13/Paradise/issues/11999.

**Changelog:**
:cl: Markolie
fix: Tightening the bolts of a falsewall now works properly.
tweak: Deconstructing plating now requires it to be unfastened using a screwdriver first, in order to prevent it from being accidentally deconstructed with a welder.
/:cl:

