### PR TITLE
Changes the colour of playtime-required jobs

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -642,7 +642,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			continue
 		var/available_in_playtime = job.available_in_playtime(user.client)
 		if(available_in_playtime)
-			HTML += "<del>[rank]</del></td><td> \[ " + get_exp_format(available_in_playtime) + " as " + job.get_exp_req_type()  + " \]</td></tr>"
+			HTML += "<del><font color=red>[rank]</font></del></td><td><font color=red> \[ " + get_exp_format(available_in_playtime) + " as " + job.get_exp_req_type()  + " \]</font></td></tr>"
 			continue
 		if(job.barred_by_disability(user.client))
 			HTML += "<del>[rank]</del></td><td> \[ DISABILITY \]</td></tr>"


### PR DESCRIPTION
**What does this PR do:**
Fixes: #12148
Makes jobs which you do not have access to due to insufficient playtime red, instead of white.

![image](https://user-images.githubusercontent.com/44811257/64052324-adc30f80-cb43-11e9-962d-7d410ecd507a.png)

(**Note**: The `none as ...` thing shouldn't happen normally. I just didn't bother to setup a DB or anything, and I just set the check to TRUE to test it.)

**Changelog:**
*Remove this line, and appropriate fields from the changelog*
:cl:
tweak: Jobs which you have insufficient playtime for are now red.
/:cl:

