### PR TITLE
Updates contributing.md with new policies and some modification based…

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,16 +34,27 @@ actual development.
  * Pull requests should be atomic; Make one commit for each distinct change, so if a part
  of a pull request needs to be removed/changed, you may simply modify that single commit.
  Due to limitations of the engine, this may not always be possible; but do try your best.
- * Document and explain your pull requests thoroughly. Detail what each commit changes,
- and why it changes it. We do not want to have to read all of you commit names to figure
- out what your pull request is about.
+
+ * Document and explain your pull requests thoroughly. Failure to do so will delay a PR as
+  we question why changes were made. This is especially important if you're porting a PR 
+  from another codebase (i.e. TG) and divert from the original. Explaining with single
+  comment on why you've made changes will help us review the PR faster and understand your
+  decision making process.
+
  * Any pull request must have a changelog, this is to allow us to know when a PR is deployed 
  on the live server. Inline changelogs are supported through the format described 
  [here](https://github.com/ParadiseSS13/Paradise/pull/3291#issuecomment-172950466)
  and should be used rather than manually edited .yml file changelogs.
+
  * Pull requests should not have any merge commits except in the case of fixing merge
  conflicts for an existing pull request. New pull requests should not have any merge
  commits. Use `git rebase` or `git reset` to update your branches, not `git pull`.
+
+ * Please explain why you are submitting the pull request, and how you think your change will be beneficial to the game. Failure to do so will be grounds for rejecting the PR.
+ 
+ * If your pull request is not finished make sure it is at least testable in a live environment. Pull requests that do not at least meet this requirement may be closed at maintainer discretion. You may request a maintainer reopen the pull request when you're ready, or make a new one.
+
+ * While we have no issue helping contributors (and especially new contributors) bring reasonably sized contributions up to standards via the pull request review process, larger contributions are expected to pass a higher bar of completeness and code quality *before* you open a pull request. Maintainers may close such pull requests that are deemed to be substantially flawed. You should take some time to discuss with maintainers or other contributors on how to improve the changes. 
 
 #### Using Changelog
  * Tags used in changelog include add/rscadd, del/rscdel, fix/fixes, typo/spellcheck. 


### PR DESCRIPTION
**What does this PR do:**
Improves our contributing.MD guide based on tg's https://github.com/tgstation/tgstation/blob/master/.github/CONTRIBUTING.md

The changes are:
```   
* Document and explain your pull requests thoroughly. Failure to do so will delay a PR as
  we question why changes were made. This is especially important if you're porting a PR 
  from another codebase (i.e. TG) and divert from the original. Explaining with single
  comment on why you've made changes will help us review the PR faster and understand your
  decision making process.

* Please explain why you are submitting the pull request, and how you think your change will be beneficial to the game. Failure to do so will be grounds for rejecting the PR.

 * If your pull request is not finished make sure it is at least testable in a live environment. Pull requests that do not at least meet this requirement may be closed at maintainer discretion. You may request a maintainer reopen the pull request when you're ready, or make a new one.

 * While we have no issue helping contributors (and especially new contributors) bring reasonably sized contributions up to standards via the pull request review process, larger contributions are expected to pass a higher bar of completeness and code quality *before* you open a pull request. Maintainers may close such pull requests that are deemed to be substantially flawed. You should take some time to discuss with maintainers or other contributors on how to improve the changes.  ```

The reasons for these changes are:
- Give guideline on best practice when porting
- Tell people to document it if they divert from original in a port, a constant issue with (TG) ports
- Make sure people explain why their PR is good
- Crack down on completely unfinished or untestable PR that's a waste of our time, while recognizing there are occasional situation where unfinished PR is warranted. (Note that we've made closing these PR a "may" and something at maintainer discretion, instead of a "will" as in the original TG wording)
- Make sure people don't make overly large PR that needs a lot of handholding to be completed. Because this problem is shared with TG.

**Changelog:**
:cl:
tweak: Contribution guideline has been updated. No in game changes.
/:cl:

