### PR TITLE
Small global midi improvements

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -28,9 +28,12 @@ var/list/sounds_cache = list()
 
 	log_admin("[key_name(src)] played sound [S]")
 	message_admins("[key_name_admin(src)] played sound [S]", 1)
+
 	for(var/mob/M in GLOB.player_list)
 		if(M.client.prefs.sound & SOUND_MIDI)
-			M << uploaded_sound
+			if(isnewplayer(M) && (M.client.prefs.sound & SOUND_LOBBY))
+				M.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+			SEND_SOUND(M, uploaded_sound)
 
 	feedback_add_details("admin_verb","PGS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
When playing a song when people are in the lobby, that music would be playing overtop of the lobby music. This will now silence the lobby music for those who have admin midis enabled when they are in the lobby listening to lobby music and a midi is played globally.


🆑 
tweak: Global admin midis will now silence lobby music for those who have midis enabled.
/ 🆑 