### PR TITLE
Adds a disk compartmentalizer to hydroponics

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -32862,8 +32862,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
+/obj/structure/table,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -36336,6 +36336,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bou" = (
+/obj/item/reagent_containers/glass/bucket,
 /obj/structure/sink{
 	icon_state = "sink";
 	dir = 8;


### PR DESCRIPTION
**What does this PR do:**
Adds a disk compartmentalizer in hydroponics, which gives botanists and convenient place to store all their plant data disks. The life bringer ghost role area already has one of these so I figured why not give one to the station as well? I removed one of the high capacity water tanks, but there's already two of these in hydroponics anyway, so it shouldn't be a problem.

Before:
![before](https://user-images.githubusercontent.com/42044220/63655751-2bf56f80-c75a-11e9-9816-2dc82521e73c.png)

After:
![after](https://user-images.githubusercontent.com/42044220/63655752-2f88f680-c75a-11e9-9cbc-26601d2c55b5.png)

**Changelog:**
:cl:
del: Removed one of the high capacity tanks in hydroponics
add: Added a disk compartmentalizer to hydroponics
/:cl:
