### PR TITLE
Animations for attacking and being hit by weapons

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -68,6 +68,9 @@
 		SEND_SIGNAL(M, COMSIG_ITEM_ATTACK)
 		if(hitsound)
 			playsound(loc, hitsound, get_clamped_volume(), 1, -1)
+			animate(M, pixel_z = 4)
+			animate(transform = turn(matrix(), user.dir == WEST ? -20 : 20), pixel_z = 0, time = 2)
+			animate(transform = matrix(), time=0)
 
 	user.lastattacked = M
 	M.lastattacker = user

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -511,8 +511,9 @@
 	else if(direction & WEST)
 		pixel_x_diff = -8
 
-	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
-	animate(pixel_x = initial(pixel_x), pixel_y = final_pixel_y, time = 2)
+	animate(src, pixel_z = 4, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
+	animate(transform = turn(matrix(), dir == WEST ? -20 : 20), pixel_z = 0, pixel_x = initial(pixel_x), pixel_y = final_pixel_y, time = 2)
+	animate(transform = matrix(), time=0)
 
 /atom/movable/proc/do_item_attack_animation(atom/A, visual_effect_icon, obj/item/used_item)
 	var/image/I


### PR DESCRIPTION
**What does this PR do:**
Adds a slight tilt to the player when they attack something and a slight recoil tilt to people being hit by items, because it's more immersive and I feel it adds more life to the game and makes hitting people feel a bit more better.

**Images of sprite/map changes (IF APPLICABLE):**
http://puu.sh/Ea38t/dfe244217d.mp4
http://puu.sh/Ea2UR/2975a89a1b.mp4

**Changelog:**
:cl:
add: small animation for being hit by items
tweak: attack animation
/:cl:

