### PR TITLE
Clarify changeling error message

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -303,7 +303,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/changeling/proc/can_absorb_dna(mob/living/carbon/user, mob/living/carbon/target)
 	if(using_stale_dna(user))//If our current DNA is the stalest, we gotta ditch it.
-		to_chat(user, "<span class='warning'>We have reached our capacity to store genetic information! We must transform before absorbing more.</span>")
+		to_chat(user, "<span class='warning'>The DNA we are wearing is stale. Transform and try again.</span>")
 		return
 
 	if(!target || !target.dna)


### PR DESCRIPTION
Change the error message for having stale DNA when absorbing/dna stinging from : 
"We have reached our capacity to store genetic information! We must transform before absorbing more."

to : 
"The DNA we are wearing is stale. Transform and try again."

The first string implies (at least to me) that transforming will get rid of our stale DNA. However, it does not! You need to transform then DNA sting/absorb to discard the old DNA. I feel like the new string is clearer, and more to the point of what the changeling player needs to do.

:cl:
tweak: Update a changeling error message to be clearer.
/:cl:
