### PR TITLE
Removes the ability to consume the divine vocal cords

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -125,6 +125,9 @@ var/static/regex/multispin_words = regex("like a record baby")
 		return
 	owner.say(".x[command]")
 
+/obj/item/organ/internal/vocal_cords/colossus/prepare_eat()
+	return
+	
 /obj/item/organ/internal/vocal_cords/colossus/can_speak_with()
 	if(world.time < next_command)
 		to_chat(owner, "<span class='notice'>You must wait [(next_command - world.time)/10] seconds before Speaking again.</span>")


### PR DESCRIPTION
**What does this PR do:**
As the title states removes the ability to consume the divine vocal cords that the colossus drops upon death, seems a waste to accidentally consume it and be unable to implant it after that point.

**Changelog:**
:cl:
tweak: removed the ability to eat the divine vocal cords
/:cl:

