### PR TITLE
Improve shuttle parallax stopping + fix shuttles flying sideways

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -8,7 +8,6 @@
 	var/last_parallax_shift //world.time of last update
 	var/parallax_throttle = 0 //ds between updates
 	var/parallax_movedir = 0
-	var/new_parallax_movedir = 0
 	var/parallax_layers_max = 3
 	var/parallax_animate_timer
 
@@ -155,7 +154,11 @@
 	var/area/areaobj = posobj.loc
 
 	// Update the movement direction of the parallax if necessary (for shuttles)
-	set_parallax_movedir(C.new_parallax_movedir)
+	var/area/shuttle/SA = areaobj
+	if(!SA || !SA.moving)
+		set_parallax_movedir(0)
+	else
+		set_parallax_movedir(SA.parallax_movedir)
 
 	var/force
 	if(!C.previous_turf || (C.previous_turf.z != posobj.z))
@@ -204,7 +207,7 @@
 			if(L.offset_y < -240)
 				L.offset_y += 480
 
-		if(!areaobj.parallax_movedir && C.dont_animate_parallax <= world.time && (offset_x || offset_y) && abs(offset_x) <= max(C.parallax_throttle/world.tick_lag+1,1) && abs(offset_y) <= max(C.parallax_throttle/world.tick_lag+1,1) && (round(abs(change_x)) > 1 || round(abs(change_y)) > 1))
+		if(!(areaobj.parallax_movedir && areaobj.moving) && C.dont_animate_parallax <= world.time && (offset_x || offset_y) && abs(offset_x) <= max(C.parallax_throttle/world.tick_lag+1,1) && abs(offset_y) <= max(C.parallax_throttle/world.tick_lag+1,1) && (round(abs(change_x)) > 1 || round(abs(change_y)) > 1))
 			L.transform = matrix(1, 0, offset_x*L.speed, 0, 1, offset_y*L.speed)
 			animate(L, transform=matrix(), time = last_delay)
 

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -100,6 +100,7 @@ var/list/ghostteleportlocs = list()
 	requires_power = FALSE
 	valid_territory = FALSE
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
+	parallax_movedir = NORTH
 
 /area/shuttle/arrival
 	name = "\improper Arrival Shuttle"
@@ -247,6 +248,7 @@ var/list/ghostteleportlocs = list()
 /area/shuttle/specops
 	name = "\improper Special Ops Shuttle"
 	icon_state = "shuttlered"
+	parallax_movedir = EAST
 
 /area/shuttle/specops/centcom
 	name = "\improper Special Ops Shuttle"

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -104,6 +104,7 @@ var/list/ghostteleportlocs = list()
 
 /area/shuttle/arrival
 	name = "\improper Arrival Shuttle"
+	parallax_movedir = EAST
 
 /area/shuttle/arrival/pre_game
 	icon_state = "shuttle2"
@@ -137,12 +138,14 @@ var/list/ghostteleportlocs = list()
 	music = "music/escape.ogg"
 	icon_state = "shuttle"
 	nad_allowed = TRUE
+	parallax_movedir = EAST
 
 /area/shuttle/pod_4
 	name = "\improper Escape Pod Four"
 	music = "music/escape.ogg"
 	icon_state = "shuttle"
 	nad_allowed = TRUE
+	parallax_movedir = EAST
 
 /area/shuttle/escape_pod1
 	name = "\improper Escape Pod One"
@@ -208,6 +211,7 @@ var/list/ghostteleportlocs = list()
 /area/shuttle/transport
 	icon_state = "shuttle"
 	name = "\improper Transport Shuttle"
+	parallax_movedir = EAST
 
 /area/shuttle/transport1
 	icon_state = "shuttle"
@@ -262,6 +266,7 @@ var/list/ghostteleportlocs = list()
 	name = "\improper Syndicate Elite Shuttle"
 	icon_state = "shuttlered"
 	nad_allowed = TRUE
+	parallax_movedir = SOUTH
 
 /area/shuttle/syndicate_elite/mothership
 	name = "\improper Syndicate Elite Shuttle"
@@ -275,6 +280,7 @@ var/list/ghostteleportlocs = list()
 	name = "\improper Syndicate SIT Shuttle"
 	icon_state = "shuttlered"
 	nad_allowed = TRUE
+	parallax_movedir = SOUTH
 
 /area/shuttle/assault_pod
 	name = "Steel Rain"
@@ -283,6 +289,7 @@ var/list/ghostteleportlocs = list()
 /area/shuttle/administration
 	name = "\improper Nanotrasen Vessel"
 	icon_state = "shuttlered"
+	parallax_movedir = EAST
 
 /area/shuttle/administration/centcom
 	name = "\improper Nanotrasen Vessel Centcom"
@@ -382,6 +389,7 @@ var/list/ghostteleportlocs = list()
 /area/shuttle/salvage/abandoned_ship
 	name = "\improper Abandoned Ship"
 	icon_state = "yellow"
+	parallax_movedir = WEST
 
 /area/shuttle/salvage/clown_asteroid
 	name = "\improper Clown Asteroid"
@@ -414,6 +422,7 @@ var/list/ghostteleportlocs = list()
 
 /area/shuttle/trade/sol
 	name = "Sol Freighter"
+	parallax_movedir = EAST
 
 /area/shuttle/freegolem
 	name = "Free Golem Ship"
@@ -1861,6 +1870,7 @@ var/list/ghostteleportlocs = list()
 /area/shuttle/constructionsite
 	name = "\improper Construction Site Shuttle"
 	icon_state = "yellow"
+	parallax_movedir = EAST
 
 /area/shuttle/constructionsite/station
 	name = "\improper Construction Site Shuttle"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -68,6 +68,7 @@
 	var/hide_attacklogs = FALSE // For areas such as thunderdome, lavaland syndiebase, etc which generate a lot of spammy attacklogs. Reduces log priority.
 
 	var/parallax_movedir = 0
+	var/moving = FALSE
 
 /area/Initialize(mapload)
 	GLOB.all_areas += src

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -106,12 +106,6 @@
 	..()
 	if((!(A) || !(src in A.locs)))
 		return
-	
-	if(ismob(A))
-		var/mob/M = A
-		if(M && M.client && M.client.new_parallax_movedir)
-			M.client.new_parallax_movedir = 0
-			M.update_parallax_contents()
 
 	if(destination_z && destination_x && destination_y)
 		A.forceMove(locate(destination_x, destination_y, destination_z))

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -30,7 +30,7 @@
 	if(id_tag == "s_docking_airlock")
 		INVOKE_ASYNC(src, .proc/lock)
 
-/mob/onShuttleMove(turf/oldT, turf/T1, rotation, travelDir)
+/mob/onShuttleMove(turf/oldT, turf/T1, rotation)
     if(!move_on_shuttle)
         return 0
     . = ..()
@@ -44,7 +44,6 @@
     else
         shake_camera(src, 7, 1)
 
-    client.new_parallax_movedir = travelDir ? WEST : NORTH
     update_parallax_contents()
 
 /mob/living/carbon/onShuttleMove()
@@ -59,14 +58,8 @@
 	if(smooth)
 		queue_smooth(src)
 
-/mob/postDock(obj/docking_port/S1, transit, list/parallax_mobs)
-    if(!client)
-        return
-    if(transit)
-        parallax_mobs.Add(src)
-        return
-    client.new_parallax_movedir = 0
-    update_parallax_contents()
+/mob/postDock()
+	update_parallax_contents()
 
 /obj/machinery/door/airlock/postDock(obj/docking_port/stationary/S1)
 	. = ..()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -215,7 +215,6 @@
 	var/roundstart_move				//id of port to send shuttle to at roundstart
 	var/travelDir = 0				//direction the shuttle would travel in
 	var/rebuildable = 0				//can build new shuttle consoles for this one
-	var/list/parallax_mobs = list()	//mobs to unparallax
 
 	var/obj/docking_port/stationary/destination
 	var/obj/docking_port/stationary/previous
@@ -493,9 +492,10 @@
 			var/turf/simulated/Ts1 = T1
 			Ts1.copy_air_with_tile(T0)
 
+		areaInstance.moving = TRUE
 		//move mobile to new location
 		for(var/atom/movable/AM in T0)
-			AM.onShuttleMove(T0, T1, rotation, travelDir)
+			AM.onShuttleMove(T0, T1, rotation)
 
 		if(rotation)
 			T1.shuttleRotate(rotation)
@@ -513,19 +513,12 @@
 		T0.CalculateAdjacentTurfs()
 		SSair.add_to_active(T0,1)
 
+	areaInstance.moving = transit
 	for(var/A1 in L1)
 		var/turf/T1 = A1
 		T1.postDock(S1)
 		for(var/atom/movable/M in T1)
-			M.postDock(S1, transit, parallax_mobs)
-
-	// For mobs who move away from a transiting shuttle for whatever reason (teleportation, jumping, etc) so that they don't get stuck parallaxing
-	if(!transit)
-		for(var/mob/M in parallax_mobs)
-			if(M.client && M.client.new_parallax_movedir)
-				M.client.new_parallax_movedir = 0
-				M.update_parallax_contents()
-		parallax_mobs = list()
+			M.postDock(S1)
 
 	loc = S1.loc
 	dir = S1.dir


### PR DESCRIPTION
**What does this PR do:**
Just found out `/area/shuttle` exists. Updated shuttle parallax to be more similar to tg's using `/area/shuttle`. This is a better/faster way to stop shuttle parallax (if you fall out or leave the shuttle), and also reactivates parallax if you move back into the transiting shuttle.

Also updates a bunch of shuttles to move east/west/south instead of north

:cl: Tayyyyyyy
fix: Many shuttle flight directions fixed
/:cl: