### PR TITLE
Use Health Analyzers inhand to switch verbosity

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -273,6 +273,8 @@ REAGENT SCANNER
 		user.show_message("<span class='notice'>Subject's genes are stable.</span>")
 	add_fingerprint(user)
 
+/obj/item/healthanalyzer/attack_self(mob/user)
+	toggle_mode()
 
 /obj/item/healthanalyzer/verb/toggle_mode()
 	set name = "Switch Verbosity"


### PR DESCRIPTION
**What does this PR do:**
Use a health analyzer (Z/click while it's in your hand/whatever) and marvel at how the verbosity changes, just like that.

**Changelog:**
*Remove this line, and appropriate fields from the changelog*
:cl:
tweak: Using a health analyzer in-hand will switch the verbosity.
/:cl: