### PR TITLE
Removes the ability of obese and matter eater to swallow people

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -409,12 +409,6 @@
 			qdel(src)
 
 /obj/item/grab/proc/checkvalid(var/mob/attacker, var/mob/prey) //does all the checking for the attack proc to see if a mob can eat another with the grab
-	if(ishuman(attacker) && (/datum/dna/gene/basic/grant_spell/mattereater in attacker.active_genes)) // MATTER EATER CARES NOT OF YOUR FORM
-		return 1
-
-	if(ishuman(attacker) && (FAT in attacker.mutations) && iscarbon(prey) && !isalien(prey)) //Fat people eating carbon mobs but not xenos
-		return 1
-
 	if(isalien(attacker) && iscarbon(prey)) //Xenomorphs eating carbon mobs
 		return 1
 


### PR DESCRIPTION
**What does this PR do:**
With this change, human carbons can no longer swallow others by having the matter eater or obese genes. After having thought about it for a while, I couldn't think about any scenarios in which swallowing others this way would be a good thing rather than an uncomfortable and awkward experience for the vast majority of people.

**Changelog:**
:cl:
del: Removes the ability of obese people and those with matter eater to swallow others.
/:cl:
