### PR TITLE
Syndie and Binary keys now use their own sprites

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -17,7 +17,7 @@
 /obj/item/encryptionkey/attackby(obj/item/W as obj, mob/user as mob, params)
 
 /obj/item/encryptionkey/syndicate
-	icon_state = "cypherkey"
+	icon_state = "syn_cypherkey"
 	channels = list("Syndicate" = 1)
 	origin_tech = "syndicate=1;engineering=3;bluespace=2"
 	syndie = TRUE //Signifies that it de-crypts Syndicate transmissions
@@ -36,7 +36,7 @@
 	change_voice = FALSE
 
 /obj/item/encryptionkey/syndteam
-	icon_state = "cypherkey"
+	icon_state = "syn_cypherkey"
 	channels = list("SyndTeam" = 1, "Syndicate" = 1)
 	origin_tech = "syndicate=4"
 	syndie = TRUE //Signifies that it de-crypts Syndicate transmissions
@@ -44,7 +44,7 @@
 /obj/item/encryptionkey/binary
 	name = "binary translator key"
 	desc = "An encryption key for a radio headset. To access the binary channel, use :+."
-	icon_state = "cypherkey"
+	icon_state = "bin_cypherkey"
 	translate_binary = TRUE
 	origin_tech = "syndicate=3;engineering=4;bluespace=3"
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -17,6 +17,7 @@
 /obj/item/encryptionkey/attackby(obj/item/W as obj, mob/user as mob, params)
 
 /obj/item/encryptionkey/syndicate
+	name = "syndicate encryption key"
 	icon_state = "syn_cypherkey"
 	channels = list("Syndicate" = 1)
 	origin_tech = "syndicate=1;engineering=3;bluespace=2"
@@ -36,6 +37,7 @@
 	change_voice = FALSE
 
 /obj/item/encryptionkey/syndteam
+	name = "syndicate encryption key"
 	icon_state = "syn_cypherkey"
 	channels = list("SyndTeam" = 1, "Syndicate" = 1)
 	origin_tech = "syndicate=4"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Syndicate and Binary radio keys have their own sprites labelled in the radio.dmi file, but the code instead makes them call the default sprite for encryption keys. This PR simply points both keys (as well as the syndteam variant) to their unique sprites.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives the items a unique look they were presumably meant to always have.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
**Before:**
![image](https://user-images.githubusercontent.com/44248086/65170906-98098180-da41-11e9-8aa0-62340e973f54.png)

**After:**
![image](https://user-images.githubusercontent.com/44248086/65170938-a9eb2480-da41-11e9-944a-66d268ed7089.png)

(Syndie key on the left, Binary on the right)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Syndie and Binary keys now use their own sprites rather than the default ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
