### PR TITLE
Tweaks Space Carp Event: Improve Performance

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -4,20 +4,18 @@
 
 	var/list/spawned_mobs = list(
     /mob/living/simple_animal/hostile/carp = 95,
-    /mob/living/simple_animal/hostile/carp/megacarp = 5,
-	)
-	var/list/spawned_carp = list()
+    /mob/living/simple_animal/hostile/carp/megacarp = 5)
 
 /datum/event/carp_migration/setup()
 	announceWhen = rand(40, 60)
-	endWhen = rand(600,1200)
+	endWhen = rand(600, 1200)
 
 /datum/event/carp_migration/announce()
 	var/announcement = ""
 	if(severity == EVENT_LEVEL_MAJOR)
 		announcement = "Massive migration of unknown biological entities has been detected near [station_name()], please stand-by."
 	else
-		announcement = "Unknown biological [spawned_carp.len == 1 ? "entity has" : "entities have"] been detected near [station_name()], please stand-by."
+		announcement = "Unknown biological entities have been detected near [station_name()], please stand-by."
 	event_announcement.Announce(announcement, "Lifesign Alert")
 
 /datum/event/carp_migration/start()
@@ -29,7 +27,7 @@
 	else
 		spawn_fish(rand(1, 3), 1, 2)	//1 to 6 carp, alone or in pairs
 
-/datum/event/carp_migration/proc/spawn_fish(var/num_groups, var/group_size_min=3, var/group_size_max=5)
+/datum/event/carp_migration/proc/spawn_fish(num_groups, group_size_min = 3, group_size_max = 5)
 	var/list/spawn_locations = list()
 
 	for(var/obj/effect/landmark/C in GLOB.landmarks_list)
@@ -43,12 +41,5 @@
 		var/group_size = rand(group_size_min, group_size_max)
 		for(var/j = 1, j <= group_size, j++)
 			var/carptype = pickweight(spawned_mobs)
-			spawned_carp.Add(new carptype(spawn_locations[i]))
+			new carptype(spawn_locations[i])
 		i++
-
-/datum/event/carp_migration/end()
-	for(var/mob/living/simple_animal/hostile/C in spawned_carp)
-		if(!C.stat)
-			var/turf/T = get_turf(C)
-			if(istype(T, /turf/space))
-				qdel(C)

--- a/code/modules/events/koi_mirgration.dm
+++ b/code/modules/events/koi_mirgration.dm
@@ -1,8 +1,7 @@
 /datum/event/carp_migration/koi
 	spawned_mobs = list(
-    /mob/living/simple_animal/hostile/retaliate/carp/koi = 95,
-    /mob/living/simple_animal/hostile/retaliate/carp/koi/honk = 2,
-	)
+    /mob/living/simple_animal/hostile/retaliate/carp/koi = 98,
+    /mob/living/simple_animal/hostile/retaliate/carp/koi/honk = 2)
 
 
 /datum/event/carp_migration/koi/start()


### PR DESCRIPTION
The Carp migration event no longer deletes all the carp when the event ends.

I wasn't a fan of this deleting the carp---what's the point to the event then? They're meant to stick around to be a threat and make space more dangerous to go to, not something you just wait out and "oh, they're gone now".

Also dramatically improves the performance of the event; the carp were added to a list on the event that was a hard reference--as such, it made deleting the carp/koi take a lot longer than it otherwise would have.

:cl: Fox McCloud
tweak: Carp Migration event no longer deletes the carp when it ends; they will continue to stick around the station
/:cl: