### PR TITLE
Fix really silly mistake

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -290,12 +290,6 @@
 	addiction_chance = 5
 	taste_description = "health"
 
-/datum/reagent/medicine/omnizine/godblood
-	name = "Godblood"
-	id = "godblood"
-	description = "Slowly heals all damage types. Has a rather high overdose threshold. Glows with mysterious power."
-	overdose_threshold = 150
-
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	update_flags |= M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
@@ -962,6 +956,12 @@
 	overdose_threshold = 30
 	metabolization_rate = 0.1
 	taste_description = "faint hope"
+
+/datum/reagent/medicine/omnizine_diluted/godblood
+	name = "Godblood"
+	id = "godblood"
+	description = "Slowly heals all damage types. Has a rather high overdose threshold. Glows with mysterious power."
+	overdose_threshold = 150
 
 /datum/reagent/medicine/omnizine_diluted/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -292,6 +292,7 @@
 
 /datum/reagent/medicine/omnizine/godblood
 	name = "Godblood"
+	id = "godblood"
 	description = "Slowly heals all damage types. Has a rather high overdose threshold. Glows with mysterious power."
 	overdose_threshold = 150
 

--- a/code/modules/ruins/lavalandruin_code/fountain_hall.dm
+++ b/code/modules/ruins/lavalandruin_code/fountain_hall.dm
@@ -38,7 +38,7 @@
 		return
 	last_process = world.time
 	to_chat(user, "<span class='notice'>The water feels warm and soothing as you touch it. The fountain immediately dries up shortly afterwards.</span>")
-	user.reagents.add_reagent("godblood", 20)	//why is add_reagent so stupid ?!?
+	user.reagents.add_reagent("godblood", 20)
 	update_icon()
 	addtimer(CALLBACK(src, .proc/update_icon), time_between_uses)
 

--- a/code/modules/ruins/lavalandruin_code/fountain_hall.dm
+++ b/code/modules/ruins/lavalandruin_code/fountain_hall.dm
@@ -38,7 +38,7 @@
 		return
 	last_process = world.time
 	to_chat(user, "<span class='notice'>The water feels warm and soothing as you touch it. The fountain immediately dries up shortly afterwards.</span>")
-	user.reagents.add_reagent(/datum/reagent/medicine/omnizine/godblood, 20)
+	user.reagents.add_reagent("godblood", 20)	//why is add_reagent so stupid ?!?
 	update_icon()
 	addtimer(CALLBACK(src, .proc/update_icon), time_between_uses)
 


### PR DESCRIPTION
**What does this PR do:**
Whoever ported the healing fountain ruin assumed the add reagent proc would be sensible. Sadly it is not. This pr fixes the fountain not healing and runtiming.


**Changelog:**
:cl:
fix: healing fountain lavaland ruin now correctly heals
/:cl:

