### PR TITLE
Fixes Romerol--Comments it Out Until Refactor

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -189,7 +189,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/fake_revolver
 	cost = 1
 	job = list("Clown")
-
+/*
 /datum/uplink_item/stealthy_weapons/romerol_kit
 	name = "Romerol"
 	reference = "ROM"
@@ -197,7 +197,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/romerol
 	cost = 25
 	cant_discount = TRUE
-
+*/
 //mime
 /datum/uplink_item/jobspecific/caneshotgun
 	name = "Cane Shotgun and Assassination Shells"

--- a/code/modules/mob/living/carbon/human/species/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species/zombies.dm
@@ -17,6 +17,7 @@
 	cold_level_1 = -1
 	cold_level_2 = -1
 	cold_level_3 = -1
+	tox_mod = 0
 	flesh_color = "#00FF00" // for green examine text
 	bodyflags = HAS_SKIN_COLOR
 	dietflags = DIET_CARN

--- a/code/modules/mob/living/carbon/human/species/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species/zombies.dm
@@ -8,14 +8,19 @@
 	deform = 'icons/mob/human_races/r_def_zombie.dmi'
 	dies_at_threshold = TRUE
 	language = "Zombie"
-	species_traits = list(NO_BLOOD,NOZOMBIE,NOTRANSSTING,NO_BREATHE, RADIMMUNE, NO_SCAN)
+	species_traits = list(NO_BLOOD, NOZOMBIE, NOTRANSSTING, NO_BREATHE, RADIMMUNE, NO_SCAN)
 	var/static/list/spooks = list('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')
-	warning_low_pressure = 50
-	hazard_low_pressure = 0
+	warning_low_pressure = -1
+	hazard_low_pressure = -1
+	hazard_high_pressure = 999999999
+	warning_high_pressure = 999999999
+	cold_level_1 = -1
+	cold_level_2 = -1
+	cold_level_3 = -1
 	flesh_color = "#00FF00" // for green examine text
 	bodyflags = HAS_SKIN_COLOR
 	dietflags = DIET_CARN
-	has_organ = list(	
+	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart,
 		"lungs" =    /obj/item/organ/internal/lungs,
 		"liver" =    /obj/item/organ/internal/liver,
@@ -23,8 +28,7 @@
 		"brain" =    /obj/item/organ/internal/brain,
 		"appendix" = /obj/item/organ/internal/appendix,
 		"eyes" =     /obj/item/organ/internal/eyes,
-		"ears" = 	/obj/item/organ/internal/ears,
-		"zombie_infection" = /obj/item/organ/internal/zombie_infection)
+		"ears" = 	/obj/item/organ/internal/ears)
 
 
 /datum/species/zombie/infectious
@@ -46,19 +50,21 @@
 	if(damage)
 		regen_cooldown = world.time + REGENERATION_DELAY
 
-/datum/species/zombie/infectious/handle_life(mob/living/carbon/human/C)
+/datum/species/zombie/infectious/handle_life(mob/living/carbon/human/H)
 	. = ..()
+	H.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
+
 	//Zombies never actually die, they just fall down until they regenerate enough to rise back up.
 	//They must be restrained, beheaded or gibbed to stop being a threat.
 	if(regen_cooldown < world.time)
 		var/heal_amt = heal_rate
-		if(C.InCritical())
+		if(H.InCritical())
 			heal_amt *= 2
-		C.heal_overall_damage(heal_amt,heal_amt)
-		C.adjustToxLoss(-heal_amt)
-	if(!C.InCritical() && prob(4))
-		playsound(C, pick(spooks), 50, TRUE, 10)
-		
+		H.heal_overall_damage(heal_amt,heal_amt)
+		H.adjustToxLoss(-heal_amt)
+	if(!H.InCritical() && prob(4))
+		playsound(H, pick(spooks), 50, TRUE, 10)
+
 //Congrats you somehow died so hard you stopped being a zombie
 /datum/species/zombie/infectious/spec_death(gibbed, mob/living/carbon/C)
 	. = ..()
@@ -67,21 +73,21 @@
 	if(infection)
 		qdel(infection)
 
-/datum/species/zombie/infectious/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
+/datum/species/zombie/infectious/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
 	// Deal with the source of this zombie corruption
 	//  Infection organ needs to be handled separately from mutant_organs
 	//  because it persists through species transitions
 	if(mutanthands)
-		C.drop_l_hand()
-		C.drop_r_hand()
-		C.put_in_hands(new mutanthands())
-		C.put_in_hands(new mutanthands())
+		H.drop_l_hand()
+		H.drop_r_hand()
+		H.put_in_hands(new mutanthands())
+		H.put_in_hands(new mutanthands())
 	var/obj/item/organ/internal/zombie_infection/infection
-	infection = C.get_organ_slot("zombie_infection")
+	infection = H.get_organ_slot("zombie_infection")
 	if(!infection)
 		infection = new()
-		infection.insert(C)
+		infection.insert(H)
 
 /datum/species/zombie/infectious/on_species_loss(mob/living/carbon/human/C, datum/species/old_species)
 	QDEL_NULL(C.r_hand)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -207,6 +207,12 @@
 
 	return ..()
 
+/datum/reagent/stable_mutagen/on_tick()
+	var/datum/reagent/blood/B = locate() in holder.reagent_list
+	if(B && islist(B.data) && !data)
+		data = B.data.Copy()
+	..()
+
 datum/reagent/romerol
 	name = "romerol"
 	// the REAL zombie powder
@@ -221,15 +227,13 @@ datum/reagent/romerol
 	can_synth = FALSE
 	taste_description = "CAAAARL"
 
-/datum/reagent/romerol/reaction_mob(mob/living/carbon/human/H)
+/datum/reagent/romerol/reaction_mob(mob/living/carbon/human/H, method = TOUCH, volume)
+	if(!istype(H))
+		return
 	// Silently add the zombie infection organ to be activated upon death
-	new /obj/item/organ/internal/zombie_infection(H)
-	..()
-
-/datum/reagent/stable_mutagen/on_tick()
-	var/datum/reagent/blood/B = locate() in holder.reagent_list
-	if(B && islist(B.data) && !data)
-		data = B.data.Copy()
+	if(!H.get_organ_slot("zombie_infection"))
+		var/obj/item/organ/internal/zombie_infection/nodamage/ZI = new()
+		ZI.insert(H)
 	..()
 
 /datum/reagent/uranium

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -236,6 +236,14 @@ datum/reagent/romerol
 		ZI.insert(H)
 	..()
 
+/datum/reagent/romerol/stable_mutagen/on_mob_life(mob/living/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!H.get_organ_slot("zombie_infection"))
+			var/obj/item/organ/internal/zombie_infection/nodamage/ZI = new()
+			ZI.insert(H)
+	return ..()
+
 /datum/reagent/uranium
 	name ="Uranium"
 	id = "uranium"

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -8,7 +8,7 @@
 	var/non_primary = 0
 	var/unremovable = FALSE //Whether it shows up as an option to remove during surgery.
 
-/obj/item/organ/internal/New(var/mob/living/carbon/holder)
+/obj/item/organ/internal/New(mob/living/carbon/holder)
 	..()
 	if(istype(holder))
 		insert(holder)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -5,12 +5,15 @@
 		sustain the zombie, forcing open airlock doors and opening \
 		child-safe caps on bottles."
 	flags = NODROP|ABSTRACT|DROPDEL
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF
+	burn_state = LAVA_PROOF
+	unacidable = TRUE
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "bloodhand_left"
 	var/icon_left = "bloodhand_left"
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
-	force = 25
+	force = 21 // Just enough to break airlocks with melee attacks
 	damtype = "brute"
 
 /obj/item/zombie_hand/equipped(mob/user, slot)
@@ -26,14 +29,14 @@
 	. = ..()
 	if(!proximity_flag)
 		return
-		
+
 	else if(isliving(target))
 		if(ishuman(target))
-			check_infection(target, user)
+			try_to_zombie_infect(target)
 		else
 			check_feast(target, user)
 
-/obj/item/zombie_hand/proc/check_infection(var/mob/living/carbon/human/target, var/mob/user)
+/proc/try_to_zombie_infect(mob/living/carbon/human/target)
 	CHECK_DNA_AND_SPECIES(target)
 
 	if(NOZOMBIE in target.dna.species.species_traits)
@@ -44,18 +47,19 @@
 	var/obj/item/organ/internal/zombie_infection/infection
 	infection = target.get_organ_slot("zombie_infection")
 	if(!infection)
-		if (target.InCritical() || (!target.check_death_method() && target.health <= HEALTH_THRESHOLD_DEAD))
-			infection = new(target)
+		infection = new()
+		infection.insert(target)
 
 /obj/item/zombie_hand/proc/check_feast(mob/living/target, mob/living/user)
 	if(target.stat == DEAD)
 		var/hp_gained = target.maxHealth
 		target.gib()
-		user.adjustBruteLoss(-hp_gained)
-		user.adjustToxLoss(-hp_gained)
-		user.adjustFireLoss(-hp_gained)
-		user.adjustCloneLoss(-hp_gained)
-		user.adjustBrainLoss(-hp_gained) // Zom Bee gibbers "BRAAAAISNSs!1!"
+		user.adjustBruteLoss(-hp_gained, FALSE)
+		user.adjustToxLoss(-hp_gained, FALSE)
+		user.adjustFireLoss(-hp_gained, FALSE)
+		user.adjustCloneLoss(-hp_gained, FALSE)
+		user.adjustBrainLoss(-hp_gained, FALSE) // Zom Bee gibbers "BRAAAAISNSs!1!"
+		user.updatehealth()
 
 /obj/item/zombie_hand/suicide_act(mob/living/carbon/human/user)
 	user.visible_message("<span class='suicide'>[user] is ripping [user.p_their()] brains out! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -4,19 +4,17 @@
 	parent_organ = "head"
 	slot = "zombie_infection"
 	icon_state = "blacktumor"
-	var/converts_living = FALSE
 	var/causes_damage = TRUE
 	var/datum/species/old_species = /datum/species/human
-	var/living_transformation_time = 3
+	var/living_transformation_time = 30
+	var/converts_living = FALSE
+
 	var/revive_time_min = 450
 	var/revive_time_max = 700
 	var/timer_id
-	var/dont_delete = FALSE // to prevent set_species proc in zombify from deleting the infection organ immediately
 
-/obj/item/organ/internal/zombie_infection/New()
-	. = ..()
-	if(ishuman(owner) && !ismachine(owner) && !iszombie(owner.dna.species))
-		old_species = owner.dna.species
+/obj/item/organ/internal/zombie_infection/New(mob/living/carbon/holder)
+	..()
 	GLOB.zombie_infection_list += src
 
 /obj/item/organ/internal/zombie_infection/Destroy()
@@ -24,70 +22,78 @@
 	. = ..()
 
 /obj/item/organ/internal/zombie_infection/insert(mob/living/carbon/human/M, special = 0)
-	. = ..()
+	..()
 	START_PROCESSING(SSobj, src)
 
 /obj/item/organ/internal/zombie_infection/remove(mob/living/carbon/human/M, special = 0)
 	STOP_PROCESSING(SSobj, src)
-	if(iszombie(M) && old_species && !dont_delete)
-		M.set_species(old_species)
+	if(iszombie(M) && old_species)
+		M.set_species(old_species, retain_damage = TRUE)
 	if(timer_id)
 		deltimer(timer_id)
-	..()
+	. = ..()
 
 /obj/item/organ/internal/zombie_infection/on_find(mob/living/finder)
-	to_chat(finder,"<span class='warning'>Inside the head is a disgusting black \
+	to_chat(finder, "<span class='warning'>Inside the head is a disgusting black \
 		web of pus and viscera, bound tightly around the brain like some \
 		biological harness.</span>")
 
 /obj/item/organ/internal/zombie_infection/process()
-	if(!ishuman(owner)) // We do not support monkey or xeno zombies. Yet.
-		qdel(src)
+	if(!owner)
+		return
+	if(!(src in owner.internal_organs))
+		remove(owner)
+	if(causes_damage && !iszombie(owner) && owner.stat != DEAD)
+		owner.adjustToxLoss(1)
+		if (prob(10))
+			to_chat(owner, "<span class='danger'>You feel sick...</span>")
+	if(timer_id)
 		return
 	if(owner.suiciding)
 		return
 	if(owner.stat != DEAD && !converts_living)
 		return
-	if(causes_damage && !iszombie(owner) && owner.stat != DEAD)
-		owner.adjustToxLoss(1)
-		if (prob(10))
-			to_chat(owner, "<span class='danger'>You feel sick...</span>")
 	if(!owner.get_int_organ(/obj/item/organ/internal/brain))
 		return
-	if(!iszombie(owner) && !timer_id)
+	if(!iszombie(owner))
 		to_chat(owner, "<span class='cultlarge'>You can feel your heart stopping, but something isn't right... \
 		life has not abandoned your broken form. You can only feel a deep and immutable hunger that \
-		not even death can stop, you will rise again!</span>")	
+		not even death can stop, you will rise again!</span>")
 	var/revive_time = rand(revive_time_min, revive_time_max)
 	var/flags = TIMER_STOPPABLE
 	timer_id = addtimer(CALLBACK(src, .proc/zombify), revive_time, flags)
 
 /obj/item/organ/internal/zombie_infection/proc/zombify()
 	timer_id = null
-	if(owner.stat != DEAD && !converts_living)
+
+	if(!converts_living && owner.stat != DEAD)
 		return
 
 	if(!iszombie(owner))
-		old_species = owner.dna.species
-		dont_delete = TRUE // make sure the remove code above does not run when the species code replaces all the organs
+		old_species = owner.dna.species.type
 		owner.set_species(/datum/species/zombie/infectious)
-		for(var/thing in owner.viruses) // cure any new crit viruses
-			var/datum/disease/D = thing
-			D.cure(0)
-		dont_delete = FALSE
+		for(var/datum/disease/critical/crit in owner.viruses) // cure any new crit viruses
+			crit.cure(0)
+
+	var/stand_up = (owner.stat == DEAD) || (owner.stat == UNCONSCIOUS)
 	//Fully heal the zombie's damage the first time they rise
 	owner.setToxLoss(0)
 	owner.setOxyLoss(0)
 	owner.setBrainLoss(0)
 	owner.setCloneLoss(0)
 	owner.SetLoseBreath(0)
-	owner.heal_overall_damage(INFINITY,INFINITY,TRUE,TRUE,FALSE)
+	owner.heal_overall_damage(INFINITY, INFINITY, TRUE, TRUE, FALSE)
+	owner.setStaminaLoss(0)
 
-	if(owner.update_revive())
-		owner.grab_ghost()
+	if(!owner.update_revive())
+		return
 
-	owner.visible_message("<span class='danger'>[owner] suddenly convulses, as [owner.p_they()] stagger to [owner.p_their()] feet and gain a ravenous hunger in [owner.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
-	playsound(owner.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
+	owner.grab_ghost()
+	owner.visible_message("<span class='danger'>[owner] suddenly convulses, as [owner.p_they()][stand_up ? " stagger to [owner.p_their()] feet and" : ""] gain a ravenous hunger in [owner.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
+	playsound(owner.loc, 'sound/hallucinations/far_noise.ogg', 50, TRUE)
 	owner.do_jitter_animation(living_transformation_time)
 	owner.Stun(living_transformation_time)
 	to_chat(owner, "<span class='alertalien'>You are now a zombie! Do not seek to be cured, do not help any non-zombies in any way, do not harm your zombie brethren and spread the disease by killing others. You are a creature of hunger and violence.</span>")
+
+/obj/item/organ/internal/zombie_infection/nodamage
+	causes_damage = FALSE


### PR DESCRIPTION
This fixes+updates Romerol, but also comments it out.

Needless to say, there's really no way for this to properly function on our code until we engage in a bit of a species refactor.

At the moment, when you change species, it deletes all your internal and external organs and recreates them.

The way it was done in the PR is NOT the way to go about it; you still wind up with wonky behavior of organs not in lists but still associate with a mob (bad).

There's not an easy way to fix this, and I don't want it runtiming all over the place.

I'd like to reach out to @KasparoVy for some help with the organs thing; he was instrumental in getting species changing to retain damage and prevent reviving from deleting augments and stuff. If it's not too much to ask, could ya look into having `set_species` not remove some types of internal organs? Basically anything outside of the species own organs should be deleted, but anything added should stay.

:cl: Fox McCloud
del: comments out romerol (much like zombies, it will rise again, don't worry!)
tweak: zombies are high and lower pressure immune in addition to immune to heat and tox damage
/:cl: