### PR TITLE
Vox Rework

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -162,4 +162,6 @@
 #define RESISTCOLD		17
 #define NO_EXAMINE		18
 #define CAN_WINGDINGS	19
-#define NOZOMBIE 20
+#define NOZOMBIE 		20
+#define NO_GERMS		21
+#define NO_DECAY		22

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -991,7 +991,7 @@
 /mob/living/carbon/human/proc/handle_decay()
 	var/decaytime = world.time - timeofdeath
 
-	if(isSynthetic())
+	if(NO_DECAY in dna.species.species_traits)
 		return
 
 	if(reagents.has_reagent("formaldehyde")) //embalming fluid stops decay

--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -21,7 +21,7 @@
 	even the simplest concepts of other minds. Their alien physiology allows them survive happily off a diet of nothing but light, \
 	water and other radiation."
 
-	species_traits = list(IS_PLANT)
+	species_traits = list(IS_PLANT, NO_GERMS, NO_DECAY)
 	clothing_flags = HAS_SOCKS
 	default_hair_colour = "#000000"
 	has_gender = FALSE

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -21,7 +21,7 @@
 	clone_mod = 0
 	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."
 
-	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NOTRANSSTING)
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING) //Computers that don't decay? What a lie!
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS
 	dietflags = 0		//IPCs can't eat, so no diet

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -19,21 +19,16 @@
 
 	brute_mod = 1.2 //20% more brute damage. Fragile bird bones.
 
-	warning_low_pressure = 50
-	hazard_low_pressure = 0
-
-	cold_level_1 = 80
-	cold_level_2 = 50
-	cold_level_3 = 0
-
 	breathid = "n2"
 
 	eyes = "vox_eyes_s"
 
-	species_traits = list(NO_SCAN, IS_WHITELISTED, NOTRANSSTING)
+	species_traits = list(NO_SCAN, NO_GERMS, NO_DECAY, IS_WHITELISTED, NOTRANSSTING)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS //Species-fitted 'em all.
 	dietflags = DIET_OMNI
 	bodyflags = HAS_ICON_SKIN_TONE | HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_BODY_MARKINGS | HAS_TAIL_MARKINGS
+
+	silent_steps = TRUE
 
 	blood_color = "#2299FC"
 	flesh_color = "#808D11"
@@ -43,7 +38,7 @@
 	default_hair_colour = "#614f19" //R: 97, G: 79, B: 25
 	butt_sprite = "vox"
 
-	reagent_tag = PROCESS_ORG
+	reagent_tag = PROCESS_ORG | PROCESS_SYN
 	scream_verb = "shrieks"
 	male_scream_sound = 'sound/voice/shriek1.ogg'
 	female_scream_sound = 'sound/voice/shriek1.ogg'
@@ -66,10 +61,9 @@
 		"lungs" =    /obj/item/organ/internal/lungs/vox,
 		"liver" =    /obj/item/organ/internal/liver/vox,
 		"kidneys" =  /obj/item/organ/internal/kidneys/vox,
-		"brain" =    /obj/item/organ/internal/brain/vox,
+		"cortical stack" =    /obj/item/organ/internal/brain/vox,
 		"appendix" = /obj/item/organ/internal/appendix,
 		"eyes" =     /obj/item/organ/internal/eyes/vox, //Default darksight of 2.
-		"stack" =    /obj/item/organ/internal/stack //Not the same as the cortical stack implant Vox Raiders spawn with. The cortical stack implant is used
 		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.
 
 	suicide_messages = list(
@@ -172,7 +166,7 @@
 
 	eyes = "blank_eyes"
 
-	species_traits = list(NO_SCAN, NO_BLOOD, NO_PAIN, IS_WHITELISTED)
+	species_traits = list(NO_SCAN, NO_GERMS, NO_DECAY, NO_BLOOD, NO_PAIN, IS_WHITELISTED)
 	clothing_flags = 0 //IDK if you've ever seen underwear on an Armalis, but it ain't pretty.
 	bodyflags = HAS_TAIL
 	dies_at_threshold = TRUE
@@ -190,9 +184,8 @@
 		"lungs" =    /obj/item/organ/internal/lungs/vox,
 		"liver" =    /obj/item/organ/internal/liver,
 		"kidneys" =  /obj/item/organ/internal/kidneys,
-		"brain" =    /obj/item/organ/internal/brain,
+		"cortical stack" =    /obj/item/organ/internal/brain/vox,
 		"eyes" =     /obj/item/organ/internal/eyes, //Default darksight of 2.
-		"stack" =    /obj/item/organ/internal/stack //Not the same as the cortical stack implant Vox Raiders spawn with. The cortical stack implant is used
 		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.
 
 	suicide_messages = list(

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -100,7 +100,7 @@
 		return
 
 	//Process infections
-	if(is_robotic() || sterile || (owner && (IS_PLANT in owner.dna.species.species_traits)))
+	if(is_robotic() || sterile || (owner && (NO_GERMS in owner.dna.species.species_traits)))
 		germ_level = 0
 		return
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -331,7 +331,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 */
 /obj/item/organ/external/proc/update_germs()
 
-	if(is_robotic() || (IS_PLANT in owner.dna.species.species_traits)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
+	if(is_robotic() || (NO_GERMS in owner.dna.species.species_traits)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
 		germ_level = 0
 		return
 

--- a/code/modules/surgery/organs/subtypes/vox.dm
+++ b/code/modules/surgery/organs/subtypes/vox.dm
@@ -2,53 +2,28 @@
 	name = "vox liver"
 	icon = 'icons/obj/species_organs/vox.dmi'
 	alcohol_intensity = 1.6
-
-
-/obj/item/organ/internal/stack
-	name = "cortical stack"
-	icon = 'icons/obj/species_organs/vox.dmi'
-	icon_state = "cortical-stack"
-	parent_organ = "head"
-	organ_tag = "stack"
-	slot = "vox_stack"
-	status = ORGAN_ROBOT
-	vital = TRUE
-	var/stackdamaged = FALSE
-
-/obj/item/organ/internal/stack/on_life()
-	if(damage < 1 && stackdamaged)
-		owner.mutations.Remove(SCRAMBLED)
-		owner.dna.SetSEState(SCRAMBLEBLOCK,0)
-		genemutcheck(owner,SCRAMBLEBLOCK,null,MUTCHK_FORCED)
-		stackdamaged = FALSE
-	..()
-
-
-/obj/item/organ/internal/stack/emp_act(severity)
-	if(owner)
-		owner.mutations.Add(SCRAMBLED)
-		owner.dna.SetSEState(SCRAMBLEBLOCK,1,1)
-		genemutcheck(owner,SCRAMBLEBLOCK,null,MUTCHK_FORCED)
-		owner.AdjustConfused(4)
-		if(!stackdamaged)
-			stackdamaged = TRUE
-	..()
+	sterile = TRUE
 
 /obj/item/organ/internal/eyes/vox
 	name = "vox eyeballs"
 	icon = 'icons/obj/species_organs/vox.dmi'
+	sterile = TRUE
 
 /obj/item/organ/internal/heart/vox
 	name = "vox heart"
 	icon = 'icons/obj/species_organs/vox.dmi'
+	sterile = TRUE
 
 /obj/item/organ/internal/brain/vox
+	name = "cortical stack"
+	desc = "A peculiarly advanced bio-electronic device that seems to hold the memories and identity of a Vox."
 	icon = 'icons/obj/species_organs/vox.dmi'
-	desc = "A brain with spikes on top of it. It has some odd metallic slot with wires on the side."
-	icon_state = "brain2"
+	icon_state = "cortical-stack"
 	mmi_icon = 'icons/obj/species_organs/vox.dmi'
 	mmi_icon_state = "mmi_full"
+	sterile = TRUE
 
 /obj/item/organ/internal/kidneys/vox
 	name = "vox kidneys"
 	icon = 'icons/obj/species_organs/vox.dmi'
+	sterile = TRUE


### PR DESCRIPTION
You knew it was coming; reworks Vox. 

After discussing this on and off for a very long time, it's finally been decided: Vox are going to lose their spaceproofness.


Removed their EMP weakness because it's really not necessary for them to retain that anymore, and, the more I saw this utilized to down a Vox, the more and more I disliked it.

Vox are being pushed into a quasi synthetic/organic race; as such, they're immune to germs, decay, and they can process synthetic reagents AND organic reagents.  They're also sneaky/shadey, so their footsteps are always silent.

Their brain organ is identical to their cortical stack; there's not separate organs anymore; they're one in the same (yes, you can put a cortical stack in an MMI).

Not Vox related, but since there's a species trait for it now, Diona no longer decay into skeletons, because that doesn't make much sense.

:cl: Fox McCloud
tweak: Vox reworked
del: Vox are no longer spaceproof
tweak: EMP's no longer wreck cortical stacks
tweak: Vox cortical stacks are their brains; there's no longer two separate organs for Vox brain+cortical stack
add: Vox are immune to decay and will not skeletonize
add: Vox internal organs will never accumulate germs or decay, even when they're outside a Vox's body
add: Vox external organs do not accumulate germs when attached to their body
add: Vox have silent footsteps
add: Vox can process BOTH organic and synthetic reagents
tweak: Diona no longer decay into skeletons
/:cl: