### PR TITLE
Fixes a couple of item descriptions

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -25,7 +25,7 @@
 	can_leave_fibers = FALSE
 
 /obj/item/clothing/gloves/combat
-	desc = "These tactical gloves are somewhat fire and impact resistant."
+	desc = "These tactical gloves are both insulated and offer protection from heat sources."
 	name = "combat gloves"
 	icon_state = "combat"
 	item_state = "swat_gl"

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -1,6 +1,6 @@
 /obj/vehicle/ambulance
 	name = "ambulance"
-	desc = "what the paramedic uses to run over people to take to medbay."
+	desc = "This is what the paramedic uses to run over people they need to take to medbay."
 	icon_state = "docwagon2"
 	keytype = /obj/item/key/ambulance
 	var/obj/structure/bed/amb_trolley/bed = null


### PR DESCRIPTION
**What does this PR do:**
Couple of minor fixes for two items with slightly off descriptions. The combat gloves are changed to no longer reference they have protection from "impacts" (they only protect from shocks and heat such as light bulbs). The ambulance had a small grammar error and also didn't seem to flow too well when read back, so it's been fixed and rewritten slightly to (hopefully) read a bit better.

**Changelog:**
:cl:
spellcheck: Fixes a grammar error with the ambulance and slightly misleading description with the combat gloves.
/:cl:

