### PR TITLE
Adds "Silence Current Midi" verb to preferences

### DIFF
--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -287,3 +287,10 @@
 	to_chat(src, "As a ghost, you will now [(prefs.toggles & CHAT_GHOSTPDA) ? "see all PDA messages" : "no longer see PDA messages"].")
 	prefs.save_preferences(src)
 	feedback_add_details("admin_verb","TGP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	
+/client/verb/silence_current_midi()
+	set name = "Silence Current Midi"
+	set category = "Preferences"
+	set desc = "Silence the current admin midi playing"
+	usr.stop_sound_channel(CHANNEL_ADMIN)
+	to_chat(src, "The current admin midi has been silenced")


### PR DESCRIPTION
Allows people to silence the current playing midi without toggling their preferences for hearing midis in case the admin has a bad taste of music.

Credit to CM for the idea

:cl:
add: You can now silence the current midi with a verb in the preferences tab, without affecting your prefrence to hear midis in the future.
/ 🆑 