### PR TITLE
Fixes Plasmamen Atmos Techs Not Getting Proper Suit

### DIFF
--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -116,7 +116,7 @@
 		if("Chief Engineer")
 			O = new /datum/outfit/plasmaman/ce
 
-		if("Atmospheric Technician")
+		if("Life Support Specialist")
 			O = new /datum/outfit/plasmaman/atmospherics
 
 		if("Mime")


### PR DESCRIPTION
I always forget that we stupidly renamed Atmospheric Technician to Life Support Specialist--and are the only codebase to have this. So weird. Should probably change that, one day.

Anyway, fixes Plasmaman atmos techs not getting their proper suit

:cl: Fox McCloud
fix: Fixes plasmamen atmos techs not getting their proper suit
/:cl: