### PR TITLE
Increases timer for blob mouse spawn

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -1,6 +1,6 @@
 /datum/event/blob
-	announceWhen	= 120
-	endWhen			= 180
+	announceWhen	= 180
+	endWhen			= 240
 
 /datum/event/blob/announce()
 	event_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -179,7 +179,7 @@
 	minbodytemp = 0
 	gold_core_spawnable = NO_SPAWN
 	var/cycles_alive = 0
-	var/cycles_limit = 30
+	var/cycles_limit = 60
 	var/has_burst = FALSE
 
 /mob/living/simple_animal/mouse/blobinfected/Life()


### PR DESCRIPTION
Increases the timer from 60 seconds to 120 seconds regarding when the blob mouse will automatically burst.

Blob is rare as it is, and 60 seconds isn't enough to find a good spot. The rare event is frequently wasted due to bad spawns and just getting roflstomped within 3 minutes. Also increases the announcement timer to compensate.

🆑 
balance: Blob mice now have 120 seconds until bursting instead of 60 and the announcement delay is increased
/ 🆑 