### PR TITLE
Readd stimpacks to mining vendors

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -404,6 +404,7 @@
 		new /datum/data/mining_equipment("1 Marker Beacon",				/obj/item/stack/marker_beacon,										10),
 		new /datum/data/mining_equipment("10 Marker Beacons",			/obj/item/stack/marker_beacon/ten,									100),
 		new /datum/data/mining_equipment("30 Marker Beacons",			/obj/item/stack/marker_beacon/thirty,								300),
+		new /datum/data/mining_equipment("Stimpack",					/obj/item/reagent_containers/hypospray/autoinjector/stimpack, 		50),
 		new /datum/data/mining_equipment("Whiskey",						/obj/item/reagent_containers/food/drinks/bottle/whiskey,			100),
 		new /datum/data/mining_equipment("Absinthe",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	100),
 		new /datum/data/mining_equipment("Cigar",						/obj/item/clothing/mask/cigarette/cigar/havana,						150),

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -405,6 +405,8 @@
 		new /datum/data/mining_equipment("10 Marker Beacons",			/obj/item/stack/marker_beacon/ten,									100),
 		new /datum/data/mining_equipment("30 Marker Beacons",			/obj/item/stack/marker_beacon/thirty,								300),
 		new /datum/data/mining_equipment("Stimpack",					/obj/item/reagent_containers/hypospray/autoinjector/stimpack, 		50),
+		new /datum/data/mining_equipment("Teporone MediPen",			/obj/item/reagent_containers/hypospray/autoinjector/teporone, 		50),
+		new /datum/data/mining_equipment("MediPen Bundle",				/obj/item/storage/box/autoinjector/utility,	 			   			200),
 		new /datum/data/mining_equipment("Whiskey",						/obj/item/reagent_containers/food/drinks/bottle/whiskey,			100),
 		new /datum/data/mining_equipment("Absinthe",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	100),
 		new /datum/data/mining_equipment("Cigar",						/obj/item/clothing/mask/cigarette/cigar/havana,						150),


### PR DESCRIPTION
This PR readds stimpacks, teporone injectors and the medipen bundle to mining vendors. 

They were removed as an undocumented change in #11981. Since it was undocumented and not discussed, I assume the change was not intentional.

If stimpacks are a balance concern, they should be removed or rebalanced in their own PR.

:cl:
add: Readds stimpacks, teporone and medipen bundle to mining vendors.
/:cl: