### PR TITLE
Fixes improvised shotgun showing up as an ammo recipe when crafting

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -246,7 +246,7 @@
 	tools = list(/obj/item/screwdriver)
 	time = 100
 	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
+	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/chainsaw
 	name = "Chainsaw"


### PR DESCRIPTION
## What Does This PR Do
The Improvised Shotgun currently shows up as an ammo recipe when crafting, this changes it a weapon recipe as intended.

(Thanks to Leanfrog for finding this!)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Puts a crafting recipe where it should be.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Improvised shotguns are now in the correct tab when trying to craft them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
