### PR TITLE
Gives abductors an objective to stay hidden/limit crew disruption

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1524,6 +1524,10 @@
 
 	SSticker.mode.abductors |= src
 
+	var/datum/objective/stay_hidden/hidden_obj = new
+	hidden_obj.owner = src
+	objectives += hidden_obj
+
 	var/datum/objective/experiment/O = new
 	O.owner = src
 	objectives += O

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -150,6 +150,8 @@
 	update_abductor_icons_added(scientist)
 
 /datum/game_mode/abduction/proc/greet_agent(datum/mind/abductor,team_number)
+	var/datum/objective/stay_hidden/O = new
+	abductor.objectives += O
 	abductor.objectives += team_objectives[team_number]
 	var/team_name = team_names[team_number]
 
@@ -160,6 +162,8 @@
 	abductor.announce_objectives()
 
 /datum/game_mode/abduction/proc/greet_scientist(datum/mind/abductor,team_number)
+	var/datum/objective/stay_hidden/O = new
+	abductor.objectives += O
 	abductor.objectives += team_objectives[team_number]
 	var/team_name = team_names[team_number]
 
@@ -227,6 +231,13 @@
 /datum/objective/experiment
 	target_amount = 6
 	var/team
+
+/datum/objective/stay_hidden
+
+/datum/objective/stay_hidden/New()
+	explanation_text = "Disrupt the primitives as little as possible."
+	completed = TRUE
+//No check completion, it defaults to being completed unless an admin sets it to failed.
 
 /datum/objective/experiment/New()
 	explanation_text = "Experiment on [target_amount] humans."

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -235,7 +235,7 @@
 /datum/objective/stay_hidden
 
 /datum/objective/stay_hidden/New()
-	explanation_text = "Disrupt the primitives as little as possible."
+	explanation_text = "Limit contact with your targets outside of conducting your experiments and abduction."
 	completed = TRUE
 //No check completion, it defaults to being completed unless an admin sets it to failed.
 


### PR DESCRIPTION
**What does this PR do:**
This gives all abductors a secondary objective, to keep disruption to the crew to a minimum. Abductors are supposed to mostly stay hidden and just kidnap people, but sometimes they steal the AI, space armory, get into shootouts with sec and dab on the captain. From talking with admins I know that's not really intended so I figured a second objective should make it clear what kind of playstyle is expected of abductor players.
The objective's exact text is:
"Disrupt the primitives as little as possible."
The objective defaults to true and can only be failed if an admin manually toggles it, perhaps because someone did something very disruptive. It is on a per abductor basis instead of per team so you can selectively have people fail, but I expect that won't be done much, if at all.

**Images of sprite/map changes (IF APPLICABLE):**

**Changelog:**
:cl:
add: Objective to abductors to not disrupt crew too much.
/:cl:

