### PR TITLE
Fixes Bug with Species-fitted Inhand Icons

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -87,6 +87,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	If index term exists and icon_override is not set, this sprite sheet will be used.
 	*/
 	var/list/sprite_sheets = null
+	var/list/sprite_sheets_inhand = null //Used to override inhand items. Use a single .dmi and suffix the icon states inside with _l and _r for each hand.
 	var/icon_override = null  //Used to override hardcoded clothing dmis in human clothing proc.
 	var/sprite_sheets_obj = null //Used to override hardcoded clothing inventory object dmis in human clothing proc.
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1020,9 +1020,9 @@ var/global/list/damage_icon_parts = list()
 			t_state = r_hand.icon_state
 
 		var/mutable_appearance/standing
-		if(r_hand.sprite_sheets && r_hand.sprite_sheets[dna.species.name])
+		if(r_hand.sprite_sheets_inhand && r_hand.sprite_sheets_inhand[dna.species.name])
 			t_state = "[t_state]_r"
-			standing = mutable_appearance(r_hand.sprite_sheets[dna.species.name], "[t_state]", layer = -R_HAND_LAYER)
+			standing = mutable_appearance(r_hand.sprite_sheets_inhand[dna.species.name], "[t_state]", layer = -R_HAND_LAYER)
 		else
 			standing = mutable_appearance(r_hand.righthand_file, "[t_state]", layer = -R_HAND_LAYER)
 			standing = center_image(standing, r_hand.inhand_x_dimension, r_hand.inhand_y_dimension)
@@ -1039,9 +1039,9 @@ var/global/list/damage_icon_parts = list()
 			t_state = l_hand.icon_state
 
 		var/mutable_appearance/standing
-		if(l_hand.sprite_sheets && l_hand.sprite_sheets[dna.species.name])
+		if(l_hand.sprite_sheets_inhand && l_hand.sprite_sheets_inhand[dna.species.name])
 			t_state = "[t_state]_l"
-			standing = mutable_appearance(l_hand.sprite_sheets[dna.species.name], "[t_state]", layer = -L_HAND_LAYER)
+			standing = mutable_appearance(l_hand.sprite_sheets_inhand[dna.species.name], "[t_state]", layer = -L_HAND_LAYER)
 		else
 			standing = mutable_appearance(l_hand.lefthand_file, "[t_state]", layer = -L_HAND_LAYER)
 			standing = center_image(standing, l_hand.inhand_x_dimension, l_hand.inhand_y_dimension)

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -80,7 +80,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/sonic)
 	cell_type = /obj/item/stock_parts/cell/super
 	restricted_species = list(/datum/species/vox/armalis)
-	sprite_sheets = list("Vox Armalis" = 'icons/mob/species/armalis/held.dmi')
+	sprite_sheets_inhand = list("Vox Armalis" = 'icons/mob/species/armalis/held.dmi') //Big guns big birds.
 
 /obj/item/gun/energy/noisecannon/update_icon()
 	return


### PR DESCRIPTION
Caused by myself in #11978, the bug presented where a species that was in the sprite_sheets of an item but didn't have a custom inhand sprite it picked up an item like a uniform and suddenly a grey jumpsuit was rendered on them. Happens for Vox when picking up regular uniforms because they have species-specific uniform sprites but not species-specific inhands, so it triggered the conditional and caused silly issues like rendering a default grey jumpsuit on them when they pick up a uniform.

Thought it was a BYOND sprite glitch at first but after reproducing it a couple times I figured I probably screwed something up.

**What does this PR do:**
Fixes a bug causing species with custom onmob sprites to have issues when they don't have custom inhand icons as well.

**Changelog:**
:cl:
fix: Picking up uniforms no longer renders a default grey jumpsuit on Vox.
/:cl:

**Ingame Screenshot:**
_The bug in action. Absolutely perfect timing as my character was blind and the overlay gives you a couple frames of vision once a minute._
![para ss13 uniform inhands bug](https://user-images.githubusercontent.com/12377767/63661504-625adb00-c7aa-11e9-87a1-2aa2db27dc97.PNG)
