### PR TITLE
Saves a Few Thousand Objects From Being Created

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -10,15 +10,14 @@
 	var/display_color = null  // Display color for vending machine listing
 	var/category = CAT_NORMAL  // CAT_HIDDEN for contraband, CAT_COIN for premium
 
-/datum/data/vending_product/New(var/path, var/name = null, var/amount = 1, var/price = 0, var/color = null, var/category = CAT_NORMAL)
+/datum/data/vending_product/New(path, name = null, amount = 1, price = 0, color = null, category = CAT_NORMAL)
 	..()
 
 	product_path = path
 
 	if(!name)
-		var/atom/tmp = new path
-		product_name = initial(tmp.name)
-		qdel(tmp)
+		var/atom/temp = path
+		product_name = initial(temp.name)
 	else
 		product_name = name
 
@@ -138,7 +137,7 @@
 		var/category = current_list[2]
 
 		for(var/entry in current_list[1])
-			var/datum/data/vending_product/product = new/datum/data/vending_product(entry)
+			var/datum/data/vending_product/product = new /datum/data/vending_product(entry)
 
 			product.price = (entry in prices) ? prices[entry] : 0
 			product.amount = (current_list[1][entry]) ? current_list[1][entry] : 1


### PR DESCRIPTION
Old code, bad code.

Vending machines created every single item in their inventory....just to get the object name.

Why do that when we can abuse `initial`?

:cl: Fox McCloud
fix: Reduces round-start lag
/:cl: