### PR TITLE
Can Move Dense Objects Around Corners

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -119,7 +119,8 @@
 */
 /mob/living/silicon/ai/UnarmedAttack(atom/A)
 	A.attack_ai(src)
-/mob/living/silicon/ai/RangedAttack(atom/A)
+
+/mob/living/silicon/ai/RangedAttack(atom/A, params)
 	A.attack_ai(src)
 
 /atom/proc/attack_ai(mob/user as mob)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -220,15 +220,8 @@
 	for things like ranged glove touches, spitting alien acid/neurotoxin,
 	animals lunging, etc.
 */
-/mob/proc/RangedAttack(var/atom/A, var/params)
-	if(!mutations.len)
-		return
-	if((LASER in mutations) && a_intent == INTENT_HARM)
-		LaserEyes(A) // moved into a proc below
-		return
-	else
-		if(TK in mutations)
-			A.attack_tk(src)
+/mob/proc/RangedAttack(atom/A, params)
+	SEND_SIGNAL(src, COMSIG_MOB_ATTACK_RANGED, A, params)
 /*
 	Restrained ClickOn
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -180,7 +180,8 @@
 */
 /mob/living/silicon/robot/UnarmedAttack(atom/A)
 	A.attack_robot(src)
-/mob/living/silicon/robot/RangedAttack(atom/A)
+
+/mob/living/silicon/robot/RangedAttack(atom/A, params)
 	A.attack_robot(src)
 
 /atom/proc/attack_robot(mob/user as mob)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -30,20 +30,21 @@
 /mob/living/carbon/RestrainedClickOn(var/atom/A)
 	return 0
 
-// Commented out to prevent overwriting RangedAttack in click.dm ~ Bone White
-/*
-/mob/living/carbon/human/RangedAttack(var/atom/A)
-	if(!gloves && !mutations.len) return
-	var/obj/item/clothing/gloves/G = gloves
+/mob/living/carbon/human/RangedAttack(atom/A, params)
+	. = ..()
+	if(gloves)
+		var/obj/item/clothing/gloves/G = gloves
+		if(istype(G) && G.Touch(A, 0)) // for magic gloves
+			return
+
 	if((LASER in mutations) && a_intent == INTENT_HARM)
-		LaserEyes(A) // moved into a proc below
+		LaserEyes(A)
 
-	else if(istype(G) && G.Touch(A,0)) // for magic gloves
-		return
-
-	else if(TK in mutations)
+	if(TK in mutations)
 		A.attack_tk(src)
-*/
+
+	if(isturf(A) && get_dist(src, A) <= 1)
+		Move_Pulled(A)
 
 /*
 	Animals & All Unspecified

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -543,7 +543,7 @@
 	else
 		..()
 
-/mob/living/simple_animal/bot/ed209/RangedAttack(atom/A)
+/mob/living/simple_animal/bot/ed209/RangedAttack(atom/A, params)
 	if(!on)
 		return
 	shootAt(A)


### PR DESCRIPTION
From TG.

If you push a dense object into a corner, you can wind up in a situation where you're kinda stuck.

With this change, you will be able to start dragging the object in question, click around the corner and move it.

Also uh, non human mobs can't use laser eyes or TK anymore---not that it really mattered anyhow.

Fixes using gloves over-rides that are ranged

:cl: Fox McCloud
add: can move dense objects around corners
/:cl: