### PR TITLE
Fixes Chaplain Plasma nullrod not spawning

### DIFF
--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -24,9 +24,9 @@
 	pda = /obj/item/pda/chaplain
 	backpack_contents = list(
 		/obj/item/camera/spooky = 1
+		/obj/item/nullrod = 1
 	)
-	r_hand = /obj/item/nullrod
-
+	
 /datum/outfit/job/chaplain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 

--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -23,7 +23,7 @@
 	l_ear = /obj/item/radio/headset/headset_service
 	pda = /obj/item/pda/chaplain
 	backpack_contents = list(
-		/obj/item/camera/spooky = 1
+		/obj/item/camera/spooky = 1,
 		/obj/item/nullrod = 1
 	)
 	


### PR DESCRIPTION

## What Does This PR Do
Moves the chaplain's nullrod to be inside of their backpack.

## Why It's Good For The Game
Moves the chaplain's nullrod to their backpack so that the nullrod is still equiped to the chaplain should he normally spawn with other items taking up their hand slots
## Changelog
:cl:
fix: Fixes #12354 
/:cl:

