### PR TITLE
Fix naked reincarnation

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -379,24 +379,26 @@
 
 
 /datum/outfit/clownsoldier
-		uniform = /obj/item/clothing/under/soldieruniform
-		suit = /obj/item/clothing/suit/soldiercoat
-		shoes = /obj/item/clothing/shoes/clown_shoes
-		l_ear = /obj/item/radio/headset
-		mask = /obj/item/clothing/mask/gas/clown_hat
-		l_pocket = /obj/item/bikehorn
-		back = /obj/item/storage/backpack/clown
-		head = /obj/item/clothing/head/stalhelm
+	name = "Clown Soldier"
+	uniform = /obj/item/clothing/under/soldieruniform
+	suit = /obj/item/clothing/suit/soldiercoat
+	shoes = /obj/item/clothing/shoes/clown_shoes
+	l_ear = /obj/item/radio/headset
+	mask = /obj/item/clothing/mask/gas/clown_hat
+	l_pocket = /obj/item/bikehorn
+	back = /obj/item/storage/backpack/clown
+	head = /obj/item/clothing/head/stalhelm
 
 /datum/outfit/clownofficer
-		uniform = /obj/item/clothing/under/officeruniform
-		suit = /obj/item/clothing/suit/officercoat
-		shoes = /obj/item/clothing/shoes/clown_shoes
-		l_ear = /obj/item/radio/headset
-		mask = /obj/item/clothing/mask/gas/clown_hat
-		l_pocket = /obj/item/bikehorn
-		back = /obj/item/storage/backpack/clown
-		head = /obj/item/clothing/head/naziofficer
+	name = "Clown Officer"
+	uniform = /obj/item/clothing/under/officeruniform
+	suit = /obj/item/clothing/suit/officercoat
+	shoes = /obj/item/clothing/shoes/clown_shoes
+	l_ear = /obj/item/radio/headset
+	mask = /obj/item/clothing/mask/gas/clown_hat
+	l_pocket = /obj/item/bikehorn
+	back = /obj/item/storage/backpack/clown
+	head = /obj/item/clothing/head/naziofficer
 
 /obj/effect/mob_spawn/human/mime
 	name = "Mime"


### PR DESCRIPTION
## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/12386.

Caused by two outfits not having a name, thus defaulting to "Naked".

## Changelog
:cl: Markolie
fix: Fixed naked equipment selection and reincarnation not working.
/:cl: