### PR TITLE
Removes Bodyscanner Console

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1274,12 +1274,6 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/administration)
-"acV" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor3"
-	},
-/area/shuttle/administration)
 "acW" = (
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -6077,10 +6071,6 @@
 "ane" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/light/spot,
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
-"anf" = (
-/obj/machinery/body_scanconsole,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "ang" = (
@@ -93584,7 +93574,6 @@
 /area/medical/medbay)
 "dll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whitebluecorner";
@@ -93598,7 +93587,7 @@
 	dir = 1;
 	network = list("SS13")
 	},
-/obj/machinery/body_scanconsole,
+/obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whitepurplecorner"
@@ -96747,7 +96736,6 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -96760,7 +96748,7 @@
 	pixel_y = 0;
 	req_access_txt = "0"
 	},
-/obj/machinery/body_scanconsole,
+/obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -145341,7 +145329,7 @@ aaa
 aaa
 acA
 acN
-acV
+acW
 acW
 acW
 acW
@@ -176978,7 +176966,7 @@ akm
 alU
 ams
 akn
-anf
+akn
 anD
 aok
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -5504,10 +5504,6 @@
 	icon_state = "vault"
 	},
 /area/security/hos)
-"ajA" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
 "ajB" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/auxsolarport)
@@ -69143,7 +69139,6 @@
 	},
 /area/medical/exam_room)
 "cok" = (
-/obj/machinery/body_scanconsole,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -69151,20 +69146,6 @@
 	c_tag = "Medbay Surgery 1 North";
 	network = list("SS13")
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whiteblue"
-	},
-/area/medical/exam_room)
-"col" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
-	},
-/obj/machinery/body_scanconsole,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -74937,12 +74918,6 @@
 	icon_state = "white"
 	},
 /area/medical/surgery1)
-"cxn" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/surgery1)
 "cxo" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
@@ -80670,12 +80645,6 @@
 /area/medical/research{
 	name = "Research Division"
 	})
-"cGE" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/surgery2)
 "cGF" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/decal/warning_stripes/south,
@@ -116445,7 +116414,7 @@ crE
 crE
 cvb
 crE
-cxo
+crE
 cyo
 czs
 czU
@@ -116453,7 +116422,7 @@ cAT
 cCM
 czs
 cEZ
-cGO
+cGo
 cGo
 cKc
 cGo
@@ -116702,7 +116671,7 @@ crV
 ctX
 cva
 cvS
-cxn
+cxo
 cyo
 czu
 cBl
@@ -116710,7 +116679,7 @@ cCu
 cAU
 cEj
 cEZ
-cGE
+cGO
 cFw
 cKb
 cKH
@@ -118494,7 +118463,7 @@ ceQ
 chH
 cdT
 cmX
-col
+cok
 cpb
 crg
 csN
@@ -148747,7 +148716,7 @@ aeF
 agJ
 ahv
 aeG
-ajA
+aeG
 akq
 all
 aaa

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -12136,13 +12136,6 @@
 	icon_state = "whitecorner"
 	},
 /area/awaymission/UO71/medical)
-"wQ" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitehall"
-	},
-/area/awaymission/UO71/medical)
 "wR" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
@@ -20566,7 +20559,7 @@ qa
 vr
 qJ
 qJ
-wQ
+wT
 qa
 ab
 ab

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -3961,12 +3961,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate)
-"ahx" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/syndicate)
 "ahy" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -5330,10 +5324,6 @@
 "ajH" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/light/spot,
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
-"ajI" = (
-/obj/machinery/body_scanconsole,
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "ajJ" = (
@@ -45995,7 +45985,6 @@
 	},
 /area/medical/morgue)
 "bHL" = (
-/obj/machinery/body_scanconsole,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
@@ -58771,18 +58760,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/body_scanconsole,
+/obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
-	},
-/area/medical/sleeper)
-"ccw" = (
-/obj/machinery/bodyscanner,
-/turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccx" = (
@@ -61165,12 +61147,6 @@
 /area/crew_quarters/hor)
 "cgw" = (
 /obj/machinery/bodyscanner,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor3"
-	},
-/area/shuttle/administration)
-"cgx" = (
-/obj/machinery/body_scanconsole,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
 	},
@@ -63837,7 +63813,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "ckU" = (
-/obj/machinery/body_scanconsole,
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery West";
 	dir = 1;
@@ -63979,7 +63954,6 @@
 	},
 /area/medical/surgery2)
 "clf" = (
-/obj/machinery/body_scanconsole,
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery East";
 	dir = 1;
@@ -72124,7 +72098,6 @@
 	pixel_y = -3
 	},
 /obj/item/circuitboard/bodyscanner,
-/obj/item/circuitboard/bodyscanner_console,
 /obj/item/circuitboard/sleeper{
 	pixel_x = 3
 	},
@@ -106627,7 +106600,7 @@ bRA
 bPI
 cdo
 ceR
-cgx
+ceR
 cii
 ckf
 clE
@@ -107567,7 +107540,7 @@ abV
 abV
 agF
 ahg
-ahx
+abV
 ahy
 ahP
 aaa
@@ -133098,7 +133071,7 @@ bXG
 bZi
 cgM
 caI
-ccw
+ccu
 ceg
 cfI
 cho
@@ -154860,7 +154833,7 @@ agZ
 ail
 aiL
 aha
-ajI
+aha
 ajY
 akp
 aaa

--- a/_maps/map_files/shuttles/admin_admin.dmm
+++ b/_maps/map_files/shuttles/admin_admin.dmm
@@ -540,12 +540,6 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/administration)
-"bj" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor3"
-	},
-/area/shuttle/administration)
 "bk" = (
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -847,7 +841,7 @@ am
 ac
 bc
 bg
-bj
+bg
 bo
 bt
 bz

--- a/_maps/map_files/shuttles/admin_hospital.dmm
+++ b/_maps/map_files/shuttles/admin_hospital.dmm
@@ -947,12 +947,6 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/administration)
-"bS" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor3"
-	},
-/area/shuttle/administration)
 "bT" = (
 /obj/machinery/light,
 /obj/structure/closet/crate/can,
@@ -1494,7 +1488,7 @@ aw
 aw
 aw
 aw
-bS
+aw
 ac
 "}
 (11,1,1) = {"
@@ -1569,12 +1563,12 @@ ac
 bx
 aw
 aw
-bS
+aw
 ac
 bx
 aw
 aw
-bS
+aw
 Kq
 "}
 (15,1,1) = {"

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -1,12 +1,3 @@
-/proc/dopage(src,target)
-	var/href_list
-	var/href
-	href_list = params2list("src=[src:UID()]&[target]=1")
-	href = "src=[src:UID()];[target]=1"
-	src:temphtml = null
-	src:Topic(href, href_list)
-	return null
-
 /proc/get_area(atom/A)
 	if(isarea(A))
 		return A

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -7,17 +7,12 @@
 	anchored = TRUE
 	idle_power_usage = 1250
 	active_power_usage = 2500
-
 	light_color = "#00FF00"
-	var/obj/machinery/body_scanconsole/console = null
-	var/mob/living/carbon/occupant = null
-	var/locked
+	var/mob/living/carbon/human/occupant
+	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/mindshield, /obj/item/implant/tracking, /obj/item/implant/health)
 
 /obj/machinery/bodyscanner/Destroy()
 	go_out()
-	if(console)
-		console.connected = null
-		console = null
 	return ..()
 
 /obj/machinery/bodyscanner/power_change()
@@ -39,16 +34,6 @@
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/bodyscanner(null)
 	component_parts += new /obj/item/stock_parts/scanning_module(null)
-	component_parts += new /obj/item/stock_parts/console_screen(null)
-	component_parts += new /obj/item/stock_parts/console_screen(null)
-	component_parts += new /obj/item/stack/cable_coil(null, 2)
-	RefreshParts()
-
-/obj/machinery/bodyscanner/upgraded/New()
-	..()
-	component_parts = list()
-	component_parts += new /obj/item/circuitboard/bodyscanner(null)
-	component_parts += new /obj/item/stock_parts/scanning_module/phasic(null)
 	component_parts += new /obj/item/stock_parts/console_screen(null)
 	component_parts += new /obj/item/stock_parts/console_screen(null)
 	component_parts += new /obj/item/stack/cable_coil(null, 2)
@@ -87,7 +72,7 @@
 		if(panel_open)
 			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 			return
-		if(!ismob(TYPECAST_YOUR_SHIT.affecting))
+		if(!ishuman(TYPECAST_YOUR_SHIT.affecting))
 			return
 		if(occupant)
 			to_chat(user, "<span class='notice'>The scanner is already occupied!</span>")
@@ -96,7 +81,7 @@
 			if(M.Victim == TYPECAST_YOUR_SHIT.affecting)
 				to_chat(user, "<span class='danger'>[TYPECAST_YOUR_SHIT.affecting.name] has a fucking slime attached to [TYPECAST_YOUR_SHIT.affecting.p_them()], deal with that first.</span>")
 				return
-		var/mob/M = TYPECAST_YOUR_SHIT.affecting
+		var/mob/living/carbon/human/M = TYPECAST_YOUR_SHIT.affecting
 		if(M.abiotic())
 			to_chat(user, "<span class='notice'>Subject cannot have abiotic items on.</span>")
 			return
@@ -110,47 +95,62 @@
 	return ..()
 
 
-/obj/machinery/bodyscanner/MouseDrop_T(mob/living/carbon/human/O, mob/user as mob)
-	if(!istype(O))
-		return 0 //not a mob
+/obj/machinery/bodyscanner/MouseDrop_T(mob/living/carbon/human/H, mob/user)
+	if(!istype(H))
+		return FALSE //not human
 	if(user.incapacitated())
-		return 0 //user shouldn't be doing things
-	if(O.anchored)
-		return 0 //mob is anchored???
-	if(get_dist(user, src) > 1 || get_dist(user, O) > 1)
-		return 0 //doesn't use adjacent() to allow for non-cardinal (fuck my life)
+		return FALSE //user shouldn't be doing things
+	if(H.anchored)
+		return FALSE //mob is anchored???
+	if(get_dist(user, src) > 1 || get_dist(user, H) > 1)
+		return FALSE //doesn't use adjacent() to allow for non-cardinal (fuck my life)
 	if(!ishuman(user) && !isrobot(user))
-		return 0 //not a borg or human
+		return FALSE //not a borg or human
 	if(panel_open)
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
-		return 0 //panel open
+		return FALSE //panel open
 	if(occupant)
 		to_chat(user, "<span class='notice'>[src] is already occupied.</span>")
-		return 0 //occupied
-
-	if(O.buckled)
-		return 0
-	if(O.abiotic())
+		return FALSE //occupied
+	if(H.buckled)
+		return FALSE
+	if(H.abiotic())
 		to_chat(user, "<span class='notice'>Subject cannot have abiotic items on.</span>")
-		return 0
-	for(var/mob/living/carbon/slime/M in range(1, O))
-		if(M.Victim == O)
-			to_chat(user, "<span class='danger'>[O] has a fucking slime attached to [O.p_them()], deal with that first.</span>")
-			return 0
+		return FALSE
+	for(var/mob/living/carbon/slime/M in range(1, H))
+		if(M.Victim == H)
+			to_chat(user, "<span class='danger'>[H] has a fucking slime attached to [H.p_them()], deal with that first.</span>")
+			return FALSE
 
-	if(O == user)
+	if(H == user)
 		visible_message("[user] climbs into [src].")
 	else
-		visible_message("[user] puts [O] into the body scanner.")
+		visible_message("[user] puts [H] into the body scanner.")
 
-	O.forceMove(src)
-	occupant = O
+	H.forceMove(src)
+	occupant = H
 	icon_state = "bodyscanner"
 	add_fingerprint(user)
 
-/obj/machinery/bodyscanner/relaymove(mob/user as mob)
+/obj/machinery/bodyscanner/attack_ai(user)
+	return attack_hand(user)
+
+/obj/machinery/bodyscanner/attack_ghost(user)
+	return attack_hand(user)
+
+/obj/machinery/bodyscanner/attack_hand(user)
+	if(stat & (NOPOWER|BROKEN))
+		return
+
+	if(panel_open)
+		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
+		return
+
+	ui_interact(user)
+
+/obj/machinery/bodyscanner/relaymove(mob/user)
 	if(user.incapacitated())
-		return 0 //maybe they should be able to get out with cuffs, but whatever
+		return FALSE //maybe they should be able to get out with cuffs, but whatever
 	go_out()
 
 /obj/machinery/bodyscanner/verb/eject()
@@ -164,7 +164,7 @@
 	add_fingerprint(usr)
 
 /obj/machinery/bodyscanner/proc/go_out()
-	if(!occupant || locked)
+	if(!occupant)
 		return
 	occupant.forceMove(loc)
 	occupant = null
@@ -175,22 +175,22 @@
 
 /obj/machinery/bodyscanner/ex_act(severity)
 	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
+		if(1)
+			for(var/atom/movable/A in src)
 				A.forceMove(loc)
 				A.ex_act(severity)
 			qdel(src)
 			return
-		if(2.0)
+		if(2)
 			if(prob(50))
-				for(var/atom/movable/A as mob|obj in src)
+				for(var/atom/movable/A in src)
 					A.forceMove(loc)
 					A.ex_act(severity)
 				qdel(src)
 				return
-		if(3.0)
+		if(3)
 			if(prob(25))
-				for(var/atom/movable/A as mob|obj in src)
+				for(var/atom/movable/A in src)
 					A.forceMove(loc)
 					A.ex_act(severity)
 				qdel(src)
@@ -208,162 +208,34 @@
 	new /obj/effect/gibspawner/generic(get_turf(loc)) //I REPLACE YOUR TECHNOLOGY WITH FLESH!
 	qdel(src)
 
-/obj/machinery/bodyscanner/attack_animal(var/mob/living/simple_animal/M)//Stop putting hostile mobs in things guise
+/obj/machinery/bodyscanner/attack_animal(mob/living/simple_animal/M)//Stop putting hostile mobs in things guise
 	if(M.environment_smash)
 		M.do_attack_animation(src)
 		visible_message("<span class='danger'>[M.name] smashes [src] apart!</span>")
 		go_out()
 		qdel(src)
-	return
 
-/obj/machinery/body_scanconsole
-	name = "Body Scanner Console"
-	icon = 'icons/obj/cryogenic2.dmi'
-	icon_state = "bodyscannerconsole"
-	density = 1
-	anchored = 1
-	dir = WEST
-	idle_power_usage = 250
-	active_power_usage = 500
-	var/obj/machinery/bodyscanner/connected = null
-	var/delete
-	var/temphtml
-	var/printing = null
-	var/printing_text = null
-	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/mindshield, /obj/item/implant/tracking, /obj/item/implant/health)
-
-/obj/machinery/body_scanconsole/power_change()
-	if(stat & BROKEN)
-		icon_state = "bodyscannerconsole-p"
-	else if(powered() && !panel_open)
-		icon_state = initial(icon_state)
-		stat &= ~NOPOWER
-	else
-		spawn(rand(0, 15))
-			icon_state = "bodyscannerconsole-p"
-			stat |= NOPOWER
-
-/obj/machinery/body_scanconsole/New()
-	..()
-	component_parts = list()
-	component_parts += new /obj/item/circuitboard/bodyscanner_console(null)
-	component_parts += new /obj/item/stock_parts/console_screen(null)
-	component_parts += new /obj/item/stock_parts/console_screen(null)
-	component_parts += new /obj/item/stack/cable_coil(null, 2)
-	RefreshParts()
-	findscanner()
-
-/obj/machinery/body_scanconsole/Destroy()
-	if(connected)
-		connected.console = null
-		connected = null
-	return ..()
-
-/obj/machinery/body_scanconsole/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			//SN src = null
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				//SN src = null
-				qdel(src)
-				return
-		else
-	return
-
-/obj/machinery/body_scanconsole/blob_act()
-	if(prob(50))
-		qdel(src)
-
-/obj/machinery/body_scanconsole/attack_animal(var/mob/living/simple_animal/M)//Stop putting hostile mobs in things guise
-	if(M.environment_smash)
-		M.do_attack_animation(src)
-		visible_message("<span class='danger'>[M.name] smashes [src] apart!</span>")
-		qdel(src)
-	return
-
-/obj/machinery/body_scanconsole/proc/findscanner()
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
-		// Try to find a scanner in that direction
-		var/temp = locate(/obj/machinery/bodyscanner, get_step(src, dir))
-		if(temp)
-			connected = temp
-			connected.console = src
-			break
-
-
-/obj/machinery/body_scanconsole/attackby(obj/item/I, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "bodyscannerconsole-p", "bodyscannerconsole", I))
-		return
-
-	if(iswrench(I))
-		if(panel_open)
-			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
-			return
-		if(dir == EAST)
-			setDir(WEST)
-		else
-			setDir(EAST)
-		playsound(loc, I.usesound, 50, 1)
-		return
-
-	if(exchange_parts(user, I))
-		return
-
-	if(default_deconstruction_crowbar(I))
-		return
-	else
-		return ..()
-
-/obj/machinery/body_scanconsole/attack_ai(user)
-	return attack_hand(user)
-
-/obj/machinery/body_scanconsole/attack_ghost(user)
-	return attack_hand(user)
-
-/obj/machinery/body_scanconsole/attack_hand(user)
-	if(stat & (NOPOWER|BROKEN))
-		return
-
-	if(panel_open)
-		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
-		return
-
-	if(!connected)
-		findscanner()
-
-	ui_interact(user)
-
-
-/obj/machinery/body_scanconsole/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
+/obj/machinery/bodyscanner/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "adv_med.tmpl", "Body Scanner", 690, 600)
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/body_scanconsole/ui_data(mob/user, datum/topic_state/state)
+/obj/machinery/bodyscanner/ui_data(mob/user, datum/topic_state/state)
 	var/data[0]
 
-	data["connected"] = connected ? 1 : 0
-
-	if(!connected)
-		return data
-
-	data["occupied"] = connected.occupant ? 1 : 0
+	data["occupied"] = occupant ? 1 : 0
 
 	var/occupantData[0]
-	if(connected.occupant)
-		var/mob/living/carbon/human/H = connected.occupant
-		occupantData["name"] = H.name
-		occupantData["stat"] = H.stat
-		occupantData["health"] = H.health
-		occupantData["maxHealth"] = H.maxHealth
+	if(occupant)
+		occupantData["name"] = occupant.name
+		occupantData["stat"] = occupant.stat
+		occupantData["health"] = occupant.health
+		occupantData["maxHealth"] = occupant.maxHealth
 
 		var/found_disease = FALSE
-		for(var/thing in H.viruses)
+		for(var/thing in occupant.viruses)
 			var/datum/disease/D = thing
 			if(D.visibility_flags & HIDDEN_SCANNER || D.visibility_flags & HIDDEN_PANDEMIC)
 				continue
@@ -371,34 +243,34 @@
 			break
 		occupantData["hasVirus"] = found_disease
 
-		occupantData["bruteLoss"] = H.getBruteLoss()
-		occupantData["oxyLoss"] = H.getOxyLoss()
-		occupantData["toxLoss"] = H.getToxLoss()
-		occupantData["fireLoss"] = H.getFireLoss()
+		occupantData["bruteLoss"] = occupant.getBruteLoss()
+		occupantData["oxyLoss"] = occupant.getOxyLoss()
+		occupantData["toxLoss"] = occupant.getToxLoss()
+		occupantData["fireLoss"] = occupant.getFireLoss()
 
-		occupantData["radLoss"] = H.radiation
-		occupantData["cloneLoss"] = H.getCloneLoss()
-		occupantData["brainLoss"] = H.getBrainLoss()
-		occupantData["paralysis"] = H.paralysis
-		occupantData["paralysisSeconds"] = round(H.paralysis / 4)
-		occupantData["bodyTempC"] = H.bodytemperature-T0C
-		occupantData["bodyTempF"] = (((H.bodytemperature-T0C) * 1.8) + 32)
+		occupantData["radLoss"] = occupant.radiation
+		occupantData["cloneLoss"] = occupant.getCloneLoss()
+		occupantData["brainLoss"] = occupant.getBrainLoss()
+		occupantData["paralysis"] = occupant.paralysis
+		occupantData["paralysisSeconds"] = round(occupant.paralysis * 0.25)
+		occupantData["bodyTempC"] = occupant.bodytemperature-T0C
+		occupantData["bodyTempF"] = (((occupant.bodytemperature-T0C) * 1.8) + 32)
 
-		occupantData["hasBorer"] = H.has_brain_worms()
+		occupantData["hasBorer"] = occupant.has_brain_worms()
 
 		var/bloodData[0]
 		bloodData["hasBlood"] = 0
-		if(ishuman(H) && !(NO_BLOOD in H.dna.species.species_traits))
+		if(!(NO_BLOOD in occupant.dna.species.species_traits))
 			bloodData["hasBlood"] = 1
-			bloodData["volume"] = H.blood_volume
-			bloodData["percent"] = round(((H.blood_volume / BLOOD_VOLUME_NORMAL)*100))
-			bloodData["pulse"] = H.get_pulse(GETPULSE_TOOL)
-			bloodData["bloodLevel"] = H.blood_volume
-			bloodData["bloodMax"] = H.max_blood
+			bloodData["volume"] = occupant.blood_volume
+			bloodData["percent"] = round(((occupant.blood_volume / BLOOD_VOLUME_NORMAL)*100))
+			bloodData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
+			bloodData["bloodLevel"] = occupant.blood_volume
+			bloodData["bloodMax"] = occupant.max_blood
 		occupantData["blood"] = bloodData
 
 		var/implantData[0]
-		for(var/obj/item/implant/I in H)
+		for(var/obj/item/implant/I in occupant)
 			if(I.implanted && is_type_in_list(I, known_implants))
 				var/implantSubData[0]
 				implantSubData["name"] = sanitize(I.name)
@@ -407,7 +279,7 @@
 		occupantData["implant_len"] = implantData.len
 
 		var/extOrganData[0]
-		for(var/obj/item/organ/external/E in H.bodyparts)
+		for(var/obj/item/organ/external/E in occupant.bodyparts)
 			var/organData[0]
 			organData["name"] = E.name
 			organData["open"] = E.open
@@ -441,7 +313,7 @@
 
 			organData["status"] = organStatus
 
-			if(istype(E, /obj/item/organ/external/chest) && H.is_lung_ruptured())
+			if(istype(E, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
 				organData["lungRuptured"] = 1
 
 			if(E.internal_bleeding)
@@ -452,7 +324,7 @@
 		occupantData["extOrgan"] = extOrganData
 
 		var/intOrganData[0]
-		for(var/obj/item/organ/internal/I in H.internal_organs)
+		for(var/obj/item/organ/internal/I in occupant.internal_organs)
 			var/organData[0]
 			organData["name"] = I.name
 			organData["desc"] = I.desc
@@ -468,199 +340,189 @@
 
 		occupantData["intOrgan"] = intOrganData
 
-		occupantData["blind"] = (H.disabilities & BLIND)
-		occupantData["colourblind"] = (H.disabilities & COLOURBLIND)
-		occupantData["nearsighted"] = (H.disabilities & NEARSIGHTED)
+		occupantData["blind"] = (occupant.disabilities & BLIND)
+		occupantData["colourblind"] = (occupant.disabilities & COLOURBLIND)
+		occupantData["nearsighted"] = (occupant.disabilities & NEARSIGHTED)
 
 	data["occupant"] = occupantData
 	return data
 
-/obj/machinery/body_scanconsole/Topic(href, href_list)
+/obj/machinery/bodyscanner/Topic(href, href_list)
 	if(..())
 		return 1
 
 	if(href_list["ejectify"])
-		connected.eject()
+		eject()
 
 	if(href_list["print_p"])
-		generate_printing_text()
+		visible_message("<span class='notice'>[src] rattles and prints out a sheet of paper.</span>")
+		var/obj/item/paper/P = new /obj/item/paper(loc)
+		playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
+		P.info = "<CENTER><B>Body Scan - [href_list["name"]]</B></CENTER><BR>"
+		P.info += "<b>Time of scan:</b> [station_time_timestamp()]<br><br>"
+		P.info += "[generate_printing_text()]"
+		P.info += "<br><br><b>Notes:</b><br>"
+		P.name = "Body Scan - [href_list["name"]]"
 
-		if(!(printing) && printing_text)
-			printing = 1
-			visible_message("<span class='notice'>[src] rattles and prints out a sheet of paper.</span>")
-			var/obj/item/paper/P = new /obj/item/paper(loc)
-			playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
-			P.info = "<CENTER><B>Body Scan - [href_list["name"]]</B></CENTER><BR>"
-			P.info += "<b>Time of scan:</b> [station_time_timestamp()]<br><br>"
-			P.info += "[printing_text]"
-			P.info += "<br><br><b>Notes:</b><br>"
-			P.name = "Body Scan - [href_list["name"]]"
-			printing = null
-			printing_text = null
-
-/obj/machinery/body_scanconsole/proc/generate_printing_text()
+/obj/machinery/bodyscanner/proc/generate_printing_text()
 	var/dat = ""
 
-	if(connected)
-		var/mob/living/carbon/human/occupant = connected.occupant
-		dat = "<font color='blue'><b>Occupant Statistics:</b></font><br>" //Blah obvious
-		if(istype(occupant)) //is there REALLY someone in there?
-			var/t1
-			switch(occupant.stat) // obvious, see what their status is
-				if(0)
-					t1 = "Conscious"
-				if(1)
-					t1 = "Unconscious"
-				else
-					t1 = "*dead*"
-			dat += "[occupant.health > 50 ? "<font color='blue'>" : "<font color='red'>"]\tHealth %: [occupant.health], ([t1])</font><br>"
+	dat = "<font color='blue'><b>Occupant Statistics:</b></font><br>" //Blah obvious
+	if(istype(occupant)) //is there REALLY someone in there?
+		var/t1
+		switch(occupant.stat) // obvious, see what their status is
+			if(0)
+				t1 = "Conscious"
+			if(1)
+				t1 = "Unconscious"
+			else
+				t1 = "*dead*"
+		dat += "[occupant.health > 50 ? "<font color='blue'>" : "<font color='red'>"]\tHealth %: [occupant.health], ([t1])</font><br>"
 
-			var/found_disease = FALSE
-			for(var/thing in occupant.viruses)
-				var/datum/disease/D = thing
-				if(D.visibility_flags & HIDDEN_SCANNER || D.visibility_flags & HIDDEN_PANDEMIC)
-					continue
-				found_disease = TRUE
-				break
-			if(found_disease)
-				dat += "<font color='red'>Disease detected in occupant.</font><BR>"
+		var/found_disease = FALSE
+		for(var/thing in occupant.viruses)
+			var/datum/disease/D = thing
+			if(D.visibility_flags & HIDDEN_SCANNER || D.visibility_flags & HIDDEN_PANDEMIC)
+				continue
+			found_disease = TRUE
+			break
+		if(found_disease)
+			dat += "<font color='red'>Disease detected in occupant.</font><BR>"
 
-			var/extra_font = null
-			extra_font = (occupant.getBruteLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\t-Brute Damage %: [occupant.getBruteLoss()]</font><br>"
+		var/extra_font = null
+		extra_font = (occupant.getBruteLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\t-Brute Damage %: [occupant.getBruteLoss()]</font><br>"
 
-			extra_font = (occupant.getOxyLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\t-Respiratory Damage %: [occupant.getOxyLoss()]</font><br>"
+		extra_font = (occupant.getOxyLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\t-Respiratory Damage %: [occupant.getOxyLoss()]</font><br>"
 
-			extra_font = (occupant.getToxLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\t-Toxin Content %: [occupant.getToxLoss()]</font><br>"
+		extra_font = (occupant.getToxLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\t-Toxin Content %: [occupant.getToxLoss()]</font><br>"
 
-			extra_font = (occupant.getFireLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\t-Burn Severity %: [occupant.getFireLoss()]</font><br>"
+		extra_font = (occupant.getFireLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\t-Burn Severity %: [occupant.getFireLoss()]</font><br>"
 
-			extra_font = (occupant.radiation < 10 ?"<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\tRadiation Level %: [occupant.radiation]</font><br>"
+		extra_font = (occupant.radiation < 10 ?"<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tRadiation Level %: [occupant.radiation]</font><br>"
 
-			extra_font = (occupant.getCloneLoss() < 1 ?"<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\tGenetic Tissue Damage %: [occupant.getCloneLoss()]<br>"
+		extra_font = (occupant.getCloneLoss() < 1 ?"<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tGenetic Tissue Damage %: [occupant.getCloneLoss()]<br>"
 
-			extra_font = (occupant.getBrainLoss() < 1 ?"<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\tApprox. Brain Damage %: [occupant.getBrainLoss()]<br>"
+		extra_font = (occupant.getBrainLoss() < 1 ?"<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tApprox. Brain Damage %: [occupant.getBrainLoss()]<br>"
 
-			dat += "Paralysis Summary %: [occupant.paralysis] ([round(occupant.paralysis / 4)] seconds left!)<br>"
-			dat += "Body Temperature: [occupant.bodytemperature-T0C]&deg;C ([occupant.bodytemperature*1.8-459.67]&deg;F)<br>"
+		dat += "Paralysis Summary %: [occupant.paralysis] ([round(occupant.paralysis / 4)] seconds left!)<br>"
+		dat += "Body Temperature: [occupant.bodytemperature-T0C]&deg;C ([occupant.bodytemperature*1.8-459.67]&deg;F)<br>"
 
-			dat += "<hr>"
+		dat += "<hr>"
 
-			if(occupant.has_brain_worms())
-				dat += "Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.<br>"
+		if(occupant.has_brain_worms())
+			dat += "Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.<br>"
 
-			var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL))
-			blood_percent *= 100
+		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL))
+		blood_percent *= 100
 
-			extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
-			dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"
+		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"
 
-			if(occupant.reagents)
-				dat += "Epinephrine units: [occupant.reagents.get_reagent_amount("Epinephrine")] units<BR>"
-				dat += "Ether: [occupant.reagents.get_reagent_amount("ether")] units<BR>"
+		if(occupant.reagents)
+			dat += "Epinephrine units: [occupant.reagents.get_reagent_amount("Epinephrine")] units<BR>"
+			dat += "Ether: [occupant.reagents.get_reagent_amount("ether")] units<BR>"
 
-				extra_font = (occupant.reagents.get_reagent_amount("silver_sulfadiazine") < 30 ? "<font color='black'>" : "<font color='red'>")
-				dat += "[extra_font]\tSilver Sulfadiazine: [occupant.reagents.get_reagent_amount("silver_sulfadiazine")]</font><br>"
+			extra_font = (occupant.reagents.get_reagent_amount("silver_sulfadiazine") < 30 ? "<font color='black'>" : "<font color='red'>")
+			dat += "[extra_font]\tSilver Sulfadiazine: [occupant.reagents.get_reagent_amount("silver_sulfadiazine")]</font><br>"
 
-				extra_font = (occupant.reagents.get_reagent_amount("styptic_powder") < 30 ? "<font color='black'>" : "<font color='red'>")
-				dat += "[extra_font]\tStyptic Powder: [occupant.reagents.get_reagent_amount("styptic_powder")] units<BR>"
+			extra_font = (occupant.reagents.get_reagent_amount("styptic_powder") < 30 ? "<font color='black'>" : "<font color='red'>")
+			dat += "[extra_font]\tStyptic Powder: [occupant.reagents.get_reagent_amount("styptic_powder")] units<BR>"
 
-				extra_font = (occupant.reagents.get_reagent_amount("salbutamol") < 30 ? "<font color='black'>" : "<font color='red'>")
-				dat += "[extra_font]\tSalbutamol: [occupant.reagents.get_reagent_amount("salbutamol")] units<BR>"
+			extra_font = (occupant.reagents.get_reagent_amount("salbutamol") < 30 ? "<font color='black'>" : "<font color='red'>")
+			dat += "[extra_font]\tSalbutamol: [occupant.reagents.get_reagent_amount("salbutamol")] units<BR>"
 
-			dat += "<hr><table border='1'>"
+		dat += "<hr><table border='1'>"
+		dat += "<tr>"
+		dat += "<th>Organ</th>"
+		dat += "<th>Burn Damage</th>"
+		dat += "<th>Brute Damage</th>"
+		dat += "<th>Other Wounds</th>"
+		dat += "</tr>"
+
+		for(var/obj/item/organ/external/e in occupant.bodyparts)
 			dat += "<tr>"
-			dat += "<th>Organ</th>"
-			dat += "<th>Burn Damage</th>"
-			dat += "<th>Brute Damage</th>"
-			dat += "<th>Other Wounds</th>"
+			var/AN = ""
+			var/open = ""
+			var/infected = ""
+			var/robot = ""
+			var/imp = ""
+			var/bled = ""
+			var/splint = ""
+			var/internal_bleeding = ""
+			var/lung_ruptured = ""
+			if(e.internal_bleeding)
+				internal_bleeding = "<br>Internal bleeding"
+			if(istype(e, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
+				lung_ruptured = "Lung ruptured:"
+			if(e.status & ORGAN_SPLINTED)
+				splint = "Splinted:"
+			if(e.status & ORGAN_BROKEN)
+				AN = "[e.broken_description]:"
+			if(e.is_robotic())
+				robot = "Robotic:"
+			if(e.open)
+				open = "Open:"
+			switch(e.germ_level)
+				if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
+					infected = "Mild Infection:"
+				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
+					infected = "Mild Infection+:"
+				if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
+					infected = "Mild Infection++:"
+				if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
+					infected = "Acute Infection:"
+				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
+					infected = "Acute Infection+:"
+				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 400)
+					infected = "Acute Infection++:"
+				if(INFECTION_LEVEL_THREE to INFINITY)
+					infected = "Septic:"
+
+			var/unknown_body = 0
+			for(var/I in e.embedded_objects)
+				unknown_body++
+
+			if(unknown_body || e.hidden)
+				imp += "Unknown body present:"
+			if(!AN && !open && !infected & !imp)
+				AN = "None:"
+			dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[e.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][internal_bleeding][lung_ruptured]</td>"
 			dat += "</tr>"
+		for(var/obj/item/organ/internal/i in occupant.internal_organs)
+			var/mech = i.desc
+			var/infection = "None"
+			switch(i.germ_level)
+				if(1 to INFECTION_LEVEL_ONE + 200)
+					infection = "Mild Infection:"
+				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
+					infection = "Mild Infection+:"
+				if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
+					infection = "Mild Infection++:"
+				if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
+					infection = "Acute Infection:"
+				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
+					infection = "Acute Infection+:"
+				if(INFECTION_LEVEL_TWO + 300 to INFINITY)
+					infection = "Acute Infection++:"
 
-			for(var/obj/item/organ/external/e in occupant.bodyparts)
-				dat += "<tr>"
-				var/AN = ""
-				var/open = ""
-				var/infected = ""
-				var/robot = ""
-				var/imp = ""
-				var/bled = ""
-				var/splint = ""
-				var/internal_bleeding = ""
-				var/lung_ruptured = ""
-				if(e.internal_bleeding)
-					internal_bleeding = "<br>Internal bleeding"
-				if(istype(e, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
-					lung_ruptured = "Lung ruptured:"
-				if(e.status & ORGAN_SPLINTED)
-					splint = "Splinted:"
-				if(e.status & ORGAN_BROKEN)
-					AN = "[e.broken_description]:"
-				if(e.is_robotic())
-					robot = "Robotic:"
-				if(e.open)
-					open = "Open:"
-				switch(e.germ_level)
-					if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
-						infected = "Mild Infection:"
-					if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
-						infected = "Mild Infection+:"
-					if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
-						infected = "Mild Infection++:"
-					if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
-						infected = "Acute Infection:"
-					if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
-						infected = "Acute Infection+:"
-					if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 400)
-						infected = "Acute Infection++:"
-					if(INFECTION_LEVEL_THREE to INFINITY)
-						infected = "Septic:"
-
-				var/unknown_body = 0
-				for(var/I in e.embedded_objects)
-					unknown_body++
-
-				if(unknown_body || e.hidden)
-					imp += "Unknown body present:"
-				if(!AN && !open && !infected & !imp)
-					AN = "None:"
-				dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[e.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][internal_bleeding][lung_ruptured]</td>"
-				dat += "</tr>"
-			for(var/obj/item/organ/internal/i in occupant.internal_organs)
-				var/mech = i.desc
-				var/infection = "None"
-				switch(i.germ_level)
-					if(1 to INFECTION_LEVEL_ONE + 200)
-						infection = "Mild Infection:"
-					if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
-						infection = "Mild Infection+:"
-					if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
-						infection = "Mild Infection++:"
-					if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
-						infection = "Acute Infection:"
-					if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
-						infection = "Acute Infection+:"
-					if(INFECTION_LEVEL_TWO + 300 to INFINITY)
-						infection = "Acute Infection++:"
-
-				dat += "<tr>"
-				dat += "<td>[i.name]</td><td>N/A</td><td>[i.damage]</td><td>[infection]:[mech]</td><td></td>"
-				dat += "</tr>"
-			dat += "</table>"
-			if(occupant.disabilities & BLIND)
-				dat += "<font color='red'>Cataracts detected.</font><BR>"
-			if(occupant.disabilities & COLOURBLIND)
-				dat += "<font color='red'>Photoreceptor abnormalities detected.</font><BR>"
-			if(occupant.disabilities & NEARSIGHTED)
-				dat += "<font color='red'>Retinal misalignment detected.</font><BR>"
-		else
-			dat += "[src] is empty."
+			dat += "<tr>"
+			dat += "<td>[i.name]</td><td>N/A</td><td>[i.damage]</td><td>[infection]:[mech]</td><td></td>"
+			dat += "</tr>"
+		dat += "</table>"
+		if(occupant.disabilities & BLIND)
+			dat += "<font color='red'>Cataracts detected.</font><BR>"
+		if(occupant.disabilities & COLOURBLIND)
+			dat += "<font color='red'>Photoreceptor abnormalities detected.</font><BR>"
+		if(occupant.disabilities & NEARSIGHTED)
+			dat += "<font color='red'>Retinal misalignment detected.</font><BR>"
 	else
-		dat = "<font color='red'> Error: No Body Scanner connected.</font>"
+		dat += "[src] is empty."
 
-	printing_text = dat
+	return dat

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -869,16 +869,6 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/stock_parts/console_screen = 2)
 
-/obj/item/circuitboard/bodyscanner_console
-	name = "circuit board (Body Scanner Console)"
-	build_path = /obj/machinery/body_scanconsole
-	board_type = "machine"
-	origin_tech = "programming=3;biotech=2;engineering=3"
-	frame_desc = "Requires 2 pieces of cable and 2 Console Screens."
-	req_components = list(
-							/obj/item/stack/cable_coil = 2,
-							/obj/item/stock_parts/console_screen = 2)
-
 /obj/item/circuitboard/cryo_tube
 	name = "circuit board (Cryotube)"
 	build_path = /obj/machinery/atmospherics/unary/cryo_cell

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -122,16 +122,6 @@
 	build_path = /obj/item/circuitboard/bodyscanner
 	category = list("Medical Machinery")
 
-/datum/design/bodyscanner_console
-	name = "Machine Board (Body Scanner Console)"
-	desc = "Allows for the construction of circuit boards used to build a Body Scanner Console."
-	id = "bodyscanner_console"
-	req_tech = list("programming" = 3, "biotech" = 2, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000)
-	build_path = /obj/item/circuitboard/bodyscanner_console
-	category = list("Medical Machinery")
-
 /datum/design/clonepod
 	name = "Machine Board (Cloning Pod)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Pod."


### PR DESCRIPTION
A waste of space, resources, time, and is generally inconsistent with the rest of consoles

Removes the need of bodyscanners having to have a console

:cl: Fox McCloud
tweak: Bodyscanners are similar to sleepers; interact with them by clicking on the scanner; there is no console anymore
/:cl: