### PR TITLE
Fix emitters again

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -19,7 +19,7 @@
 
 #define NEW_SS_GLOBAL(varname) if(varname != src){if(istype(varname)){Recover();qdel(varname);}varname = src;}
 
-#define START_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = TRUE;Processor.processing += Datum}
+#define START_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = TRUE;if(is_battery(Datum)){Processor.processing.Insert(1,Datum)}else{Processor.processing += Datum}}
 #define STOP_PROCESSING(Processor, Datum) Datum.isprocessing = FALSE;Processor.processing -= Datum
 
 //SubSystem flags (Please design any new flags so that the default is off, to make adding flags to subsystems easier)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -15,6 +15,8 @@
 
 #define ismachinery(A) (istype(A, /obj/machinery))
 
+#define is_battery(A) (istype(A, /obj/machinery/power/smes)) // If something needs to be last in line to get power from the powernet
+
 #define ismecha(A) (istype(A, /obj/mecha))
 
 #define iseffect(A) (istype(A, /obj/effect))


### PR DESCRIPTION
Back in #9114 I fixed emitters by making it so batteries would act like batteries by being the last in line to take power in.
This code got removed in #11364 I blame the lack of obvious naming. So this time around I went the route of adding a "is_battery" helper to try and make it a bit more obvious what's going on so hopefully it doesn't end up getting dropped again.

**What does this PR do:**
SMES once again act like batteries and are last in line to get power, this means no more having to rebuild emitters while setting up the engine ( or otherwise turning off SMES power input ) in order to force the powernet to do what it should have done in the first place. Which is use the SMES as a battery instead of it feeding itself.

**Changelog:**
:cl: MINIMAN10000
fix: SMES once again act like batteries and are last in line to get power
/:cl:

