### PR TITLE
Removes all one-way airlocks except for the ones in medbay and brig

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -11418,20 +11418,12 @@
 	id_tag = "secmaintdorm1";
 	name = "Room 1"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "ats" = (
 /obj/machinery/door/airlock{
 	id_tag = "secmaintdorm2";
 	name = "Room 2"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -13181,16 +13173,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
-"avU" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "avV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13213,10 +13195,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	level = 1
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-cult";
@@ -14352,16 +14330,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
-"axN" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "axO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17788,10 +17756,6 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -19009,13 +18973,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
-"aGv" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "aGw" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -20068,10 +20025,6 @@
 	name = "Magistrate's Office";
 	req_access_txt = "74"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-cult";
 	icon_state = "cult";
@@ -20159,10 +20112,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -20743,16 +20692,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
-"aKp" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "aKq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20825,10 +20764,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-cult";
@@ -21150,10 +21085,6 @@
 	req_access = null;
 	req_access_txt = "4"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -21191,10 +21122,6 @@
 "aLk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -21234,10 +21161,6 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/wood{
 	tag = "icon-wood-broken3";
 	icon_state = "wood-broken3"
@@ -22079,16 +22002,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
-"aNe" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "aNf" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -22464,10 +22377,6 @@
 	name = "Courtroom Privacy Shutters";
 	opacity = 0
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aNT" = (
@@ -22567,16 +22476,6 @@
 	icon_state = "barber"
 	},
 /area/civilian/barber)
-"aOa" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "aOb" = (
 /obj/machinery/prize_counter,
 /obj/machinery/light{
@@ -22895,10 +22794,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aOO" = (
@@ -22925,10 +22820,6 @@
 	layer = 3.21;
 	name = "Courtroom Privacy Shutters";
 	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -23025,10 +22916,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aPc" = (
@@ -23103,10 +22990,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -23418,10 +23301,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aPQ" = (
@@ -23476,10 +23355,6 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aPV" = (
@@ -25238,10 +25113,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aTt" = (
@@ -26043,7 +25914,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aVc" = (
@@ -26512,10 +26382,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aVM" = (
@@ -27629,13 +27495,6 @@
 /obj/machinery/lapvend,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
-"aXT" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "aXU" = (
 /obj/item/flag/mime,
 /obj/machinery/power/apc{
@@ -29493,16 +29352,6 @@
 	dir = 2
 	},
 /area/crew_quarters/dorms)
-"bbx" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
 "bby" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
@@ -30064,10 +29913,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -31207,10 +31052,6 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bex" = (
@@ -31510,10 +31351,6 @@
 	name = "Mime's Office";
 	req_access_txt = "46"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "tranquillite";
 	dir = 4;
@@ -31584,10 +31421,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "bfg" = (
@@ -33841,7 +33674,6 @@
 	name = "Clown's Office";
 	req_access_txt = "46"
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "bjf" = (
@@ -33855,10 +33687,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bjh" = (
@@ -33872,10 +33700,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "bji" = (
@@ -37143,7 +36967,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bpF" = (
@@ -37423,10 +37246,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bqk" = (
@@ -40030,10 +39849,6 @@
 	name = "Chapel Office";
 	req_access_txt = "22"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -40309,10 +40124,6 @@
 /obj/machinery/door/airlock{
 	name = "Bar Office";
 	req_access_txt = "25"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -40716,10 +40527,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bwY" = (
@@ -41513,10 +41320,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "byt" = (
@@ -43420,10 +43223,6 @@
 "bCq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -48798,20 +48597,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
-"bMz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Chapel Office";
-	req_access_txt = "22"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "bMA" = (
 /obj/machinery/mineral/ore_redemption,
 /turf/simulated/floor/plasteel,
@@ -48856,10 +48641,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -49725,7 +49506,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bNQ" = (
@@ -50007,7 +49787,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bOo" = (
@@ -50668,7 +50447,6 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
 "bPs" = (
@@ -50727,10 +50505,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bPy" = (
@@ -50924,10 +50698,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
 	req_access_txt = "28"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -52143,10 +51913,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bRI" = (
@@ -52629,7 +52395,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -52654,10 +52419,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -54252,10 +54013,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bVl" = (
@@ -54269,10 +54026,6 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -54541,10 +54294,6 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
 	req_access_txt = "50"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -55259,10 +55008,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bWP" = (
@@ -55483,7 +55228,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "bXj" = (
@@ -58284,10 +58028,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
@@ -58365,10 +58105,6 @@
 	name = "Medical Supplies";
 	req_access_txt = "5"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
@@ -58385,10 +58121,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -63283,10 +63015,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cjB" = (
@@ -63338,7 +63066,6 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cjE" = (
@@ -64003,7 +63730,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/wood,
 /area/blueshield)
 "ckJ" = (
@@ -64047,7 +63773,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/wood,
 /area/ntrep)
 "ckO" = (
@@ -64063,7 +63788,6 @@
 	req_access_txt = "26"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "ckQ" = (
@@ -64097,7 +63821,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "ckU" = (
@@ -64185,7 +63908,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "clb" = (
@@ -64960,10 +64682,6 @@
 "cmt" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -66667,10 +66385,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cpl" = (
@@ -67408,10 +67122,6 @@
 /obj/machinery/holosign/surgery{
 	id = "surgery1"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -67595,10 +67305,6 @@
 /obj/machinery/holosign/surgery{
 	id = "surgery2"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -67680,7 +67386,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cqG" = (
@@ -69558,13 +69263,6 @@
 /area/medical/research{
 	name = "Research Division"
 	})
-"ctD" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "ctE" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -69648,16 +69346,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
-"ctK" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/apmaint)
 "ctL" = (
 /obj/machinery/light{
 	dir = 4;
@@ -71699,10 +71387,6 @@
 	req_access_txt = "5";
 	req_one_access_txt = "0"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -72356,16 +72040,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
-"cyu" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "cyv" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -72501,10 +72175,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
 	req_access_txt = "5"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -72643,10 +72313,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -72952,10 +72618,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -73657,10 +73319,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cAH" = (
@@ -74102,10 +73760,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -74704,16 +74358,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"cCF" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/apmaint)
 "cCG" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -74751,10 +74395,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -75213,7 +74853,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -76075,10 +75714,6 @@
 	name = "Alternate Construction Area";
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cFf" = (
@@ -76612,10 +76247,6 @@
 	name = "Alternate Construction Area";
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/consarea)
 "cFU" = (
@@ -77113,7 +76744,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "cGM" = (
@@ -77620,10 +77250,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cHF" = (
@@ -77776,10 +77402,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cHS" = (
@@ -79005,10 +78627,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -80228,10 +79846,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cMr" = (
@@ -81301,7 +80915,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cOt" = (
@@ -84373,10 +83986,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -88570,7 +88179,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dbi" = (
@@ -88636,7 +88244,6 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dbq" = (
@@ -89107,10 +88714,6 @@
 /area/maintenance/asmaint)
 "dci" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "dcj" = (
@@ -89963,7 +89566,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/engi_shuttle)
 "ddX" = (
@@ -89979,13 +89581,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"ddY" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "ddZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/cable{
@@ -90159,10 +89754,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dep" = (
@@ -90173,7 +89764,6 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
 "deq" = (
@@ -90574,10 +90164,6 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -91015,16 +90601,6 @@
 "dfV" = (
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"dfW" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "dfX" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -91095,15 +90671,10 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dgf" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dgg" = (
@@ -114520,7 +114091,7 @@ aaa
 cng
 coL
 coL
-ctK
+cqF
 coL
 cvk
 cwx
@@ -115241,7 +114812,7 @@ aGn
 aGn
 aGn
 aGn
-bbx
+aLk
 aGn
 aGn
 aUy
@@ -115291,7 +114862,7 @@ aaa
 cng
 coL
 coL
-ctK
+cqF
 coL
 coL
 cwx
@@ -117095,7 +116666,7 @@ ctU
 cgQ
 cgQ
 cgQ
-cCF
+cqF
 cgQ
 cgQ
 cgQ
@@ -118377,7 +117948,7 @@ cam
 aab
 cgQ
 ctU
-ctK
+cqF
 coL
 coL
 coL
@@ -121982,7 +121553,7 @@ czN
 cyg
 cCH
 coL
-ctK
+cqF
 cEQ
 cGj
 cJZ
@@ -126808,7 +126379,7 @@ avq
 avq
 avq
 avq
-axN
+aHp
 aRx
 aUw
 aDN
@@ -128911,7 +128482,7 @@ cPd
 cos
 cPd
 cqY
-ctD
+cmt
 csL
 csL
 cvI
@@ -130712,7 +130283,7 @@ csL
 cqD
 csL
 chf
-cyu
+cmt
 chf
 chf
 chf
@@ -132960,7 +132531,7 @@ aIq
 avq
 aAc
 aBt
-aGv
+aHp
 aCh
 aEw
 aFI
@@ -133725,7 +133296,7 @@ ajb
 awl
 arR
 awl
-avU
+aHp
 aqc
 aya
 awl
@@ -135271,7 +134842,7 @@ avb
 aAQ
 awF
 aye
-axN
+aHp
 avq
 aAS
 atG
@@ -137342,7 +136913,7 @@ aFJ
 aPq
 aRv
 aTb
-aXT
+aMn
 aGY
 aGY
 aGY
@@ -139906,7 +139477,7 @@ aGX
 aHc
 aIv
 aGX
-aOa
+aMn
 aGX
 aGX
 aGX
@@ -140419,10 +139990,10 @@ aCy
 aMf
 aNf
 aGY
-aNe
+aMn
 aGY
 aGY
-aNe
+aMn
 aGY
 aGY
 aPK
@@ -140935,7 +140506,7 @@ aJI
 aGY
 aGX
 aGX
-aKp
+aMn
 aGX
 aGX
 aGY
@@ -142472,14 +142043,14 @@ aab
 aAf
 aAf
 aAf
-aKp
+aMn
 aAf
 aHb
 aMz
 aMz
 aIE
 aGX
-aKp
+aMn
 aMz
 aGX
 aOG
@@ -143522,7 +143093,7 @@ bcu
 ber
 bga
 bis
-bMz
+bvN
 bcD
 bld
 blw
@@ -147196,7 +146767,7 @@ bGH
 bGG
 dgy
 bGG
-dfW
+cjA
 dia
 cuQ
 djQ
@@ -148472,7 +148043,7 @@ aab
 bGH
 bGG
 bGG
-ddY
+cjA
 bGG
 dcJ
 ddJ
@@ -148737,7 +148308,7 @@ cuQ
 dfc
 bGG
 bGG
-ddY
+cjA
 bGG
 bGG
 bGH


### PR DESCRIPTION
**What does this PR do:**
At the request of the staff team I removed most one-way airlocks excluding the ones at cloning, medbay and brig


**Changelog:**
:cl:
tweak: there are much less one-way airlocks on station
/:cl:

