### PR TITLE
Blobbernauts no longer move right after being spawned.

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -180,6 +180,7 @@
 	throw_pressure_limit = 120  //120 kPa difference required to throw
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	var/selectingplayer = FALSE
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life(seconds, times_fired)
 	if(stat != DEAD && (getBruteLoss() || getFireLoss())) // Heal on blob structures
@@ -189,6 +190,11 @@
 		else
 			adjustBruteLoss(0.2) // If you are at full health, you won't lose health. You'll need it. However the moment anybody sneezes on you, the decaying will begin.
 			adjustFireLoss(0.2)
+	if(selectingplayer == TRUE)
+		AIStatus = AI_OFF
+		LoseTarget()
+	else
+		AIStatus = AI_ON
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()
 	return

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -180,7 +180,6 @@
 	throw_pressure_limit = 120  //120 kPa difference required to throw
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-	var/selectingplayer = FALSE
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life(seconds, times_fired)
 	if(stat != DEAD && (getBruteLoss() || getFireLoss())) // Heal on blob structures
@@ -190,11 +189,6 @@
 		else
 			adjustBruteLoss(0.2) // If you are at full health, you won't lose health. You'll need it. However the moment anybody sneezes on you, the decaying will begin.
 			adjustFireLoss(0.2)
-	if(selectingplayer == TRUE)
-		AIStatus = AI_OFF
-		LoseTarget()
-	else
-		AIStatus = AI_ON
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()
 	return

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -234,14 +234,16 @@
 	blobber.color = blob_reagent_datum.complementary_color
 	blobber.overmind = src
 	blob_mobs.Add(blobber)
+	blobber.selectingplayer = TRUE
 	spawn()
-		var/list/candidates = pollCandidates("Do you want to play as a blobbernaut?", ROLE_BLOB, 1, 150)
+		var/list/candidates = pollCandidates("Do you want to play as a blobbernaut?", ROLE_BLOB, 1, 100)
 		if(candidates.len)
 			var/mob/C = pick(candidates)
 			if(C)
 				blobber.key = C.key
 				to_chat(blobber, "<span class='biggerdanger'>You are a blobbernaut! You must assist all blob lifeforms in their mission to consume everything!</span>")
 				to_chat(blobber, "<span class='danger'>You heal while standing on blob structures, however you will decay slowly if you are damaged outside of the blob.</span>")
+		blobber.selectingplayer = FALSE
 	return
 
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -234,7 +234,8 @@
 	blobber.color = blob_reagent_datum.complementary_color
 	blobber.overmind = src
 	blob_mobs.Add(blobber)
-	blobber.selectingplayer = TRUE
+	blobber.AIStatus = AI_OFF
+	blobber.LoseTarget()
 	spawn()
 		var/list/candidates = pollCandidates("Do you want to play as a blobbernaut?", ROLE_BLOB, 1, 100)
 		if(candidates.len)
@@ -243,7 +244,8 @@
 				blobber.key = C.key
 				to_chat(blobber, "<span class='biggerdanger'>You are a blobbernaut! You must assist all blob lifeforms in their mission to consume everything!</span>")
 				to_chat(blobber, "<span class='danger'>You heal while standing on blob structures, however you will decay slowly if you are damaged outside of the blob.</span>")
-		blobber.selectingplayer = FALSE
+		if(!blobber.ckey)
+			blobber.AIStatus = AI_ON
 	return
 
 


### PR DESCRIPTION
**What does this PR do:**
The poll that asks ghosts if they want to control a blobbernaut now only lasts 10 seconds.
The blobbernaut doesn't chase after people right after being spawned anymore, however after the poll is over, it will be able to, if somehow no player was put in control of it.

**Changelog:**
:cl:
tweak: The poll to play as a blobbernaut now lasts 10 seconds from 15.
tweak: Blobbernauts no longer chase after people while players are being polled to play as one.
/:cl: