### PR TITLE
GPS Location Status

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -168,6 +168,9 @@
 	show_stat_emergency_shuttle_eta()
 
 	if(client.statpanel == "Status")
+		if(locate(/obj/item/gps) in GetAllContents())
+			var/turf/T = get_turf(src)
+			stat(null, "GPS: [COORD(T)]")
 		if(locate(/obj/item/assembly/health) in src)
 			stat(null, "Health: [health]")
 		if(internal)
@@ -852,7 +855,7 @@
 				return
 			var/read = 0
 			var/perpname = get_visible_name(TRUE)
-			
+
 			for(var/datum/data/record/E in data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in data_core.medical)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -168,10 +168,11 @@
 	show_stat_emergency_shuttle_eta()
 
 	if(client.statpanel == "Status")
-		if(locate(/obj/item/gps) in GetAllContents())
+		var/total_user_contents = GetAllContents() // cache it
+		if(locate(/obj/item/gps) in total_user_contents)
 			var/turf/T = get_turf(src)
 			stat(null, "GPS: [COORD(T)]")
-		if(locate(/obj/item/assembly/health) in src)
+		if(locate(/obj/item/assembly/health) in total_user_contents)
 			stat(null, "Health: [health]")
 		if(internal)
 			if(!internal.air_contents)


### PR DESCRIPTION
It occurred to the other day just how inconvenient it is to keep track of GPS status when you're on the go, particularly if you're trying to track a stationary target--especially relevant for Lavaland.

Either case, I just added this little feature, whereby, if you have a GPS on you, it will show your current location in the status tab. 

I don't think it's appropriate for it to show more than this, but showing your own location? Yeah, that seems fine to me.

Also, I refactored it so the health sensor detection is a bit more robust in tracking it being on your person; if it was in your backpack or on your persondirectly, it'd be fine, but if it was in a box inside your backpack, then it would fail to show up. Post refactor, it should work up to 5 storage layers deep for detection, which should cover like 99.9% of the cases of having a GPS.

:cl: Fox McCloud
add; Having a GPS on your person will display your precise location in the status tab
/:cl: