### PR TITLE
Fixes Plasmaman Karma Displayed Cost

### DIFF
--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -222,7 +222,7 @@ var/list/karma_spenders = list()
 			<a href='?src=[UID()];karmashop=shop;KarmaBuy2=7'>Unlock Drask -- 30KP</a><br>
 			<a href='?src=[UID()];karmashop=shop;KarmaBuy2=4'>Unlock Vox -- 45KP</a><br>
 			<a href='?src=[UID()];karmashop=shop;KarmaBuy2=5'>Unlock Slime People -- 45KP</a><br>
-			<a href='?src=[UID()];karmashop=shop;KarmaBuy2=6'>Unlock Plasmaman -- 100KP</a><br>
+			<a href='?src=[UID()];karmashop=shop;KarmaBuy2=6'>Unlock Plasmaman -- 45KP</a><br>
 			"}
 
 		if(2) // Karma Refunds


### PR DESCRIPTION
Fixes the displayed cost of Plasmamen.

They're actually just 45Karma, but it says they're 100

:cl: Fox McCloud
fix: Fixes the displayed cost of Plasmamen
/:cl: