### PR TITLE
Fixes Door Timer Override

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -20,7 +20,7 @@
 	var/welded = FALSE
 	var/normalspeed = 1
 	var/auto_close_time = 150
-	var/auto_close_time_dangerous = 5
+	var/auto_close_time_dangerous = 15
 	var/assemblytype //the type of door frame to drop during deconstruction
 	var/datum/effect_system/spark_spread/spark_system
 	var/damage_deflection = 10


### PR DESCRIPTION
Fixes door timer overrides not working.

When I did the refactor, I kept the old value to keep balance more or less the same; little did I know, that'd have an actual impact---the timer value was just too small for actually be registered on the timer SS, so the door would never close. Very strange---actual delay difference you probably won't notice

fixes: https://github.com/ParadiseSS13/Paradise/issues/12054

PS: Door timing overriding is powergaming, change my mind.

:cl: Fox McCloud
fix: Fixes overriden door timers not working
/:cl: