### PR TITLE
Fixes incorrect names of syndie/antag coins

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -322,6 +322,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	var/string_attached
 	var/list/sideslist = list("heads","tails")
 	var/cmineral = null
+	var/name_by_cmineral = TRUE
 	var/cooldown = 0
 	var/credits = 10
 
@@ -330,7 +331,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	pixel_y = rand(0,8)-8
 
 	icon_state = "coin_[cmineral]_[sideslist[1]]"
-	if(cmineral)
+	if(cmineral && name_by_cmineral)
 		name = "[cmineral] coin"
 
 /obj/item/coin/gold
@@ -405,6 +406,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	desc = "A novelty coin that helps the heart know what hard evidence cannot prove."
 	sideslist = list("valid", "salad")
 	credits = 20
+	name_by_cmineral = FALSE
 
 /obj/item/coin/antagtoken/syndicate
 	name = "syndicate coin"


### PR DESCRIPTION
## What Does This PR Do
Currently, there are two syndicate-like coins in the codebase:
/obj/item/coin/antagtoken named "antag token"  https://github.com/ParadiseSS13/Paradise/blob/21155b69401af8f3e4fe6608dcc5b8612ce6d503/code/modules/mining/ores_coins.dm#L402
and
/obj/item/coin/antagtoken/syndicate named "syndicate coin" https://github.com/ParadiseSS13/Paradise/blob/21155b69401af8f3e4fe6608dcc5b8612ce6d503/code/modules/mining/ores_coins.dm#L410
When you actually spawn these in game though, they don't get their intended names. Their New() proc overrides their name, turning them both into "valid coin" and making them indistinguishable from each other.

This PR fixes this, by adding a name_by_cmineral var (default TRUE, but false for these coins) which stops them being renamed in New() and ensures they get their correct names.
Changing their cmineral wasn't possible because that would result in issues with their icon states (which are based on cmineral).

## Why It's Good For The Game
Fixes a bug that results in syndicate coins getting incorrect names.

:cl: Kyep
fix: Fixed a small bug that caused coins named "syndicate coin" or "antag token" to both incorrectly appear as "valid coin". 
/:cl: