### PR TITLE
Round start delay works properly again

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -68,8 +68,14 @@ SUBSYSTEM_DEF(ticker)
 			current_state = GAME_STATE_PREGAME
 			fire() // TG says this is a good idea
 		if(GAME_STATE_PREGAME)
+			if(!going)
+				return
+
 			// This is so we dont have sleeps in controllers, because that is a bad, bad thing
-			pregame_timeleft = max(0,round_start_time - world.time)
+			if(!delay_end)
+				pregame_timeleft = max(0,round_start_time - world.time) // Normal lobby countdown when roundstart was not delayed			
+			else
+				pregame_timeleft = max(0,pregame_timeleft - 20) // If roundstart was delayed, we should resume the countdown where it left off
 
 			if(pregame_timeleft <= 600 && !tipped) // 60 seconds
 				send_tip_of_the_round()
@@ -83,6 +89,7 @@ SUBSYSTEM_DEF(ticker)
 				current_state = GAME_STATE_STARTUP
 				Master.SetRunLevel(RUNLEVEL_LOBBY)
 		if(GAME_STATE_PLAYING)
+			delay_end = 0 // reset this in case round start was delayed
 			mode.process()
 			mode.process_job_tasks()
 			var/game_finished = SSshuttle.emergency.mode >= SHUTTLE_ENDGAME || mode.station_was_nuked

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -784,11 +784,13 @@ var/global/nologevent = 0
 		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
 		message_admins("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].", 1)
 		return //alert("Round end delayed", null, null, null, null, null)
-	going = !( going )
-	if(!( going ))
+	if(going)
+		going = FALSE
+		SSticker.delay_end = TRUE
 		to_chat(world, "<b>The game start has been delayed.</b>")
 		log_admin("[key_name(usr)] delayed the game.")
 	else
+		going = TRUE
 		to_chat(world, "<b>The game will start soon.</b>")
 		log_admin("[key_name(usr)] removed the delay.")
 	feedback_add_details("admin_verb","DELAY") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
**What does this PR do:**
The admin command to delay round start now properly delays round start again. When you un-delay it, the pre-game lobby timer resumes where it left off.

**Changelog:**
:cl:
fix: Delaying round start actually delays round start again
/:cl:

