### PR TITLE
Sets Blood-Drunk Miner crusher trophy attack logs to all logs only

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -64,7 +64,7 @@
 			H.dna.species.oxy_mod *= 0.1
 			H.dna.species.clone_mod *= 0.1
 			H.dna.species.stamina_mod *= 0.1
-		add_attack_logs(owner, owner, "gained blood-drunk stun immunity")
+		add_attack_logs(owner, owner, "gained blood-drunk stun immunity", ATKLOG_ALL)
 		var/status = CANSTUN | CANWEAKEN | CANPARALYSE | IGNORESLOWDOWN
 		owner.status_flags &= ~status
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, 1)
@@ -80,7 +80,7 @@
 		H.dna.species.oxy_mod *= 10
 		H.dna.species.clone_mod *= 10
 		H.dna.species.stamina_mod *= 10
-	add_attack_logs(owner, owner, "lost blood-drunk stun immunity")
+	add_attack_logs(owner, owner, "lost blood-drunk stun immunity", ATKLOG_ALL)
 	owner.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | IGNORESLOWDOWN
 
 /datum/status_effect/exercised


### PR DESCRIPTION
**What does this PR do:**
Makes it so that admins only see the blood-drunk miner crusher trophy attack logs if they have their attack log preference set to all. The chat doesn't need to be spammed with 20 logs in a very short time span every time a miner gets a 1 second buff because he fights something on lavaland.

**Changelog:**
:cl:
tweak: Changes the attack log setting required to have the blood-drunk miner buff actively log to all attack logs.
/:cl:

