### PR TITLE
Changed CA to TP link in adminhelp

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -495,7 +495,7 @@ GLOBAL_LIST_INIT(do_after_once_tracker, list())
 	to_chat(user, "Name = <b>[M.name]</b>; Real_name = [M.real_name]; Mind_name = [M.mind?"[M.mind.name]":""]; Key = <b>[M.key]</b>;")
 	to_chat(user, "Location = [location_description];")
 	to_chat(user, "[special_role_description]")
-	to_chat(user, "(<a href='?src=[usr.UID()];priv_msg=[M.client ? M.client.UID(): null]'>PM</a>) ([ADMIN_PP(M,"PP")]) ([ADMIN_VV(M,"VV")]) ([ADMIN_SM(M,"SM")]) ([ADMIN_FLW(M,"FLW")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>)")
+	to_chat(user, "(<a href='?src=[usr.UID()];priv_msg=[M.client ? M.client.UID(): null]'>PM</a>) ([ADMIN_PP(M,"PP")]) ([ADMIN_VV(M,"VV")]) ([ADMIN_TP(M,"TP")]) ([ADMIN_SM(M,"SM")]) ([ADMIN_FLW(M,"FLW")])")
 
 // Gets the first mob contained in an atom, and warns the user if there's not exactly one
 /proc/get_mob_in_atom_with_warning(atom/A, mob/user = usr)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -120,12 +120,12 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 			T = SStickets.checkForOpenTicket(src) // Make T equal to the ticket they have open
 		else
 			ticketNum = SStickets.getTicketCounter() // ticketNum is the ticket ready to be assigned.
-	
+
 	if(T)
 		ticketNum = T.ticketNum // ticketNum is the number of their ticket.
 		T.addResponse(src, msg)
-	
-	msg = "[span][selected_type]: </span><span class='boldnotice'>[key_name(src, TRUE, selected_type)] ([ADMIN_QUE(mob,"?")]) ([ADMIN_PP(mob,"PP")]) ([ADMIN_VV(mob,"VV")]) ([ADMIN_SM(mob,"SM")]) ([admin_jump_link(mob)]) (<A HREF='?_src_=holder;check_antagonist=1'>CA</A>) (<A HREF='?_src_=holder;[isMhelp ? "openmentorticket" : "openadminticket"]=[ticketNum]'>TICKET</A>) [ai_found ? "(<A HREF='?_src_=holder;adminchecklaws=[mob.UID()]'>CL</A>)" : ""] (<A HREF='?_src_=holder;take_question=[ticketNum][isMhelp ? ";is_mhelp=1" : ""]'>TAKE</A>) (<A HREF='?_src_=holder;resolve=[ticketNum][isMhelp ? ";is_mhelp=1" : ""]'>RESOLVE</A>)  :</span> [span][msg]</span>"
+
+	msg = "[span][selected_type]: </span><span class='boldnotice'>[key_name(src, TRUE, selected_type)] ([ADMIN_QUE(mob,"?")]) ([ADMIN_PP(mob,"PP")]) ([ADMIN_VV(mob,"VV")]) ([ADMIN_TP(mob,"TP")]) ([ADMIN_SM(mob,"SM")]) ([admin_jump_link(mob)]) (<A HREF='?_src_=holder;[isMhelp ? "openmentorticket" : "openadminticket"]=[ticketNum]'>TICKET</A>) [ai_found ? "(<A HREF='?_src_=holder;adminchecklaws=[mob.UID()]'>CL</A>)" : ""] (<A HREF='?_src_=holder;take_question=[ticketNum][isMhelp ? ";is_mhelp=1" : ""]'>TAKE</A>) (<A HREF='?_src_=holder;resolve=[ticketNum][isMhelp ? ";is_mhelp=1" : ""]'>RESOLVE</A>)  :</span> [span][msg]</span>"
 	if(isMhelp)
 		//Open a new adminticket and inform the user.
 		SSmentor_tickets.newTicket(src, prunedmsg, msg)
@@ -142,7 +142,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 			window_flash(X)
 			to_chat(X, msg)
 
-			
+
 
 	//show it to the person adminhelping too
 	to_chat(src, "<span class='boldnotice'>[selected_type]</b>: [original_msg]</span>")
@@ -185,4 +185,3 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 		else
 			send2irc(source, "[msg] - All admins AFK ([admin_number_afk]/[admin_number_total]) or skipped ([admin_number_ignored]/[admin_number_total])")
 	return admin_number_present
-	


### PR DESCRIPTION
![tpCZvsshBU](https://user-images.githubusercontent.com/7946481/64484455-59bdc800-d1e0-11e9-8a2a-6d0217093970.png)
![jfir39Pmbh](https://user-images.githubusercontent.com/7946481/64484461-5fb3a900-d1e0-11e9-8993-25ee8741444e.png)
![dreamseeker_xwVgxawC5h](https://user-images.githubusercontent.com/7946481/64487471-407d4180-d209-11e9-8d16-46fae1420594.png)
![dreamseeker_dAp4I8FjJu](https://user-images.githubusercontent.com/7946481/64487474-41ae6e80-d209-11e9-9233-e6db9f293090.png)

**What does this PR do:**
Changed the CA link in admin helps to TP link. Also moved earlier in the list.
A good portion of our ahelps are people asking to have their antag role removed. This shortcut will be used more then a "Check Antag" button. This feels like a good QoL change.

(Also it doesn't change the color, that's just my screenshots looking weird)

**Changelog:**
:cl: xProlithium
tweak: Replaced link to CA (check antags) in adminhelps, tickets, and adminmoreinfo with a link to TP (traitor panel)
/:cl:

