### PR TITLE
Allows people to float on shallow water

### DIFF
--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -116,7 +116,7 @@
 	if(!drownee)
 		return
 
-	if(drownee && (drownee.lying || deep_water)) //Mob lying down or water is deep (determined by controller)
+	if(drownee && ((drownee.lying && !drownee.player_logged) || deep_water)) //Mob lying down and not SSD or water is deep (determined by controller)
 		if(drownee.internal)
 			return //Has internals, no drowning
 		if((NO_BREATHE in drownee.dna.species.species_traits) || (BREATHLESS in drownee.mutations))

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -116,7 +116,7 @@
 	if(!drownee)
 		return
 
-	if(drownee && ((drownee.lying && !drownee.player_logged) || deep_water)) //Mob lying down and not SSD or water is deep (determined by controller)
+	if(drownee && deep_water) //Water is deep (determined by controller)
 		if(drownee.internal)
 			return //Has internals, no drowning
 		if((NO_BREATHE in drownee.dna.species.species_traits) || (BREATHLESS in drownee.mutations))


### PR DESCRIPTION
You can now float (lie down) on water that isn't deep without drowning

Resolves the issue of SSD people from being dragged to the pool to drown as a joke.

I've never seen a case where someone has legitimately drowned because of this, just SSDs getting griefed.

🆑 
tweak: Players will no longer drown and instead float when lying down on shallow water.
/ 🆑 