### PR TITLE
Refactors Gloves of the North Star. Adds Gloves of Headpats

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1599,7 +1599,7 @@
 					/obj/item/fish_eggs/electric_eel = 10, /obj/item/fish_eggs/shrimp = 5, /obj/item/toy/pet_rock = 100,
 					)
 	contraband = list(/obj/item/fish_eggs/babycarp = 5)
-	premium = list(/obj/item/toy/pet_rock/fred = 1, /obj/item/toy/pet_rock/roxie = 1)
+	premium = list(/obj/item/toy/pet_rock/fred = 1, /obj/item/toy/pet_rock/roxie = 1, /obj/item/clothing/gloves/fingerless/rapid/headpat = 1)
 	refill_canister = /obj/item/vending_refill/crittercare
 
 /obj/machinery/vending/crittercare/free

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -168,3 +168,9 @@
 	accepted_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	click_speed_modifier = 0
 	siemens_coefficient = 0
+
+/obj/item/clothing/gloves/fingerless/rapid/headpat
+	name = "Gloves of Headpats"
+	desc = "You feel the irresistable urge to give headpats by merely glimpsing these."
+	accepted_intents = list(INTENT_HELP)
+	click_speed_modifier = 0 // That's some serious headpatting

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -152,10 +152,19 @@
 /obj/item/clothing/gloves/fingerless/rapid
 	name = "Gloves of the North Star"
 	desc = "Just looking at these fills you with an urge to beat the shit out of people."
+	var/accepted_intents = list(INTENT_HARM)
+	var/click_speed_modifier = CLICK_CD_RAPID
 
 /obj/item/clothing/gloves/fingerless/rapid/Touch(mob/living/target, proximity = TRUE)
 	var/mob/living/M = loc
 
-	if(M.a_intent == INTENT_HARM)
-		M.changeNext_move(CLICK_CD_RAPID)
+	if(M.a_intent in accepted_intents)
+		M.changeNext_move(click_speed_modifier)
 	.= FALSE
+
+/obj/item/clothing/gloves/fingerless/rapid/admin
+	name = "Advanced Interactive Gloves"
+	desc = "The gloves are covered in indecipherable buttons and dials, your mind warps my merely looking at them."
+	accepted_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
+	click_speed_modifier = 0
+	siemens_coefficient = 0


### PR DESCRIPTION
Refactors gloves of the North Star to be var-editable.

You can now var edit these properties:
- Which intents it works with
- How much click delay it sets.

You could feasibly do any number of things with this, like `NO_DROP` gloves that apply to all intents and double your click delay, or be super adminbusy and have a pair of gloves that removes the click delay from all intents.

Adds and adminbus varient to the code, directly, to go with the laser glasses, ACJ, and Advanced Protective Suit.

Lastly, adds a gimmick variety of these gloves, called "Gloves of Headpats" that is available as a premium item from the pet vendor (only 1) that removes the click delay for help intent.

:cl: Fox McCloud
tweak: refactored gloves of the North Star to be more adminbusy
add: Adds Gloves of Headpats to the pet vendor as a premium item
/:cl: