### PR TITLE
Lavaland Update Part 3: Fixes Megafauna Spawning, Rivers, and Turfs

### DIFF
--- a/code/__HELPERS/typelists.dm
+++ b/code/__HELPERS/typelists.dm
@@ -1,0 +1,43 @@
+GLOBAL_LIST_EMPTY(typelists)
+
+#ifndef TESTING
+
+/datum/proc/typelist(key, list/values = list())
+	var/list/mytypelist = GLOB.typelists[type] || (GLOB.typelists[type] = list())
+	return mytypelist[key] || (mytypelist[key] = values.Copy())
+
+#else
+// mostly the same code as above, just more verbose, slower and has tallying for saved lists
+/datum/proc/typelist(key, list/values)
+	if (!values)
+		values = list()
+	GLOB.typelistkeys |= key
+	if (GLOB.typelists[type])
+		if (GLOB.typelists[type][key])
+			GLOB.typelists[type]["[key]-saved"]++
+			return GLOB.typelists[type][key]
+		else
+			GLOB.typelists[type][key] = values.Copy()
+	else
+		GLOB.typelists[type] = list()
+		GLOB.typelists[type][key] = values.Copy()
+	return GLOB.typelists[type][key]
+
+GLOBAL_LIST_EMPTY(typelistkeys)
+
+/proc/tallytypelistsavings()
+	var/savings = list()
+	var/saveditems = list()
+	for (var/key in GLOB.typelistkeys)
+		savings[key] = 0
+		saveditems[key] = 0
+
+	for (var/type in GLOB.typelists)
+		for (var/saving in savings)
+			if (GLOB.typelists[type]["[saving]-saved"])
+				savings[saving] += GLOB.typelists[type]["[saving]-saved"]
+				saveditems[saving] += (GLOB.typelists[type]["[saving]-saved"] * length(GLOB.typelists[type][saving]))
+
+	for (var/saving in savings)
+		to_chat(world, "Savings for [saving]: [savings[saving]] lists, [saveditems[saving]] items")
+#endif

--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -34,8 +34,6 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list(
 	"Hotel"
 	)) //Those networks can only be accessed by preexisting terminals. AIs and new terminals can't use them.
 
-GLOBAL_LIST_INIT(mineral_turfs, list())
-
 GLOBAL_LIST_INIT(ruin_landmarks, list())
 
 GLOBAL_LIST_INIT(round_end_sounds, list(

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(mapping)
 	if (mining_type == "lavaland")
 		// Spawn Lavaland ruins and rivers.
 		seedRuins(list(level_name_to_num(MINING)), config.lavaland_budget, /area/lavaland/surface/outdoors/unexplored, lava_ruins_templates)
-		spawn_rivers()
+		spawn_rivers(list(level_name_to_num(MINING)))
 	else
 		// Populate mining Z-level hidden rooms
 		for(var/i = 0, i < max_secret_rooms, i++)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -45,13 +45,7 @@
 		loc.handle_atom_del(src)
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
-	var/turf/un_opaque
-	if(opacity && isturf(loc))
-		un_opaque = loc
-
 	loc = null
-	if(un_opaque)
-		un_opaque.recalc_atom_opacity()
 	if(pulledby)
 		if(pulledby.pulling == src)
 			pulledby.pulling = null
@@ -120,7 +114,7 @@
 			return
 	if(pulledby && moving_diagonally != FIRST_DIAG_STEP && get_dist(src, pulledby) > 1)		//separated from our puller and not in the middle of a diagonal move.
 		pulledby.stop_pulling()
-		
+
 /atom/movable/proc/can_be_pulled(user, grab_state, force)
 	if(src == user || !isturf(loc))
 		return FALSE

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -492,7 +492,7 @@
 							playsound(src.loc, 'sound/weapons/genhit.ogg', 100, 1)
 							var/turf/space/T
 							for(T in orange(1, src))
-								T.ChangeTurf(/turf/simulated/floor/plating/)
+								T.ChangeTurf(/turf/simulated/floor/plating)
 					else
 						atom_say("Something slams into the floor around [src] - luckily, it didn't get through!")
 						playsound(src.loc, 'sound/effects/bang.ogg', 20, 1)

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -77,7 +77,7 @@
 /turf/simulated/floor/plating/asteroid/drill_act(obj/item/mecha_parts/mecha_equipment/drill/drill)
 	for(var/turf/simulated/floor/plating/asteroid/M in range(1, drill.chassis))
 		if((get_dir(drill.chassis, M) & drill.chassis.dir) && !M.dug)
-			M.gets_dug()
+			M.getDug()
 	drill.log_message("Drilled through [src]")
 	drill.move_ores()
 

--- a/code/game/turfs/simulated/floor/asteroid.dm
+++ b/code/game/turfs/simulated/floor/asteroid.dm
@@ -1,6 +1,8 @@
+
 /**********************Asteroid**************************/
 
 /turf/simulated/floor/plating/asteroid
+	gender = PLURAL
 	name = "asteroid sand"
 	baseturf = /turf/simulated/floor/plating/asteroid
 	icon_state = "asteroid"
@@ -8,16 +10,31 @@
 	footstep_sounds = list()
 	var/environment_type = "asteroid"
 	var/turf_type = /turf/simulated/floor/plating/asteroid //Because caves do whacky shit to revert to normal
-	var/dug = 0       //0 = has not yet been dug, 1 = has already been dug
-	var/sand_type = /obj/item/stack/ore/glass
 	var/floor_variance = 20 //probability floor has a different icon state
+	var/obj/item/stack/digResult = /obj/item/stack/ore/glass/basalt
+	var/dug
 
-/turf/simulated/floor/plating/asteroid/New()
+/turf/simulated/floor/plating/asteroid/Initialize(mapload)
 	var/proper_name = name
-	..()
+	. = ..()
 	name = proper_name
 	if(prob(floor_variance))
 		icon_state = "[environment_type][rand(0,12)]"
+
+/turf/simulated/floor/plating/asteroid/proc/getDug()
+	new digResult(src, 5)
+	icon_plating = "[environment_type]_dug"
+	icon_state = "[environment_type]_dug"
+	dug = TRUE
+
+/turf/simulated/floor/plating/asteroid/proc/can_dig(mob/user)
+	if(!dug)
+		return TRUE
+	if(user)
+		to_chat(user, "<span class='notice'>Looks like someone has dug here already.</span>")
+
+/turf/simulated/floor/plating/asteroid/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
+	return
 
 /turf/simulated/floor/plating/asteroid/burn_tile()
 	return
@@ -31,46 +48,50 @@
 /turf/simulated/floor/plating/asteroid/remove_plating()
 	return
 
-/turf/simulated/floor/plating/asteroid/ex_act(severity, target)
+/turf/simulated/floor/plating/asteroid/ex_act(severity)
+	if(!can_dig())
+		return
 	switch(severity)
 		if(3)
 			return
 		if(2)
 			if(prob(20))
-				gets_dug()
+				getDug()
 		if(1)
-			gets_dug()
+			getDug()
 
-/turf/simulated/floor/plating/asteroid/attackby(obj/item/W, mob/user, params)
+/turf/simulated/floor/plating/asteroid/attackby(obj/item/I, mob/user, params)
 	//note that this proc does not call ..()
-	if(!W || !user)
-		return 0
+	if(!I|| !user)
+		return FALSE
 
-	if((istype(W, /obj/item/shovel) || istype(W, /obj/item/pickaxe)))
+	if((istype(I, /obj/item/shovel) || istype(I, /obj/item/pickaxe)))
+		if(!can_dig(user))
+			return TRUE
+
 		var/turf/T = get_turf(user)
 		if(!istype(T))
 			return
 
-		if(dug)
-			to_chat(user, "<span class='warning'>This area has already been dug!</span>")
-			return
-
 		to_chat(user, "<span class='notice'>You start digging...</span>")
-		playsound(src, W.usesound, 50, 1)
-		if(do_after(user, 20 * W.toolspeed, target = src))
-			to_chat(user, "<span class='notice'>You dig a hole.</span>")
-			gets_dug()
-			return
 
-	else if(istype(W,/obj/item/storage/bag/ore))
-		var/obj/item/storage/bag/ore/S = W
+		playsound(src, I.usesound, 50, TRUE)
+		if(do_after(user, 40 * I.toolspeed, target = src))
+			if(!can_dig(user))
+				return TRUE
+			to_chat(user, "<span class='notice'>You dig a hole.</span>")
+			getDug()
+			return TRUE
+
+	else if(istype(I, /obj/item/storage/bag/ore))
+		var/obj/item/storage/bag/ore/S = I
 		if(S.collection_mode == 1)
-			for(var/obj/item/stack/ore/O in src.contents)
-				O.attackby(W,user)
+			for(var/obj/item/stack/ore/O in contents)
+				O.attackby(I, user)
 				return
 
-	else if(istype(W, /obj/item/stack/tile))
-		var/obj/item/stack/tile/Z = W
+	else if(istype(I, /obj/item/stack/tile))
+		var/obj/item/stack/tile/Z = I
 		if(!Z.use(1))
 			return
 		if(istype(Z, /obj/item/stack/tile/plasteel)) // Turn asteroid floors into plating by default
@@ -79,25 +100,14 @@
 			ChangeTurf(Z.turf_type, keep_icon = FALSE)
 		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 
-/turf/simulated/floor/plating/asteroid/proc/gets_dug()
-	if(dug)
-		return
-	for(var/i in 1 to 5)
-		new sand_type(src)
-	dug = 1
-	icon_plating = "[environment_type]_dug"
-	icon_state = "[environment_type]_dug"
-	slowdown = 0
-	return
-
 /turf/simulated/floor/plating/asteroid/basalt
 	name = "volcanic floor"
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt
 	icon_state = "basalt"
 	icon_plating = "basalt"
 	environment_type = "basalt"
-	sand_type = /obj/item/stack/ore/glass/basalt
 	floor_variance = 15
+	digResult = /obj/item/stack/ore/glass/basalt
 
 /turf/simulated/floor/plating/asteroid/basalt/lava //lava underneath
 	baseturf = /turf/simulated/floor/plating/lava/smooth
@@ -107,9 +117,13 @@
 	oxygen = 0
 	nitrogen = 0
 
-/turf/simulated/floor/plating/asteroid/basalt/Initialize()
+/turf/simulated/floor/plating/asteroid/basalt/Initialize(mapload)
 	. = ..()
 	set_basalt_light(src)
+
+/turf/simulated/floor/plating/asteroid/basalt/getDug()
+	set_light(0)
+	return ..()
 
 /proc/set_basalt_light(turf/simulated/floor/B)
 	switch(B.icon_state)
@@ -117,11 +131,6 @@
 			B.set_light(2, 0.6, LIGHT_COLOR_LAVA) //more light
 		if("basalt5", "basalt9")
 			B.set_light(1.4, 0.6, LIGHT_COLOR_LAVA) //barely anything!
-
-/turf/simulated/floor/plating/asteroid/basalt/gets_dug()
-	if(!dug)
-		set_light(0)
-	..()
 
 ///////Surface. The surface is warm, but survivable without a suit. Internals are required. The floors break to chasms, which drop you into the underground.
 
@@ -138,9 +147,10 @@
 	nitrogen = 0
 	turf_type = /turf/simulated/floor/plating/asteroid/airless
 
-#define SPAWN_MEGAFAUNA "MEGAFAUNA"
+#define SPAWN_MEGAFAUNA "bluh bluh huge boss"
+#define SPAWN_BUBBLEGUM 6
 
-GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = 6))
+GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM))
 
 /turf/simulated/floor/plating/asteroid/airless/cave
 	var/length = 100
@@ -169,22 +179,20 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 
 /turf/simulated/floor/plating/asteroid/airless/cave/volcanic/has_data //subtype for producing a tunnel with given data
 	has_data = TRUE
 
-/turf/simulated/floor/plating/asteroid/airless/cave/New()
+/turf/simulated/floor/plating/asteroid/airless/cave/Initialize(mapload)
 	if (!mob_spawn_list)
 		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
 	if (!megafauna_spawn_list)
 		megafauna_spawn_list = GLOB.megafauna_spawn_list
 	if (!flora_spawn_list)
 		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
-
+	. = ..()
 	if(!has_data)
 		produce_tunnel_from_data()
-	..()
 
 /turf/simulated/floor/plating/asteroid/airless/cave/proc/get_cave_data(set_length, exclude_dir = -1)
 	// If set_length (arg1) isn't defined, get a random length; otherwise assign our length to the length arg.
@@ -234,7 +242,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 		if(istype(tunnel))
 			// Small chance to have forks in our tunnel; otherwise dig our tunnel.
 			if(i > 3 && prob(20))
-				var/turf/simulated/floor/plating/asteroid/airless/cave/C = tunnel.ChangeTurf(data_having_type,FALSE,TRUE)
+				var/turf/simulated/floor/plating/asteroid/airless/cave/C = tunnel.ChangeTurf(data_having_type, FALSE, TRUE)
 				C.going_backwards = FALSE
 				C.produce_tunnel_from_data(rand(10, 15), dir)
 			else
@@ -260,19 +268,22 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	SpawnFlora(T)
 
 	SpawnMonster(T)
-	T.ChangeTurf(turf_type,FALSE,FALSE,TRUE)
+	T.ChangeTurf(turf_type, FALSE, FALSE, TRUE)
 
 /turf/simulated/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)
 	if(prob(30))
-		if(istype(loc, /area/mine/explored) || istype(loc, /area/lavaland/surface/outdoors/explored))
+		if(istype(loc, /area/mine/explored) || !istype(loc, /area/lavaland/surface/outdoors/unexplored))
 			return
 		var/randumb = pickweight(mob_spawn_list)
 		while(randumb == SPAWN_MEGAFAUNA)
-			var/maybe_boss = pickweight(megafauna_spawn_list)
-			if(megafauna_spawn_list[maybe_boss])
-				randumb = maybe_boss
-				if(ispath(maybe_boss, /mob/living/simple_animal/hostile/megafauna/bubblegum)) //there can be only one bubblegum, so don't waste spawns on it
-					megafauna_spawn_list.Remove(maybe_boss)
+			if(istype(loc, /area/lavaland/surface/outdoors/unexplored/danger)) //this is danger. it's boss time.
+				var/maybe_boss = pickweight(megafauna_spawn_list)
+				if(megafauna_spawn_list[maybe_boss])
+					randumb = maybe_boss
+					if(ispath(maybe_boss, /mob/living/simple_animal/hostile/megafauna/bubblegum)) //there can be only one bubblegum, so don't waste spawns on it
+						megafauna_spawn_list.Remove(maybe_boss)
+			else //this is not danger, don't spawn a boss, spawn something else
+				randumb = pickweight(mob_spawn_list)
 
 		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents mob clumps
 			if((ispath(randumb, /mob/living/simple_animal/hostile/megafauna) || ismegafauna(H)) && get_dist(src, H) <= 7)
@@ -286,6 +297,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	return
 
 #undef SPAWN_MEGAFAUNA
+#undef SPAWN_BUBBLEGUM
 
 /turf/simulated/floor/plating/asteroid/airless/cave/proc/SpawnFlora(turf/T)
 	if(prob(12))
@@ -300,6 +312,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 
 
 /turf/simulated/floor/plating/asteroid/snow
+	gender = PLURAL
 	name = "snow"
 	desc = "Looks cold."
 	icon = 'icons/turf/snow.dmi'
@@ -309,7 +322,18 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	temperature = 180
 	slowdown = 2
 	environment_type = "snow"
-	sand_type = /obj/item/stack/sheet/mineral/snow
+	planetary_atmos = TRUE
+	burnt_states = list("snow_dug")
+	digResult = /obj/item/stack/sheet/mineral/snow
+
+/turf/simulated/floor/plating/asteroid/snow/burn_tile()
+	if(!burnt)
+		visible_message("<span class='danger'>[src] melts away!.</span>")
+		slowdown = 0
+		burnt = TRUE
+		icon_state = "snow_dug"
+		return TRUE
+	return FALSE
 
 /turf/simulated/floor/plating/asteroid/snow/airless
 	temperature = TCMB
@@ -323,3 +347,4 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	oxygen = 22
 	nitrogen = 82
 	temperature = 180
+	planetary_atmos = FALSE

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -48,7 +48,7 @@
 	temperature = 300
 	planetary_atmos = TRUE
 
-/turf/simulated/floor/indestructible/necropolis/Initialize()
+/turf/simulated/floor/indestructible/necropolis/Initialize(mapload)
 	. = ..()
 	if(prob(12))
 		icon_state = "necro[rand(2,3)]"

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -6,12 +6,12 @@
 	icon_state = "rock"
 	var/smooth_icon = 'icons/turf/smoothrocks.dmi'
 	smooth = SMOOTH_MORE | SMOOTH_BORDER
-	canSmoothWith
+	canSmoothWith = null
 	baseturf = /turf/simulated/floor/plating/asteroid/airless
 	temperature = 2.7
 	opacity = 1
-	density = 1
-	blocks_air = 1
+	density = TRUE
+	blocks_air = TRUE
 	layer = EDGED_TURF_LAYER
 	temperature = TCMB
 	var/environment_type = "asteroid"
@@ -21,21 +21,18 @@
 	var/spread = 0 //will the seam spread?
 	var/spreadChance = 0 //the percentual chance of an ore spreading to the neighbouring tiles
 	var/last_act = 0
-	var/scan_state = null //Holder for the image we display when we're pinged by a mining scanner
-	var/defer_change = FALSE
+	var/scan_state = "" //Holder for the image we display when we're pinged by a mining scanner
+	var/defer_change = 0
 
-/turf/simulated/mineral/New()
-	if (!canSmoothWith)
+/turf/simulated/mineral/Initialize(mapload)
+	if(!canSmoothWith)
 		canSmoothWith = list(/turf/simulated/mineral)
 	var/matrix/M = new
 	M.Translate(-4, -4)
 	transform = M
 	icon = smooth_icon
-
-	..()
-	GLOB.mineral_turfs += src
-
-	if (mineralType && mineralAmt && spread && spreadChance)
+	. = ..()
+	if(mineralType && mineralAmt && spread && spreadChance)
 		for(var/dir in cardinal)
 			if(prob(spreadChance))
 				var/turf/T = get_step(src, dir)
@@ -56,37 +53,34 @@
 		return TRUE
 	return ..()
 
-/turf/simulated/mineral/attackby(var/obj/item/pickaxe/P as obj, mob/user as mob, params)
+/turf/simulated/mineral/attackby(obj/item/I, mob/user, params)
 	if(!user.IsAdvancedToolUser())
 		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	if(istype(P, /obj/item/pickaxe))
+	if(istype(I, /obj/item/pickaxe))
+		var/obj/item/pickaxe/P = I
 		var/turf/T = user.loc
 		if(!isturf(T))
 			return
 
 		if(last_act + (40 * P.toolspeed) > world.time) // Prevents message spam
 			return
-
 		last_act = world.time
 		to_chat(user, "<span class='notice'>You start picking...</span>")
 		P.playDigSound()
 
 		if(do_after(user, 40 * P.toolspeed, target = src))
-			if(istype(src, /turf/simulated/mineral)) //sanity check against turf being deleted during digspeed delay
+			if(ismineralturf(src)) //sanity check against turf being deleted during digspeed delay
 				to_chat(user, "<span class='notice'>You finish cutting into the rock.</span>")
-				P.update_icon()
 				gets_drilled(user)
 				feedback_add_details("pick_used_mining","[P.name]")
 	else
 		return attack_hand(user)
 
 /turf/simulated/mineral/proc/gets_drilled()
-	if(mineralType && (mineralAmt > 0) && (mineralAmt < 11))
-		var/i
-		for(i=0; i < mineralAmt; i++)
-			new mineralType(src)
+	if(mineralType && (mineralAmt > 0))
+		new mineralType(src, mineralAmt)
 		feedback_add_details("ore_mined","[mineralType]|[mineralAmt]")
 	for(var/obj/effect/temp_visual/mining_overlay/M in src)
 		qdel(M)
@@ -94,26 +88,20 @@
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
 
-	if(rand(1, 750) == 1)
-		visible_message("<span class='notice'>An old dusty crate was buried within!</span>")
-		new /obj/structure/closet/crate/secure/loot(src)
-
-	return
-
 /turf/simulated/mineral/attack_animal(mob/living/simple_animal/user as mob)
 	if((user.environment_smash & ENVIRONMENT_SMASH_WALLS) || (user.environment_smash & ENVIRONMENT_SMASH_RWALLS))
 		gets_drilled()
 	..()
 
-/turf/simulated/mineral/attack_alien(var/mob/living/carbon/alien/M)
+/turf/simulated/mineral/attack_alien(mob/living/carbon/alien/M)
 	to_chat(M, "<span class='notice'>You start digging into the rock...</span>")
-	playsound(src, 'sound/effects/break_stone.ogg', 50, 1)
+	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE)
 	if(do_after(M, 40, target = src))
 		to_chat(M, "<span class='notice'>You tunnel into the rock.</span>")
-		gets_drilled()
+		gets_drilled(M)
 
-/turf/simulated/mineral/Bumped(AM as mob|obj)
-	. = ..()
+/turf/simulated/mineral/Bumped(atom/movable/AM)
+	..()
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
 		if((istype(H.l_hand,/obj/item/pickaxe)) && (!H.hand))
@@ -124,15 +112,15 @@
 
 	else if(isrobot(AM))
 		var/mob/living/silicon/robot/R = AM
-		if(istype(R.module_active,/obj/item/pickaxe))
-			attackby(R.module_active,R)
+		if(istype(R.module_active, /obj/item/pickaxe))
+			attackby(R.module_active, R)
 
 	else if(ismecha(AM))
 		var/obj/mecha/M = AM
-		if(istype(M.selected,/obj/item/mecha_parts/mecha_equipment/drill))
+		if(istype(M.selected, /obj/item/mecha_parts/mecha_equipment/drill))
 			M.selected.action(src)
 
-/turf/simulated/mineral/ex_act(severity, target)
+/turf/simulated/mineral/ex_act(severity)
 	..()
 	switch(severity)
 		if(3)
@@ -145,22 +133,23 @@
 			gets_drilled(null, 1)
 
 /turf/simulated/mineral/random
-	var/mineralSpawnChanceList
+	var/mineralSpawnChanceList = list(/turf/simulated/mineral/uranium = 5, /turf/simulated/mineral/diamond = 1, /turf/simulated/mineral/gold = 10,
+		/turf/simulated/mineral/silver = 12, /turf/simulated/mineral/plasma = 20, /turf/simulated/mineral/iron = 40, /turf/simulated/mineral/titanium = 11,
+		/turf/simulated/mineral/gibtonite = 4, /turf/simulated/floor/plating/asteroid/airless/cave = 2, /turf/simulated/mineral/bscrystal = 1)
+		//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 13
 	var/display_icon_state = "rock"
 
-/turf/simulated/mineral/random/New()
-	if (!mineralSpawnChanceList)
-		mineralSpawnChanceList = list(
-			/turf/simulated/mineral/uranium = 5, /turf/simulated/mineral/diamond = 1, /turf/simulated/mineral/gold = 10,
-			/turf/simulated/mineral/silver = 12, /turf/simulated/mineral/plasma = 20, /turf/simulated/mineral/iron = 40, /turf/simulated/mineral/titanium = 11,
-			/turf/simulated/mineral/gibtonite = 4, /turf/simulated/floor/plating/asteroid/airless/cave = 2, /turf/simulated/mineral/bscrystal = 1)
-	if (display_icon_state)
+/turf/simulated/mineral/random/Initialize(mapload)
+
+	mineralSpawnChanceList = typelist("mineralSpawnChanceList", mineralSpawnChanceList)
+
+	if(display_icon_state)
 		icon_state = display_icon_state
-	..()
+	. = ..()
 	if (prob(mineralChance))
 		var/path = pickweight(mineralSpawnChanceList)
-		var/turf/T = ChangeTurf(path,FALSE,TRUE)
+		var/turf/T = ChangeTurf(path, FALSE, TRUE)
 
 		if(T && ismineralturf(T))
 			var/turf/simulated/mineral/M = T
@@ -191,7 +180,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 	mineralSpawnChanceList = list(
 		/turf/simulated/mineral/uranium/volcanic = 35, /turf/simulated/mineral/diamond/volcanic = 30, /turf/simulated/mineral/gold/volcanic = 45, /turf/simulated/mineral/titanium/volcanic = 45,
@@ -212,7 +200,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 	mineralChance = 10
@@ -223,9 +210,9 @@
 
 /turf/simulated/mineral/random/labormineral
 	mineralSpawnChanceList = list(
-		/turf/simulated/mineral/uranium = 2, /turf/simulated/mineral/diamond = 1, /turf/simulated/mineral/gold = 3, /turf/simulated/mineral/titanium = 4,
-		/turf/simulated/mineral/silver = 6, /turf/simulated/mineral/plasma = 15, /turf/simulated/mineral/iron = 80,
-		/turf/simulated/mineral/gibtonite = 3)
+		/turf/simulated/mineral/uranium = 3, /turf/simulated/mineral/diamond = 1, /turf/simulated/mineral/gold = 8, /turf/simulated/mineral/titanium = 8,
+		/turf/simulated/mineral/silver = 20, /turf/simulated/mineral/plasma = 30, /turf/simulated/mineral/iron = 95,
+		/turf/simulated/mineral/gibtonite = 2)
 	icon_state = "rock_labor"
 
 /turf/simulated/mineral/random/labormineral/volcanic
@@ -235,12 +222,11 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 	mineralSpawnChanceList = list(
-		/turf/simulated/mineral/uranium/volcanic = 2, /turf/simulated/mineral/diamond/volcanic = 1, /turf/simulated/mineral/gold/volcanic = 3, /turf/simulated/mineral/titanium/volcanic = 4,
-		/turf/simulated/mineral/silver/volcanic = 6, /turf/simulated/mineral/plasma/volcanic = 15, /turf/simulated/mineral/iron/volcanic = 80,
-		/turf/simulated/mineral/gibtonite/volcanic = 3)
+		/turf/simulated/mineral/uranium/volcanic = 3, /turf/simulated/mineral/diamond/volcanic = 1, /turf/simulated/mineral/gold/volcanic = 8, /turf/simulated/mineral/titanium/volcanic = 8,
+		/turf/simulated/mineral/silver/volcanic = 20, /turf/simulated/mineral/plasma/volcanic = 30, /turf/simulated/mineral/bscrystal/volcanic = 1, /turf/simulated/mineral/gibtonite/volcanic = 2,
+		/turf/simulated/mineral/iron/volcanic = 95)
 
 // Actual minerals
 /turf/simulated/mineral/iron
@@ -256,7 +242,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/uranium
@@ -272,7 +257,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/diamond
@@ -288,7 +272,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/gold
@@ -304,7 +287,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/silver
@@ -320,7 +302,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/titanium
@@ -336,7 +317,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/plasma
@@ -352,7 +332,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/clown
@@ -369,7 +348,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/mime
@@ -385,7 +363,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/bscrystal
@@ -402,7 +379,6 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 	defer_change = 1
 
 /turf/simulated/mineral/volcanic
@@ -412,13 +388,18 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	planetary_atmos = TRUE
 
 /turf/simulated/mineral/volcanic/lava_land_surface
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/lava/smooth/lava_land_surface
 	defer_change = 1
+
+//gibtonite state defines
+#define GIBTONITE_UNSTRUCK 0
+#define GIBTONITE_ACTIVE 1
+#define GIBTONITE_STABLE 2
+#define GIBTONITE_DETONATE 3
 
 // Gibtonite
 /turf/simulated/mineral/gibtonite
@@ -427,39 +408,29 @@
 	spread = 0
 	scan_state = "rock_Gibtonite"
 	var/det_time = 8 //Countdown till explosion, but also rewards the player for how close you were to detonation when you defuse it
-	var/stage = 0 //How far into the lifecycle of gibtonite we are, 0 is untouched, 1 is active and attempting to detonate, 2 is benign and ready for extraction
+	var/stage = GIBTONITE_UNSTRUCK //How far into the lifecycle of gibtonite we are
 	var/activated_ckey = null //These are to track who triggered the gibtonite deposit for logging purposes
 	var/activated_name = null
-	var/activated_image = null
+	var/mutable_appearance/activated_overlay
 
-/turf/simulated/mineral/gibtonite/volcanic
-	environment_type = "basalt"
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 14
-	nitrogen = 23
-	temperature = 300
-	planetary_atmos = TRUE
-	defer_change = 1
-
-/turf/simulated/mineral/gibtonite/New()
+/turf/simulated/mineral/gibtonite/Initialize(mapload)
 	det_time = rand(8,10) //So you don't know exactly when the hot potato will explode
-	..()
+	. = ..()
 
 /turf/simulated/mineral/gibtonite/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/mining_scanner) || istype(I, /obj/item/t_scanner/adv_mining_scanner) && stage == 1)
-		user.visible_message("<span class='notice'>You use [I] to locate where to cut off the chain reaction and attempt to stop it...</span>")
+		user.visible_message("<span class='notice'>[user] holds [I] to [src]...</span>", "<span class='notice'>You use [I] to locate where to cut off the chain reaction and attempt to stop it...</span>")
 		defuse()
-	..()
+	else
+		return ..()
 
-/turf/simulated/mineral/gibtonite/proc/explosive_reaction(var/mob/user = null, triggered_by_explosion = 0)
-	if(stage == 0)
-		var/image/I = image('icons/turf/smoothrocks.dmi', loc = src, icon_state = "rock_Gibtonite_active", layer = ON_EDGED_TURF_LAYER)
-		add_overlay(I)
-		activated_image = I
+/turf/simulated/mineral/gibtonite/proc/explosive_reaction(mob/user = null, triggered_by_explosion = 0)
+	if(stage == GIBTONITE_UNSTRUCK)
+		activated_overlay = mutable_appearance('icons/turf/smoothrocks.dmi', "rock_Gibtonite_active", ON_EDGED_TURF_LAYER)
+		add_overlay(activated_overlay)
 		name = "gibtonite deposit"
 		desc = "An active gibtonite reserve. Run!"
-		stage = 1
+		stage = GIBTONITE_ACTIVE
 		visible_message("<span class='danger'>There was gibtonite inside! It's going to explode!</span>")
 		var/turf/bombturf = get_turf(src)
 		var/area/A = get_area(bombturf)
@@ -481,39 +452,39 @@
 
 /turf/simulated/mineral/gibtonite/proc/countdown(notify_admins = 0)
 	set waitfor = 0
-	while(istype(src, /turf/simulated/mineral/gibtonite) && stage == 1 && det_time > 0 && mineralAmt >= 1)
+	while(istype(src, /turf/simulated/mineral/gibtonite) && stage == GIBTONITE_ACTIVE && det_time > 0 && mineralAmt >= 1)
 		det_time--
 		sleep(5)
 	if(istype(src, /turf/simulated/mineral/gibtonite))
-		if(stage == 1 && det_time <= 0 && mineralAmt >= 1)
+		if(stage == GIBTONITE_ACTIVE && det_time <= 0 && mineralAmt >= 1)
 			var/turf/bombturf = get_turf(src)
 			mineralAmt = 0
-			stage = 3
+			stage = GIBTONITE_DETONATE
 			explosion(bombturf,1,3,5, adminlog = notify_admins)
 
 /turf/simulated/mineral/gibtonite/proc/defuse()
-	if(stage == 1)
-		overlays -= activated_image
-		var/image/I = image('icons/turf/smoothrocks.dmi', loc = src, icon_state = "rock_Gibtonite_inactive", layer = ON_EDGED_TURF_LAYER)
-		add_overlay(I)
+	if(stage == GIBTONITE_ACTIVE)
+		cut_overlay(activated_overlay)
+		activated_overlay.icon_state = "rock_Gibtonite_inactive"
+		add_overlay(activated_overlay)
 		desc = "An inactive gibtonite reserve. The ore can be extracted."
-		stage = 2
+		stage = GIBTONITE_STABLE
 		if(det_time < 0)
 			det_time = 0
-		visible_message("<span class='notice'>The chain reaction was stopped! The gibtonite had [src.det_time] reactions left till the explosion!</span>")
+		visible_message("<span class='notice'>The chain reaction was stopped! The gibtonite had [det_time] reactions left till the explosion!</span>")
 
 /turf/simulated/mineral/gibtonite/gets_drilled(var/mob/user, triggered_by_explosion = 0)
-	if(stage == 0 && mineralAmt >= 1) //Gibtonite deposit is activated
-		playsound(src, 'sound/effects/hit_on_shattered_glass.ogg',50,1)
+	if(stage == GIBTONITE_UNSTRUCK && mineralAmt >= 1) //Gibtonite deposit is activated
+		playsound(src,'sound/effects/hit_on_shattered_glass.ogg', 50, TRUE)
 		explosive_reaction(user, triggered_by_explosion)
 		return
-	if(stage == 1 && mineralAmt >= 1) //Gibtonite deposit goes kaboom
+	if(stage == GIBTONITE_ACTIVE && mineralAmt >= 1) //Gibtonite deposit goes kaboom
 		var/turf/bombturf = get_turf(src)
 		mineralAmt = 0
-		stage = 3
-		explosion(bombturf, 1, 2, 5, adminlog = 0)
-	if(stage == 2) //Gibtonite deposit is now benign and extractable. Depending on how close you were to it blowing up before defusing, you get better quality ore.
-		var/obj/item/twohanded/required/gibtonite/G = new /obj/item/twohanded/required/gibtonite/(src)
+		stage = GIBTONITE_DETONATE
+		explosion(bombturf,1,2,5, adminlog = 0)
+	if(stage == GIBTONITE_STABLE) //Gibtonite deposit is now benign and extractable. Depending on how close you were to it blowing up before defusing, you get better quality ore.
+		var/obj/item/twohanded/required/gibtonite/G = new(src)
 		if(det_time <= 0)
 			G.quality = 3
 			G.icon_state = "Gibtonite ore 3"
@@ -523,3 +494,18 @@
 
 	ChangeTurf(turf_type, defer_change)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
+
+
+/turf/simulated/mineral/gibtonite/volcanic
+	environment_type = "basalt"
+	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
+	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
+	oxygen = 14
+	nitrogen = 23
+	temperature = 300
+	defer_change = 1
+
+#undef GIBTONITE_UNSTRUCK
+#undef GIBTONITE_ACTIVE
+#undef GIBTONITE_STABLE
+#undef GIBTONITE_DETONATE

--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -4,7 +4,7 @@
 #define RANDOM_LOWER_X 50
 #define RANDOM_LOWER_Y 50
 
-/proc/spawn_rivers(target_z, nodes = 4, turf_type = /turf/simulated/floor/plating/lava/smooth/lava_land_surface, whitelist_area = /area/lavaland/surface/outdoors/unexplored, min_x = RANDOM_LOWER_X, min_y = RANDOM_LOWER_Y, max_x = RANDOM_UPPER_X, max_y = RANDOM_UPPER_Y)
+/proc/spawn_rivers(target_z, nodes = 4, turf_type = /turf/simulated/floor/plating/lava/smooth/lava_land_surface, whitelist_area = /area/lavaland/surface/outdoors, min_x = RANDOM_LOWER_X, min_y = RANDOM_LOWER_Y, max_x = RANDOM_UPPER_X, max_y = RANDOM_UPPER_Y)
 	var/list/river_nodes = list()
 	var/num_spawned = 0
 	var/list/possible_locs = block(locate(min_x, min_y, target_z), locate(max_x, max_y, target_z))

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -79,7 +79,7 @@
 	holds_charge = TRUE
 	unique_frequency = TRUE
 
-/obj/item/gun/energy/kinetic_accelerator/New()
+/obj/item/gun/energy/kinetic_accelerator/Initialize(mapload)
 	. = ..()
 	if(!holds_charge)
 		empty()
@@ -98,8 +98,7 @@
 	if(!QDELING(src) && !holds_charge)
 		// Put it on a delay because moving item from slot to hand
 		// calls dropped().
-		spawn(2)
-			empty_if_not_held()
+		addtimer(CALLBACK(src, .proc/empty_if_not_held), 2)
 
 /obj/item/gun/energy/kinetic_accelerator/proc/empty_if_not_held()
 	if(!ismob(loc))
@@ -143,17 +142,17 @@
 	overheat = FALSE
 
 /obj/item/gun/energy/kinetic_accelerator/update_icon()
-	overlays.Cut()
+	cut_overlays()
 	if(empty_state && !can_shoot())
-		overlays += empty_state
+		add_overlay(empty_state)
 
 	if(gun_light && can_flashlight)
 		var/iconF = "flight"
 		if(gun_light.on)
 			iconF = "flight_on"
-		overlays += image(icon = icon, icon_state = iconF, pixel_x = flight_x_offset, pixel_y = flight_y_offset)
+		add_overlay(image(icon = icon, icon_state = iconF, pixel_x = flight_x_offset, pixel_y = flight_y_offset))
 	if(bayonet && can_bayonet)
-		overlays += knife_overlay
+		add_overlay(knife_overlay)
 
 
 /obj/item/gun/energy/kinetic_accelerator/experimental

--- a/paradise.dme
+++ b/paradise.dme
@@ -89,6 +89,7 @@
 #include "code\__HELPERS\text.dm"
 #include "code\__HELPERS\time.dm"
 #include "code\__HELPERS\type2type.dm"
+#include "code\__HELPERS\typelists.dm"
 #include "code\__HELPERS\unique_ids.dm"
 #include "code\__HELPERS\unsorted.dm"
 #include "code\__HELPERS\sorts\__main.dm"


### PR DESCRIPTION
Last of the previous Lavaland PR that I split up.

- Fixes lava rivers never spawning
- Fixes Megafauna spawning near the base
- Labor mineral rates have been upped a bit
- Removes the ability to find random deca locked crates 

This also removes a bunch of instances of `planetary_atmos` being set where it probably shouldn't be; this should really only be used for the surface and a few other areas; it was set on turfs that are mineral turfs that block air/don't have air on them...which is strange and likely was probably causing issues.

:cl: Fox McCloud
fix: Fixes Megafauna spawning near the base
fix: Fixes lava rivers not forming
tweak: Upped the labor mineral spawn rate
del: Removed the ability to find random code-locked crates when mining
/:cl: