### PR TITLE
Add an officer starter pack crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -508,6 +508,25 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 30
 	containername = "security clothing crate"
 
+/datum/supply_packs/security/officerpack // Starter pack for an officer. Contains everything in a locker but backpack (officer already start with one). Convenient way to equip new officer on highpop.
+	name = "Officer Starter Pack"
+	contains = 	list(/obj/item/clothing/suit/armor/vest/security,
+				/obj/item/radio/headset/headset_sec/alt,
+				/obj/item/clothing/head/soft/sec,
+				/obj/item/reagent_containers/spray/pepper,
+				/obj/item/flash,
+				/obj/item/grenade/flashbang,
+				/obj/item/storage/belt/security/sec,
+				/obj/item/holosign_creator/security,
+				/obj/item/clothing/mask/gas/sechailer,
+				/obj/item/clothing/glasses/hud/security/sunglasses,
+				/obj/item/clothing/head/helmet,
+				/obj/item/melee/baton/loaded,
+				/obj/item/clothing/suit/armor/secjacket)
+	cost = 30 // Convenience has a price and this pack is genuinely loaded
+	containername = "officer starter crate"
+
+
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Engineering /////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This add an officer starter pack crate to cargo, available for 30 cargo points. It is an exact copy of the security officer closet's content, except for the backpack.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It helps equipping officers in high pop rounds. Its cost is high so that equipping a large security force would not be cheap

## Changelog
:cl:
add: Officer starter pack to cargo. For 30 cargo points you can equip an officer just like an officer closet! Backpack not included due to budget cut.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
