### PR TITLE
Add a config option for making gamemode ignore required players number

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -242,6 +242,9 @@
 	// Lavaland
 	var/lavaland_budget = 60
 
+	// Makes gamemodes respect player limits
+	var/enable_gamemode_player_limit = 0
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -720,6 +723,8 @@
 					config.developer_express_start = 1
 				if("disable_localhost_admin")
 					config.disable_localhost_admin = 1
+				if("enable_gamemode_player_limit")
+					config.enable_gamemode_player_limit = 1
 				else
 					log_config("Unknown setting in configuration: '[name]'")
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -50,7 +50,7 @@
 		if((player.client)&&(player.ready))
 			playerC++
 
-	if(playerC >= required_players)
+	if(!config.enable_gamemode_player_limit || (playerC >= required_players))
 		return 1
 	return 0
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -439,6 +439,8 @@ HIGH_POP_MC_MODE_AMOUNT 65
 ##Disengage high pop mode if player count drops below this
 DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
+##Developer options
+
 ##Uncomment to enable developer start. Auto starts the server after initialization
 ##DEVELOPER_EXPRESS_START
 
@@ -447,3 +449,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ## Uncomment to give a confirmation before hitting start now
 #START_NOW_CONFIRMATION
+
+## If uncommented, all gamemodes will respect the number of required players. Defaults to no.
+#ENABLE_GAMEMODE_PLAYER_LIMIT


### PR DESCRIPTION
**What does this PR do:**
It defaults to yes. Meant to help people with testing out gamemode without manually editing the number of required players.

Additional Note: It defaults to yes because the majority of people who branch off Paradise is using it to develop, not for hosting. This means anyone who hosts a server (Downstream, or ourselves) need to change the default to No. But every developer don't need to do anything after updating master.

**Changelog:**
:cl:
add: Config option to let gamemode ignore the number of required players.
/:cl:

