### PR TITLE
Revert "Middle Mouse button now toggles airlock safeties for AIs."

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -209,13 +209,11 @@
 /atom/proc/AIMiddleClick()
 	return
 
-/obj/machinery/door/airlock/AIMiddleClick() // Toggles door safety.
-	if(safe)
-		Topic(src, list("src" = UID(), "command"="safeties", "activate" = "1"), 1) // 1 meaning no window (consistency!)
-		to_chat(usr, "The door safeties have been overridden.")
+/obj/machinery/door/airlock/AIMiddleClick() // Toggles door bolt lights.
+	if(!src.lights)
+		Topic(src, list("src" = UID(), "command"="lights", "activate" = "1"), 1) // 1 meaning no window (consistency!)
 	else
-		Topic(src, list("src" = UID(), "command"="safeties", "activate" = "0"), 1)
-		to_chat(usr, "The door safeties have been reset.")
+		Topic(src, list("src" = UID(), "command"="lights", "activate" = "0"), 1)
 	return
 
 /obj/machinery/ai_slipper/AICtrlClick() //Turns liquid dispenser on or off


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#11863

Having played around with this for a few rounds... not digging it even remotely. Had this been attached to a different combination, maybe, but even then I and a good few others might argue that door safeties probably shouldn't be a macro.

As is, door bolt lights see much more use than the safeties. It makes a lot more sense to be macro'd where it is.