### PR TITLE
Adds Analyzer Examine Hint

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -338,6 +338,10 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 	var/cooldown_time = 250
 	var/accuracy // 0 is the best accuracy.
 
+/obj/item/analyzer/examine(mob/user)
+	.=..()
+	to_chat(user, "<span class='info'>Alt-click [src] to activate the barometer function.</span>")
+
 /obj/item/analyzer/attack_self(mob/user as mob)
 
 	if(user.stat)


### PR DESCRIPTION
## What Does This PR Do
Adds a description hint to the air analyzer which informs the examiner of the lesser known barometer mode.

## Why It's Good For The Game
Revealing the modes our tools can operate in is generally healthy for the game.

## Changelog
:cl:
tweak: Examining an air analyzer now informs you about its lesser-known function!
/:cl: