### PR TITLE
Fixes Airlock Close Spam

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -181,12 +181,6 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/bumpopen(mob/living/simple_animal/user)
 	..(user)
 
-/obj/machinery/door/airlock/autoclose()
-	autoclose_timer = 0
-	if(!QDELETED(src) && !density && !operating && !locked && !welded && autoclose)
-		close()
-	return
-
 /obj/machinery/door/airlock/proc/isElectrified()
 	if(electrified_until != 0)
 		return 1
@@ -645,7 +639,7 @@ About the new airlock wires panel:
 			add_overlay(I)
 	else
 		set_light(0)
-		
+
 /obj/machinery/door/airlock/CanPass(atom/movable/mover, turf/target, height=0)
 	if(isElectrified() && density && istype(mover, /obj/item))
 		var/obj/item/I = mover
@@ -1103,6 +1097,10 @@ About the new airlock wires panel:
 		playsound(loc, doorOpen, 30, 1)
 	if(closeOther != null && istype(closeOther, /obj/machinery/door/airlock/) && !closeOther.density)
 		closeOther.close()
+
+	if(autoclose)
+		autoclose_in(normalspeed ? auto_close_time : auto_close_time_dangerous)
+
 	if(!density)
 		return TRUE
 	operating = TRUE
@@ -1117,10 +1115,6 @@ About the new airlock wires panel:
 	layer = OPEN_DOOR_LAYER
 	update_icon(AIRLOCK_OPEN, 1)
 	operating = FALSE
-
-	// The `addtimer` system has the advantage of being cancelable
-	if(autoclose)
-		autoclose_timer = addtimer(CALLBACK(src, .proc/autoclose), normalspeed ? auto_close_time : auto_close_time_dangerous, TIMER_UNIQUE | TIMER_STOPPABLE)
 	return TRUE
 
 /obj/machinery/door/airlock/close(forced=0, override = 0)
@@ -1137,7 +1131,8 @@ About the new airlock wires panel:
 		for(var/turf/turf in locs)
 			for(var/atom/movable/M in turf)
 				if(M.density && M != src) //something is blocking the door
-					addtimer(CALLBACK(src, .proc/autoclose), 60)
+					autoclose_in(60)
+					return
 
 	use_power(360)	//360 W seems much more appropriate for an actuator moving an industrial door capable of crushing people
 	if(forced)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -20,7 +20,7 @@
 	var/welded = FALSE
 	var/normalspeed = 1
 	var/auto_close_time = 150
-	var/auto_close_time_dangerous = 15
+	var/auto_close_time_dangerous = 5
 	var/assemblytype //the type of door frame to drop during deconstruction
 	var/datum/effect_system/spark_spread/spark_system
 	var/damage_deflection = 10

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -279,7 +279,7 @@
 	air_update_turf(1)
 	update_freelook_sight()
 	if(autoclose)
-		addtimer(CALLBACK(src, .proc/close), autoclose)
+		autoclose_in(normalspeed ? auto_close_time : auto_close_time_dangerous)
 	return TRUE
 
 /obj/machinery/door/proc/close()


### PR DESCRIPTION
Fixes airlocks trying to repeatedly spam `close` when someone is standing in them, thus resulting opening and closing rapidly....constantly. An airlock refactor a while back caused this; it's absolutely not supposed to do this; the door is just supposed to stay open and only attempt to close when there's not a mob standing in the way.

Also refactors the door closing timers to behave like TG's does

:cl: Fox McCloud
fix: Fixes airlocks spamming their open and close when you stand in them
/:cl: