### PR TITLE
Fixes Energy Shield Descriptions

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1459,7 +1459,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/shield
 	name = "Energy Shield"
-	desc = "A handheld personal shield projector, capable of reflecting energy projectiles but not other attacks."
+	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles, but it cannot block other attacks. Pair with an Energy Sword for a killer combination."
 	item = /obj/item/shield/energy
 	reference = "ESD"
 	cost = 16

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1459,7 +1459,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/shield
 	name = "Energy Shield"
-	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending against other attacks."
+	desc = "A handheld personal shield projector, capable of reflecting energy projectiles but not other attacks."
 	item = /obj/item/shield/energy
 	reference = "ESD"
 	cost = 16

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -58,7 +58,7 @@
 
 /obj/item/shield/energy
 	name = "energy combat shield"
-	desc = "A handheld shield projector which reflects energy bolts but will not stop other attacks. It can be retracted, expanded, and stored anywhere."
+	desc = "A shield that reflects almost all energy projectiles, but is useless against physical attacks. It can be retracted, expanded, and stored anywhere."
 	icon_state = "eshield0" // eshield1 for expanded
 	force = 3
 	throwforce = 3

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -58,7 +58,7 @@
 
 /obj/item/shield/energy
 	name = "energy combat shield"
-	desc = "A shield capable of stopping most melee attacks. Protects user from almost all energy projectiles. It can be retracted, expanded, and stored anywhere."
+	desc = "A handheld shield projector which reflects energy bolts but will not stop other attacks. It can be retracted, expanded, and stored anywhere."
 	icon_state = "eshield0" // eshield1 for expanded
 	force = 3
 	throwforce = 3


### PR DESCRIPTION
## What Does This PR Do
Changes the uplink and item descriptions of the energy shield to reflect its behavior. Energy shields have not stopped melee attacks or bullets for THREE YEARS NOW and we were still being lied to about this.

## Why It's Good For The Game
Because players knowing what their items actually do is a good thing.

## Changelog
:cl:
fix: Fixes the description of energy shields, which said they block things that they do not.
/:cl:

