### PR TITLE
Zombie language is no longer selectable as a secondary language

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -770,6 +770,7 @@
 	exclaim_verb = "wails"
 	colour = "zombie"
 	key = "zom"
+	flags = RESTRICTED
 	syllables = list("BRAAAAAAAAAAAAAAAAINS", "BRAAINS", "BRAINS")
 
 /mob/proc/grant_all_languages()


### PR DESCRIPTION
**What does this PR do:**
Restricts normal people from speaking zombie

**Changelog:**
:cl:
fix: removes zombie from the secondary language list
/:cl:

