### PR TITLE
Giant spider fixes

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -256,10 +256,10 @@
 		death()
 		to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
 
-	
+
 /mob/living/proc/InCritical()
 	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)
-	
+
 
 /mob/living/ex_act(severity)
 	..()
@@ -385,6 +385,7 @@
 
 /mob/living/proc/revive()
 	rejuvenate()
+	lying = 0
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -149,7 +149,7 @@
 	set category = "Spider"
 	set desc = "Spread a sticky web to slow down prey."
 
-	if(stat == DEAD)
+	if(stat == UNCONSCIOUS)
 		return
 
 	var/T = src.loc
@@ -170,7 +170,7 @@
 	set category = "Spider"
 	set desc = "Wrap up prey to feast upon and objects for safe keeping."
 
-	if(stat == DEAD)
+	if(stat == UNCONSCIOUS)
 		return
 
 	if(!cocoon_target)
@@ -229,7 +229,7 @@
 	set category = "Spider"
 	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
 
-	if(stat == DEAD)
+	if(stat == UNCONSCIOUS)
 		return
 
 	var/obj/structure/spider/eggcluster/E = locate() in get_turf(src)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -47,6 +47,11 @@
 		if(C.can_inject(null, 0, inject_target, 0))
 			C.reagents.add_reagent("spidertoxin", venom_per_bite)
 
+/mob/living/simple_animal/hostile/poison/giant_spider/New()
+	..()
+	if(!faction.len)
+		faction = list("spiders")
+
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 	desc = "Furry and black, it makes you shudder to look at it. This one has brilliant green eyes."
@@ -144,6 +149,9 @@
 	set category = "Spider"
 	set desc = "Spread a sticky web to slow down prey."
 
+	if(stat == DEAD)
+		return
+
 	var/T = src.loc
 
 	if(busy != SPINNING_WEB)
@@ -161,6 +169,9 @@
 	set name = "Wrap"
 	set category = "Spider"
 	set desc = "Wrap up prey to feast upon and objects for safe keeping."
+
+	if(stat == DEAD)
+		return
 
 	if(!cocoon_target)
 		var/list/choices = list()
@@ -217,6 +228,9 @@
 	set name = "Lay Eggs"
 	set category = "Spider"
 	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
+
+	if(stat == DEAD)
+		return
 
 	var/obj/structure/spider/eggcluster/E = locate() in get_turf(src)
 	if(E)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -149,7 +149,7 @@
 	set category = "Spider"
 	set desc = "Spread a sticky web to slow down prey."
 
-	if(stat == UNCONSCIOUS)
+	if(incapacitated())
 		return
 
 	var/T = src.loc
@@ -170,7 +170,7 @@
 	set category = "Spider"
 	set desc = "Wrap up prey to feast upon and objects for safe keeping."
 
-	if(stat == UNCONSCIOUS)
+	if(incapacitated())
 		return
 
 	if(!cocoon_target)
@@ -229,7 +229,7 @@
 	set category = "Spider"
 	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
 
-	if(stat == UNCONSCIOUS)
+	if(incapacitated())
 		return
 
 	var/obj/structure/spider/eggcluster/E = locate() in get_turf(src)


### PR DESCRIPTION
**What does this PR do:**
Nurse spiders can no longer use abilities when dead.
Giant spiders born without a faction will automatically join the spiders' faction. This fixes changeling spiders attacking eachother.

**Changelog:**
:cl:
fix: Fixed giant spiders being born without a faction when created by changelings. They will no longer attack eachother.
fix: Fixed player controlled nurse giant spiders being able to use abilities while dead.
fix: Revived mobs are no longer pass-through.
/:cl: