### PR TITLE
Romerol zombies hotfix

### DIFF
--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -44,7 +44,7 @@
 	var/obj/item/organ/internal/zombie_infection/infection
 	infection = target.get_organ_slot("zombie_infection")
 	if(!infection)
-		if (target.InCritical() || (!target.check_death_method() && target.health <= HEALTH_THRESHOLD_DEAD))
+		if(target.InCritical() || (!target.check_death_method() && target.health <= HEALTH_THRESHOLD_DEAD))
 			infection = new(target)
 
 /obj/item/zombie_hand/proc/check_feast(mob/living/target, mob/living/user)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -15,8 +15,8 @@
 
 /obj/item/organ/internal/zombie_infection/New()
 	. = ..()
-	if(ishuman(owner) && !ismachine(owner) && !iszombie(owner.dna.species))
-		old_species = owner.dna.species
+	if(ishuman(owner) && !iszombie(owner))
+		old_species = owner.dna.species.type
 	GLOB.zombie_infection_list += src
 
 /obj/item/organ/internal/zombie_infection/Destroy()


### PR DESCRIPTION
**What does this PR do:**
fixes a circular reference added by romerol zombies

**Changelog:**
:cl:
fix: fixes a circular reference
/:cl:

