### PR TITLE
Loadout Updates

### DIFF
--- a/code/modules/client/preference/loadout/loadout_cosmetics.dm
+++ b/code/modules/client/preference/loadout/loadout_cosmetics.dm
@@ -22,11 +22,3 @@
 /datum/gear/lipstick/lime
 	display_name = "lipstick, lime"
 	path = /obj/item/lipstick/lime
-
-/datum/gear/monocle
-	display_name = "monocle"
-	path = /obj/item/clothing/glasses/monocle
-
-/datum/gear/sunglasses
-	display_name = "cheap sunglasses"
-	path = /obj/item/clothing/glasses/sunglasses/fake

--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -1,5 +1,4 @@
 /datum/gear/donor
-	donator_tier = 2
 	sort_category = "Donor"
 	subtype_path = /datum/gear/donor
 
@@ -18,12 +17,10 @@
 /datum/gear/donor/furcape
 	display_name = "Fur Cape"
 	path = /obj/item/clothing/suit/furcape
-	cost = 2
 
 /datum/gear/donor/furcoat
 	display_name = "Fur Coat"
 	path = /obj/item/clothing/suit/furcoat
-	cost = 2
 
 /datum/gear/donor/kamina
 	display_name = "Spiky Orange-tinted Shades"

--- a/code/modules/client/preference/loadout/loadout_glasses.dm
+++ b/code/modules/client/preference/loadout/loadout_glasses.dm
@@ -1,0 +1,24 @@
+/datum/gear/glasses
+	subtype_path = /datum/gear/glasses
+	slot = slot_glasses
+	sort_category = "Glasses"
+
+/datum/gear/glasses/sunglasses
+	display_name = "cheap sunglasses"
+	path = /obj/item/clothing/glasses/sunglasses/fake
+
+/datum/gear/glasses/eyepatch
+	display_name = "Eyepatch"
+	path = /obj/item/clothing/glasses/eyepatch
+
+/datum/gear/glasses/hipster
+	display_name = "Hipster glasses"
+	path = /obj/item/clothing/glasses/regular/hipster
+
+/datum/gear/glasses/monocle
+	display_name = "Monocle"
+	path = /obj/item/clothing/glasses/monocle
+
+/datum/gear/glasses/prescription
+	display_name = "Prescription glasses"
+	path = /obj/item/clothing/glasses/regular

--- a/code/modules/client/preference/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference/loadout/loadout_gloves.dm
@@ -1,0 +1,8 @@
+/datum/gear/gloves
+	subtype_path = /datum/gear/gloves
+	slot = slot_gloves
+	sort_category = "Gloves"
+
+/datum/gear/gloves/fingerless
+	display_name = "Fingerless Gloves"
+	path = /obj/item/clothing/gloves/fingerless

--- a/code/modules/client/preference/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference/loadout/loadout_shoes.dm
@@ -27,25 +27,32 @@
 
 /datum/gear/shoes/cowboyboots
 	display_name = "cowboy boots, brown"
-	cost = 1
 	path = /obj/item/clothing/shoes/cowboyboots
 
 /datum/gear/shoes/cowboyboots_black
 	display_name = "cowboy boots, black"
-	cost = 1
 	path = /obj/item/clothing/shoes/cowboyboots/black
 
 /datum/gear/shoes/cowboyboots/white
 	display_name = "cowboy boots, white"
-	cost = 1
 	path = /obj/item/clothing/shoes/cowboyboots/white
 
 /datum/gear/shoes/cowboyboots/pink
 	display_name = "cowboy boots, pink"
-	cost = 1
 	path = /obj/item/clothing/shoes/cowboyboots/pink
-	
+
 /datum/gear/shoes/laceup
 	display_name = "laceup shoes"
-	cost = 1
 	path = /obj/item/clothing/shoes/laceup
+
+/datum/gear/shoes/blackshoes
+	display_name = "Black shoes"
+	path = /obj/item/clothing/shoes/black
+
+/datum/gear/shoes/brownshoes
+	display_name = "Brown shoes"
+	path = /obj/item/clothing/shoes/brown
+
+/datum/gear/shoes/whiteshoes
+	display_name = "White shoes"
+	path = /obj/item/clothing/shoes/white

--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -1,7 +1,6 @@
 /datum/gear/suit
 	subtype_path = /datum/gear/suit
 	slot = slot_wear_suit
-	cost = 2
 	sort_category = "External Wear"
 
 //WINTER COATS
@@ -104,6 +103,10 @@
 	display_name = "security jacket"
 	path = /obj/item/clothing/suit/armor/secjacket
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer", "Security Pod Pilot")
+
+/datum/gear/suit/ianshirt
+	display_name = "Ian Shirt"
+	path = /obj/item/clothing/suit/ianshirt
 
 /datum/gear/suit/poncho
 	display_name = "poncho, classic"

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -2,7 +2,6 @@
 /datum/gear/uniform
 	subtype_path = /datum/gear/uniform
 	slot = slot_w_uniform
-	cost = 2
 	sort_category = "Uniforms and Casual Dress"
 
 /datum/gear/uniform/skirt

--- a/paradise.dme
+++ b/paradise.dme
@@ -1323,6 +1323,8 @@
 #include "code\modules\client\preference\loadout\loadout_cosmetics.dm"
 #include "code\modules\client\preference\loadout\loadout_donor.dm"
 #include "code\modules\client\preference\loadout\loadout_general.dm"
+#include "code\modules\client\preference\loadout\loadout_glasses.dm"
+#include "code\modules\client\preference\loadout\loadout_gloves.dm"
 #include "code\modules\client\preference\loadout\loadout_hat.dm"
 #include "code\modules\client\preference\loadout\loadout_racial.dm"
 #include "code\modules\client\preference\loadout\loadout_shoes.dm"


### PR DESCRIPTION
Adds a few more things to loadouts and tweaks costs.

For the most part, loadout costs have been cut--most things are only 1 point now, instead of 2; there's still some exceptions for exceptional items, but I really don't see much point in the majority of these suits, uniforms, and such costing 2 points.

Additions:
- Fingerless gloves
- Eyepatch
- Hipster glasses
- Prescription glasses
- Black shoes
- Brown shoes
- White Shoes
- Ian Shirt

:cl: Fox McCloud
tweak: loadout costs for most things cut from 2 to 1
add: Adds fingerless gloves, eyepatch, hipster glasses, prescription glasses, black shoes, brown shoes, white shoes, and ian's shirt to the loadout
/:cl: