### PR TITLE
[Review Time] Refactors Species Changing, Zombie Fixes & Extra Brain Flavour

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -167,3 +167,4 @@
 #define NO_DECAY		"no_decay"
 #define PIERCEIMMUNE	"pierce_immunity"
 #define NO_HUNGER		"no_hunger"
+#define REBUILD_ON_GAIN "rebuild_on_gain" //If this is true, when you set_species to this species it'll build up the mob from scratch legacy style.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -1,11 +1,12 @@
 ///////////////////ORGAN DEFINES///////////////////
 
 // Organ defines.
-#define ORGAN_BROKEN     1
-#define ORGAN_ROBOT      2
-#define ORGAN_SPLINTED   4
-#define ORGAN_DEAD       8
-#define ORGAN_MUTATED    16
+#define ORGAN_BROKEN			(1<<0)
+#define ORGAN_ROBOT				(1<<1)
+#define ORGAN_SPLINTED			(1<<2)
+#define ORGAN_DEAD				(1<<3)
+#define ORGAN_MUTATED			(1<<4)
+#define ORGAN_SPECIES_CHANGING	(1<<5)
 
 #define PROCESS_ACCURACY 10
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1029,6 +1029,7 @@
 						SSticker.mode.prepare_syndicate_leader(src)
 					else
 						current.real_name = "[syndicate_name()] Operative #[SSticker.mode.syndicates.len-1]"
+					H.change_real_name(H.real_name, TRUE) //Write it to DNA all over the body.
 					special_role = SPECIAL_ROLE_NUKEOPS
 					to_chat(current, "<span class='notice'>You are a [syndicate_name()] agent!</span>")
 					SSticker.mode.forge_syndicate_objectives(src)
@@ -1446,6 +1447,9 @@
 		current.loc = get_turf(locate("landmark*Syndicate-Spawn"))
 
 		var/mob/living/carbon/human/H = current
+		H.update_dna() //Commit real_name to DNA.
+		H.sync_organ_dna(TRUE) //Sort the whole body out with the real_name.
+
 		qdel(H.belt)
 		qdel(H.back)
 		qdel(H.l_ear)

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -674,6 +674,7 @@
 	else
 		H.real_name = "[pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant First Class", "Master Sergeant", "Sergeant Major")] [pick(GLOB.last_names)]"
 	H.name = H.real_name
+	H.change_real_name(H.real_name, TRUE)
 	var/obj/item/card/id/I = H.wear_id
 	if(istype(I))
 		apply_to_card(I, H, get_all_accesses(), name, "lifetimeid")

--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -66,7 +66,7 @@
 
 			var/mob/living/carbon/human/lich = new /mob/living/carbon/human(item_turf)
 
-			lich.real_name = M.mind.name
+			lich.change_real_name(M.mind.name, TRUE)
 			M.mind.transfer_to(lich)
 			lich.set_species(/datum/species/skeleton)
 			to_chat(lich, "<span class='warning'>Your bones clatter and shutter as they're pulled back into this world!</span>")

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -494,8 +494,8 @@
 			var/mob/living/carbon/human/H = user
 			var/mob/living/carbon/human/target = M
 			H.UpdateAppearance(target.dna.UI)
-			H.real_name = target.real_name
 			H.name = target.name
+			H.change_real_name(target.real_name, TRUE)
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -74,7 +74,7 @@
 		H.gib()
 		return
 
-	H.real_name = H.dna.real_name
+	H.change_real_name(H.dna.real_name, TRUE)
 	H.name = H.real_name
 
 	to_chat(H, "<B>You are now a [H.dna.species.name].</B>")

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -29,7 +29,7 @@
 		var/mob/living/carbon/human/H = user
 		H.restore_blood()
 		H.next_pain_time = 0
-		H.dna.species.create_organs(H)
+		H.check_and_regenerate_organs(H)
 		// Now that recreating all organs is necessary, the rest of this organ stuff probably
 		//  isn't, but I don't want to remove it, just in case.
 		for(var/organ_name in H.bodyparts_by_name)

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -97,10 +97,6 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	var/mob/living/carbon/human/vox = newraider.current
 	var/obj/item/organ/external/head/head_organ = vox.get_organ("head")
 
-	vox.real_name = capitalize(newname)
-	vox.dna.real_name = vox.real_name
-	vox.name = vox.real_name
-	newraider.name = vox.name
 	vox.age = rand(12,20)
 	vox.set_species(/datum/species/vox)
 	vox.s_tone = rand(1, 6)
@@ -111,15 +107,17 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	vox.add_language("Tradeband")
 	head_organ.h_style = "Short Vox Quills"
 	head_organ.f_style = "Shaved"
-	vox.change_hair_color(97, 79, 25) //Same as the species default colour.
-	vox.change_eye_color(rand(1, 255), rand(1, 255), rand(1, 255))
+	vox.change_hair_color(rgb(97, 79, 25)) //Same as the species default colour.
+	vox.change_eye_color(rgb(rand(1, 255), rand(1, 255), rand(1, 255)))
 	vox.underwear = "Nude"
 	vox.undershirt = "Nude"
 	vox.socks = "Nude"
 
 	// Do the initial caching of the player's body icons.
 	vox.force_update_limbs()
-	vox.update_dna()
+	vox.change_real_name(capitalize(newname), TRUE) //update_dna() implied here.
+	vox.name = vox.real_name
+	newraider.name = vox.name
 	vox.update_eyes()
 
 	for(var/obj/item/organ/external/limb in vox.bodyparts)

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -107,7 +107,7 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	vox.add_language("Tradeband")
 	head_organ.h_style = "Short Vox Quills"
 	head_organ.f_style = "Shaved"
-	vox.change_hair_color(rgb(97, 79, 25)) //Same as the species default colour.
+	vox.change_hair_color("#614f19") //Same as the species default colour.
 	vox.change_eye_color(rgb(rand(1, 255), rand(1, 255), rand(1, 255)))
 	vox.underwear = "Nude"
 	vox.undershirt = "Nude"

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -124,7 +124,7 @@
 	H.set_species(/datum/species/abductor)
 	S = H.dna.species
 	S.team = team_number
-	H.real_name = team_name + " Agent"
+	H.change_real_name("[team_name] Agent", TRUE)
 	H.cleanSE() //No fat/blind/colourblind/epileptic/whatever ayys.
 	H.overeatduration = 0
 	H.flavor_text = null
@@ -141,7 +141,7 @@
 	S = H.dna.species
 	S.scientist = TRUE
 	S.team = team_number
-	H.real_name = team_name + " Scientist"
+	H.change_real_name("[team_name] Scientist", TRUE)
 	H.cleanSE() //No fat/blind/colourblind/epileptic/whatever ayys.
 	H.overeatduration = 0
 	H.flavor_text = null

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -126,6 +126,8 @@ proc/issyndicate(mob/living/M as mob)
 
 			agent_number++
 		spawnpos++
+		var/mob/living/carbon/human/H = synd_mind.current
+		H.change_real_name(synd_mind.current.real_name, TRUE) //Write the true_name and other attributes to everything.
 		update_synd_icons_added(synd_mind)
 
 	scale_telecrystals()
@@ -161,13 +163,11 @@ proc/issyndicate(mob/living/M as mob)
 
 /datum/game_mode/proc/create_syndicate(datum/mind/synd_mind) // So we don't have inferior species as ops - randomize a human
 	var/mob/living/carbon/human/M = synd_mind.current
-
-	M.set_species(/datum/species/human, TRUE)
-	M.dna.ready_dna(M) // Quadriplegic Nuke Ops won't be participating in the paralympics
-	M.dna.species.create_organs(M)
-	M.cleanSE() //No fat/blind/colourblind/epileptic/whatever ops.
 	M.overeatduration = 0
 	M.flavor_text = null
+	M.dna.ready_dna(M) // Quadriplegic Nuke Ops won't be participating in the paralympics
+	M.cleanSE() //No fat/blind/colourblind/epileptic/whatever ops.
+	M.set_species(/datum/species/human, TRUE)
 
 	var/obj/item/organ/external/head/head_organ = M.get_organ("head")
 	var/hair_c = pick("#8B4513","#000000","#FF4500","#FFD700") // Brown, black, red, blonde

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -68,7 +68,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				playsound(H.loc, 'sound/effects/ghost.ogg', 100, 1)
 				var/newNameId = pick(possibleShadowlingNames)
 				possibleShadowlingNames.Remove(newNameId)
-				H.real_name = newNameId
+				H.change_real_name(newNameId, TRUE)
 				H.name = user.real_name
 				H.SetStunned(0)
 				to_chat(H, "<i><b><font size=3>YOU LIVE!!!</i></b></font>")
@@ -84,7 +84,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H.socks = "None"
 				H.faction |= "faithless"
 
-				H.set_species(/datum/species/shadow/ling)	//can't be a shadowling without being a shadowling
+				H.set_species(/datum/species/shadow/ling, new_mob = TRUE)	//can't be a shadowling without being a shadowling
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/shadowling(user), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/shadowling(user), slot_shoes)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/space/shadowling(user), slot_wear_suit)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -241,8 +241,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		scramble(1, H, 100)
-		H.real_name = random_name(H.gender, H.dna.species.name) //Give them a name that makes sense for their species.
-		H.sync_organ_dna(assimilate = 1)
+		H.change_real_name(random_name(H.gender, H.dna.species.name), TRUE) //Give them a name that makes sense for their species.
 		H.update_body(0)
 		H.reset_hair() //No more winding up with hairstyles you're not supposed to have, and blowing your cover.
 		H.reset_markings() //...Or markings.

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -92,7 +92,7 @@
 				if(!newname)
 					newname = randomname
 				M.mind.name = newname
-				M.real_name = newname
+				M.change_real_name(newname, TRUE)
 				M.name = newname
 				var/datum/objective/protect/new_objective = new /datum/objective/protect
 				new_objective.owner = M:mind
@@ -335,7 +335,7 @@ var/global/list/multiverse = list()
 		if(prob(50))
 			var/list/list_all_species = list(/datum/species/human, /datum/species/unathi, /datum/species/skrell, /datum/species/tajaran, /datum/species/kidan, /datum/species/golem, /datum/species/diona, /datum/species/machine, /datum/species/slime, /datum/species/grey, /datum/species/vulpkanin)
 			M.set_species(pick(list_all_species))
-	M.real_name = user.real_name //this is clear down here in case the user happens to become a golem; that way they have the proper name.
+	M.change_real_name(user.real_name, TRUE) //this is clear down here in case the user happens to become a golem; that way they have the proper name.
 	M.name = user.real_name
 	if(duplicate_self)
 		M.dna = user.dna.Clone()
@@ -751,6 +751,7 @@ var/global/list/multiverse = list()
 		H.real_name = "Neko-chan"
 	else
 		H.real_name = "[H.name]-chan"
+	H.change_real_name(H.real_name, TRUE)
 	H.say("NYA!~")
 
 /obj/item/necromantic_stone/nya

--- a/code/game/objects/items/weapons/dnascrambler.dm
+++ b/code/game/objects/items/weapons/dnascrambler.dm
@@ -43,8 +43,7 @@
 	if(istype(target))
 		var/mob/living/carbon/human/H = target
 		scramble(1, H, 100)
-		H.real_name = random_name(H.gender, H.dna.species.name) //Give them a name that makes sense for their species.
-		H.sync_organ_dna(assimilate = 1)
+		H.change_real_name(random_name(H.gender, H.dna.species.name), TRUE) //Give them a name that makes sense for their species.
 		H.update_body(0)
 		H.reset_hair() //No more winding up with hairstyles you're not supposed to have, and blowing your cover.
 		H.reset_markings() //...Or markings.

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -101,10 +101,8 @@
 
 			if(!newname)
 				return
-			H.real_name = newname
+			H.change_real_name(newname)
 			H.name = newname
-			if(H.dna)
-				H.dna.real_name = newname
 			if(H.mind)
 				H.mind.name = newname
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -494,9 +494,6 @@ client/proc/one_click_antag()
 	var/mob/living/carbon/human/new_vox = new /mob/living/carbon/human/vox(spawn_location.loc)
 
 	new_vox.add_language("Tradeband")
-	new_vox.real_name = capitalize(newname)
-	new_vox.dna.real_name = new_vox.real_name
-	new_vox.name = new_vox.real_name
 	new_vox.age = rand(12,20)
 	new_vox.flavor_text = ""
 	new_vox.change_eye_color(rand(1, 255), rand(1, 255), rand(1, 255))
@@ -504,7 +501,8 @@ client/proc/one_click_antag()
 
 	// Do the initial caching of the player's body icons.
 	new_vox.force_update_limbs()
-	new_vox.update_dna()
+	new_vox.change_real_name(capitalize(newname), TRUE)
+	new_vox.name = new_vox.real_name
 	new_vox.update_eyes()
 
 	for(var/obj/item/organ/external/limb in new_vox.bodyparts)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -190,7 +190,7 @@
 
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)
-		H.set_species(mob_species)
+		H.set_species(mob_species, new_mob = TRUE)
 
 	if(husk)
 		H.ChangeToHusk()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -91,6 +91,7 @@
 		H.Initialize(null)
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
+		H.change_real_name(H.real_name, TRUE)
 		if(!mob_gender)
 			mob_gender = pick(MALE, FEMALE)
 		M.gender = mob_gender

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -90,7 +90,7 @@
 	if(make_podman)	//all conditions met!
 		var/mob/living/carbon/human/pod_diona/podman = new /mob/living/carbon/human/pod_diona(parent.loc)
 		if(realName)
-			podman.real_name = realName
+			podman.change_real_name(realName, TRUE)
 		mind.transfer_to(podman)
 		if(ckey)
 			podman.ckey = ckey

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1131,9 +1131,7 @@
 
 /mob/living/carbon/human/revive()
 	//Fix up all organs and replace lost ones.
-	restore_all_organs() //Rejuvenate and reset all existing organs.
 	check_and_regenerate_organs(src) //Regenerate limbs and organs only if they're really missing.
-	surgeries.Cut() //End all surgeries.
 
 	if(!isskeleton(src) && (SKELETON in mutations))
 		mutations.Remove(SKELETON)
@@ -1150,7 +1148,7 @@
 						H.brainmob.mind.transfer_to(src)
 						qdel(H)
 
-	..()
+	..() //Restoration of organs and cutting of surgeries happens during a call of rejuvenate() from the parent /living type.
 
 /mob/living/carbon/human/proc/is_lung_ruptured()
 	var/obj/item/organ/internal/lungs/L = get_int_organ(/obj/item/organ/internal/lungs)
@@ -1282,7 +1280,7 @@
 	if(!(dna.species.bodyflags & HAS_SKIN_TONE))
 		s_tone = 0
 
-	if(dna.species.rebuild_on_gain)
+	if(REBUILD_ON_GAIN in dna.species.species_traits)
 		new_mob = TRUE
 
 	var/list/thing_to_check = list(slot_wear_mask, slot_head, slot_shoes, slot_gloves, slot_l_ear, slot_r_ear, slot_glasses, slot_l_hand, slot_r_hand)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1241,7 +1241,7 @@
 	if(!skip_same_check)
 		if(dna.species.name == initial(new_species.name))
 			return
-	var/datum/species/oldspecies = new dna.species.type()
+	var/datum/species/oldspecies = dna.species
 
 	if(oldspecies)
 		if(oldspecies.language)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1282,6 +1282,9 @@
 	if(!(dna.species.bodyflags & HAS_SKIN_TONE))
 		s_tone = 0
 
+	if(dna.species.rebuild_on_gain)
+		new_mob = TRUE
+
 	var/list/thing_to_check = list(slot_wear_mask, slot_head, slot_shoes, slot_gloves, slot_l_ear, slot_r_ear, slot_glasses, slot_l_hand, slot_r_hand)
 	var/list/kept_items[0]
 	var/list/item_flags[0]

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -169,9 +169,10 @@ old_ue: Set this to a UE string, and this proc will overwrite the dna of organs 
 			O.status &= ~ORGAN_SPECIES_CHANGING
 
 /mob/living/carbon/human/proc/update_organ_parenthood() //Refresh the parenthood of all organs - namely after species changes.
-	for(var/B in bodyparts)
-		var/obj/item/organ/external/E = B
-		E.update_parenthood()
+	var/list/all_bits = internal_organs|bodyparts
+	for(var/B in all_bits)
+		var/obj/item/organ/O = B
+		O.update_parenthood()
 
 /mob/living/carbon/human/proc/sort_organ_lists() //Sort mob organ lists matched as closely as possible to the species defines.
 	if(dna.species)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -159,6 +159,15 @@ old_ue: Set this to a UE string, and this proc will overwrite the dna of organs 
 		if(assimilate || O.dna.unique_enzymes == ue_to_compare)
 			O.set_dna(dna)
 
+/mob/living/carbon/human/proc/toggle_species_changing(activate = FALSE) //Toggle the status flag for species changing. Gets toggled during species create_organs() to avoid unintended behaviour.
+	var/list/all_bits = internal_organs|bodyparts
+	for(var/B in all_bits)
+		var/obj/item/organ/O = B
+		if(activate)
+			O.status |= ORGAN_SPECIES_CHANGING
+		else
+			O.status &= ~ORGAN_SPECIES_CHANGING
+
 /mob/living/carbon/human/proc/update_organ_parenthood() //Refresh the parenthood of all organs - namely after species changes.
 	for(var/B in bodyparts)
 		var/obj/item/organ/external/E = B

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -152,7 +152,7 @@ Otherwise, this restricts itself to organs that share the UE of the host.
 
 old_ue: Set this to a UE string, and this proc will overwrite the dna of organs that have that UE, instead of the host's present UE
 */
-/mob/living/carbon/human/proc/sync_organ_dna(var/assimilate = 1, var/old_ue = null)
+/mob/living/carbon/human/proc/sync_organ_dna(assimilate = 1, old_ue)
 	var/ue_to_compare = (old_ue) ? old_ue : dna.unique_enzymes
 	var/list/all_bits = internal_organs|bodyparts
 	for(var/obj/item/organ/O in all_bits)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -159,6 +159,30 @@ old_ue: Set this to a UE string, and this proc will overwrite the dna of organs 
 		if(assimilate || O.dna.unique_enzymes == ue_to_compare)
 			O.set_dna(dna)
 
+/mob/living/carbon/human/proc/update_organ_parenthood() //Refresh the parenthood of all organs - namely after species changes.
+	for(var/B in bodyparts)
+		var/obj/item/organ/external/E = B
+		E.update_parenthood()
+
+/mob/living/carbon/human/proc/sort_organ_lists() //Sort mob organ lists matched as closely as possible to the species defines.
+	if(dna.species)
+		var/list/sorted_bodyparts = list()
+		var/list/sorted_bodyparts_by_name = list()
+
+		for(var/B in dna.species.has_limbs) //As close as we can get. This method is index-wise!
+			var/obj/item/organ/external/E = bodyparts_by_name[B]
+			if(E && (E in bodyparts))
+				sorted_bodyparts += E
+				bodyparts -= E
+		sorted_bodyparts += bodyparts //Unceremoniously dump the last of the elements off at the end of the sorted list.
+
+		for(var/B in sorted_bodyparts) //Take the easy way out and make use of our previous work.
+			var/obj/item/organ/external/E = B
+			sorted_bodyparts_by_name[E.limb_name] = E
+
+		bodyparts = sorted_bodyparts
+		bodyparts_by_name = sorted_bodyparts_by_name
+
 /*
 Given the name of an organ, returns the external organ it's contained in
 I use this to standardize shadowling dethrall code

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -194,28 +194,22 @@
 		/**HANDLE INTERNAL ORGANS**/
 		for(var/organ_type in species_organs) //Account for switching from a species with less organs to a species with more, excepting amputations.
 			if(!H.get_organ_slot(organ_type) && !(organ_type in oldspecies_organs))
-				to_chat(H, "PI1 - [organ_type]")
 				add_after["organs"][organ_type] = TRUE //Make sure missing stuff is regenerated or we DIE!
 
 		for(var/O in H.internal_organs) //Same as above but for innards. Gotta go inside out to avoid runtimes.
 			var/obj/item/organ/internal/I = O
 			if(I.is_robotic() && !(initial(I.status) & ORGAN_ROBOT)) //Were ya born that way? Allows for correct removal of IPC/Vox organs.
-				to_chat(H, "I1 - [I.slot]")
 				continue
 			if((I?.dna.species.name != OS.name) || (I?.dna.real_name != H.real_name)) //Same slot, different species?
-				to_chat(H, "I2 - [I.slot]")
 				continue
 			if(I.slot in oldspecies_organs)
 				if(I.type != oldspecies_organs[I.slot]) //Organs with cybernetic in the type should be preserved because of this. Augments/implants etc. survive too.
-					to_chat(H, "I3 - [I.slot]")
 					continue
 				if(!(I.slot in species_organs)) //Liquidate surplus.
-					to_chat(H, "I4 - [I.slot]")
 					remove_after["organs"] |= I
 					I.prep_replace(H)
 					continue
 			else //if(I.slot in species_organs) Organ's already the right kind and belongs to us, don't screw with it. Also accounts for additional non-synthetic augmentations.
-				to_chat(H, "I5 - [I.slot]")
 				continue
 
 			//You ran the gauntlet and survived, I am pleased.
@@ -223,46 +217,32 @@
 			remove_after["organs"] |= I
 			I.prep_replace(H)
 
-		for(var/I in remove_after["organs"])
-			to_chat(H, "Remove - [I]")
-		for(var/I in add_after["organs"])
-			to_chat(H, "Replace - [I]")
 		QDEL_LIST(remove_after["organs"]) //This needs to be broken out here because it made the loops above unable to read properties properly.
 
 		/**HANDLE LIMBS**/
 		for(var/limb_type in has_limbs) //Just doing this 'cause I don't know what the future holds. Something about third leg jokes.
 			if(!H.get_organ(limb_type) && !(limb_type in OS.has_limbs))
-				to_chat(H, "PE1 - [limb_type]")
 				add_after["limbs"][limb_type] = TRUE //Just need to fill this in with something.
 
 		for(var/B in H.bodyparts) //Is it mine?
 			var/obj/item/organ/external/E = B
 			if(E.is_robotic() && !(initial(E.status) & ORGAN_ROBOT)) //Preserves augmented or prosthetic limbs. FBPs will be fine due to rebuild_on_gain == true and their limbs starting robotic.
-				to_chat(H, "E1 - [E.limb_name]")
 				continue
 			if((E?.dna.species.name != OS.name) || (E?.dna.real_name != H.real_name))
-				to_chat(H, "E2 - [E.limb_name]")
 				continue
 			if(E.limb_name in OS.has_limbs)
 				if(E.type != OS.has_limbs[E.limb_name]["path"])
-					to_chat(H, "E3 - [E.limb_name]")
 					continue
 				if(!(E.limb_name in has_limbs))
-					to_chat(H, "E4 - [E.limb_name]")
 					remove_after["limbs"] |= E
 					E.prep_replace(H)
 			else //if(E.limb_name in has_limbs)
-				to_chat(H, "E5 - [E.limb_name]")
 				continue
 
 			add_after["limbs"][E.limb_name] = E
 			remove_after["limbs"] |= E
 			E.prep_replace(H) //Planned parenthood is important, even in space.
 
-		for(var/E in remove_after["limbs"])
-			to_chat(H, "Remove - [E]")
-		for(var/E in add_after["limbs"])
-			to_chat(H, "Replace - [E]")
 		QDEL_LIST(remove_after["limbs"])
 
 	else //Maintain old behaviour. Legacy support

--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -36,28 +36,28 @@
 	reagent_tag = PROCESS_ORG
 
 	has_organ = list(
-		"nutrient channel" =   /obj/item/organ/internal/liver/diona,
-		"respiratory vacuoles" =   /obj/item/organ/internal/lungs/diona,
-		"neural strata" =      /obj/item/organ/internal/heart/diona,
-		"receptor node" =      /obj/item/organ/internal/eyes/diona, //Default darksight of 2.
-		"gas bladder" =        /obj/item/organ/internal/brain/diona,
-		"polyp segment" =      /obj/item/organ/internal/kidneys/diona,
-		"anchoring ligament" = /obj/item/organ/internal/appendix/diona
+		"heart"		= /obj/item/organ/internal/heart/diona,
+		"lungs"		= /obj/item/organ/internal/lungs/diona,
+		"liver"		= /obj/item/organ/internal/liver/diona,
+		"kidneys"	= /obj/item/organ/internal/kidneys/diona,
+		"brain"		= /obj/item/organ/internal/brain/diona,
+		"appendix"	= /obj/item/organ/internal/appendix/diona,
+		"eyes"		= /obj/item/organ/internal/eyes/diona //Default darksight of 2.
 		)
 
 	vision_organ = /obj/item/organ/internal/eyes/diona
 	has_limbs = list(
-		"chest" =  list("path" = /obj/item/organ/external/chest/diona),
-		"groin" =  list("path" = /obj/item/organ/external/groin/diona),
-		"head" =   list("path" = /obj/item/organ/external/head/diona),
-		"l_arm" =  list("path" = /obj/item/organ/external/arm/diona),
-		"r_arm" =  list("path" = /obj/item/organ/external/arm/right/diona),
-		"l_leg" =  list("path" = /obj/item/organ/external/leg/diona),
-		"r_leg" =  list("path" = /obj/item/organ/external/leg/right/diona),
-		"l_hand" = list("path" = /obj/item/organ/external/hand/diona),
-		"r_hand" = list("path" = /obj/item/organ/external/hand/right/diona),
-		"l_foot" = list("path" = /obj/item/organ/external/foot/diona),
-		"r_foot" = list("path" = /obj/item/organ/external/foot/right/diona)
+		"chest"		= list("path" = /obj/item/organ/external/chest/diona),
+		"groin"		= list("path" = /obj/item/organ/external/groin/diona),
+		"head"		= list("path" = /obj/item/organ/external/head/diona),
+		"l_arm"		= list("path" = /obj/item/organ/external/arm/diona),
+		"r_arm"		= list("path" = /obj/item/organ/external/arm/right/diona),
+		"l_leg"		= list("path" = /obj/item/organ/external/leg/diona),
+		"r_leg"		= list("path" = /obj/item/organ/external/leg/right/diona),
+		"l_hand"	= list("path" = /obj/item/organ/external/hand/diona),
+		"r_hand"	= list("path" = /obj/item/organ/external/hand/right/diona),
+		"l_foot"	= list("path" = /obj/item/organ/external/foot/diona),
+		"r_foot"	= list("path" = /obj/item/organ/external/foot/right/diona)
 		)
 
 	suicide_messages = list(

--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -55,9 +55,9 @@
 	butt_sprite = "drask"
 
 	has_organ = list(
-		"heart" =      				/obj/item/organ/internal/heart/drask,
-		"lungs" =     				/obj/item/organ/internal/lungs/drask,
-		"metabolic strainer" =      /obj/item/organ/internal/liver/drask,
-		"eyes" =     				/obj/item/organ/internal/eyes/drask, //5 darksight.
-		"brain" =  					/obj/item/organ/internal/brain/drask
+		"heart"	= /obj/item/organ/internal/heart/drask,
+		"lungs"	= /obj/item/organ/internal/lungs/drask,
+		"liver"	= /obj/item/organ/internal/liver/drask,
+		"eyes"	= /obj/item/organ/internal/eyes/drask, //5 darksight.
+		"brain"	= /obj/item/organ/internal/brain/drask
 		)

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -94,7 +94,7 @@
 			H.mind.special_role = SPECIAL_ROLE_GOLEM
 		else
 			H.mind.special_role = SPECIAL_ROLE_FREE_GOLEM
-	H.real_name = get_random_name()
+	H.change_real_name(get_random_name(), TRUE)
 	H.name = H.real_name
 	to_chat(H, info_text)
 

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -5,8 +5,7 @@
 	icobase = 'icons/mob/human_races/r_golem.dmi'
 	deform = 'icons/mob/human_races/r_golem.dmi'
 
-	rebuild_on_gain = TRUE
-	species_traits = list(NO_BREATHE, NO_BLOOD, NO_PAIN, RADIMMUNE, NOGUNS, PIERCEIMMUNE)
+	species_traits = list(NO_BREATHE, NO_BLOOD, NO_PAIN, RADIMMUNE, NOGUNS, PIERCEIMMUNE, REBUILD_ON_GAIN)
 	dies_at_threshold = TRUE
 	speed_mod = 2
 	brute_mod = 0.45 //55% damage reduction

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -5,6 +5,7 @@
 	icobase = 'icons/mob/human_races/r_golem.dmi'
 	deform = 'icons/mob/human_races/r_golem.dmi'
 
+	rebuild_on_gain = TRUE
 	species_traits = list(NO_BREATHE, NO_BLOOD, NO_PAIN, RADIMMUNE, NOGUNS, PIERCEIMMUNE)
 	dies_at_threshold = TRUE
 	speed_mod = 2

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -21,8 +21,7 @@
 	clone_mod = 0
 	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."
 
-	rebuild_on_gain = TRUE
-	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING) //Computers that don't decay? What a lie!
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING, REBUILD_ON_GAIN) //Computers that don't decay? What a lie!
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS
 	dietflags = 0		//IPCs can't eat, so no diet

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -51,7 +51,7 @@
 	has_organ = list(
 		"brain" = /obj/item/organ/internal/brain/mmi_holder/posibrain,
 		"cell" = /obj/item/organ/internal/cell,
-		"optics" = /obj/item/organ/internal/eyes/optical_sensor, //Default darksight of 2.
+		"eyes" = /obj/item/organ/internal/eyes/optical_sensor, //Default darksight of 2.
 		"charger" = /obj/item/organ/internal/cyberimp/arm/power_cord
 		)
 

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -21,6 +21,7 @@
 	clone_mod = 0
 	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."
 
+	rebuild_on_gain = TRUE
 	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING) //Computers that don't decay? What a lie!
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -50,7 +50,7 @@
 
 /datum/species/monkey/on_species_gain(mob/living/carbon/human/H)
 	..()
-	H.real_name = "[lowertext(name)] ([rand(100,999)])"
+	H.change_real_name("[lowertext(name)] ([rand(100,999)])", TRUE)
 	H.name = H.real_name
 	H.butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/monkey = 5)
 

--- a/code/modules/mob/living/carbon/human/species/nucleation.dm
+++ b/code/modules/mob/living/carbon/human/species/nucleation.dm
@@ -22,9 +22,9 @@
 
 	reagent_tag = PROCESS_ORG
 	has_organ = list(
-		"heart" =    /obj/item/organ/internal/heart,
-		"crystallized brain" =    /obj/item/organ/internal/brain/crystal,
-		"eyes" =     /obj/item/organ/internal/eyes/luminescent_crystal, //Standard darksight of 2.
+		"heart"	= /obj/item/organ/internal/heart,
+		"brain"	= /obj/item/organ/internal/brain/crystal,
+		"eyes"	= /obj/item/organ/internal/eyes/luminescent_crystal, //Standard darksight of 2.
 		"strange crystal" = /obj/item/organ/internal/nucleation/strange_crystal
 		)
 	vision_organ = /obj/item/organ/internal/eyes/luminescent_crystal

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -10,8 +10,7 @@
 	blood_color = "#FFFFFF"
 	flesh_color = "#E6E6C6"
 
-	rebuild_on_gain = TRUE
-	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, VIRUSIMMUNE, NO_HUNGER, PIERCEIMMUNE)
+	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, VIRUSIMMUNE, NO_HUNGER, PIERCEIMMUNE, REBUILD_ON_GAIN)
 	dies_at_threshold = TRUE
 	skinned_type = /obj/item/stack/sheet/bone
 

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -10,6 +10,7 @@
 	blood_color = "#FFFFFF"
 	flesh_color = "#E6E6C6"
 
+	rebuild_on_gain = TRUE
 	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, VIRUSIMMUNE, NO_HUNGER, PIERCEIMMUNE)
 	dies_at_threshold = TRUE
 	skinned_type = /obj/item/stack/sheet/bone

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -61,7 +61,7 @@
 		"lungs" =    /obj/item/organ/internal/lungs/vox,
 		"liver" =    /obj/item/organ/internal/liver/vox,
 		"kidneys" =  /obj/item/organ/internal/kidneys/vox,
-		"cortical stack" =    /obj/item/organ/internal/brain/vox,
+		"brain" =    /obj/item/organ/internal/brain/vox,
 		"appendix" = /obj/item/organ/internal/appendix,
 		"eyes" =     /obj/item/organ/internal/eyes/vox, //Default darksight of 2.
 		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.

--- a/code/modules/mob/living/carbon/human/species/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species/zombies.dm
@@ -29,8 +29,8 @@
 		"brain" =    /obj/item/organ/internal/brain,
 		"appendix" = /obj/item/organ/internal/appendix,
 		"eyes" =     /obj/item/organ/internal/eyes,
-		"ears" = 	/obj/item/organ/internal/ears)
-
+		"ears" = 	/obj/item/organ/internal/ears,
+		"zombie_infection" = /obj/item/organ/internal/zombie_infection)
 
 /datum/species/zombie/infectious
 	name = "Infectious Zombie"
@@ -88,11 +88,6 @@
 		H.drop_r_hand()
 		H.put_in_hands(new mutanthands())
 		H.put_in_hands(new mutanthands())
-	var/obj/item/organ/internal/zombie_infection/infection
-	infection = H.get_organ_slot("zombie_infection")
-	if(!infection)
-		infection = new()
-		infection.insert(H)
 
 /datum/species/zombie/infectious/on_species_loss(mob/living/carbon/human/C, datum/species/old_species)
 	QDEL_NULL(C.r_hand)

--- a/code/modules/mob/living/carbon/human/species/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species/zombies.dm
@@ -9,7 +9,11 @@
 	dies_at_threshold = TRUE
 	language = "Zombie"
 	species_traits = list(NO_BLOOD, NOZOMBIE, NOTRANSSTING, NO_BREATHE, RADIMMUNE, NO_SCAN)
-	var/static/list/spooks = list('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')
+	speech_sounds = list('sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg', 'sound/hallucinations/veryfar_noise.ogg', 'sound/hallucinations/wail.ogg')
+	speech_chance = 20
+	male_scream_sound = 'sound/hallucinations/wail.ogg'
+	female_scream_sound = 'sound/hallucinations/wail.ogg'
+	scream_verb = "wails"
 	warning_low_pressure = -1
 	hazard_low_pressure = -1
 	hazard_high_pressure = 999999999
@@ -68,7 +72,7 @@
 		H.heal_overall_damage(heal_amt,heal_amt)
 		H.adjustToxLoss(-heal_amt)
 	if(!H.InCritical() && prob(4))
-		playsound(H, pick(spooks), 50, TRUE, 10)
+		playsound(H, pick(speech_sounds), 50, TRUE, 10)
 
 //Congrats you somehow died so hard you stopped being a zombie
 /datum/species/zombie/infectious/handle_death(gibbed, mob/living/carbon/C)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -400,7 +400,7 @@
 
 // rejuvenate: Called by `revive` to get the mob into a revivable state
 // the admin "rejuvenate" command calls `revive`, not this proc.
-/mob/living/proc/rejuvenate()
+/mob/living/proc/rejuvenate(no_release = FALSE)
 	var/mob/living/carbon/human/human_mob = null //Get this declared for use later.
 
 	// shut down various types of badness
@@ -440,12 +440,13 @@
 	fire_stacks = 0
 	on_fire = 0
 	suiciding = 0
-	if(buckled) //Unbuckle the mob and clear the alerts.
+	if(!no_release && buckled) //Unbuckle the mob and clear the alerts.
 		buckled.unbuckle_mob(src, force = TRUE)
 
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
-		C.handcuffed = initial(C.handcuffed)
+		if(!no_release)
+			C.handcuffed = initial(C.handcuffed)
 
 		for(var/thing in C.viruses)
 			var/datum/disease/D = thing
@@ -462,7 +463,7 @@
 	restore_all_organs()
 	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
-		update_revive()
+		. = update_revive()
 	else if(stat == UNCONSCIOUS)
 		WakeUp()
 
@@ -472,7 +473,7 @@
 	if(human_mob)
 		human_mob.update_eyes()
 		human_mob.update_dna()
-	return
+	return .
 
 /mob/living/proc/remove_CC(should_update_canmove = TRUE)
 	SetWeakened(0, FALSE)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -280,8 +280,8 @@
 		var/tail_shift_y
 		var/blend_mode = ICON_ADD
 
-		if(body_accessory)
-			var/datum/body_accessory/accessory = body_accessory_by_name[body_accessory]
+		var/datum/body_accessory/accessory = body_accessory_by_name[body_accessory]
+		if(istype(accessory))
 			tail_icon = accessory.icon
 			tail_icon_state = accessory.icon_state
 			if(accessory.blend_mode)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -13,6 +13,7 @@
 	var/organ_tag = "organ"
 
 	var/parent_organ = "chest"
+	var/changing_parent = FALSE //Set TRUE during species changes whereby organs may be temporarily orphaned during regeneration until parenthood is updated.
 
 	var/list/datum/autopsy_data/autopsy_data = list()
 	var/list/trace_chemicals = list() // traces of chemicals in the organ,
@@ -42,6 +43,13 @@
 
 /obj/item/organ/proc/become_orphan() //Useful in species changes where we don't need to be sensitive about this. Abandons children and isolates organ from parents.
 	return
+
+/*Again useful in species changes -- we need to be very careful of how we handle references.
+Traditionally you'd be working with extremities and leaving the torso alone -- but it takes the Midas touch
+to keep an extremity, replace the core and rebuild the references properly so stuff still works.*/
+/obj/item/organ/proc/prep_replace(mob/living/carbon/human/H)
+	if(H)
+		become_orphan(H)
 
 /obj/item/organ/proc/update_health()
 	return

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -13,7 +13,6 @@
 	var/organ_tag = "organ"
 
 	var/parent_organ = "chest"
-	var/changing_parent = FALSE //Set TRUE during species changes whereby organs may be temporarily orphaned during regeneration until parenthood is updated.
 
 	var/list/datum/autopsy_data/autopsy_data = list()
 	var/list/trace_chemicals = list() // traces of chemicals in the organ,
@@ -40,6 +39,9 @@
 	QDEL_LIST_ASSOC_VAL(autopsy_data)
 	QDEL_NULL(dna)
 	return ..()
+
+/obj/item/organ/proc/update_parenthood() //Check to see if there's an available parent organ and become their child -- or become internal organ to appropriate parent.
+	return
 
 /obj/item/organ/proc/become_orphan() //Useful in species changes where we don't need to be sensitive about this. Abandons children and isolates organ from parents.
 	return

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -40,6 +40,9 @@
 	QDEL_NULL(dna)
 	return ..()
 
+/obj/item/organ/proc/become_orphan() //Useful in species changes where we don't need to be sensitive about this. Abandons children and isolates organ from parents.
+	return
+
 /obj/item/organ/proc/update_health()
 	return
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -72,7 +72,7 @@
 		if(vital)
 			owner.death()
 
-/obj/item/organ/external/proc/become_orphan()
+/obj/item/organ/external/become_orphan()
 	if(parent && parent.children)
 		parent.children -= src
 	parent = null

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -72,11 +72,13 @@
 		if(vital)
 			owner.death()
 
-/obj/item/organ/external/Destroy()
+/obj/item/organ/external/proc/become_orphan()
 	if(parent && parent.children)
 		parent.children -= src
-
 	parent = null
+
+/obj/item/organ/external/Destroy()
+	become_orphan()
 
 	if(internal_organs)
 		for(var/obj/item/organ/internal/O in internal_organs)
@@ -111,7 +113,15 @@
 		sync_colour_to_human(H)
 	get_icon()
 
-/obj/item/organ/external/replaced(var/mob/living/carbon/human/target)
+/obj/item/organ/external/proc/update_parenthood()
+	if(parent_organ)
+		parent = owner.bodyparts_by_name[parent_organ]
+		if(parent)
+			if(!parent.children)
+				parent.children = list()
+			parent.children |= src
+
+/obj/item/organ/external/replaced(mob/living/carbon/human/target)
 	owner = target
 	forceMove(owner)
 	if(istype(owner))
@@ -122,12 +132,7 @@
 		for(var/atom/movable/stuff in src)
 			stuff.attempt_become_organ(src, owner)
 
-	if(parent_organ)
-		parent = owner.bodyparts_by_name[src.parent_organ]
-		if(parent)
-			if(!parent.children)
-				parent.children = list()
-			parent.children.Add(src)
+	update_parenthood()
 
 /obj/item/organ/external/attempt_become_organ(obj/item/organ/external/parent,mob/living/carbon/human/H)
 	if(parent_organ != parent.limb_name)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -96,7 +96,6 @@
 
 	return ..()
 
-
 /obj/item/organ/external/update_health()
 	damage = min(max_damage, (brute_dam + burn_dam))
 	return
@@ -695,7 +694,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/is_malfunctioning()
 	return (is_robotic() && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam) && !tough)
 
-/obj/item/organ/external/remove(var/mob/living/user, var/ignore_children)
+/obj/item/organ/external/remove(mob/living/user, ignore_children, ignore_malf)
 
 	if(!owner)
 		return
@@ -731,7 +730,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		victim.bodyparts_by_name[limb_name] = null	// Remove from owner's vars.
 
 	//Robotic limbs explode if sabotaged.
-	if(is_robotic() && sabotaged)
+	if(!ignore_malf && is_robotic() && sabotaged)
 		victim.visible_message(
 			"<span class='danger'>\The [victim]'s [src.name] explodes violently!</span>",\
 			"<span class='danger'>Your [src.name] explodes!</span>",\

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -44,6 +44,9 @@
 	if(vital)
 		M.update_stat("Vital organ inserted")
 
+/obj/item/organ/internal/become_orphan()
+	parent_organ = null
+
 // Removes the given organ from its owner.
 // Returns the removed object, which is usually just itself
 // However, you MUST set the object's positiion yourself when you call this!

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -36,7 +36,6 @@
 			log_runtime(EXCEPTION("[src] attempted to insert into a [parent_organ], but [parent_organ] wasn't an organ! [atom_loc_line(M)]"), src)
 		else
 			parent.internal_organs |= src
-			changing_parent = FALSE
 	//M.internal_bodyparts_by_name[src] |= src(H,1)
 	loc = null
 	for(var/X in actions)
@@ -45,12 +44,18 @@
 	if(vital)
 		M.update_stat("Vital organ inserted")
 
+/obj/item/organ/internal/update_parenthood() //Find parent and internalize.
+	var/mob/living/carbon/human/H = owner
+	if(parent_organ && istype(H))
+		var/obj/item/organ/external/parent = H.get_organ(check_zone(parent_organ))
+		if(istype(parent))
+			parent.internal_organs |= src
+
 /obj/item/organ/internal/become_orphan(mob/living/carbon/human/H)
 	if(H)
 		var/obj/item/organ/external/parent = H.get_organ(check_zone(parent_organ))
-		if(parent && parent.children)
+		if(parent)
 			parent.internal_organs -= src
-			parent = null
 	parent_organ = null
 	..()
 
@@ -63,7 +68,7 @@
 // Removes the given organ from its owner.
 // Returns the removed object, which is usually just itself
 // However, you MUST set the object's positiion yourself when you call this!
-/obj/item/organ/internal/remove(mob/living/carbon/M, special = 0, prep_replace)
+/obj/item/organ/internal/remove(mob/living/carbon/M, special = 0)
 	if(!owner && !(status & ORGAN_SPECIES_CHANGING))
 		log_runtime(EXCEPTION("\'remove\' called on [src] without an owner! Mob: [M], [atom_loc_line(M)]"), src)
 	owner = null

--- a/code/modules/surgery/organs/subtypes/standard.dm
+++ b/code/modules/surgery/organs/subtypes/standard.dm
@@ -57,6 +57,7 @@
 	min_broken_damage = 30
 	w_class = WEIGHT_CLASS_NORMAL
 	body_part = ARM_LEFT
+	icon_position = LEFT
 	parent_organ = "chest"
 	amputation_point = "left shoulder"
 	can_grasp = 1
@@ -67,6 +68,7 @@
 	name = "right arm"
 	icon_name = "r_arm"
 	body_part = ARM_RIGHT
+	icon_position = RIGHT
 	amputation_point = "right shoulder"
 	convertable_children = list(/obj/item/organ/external/hand/right)
 
@@ -127,6 +129,7 @@
 	min_broken_damage = 15
 	w_class = WEIGHT_CLASS_SMALL
 	body_part = HAND_LEFT
+	icon_position = LEFT
 	parent_organ = "l_arm"
 	amputation_point = "left wrist"
 	can_grasp = 1
@@ -147,6 +150,7 @@
 	name = "right hand"
 	icon_name = "r_hand"
 	body_part = HAND_RIGHT
+	icon_position = RIGHT
 	parent_organ = "r_arm"
 	amputation_point = "right wrist"
 

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -45,8 +45,7 @@
 	var/obj/item/organ/internal/zombie_infection/infection
 	infection = target.get_organ_slot("zombie_infection")
 	if(!infection)
-		infection = new()
-		infection.insert(target)
+		infection = new(target)
 
 /obj/item/zombie_hand/proc/check_feast(mob/living/target, mob/living/user)
 	if(target.stat == DEAD)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -83,7 +83,7 @@
 		return
 
 	Z.grab_ghost()
-	Z.visible_message("<span class='danger'>[Z] suddenly convulses, as [Z.p_they()][stand_up ? " stagger to [Z.p_their()] feet and" : ""] gain a ravenous hunger in [Z.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
+	Z.visible_message("<span class='danger'>[Z] suddenly convulses[stand_up ? ", staggers to [Z.p_their()] feet" : ""] and gains a ravenous hunger in [Z.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
 	playsound(Z.loc, 'sound/hallucinations/far_noise.ogg', 50, TRUE)
 	Z.do_jitter_animation(living_transformation_time)
 	Z.Stun(living_transformation_time * 0.05)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -5,7 +5,7 @@
 	slot = "zombie_infection"
 	icon_state = "blacktumor"
 	var/causes_damage = TRUE
-	var/datum/species/old_species = /datum/species/human
+	var/datum/species/old_species
 	var/living_transformation_time = 30
 	var/converts_living = FALSE
 
@@ -24,13 +24,16 @@
 /obj/item/organ/internal/zombie_infection/insert(mob/living/carbon/human/M, special = 0)
 	..()
 	START_PROCESSING(SSobj, src)
+	if(!old_species)
+		old_species = M.dna.species.type
 
 /obj/item/organ/internal/zombie_infection/remove(mob/living/carbon/human/M, special = 0)
-	STOP_PROCESSING(SSobj, src)
-	if(iszombie(M) && old_species)
-		M.set_species(old_species, retain_damage = TRUE)
-	if(timer_id)
-		deltimer(timer_id)
+	if(!(status & ORGAN_SPECIES_CHANGING))
+		STOP_PROCESSING(SSobj, src)
+		if(iszombie(M) && old_species)
+			M.set_species(old_species, retain_damage = TRUE)
+		if(timer_id)
+			deltimer(timer_id)
 	. = ..()
 
 /obj/item/organ/internal/zombie_infection/on_find(mob/living/finder)
@@ -41,8 +44,6 @@
 /obj/item/organ/internal/zombie_infection/process()
 	if(!owner)
 		return
-	if(!(src in owner.internal_organs))
-		remove(owner)
 	if(causes_damage && !iszombie(owner) && owner.stat != DEAD)
 		owner.adjustToxLoss(1)
 		if(prob(10))
@@ -64,36 +65,29 @@
 	timer_id = addtimer(CALLBACK(src, .proc/zombify), revive_time, flags)
 
 /obj/item/organ/internal/zombie_infection/proc/zombify()
+	var/mob/living/carbon/human/Z = owner //Figure this out before changing species.
 	timer_id = null
 
-	if(!converts_living && owner.stat != DEAD)
+	if(!converts_living && Z.stat != DEAD)
 		return
 
-	if(!iszombie(owner))
-		old_species = owner.dna.species.type
-		owner.set_species(/datum/species/zombie/infectious)
-		for(var/datum/disease/critical/crit in owner.viruses) // cure any new crit viruses
-			crit.cure(0)
+	if(!iszombie(Z))
+		if(!old_species)
+			old_species = Z.dna.species.type
+		Z.set_species(/datum/species/zombie/infectious)
 
-	var/stand_up = (owner.stat == DEAD) || (owner.stat == UNCONSCIOUS)
+	var/stand_up = (Z.stat == DEAD) || (Z.stat == UNCONSCIOUS)
 	//Fully heal the zombie's damage the first time they rise
-	owner.setToxLoss(0)
-	owner.setOxyLoss(0)
-	owner.setBrainLoss(0)
-	owner.setCloneLoss(0)
-	owner.SetLoseBreath(0)
-	owner.heal_overall_damage(INFINITY, INFINITY, TRUE, TRUE, FALSE)
-	owner.setStaminaLoss(0)
-
-	if(!owner.update_revive())
+	Z.surgeries.Cut() //End all surgeries.
+	if(!Z.rejuvenate(TRUE)) //Fix this damn zombie but don't turn them loose. Cures crit and literally everything else.
 		return
 
-	owner.grab_ghost()
-	owner.visible_message("<span class='danger'>[owner] suddenly convulses, as [owner.p_they()][stand_up ? " stagger to [owner.p_their()] feet and" : ""] gain a ravenous hunger in [owner.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
-	playsound(owner.loc, 'sound/hallucinations/far_noise.ogg', 50, TRUE)
-	owner.do_jitter_animation(living_transformation_time)
-	owner.Stun(living_transformation_time * 0.05)
-	to_chat(owner, "<span class='alertalien'>You are now a zombie! Do not seek to be cured, do not help any non-zombies in any way, do not harm your zombie brethren and spread the disease by killing others. You are a creature of hunger and violence.</span>")
+	Z.grab_ghost()
+	Z.visible_message("<span class='danger'>[Z] suddenly convulses, as [Z.p_they()][stand_up ? " stagger to [Z.p_their()] feet and" : ""] gain a ravenous hunger in [Z.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
+	playsound(Z.loc, 'sound/hallucinations/far_noise.ogg', 50, TRUE)
+	Z.do_jitter_animation(living_transformation_time)
+	Z.Stun(living_transformation_time * 0.05)
+	to_chat(Z, "<span class='alertalien'>You are now a zombie! Do not seek to be cured, do not help any non-zombies in any way, do not harm your zombie brethren and spread the disease by killing others. You are a creature of hunger and violence.</span>")
 
 /obj/item/organ/internal/zombie_infection/nodamage
 	causes_damage = FALSE

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -45,7 +45,7 @@
 		remove(owner)
 	if(causes_damage && !iszombie(owner) && owner.stat != DEAD)
 		owner.adjustToxLoss(1)
-		if (prob(10))
+		if(prob(10))
 			to_chat(owner, "<span class='danger'>You feel sick...</span>")
 	if(timer_id)
 		return


### PR DESCRIPTION
**What does this PR do:**
As requested in #12203 this PR refactors species changes. Reworked this multiple times during development after running into numerous quirks and discovering a couple underlying issues that first needed to be resolved.

/>>>
Creating a new mob from scratch will behave exactly as it did before -- a net new action, just sets up all the organs and limbs with no fancy logic.

But if you're changing the species of an existing mob, prior to switching species it now checks to see whether...

1. Any of their bodyparts/organs were missing
2. Any of their bodyparts/organs were augmented
3. Any of their bodyparts/organs were frankensteined/transplanted onto them

And will not replace or regenerate those bodyparts/organs.
This means that changing species (with few exceptions that can be determined by the `new_mob` or `regen_all` arguments and the `rebuild_on_gain` species trait. If a species has the `rebuild_on_gain` trait, it will force full wipe/regeneration of organs and bodyparts to maintain legacy behaviour and will be unaffected by this PR.

To accomplish this I had to introduce some helper procs and resolve issues where in most cases, when a mob's `real_name` was changed it wasn't properly committed to DNA.

**Images of sprite/map changes (IF APPLICABLE):**
![para ss13 species refactor 20190908 preserves frankensteins, augments and amputations](https://user-images.githubusercontent.com/12377767/64492677-07bf8580-d266-11e9-90f5-c55f49e8a092.png)
![para ss13 zombie working properly](https://user-images.githubusercontent.com/12377767/65938930-e9d3e380-e413-11e9-9b29-b2bc503c419f.png)

**Changelog:**
:cl:
add: Changing the species of an existing humanoid now preserves amputations, augmentations/cybernetics and transplanted or frankensteined bodyparts and organs.
add: Zombies now have a 20% chance to make a spooky sound when they talk.
add: Zombies now 'wail' when they scream, with the verb changed appropriately.
tweak: Organs defined for a species must be associated in the list with a string matching its slot (eg. brain, heart, etc.).
tweak: Adjusts grammar for zombification message.
fix: Fixes an issue preventing Vox raiders from getting the right hair and eye colours.
fix: Fixes multiple occurrences of an issue where changes to a humanoid's real_name weren't properly or fully committed to their DNA.
fix: Fixes an issue preventing the loss of the tail lash ability when becoming something other than an Unathi.
fix: Changing species no longer drops cuffs. Changelings changing into other folks won't drop cuffs either.
fix: Fixes zombification (zombies now fully regenerate when they turn).
fix: Fixes being infected by zombies, and being turned back to normal by removing the ooze.
/:cl:

