### PR TITLE
Fixes Blooddrunk Buff

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -45,13 +45,6 @@
 	duration = 10
 	tick_interval = 0
 	alert_type = /obj/screen/alert/status_effect/blooddrunk
-	var/last_health = 0
-	var/last_bruteloss = 0
-	var/last_fireloss = 0
-	var/last_toxloss = 0
-	var/last_oxyloss = 0
-	var/last_cloneloss = 0
-	var/last_staminaloss = 0
 
 /obj/screen/alert/status_effect/blooddrunk
 	name = "Blood-Drunk"
@@ -61,108 +54,32 @@
 /datum/status_effect/blooddrunk/on_apply()
 	. = ..()
 	if(.)
-		owner.maxHealth *= 10
-		owner.bruteloss *= 10
-		owner.fireloss *= 10
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 			for(var/X in H.bodyparts)
 				var/obj/item/organ/external/BP = X
-				BP.max_damage *= 10
-				BP.min_broken_damage *= 10
-				BP.brute_dam *= 10
-				BP.burn_dam *= 10
-		owner.toxloss *= 10
-		owner.oxyloss *= 10
-		owner.cloneloss *= 10
-		owner.staminaloss *= 10
-		owner.updatehealth()
-		last_health = owner.health
-		last_bruteloss = owner.getBruteLoss()
-		last_fireloss = owner.getFireLoss()
-		last_toxloss = owner.getToxLoss()
-		last_oxyloss = owner.getOxyLoss()
-		last_cloneloss = owner.getCloneLoss()
-		last_staminaloss = owner.getStaminaLoss()
+				BP.brute_mod *= 0.1
+				BP.burn_mod *= 0.1
+			H.dna.species.tox_mod *= 0.1
+			H.dna.species.oxy_mod *= 0.1
+			H.dna.species.clone_mod *= 0.1
+			H.dna.species.stamina_mod *= 0.1
 		add_attack_logs(owner, owner, "gained blood-drunk stun immunity")
 		var/status = CANSTUN | CANWEAKEN | CANPARALYSE | IGNORESLOWDOWN
 		owner.status_flags &= ~status
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, 1)
 
-/datum/status_effect/blooddrunk/tick() //multiply the effect of healing by 10
-	if(owner.health > last_health)
-		var/needs_health_update = FALSE
-		var/new_bruteloss = owner.getBruteLoss()
-		if(new_bruteloss < last_bruteloss)
-			var/heal_amount = (new_bruteloss - last_bruteloss) * 10
-			owner.adjustBruteLoss(heal_amount, updating_health = FALSE)
-			new_bruteloss = owner.getBruteLoss()
-			needs_health_update = TRUE
-		last_bruteloss = new_bruteloss
-
-		var/new_fireloss = owner.getFireLoss()
-		if(new_fireloss < last_fireloss)
-			var/heal_amount = (new_fireloss - last_fireloss) * 10
-			owner.adjustFireLoss(heal_amount, updating_health = FALSE)
-			new_fireloss = owner.getFireLoss()
-			needs_health_update = TRUE
-		last_fireloss = new_fireloss
-
-		var/new_toxloss = owner.getToxLoss()
-		if(new_toxloss < last_toxloss)
-			var/heal_amount = (new_toxloss - last_toxloss) * 10
-			owner.adjustToxLoss(heal_amount, updating_health = FALSE)
-			new_toxloss = owner.getToxLoss()
-			needs_health_update = TRUE
-		last_toxloss = new_toxloss
-
-		var/new_oxyloss = owner.getOxyLoss()
-		if(new_oxyloss < last_oxyloss)
-			var/heal_amount = (new_oxyloss - last_oxyloss) * 10
-			owner.adjustOxyLoss(heal_amount, updating_health = FALSE)
-			new_oxyloss = owner.getOxyLoss()
-			needs_health_update = TRUE
-		last_oxyloss = new_oxyloss
-
-		var/new_cloneloss = owner.getCloneLoss()
-		if(new_cloneloss < last_cloneloss)
-			var/heal_amount = (new_cloneloss - last_cloneloss) * 10
-			owner.adjustCloneLoss(heal_amount, updating_health = FALSE)
-			new_cloneloss = owner.getCloneLoss()
-			needs_health_update = TRUE
-		last_cloneloss = new_cloneloss
-
-		var/new_staminaloss = owner.getStaminaLoss()
-		if(new_staminaloss < last_staminaloss)
-			var/heal_amount = (new_staminaloss - last_staminaloss) * 10
-			owner.adjustStaminaLoss(heal_amount, updating_health = FALSE)
-			new_staminaloss = owner.getStaminaLoss()
-			needs_health_update = TRUE
-		last_staminaloss = new_staminaloss
-
-		if(needs_health_update)
-			owner.updatehealth()
-			owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, 1)
-	last_health = owner.health
-
 /datum/status_effect/blooddrunk/on_remove()
-	tick()
-	owner.maxHealth *= 0.1
-	owner.bruteloss *= 0.1
-	owner.fireloss *= 0.1
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		for(var/X in H.bodyparts)
 			var/obj/item/organ/external/BP = X
-			BP.brute_dam *= 0.1
-			BP.burn_dam *= 0.1
-			BP.max_damage /= 10
-			BP.min_broken_damage /= 10
-	owner.toxloss *= 0.1
-	owner.oxyloss *= 0.1
-	owner.cloneloss *= 0.1
-	owner.staminaloss *= 0.1
-	owner.updatehealth()
+			BP.brute_mod *= 10
+			BP.burn_mod *= 10
+		H.dna.species.tox_mod *= 10
+		H.dna.species.oxy_mod *= 10
+		H.dna.species.clone_mod *= 10
+		H.dna.species.stamina_mod *= 10
 	add_attack_logs(owner, owner, "lost blood-drunk stun immunity")
 	owner.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | IGNORESLOWDOWN
 

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -209,7 +209,7 @@
 		if(istype(T, denied_type) || istype(src, T.denied_type))
 			to_chat(user, "<span class='warning'>You can't seem to attach [src] to [H]. Maybe remove a few trophies?</span>")
 			return FALSE
-	if(!user.drop_item())
+	if(!user.unEquip(src))
 		return
 	forceMove(H)
 	H.trophies += src

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -202,6 +202,16 @@
 		amount = amount * dna.species.tox_mod
 	. = ..()
 
+/mob/living/carbon/human/adjustStaminaLoss(amount, updating = TRUE)
+	if(dna.species && amount > 0)
+		amount = amount * dna.species.stamina_mod
+	. = ..()
+
+/mob/living/carbon/human/setStaminaLoss(amount, updating = TRUE)
+	if(dna.species && amount > 0)
+		amount = amount * dna.species.stamina_mod
+	. = ..()
+
 ////////////////////////////////////////////
 
 //Returns a list of damaged organs

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -50,6 +50,7 @@
 	var/oxy_mod = 1		 // Oxy damage reduction/amplification
 	var/clone_mod = 1	 // Clone damage reduction/amplification
 	var/brain_mod = 1    // Brain damage damage reduction/amplification
+	var/stamina_mod = 1
 	var/stun_mod = 1	 // If a species is more/less impacated by stuns/weakens/paralysis
 
 	var/blood_damage_type = OXY //What type of damage does this species take if it's low on blood?


### PR DESCRIPTION
As I suspected, TG's logic of handling the blood drunk buff wasn't adequate.

It should now function, as intended; a short, 1 second buff that makes you stun immune+reduces the damage you take by 90% in addition to allowing you to ignore slowdown.

Also fixes the logic with attacking a crusher trophy with your Kinetic Crusher; it'd properly equip the trophy, but make you drop your Crusher; now it just equips the trophy to the crusher, properly

fixes: https://github.com/ParadiseSS13/Paradise/issues/12141

:cl: Fox McCloud
fix: Fixes blood drunk buff
fix: Fixes using a crusher on a trophy to equip it causing you to drop the crusher
/:cl: