### PR TITLE
Fixes Stun Absorbtion Not Working

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -397,6 +397,9 @@
 // STUN
 
 /mob/living/Stun(amount, updating = 1, force = 0)
+	if(status_flags & CANSTUN || force)
+		if(absorb_stun(amount, force))
+			return FALSE
 	return SetStunned(max(stunned, amount), updating, force)
 
 /mob/living/SetStunned(amount, updating = 1, force = 0) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
@@ -434,6 +437,9 @@
 // WEAKEN
 
 /mob/living/Weaken(amount, updating = 1, force = 0)
+	if(status_flags & CANWEAKEN || force)
+		if(absorb_stun(amount, force))
+			return FALSE
 	return SetWeakened(max(weakened, amount), updating, force)
 
 /mob/living/SetWeakened(amount, updating = 1, force = 0)


### PR DESCRIPTION
We had stun absorbing, but it wasn't properly plugged in...

In any event, this fixes that.

If you're curious why this doesn't apply on `setStunned/Weakened` or `adjustStunned/Weakened`, it's pretty simple; having stun absorbing on would then prevent you from recovering from stuns, which isn't the intend purpose; this is meant to prevent all stuns for X amount of time.

:cl: Fox McCloud
fix: Fixes stun absorbing not working
/:cl: