### PR TITLE
Fixes hierophant club and warp cube ignoring area/tele_proof

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -166,6 +166,18 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	return destination
 
+
+/proc/is_in_teleport_proof_area(atom/O)
+	if(!O)
+		return FALSE
+	var/area/A = get_area(O)
+	if(!A)
+		return FALSE
+	if(A.tele_proof)
+		return TRUE
+	else
+		return FALSE
+
 // Returns true if direction is blocked from loc
 // Checks if doors are open
 /proc/DirBlocked(turf/loc,var/dir)

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -114,6 +114,10 @@
 	if(user.is_in_active_hand(src) && user.is_in_inactive_hand(src)) //you need to hold the staff to teleport
 		to_chat(user, "<span class='warning'>You need to hold the club in your hands to [beacon ? "teleport with it":"detach the beacon"]!</span>")
 		return
+	var/area/A = get_area(user)
+	if(A.tele_proof)
+		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
+		return
 	if(!beacon || QDELETED(beacon))
 		if(isturf(user.loc))
 			user.visible_message("<span class='hierophant_warning'>[user] starts fiddling with [src]'s pommel...</span>", \

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -114,8 +114,7 @@
 	if(user.is_in_active_hand(src) && user.is_in_inactive_hand(src)) //you need to hold the staff to teleport
 		to_chat(user, "<span class='warning'>You need to hold the club in your hands to [beacon ? "teleport with it":"detach the beacon"]!</span>")
 		return
-	var/area/A = get_area(user)
-	if(A.tele_proof)
+	if(is_in_teleport_proof_area(user))
 		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
 		return
 	if(!beacon || QDELETED(beacon))

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -312,9 +312,7 @@
 		to_chat(user, "[src] fizzles uselessly.")
 		return
 
-	var/area/A = get_area(user)
-	var/area/B = get_area(linked)
-	if(A.tele_proof || B.tele_proof)
+	if(is_in_teleport_proof_area(user) || is_in_teleport_proof_area(linked))
 		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
 		return
 

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -312,6 +312,12 @@
 		to_chat(user, "[src] fizzles uselessly.")
 		return
 
+	var/area/A = get_area(user)
+	var/area/B = get_area(linked)
+	if(A.tele_proof || B.tele_proof)
+		to_chat(user, "<span class='warning'>[src] sparks and fizzles.</span>")
+		return
+
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(1, 0, user.loc)
 	smoke.start()


### PR DESCRIPTION
## What Does This PR Do
The Hierophant club and warp cube (from lavaland) currently allow you to teleport into/out of areas even when they're marked as having teleportation disallowed (via the area/tele_proof flag).
This PR fixes the oversight, so that these items no longer allow you to teleport into or out of areas flagged as tele_proof.

## Why It's Good For The Game
The tele_proof flag exists to prevent players using teleports to largely negate the difficulty of certain areas. Items ignoring this flag is bad, as opens up cheese strategies which allow players to defeat the content in those areas without the risk that was intended.

:cl: Kyep
fix: The Hierophant club and warp cubes (lavaland loot) no longer allow you to teleport into or out of areas that are set to forbid teleports.
/:cl:
