### PR TITLE
Add the paranormal scanner to Inquisitor ERT

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -856,3 +856,38 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 		dat += "<font color='red'>Retinal misalignment detected.</font><BR>"
 
 	return dat
+
+/obj/item/paranormal_scanner
+	name = "paranormal scanner"
+	desc = "A device able to deep-scan a person to identify anomalous elements. Able to spot vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "spectrometer"
+	w_class = WEIGHT_CLASS_SMALL
+	slot_flags = SLOT_BELT
+	var/scan_time = 20 SECONDS
+
+/obj/item/paranormal_scanner/advanced
+	name = "advanced paranormal scanner"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "adv_spectrometer"
+	scan_time = 10 SECONDS
+
+/obj/item/paranormal_scanner/attack(mob/living/M, mob/living/user)
+	if(user.incapacitated() || !user.Adjacent(M))
+		return
+	if(M && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		user.visible_message("[user] begins scanning [M] with [src].", "You begin scanning [M].")
+		if(do_after(user, scan_time, target = M))
+			if(H.mind && H.mind.vampire)
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='danger'>VAMPIRE</span>")
+			else if(isvampirethrall(H))
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='warning'>VAMPIRE THRALL</span>")
+			else if(iscultist(H))
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='danger'>NAR'SIE CULTIST</span>")
+			else if(iswizard(H) || (H.mind && H.mind.special_role == SPECIAL_ROLE_WIZARD_APPRENTICE))
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='userdanger'>WIZARD</span>")
+			else
+				to_chat(user, "<span class='notice'>Scan result : Ordinary</span>")
+	else
+		to_chat(user, "<span class='notice'>Error : Cannot scan [M].</span>")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -862,7 +862,7 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 
 /obj/item/paranormal_scanner
 	name = "paranormal scanner"
-	desc = "A device able to deep-scan a person to identify anomalous elements. Able to spot vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
+	desc = "A device used to deep-scan a person to identify anomalous elements. Spots vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
 	item_state = "analyzer"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -6,7 +6,10 @@ HEALTH ANALYZER
 GAS ANALYZER
 PLANT ANALYZER
 REAGENT SCANNER
+BODY ANALYZER
+PARANORMAL SCANNER
 */
+
 /obj/item/t_scanner
 	name = "T-ray scanner"
 	desc = "A terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
@@ -862,13 +865,13 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 	desc = "A device able to deep-scan a person to identify anomalous elements. Able to spot vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
+	item_state = "analyzer"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = SLOT_BELT
 	var/scan_time = 20 SECONDS
 
 /obj/item/paranormal_scanner/advanced
 	name = "advanced paranormal scanner"
-	icon = 'icons/obj/device.dmi'
 	icon_state = "adv_spectrometer"
 	scan_time = 10 SECONDS
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -862,7 +862,7 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 
 /obj/item/paranormal_scanner
 	name = "paranormal scanner"
-	desc = "A device used to deep-scan a person to identify anomalous elements. Spots vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
+	desc = "A device used to deep-scan a person to identify anomalous elements. Spots vampires and their thralls, Nar'Sie cultists, wizards and devils. Must be used next to the target, and takes a while to scan."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
 	item_state = "analyzer"
@@ -890,6 +890,8 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 				to_chat(user, "<span class='notice'>Scan result : </span><span class='danger'>NAR'SIE CULTIST</span>")
 			else if(iswizard(H) || (H.mind && H.mind.special_role == SPECIAL_ROLE_WIZARD_APPRENTICE))
 				to_chat(user, "<span class='notice'>Scan result : </span><span class='userdanger'>WIZARD</span>")
+			else if(H.mind && H.mind.devilinfo)
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='userdanger'>DEVIL</span>")
 			else
 				to_chat(user, "<span class='notice'>Scan result : Ordinary</span>")
 	else

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -416,6 +416,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
 	suit_store = /obj/item/gun/energy/gun
 	r_pocket = /obj/item/nullrod/ert
+	l_pocket = /obj/item/paranormal_scanner
 	glasses = /obj/item/clothing/glasses/sunglasses
 
 	cybernetic_implants = list(
@@ -429,8 +430,9 @@
 	suit_store = /obj/item/gun/energy/gun/nuclear
 	l_pocket = /obj/item/grenade/clusterbuster/holy
 	shoes = /obj/item/clothing/shoes/magboots/advance
-	glasses = /obj/item/clothing/glasses/night
 	r_pocket = /obj/item/nullrod/ert
+	l_pocket = /obj/item/paranormal_scanner/advanced
+	glasses = /obj/item/clothing/glasses/night
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,


### PR DESCRIPTION
This PR adds the paranormal scanner to Red Inquisitors and the advanced paranormal scanner to Gamma Inquisitors.

The paranormal scanner when used on a human will scan them. After 20 (10 for advanced) seconds, it will reveal if the target is a Vampire, Vampire Thrall, Cultist, Devil, or Wizard.

The main purpose and use case of the scanner is as an admin response to an effective mindswap wizard, which currently has no existing counters as there is no possible test for wizards (other than knowing who was swapped or seeing the wiz cast shit, which removes the need for a test).

As it is slow to use and requires both you and the target to be immobile, it is probably still better to use holy water to test for vamps and cultists, which is intentional. This can still be used to test non-mindshielded command and make sure they are trustworthy, for example.

Currently the scanner uses the spectrometer/advanced spectrometer sprites. I will look into getting unique sprites for it if feedback is positive.

:cl:
add: Added the paranormal scanner to Red and Gamma Inquisitor ERT.
/:cl: