### PR TITLE
Lowers logging level of harmless chems/food

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -294,9 +294,7 @@ This is always put in the attack log.
 	if(!isnull(custom_level))
 		loglevel = custom_level
 	else if(istype(target))
-		if(isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE
-			loglevel = ATKLOG_FEW
-		else if(istype(user) && !user.ckey && !target.ckey) // Attacks between NPCs are only shown to admins with ATKLOG_ALL
+		if(istype(user) && !user.ckey && !target.ckey) // Attacks between NPCs are only shown to admins with ATKLOG_ALL
 			loglevel = ATKLOG_ALL
 		else if(!user.ckey || !target.ckey || (user.ckey == target.ckey)) // Player v NPC combat is de-prioritized. Also no self-harm, nobody cares
 			loglevel = ATKLOG_ALMOSTALL
@@ -304,6 +302,8 @@ This is always put in the attack log.
 			var/area/A = get_area(target)
 			if(A && A.hide_attacklogs)
 				loglevel = ATKLOG_ALMOSTALL
+	if(isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE. Overrides custom level
+		loglevel = ATKLOG_FEW
 
 	msg_admin_attack("[key_name_admin(user)] vs [key_name_admin(target)]: [what_done]", loglevel)
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -196,8 +196,9 @@
 	var/to_inject = min(R.volume, inject_amount)
 	if(to_inject && patient.reagents.get_reagent_amount(R.id) + to_inject <= inject_amount*2)
 		occupant_message("Injecting [patient] with [to_inject] units of [R.name].")
+		
 		log_message("Injecting [patient] with [to_inject] units of [R.name].")
-		add_attack_logs(chassis.occupant, patient, "Injected with [name] containing [R], transferred [to_inject] units")
+		add_attack_logs(chassis.occupant, patient, "Injected with [name] containing [R], transferred [to_inject] units", R.harmless ? ATKLOG_ALMOSTALL : null)
 		SG.reagents.trans_id_to(patient,R.id,to_inject)
 		update_equip_info()
 	return

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -196,7 +196,6 @@
 	var/to_inject = min(R.volume, inject_amount)
 	if(to_inject && patient.reagents.get_reagent_amount(R.id) + to_inject <= inject_amount*2)
 		occupant_message("Injecting [patient] with [to_inject] units of [R.name].")
-		
 		log_message("Injecting [patient] with [to_inject] units of [R.name].")
 		add_attack_logs(chassis.occupant, patient, "Injected with [name] containing [R], transferred [to_inject] units", R.harmless ? ATKLOG_ALMOSTALL : null)
 		SG.reagents.trans_id_to(patient,R.id,to_inject)

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -44,7 +44,7 @@
 		if(!reagents || !reagents.total_volume)
 			return // The condiment might be empty after the delay.
 		user.visible_message("<span class='warning'>[user] feeds [M] from [src].</span>")
-		add_attack_logs(user, M, "Fed [src] containing [reagents.log_list()]")
+		add_attack_logs(user, M, "Fed [src] containing [reagents.log_list()]", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
 
 	var/fraction = min(10/reagents.total_volume, 1)
 	reagents.reaction(M, INGEST, fraction)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1042,7 +1042,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return 1
 
 /mob/living/carbon/proc/forceFedAttackLog(var/obj/item/reagent_containers/food/toEat, mob/user)
-	add_attack_logs(user, src, "Fed [toEat]. Reagents: [toEat.reagents.log_list(toEat)]", ATKLOG_MOST)
+	add_attack_logs(user, src, "Fed [toEat]. Reagents: [toEat.reagents.log_list(toEat)]", toEat.reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
 	if(!iscarbon(user))
 		LAssailant = null
 	else

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -750,6 +750,13 @@ var/const/INGEST = 2
 		//Using IDs because SOME chemicals (I'm looking at you, chlorhydrate-beer) have the same names as other chemicals.
 	return english_list(data)
 
+//helper for attack logs, tells you if all reagents are harmless or not. returns true if harmless.
+/datum/reagents/proc/harmless_helper()
+	for(var/datum/reagent/r in reagent_list)
+		if(!r.harmless)
+			return FALSE
+	return TRUE
+
 //two helper functions to preserve data across reactions (needed for xenoarch)
 /datum/reagents/proc/get_data(reagent_id)
 	for(var/datum/reagent/D in reagent_list)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -16,6 +16,7 @@
 	//Processing flags, defines the type of mobs the reagent will affect
 	//By default, all reagents will ONLY affect organics, not synthetics. Re-define in the reagent's definition if the reagent is meant to affect synths
 	var/process_flags = ORGANIC
+	var/harmless = FALSE //flag used for attack logs
 	var/can_synth = TRUE //whether or not a mech syringe gun and synthesize this reagent
 	var/overdose_threshold = 0
 	var/addiction_chance = 0

--- a/code/modules/reagents/chemistry/reagents/drink_base.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_base.dm
@@ -4,6 +4,7 @@
 	description = "Uh, some kind of drink."
 	reagent_state = LIQUID
 	color = "#E78108" // rgb: 231, 129, 8
+	harmless = TRUE
 	taste_description = "something which should not exist"
 	var/adj_dizzy = 0
 	var/adj_drowsy = 0

--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -64,6 +64,7 @@
 	drink_icon = "nuka_colaglass"
 	drink_name = "Nuka Cola"
 	drink_desc = "Don't cry, Don't raise your eye, It's only nuclear wasteland"
+	harmless = FALSE
 	taste_description = "radioactive cola"
 
 /datum/reagent/consumable/drink/cold/nuka_cola/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -5,6 +5,7 @@
 /datum/reagent/consumable
 	name = "Consumable"
 	id = "consumable"
+	harmless = TRUE
 	taste_description = "generic food"
 	taste_mult = 4
 	var/nutriment_factor = 1 * REAGENTS_METABOLISM
@@ -287,6 +288,7 @@
 	description = "Sodium chloride, common table salt."
 	reagent_state = SOLID
 	color = "#B1B0B0"
+	harmless = FALSE
 	overdose_threshold = 100
 	taste_mult = 2
 	taste_description = "salt"
@@ -604,6 +606,7 @@
 	color = "#AB5D5D"
 	metabolization_rate = 0.2
 	overdose_threshold = 133
+	harmless = FALSE
 	taste_description = "bacon"
 
 /datum/reagent/consumable/porktonium/overdose_process(mob/living/M, severity)
@@ -648,6 +651,7 @@
 	reagent_state = LIQUID
 	color = "#B2B139"
 	overdose_threshold = 50
+	harmless = FALSE
 	taste_description = "cheese?"
 
 /datum/reagent/consumable/fake_cheese/overdose_process(mob/living/M, severity)
@@ -714,6 +718,7 @@
 	color = "#B1B0B0"
 	metabolization_rate = 0.2
 	overdose_threshold = 75
+	harmless = FALSE
 	taste_description = "oil"
 
 /datum/reagent/consumable/hydrogenated_soybeanoil/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -2,6 +2,7 @@
 	name = "Medicine"
 	id = "medicine"
 	taste_description = "bitterness"
+	harmless = TRUE
 
 /datum/reagent/medicine/on_mob_life(mob/living/M)
 	current_cycle++
@@ -44,6 +45,7 @@
 	reagent_state = LIQUID
 	color = "#FA46FA"
 	overdose_threshold = 40
+	harmless = FALSE
 	taste_description = "stimulant"
 
 /datum/reagent/medicine/synaptizine/on_mob_life(mob/living/M)
@@ -135,6 +137,7 @@
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
 	overdose_threshold = 30
+	harmless = FALSE
 	taste_description = "reformation"
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
@@ -173,6 +176,7 @@
 	reagent_state = LIQUID
 	color = "#F0C814"
 	metabolization_rate = 3
+	harmless = FALSE	//toxic if ingested, and I am NOT going to account for the difference
 	taste_description = "burn cream"
 
 /datum/reagent/medicine/silver_sulfadiazine/on_mob_life(mob/living/M)
@@ -199,6 +203,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 3
+	harmless = FALSE
 	taste_description = "wound cream"
 
 /datum/reagent/medicine/styptic_powder/on_mob_life(mob/living/M)
@@ -289,6 +294,7 @@
 	metabolization_rate = 0.2
 	overdose_threshold = 30
 	addiction_chance = 5
+	harmless = FALSE
 	taste_description = "health"
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/M)
@@ -345,6 +351,7 @@
 	reagent_state = LIQUID
 	color = "#22AB35"
 	metabolization_rate = 0.8
+	harmless = FALSE
 	taste_description = "a painful cleansing"
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/M)
@@ -377,6 +384,7 @@
 	description = "Pentetic Acid is an aggressive chelation agent. May cause tissue damage. Use with caution."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	harmless = FALSE
 	taste_description = "a purge"
 
 /datum/reagent/medicine/pen_acid/on_mob_life(mob/living/M)
@@ -401,6 +409,7 @@
 	metabolization_rate = 0.1
 	shock_reduction = 25
 	overdose_threshold = 25
+	harmless = FALSE
 	taste_description = "relief"
 
 /datum/reagent/medicine/sal_acid/on_mob_life(mob/living/M)
@@ -432,6 +441,7 @@
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
 	addiction_chance = 20
+	harmless = FALSE
 	taste_description = "oxygenation"
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
@@ -453,6 +463,7 @@
 	metabolization_rate = 0.3
 	overdose_threshold = 35
 	addiction_chance = 25
+	harmless = FALSE
 	taste_description = "stimulation"
 
 /datum/reagent/medicine/ephedrine/on_mob_life(mob/living/M)
@@ -502,6 +513,7 @@
 	reagent_state = LIQUID
 	color = "#5BCBE1"
 	addiction_chance = 10
+	harmless = FALSE
 	taste_description = "antihistamine"
 
 /datum/reagent/medicine/diphenhydramine/on_mob_life(mob/living/M)
@@ -525,6 +537,7 @@
 	overdose_threshold = 20
 	addiction_chance = 50
 	shock_reduction = 50
+	harmless = FALSE
 	taste_description = "a delightful numbing"
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/M)
@@ -579,6 +592,7 @@
 	color = "#000000"
 	metabolization_rate = 0.2
 	overdose_threshold = 25
+	harmless = FALSE
 	taste_description = "a moment of respite"
 
 /datum/reagent/medicine/atropine/on_mob_life(mob/living/M)
@@ -607,6 +621,7 @@
 	color = "#96B1AE"
 	metabolization_rate = 0.2
 	overdose_threshold = 20
+	harmless = FALSE
 	taste_description = "borrowed time"
 
 /datum/reagent/medicine/epinephrine/on_mob_life(mob/living/M)
@@ -664,6 +679,7 @@
 	color = "#A0E85E"
 	metabolization_rate = 0.2
 	taste_description = "life"
+	harmless = FALSE
 	var/revive_type = SENTIENCE_ORGANIC //So you can't revive boss monsters or robots with it
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/M)
@@ -781,6 +797,7 @@
 	id = "stimulants"
 	description = "Increases run speed and eliminates stuns, can heal minor damage. If overdosed it will deal toxin damage and stun."
 	color = "#C8A5DC"
+	harmless = FALSE
 	can_synth = FALSE
 	taste_description = "<span class='userdanger'>an unstoppable force</span>"
 
@@ -819,6 +836,7 @@
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 60
+	harmless = FALSE
 	can_synth = FALSE
 
 /datum/reagent/medicine/stimulative_agent/on_mob_life(mob/living/M)
@@ -914,6 +932,7 @@
 	reagent_state = LIQUID
 	color = "#96DEDE"
 	metabolization_rate = 0.1
+	harmless = FALSE
 	taste_description = "sleepiness"
 
 /datum/reagent/medicine/ether/on_mob_life(mob/living/M)
@@ -957,6 +976,7 @@
 	color = "#DCDCDC"
 	overdose_threshold = 30
 	metabolization_rate = 0.1
+	harmless = FALSE
 	taste_description = "faint hope"
 
 /datum/reagent/medicine/omnizine_diluted/godblood
@@ -1041,6 +1061,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
+	harmless = FALSE
 	taste_description = "knitting wounds"
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/M)
@@ -1060,6 +1081,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
+	harmless = FALSE
 	taste_description = "soothed burns"
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/M)
@@ -1079,6 +1101,7 @@
 	description = "Ichor from an extremely powerful plant. Great for restoring wounds, but it's a little heavy on the brain."
 	color = "#FFAF00"
 	overdose_threshold = 25
+	harmless = FALSE
 	taste_description = "a gift from nature"
 
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/M)
@@ -1116,6 +1139,7 @@
 	color = "#9b3401"
 	metabolization_rate = 0.5
 	can_synth = FALSE
+	harmless = FALSE
 	taste_description = "wholeness"
 
 /datum/reagent/medicine/nanocalcium/on_mob_life(mob/living/carbon/human/M)
@@ -1155,6 +1179,7 @@
 	description = "An extract of lavaland atmospheric and mineral elements. Heals the user in small doses, but is extremely toxic otherwise."
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	overdose_threshold = 3 //To prevent people stacking massive amounts of a very strong healing reagent
+	harmless = FALSE
 	can_synth = FALSE
 
 /datum/reagent/medicine/lavaland_extract/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -36,6 +36,7 @@
 	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	reagent_state = LIQUID
 	color = "#1BB1AB"
+	harmless = TRUE
 	taste_description = "cherry"
 
 /datum/reagent/lube/reaction_turf(turf/simulated/T, volume)
@@ -49,6 +50,7 @@
 	description = "A compound used to clean things. Now with 50% more sodium hypochlorite!"
 	reagent_state = LIQUID
 	color = "#61C2C2"
+	harmless = TRUE
 	taste_description = "floor cleaner"
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, volume)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -85,7 +85,7 @@
 			var/datum/reagent/injected = GLOB.chemical_reagents_list[reagent_ids[mode]]
 			var/contained = injected.name
 			var/trans = R.trans_to(M, amount_per_transfer_from_this)
-			add_attack_logs(user, M, "Injected with [name] containing [contained], transfered [trans] units")
+			add_attack_logs(user, M, "Injected with [name] containing [contained], transfered [trans] units", injected.harmless ? ATKLOG_ALMOSTALL : null)
 			M.LAssailant = user
 			to_chat(user, "<span class='notice'>[trans] units injected. [R.total_volume] units remaining.</span>")
 	return

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -44,7 +44,7 @@
 
 			var/contained = english_list(injected)
 
-			add_attack_logs(user, M, "Injected with [src] containing ([contained])")
+			add_attack_logs(user, M, "Injected with [src] containing ([contained])", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
 
 		return TRUE
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -146,7 +146,7 @@
 					rinject += R.name
 				var/contained = english_list(rinject)
 
-				add_attack_logs(user, L, "Injected with [name] containing [contained], transfered [amount_per_transfer_from_this] units")
+				add_attack_logs(user, L, "Injected with [name] containing [contained], transfered [amount_per_transfer_from_this] units", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
 
 			var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
 			reagents.reaction(L, INGEST, fraction)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it so that the logging level of feeding people food/drinks or injecting them with chems is reduced for certain reagents that have been flagged as harmless. Chems flagged as harmless have no overdose thresholds, and no negative side effects. This means that they are, as the name says, mostly harmless and there is no need to have them spam admin chat with attack logs.

I had to slightly refactor/rewrite the logging proc so that the SSD check overrides the custom logging level, which I assume is a good idea anyway. You care about even harmless things happening to SSD players.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins will have less spammy chats and notice actual issues more often.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: certain harmless chems and food have reduced attack log logging levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
