### PR TITLE
Remove normal subtype of wooden chair

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -22514,7 +22514,7 @@
 	},
 /area/crew_quarters/bar/atrium)
 "aRy" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
 "aRz" = (
@@ -23422,7 +23422,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -24305,7 +24305,7 @@
 	},
 /area/crew_quarters/bar/atrium)
 "aUH" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
@@ -89006,7 +89006,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
@@ -89016,12 +89016,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "dcT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -90537,7 +90537,7 @@
 /area/maintenance/gambling_den)
 "dfP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood{
@@ -91371,7 +91371,7 @@
 	},
 /area/maintenance/gambling_den)
 "dhw" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -91380,7 +91380,7 @@
 /area/maintenance/gambling_den)
 "dhx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -92327,7 +92327,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "diY" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood{
@@ -92346,7 +92346,7 @@
 /area/maintenance/gambling_den)
 "dja" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -93121,7 +93121,7 @@
 	},
 /area/maintenance/gambling_den)
 "dkr" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -94305,7 +94305,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/construction)
 "dmM" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "dmN" = (
@@ -96153,7 +96153,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dpR" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -96848,7 +96848,7 @@
 	},
 /area/maintenance/gambling_den)
 "dra" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -101412,7 +101412,7 @@
 	},
 /area/crew_quarters/theatre)
 "dzq" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -102176,7 +102176,7 @@
 	dir = 4;
 	level = 1
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -102619,7 +102619,7 @@
 	},
 /area/crew_quarters/theatre)
 "dBq" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -108948,21 +108948,21 @@
 	},
 /area/chapel/office)
 "dMT" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "dMU" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "dMV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
@@ -108970,14 +108970,14 @@
 /area/chapel/main)
 "dMW" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "dMX" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
@@ -109317,14 +109317,14 @@
 	},
 /area/chapel/office)
 "dNJ" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
 "dNK" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "chapel"
@@ -109332,7 +109332,7 @@
 /area/chapel/main)
 "dNL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
@@ -109340,7 +109340,7 @@
 /area/chapel/main)
 "dNM" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
@@ -109692,7 +109692,7 @@
 	},
 /area/chapel/office)
 "dOq" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
@@ -109715,7 +109715,7 @@
 	},
 /area/chapel/main)
 "dOt" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -111770,7 +111770,7 @@
 /area/chapel/office)
 "dSf" = (
 /obj/machinery/light/small,
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /obj/machinery/newscaster{
@@ -111783,7 +111783,7 @@
 /area/chapel/main)
 "dSg" = (
 /obj/machinery/light/small,
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/machinery/newscaster{

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -13578,7 +13578,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "aya" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
 "ayb" = (
@@ -14935,7 +14935,7 @@
 	name = "Port Maintenance"
 	})
 "aAB" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -14952,7 +14952,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -15652,7 +15652,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
 "aBS" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -21926,7 +21926,7 @@
 	name = "\improper Warehouse"
 	})
 "aMA" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -78,7 +78,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -128,7 +128,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/unpowered)
 "av" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -201,7 +201,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/unpowered)
 "aH" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,

--- a/_maps/map_files/RandomZLevels/academy.dmm
+++ b/_maps/map_files/RandomZLevels/academy.dmm
@@ -1134,7 +1134,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/academy/classrooms)
 "ds" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -2204,7 +2204,7 @@
 	},
 /area/awaymission/academy/classrooms)
 "gb" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/wood,
 /area/awaymission/academy/classrooms)
 "gc" = (

--- a/_maps/map_files/RandomZLevels/example.dmm
+++ b/_maps/map_files/RandomZLevels/example.dmm
@@ -605,7 +605,7 @@
 	},
 /area/awaymission/example)
 "bB" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -670,7 +670,7 @@
 	},
 /area/awaymission/example)
 "bJ" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
@@ -680,7 +680,7 @@
 	},
 /area/awaymission/example)
 "bK" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
@@ -706,7 +706,7 @@
 	},
 /area/awaymission/example)
 "bN" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -2195,7 +2195,7 @@
 	name = "Syndicate Outpost"
 	})
 "dh" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /obj/machinery/alarm/monitor{
 	dir = 4;
 	frequency = 1439;
@@ -7981,7 +7981,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /obj/machinery/alarm/monitor{
 	dir = 8;
 	frequency = 1439;
@@ -8717,7 +8717,7 @@
 	name = "MO19 Arrivals"
 	})
 "mB" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -224,7 +224,7 @@
 	},
 /area/awaymission/UO71/plaza)
 "aH" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
@@ -873,7 +873,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
@@ -921,7 +921,7 @@
 	on = 1;
 	pressure_checks = 1
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
@@ -2216,7 +2216,7 @@
 	on = 1;
 	pressure_checks = 1
 	},
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
 "eW" = (
@@ -6161,7 +6161,7 @@
 	pixel_y = 23;
 	req_access = null
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/item/paper/terrorspiders4,
@@ -6479,7 +6479,7 @@
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
@@ -8632,7 +8632,7 @@
 	},
 /area/awaymission/UO71/centralhall)
 "qL" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/centralhall)
 "qM" = (
@@ -9040,7 +9040,7 @@
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/centralhall)
 "ru" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -12195,7 +12195,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -12540,7 +12540,7 @@
 	},
 /area/awaymission/UO71/eng)
 "xF" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/mining)
 "xG" = (
@@ -13396,7 +13396,7 @@
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/loot)
 "zt" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /obj/item/clothing/shoes/chameleon/noslip,
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/loot)
@@ -13506,12 +13506,12 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "zW" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "zX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
@@ -13523,7 +13523,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "zZ" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
@@ -13531,7 +13531,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "Aa" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -13544,7 +13544,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "Ac" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
@@ -13568,7 +13568,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
 "Ag" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/machinery/light,

--- a/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
@@ -1423,7 +1423,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
@@ -1491,7 +1491,7 @@
 	on = 1;
 	pressure_checks = 1
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
@@ -3362,7 +3362,7 @@
 	on = 1;
 	pressure_checks = 1
 	},
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a1{
 	has_gravity = 1;
@@ -8156,7 +8156,7 @@
 	pixel_y = 23;
 	req_access = null
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -8519,7 +8519,7 @@
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
@@ -11135,7 +11135,7 @@
 	name = "UO45 Crew Quarters"
 	})
 "qt" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a2{
 	has_gravity = 1;
@@ -11629,7 +11629,7 @@
 	name = "UO45 Crew Quarters"
 	})
 "ra" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -15331,7 +15331,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -15833,7 +15833,7 @@
 	name = "UO45 Engineering"
 	})
 "wN" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/awaycontent/a4{
 	has_gravity = 1;

--- a/_maps/map_files/RandomZLevels/wildwest.dmm
+++ b/_maps/map_files/RandomZLevels/wildwest.dmm
@@ -682,7 +682,7 @@
 	},
 /area/awaymission/wwmines)
 "cc" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -704,7 +704,7 @@
 	},
 /area/awaymission/wwmines)
 "ce" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -861,7 +861,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "cA" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -995,13 +995,13 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "cV" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "cW" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -2303,7 +2303,7 @@
 /turf/simulated/wall/mineral/sandstone,
 /area/awaymission/wwmines)
 "gm" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -2312,7 +2312,7 @@
 	},
 /area/awaymission/wwmines)
 "gn" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -2428,7 +2428,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gD" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -2479,7 +2479,7 @@
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gL" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -2528,7 +2528,7 @@
 	tag = "icon-gibup1";
 	icon_state = "gibup1"
 	},
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -18897,7 +18897,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aGk" = (
@@ -33468,7 +33468,7 @@
 	},
 /area/hallway/primary/central/north)
 "biP" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -33483,7 +33483,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "biR" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -79735,7 +79735,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cMb" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood{
@@ -79748,7 +79748,7 @@
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
 "cMd" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -83569,7 +83569,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "cSX" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -84339,7 +84339,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cUi" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "cUj" = (
@@ -91152,7 +91152,7 @@
 	name = "station intercom (General)";
 	pixel_y = -28
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -3384,7 +3384,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "hx" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/wood{
 	tag = "icon-wood-broken7";
 	icon_state = "wood-broken7"
@@ -3946,7 +3946,7 @@
 	},
 /area/derelict/crew_quarters)
 "ix" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood{
@@ -4279,7 +4279,7 @@
 	name = "Derelict Annex"
 	})
 "je" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -4296,7 +4296,7 @@
 	},
 /area/derelict/arrival)
 "jg" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/random{
@@ -4370,7 +4370,7 @@
 /turf/simulated/floor/plasteel,
 /area/derelict/crew_quarters)
 "jn" = (
-/obj/structure/chair/wood/normal,
+/obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -4613,7 +4613,7 @@
 	},
 /area/derelict/crew_quarters)
 "jM" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -7287,7 +7287,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -7301,7 +7301,7 @@
 	},
 /area/derelict/crew_quarters)
 "qo" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -8210,7 +8210,7 @@
 	name = "Derelict Annex"
 	})
 "sd" = (
-/obj/structure/chair/wood/normal{
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -166,7 +166,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list(
 	new /datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1),
 	new /datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20),
 	new /datum/stack_recipe("wood table frame", /obj/structure/table_frame/wood, 2, time = 10), \
-	new /datum/stack_recipe("wooden chair", /obj/structure/chair/wood/normal, 3, time = 10, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("wooden chair", /obj/structure/chair/wood, 3, time = 10, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, 5, time = 50, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("bookcase", /obj/structure/bookcase, 5, time = 50, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("dresser", /obj/structure/dresser, 30, time = 50, one_per_turf = 1, on_floor = 1),

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -133,6 +133,9 @@
 
 // Chair types
 /obj/structure/chair/wood
+	name = "wooden chair"
+	desc = "Old is never too old to not be in fashion."
+	icon_state = "wooden_chair"
 	burn_state = FLAMMABLE
 	burntime = 20
 	buildstackamount = 3
@@ -142,15 +145,8 @@
 /obj/structure/chair/wood/narsie_act()
 	return
 
-/obj/structure/chair/wood/normal
-	icon_state = "wooden_chair"
-	name = "wooden chair"
-	desc = "Old is never too old to not be in fashion."
-
 /obj/structure/chair/wood/wings
 	icon_state = "wooden_chair_wings"
-	name = "wooden chair"
-	desc = "Old is never too old to not be in fashion."
 	item_chair = /obj/item/chair/wood/wings
 
 /obj/structure/chair/comfy

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -213,13 +213,13 @@
 		if("winter") //Snow terrain is slow to move in and cold! Get the assistants to shovel your driveway.
 			NewTerrainFloors = /turf/simulated/floor/snow // Needs to be updated after turf update
 			NewTerrainWalls = /turf/simulated/wall/mineral/wood
-			NewTerrainChairs = /obj/structure/chair/wood/normal
+			NewTerrainChairs = /obj/structure/chair/wood
 			NewTerrainTables = /obj/structure/table/glass
 			NewFlora = list(/obj/structure/flora/grass/green, /obj/structure/flora/grass/brown, /obj/structure/flora/grass/both)
 		if("jungle") //Beneficial due to actually having breathable air. Plus, monkeys and bows and arrows.
 			NewTerrainFloors = /turf/simulated/floor/grass
 			NewTerrainWalls = /turf/simulated/wall/mineral/sandstone
-			NewTerrainChairs = /obj/structure/chair/wood/normal
+			NewTerrainChairs = /obj/structure/chair/wood
 			NewTerrainTables = /obj/structure/table/wood
 			NewFlora = list(/obj/structure/flora/ausbushes/sparsegrass, /obj/structure/flora/ausbushes/fernybush, /obj/structure/flora/ausbushes/leafybush,
 							/obj/structure/flora/ausbushes/grassybush, /obj/structure/flora/ausbushes/sunnybush, /obj/structure/flora/tree/palm, /mob/living/carbon/human/monkey,


### PR DESCRIPTION
**What does this PR do:**
Fix #12252 

Remove the /normal subtype of wooden chair. Why does it exists anyway? 

The issue in #12252 was caused by normal wooden chair having a parent that don't have icon_state specified and inherit its parent's icon state, which is normal chair icon.

100+ lines but basically only 7 or so matter, rest is just typepath change.

Sorry mapper, but this should be an easy change to make.

**Changelog:**
:cl:
fix: Refactored wooden chair so placing them won't make you see normal metallic chair anymore.
/:cl:

