### PR TITLE
Crayon Fixes

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -6,6 +6,7 @@
 	layer = MID_TURF_LAYER
 	plane = GAME_PLANE //makes the graffiti visible over a wall.
 	anchored = TRUE
+	mergeable_decal = FALSE // Allows crayon drawings to overlap one another.
 
 
 /obj/effect/decal/cleanable/crayon/Initialize(mapload, main = "#FFFFFF", var/type = "rune1", var/e_name = "rune")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -19,6 +19,7 @@
 	var/instant = 0
 	var/colourName = "red" //for updateIcon purposes
 	var/dat
+	var/busy = FALSE
 	var/list/validSurfaces = list(/turf/simulated/floor)
 
 /obj/item/toy/crayon/suicide_act(mob/user)
@@ -80,22 +81,25 @@
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return
+	if(busy) return
 	if(is_type_in_list(target,validSurfaces))
 		var/temp = "rune"
 		if(letters.Find(drawtype))
 			temp = "letter"
 		else if(graffiti.Find(drawtype))
 			temp = "graffiti"
-		to_chat(user, "You start drawing a [temp] on the [target.name].")
+		to_chat(user, "<span class='info'>You start drawing a [temp] on the [target.name].</span>")
+		busy = TRUE
 		if(instant || do_after(user, 50 * toolspeed, target = target))
 			var/obj/effect/decal/cleanable/crayon/C = new /obj/effect/decal/cleanable/crayon(target,colour,drawtype,temp)
 			C.add_hiddenprint(user)
-			to_chat(user, "You finish drawing [temp].")
+			to_chat(user, "<span class='info'>You finish drawing [temp].</span>")
 			if(uses)
 				uses--
 				if(!uses)
 					to_chat(user, "<span class='danger'>You used up your [name]!</span>")
 					qdel(src)
+		busy = FALSE
 
 /obj/item/toy/crayon/attack(mob/M, mob/user)
 	var/huffable = istype(src,/obj/item/toy/crayon/spraycan)


### PR DESCRIPTION
## What Does This PR Do
Crayons and spraycans now allow multiple decals on the same tile again.
Adds an info span class to the messages crayons give to the user as previously they were unformatted.
Crayons now cannot draw more than one drawing at a time.
Fixes #12244

## Why It's Good For The Game
Because of the freedom of artistic expression!
Also because it probably ought to be a bit more difficult to completely fill hallways with graffiti.

## Changelog
:cl:
fix: Crayon drawings can stack again.
fix: Crayons can no longer draw on multiple tiles at the same time, sorry octo-artist!
/:cl:
