### PR TITLE
Fix Incorrect Eye-Colour for Races Without Shiny Eyes

### DIFF
--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -103,6 +103,7 @@ var/global/list/limb_icon_cache = list()
 	if(dna.species.has_organ["eyes"])
 		var/icon/eyes_icon = owner.get_eyecon()
 		if(eyes_icon)
+			mob_icon.Blend(eyes_icon, ICON_OVERLAY)
 			add_overlay(eyes_icon)
 
 	if(owner.lip_style && (LIPS in dna.species.species_traits))

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -103,7 +103,7 @@ var/global/list/limb_icon_cache = list()
 	if(dna.species.has_organ["eyes"])
 		var/icon/eyes_icon = owner.get_eyecon()
 		if(eyes_icon)
-			mob_icon.Blend(eyes_icon, ICON_OVERLAY)
+			mob_icon.Blend(eyes_icon, ICON_OVERLAY) //This is required since update_icons.dm relies on this proc to render non-shining eyes.
 			add_overlay(eyes_icon)
 
 	if(owner.lip_style && (LIPS in dna.species.species_traits))


### PR DESCRIPTION
Overlays don't carry over from organ get_icon() and have to be blended if we want to use them in that way - currently eyes are the only thing update_icons() doesn't have its own way of rendering so eyes are the only thing here that get blended AND overlayed

**What does this PR do:**
Reverts a change I made in #12114 because `update_icons.dm` requires the head organ get eyes blended onto it from `get_icon()` as it's the only thing `update_icons.dm` doesn't have its own method of rendering.

See a more detailed explanation in the linked issue - resolves #12143 

**Images of sprite/map changes (IF APPLICABLE):**
_Spawned in with proper eye colour on left - used C.M.A. Admin to become satanic on the right_
![para ss13 fix the eyes I broke](https://user-images.githubusercontent.com/12377767/63993936-3ad57c80-cae2-11e9-899c-185895bff7d2.png)

**Changelog:**
:cl:
fix: Non-shining eyes render the proper colour again.
/:cl:

