### PR TITLE
Changes station goal crate to engi crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1252,7 +1252,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/melee/flyswatter)
 	cost = 15
+	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "beekeeping starter kit"
+	access = access_hydroponics
 
 /datum/supply_packs/organic/hydroponics/beekeeping_suits
 	name = "2 Beekeeper suits"
@@ -1748,10 +1750,17 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 
 ///////////// Station Goals
 
-/datum/supply_packs/misc/bsa
+/datum/supply_packs/misc/station_goal
+	name = "Empty Station Goal Crate"
+	cost = 10
+	special = TRUE
+	containername = "empty station goal crate"
+	containertype = /obj/structure/closet/crate/secure/engineering
+	access = access_engine
+
+/datum/supply_packs/misc/station_goal/bsa
 	name = "Bluespace Artillery Parts"
 	cost = 150
-	special = TRUE
 	contains = list(/obj/item/circuitboard/machine/bsa/front,
 					/obj/item/circuitboard/machine/bsa/middle,
 					/obj/item/circuitboard/machine/bsa/back,
@@ -1759,19 +1768,17 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					)
 	containername = "bluespace artillery parts crate"
 
-/datum/supply_packs/misc/dna_vault
+/datum/supply_packs/misc/station_goal/dna_vault
 	name = "DNA Vault Parts"
 	cost = 120
-	special = TRUE
 	contains = list(
 					/obj/item/circuitboard/machine/dna_vault
 					)
 	containername = "dna vault parts crate"
 
-/datum/supply_packs/misc/dna_probes
+/datum/supply_packs/misc/station_goal/dna_probes
 	name = "DNA Vault Samplers"
 	cost = 30
-	special = TRUE
 	contains = list(/obj/item/dna_probe,
 					/obj/item/dna_probe,
 					/obj/item/dna_probe,
@@ -1779,9 +1786,10 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/dna_probe
 					)
 	containername = "dna samplers crate"
+	containertype = /obj/structure/closet/crate/engineering
+	access = null
 
-
-/datum/supply_packs/misc/shield_sat
+/datum/supply_packs/misc/station_goal/shield_sat
 	name = "Shield Generator Satellite"
 	cost = 30
 	special = TRUE
@@ -1792,8 +1800,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					)
 	containername = "shield sat crate"
 
-
-/datum/supply_packs/misc/shield_sat_control
+/datum/supply_packs/misc/station_goal/shield_sat_control
 	name = "Shield System Control Board"
 	cost = 50
 	special = TRUE

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1252,9 +1252,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/clothing/suit/beekeeper_suit,
 					/obj/item/melee/flyswatter)
 	cost = 15
-	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "beekeeping starter kit"
-	access = access_hydroponics
 
 /datum/supply_packs/organic/hydroponics/beekeeping_suits
 	name = "2 Beekeeper suits"
@@ -1755,8 +1753,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 10
 	special = TRUE
 	containername = "empty station goal crate"
-	containertype = /obj/structure/closet/crate/secure/engineering
-	access = access_engine
+	containertype = /obj/structure/closet/crate/engineering
 
 /datum/supply_packs/misc/station_goal/bsa
 	name = "Bluespace Artillery Parts"
@@ -1786,13 +1783,10 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/dna_probe
 					)
 	containername = "dna samplers crate"
-	containertype = /obj/structure/closet/crate/engineering
-	access = null
 
 /datum/supply_packs/misc/station_goal/shield_sat
 	name = "Shield Generator Satellite"
 	cost = 30
-	special = TRUE
 	contains = list(
 					/obj/machinery/satellite/meteor_shield,
 					/obj/machinery/satellite/meteor_shield,
@@ -1803,7 +1797,6 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 /datum/supply_packs/misc/station_goal/shield_sat_control
 	name = "Shield System Control Board"
 	cost = 50
-	special = TRUE
 	contains = list(
 					/obj/item/circuitboard/computer/sat_control
 					)

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -16,7 +16,7 @@
 
 /datum/station_goal/bluespace_cannon/on_report()
 	//Unlock BSA parts
-	var/datum/supply_packs/misc/bsa/P = SSshuttle.supply_packs["[/datum/supply_packs/misc/bsa]"]
+	var/datum/supply_packs/misc/station_goal/bsa/P = SSshuttle.supply_packs["[/datum/supply_packs/misc/station_goal/bsa]"]
 	P.special_enabled = TRUE
 
 /datum/station_goal/bluespace_cannon/check_completion()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -37,10 +37,10 @@
 	The base vault parts should be available for shipping by your cargo shuttle."}
 
 /datum/station_goal/dna_vault/on_report()
-	var/datum/supply_packs/P = SSshuttle.supply_packs["[/datum/supply_packs/misc/dna_vault]"]
+	var/datum/supply_packs/P = SSshuttle.supply_packs["[/datum/supply_packs/misc/station_goal/dna_vault]"]
 	P.special_enabled = TRUE
 
-	P = SSshuttle.supply_packs["[/datum/supply_packs/misc/dna_probes]"]
+	P = SSshuttle.supply_packs["[/datum/supply_packs/misc/station_goal/dna_probes]"]
 	P.special_enabled = TRUE
 
 /datum/station_goal/dna_vault/check_completion()

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -13,10 +13,10 @@
 
 /datum/station_goal/station_shield/on_report()
 	//Unlock
-	var/datum/supply_packs/P = SSshuttle.supply_packs["[/datum/supply_packs/misc/shield_sat]"]
+	var/datum/supply_packs/P = SSshuttle.supply_packs["[/datum/supply_packs/misc/station_goal/shield_sat]"]
 	P.special_enabled = TRUE
 
-	P = SSshuttle.supply_packs["[/datum/supply_packs/misc/shield_sat_control]"]
+	P = SSshuttle.supply_packs["[/datum/supply_packs/misc/station_goal/shield_sat_control]"]
 	P.special_enabled = TRUE
 
 /datum/station_goal/station_shield/check_completion()


### PR DESCRIPTION
This PR changes the station goal crates to engineering crates.

I've seen a few techs confused at to where station goals should be delivered as they come in grey crates, with the engineering paint job it should be clearer.

:cl:
tweak: Station goal crates now come in engineering crates.
/:cl: