### PR TITLE
Fixes Stuns

### DIFF
--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -7,19 +7,19 @@
 /mob/living/carbon/human/SetStunned(amount, updating = 1, force = 0)
 	if(dna.species)
 		amount = amount * dna.species.stun_mod
-	..()
+	return ..()
 
 /mob/living/carbon/human/SetWeakened(amount, updating = 1, force = 0)
 	if(dna.species)
 		amount = amount * dna.species.stun_mod
-	..()
+	return ..()
 
 /mob/living/carbon/human/SetParalysis(amount, updating = 1, force = 0)
 	if(dna.species)
 		amount = amount * dna.species.stun_mod
-	..()
+	return ..()
 
 /mob/living/carbon/human/SetSleeping(amount, updating = 1, no_alert = FALSE)
 	if(dna.species)
 		amount = amount * dna.species.stun_mod
-	..()
+	return ..()


### PR DESCRIPTION
This has been bugged since: https://github.com/ParadiseSS13/Paradise/pull/9221

I am utterly shocked this wasn't a problem until now, or that no one noticed.

Simply up, human's `status_procs` was never updated to return the value of their parent...which would cause a problem for reagents that stun or weaken.

Paralysis and Sleeping worked fine (though there'd usually be a 2 second delay), but stuns and weakens were the ones that manifested more evidently.

Either case, this is now fixed. 

Fixes: https://github.com/ParadiseSS13/Paradise/issues/12067

This is a likely culprit of why people "wouldn't go down with newcrit", amongst a few other stun related oddities; again, how this wasn't found prior to now is a bit shocking.

:cl: Fox McCloud
fix: Fixes stuns and weakens related to reagents
/:cl: