### PR TITLE
Wall repair fixes

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -345,7 +345,7 @@
 				if(do_after(user, max(5, damage / 5) * WT.toolspeed, target = src) && WT && WT.isOn())
 					to_chat(user, "<span class='notice'>You finish repairing the damage to [src].</span>")
 					cut_overlay(dent_decals)
-					dent_decals.Cut()
+					dent_decals?.Cut()
 					take_damage(-damage)
 			else
 				to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -40,7 +40,7 @@
 	return ..()
 
 /turf/simulated/wall/r_wall/proc/try_repair(obj/item/I, mob/user, params)
-	if(damage && iswelder(I))
+	if((damage || LAZYLEN(dent_decals)) && iswelder(I))
 		var/obj/item/weldingtool/WT = I
 		if(!WT.remove_fuel(0, user))
 			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
@@ -50,6 +50,8 @@
 		playsound(src, WT.usesound, 100, 1)
 		if(do_after(user, max(5, damage / 5) * WT.toolspeed, target = src) && WT && WT.isOn())
 			to_chat(user, "<span class='notice'>You finish repairing the damage to [src].</span>")
+			cut_overlay(dent_decals)
+			dent_decals?.Cut()
 			take_damage(-damage)
 			return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It turns out that if the list `dent_decals` that stores bullet hole decals on walls, was `null`, it would cause a runtime and not allow a wall with only structural damage to be repaired. I just added a check to see if the list was null before attempting to call the `Cut()` function which caused the runtime.

I also made it so you can repair and remove the bullet holes from reinforced walls even if there is no structural damage on them.

Fixes  #12314

## Why It's Good For The Game
It allows engineers and others to repair walls properly withing having to dismantle and rebuild them just to get damage to go away. Also it prevents runtimes.

## Changelog
:cl:
fix: Fixes a runtime preventing walls from being repaired properly
add: Adds the ability to repair and remove bullet holes from reinforced walls that have no structural damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
