### PR TITLE
Make stunprods bulky

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -227,7 +227,7 @@
 	icon_state = "stunprod_nocell"
 	base_icon = "stunprod"
 	item_state = "prod"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	force = 3
 	throwforce = 5
 	stunforce = 5

--- a/code/game/objects/items/weapons/teleprod.dm
+++ b/code/game/objects/items/weapons/teleprod.dm
@@ -1,6 +1,7 @@
 /obj/item/melee/baton/cattleprod/teleprod
 	name = "teleprod"
 	desc = "A prod with a bluespace crystal on the end. The crystal doesn't look too fun to touch."
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "teleprod_nocell"
 	base_icon = "teleprod"
 	item_state = "teleprod"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes ghetto stunbatons, the stunprods into bulky objects.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I don't think the ghetto version of a stunbaton should be so easily concealable. The case with security is that you can easily assume they have a stunbaton but you can't assume any crew member has a stunprod. I don't think these instant stun items should be so easy to hide and remove on a whim and if you're planning to use a stunprod you'll need to accept the risk of being openly visible or attempt to get an upgrade to a stunbaton or use a bag of holding. Stunprods barely have a downside in comparison to stunbatons especially when you pair them with a yellow cell. The stun for stunprods only last 4 seconds less than a stunbaton and that's more than enough time to cuff or do whatever nefarious deeds. I think it would be better to make an item that is so easily available(0 TC, uses things that can be mass produced out of an autolathe excluding the high cap cell that you can get from science) have a downside

## Changelog
:cl:
balance: stunprods are now bulky and will not fit in bags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
