### PR TITLE
Sword Shade Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -46,3 +46,7 @@
 /mob/living/simple_animal/shade/sword
 	universal_speak = 1
 	faction = list("neutral")
+
+/mob/living/simple_animal/shade/sword/Initialize(mapload)
+	.=..()
+	status_flags |= GODMODE


### PR DESCRIPTION
## What Does This PR Do
The ghosts inside of possessed swords now have godmode enabled to prevent scenarios where they are getting damaged when they should not be. The shade will still be destroyed if the blade is destroyed, but this will prevent scenarios where the blade is unharmed but the ghost inside mysteriously dies. Fixes #12395

## Changelog
:cl:
fix: The ghosts inside possessed blades are now invincible and will not die to weird edge cases.
/:cl: