### PR TITLE
Fix blood stacking

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -59,7 +59,8 @@
 		for(var/obj/effect/decal/cleanable/C in loc)
 			if(C != src && C.type == type && !QDELETED(C))
 				if(replace_decal(C))
-					return INITIALIZE_HINT_QDEL
+					qdel(src)
+					return
 	if(random_icon_states && length(src.random_icon_states) > 0)
 		src.icon_state = pick(src.random_icon_states)
 	if(smooth)


### PR DESCRIPTION
**What does this PR do:**
after some tests and looking through comments in the code it seems that INITIALIZE_HINT_QDEL doesn't work as intended. I can't figure out how to fix it myself but for the time being this is the only way to reliably qdelete items during initialization until the initialize hint can be fixed

fixes: #12163 

**Changelog:**
:cl:
fix: blood no longer stacks on itself endlessly
/:cl:

