### PR TITLE
Fixes Some Tastes; Tweaks a Few

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -4,7 +4,7 @@ GLOBAL_LIST_INIT(base_chemicals, list("water","oxygen","nitrogen","hydrogen","po
 							"iron","aluminum","silicon","sugar","ethanol"))
 // Standard chemicals
 GLOBAL_LIST_INIT(standard_chemicals, list("slimejelly","blood","water","lube","charcoal","toxin","cyanide",
-								"morphine","epinephrine","space_drugs","serotrotium","oxygen","copper",
+								"morphine","epinephrine","space_drugs","oxygen","copper",
 								"nitrogen","hydrogen","potassium","mercury","sulfur","carbon","chlorine",
 								"fluorine","sodium","phosphorus","lithium","sugar","sacid","facid",
 								"glycerol","radium","mutadone","thermite","mutagen","virusfood","iron",
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(standard_chemicals, list("slimejelly","blood","water","lube","c
 GLOBAL_LIST_INIT(rare_chemicals, list("minttoxin","syndicate_nanites", "xenomicrobes"))
 // Standard medicines
 GLOBAL_LIST_INIT(standard_medicines, list("charcoal","toxin","cyanide","morphine","epinephrine","space_drugs",
-								"serotrotium","mutadone","mutagen","teporone","lexorin","silver_sulfadiazine",
+								"mutadone","mutagen","teporone","lexorin","silver_sulfadiazine",
 								"salbutamol","perfluorodecalin","omnizine","synaptizine","haloperidol",
 								"potass_iodide","pen_acid","mannitol","oculine","styptic_powder",
 								"methamphetamine","spaceacillin","carpotoxin","lsd","ethanol","ammonia",

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -362,7 +362,6 @@
 	drink_icon = "cubalibreglass"
 	drink_name = "Cuba Libre"
 	drink_desc = "A classic mix of rum and cola."
-	taste_description = "fruity alcohol"
 	taste_description = "liberation"
 
 /datum/reagent/consumable/ethanol/whiskey_cola

--- a/code/modules/reagents/chemistry/reagents/disease.dm
+++ b/code/modules/reagents/chemistry/reagents/disease.dm
@@ -5,6 +5,7 @@
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/spider_eggs/on_mob_life(mob/living/M)
 	if(volume > 2.5)
@@ -20,6 +21,7 @@
 	description = "Microscopic construction robots."
 	color = "#535E66" // rgb: 83, 94, 102
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/nanomachines/on_mob_life(mob/living/carbon/M)
 	if(volume > 1.5)
@@ -33,6 +35,7 @@
 	description = "Microbes with an entirely alien cellular structure."
 	color = "#535E66" // rgb: 83, 94, 102
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/xenomicrobes/on_mob_life(mob/living/carbon/M)
 	if(volume > 1.5)
@@ -45,6 +48,7 @@
 	description = "Active fungal spores."
 	color = "#92D17D" // rgb: 146, 209, 125
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/fungalspores/on_mob_life(mob/living/carbon/M)
 	if(volume > 2.5)
@@ -58,6 +62,7 @@
 	reagent_state = SOLID
 	color = "#FA0000" // rgb: 250, 0, 0
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/jagged_crystals/on_mob_life(mob/living/carbon/M)
 	M.ForceContractDisease(new /datum/disease/berserker(0))
@@ -70,6 +75,7 @@
 	reagent_state = LIQUID
 	color = "#1E4600"
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/salmonella/on_mob_life(mob/living/carbon/M)
 	M.ForceContractDisease(new /datum/disease/food_poisoning(0))
@@ -82,6 +88,7 @@
 	reagent_state = LIQUID
 	color = "#FF0000"
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/gibbis/on_mob_life(mob/living/carbon/M)
 	if(volume > 2.5)
@@ -95,6 +102,7 @@
 	reagent_state = LIQUID
 	color = "#FFFFFF"
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/prions/on_mob_life(mob/living/carbon/M)
 	if(volume > 4.5)
@@ -108,6 +116,7 @@
 	reagent_state = LIQUID
 	color = "#465046"
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/grave_dust/on_mob_life(mob/living/carbon/M)
 	if(volume > 4.5)
@@ -121,6 +130,7 @@
 	reagent_state = LIQUID
 	color = "#F7E6B1"
 	can_synth = FALSE
+	taste_description = "bacon"
 
 /datum/reagent/bacon_grease/on_mob_life(mob/living/carbon/M)
 	if(volume > 4.5)
@@ -134,6 +144,7 @@
 	reagent_state = SOLID
 	color = "#925D6C"
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/heartworms/on_mob_life(mob/living/carbon/M)
 	if(volume > 4.5)
@@ -152,6 +163,7 @@
 	reagent_state = LIQUID
 	color = "#AB1CCF"
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/concentrated_initro/on_mob_life(mob/living/M)
 	if(volume >= 5)
@@ -170,6 +182,7 @@
 	reagent_state = LIQUID
 	nutriment_factor = 2 * REAGENTS_METABOLISM
 	color = "#899613" // rgb: 137, 150, 19
+	taste_description = "watery milk"
 
 /datum/reagent/mutagen/mutagenvirusfood
 	name = "mutagenic agar"

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -1,18 +1,3 @@
-/datum/reagent/serotrotium
-	name = "Serotrotium"
-	id = "serotrotium"
-	description = "A chemical compound that promotes concentrated production of the serotonin neurotransmitter in humans."
-	reagent_state = LIQUID
-	color = "#202040" // rgb: 20, 20, 40
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-
-/datum/reagent/serotrotium/on_mob_life(mob/living/M)
-	if(ishuman(M))
-		if(prob(7))
-			M.emote(pick("twitch","drool","moan","gasp"))
-	return ..()
-
-
 /datum/reagent/lithium
 	name = "Lithium"
 	id = "lithium"
@@ -170,6 +155,7 @@
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 20
 	addiction_chance = 50
+	taste_description = "bitterness"
 
 /datum/reagent/crank/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -475,7 +461,7 @@
 	reagent_state = LIQUID
 	color = "#644600"
 	addiction_chance = 30
-	taste_description = "puke... or worse"
+	taste_description = "the inside of a toilet... or worse"
 
 /datum/reagent/jenkem/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -491,6 +477,7 @@
 	description = "An illegal performance enhancing drug. Side effects might include chest pain, seizures, swelling, headache, fever... ... ..."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
+	taste_description = "bitterness"
 
 /datum/reagent/aranesp/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -515,6 +502,7 @@
 	description = "A mild psychoactive chemical extracted from the cannabis plant."
 	reagent_state = LIQUID
 	color = "#0FBE0F"
+	taste_description = "man like, totally the best like, thing ever dude"
 
 /datum/reagent/thc/on_mob_life(mob/living/M)
 	M.stuttering += rand(0,2)
@@ -697,7 +685,7 @@
 	process_flags = SYNTHETIC
 	overdose_threshold = 20
 	addiction_chance = 50
-	taste_description = "silicone"
+	taste_description = "silicon"
 
 
 /datum/reagent/surge/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -25,6 +25,8 @@
 	reagent_state = SOLID
 	nutriment_factor = 15 * REAGENTS_METABOLISM
 	color = "#664330" // rgb: 102, 67, 48
+	var/brute_heal = 1
+	var/burn_heal = 0
 
 /datum/reagent/consumable/nutriment/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -33,10 +35,8 @@
 			var/mob/living/carbon/human/H = M
 			if(H.can_eat(diet_flags))	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
 				if(prob(50))
-					update_flags |= M.adjustBruteLoss(-1, FALSE)
-					if(!(NO_BLOOD in H.dna.species.species_traits))//do not restore blood on things with no blood by nature.
-						if(H.blood_volume < BLOOD_VOLUME_NORMAL)
-							H.blood_volume += 0.4
+					update_flags |= M.adjustBruteLoss(-brute_heal, FALSE)
+					update_flags |= M.adjustFireLoss(-burn_heal, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/nutriment/on_new(list/supplied_data)
@@ -66,36 +66,26 @@
 	id = "protein"
 	description = "Various essential proteins and fats commonly found in animal flesh and blood."
 	diet_flags = DIET_CARN | DIET_OMNI
-	taste_description = "meat" //TODO: Remove
 
 /datum/reagent/consumable/nutriment/plantmatter		// Plant-based biomatter, digestable by herbivores and omnivores, worthless to carnivores
 	name = "Plant-matter"
 	id = "plantmatter"
 	description = "Vitamin-rich fibers and natural sugars commonly found in fresh produce."
 	diet_flags = DIET_HERB | DIET_OMNI
-	taste_description = "vegetables" //TODO: Remove
 
-/datum/reagent/consumable/vitamin
+/datum/reagent/consumable/nutriment/vitamin
 	name = "Vitamin"
 	id = "vitamin"
 	description = "All the best vitamins, minerals, and carbohydrates the body needs in pure form."
 	reagent_state = SOLID
 	color = "#664330" // rgb: 102, 67, 48
-	taste_description = "nutrition"
+	brute_heal = 1
+	burn_heal = 1
 
-/datum/reagent/consumable/vitamin/on_mob_life(mob/living/M)
-	var/update_flags = STATUS_UPDATE_NONE
-	if(prob(50))
-		update_flags |= M.adjustBruteLoss(-1, FALSE)
-		update_flags |= M.adjustFireLoss(-1, FALSE)
+/datum/reagent/consumable/nutriment/vitamin/on_mob_life(mob/living/M)
 	if(M.satiety < 600)
 		M.satiety += 30
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(!(NO_BLOOD in H.dna.species.species_traits))//do not restore blood on things with no blood by nature.
-			if(H.blood_volume < BLOOD_VOLUME_NORMAL)
-				H.blood_volume += 0.5
-	return ..() | update_flags
+	return ..()
 
 /datum/reagent/consumable/sugar
 	name = "Sugar"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -787,7 +787,7 @@
 	description = "Increases run speed and eliminates stuns, can heal minor damage. If overdosed it will deal toxin damage and stun."
 	color = "#C8A5DC"
 	can_synth = FALSE
-	taste_description = "<span class='userdanger'>and unstoppable force</span>"
+	taste_description = "<span class='userdanger'>an unstoppable force</span>"
 
 /datum/reagent/medicine/stimulants/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1,6 +1,7 @@
 /datum/reagent/medicine
 	name = "Medicine"
 	id = "medicine"
+	taste_description = "bitterness"
 
 /datum/reagent/medicine/on_mob_life(mob/living/M)
 	current_cycle++
@@ -728,7 +729,7 @@
 	id = "mannitol"
 	description = "Mannitol is a sugar alcohol that can help alleviate cranial swelling."
 	color = "#D1D1F1"
-	taste_description = "neurogenisis"
+	taste_description = "sweetness"
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -786,6 +787,7 @@
 	description = "Increases run speed and eliminates stuns, can heal minor damage. If overdosed it will deal toxin damage and stun."
 	color = "#C8A5DC"
 	can_synth = FALSE
+	taste_description = "<span class='userdanger'>and unstoppable force</span>"
 
 /datum/reagent/medicine/stimulants/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -614,6 +614,7 @@
 	description = "A potent alchemic ingredient."
 	reagent_state = LIQUID
 	color = "#092D09"
+	taste_description = "alchemy"
 
 /datum/reagent/woolbat
 	name = "Wool of bat"
@@ -621,6 +622,7 @@
 	description = "A potent alchemic ingredient."
 	reagent_state = LIQUID
 	color = "#080808"
+	taste_description = "alchemy"
 
 /datum/reagent/tonguedog
 	name = "Tongue of dog"
@@ -628,6 +630,7 @@
 	description = "A potent alchemic ingredient."
 	reagent_state = LIQUID
 	color = "#2D0909"
+	taste_description = "alchemy"
 
 /datum/reagent/triplepiss
 	name = "Triplepiss"
@@ -635,6 +638,7 @@
 	description = "Ewwwwwwwww."
 	reagent_state = LIQUID
 	color = "#857400"
+	taste_description = "alchemy"
 
 /datum/reagent/spraytan
 	name = "Spray Tan"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -5,6 +5,7 @@
 	reagent_state = LIQUID
 	color = "#FFAF00"
 	process_flags = ORGANIC | SYNTHETIC
+	taste_description = "burning"
 	var/temp_fire = 4000
 	var/temp_deviance = 1000
 	var/size_divisor = 40
@@ -49,6 +50,7 @@
 	reagent_state = LIQUID
 	process_flags = ORGANIC | SYNTHETIC
 	color = "#C86432"
+	taste_description = "burning"
 
 /datum/reagent/napalm/reaction_temperature(exposed_temperature, exposed_volume)
 	if(exposed_temperature > T0C + 100)
@@ -253,6 +255,7 @@
 	description = "Sends everything flying from the detonation point."
 	reagent_state = LIQUID
 	color = "#FFA500"
+	taste_description = "air and bitterness"
 
 /datum/reagent/sorium/reaction_turf(turf/T, volume) // oh no
 	if(prob(75))
@@ -269,7 +272,7 @@
 	description = "Sucks everything into the detonation point."
 	reagent_state = LIQUID
 	color = "#800080"
-	taste_description = "the end of the world"
+	taste_description = "compressed bitterness"
 
 /datum/reagent/liquid_dark_matter/reaction_turf(turf/T, volume) //Oh gosh, why
 	if(prob(75))
@@ -302,6 +305,7 @@
 	reagent_state = LIQUID
 	color = "#FFFF00"
 	penetrates_skin = TRUE
+	taste_description = "salt"
 
 /datum/reagent/smoke_powder
 	name = "Smoke Powder"
@@ -309,6 +313,7 @@
 	description = "Makes a large cloud of smoke that can carry reagents."
 	reagent_state = LIQUID
 	color = "#808080"
+	taste_description = "smoke"
 
 /datum/reagent/sonic_powder
 	name = "Sonic Powder"
@@ -317,6 +322,7 @@
 	reagent_state = LIQUID
 	color = "#0000FF"
 	penetrates_skin = TRUE
+	taste_description = "loud noises"
 
 /datum/reagent/cryostylane
 	name = "Cryostylane"
@@ -324,6 +330,7 @@
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Cryostylane slowly cools all other reagents in the mob down to 0K."
 	color = "#B2B2FF" // rgb: 139, 166, 233
 	process_flags = ORGANIC | SYNTHETIC
+	taste_description = "bitterness"
 
 /datum/reagent/cryostylane/on_mob_life(mob/living/M) //TODO: code freezing into an ice cube
 	if(M.reagents.has_reagent("oxygen"))
@@ -358,6 +365,7 @@
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Pyrosium slowly heats all other reagents."
 	color = "#B20000" // rgb: 139, 166, 233
 	process_flags = ORGANIC | SYNTHETIC
+	taste_description = "bitterness"
 
 /datum/reagent/pyrosium/on_mob_life(mob/living/M)
 	if(M.reagents.has_reagent("oxygen"))
@@ -380,6 +388,7 @@
 	reagent_state = LIQUID
 	color = "#A0A090"
 	var/cooling_temperature = 3 // more effective than water
+	taste_description = "the inside of a fire extinguisher"
 
 /datum/reagent/firefighting_foam/reaction_mob(mob/living/M, method=TOUCH, volume)
 // Put out fire

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -5,6 +5,7 @@
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
 	taste_mult = 1.2
+	taste_description = "bitterness"
 
 /datum/reagent/toxin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -17,6 +18,7 @@
 	description = "A toxic venom injected by spacefaring arachnids."
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
+	taste_description = "bitterness"
 
 /datum/reagent/spider_venom/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -81,6 +83,7 @@
 	reagent_state = LIQUID
 	color = "#13BC5E" // rgb: 19, 188, 94
 	can_synth = FALSE
+	taste_description = "slime"
 
 /datum/reagent/aslimetoxin/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(method != TOUCH)
@@ -95,7 +98,6 @@
 	color = "#484848" // rgb: 72, 72, 72
 	metabolization_rate = 0.2
 	penetrates_skin = TRUE
-	taste_description = "metal"
 	taste_mult = 0 // elemental mercury is tasteless
 
 /datum/reagent/mercury/on_mob_life(mob/living/M)
@@ -127,7 +129,7 @@
 	color = "#6A6054"
 	penetrates_skin = TRUE
 	process_flags = ORGANIC | SYNTHETIC
-	taste_description = "spicy freshness"
+	taste_description = "acid"
 
 /datum/reagent/fluorine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -142,6 +144,7 @@
 	reagent_state = SOLID
 	color = "#C7C7C7" // rgb: 199,199,199
 	penetrates_skin = TRUE
+	taste_description = "the colour blue and regret"
 
 /datum/reagent/radium/on_mob_life(mob/living/M)
 	if(M.radiation < 80)
@@ -160,6 +163,7 @@
 	color = "#04DF27"
 	metabolization_rate = 0.3
 	taste_mult = 0.9
+	taste_description = "slime"
 
 /datum/reagent/mutagen/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(!..())
@@ -186,6 +190,7 @@
 	description = "Just the regular, boring sort of mutagenic compound.  Works in a completely predictable manner."
 	reagent_state = LIQUID
 	color = "#7DFF00"
+	taste_description = "slime"
 
 /datum/reagent/stable_mutagen/on_mob_life(mob/living/M)
 	if(!ishuman(M) || !M.dna)
@@ -251,6 +256,7 @@
 	reagent_state = SOLID
 	color = "#B8B8C0" // rgb: 184, 184, 192
 	taste_mult = 0
+	taste_description = "the inside of a reactor"
 
 /datum/reagent/uranium/on_mob_life(mob/living/M)
 	M.apply_effect(2, IRRADIATE, negate_armor = 1)
@@ -268,6 +274,7 @@
 	reagent_state = LIQUID
 	color = "#52685D"
 	metabolization_rate = 0.2
+	taste_description = "sweetness"
 
 /datum/reagent/lexorin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -332,6 +339,7 @@
 	description = "A deadly neurotoxin produced by the dreaded spess carp."
 	reagent_state = LIQUID
 	color = "#003333" // rgb: 0, 51, 51
+	taste_description = "fish"
 
 /datum/reagent/carpotoxin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -345,6 +353,7 @@
 	reagent_state = LIQUID
 	color = "#6E2828"
 	data = 13
+	taste_description = "bitterness"
 
 /datum/reagent/staminatoxin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -358,6 +367,7 @@
 	id = "spore"
 	description = "A natural toxin produced by blob spores that inhibits vision when ingested."
 	color = "#9ACD32"
+	taste_description = "bitterness"
 
 /datum/reagent/spores/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -376,6 +386,7 @@
 	drink_name = "Beer glass"
 	drink_desc = "A freezing pint of beer"
 	taste_description = "beer"
+	taste_description = "piss water"
 
 /datum/reagent/beer2/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -487,6 +498,7 @@
 	reagent_state = LIQUID
 	color = "#DED6D0"
 	penetrates_skin = TRUE
+	taste_description = "bitterness"
 
 /datum/reagent/formaldehyde/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -504,6 +516,7 @@
 	metabolization_rate = 0.2
 	overdose_threshold = 40
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/venom/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -529,6 +542,7 @@
 	reagent_state = LIQUID
 	color = "#60A584"
 	metabolization_rate = 1
+	taste_mult = 0
 
 /datum/reagent/neurotoxin2/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -593,6 +607,7 @@
 	color = "#B0B0B0"
 	metabolization_rate = 0.3
 	penetrates_skin = TRUE
+	taste_description = "prickliness"
 
 /datum/reagent/itching_powder/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_STAT
@@ -806,6 +821,7 @@
 	reagent_state = LIQUID
 	color = "#6BA688"
 	metabolization_rate = 0.1
+	taste_mult = 0
 
 /datum/reagent/sulfonal/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -871,6 +887,7 @@
 	color = "#C2D8CD"
 	metabolization_rate = 0.05
 	can_synth = FALSE
+	taste_mult = 0
 
 /datum/reagent/coniine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -886,6 +903,7 @@
 	color = "#191919"
 	metabolization_rate = 0.1
 	penetrates_skin = TRUE
+	taste_mult = 0
 
 /datum/reagent/curare/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -919,6 +937,7 @@
 	reagent_state = LIQUID
 	color = "#C8C8C8" //RGB: 200, 200, 200
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
+	taste_mult = 0
 
 /datum/reagent/heparin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -993,6 +1012,7 @@
 	reagent_state = LIQUID
 	color = "#d3cf50"
 	var/lethality = 0 //Glyphosate is non-toxic to people
+	taste_description = "bitterness"
 
 /datum/reagent/glyphosate/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1045,6 +1065,7 @@
 	id = "pestkiller"
 	description = "A harmful toxic mixture to kill pests. Do not ingest!"
 	color = "#4B004B" // rgb: 75, 0, 75
+	taste_description = "bitterness"
 
 /datum/reagent/pestkiller/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1125,6 +1146,7 @@
 	description = "A filthy, carcinogenic sludge produced by the Slurrypod plant."
 	reagent_state = LIQUID
 	color = "#00C81E"
+	taste_description = "slime"
 
 /datum/reagent/toxic_slurry/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1143,6 +1165,7 @@
 	description = "This is probably not good for you."
 	reagent_state = LIQUID
 	color = "#00FD00"
+	taste_description = "slime"
 
 /datum/reagent/glowing_slurry/reaction_mob(mob/living/M, method=TOUCH, volume) //same as mutagen
 	if(!..())

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -246,7 +246,7 @@
 	description = "Filthy water scoured from a nasty toilet bowl. Absolutely disgusting."
 	reagent_state = LIQUID
 	color = "#757547"
-	taste_description = taste_description = "the inside of a toilet... or worse"
+	taste_description = "the inside of a toilet... or worse"
 
 /datum/reagent/fishwater/toiletwater/reaction_mob(mob/living/M, method=TOUCH, volume) //For shennanigans
 	return

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -246,7 +246,7 @@
 	description = "Filthy water scoured from a nasty toilet bowl. Absolutely disgusting."
 	reagent_state = LIQUID
 	color = "#757547"
-	taste_description = "puke"
+	taste_description = taste_description = "the inside of a toilet... or worse"
 
 /datum/reagent/fishwater/toiletwater/reaction_mob(mob/living/M, method=TOUCH, volume) //For shennanigans
 	return
@@ -391,7 +391,7 @@
 	process_flags = ORGANIC | SYNTHETIC		//Admin-bus has no brakes! KILL THEM ALL.
 	metabolization_rate = 1
 	can_synth = FALSE
-	taste_description = "admin abuse"
+	taste_description = "burning"
 
 /datum/reagent/hellwater/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE


### PR DESCRIPTION
Fixes being able to taste "metaphorical salt" and tweaks a few tastes.

Also removes serorotium, because it's a worthless Baychem that's not really makeable/findable

This also makes vitamin a subtype of nutriment, so it can better handle the new taste system and holding data on it.

Nutriment no longer restores blood

:cl: Fox McCloud
tweak: Tweaks a few reagents tastes
fix: fixes being able to taste metaphorical salt
tweak: nutriment no longer restores blood
/:cl: