### PR TITLE
Fixes APC menus not opening after the powerloss hack

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -107,6 +107,8 @@
 							aiRestorePowerRoutine = 0
 							update_blind_effects()
 							update_sight()
+							to_chat(src, "Here are your current laws:")
+							src.show_laws()
 							return
 
 						switch(PRP)
@@ -126,8 +128,6 @@
 								theAPC.attack_ai(src)
 								apc_override = 0
 								aiRestorePowerRoutine = 3
-								to_chat(src, "Here are your current laws:")
-								src.show_laws() //WHY THE FUCK IS THIS HERE
 						sleep(50)
 						theAPC = null
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -108,7 +108,7 @@
 							update_blind_effects()
 							update_sight()
 							to_chat(src, "Here are your current laws:")
-							src.show_laws()
+							show_laws()
 							return
 
 						switch(PRP)

--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -24,6 +24,8 @@
 	return STATUS_UPDATE						// Ghosts can view updates
 
 /mob/living/silicon/ai/shared_nano_interaction()
+	if(apc_override)
+		return STATUS_INTERACTIVE
 	if(lacks_power())
 		return STATUS_CLOSE
 	if(check_unable(1, 0))


### PR DESCRIPTION
**What does this PR do:**
Fixes: #10286

You're supposed to open the menu of whatever area you're in (after around 30 seconds) so you can save yourself.
This fixes not being able to do that.

Also moves the law reminder to a more sensible place.

**Changelog:**
*Remove this line, and appropriate fields from the changelog*
:cl:
fix: AIs not being able to restore their own power if in an area with an APC.
/:cl:

