### PR TITLE
Allows Pickable Species for Lavaland Ghost Roles

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -53,6 +53,8 @@
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)
 		return
+	if(!species_prompt())
+		return
 	log_game("[user.ckey] became [mob_name]")
 	create(ckey = user.ckey)
 
@@ -71,6 +73,9 @@
 	if(!LAZYLEN(spawners))
 		GLOB.mob_spawners -= name
 	return ..()
+
+/obj/effect/mob_spawn/proc/species_prompt()
+	return TRUE
 
 /obj/effect/mob_spawn/proc/special(mob/M)
 	return
@@ -124,6 +129,8 @@
 	mob_type = /mob/living/carbon/human
 	//Human specific stuff.
 	var/mob_species = null		//Set species
+	var/allow_species_pick = FALSE
+	var/list/pickable_species = list("Human", "Vulpkanin", "Tajaran", "Unathi", "Skrell", "Diona")
 	var/datum/outfit/outfit = /datum/outfit	//If this is a path, it will be instanced in Initialize()
 	var/disable_pda = TRUE
 	var/disable_sensors = TRUE
@@ -170,10 +177,19 @@
 		mob_name = id_job
 	return ..()
 
+/obj/effect/mob_spawn/human/species_prompt()
+	if(allow_species_pick)
+		var/selected_species = input("Select a species", "Species Selection") as null|anything in pickable_species
+		if(!selected_species)
+			return	TRUE	// You didn't pick, so just continue on with the spawning process as a human
+		var/datum/species/S = GLOB.all_species[selected_species]
+		mob_species = S.type
+	return TRUE
+
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)
-		if(H.set_species(mob_species))
-			H.regenerate_icons()
+		H.set_species(mob_species)
+
 	if(husk)
 		H.ChangeToHusk()
 	else //Because for some reason I can't track down, things are getting turned into husks even if husk = false. It's in some damage proc somewhere.
@@ -186,19 +202,23 @@
 		if(hair_style)
 			D.h_style = hair_style
 		else
-			D.h_style = random_hair_style(gender)
+			D.h_style = random_hair_style(gender, D.dna.species.name)
 		D.hair_colour = rand_hex_color()
 		if(facial_hair_style)
 			D.f_style = facial_hair_style
 		else
-			D.f_style = random_facial_hair_style(gender)
+			D.f_style = random_facial_hair_style(gender, D.dna.species.name)
 		D.facial_colour = rand_hex_color()
 	if(skin_tone)
-		H.s_tone = skin_tone
+		H.change_skin_tone(skin_tone)
 	else
-		H.s_tone = random_skin_tone()
+		H.change_skin_tone(random_skin_tone())
+		H.change_skin_color(rand_hex_color())
 	H.update_hair()
+	H.update_fhair()
 	H.update_body()
+	H.update_dna()
+	H.regenerate_icons()
 	if(outfit)
 		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id", "neck", "backpack_contents", "suit_store")
 		for(var/slot in slots)
@@ -444,6 +464,7 @@
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
+	allow_species_pick = TRUE
 	name = "bartender sleeper"
 	icon = 'icons/obj/cryogenic2.dmi'
 	icon_state = "sleeper"
@@ -474,6 +495,7 @@
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
+	allow_species_pick = TRUE
 	mob_name = "Beach Bum"
 	name = "beach bum sleeper"
 	icon = 'icons/obj/cryogenic2.dmi'

--- a/code/modules/ruins/lavalandruin_code/animal_hospital.dm
+++ b/code/modules/ruins/lavalandruin_code/animal_hospital.dm
@@ -10,6 +10,7 @@
 	everyone's gone. One of the cats scratched you just a few minutes ago. That's why you were in the pod - to heal the scratch. The scabs are still fresh; you see them right now. So where is \
 	everyone? Where did they go? What happened to the hospital? And is that <i>smoke</i> you smell? You need to find someone else. Maybe they can tell you what happened.</b>"
 	assignedrole = "Translocated Vet"
+	allow_species_pick = TRUE
 
 /obj/effect/mob_spawn/human/doctor/alive/lavaland/Destroy()
 	var/obj/structure/fluff/empty_sleeper/S = new(drop_location())

--- a/code/modules/ruins/lavalandruin_code/hermit.dm
+++ b/code/modules/ruins/lavalandruin_code/hermit.dm
@@ -8,6 +8,7 @@
 	roundstart = FALSE
 	death = FALSE
 	random = TRUE
+	allow_species_pick = TRUE
 	mob_species = /datum/species/human
 	flavour_text = "<span class='big bold'>You've been stranded in this godless prison of a planet for longer than you can remember.</span><b> Each day you barely scrape by, and between the terrible \
 	conditions of your makeshift shelter, the hostile creatures, and the ash drakes swooping down from the cloudless skies, all you can wish for is the feel of soft grass between your toes and \

--- a/code/modules/ruins/lavalandruin_code/syndicate_base.dm
+++ b/code/modules/ruins/lavalandruin_code/syndicate_base.dm
@@ -32,6 +32,7 @@
 	<br><i>You are free to attack anyone not aligned with the Syndicate in the vicinity of your base. <font size=6>DO NOT</font> work against Syndicate personnel (such as traitors or nuclear operatives). You may work with or against non-Syndicate antagonists on a case-by-case basis. <font size=6>DO NOT</font> leave your base without admin permission.</i>"
 	outfit = /datum/outfit/lavaland_syndicate
 	assignedrole = "Lavaland Syndicate"
+	allow_species_pick = TRUE
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/Destroy()
 	var/obj/structure/fluff/empty_sleeper/syndicate/S = new /obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))


### PR DESCRIPTION
I don't really see any reason why the Lavaland ghost roles should force you to play a human--additionally, it could give players a chance to explore other species for a temporary measure, if they really want to.

This adds support for human spawners allowing players to pick their species (can only pick human, vulp, taj, unathi, skrell, or diona); your appearance will properly be randomized, as well (that is to say, you won't always be a pitch black <insert species here>). 

This is enabled for all lavaland ghost roles, minus Ashwalkers and Lifebringers (obviously).

Just thought this would be fun for people who want to explore a bit more species, or really really want to play as their favorite species on Lavaland.

:cl: Fox McCloud
add: Can now pick the species you want to play as for lavaland ghost roles
/:cl: