### PR TITLE
Nerfs Book of Babel

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -16,6 +16,7 @@
 #define INNATE 64			// All mobs can be assumed to speak and understand this language (audible emotes)
 #define NO_TALK_MSG 128		// Do not show the "\The [speaker] talks into \the [radio]" message
 #define NO_STUTTER 256		// No stuttering, slurring, or other speech problems
+#define NOBABEL 512			// Not granted by book of babel. Typically antag languages.
 
 //Auto-accent level defines.
 #define AUTOHISS_OFF 0

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -88,7 +88,7 @@
 
 /obj/item/book_of_babel/attack_self(mob/user)
 	to_chat(user, "You flip through the pages of the book, quickly and conveniently learning every language in existence. Somewhat less conveniently, the aging book crumbles to dust in the process. Whoops.")
-	user.grant_all_languages()
+	user.grant_all_nonhivemind_languages()
 	new /obj/effect/decal/cleanable/ash(get_turf(user))
 	qdel(src)
 

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -88,7 +88,7 @@
 
 /obj/item/book_of_babel/attack_self(mob/user)
 	to_chat(user, "You flip through the pages of the book, quickly and conveniently learning every language in existence. Somewhat less conveniently, the aging book crumbles to dust in the process. Whoops.")
-	user.grant_all_nonhivemind_languages()
+	user.grant_all_babel_languages()
 	new /obj/effect/decal/cleanable/ash(get_turf(user))
 	qdel(src)
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -773,8 +773,13 @@
 	flags = RESTRICTED
 	syllables = list("BRAAAAAAAAAAAAAAAAINS", "BRAAINS", "BRAINS")
 
-/mob/proc/grant_all_languages()
+/mob/proc/grant_all_nonhivemind_languages()
 	for(var/la in GLOB.all_languages)
-		add_language(la)
+		var/datum/language/new_language = GLOB.all_languages[la]
+		if(!istype(new_language) || (new_language in languages))
+			continue
+		if(new_language.flags & HIVEMIND)
+			continue
+		languages |= new_language
 
 #undef SCRAMBLE_CACHE_LEN

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -454,7 +454,7 @@
 	exclaim_verb = "chitters"
 	colour = "alien"
 	key = "y"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 /datum/language/wryn/check_special_condition(mob/other)
@@ -485,7 +485,7 @@
 	exclaim_verb = "hisses"
 	colour = "alien"
 	key = "a"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 /datum/language/terrorspider
@@ -496,7 +496,7 @@
 	exclaim_verb = "chitters"
 	colour = "terrorspider"
 	key = "ts"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 /datum/language/ling
@@ -505,7 +505,7 @@
 	speech_verb = "says"
 	colour = "changeling"
 	key = "g"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 /datum/language/ling/broadcast(mob/living/speaker, message, speaker_mask)
@@ -522,7 +522,7 @@
 	speech_verb = "says"
 	colour = "shadowling"
 	key = "8"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 /datum/language/shadowling/broadcast(mob/living/speaker, message, speaker_mask)
@@ -541,7 +541,7 @@
 	exclaim_verb = "gibbers"
 	colour = "abductor"
 	key = "zw" //doesn't matter, this is their default and only language
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 /datum/language/abductor/broadcast(mob/living/speaker, message, speaker_mask)
@@ -570,7 +570,7 @@
 	exclaim_verb = "sings"
 	colour = "alien"
 	key = "bo"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 /datum/language/corticalborer/broadcast(mob/living/speaker, message, speaker_mask)
@@ -594,7 +594,7 @@
 	ask_verb = "queries"
 	exclaim_verb = "declares"
 	key = "b"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 	var/drone_only
 
@@ -640,7 +640,7 @@
 	exclaim_verb = "transmits"
 	colour = "say_quote"
 	key = "d"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	drone_only = TRUE
 	follow = TRUE
 
@@ -663,7 +663,7 @@
 	exclaim_verb = "tones"
 	colour = "say_quote"
 	key = "z"//Zwarmer...Or Zerg!
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOBABEL
 	follow = TRUE
 
 // Language handling.
@@ -773,12 +773,10 @@
 	flags = RESTRICTED
 	syllables = list("BRAAAAAAAAAAAAAAAAINS", "BRAAINS", "BRAINS")
 
-/mob/proc/grant_all_nonhivemind_languages()
+/mob/proc/grant_all_babel_languages()
 	for(var/la in GLOB.all_languages)
 		var/datum/language/new_language = GLOB.all_languages[la]
-		if(!istype(new_language) || (new_language in languages))
-			continue
-		if(new_language.flags & HIVEMIND)
+		if(new_language.flags & NOBABEL)
 			continue
 		languages |= new_language
 


### PR DESCRIPTION
## What Does This PR Do
Alters the mining loot item "Book of Babel" so that instead of granting you EVERY language, it only grants you non-hivemind languages.

## Why It's Good For The Game
Currently, the Book of Babel lets you spy on Xeno/Borer/Abductor/TerrorSpider/etc hivemind chat.
This completely breaks all of those antags' ability to be stealthy, or to co-ordinate as a team.
With this PR in place, the book still grants you standard crew racial languages for crew races, even unusual languages like chimp, but won't grant you the ability to single-handedly wreck most of the late-round antags by spying on their hivemind and relaying their thoughts to the crew.

:cl: Kyep
balance: Nerfed Book of Babel so it is no longer wrecking the balance of late-round antags.
/:cl: