### PR TITLE
Fixes Endless Deletes Overwhelming the GC

### DIFF
--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -62,8 +62,8 @@ var/global/list/obj/item/pda/PDAs = list()
 /*
  *	The Actual PDA
  */
-/obj/item/pda/New()
-	..()
+/obj/item/pda/Initialize(mapload)
+	. = ..()
 	PDAs += src
 	PDAs = sortAtom(PDAs)
 	update_programs()

--- a/code/modules/pda/cart.dm
+++ b/code/modules/pda/cart.dm
@@ -59,9 +59,9 @@
 		new/datum/data/pda/app/crew_records/security,
 		new/datum/data/pda/app/secbot_control)
 
-/obj/item/cartridge/security/Initialize()
+/obj/item/cartridge/security/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/beepsky(src)
-	..()
 
 /obj/item/cartridge/detective
 	name = "D.E.T.E.C.T. Cartridge"
@@ -109,9 +109,9 @@
 	desc = "A data cartridge with an integrated radio signaler module."
 	programs = list(new/datum/data/pda/app/signaller)
 
-/obj/item/cartridge/signal/Initialize()
+/obj/item/cartridge/signal/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/signal(src)
-	..()
 
 /obj/item/cartridge/signal/toxins
 	name = "Signal Ace 2"
@@ -132,9 +132,9 @@
 		new/datum/data/pda/app/supply,
 		new/datum/data/pda/app/mule_control)
 
-/obj/item/cartridge/quartermaster/Initialize()
+/obj/item/cartridge/quartermaster/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/mule(src)
-	..()
 
 /obj/item/cartridge/head
 	name = "Easy-Record DELUXE"
@@ -154,9 +154,9 @@
 
 		new/datum/data/pda/app/status_display)
 
-/obj/item/cartridge/hop/Initialize()
+/obj/item/cartridge/hop/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/mule(src)
-	..()
 
 /obj/item/cartridge/hos
 	name = "R.O.B.U.S.T. DELUXE"
@@ -167,9 +167,9 @@
 
 		new/datum/data/pda/app/status_display)
 
-/obj/item/cartridge/hos/Initialize()
+/obj/item/cartridge/hos/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/beepsky(src)
-	..()
 
 /obj/item/cartridge/ce
 	name = "Power-On DELUXE"
@@ -205,9 +205,9 @@
 
 		new/datum/data/pda/app/status_display)
 
-/obj/item/cartridge/rd/Initialize()
+/obj/item/cartridge/rd/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/signal(src)
-	..()
 
 /obj/item/cartridge/captain
 	name = "Value-PAK Cartridge"
@@ -234,9 +234,9 @@
 
 		new/datum/data/pda/app/status_display)
 
-/obj/item/cartridge/captain/Initialize()
+/obj/item/cartridge/captain/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/beepsky(src)
-	..()
 
 /obj/item/cartridge/supervisor
 	name = "Easy-Record DELUXE"
@@ -271,9 +271,9 @@
 
 		new/datum/data/pda/app/status_display)
 
-/obj/item/cartridge/centcom/Initialize()
+/obj/item/cartridge/centcom/Initialize(mapload)
+	. = ..()
 	radio = new /obj/item/integrated_radio/beepsky(src)
-	..()
 
 /obj/item/cartridge/syndicate
 	name = "Detomatix Cartridge"
@@ -283,7 +283,8 @@
 	programs = list(new/datum/data/pda/utility/toggle_door)
 	messenger_plugins = list(new/datum/data/pda/messenger_plugin/virus/detonate)
 
-/obj/item/cartridge/syndicate/New()
+/obj/item/cartridge/syndicate/Initialize(mapload)
+	. = ..()
 	var/datum/data/pda/utility/toggle_door/D = programs[1]
 	if(istype(D))
 		D.remote_door_id = initial_remote_door_id

--- a/code/modules/pda/radio.dm
+++ b/code/modules/pda/radio.dm
@@ -17,13 +17,12 @@
 	var/on = 0 //Are we currently active??
 	var/menu_message = ""
 
-/obj/item/integrated_radio/New()
-	..()
+/obj/item/integrated_radio/Initialize(mapload)
+	. = ..()
 	if(istype(loc.loc, /obj/item/pda))
 		hostpda = loc.loc
 	if(bot_filter)
-		spawn(5)
-			add_to_radio(bot_filter)
+		add_to_radio(bot_filter)
 
 /obj/item/integrated_radio/Destroy()
 	if(SSradio)
@@ -176,7 +175,8 @@
 	radio_connection = null
 	return ..()
 
-/obj/item/integrated_radio/signal/Initialize()
+/obj/item/integrated_radio/signal/Initialize(mapload)
+	. = ..()
 	if(!SSradio)
 		return
 	if(src.frequency < PUBLIC_LOW_FREQ || src.frequency > PUBLIC_HIGH_FREQ)


### PR DESCRIPTION
Initialization biting us in the butt---again.

Either case, cartridges were causing endless amounts of `/obj/item/integrated_radio/mule` and `/obj/item/integrated_radio/beepsky` to be deleted---constantly and incessantly. There was so many of them it was overwhelming the GC.

This is probably why the GC was so high for a time. 

:cl: Fox McCloud
fix: Fixes certain PDA cartridges causing insane performance loss
/:cl: