### PR TITLE
stops bloody footprints from stacking

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -47,7 +47,8 @@ var/global/list/image/splatter_cache = list()
 				mode_ticker.blood_check()
 	if(type == /obj/effect/decal/cleanable/blood/gibs)
 		return
-	dry_timer = addtimer(CALLBACK(src, .proc/dry), DRYING_TIME * (amount+1), TIMER_STOPPABLE)
+	if(!.)
+		dry_timer = addtimer(CALLBACK(src, .proc/dry), DRYING_TIME * (amount+1), TIMER_STOPPABLE)
 
 /obj/effect/decal/cleanable/blood/Destroy()
 	if(GAMEMODE_IS_CULT)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -47,13 +47,6 @@ var/global/list/image/splatter_cache = list()
 				mode_ticker.blood_check()
 	if(type == /obj/effect/decal/cleanable/blood/gibs)
 		return
-	if(type == /obj/effect/decal/cleanable/blood)
-		if(loc && isturf(loc))
-			for(var/obj/effect/decal/cleanable/blood/B in loc)
-				if(B != src)
-					if(B.blood_DNA)
-						blood_DNA |= B.blood_DNA.Copy()
-					qdel(B)
 	dry_timer = addtimer(CALLBACK(src, .proc/dry), DRYING_TIME * (amount+1), TIMER_STOPPABLE)
 
 /obj/effect/decal/cleanable/blood/Destroy()

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -55,6 +55,7 @@ var/global/list/image/fluidtrack_cache = list()
 			if(!(entered_dirs & H.dir))
 				entered_dirs |= H.dir
 				update_icon()
+				
 /obj/effect/decal/cleanable/blood/footprints/Uncrossed(atom/movable/O)
 	..()
 	if(ishuman(O))

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -60,7 +60,7 @@
 			if(C != src && C.type == type && !QDELETED(C))
 				if(replace_decal(C))
 					qdel(src)
-					return
+					return TRUE
 	if(random_icon_states && length(src.random_icon_states) > 0)
 		src.icon_state = pick(src.random_icon_states)
 	if(smooth)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -58,25 +58,23 @@
 
 	if(shoes)
 		if(S.bloody_shoes && S.bloody_shoes[S.blood_state])
-			var/obj/effect/decal/cleanable/blood/footprints/oldFP = locate(/obj/effect/decal/cleanable/blood/footprints) in T
-			if(oldFP && oldFP.blood_state == S.blood_state && oldFP.basecolor == S.blood_color)
-				return
-			else
-				//No oldFP or it's a different kind of blood
-				S.bloody_shoes[S.blood_state] = max(0, S.bloody_shoes[S.blood_state] - BLOOD_LOSS_PER_STEP)
-				if(S.bloody_shoes[S.blood_state] > BLOOD_LOSS_IN_SPREAD)
-					createFootprintsFrom(shoes, dir, T)
-				update_inv_shoes()
+			for(var/obj/effect/decal/cleanable/blood/footprints/oldFP in T)
+				if(oldFP && oldFP.blood_state == S.blood_state && oldFP.basecolor == S.blood_color)
+					return
+			//No oldFP or it's a different kind of blood
+			S.bloody_shoes[S.blood_state] = max(0, S.bloody_shoes[S.blood_state] - BLOOD_LOSS_PER_STEP)
+			if(S.bloody_shoes[S.blood_state] > BLOOD_LOSS_IN_SPREAD)
+				createFootprintsFrom(shoes, dir, T)
+			update_inv_shoes()
 	else if(hasfeet)
 		if(bloody_feet && bloody_feet[blood_state])
-			var/obj/effect/decal/cleanable/blood/footprints/oldFP = locate(/obj/effect/decal/cleanable/blood/footprints) in T
-			if(oldFP && oldFP.blood_state == blood_state && oldFP.basecolor == feet_blood_color)
-				return
-			else
-				bloody_feet[blood_state] = max(0, bloody_feet[blood_state] - BLOOD_LOSS_PER_STEP)
-				if(bloody_feet[blood_state] > BLOOD_LOSS_IN_SPREAD)
-					createFootprintsFrom(src, dir, T)
-				update_inv_shoes()
+			for(var/obj/effect/decal/cleanable/blood/footprints/oldFP in T)
+				if(oldFP && oldFP.blood_state == blood_state && oldFP.basecolor == feet_blood_color)
+					return
+			bloody_feet[blood_state] = max(0, bloody_feet[blood_state] - BLOOD_LOSS_PER_STEP)
+			if(bloody_feet[blood_state] > BLOOD_LOSS_IN_SPREAD)
+				createFootprintsFrom(src, dir, T)
+			update_inv_shoes()
 	//End bloody footprints
 	if(S)
 		S.step_action(src)


### PR DESCRIPTION
**What does this PR do:**
Follow up to the first blood fix, this one should fix it for real this time. The issue was blood from multiple species would endlessly stack, now the code for the footprint checks all the blood on the tile rather than only the first one. There should now only be one footprint per blood colour, when testing there were three blood tracks one being human blood, another being IPC oil and the third being vox blood.

**Changelog:**
:cl:
fix: fixes footprints stacking
/:cl:

