### PR TITLE
Stops SSDs from drowning in shallow water

### DIFF
--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -116,7 +116,7 @@
 	if(!drownee)
 		return
 
-	if(drownee && (drownee.lying || deep_water)) //Mob lying down or water is deep (determined by controller)
+	if(drownee && ((drownee.lying && !drownee.player_logged) || deep_water)) //Mob lying down and not SSD or water is deep (determined by controller)
 		if(drownee.internal)
 			return //Has internals, no drowning
 		if((NO_BREATHE in drownee.dna.species.species_traits) || (BREATHLESS in drownee.mutations))


### PR DESCRIPTION
Stops SSDs from drowning in shallow water when lying down

People drag SSD players to the pool to grief, people who go SSD in deep water such as the gateway ocean will still drown to prevent people from gaming it.

🆑 
fix: SSD players no longer drown in shallow water
/ 🆑 


