### PR TITLE
Fix clown changeling not losing comic sans on transform

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -286,9 +286,14 @@
 		var/obj/item/organ/internal/cyberimp/brain/clown_voice/implant = new
 		implant.insert(H)
 
-	H.mutations.Add(CLUMSY)
+	H.dna.SetSEState(CLUMSYBLOCK, TRUE)
+	genemutcheck(H, CLUMSYBLOCK, null, MUTCHK_FORCED)
+	H.dna.default_blocks.Add(CLUMSYBLOCK)
 	if(!ismachine(H))
-		H.mutations.Add(COMIC)
+		H.dna.SetSEState(COMICBLOCK, TRUE)
+		genemutcheck(H, COMICBLOCK, null, MUTCHK_FORCED)
+		H.dna.default_blocks.Add(COMICBLOCK)
+	H.check_mutations = TRUE
 
 //action given to antag clowns
 /datum/action/innate/toggle_clumsy


### PR DESCRIPTION
When I changed how default DNA worked with the wingdings PR, I made clowns unable to lose clumsy and comic sans through genetics. This was intentional (because lmao fuck you if youre trying to lose comic sans and clumsy as a clown), however this had the unintended side effect of making roundstart clowns who rolled changelings unable to lose the comic sans gene on transform.

Clown roundstart genes now work similarly to other roundstart genes : They can be removed by genetics/changeling powers, but cannot be removed by mutadone.

:cl:
fix: Fixed clown changelings not losing comic sans on transformation
tweak: Clowns can now lose the clumsy and comic genes through DNA manipulation (but not mutadone)
/:cl: