### PR TITLE
Revert "Adds Auto-Note for Manual Bans"

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -169,14 +169,6 @@
 			message_admins("Ban process: A mob matching [playermob.ckey] was found at location [playermob.x], [playermob.y], [playermob.z]. Custom IP and computer id fields replaced with the IP and computer id from the located mob")
 
 		DB_ban_record(bantype, playermob, banduration, banreason, banjob, null, banckey, banip, bancid )
-		if(BANTYPE_PERMA)
-			add_note(banckey, "Permanently Banned - [banreason]", null, usr.ckey, 0)
-		else if(BANTYPE_TEMP)
-			add_note(banckey, "Banned for [banduration] minutes - [banreason]", null, usr.ckey, 0)
-		else if(BANTYPE_JOB_PERMA)
-			add_note(banckey, "Banned from [banjob] - [banreason]", null, usr.ckey, 0)
-		else
-			add_note(banckey, "[banreason]", null, usr.ckey, 0)
 
 
 	else if(href_list["editrights"])


### PR DESCRIPTION
Removes auto note for manual bans

grouped manual bans such as "security" bans spam notes because of how bans are handled and this doesn't have the proper logic to not spam the notes with "banned banned banned banned banned banned" in 1 group such as "banned from security roles"

also they are getting flagged as all permabans for whatever reason

:cl:
del: Autonote for manual bans removed
/ 🆑 