### PR TITLE
Adds an ATMOS Holofan Creator to the Chief Engineer's locker (Take 2)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -40,6 +40,7 @@
 	new /obj/item/reagent_containers/food/drinks/mug/ce(src)
 	new /obj/item/organ/internal/cyberimp/eyes/meson(src)
 	new /obj/item/clothing/accessory/medal/engineering(src)
+	new /obj/item/holosign_creator/atmos(src)
 
 
 /obj/structure/closet/secure_closet/engineering_electrical


### PR DESCRIPTION

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR adds an ATMOS Holofan creator to the CE's locker.

(Hopefully the PR works properly this time)
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Since CE has atmos access and often steals one from the techies' lockers anyways, it only makes sense to let them have their own; especially considering the great use the projectors have in constructing the DNA Vault or BSA.

## Changelog
:cl:
:tweak: The CE's locker now has an ATMOS Holofan Projector.
/:cl:
