### PR TITLE
Makes Wizards Twice As Cool

### DIFF
--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -23,7 +23,6 @@
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 
 /obj/item/gun/magic/afterattack(atom/target, mob/living/user, flag)
-	newshot()
 	if(no_den_usage)
 		var/area/A = get_area(user)
 		if(istype(A, /area/wizard_station))
@@ -37,9 +36,13 @@
 	return charges
 
 /obj/item/gun/magic/newshot(params)
-	if(charges && chambered)
+	if(charges && chambered && !chambered.BB)
 		chambered.newshot(params)
 	return
+
+/obj/item/gun/magic/process_fire()
+	newshot()
+	return ..()
 
 /obj/item/gun/magic/process_chamber()
 	if(chambered && !chambered.BB) //if BB is null, i.e the shot has been fired...


### PR DESCRIPTION
## What Does This PR Do
Fixes dual wielding with magical weapons. Fixes #12309. The error was that the chambering of the rounds was handled by the afterattack on magical weapons, but the offhand weapon went directly to process_fire which caused problems. Further problems may exist with the dual wielding system regarding things like the clumsy gene and heavy weapons falling out of hands.

## Why It's Good For The Game
Because we definitely need a wizard running around with two staves of chaos. D-Definitely.

## Changelog
:cl:
fix: Magical weapons can now be properly dual-wielded.
/:cl:
