### PR TITLE
Nerfs Miners

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -121,9 +121,10 @@
 	product_records = list()
 	hidden_records = list()
 	coin_records = list()
-	build_inventory(products, product_records, start_empty = TRUE)
-	build_inventory(contraband, hidden_records, start_empty = TRUE)
-	build_inventory(premium, coin_records, start_empty = TRUE)
+	if(refill_canister)
+		build_inventory(products, product_records, start_empty = TRUE)
+		build_inventory(contraband, hidden_records, start_empty = TRUE)
+		build_inventory(premium, coin_records, start_empty = TRUE)
 	for(var/obj/item/vending_refill/VR in component_parts)
 		restock(VR)
 

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -164,7 +164,6 @@
 	name = "survival pod medical supply"
 	desc = "Wall-mounted Medical Equipment dispenser. This one seems just a tiny bit smaller."
 	req_access = list()
-	refill_canister = null
 
 	products = list(/obj/item/reagent_containers/food/pill/patch/styptic = 5,
 					/obj/item/reagent_containers/food/pill/patch/silver_sulf = 5,


### PR DESCRIPTION
Recent health insurance cutbacks (Having health insurance at all? In _this_ economy?) means we must literally halve the amount of medicine provided to miners.

Seriously, though. Fixes a bug where vending machines that didn't have a refill type would double up on their contents because product was loaded once during init and again when RefreshParts is called down the line. Whoops!

Also gives mining nanomeds a restocking module per Fox's request.

Fixes #12273

:cl:
fix: Fixes some vending machines (namely miner nanomeds) from adding all of their product twice.
/:cl:

