### PR TITLE
Introduces local gps signals

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -11,6 +11,7 @@ var/list/GPS_list = list()
 	var/emped = 0
 	var/turf/locked_location
 	var/tracking = TRUE
+	var/local = FALSE	//local gps show up only to gps on same z level
 
 /obj/item/gps/New()
 	..()
@@ -63,13 +64,15 @@ var/list/GPS_list = list()
 			t += "<BR>Bluespace coordinates saved: [locked_location.loc]"
 			gps_window_height += 20
 
+		var/turf/own_pos = get_turf(src)
+		var/own_z = own_pos.z
 		for(var/obj/item/gps/G in GPS_list)
 			var/turf/pos = get_turf(G)
 			var/area/gps_area = get_area(G)
 			var/tracked_gpstag = G.gpstag
 			if(G.emped == 1)
 				t += "<BR>[tracked_gpstag]: ERROR"
-			else if(G.tracking)
+			else if(G.tracking && (!G.local || (own_z == pos.z)))
 				t += "<BR>[tracked_gpstag]: [format_text(gps_area.name)] ([pos.x], [pos.y], [pos.z])"
 			else
 				continue
@@ -115,6 +118,7 @@ var/list/GPS_list = list()
 /obj/item/gps/internal
 	icon_state = null
 	flags = ABSTRACT
+	local = TRUE
 	gpstag = "Eerie Signal"
 	desc = "Report to a coder immediately."
 	invisibility = INVISIBILITY_MAXIMUM


### PR DESCRIPTION
**What does this PR do:**
This PR modifies gps so that they can be marked as 'local'. A local gps is only visible to other gps on the same z level. For the moment the only local gps are the internal ones in lavaland megafauna, but I plan to add some to some space ruins to make them easier but not totally trivial to find. 

They aren't intended for being used by crew for the moment, as seeing other gps and your own coordiantes without being seen in turn has balance implications.

Just compare the before/after when going to/from lavaland:
![Capture1](https://user-images.githubusercontent.com/32099540/64478069-20b33280-d1a3-11e9-9b6b-cb53249a08d5.PNG)
![Capture2](https://user-images.githubusercontent.com/32099540/64478071-227cf600-d1a3-11e9-8a50-9206478e7d29.PNG)
I got really tired of the gps clutter

**Changelog:**
:cl:
add: local gps signals, visible only on the same z level
tweak: lavaland mob signals were made local, reducing gps clutter
/:cl:

