### PR TITLE
Buffs the uplink syringe gun, it now comes with some syringes

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -925,10 +925,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 50
 
 /datum/uplink_item/stealthy_weapons/dart_pistol
-	name = "Dart Pistol"
-	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any space a small item can."
+	name = "Dart Pistol Kit"
+	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any space a small item can. Comes with 3 syringes, a knockout poison, a silencing agent and a deadly neurotoxin."
 	reference = "DART"
-	item = /obj/item/gun/syringe/syndicate
+	item = /obj/item/storage/box/syndie_kit/dart_gun
 	cost = 4
 	surplus = 50
 	excludefrom = list(/datum/game_mode/nuclear)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -357,3 +357,14 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 	new /obj/item/radio/headset/chameleon(src)
 	new /obj/item/stamp/chameleon(src)
 	new /obj/item/pda/chameleon(src)
+
+/obj/item/storage/box/syndie_kit/dart_gun
+	name = "dart gun kit"
+
+/obj/item/storage/box/syndie_kit/dart_gun/New()
+	..()
+	new /obj/item/gun/syringe/syndicate(src)
+	new /obj/item/reagent_containers/syringe/capulettium_plus(src)
+	new /obj/item/reagent_containers/syringe/sarin(src)
+	new /obj/item/reagent_containers/syringe/pancuronium(src)
+

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -328,3 +328,18 @@
 	amount_per_transfer_from_this = 1
 	volume = 1
 	list_reagents = list("gluttonytoxin" = 1)
+
+/obj/item/reagent_containers/syringe/capulettium_plus
+	name = "capulettium plus syringe"
+	desc = "For silencing targets. Allows for fake deaths."
+	list_reagents = list("capulettium_plus" = 15)
+
+/obj/item/reagent_containers/syringe/sarin
+	name = "sarin syringe"
+	desc = "A deadly neurotoxin, for killing."
+	list_reagents = list("sarin" = 15)
+
+/obj/item/reagent_containers/syringe/pancuronium
+	name = "pancuronium syringe"
+	desc = "A powerful paralyzing poison."
+	list_reagents = list("pancuronium" = 15)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR changes the 'dart pistol' in the uplink into a dart pistol kit, which contains the dart pistol itself, 1 syringe of sarin for killing, 1 syringe of capulettium plus for silencing and 1 syringe of pancuronium as a knockout toxin.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The dart gun is pretty damn useless. On its own it does nothing, requiring you to get nasty chems and syringes for use with it. The issue is, all jobs that have access to nasty chems (medbay and science) also have access to both normal syringe guns and rapid syringe guns. They'd be effectively paying 4 TC for a minor stealth boost, which is in no way worth it.

With this PR, the syringe gun is an actual worthwhile purchase for any traitor looking for an alternative weapon. Other weapons come with some ammo to use with them. However, the kit shouldn't be too overpowered because it's still just 3 syringes, one of which just silences. Considering you only get 2 real shots, it seems still fair at its old cost of 4 TC, but I could be convinced to go to let's say 5 or 6 TC.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
tweak: The uplink dart gun now comes with some syringes to use with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
