### PR TITLE
Replace emergency toolbox in hermit ruin by regular

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -50,7 +50,7 @@
 	},
 /area/ruin/powered)
 "l" = (
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plating/asteroid{
 	name = "dirt"
 	},


### PR DESCRIPTION
This PR replaces the emergency red toolbox in the lavaland hermit ruin by a regular blue one that just contains tools.

The red toolbox contains an handheld station bounced radio, letting the hermit immediately contact the Cyberiad and ask for a rescue. An hermit that isnt actually stranded does not make much sense, and makes for IMO a less interesting/difficult character to play as.

:cl:
tweak: Replaced the red emergency toolbox in hermit ruin by a regular blue toolbox.
/:cl: