### PR TITLE
Close Quarters Cooking

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -66,6 +66,12 @@
 	l_ear = /obj/item/radio/headset/headset_service
 	pda = /obj/item/pda/chef
 
+/datum/outfit/job/chef/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	var/datum/martial_art/cqc/under_siege/justacook = new
+	justacook.teach(H)
 
 
 /datum/job/hydro


### PR DESCRIPTION
The chef now has CQC at round start, by default.

This is a special variety of CQC that *only* works in the bar and kitchen area. This prevents it from being valid hunty, and will primarily be used to throw unruly people out of the bar, or put a quick stop to fights.

This gives the bar/kitchen a way of dealing with disruptive individuals without having to add an entirely new job--it's as easy as "Hey chef, this jerkface won't leave".

Also ties in well to the stereotype of the chef being the  person who, despite their demeanor, you don't mess with

:cl: Fox McCloud
add: Chefs are now trained in the art of Close Quarters Cooking
/:cl: