### PR TITLE
Fixes Extinguishing Some Fires

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -154,10 +154,6 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 /obj/item/blob_act()
 	qdel(src)
 
-/obj/item/water_act(volume, temperature, source, method = TOUCH)
-	. = ..()
-	extinguish()
-
 /obj/item/verb/move_to_top()
 	set name = "Move To Top"
 	set category = null

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -272,6 +272,10 @@ a {
 	user.set_machine(src)
 	onclose(user, "mtcomputer")
 
+/obj/water_act(volume, temperature, source, method = TOUCH)
+	. = ..()
+	extinguish()
+
 /obj/singularity_pull(S, current_size)
 	if(anchored)
 		if(current_size >= STAGE_FIVE)


### PR DESCRIPTION
`water_act` calling `extinguish` is defined at the `item` level for some reason, when `obj` level things can catch on fire.

:cl: Fox McCloud
fix: Fixes not being able to extinguish some items
/:cl: