### PR TITLE
IV bag tweaks, adds handheld defib to paramedic's locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -273,6 +273,7 @@
 	new /obj/item/key/ambulance(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/clothing/shoes/magboots(src)
+	new /obj/item/handheld_defibrillator(src)
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -9,7 +9,7 @@
 	righthand_file = 'icons/goonstation/mob/inhands/items_righthand.dmi'
 	icon_state = "ivbag"
 	volume = 200
-	possible_transfer_amounts = list(1,5,10)
+	possible_transfer_amounts = list(1,5,10,15,25,30,50) // Everything above 10 is NOT usable on a person and is instead used for transfering to other containers
 	amount_per_transfer_from_this = 1
 	container_type = OPENCONTAINER
 	var/label_text
@@ -50,6 +50,11 @@
 
 /obj/item/reagent_containers/iv_bag/process()
 	if(!injection_target)
+		end_processing()
+		return
+
+	if(amount_per_transfer_from_this > 10) // Prevents people from switching to illegal transfer values while the IV is already in someone, i.e. anything over 10
+		to_chat(injection_target, "<span class='warning'>The IV bag can only be used on someone with a transfer amount of 1, 5 or 10.</span>")
 		end_processing()
 		return
 
@@ -98,6 +103,9 @@
 		else // Inserting the needle
 			if(!L.can_inject(user, 1))
 				return
+			if(amount_per_transfer_from_this > 10) // We only want to be able to transfer 1, 5, or 10 units to people. Higher numbers are for transfering to other containers
+				to_chat(user, "<span class='warning'>The IV bag can only be used on someone with a transfer amount of 1, 5 or 10.</span>")
+				return
 			if(L != user)
 				L.visible_message("<span class='danger'>[user] is trying to insert [src]'s needle into [L]'s arm!</span>", \
 									"<span class='userdanger'>[user] is trying to insert [src]'s needle into [L]'s arm!</span>")
@@ -106,6 +114,22 @@
 			L.visible_message("<span class='danger'>[user] inserts [src]'s needle into [L]'s arm!</span>", \
 									"<span class='userdanger'>[user] inserts [src]'s needle into [L]'s arm!</span>")
 			begin_processing(L)
+
+	else if(target.is_refillable() && is_drainable()) // Transferring from IV bag to other containers
+		if(!reagents.total_volume)
+			to_chat(user, "<span class='warning'>[src] is empty.</span>")
+			return
+
+		if(target.reagents.total_volume >= target.reagents.maximum_volume)
+			to_chat(user, "<span class='warning'>[target] is full.</span>")
+			return
+
+		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
+		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution to [target].</span>")
+	
+	else if(istype(target, /obj/item/reagent_containers/glass) && !target.is_open_container())
+		to_chat(user, "<span class='warning'>You cannot fill [target] while it is sealed.</span>")
+		return
 
 
 /obj/item/reagent_containers/iv_bag/update_icon()

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -54,7 +54,7 @@
 		return
 
 	if(amount_per_transfer_from_this > 10) // Prevents people from switching to illegal transfer values while the IV is already in someone, i.e. anything over 10
-		to_chat(injection_target, "<span class='warning'>The IV bag can only be used on someone with a transfer amount of 1, 5 or 10.</span>")
+		visible_message("<span class='danger'>The IV bag's needle pops out of [injection_target]'s arm. The transfer amount is too high!</span>")
 		end_processing()
 		return
 


### PR DESCRIPTION
**What does this PR do:**
The IV bag can now transfer its contents to other containers by clicking on the container with the bag. It has a few new transfer amounts being: 15, 25, 30, 50. 

However, you cannot use these new transfer amounts when using the IV on a person as it would be silly to be able to push 50 units of something through the small tube on an IV bag. If you try to inject someone while on these high settings you'll get this message:

![Untitled-1](https://user-images.githubusercontent.com/42044220/63645098-2ac63300-c6c5-11e9-8788-d2d8a7567cb1.jpg)

Likewise you cannot change the transfer amount from something acceptable to a value not allowed while you have an IV in someone. It will display a similar error message and remove the needle from them. Hopefully that retains the balance on IV bags, while making it not so annoying to remove chems from them using a syringe at 5u per click.

**Changelog**:
:cl:
tweak: IV bags are able to transfer their contents to other containers by clicking on them with the bag
add: Adds a handheld defibrillator to the Paramedic's EVA closet
/:cl: