### PR TITLE
Makes Toxic Compensation do the toxin damage it healed

### DIFF
--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -44,7 +44,7 @@ Bonus
 
 		if(!parts.len)
 			return
-		var/healed = 0;
+		var/healed = 0
 		for(var/obj/item/organ/external/E in parts)
 			healed = min(E.brute_dam, get_damage) + min(E.burn_dam, get_damage)
 			E.heal_damage(get_damage, get_damage, 0, 0)

--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -44,10 +44,11 @@ Bonus
 
 		if(!parts.len)
 			return
-
+		var/healed = 0;
 		for(var/obj/item/organ/external/E in parts)
+			healed = min(E.brute_dam, get_damage) + min(E.burn_dam, get_damage)
 			E.heal_damage(get_damage, get_damage, 0, 0)
-		M.adjustToxLoss(get_damage*parts.len)
+		M.adjustToxLoss(healed)
 
 
 	else


### PR DESCRIPTION
## What Does This PR Do
Makes toxic compensation deal the toxin damage it also heals.

## Why It's Good For The Game
Currently you get a set amount of damage (between 1 and 2) for every limb that is hurt. This limb can be utterly fucked with both brute and burn giving you a net positive on the damage. Or this limb can just have 0.00001 brute meaning you get a shit ton more damage in return.

This PR makes it so that the amount of damage healed is equal to the amount of damaged given in toxins.

## Changelog
:cl:
balance: Toxic compensation now deals the amount of toxin damage that it also healed
/:cl: