### PR TITLE
Headpat Gloves now use the same click speed modifier as the North Star gloves

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -173,4 +173,3 @@
 	name = "Gloves of Headpats"
 	desc = "You feel the irresistable urge to give headpats by merely glimpsing these."
 	accepted_intents = list(INTENT_HELP)
-	click_speed_modifier = 0 // That's some serious headpatting


### PR DESCRIPTION
**What does this PR do:**

Adds in the requested change from #12189 as asked for by the maintainers.

**Changelog:**
:cl:
tweak: Headpat gloves now inherit their click speed from the North Star gloves and are no longer as fast as before.
/:cl:

