### PR TITLE
Fixes space syndis being unable to navigate space

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1191,8 +1191,8 @@ About the new airlock wires panel:
 	return 1
 
 /obj/machinery/door/airlock/CanAStarPass(obj/item/card/id/ID)
-//Airlock is passable if it is open (!density), bot has access, and is not bolted shut)
-	return !density || (check_access(ID) && !locked && arePowerSystemsOn())
+//Airlock is passable if it is open (!density), bot has access, and is not bolted or welded shut)
+	return !density || (check_access(ID) && !locked && !welded && arePowerSystemsOn())
 
 /obj/machinery/door/airlock/emag_act(mob/user)
 	if(!operating && density && arePowerSystemsOn() && !emagged)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -288,7 +288,7 @@
 	alert_on_spacing = FALSE
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space/Process_Spacemove(var/movement_dir = 0)
-	return
+	return TRUE
 
 
 
@@ -302,7 +302,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando, /obj/item/melee/energy/sword/saber/red, /obj/item/shield/energy)
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(var/movement_dir = 0)
-	return
+	return TRUE
 
 
 /mob/living/simple_animal/hostile/syndicate/ranged
@@ -326,7 +326,7 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando, /obj/item/gun/projectile/automatic/c20r)
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Process_Spacemove(var/movement_dir = 0)
-	return
+	return TRUE
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/autogib
 	loot = list()//gonna gibe, no loot.

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -116,7 +116,9 @@
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/Aggro()
 	. = ..()
-	if(target && istype(depotarea))
+	if(!istype(depotarea))
+		return .
+	if(target)
 		if(!seen_enemy)
 			seen_enemy = TRUE
 			if(!ranged)
@@ -148,11 +150,13 @@
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/handle_automated_movement()
 	. = ..()
+	if(!istype(depotarea))
+		return .
 	if(seen_enemy)
 		aggro_cycles++
 		if(alert_on_timeout && !raised_alert && aggro_cycles >= 60)
 			raise_alert("[name] has reported contact with hostile entity: [seen_enemy_name]")
-	if(scan_cycles >= 15 && istype(depotarea))
+	if(scan_cycles >= 15)
 		scan_cycles = 0
 		if(!atoms_share_level(src, spawn_turf))
 			if(istype(loc, /obj/structure/closet))
@@ -187,6 +191,8 @@
 		depotarea.increase_alert(reason)
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/death()
+	if(!istype(depotarea))
+		return ..()
 	if(alert_on_death)
 		if(seen_enemy_name)
 			raise_alert("[name] has died in combat with [seen_enemy_name].")

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -117,7 +117,7 @@
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/Aggro()
 	. = ..()
 	if(!istype(depotarea))
-		return .
+		return
 	if(target)
 		if(!seen_enemy)
 			seen_enemy = TRUE
@@ -151,7 +151,7 @@
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/handle_automated_movement()
 	. = ..()
 	if(!istype(depotarea))
-		return .
+		return
 	if(seen_enemy)
 		aggro_cycles++
 		if(alert_on_timeout && !raised_alert && aggro_cycles >= 60)


### PR DESCRIPTION
## What Does This PR Do
Fixes #12403 
Fixes NPC syndies in red hardsuits (nuke op suits) being unable to move in space.

Fixes NPC bots thinking that they can path through airlocks that are completely welded shut.

Refactors some safety checks to make them more reliable, which prevents runtimes in syndicate.dm in rare situations (like admins manually spawning depot mobs outside of the correct /area).

## Changelog
:cl: Kyep
fix: Fixed NPC redsuited syndicates from being unable to move in space.
fix: Fixed NPC bots thinking that they can path through airlocks which are welded shut.
refactor: Refactors some safety checks so that its impossible for depot mobs to generate runtimes in rare cases (e.g: admins spawning them outside the depot for testing)
/:cl: