### PR TITLE
fix recycled monkeys not being removed from the cubemonkey list

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -57,6 +57,7 @@
 
 /mob/living/carbon/human/Destroy()
 	. = ..()
+	SSmobs.cubemonkeys -= src
 	QDEL_LIST(bodyparts)
 	splinted_limbs.Cut()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
When you recycle a monkey it qdeletes it, due to monkeys only being removed from the list when they're killed they would remain in the list if they were recycled before fully dying this is fixed by removing them from the cubemonkey list in the destroy proc

## Changelog
:cl:
fix: recycled monkeys were not being subtracted from the monkey cap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
