### PR TITLE
Fixes Seed Vault Gene Modder

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -30,7 +30,7 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "f" = (
-/obj/machinery/plantgenes/upgraded{
+/obj/machinery/plantgenes/seedvault{
 	pixel_y = 6
 	},
 /obj/structure/table/wood,

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -382,6 +382,8 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stock_parts/console_screen = 1,
 							/obj/item/stock_parts/scanning_module = 1)
 
+/obj/item/circuitboard/plantgenes/vault
+
 /obj/item/circuitboard/seed_extractor
 	name = "circuit board (Seed Extractor)"
 	build_path = /obj/machinery/seed_extractor

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -33,14 +33,14 @@
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	RefreshParts()
 
-/obj/machinery/plantgenes/upgraded/New()
+/obj/machinery/plantgenes/seedvault/New()
 	..()
 	component_parts = list()
-	component_parts += new /obj/item/circuitboard/plantgenes(null)
+	component_parts += new /obj/item/circuitboard/plantgenes/vault(null)
 	component_parts += new /obj/item/stock_parts/console_screen(null)
-	component_parts += new /obj/item/stock_parts/scanning_module/phasic(null)
-	component_parts += new /obj/item/stock_parts/micro_laser/ultra(null)
-	component_parts += new /obj/item/stock_parts/manipulator/pico(null)
+	component_parts += new /obj/item/stock_parts/scanning_module(null)
+	component_parts += new /obj/item/stock_parts/micro_laser(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
 	RefreshParts()
 
 /obj/machinery/plantgenes/Destroy()
@@ -73,6 +73,14 @@
 		var/wratemod = ML.rating * 2.5
 		min_wrate = Floor(10-wratemod) // 7,5,2,0	Clamps at 0 and 10	You want this low
 		min_wchance = 67-(ML.rating*16) // 48,35,19,3 	Clamps at 0 and 67	You want this low
+	for(var/obj/item/circuitboard/plantgenes/vaultcheck in component_parts)
+		if(istype(vaultcheck, /obj/item/circuitboard/plantgenes/vault)) // TRAIT_DUMB BOTANY TUTS
+			max_potency = 100
+			max_yield = 10
+			min_production = 1
+			max_endurance = 100
+			min_wchance = 0
+			min_wrate = 0
 
 /obj/machinery/plantgenes/update_icon()
 	..()


### PR DESCRIPTION
The Seed Vault gene modder is supposed to be special in that it has no restriction on its capabilities; it can extra any value that exists for seeds; it's even better than a gene modder upgraded with tier 4 partrs.

At the moment, the one in the code is just a tier 3 parts upgraded gene modder, so it's nowhere near where it's supposed to be.

:cl: Fox McCloud
fix: Fixes Seed Vault gene modder having limitations
/:cl: