### PR TITLE
Karma purchase infinite loop fix

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -127,6 +127,7 @@
 							karma_purchase(karma,45,"job","Magistrate")
 						if("9")
 							karma_purchase(karma,30,"job","Security Pod Pilot")
+					return
 				if(href_list["KarmaBuy2"])
 					var/karma=verify_karma()
 					if(isnull(karma)) //Doesn't display anything if karma database is down.
@@ -146,6 +147,7 @@
 							karma_purchase(karma,100,"species","Plasmaman")
 						if("7")
 							karma_purchase(karma,30,"species","Drask")
+					return
 				if(href_list["KarmaRefund"])
 					var/type = href_list["KarmaRefundType"]
 					var/job = href_list["KarmaRefund"]


### PR DESCRIPTION
**What does this PR do:**
Fixes #11398
I can't exactly explain it, but switch() responsible for choosing karma_purchase() are parts of an infinite loop I couldn't locate.
Return statements break that loop.
Client appeared to remain fully functional with these changes on private server.

**Changelog:**
:cl:
fix: Karma purchases no longer loop infinitely, leading to repeated purchase prompts or "You do not have enough karma!" message after successful purchase.
/:cl:

