### PR TITLE
[WIP] Add vox/plasmaman anesthetics, remove sleep surgery

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -59,6 +59,28 @@ obj/item/tank/oxygen/empty/New()
 
 	air_contents.trace_gases += trace_gas
 
+/obj/item/tank/anesthetic/vox
+	name = "vox anesthetic tank"
+	desc = "A tank with an N2O/N2 gas mix."
+	icon_state = "anesthetic"
+	item_state = "an_tank"
+
+/obj/item/tank/anesthetic/vox/New()
+	..()
+	air_contents.oxygen = 0
+	air_contents.nitrogen = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
+
+/obj/item/tank/anesthetic/plasmaman
+	name = "plasmaman anesthetic tank"
+	desc = "A tank with an N2O/Plasma gas mix."
+	icon_state = "anesthetic"
+	item_state = "an_tank"
+
+/obj/item/tank/anesthetic/plasmaman/New()
+	..()
+	air_contents.oxygen = 0
+	air_contents.toxins = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
+
 /*
  * Air
  */

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -45,6 +45,8 @@
 	new /obj/item/clothing/mask/breath/medical(src)
 	new /obj/item/clothing/mask/breath/medical(src)
 	new /obj/item/clothing/mask/breath/medical(src)
+	new /obj/item/tank/anesthetic/vox(src)
+	new /obj/item/tank/anesthetic/plasmaman(src)
 
 
 /obj/structure/closet/secure_closet/medical3

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -111,9 +111,11 @@
 
 
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
+	if(M.stat == DEAD) //Operating on dead people is easy.
 		return 1
 	if(NO_PAIN in M.dna.species.species_traits)//if you don't feel pain, you can hold still
+		return 1
+	if(M.stat == UNCONSCIOUS && M.paralysis) //Under anesthethics or another form of forced sleep such as reagents. Sleeping is not good enough.
 		return 1
 	if(M.reagents.has_reagent("hydrocodone"))//really good pain killer
 		return 0.99

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -5,7 +5,9 @@
 // partname is the name of a body part
 // amount is a num from 1 to 100
 /mob/living/carbon/human/proc/pain(partname, amount)
-	if(stat >= UNCONSCIOUS)
+	if(stat == DEAD || status_flags & FAKEDEATH)
+		return
+	if(stat == UNCONSCIOUS && paralysis)
 		return
 	if(reagents.has_reagent("sal_acid"))
 		return
@@ -31,9 +33,10 @@
 
 // message is the custom message to be displayed
 mob/living/carbon/human/proc/custom_pain(message)
-	if(stat >= UNCONSCIOUS)
+	if(stat == DEAD || status_flags & FAKEDEATH)
 		return
-
+	if(stat == UNCONSCIOUS && paralysis)
+		return
 	if(NO_PAIN in dna.species.species_traits)
 		return
 	if(reagents.has_reagent("morphine"))
@@ -41,6 +44,9 @@ mob/living/carbon/human/proc/custom_pain(message)
 	if(reagents.has_reagent("hydrocodone"))
 		return
 
+	if(sleeping)
+		SetSleeping(0)
+		to_chat(src, "<span class='userdanger'>Pain wakes you up!</span>")
 	var/msg = "<span class='userdanger'>[message]</span>"
 
 	// Anti message spam checks


### PR DESCRIPTION
This PR adds one Vox and one Plasmaman anesthetics tank to surgery ORs, and removes being able to sleep to undergo surgery safely. 

If any surgery step is performed without anesthetics, the patient will wake up with a message warning him of the pain, making it very clear that it is no longer an effective method of anesthesia.

Reagents that force you to sleep such as ketamine (sleepy pens) are effective painkillers too.

Aside from the patient sleeping being an effective form of painkiller making no sense, it is not intended in code either :
 
`
if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
`

TODO : Sprites for the new anesthetics tanks.

:cl:
add: Added vox and plasmaman anesthetics tanks to OR closets.
tweak: You can no longer use the Sleep verb as an effective method of anesthesia.
/:cl: