### PR TITLE
Mining shuttle launch delay and warning message

### DIFF
--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -41,6 +41,7 @@
 #define SHUTTLE_STRANDED 4
 #define SHUTTLE_ESCAPE 5
 #define SHUTTLE_ENDGAME 6
+#define SHUTTLE_IGNITING 7
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -213,7 +213,7 @@
 	var/last_timer_length
 	var/mode = SHUTTLE_IDLE			//current shuttle mode (see global defines)
 	var/callTime = 50				//time spent in transit (deciseconds)
-	var/ignitionTime = 50			// time spent "starting the engines". Also rate limits how often we try to reserve transit space if its ever full of transiting shuttles.
+	var/ignitionTime = 30			// time spent "starting the engines". Also rate limits how often we try to reserve transit space if its ever full of transiting shuttles.
 	var/roundstart_move				//id of port to send shuttle to at roundstart
 	var/travelDir = 0				//direction the shuttle would travel in
 	var/rebuildable = 0				//can build new shuttle consoles for this one


### PR DESCRIPTION
**What does this PR do:**
The mining shuttle now has a three second delay before launching and sends a warning message prior to launching. Also cleaned up a bit of the timer code(credit to TG for a large portion of this code!)

**Images of sprite/map changes (IF APPLICABLE):**
![image](https://user-images.githubusercontent.com/30060146/63246913-c1ac6e80-c231-11e9-90e3-080802802923.png)

**Changelog:**
:cl:
add: mining shuttle warning message and delay before launching
/:cl:

