### PR TITLE
Tweaks/Buffs Survival Pen

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1149,24 +1149,19 @@
 	id = "lavaland_extract"
 	description = "An extract of lavaland atmospheric and mineral elements. Heals the user in small doses, but is extremely toxic otherwise."
 	color = "#C8A5DC" // rgb: 200, 165, 220
-	metabolization_rate = 0.7 //VERY strong chemical
 	overdose_threshold = 3 //To prevent people stacking massive amounts of a very strong healing reagent
 	can_synth = FALSE
 
 /datum/reagent/medicine/lavaland_extract/on_mob_life(mob/living/carbon/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustToxLoss(-3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustOxyLoss(-3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustBruteLoss(-6*REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustFireLoss(-6*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.adjustBruteLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.adjustFireLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/lavaland_extract/overdose_process(mob/living/M) // This WILL be brutal
 	var/update_flags = STATUS_UPDATE_NONE
 	M.AdjustConfused(5)
-	update_flags |= M.adjustBruteLoss(10*REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustFireLoss(10*REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustToxLoss(10*REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.Stun(7, FALSE)
-	update_flags |= M.Weaken(7, FALSE)
+	update_flags |= M.adjustBruteLoss(3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.adjustFireLoss(3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.adjustToxLoss(3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -155,9 +155,9 @@
 	name = "survival medipen"
 	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. <br><span class='boldwarning'>WARNING: Do not inject more than one pen in quick succession.</span>"
 	icon_state = "stimpen"
-	volume = 22
-	amount_per_transfer_from_this = 22
-	list_reagents = list("salbutamol" = 10, "epinephrine" = 5, "lavaland_extract" = 2, "salglu_solution" = 5) //Short burst of healing, followed by minor healing from the saline
+	volume = 42
+	amount_per_transfer_from_this = 42
+	list_reagents = list("salbutamol" = 10, "teporone" = 15, "epinephrine" = 10, "lavaland_extract" = 2, "weak_omnizine" = 5) //Short burst of healing, followed by minor healing from the saline
 
 /obj/item/reagent_containers/hypospray/autoinjector/nanocalcium
 	name = "nanocalcium autoinjector"


### PR DESCRIPTION
Alternative to: https://github.com/ParadiseSS13/Paradise/pull/12020

Removing stimulant+teporone injectors was, indeed, a mistake; that said, I do believe they should probably be removed and their functionality largely rolled into the survival autoinjectors.

Changes to the survival pen:
- Added 15 units of teporone in it
- Increased epinephrine from 5 to 10
- Change out the 5 units of saline-glucose for weak omnizine
- Lavaland extract now only heals 5 brute and 5 burn (instead of 6 brute, 6 burn, 3 tox, and 3 oxy), but has a weaker overdose (deals 3 brute and 3 burn), and much slower metabolization rate (0.4 instead of 0.7)

Should make survival pens a bit better at healing, overall, not to mention they'll last quite a bit longer than they previously did, especially for the damage types you typically encounter in lavaland (largely brute and some burn).

On average, current survival injectors (if you're not in crit) will heal, roughly, 40 brute and 40 burn, though a large component of this is random; you could get more, or you could get less. With the injectors, changed, the healing you get will be guaranteed---the total amount it will heal is 50 brute and 50 burn.

While lavaland extract no longer heals toxin or oxy, this is *more* than offset by the inclusion of diluted omnizine over saline-glucose; the extract would only heal 9 tox and 9 oxy; the diluted omnizine will recover 25 tox and 25 oxy in the same time period.

On the removal of stimulant pens:

While these do have some merit for fighting megafauna, I ultimately to believe they have more use and are utilized more for shennigans and antagging; as such, I think rolling things into a single injector is, overall better, and just ditching the stimulant pen.  When miners are already so good at combat due to their crazy amounts of armor and other buffs, I don't think giving them anti-stun, as a default bread and butter part of their package, is really a good thing, overall, for the game.

I know a lot of individuals say "but movement speed is slower than on TG!". This is a correct assessment---but what is never spoken of is that our simple mobs are *also* slower than here on TG--the scale at which our mobs are slower is the same scale that simple mobs are slower than humans, so it really all comes out in the wash.

:cl: Fox McCloud
tweak: Survival autoinjectors tweaked
add: Survival autoinjectors have 15 units of teporone in them
tweak: Survival autoinjectors have double the epinpehrine and weak omnizine instead of saline glucose.
tweak: lavaland extract altered; it no longer heals tox or oxy, and heals slightly less brute and burn, but has nearly halved the metabolization rate and has a less harsh overdose
/:cl: