### PR TITLE
Fixes pushing necropolis tendrils

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -99,6 +99,8 @@
 			itemcount++
 
 	for(var/mob/M in loc)
+		if(M.mob_size <= MOB_SIZE_LARGE) // No more stuffing xeno empresses into lockers
+			return FALSE
 		if(itemcount >= storage_capacity)
 			break
 		if(istype(M, /mob/dead/observer))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -19,7 +19,6 @@
 	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate then open it in a populated area to crash clients.
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
-	var/mob_size = MOB_SIZE_LARGE
 
 /obj/structure/closet/New()
 	..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -19,6 +19,7 @@
 	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate then open it in a populated area to crash clients.
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
+	var/mob_size = MOB_SIZE_LARGE
 
 /obj/structure/closet/New()
 	..()
@@ -99,15 +100,13 @@
 			itemcount++
 
 	for(var/mob/M in loc)
-		if(M.mob_size <= MOB_SIZE_LARGE) // No more stuffing xeno empresses into lockers
-			return FALSE
 		if(itemcount >= storage_capacity)
 			break
 		if(istype(M, /mob/dead/observer))
 			continue
 		if(istype(M, /mob/living/simple_animal/bot/mulebot))
 			continue
-		if(M.buckled)
+		if(M.buckled || M.anchored)
 			continue
 
 		M.forceMove(src)

--- a/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
@@ -18,6 +18,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	move_resist = INFINITY
+	anchored = TRUE
 	loot = list(/obj/effect/collapse, /obj/structure/closet/crate/necropolis/tendril)
 	del_on_death = 1
 	var/gps = null

--- a/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
@@ -17,6 +17,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
+	move_resist = INFINITY
 	loot = list(/obj/effect/collapse, /obj/structure/closet/crate/necropolis/tendril)
 	del_on_death = 1
 	var/gps = null

--- a/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
@@ -18,6 +18,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	move_resist = INFINITY
+	anchored = TRUE
 	mob_size = MOB_SIZE_LARGE
 	loot = list(/obj/effect/collapse, /obj/structure/closet/crate/necropolis/tendril)
 	del_on_death = 1

--- a/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
@@ -18,7 +18,6 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	move_resist = INFINITY
-	anchored = TRUE
 	loot = list(/obj/effect/collapse, /obj/structure/closet/crate/necropolis/tendril)
 	del_on_death = 1
 	var/gps = null

--- a/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
@@ -19,7 +19,6 @@
 	maxbodytemp = INFINITY
 	move_resist = INFINITY
 	anchored = TRUE
-	mob_size = MOB_SIZE_LARGE
 	loot = list(/obj/effect/collapse, /obj/structure/closet/crate/necropolis/tendril)
 	del_on_death = 1
 	var/gps = null

--- a/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/necropolis_tendril.dm
@@ -18,6 +18,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	move_resist = INFINITY
+	mob_size = MOB_SIZE_LARGE
 	loot = list(/obj/effect/collapse, /obj/structure/closet/crate/necropolis/tendril)
 	del_on_death = 1
 	var/gps = null


### PR DESCRIPTION
**What does this PR do:**
Anchors necropolis tendrils, and makes them very stronk against pushing.
Lockers won't be able to move anchored mobs now.
Fixes #12132 

**Changelog:**

:cl:
fix: Lockers can no longer move around anchored mobs. 
/:cl: