### PR TITLE
Mining borg QoL update and fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -572,6 +572,10 @@ var/list/robot_verbs_default = list(
 	statpanel("Status")
 	if(client.statpanel == "Status")
 		show_cell_power()
+	var/total_user_contents = GetAllContents()
+	if(locate(/obj/item/gps/cyborg) in total_user_contents)
+		var/turf/T = get_turf(src)
+		stat(null, "GPS: [COORD(T)]")
 
 /mob/living/silicon/robot/restrained()
 	return 0

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -111,6 +111,13 @@
 	chambered = null //either way, released the prepared shot
 	newshot()
 
+/obj/item/gun/energy/kinetic_accelerator/process_chamber()
+	if(chambered && !chambered.BB)
+		var/obj/item/ammo_casing/energy/shot = chambered
+		power_supply.use(shot.e_cost)
+	chambered = null
+	newshot()
+
 /obj/item/gun/energy/proc/select_fire(mob/living/user)
 	select++
 	if(select > ammo_type.len)
@@ -198,8 +205,7 @@
 		if(R && R.cell)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select] //Necessary to find cost of shot
 			if(R.cell.use(shot.e_cost)) 		//Take power from the borg...
-				if(!istype(src, /obj/item/gun/energy/kinetic_accelerator/cyborg)) // Mining borg KA's can be spammed with no cooldown without this check
-					power_supply.give(shot.e_cost)	//... to recharge the shot
+				power_supply.give(shot.e_cost)	//... to recharge the shot
 
 /obj/item/gun/energy/proc/get_external_power_supply()
 	if(istype(loc, /obj/item/rig_module))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -198,7 +198,8 @@
 		if(R && R.cell)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select] //Necessary to find cost of shot
 			if(R.cell.use(shot.e_cost)) 		//Take power from the borg...
-				power_supply.give(shot.e_cost)	//... to recharge the shot
+				if(!istype(src, /obj/item/gun/energy/kinetic_accelerator/cyborg)) // Mining borg KA's can be spammed with no cooldown without this check
+					power_supply.give(shot.e_cost)	//... to recharge the shot
 
 /obj/item/gun/energy/proc/get_external_power_supply()
 	if(istype(loc, /obj/item/rig_module))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -111,13 +111,6 @@
 	chambered = null //either way, released the prepared shot
 	newshot()
 
-/obj/item/gun/energy/kinetic_accelerator/process_chamber()
-	if(chambered && !chambered.BB)
-		var/obj/item/ammo_casing/energy/shot = chambered
-		power_supply.use(shot.e_cost)
-	chambered = null
-	newshot()
-
 /obj/item/gun/energy/proc/select_fire(mob/living/user)
 	select++
 	if(select > ammo_type.len)
@@ -198,6 +191,9 @@
 			else
 				STOP_PROCESSING(SSobj, src)
 	. = ..()
+
+/obj/item/gun/energy/kinetic_accelerator/proc/robocharge()
+	return
 
 /obj/item/gun/energy/proc/robocharge()
 	if(isrobot(loc))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -192,9 +192,6 @@
 				STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-/obj/item/gun/energy/kinetic_accelerator/proc/robocharge()
-	return
-
 /obj/item/gun/energy/proc/robocharge()
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/R = loc

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -131,6 +131,9 @@
 /obj/item/gun/energy/kinetic_accelerator/emp_act(severity)
 	return
 
+/obj/item/gun/energy/kinetic_accelerator/proc/robocharge()
+	return
+
 /obj/item/gun/energy/kinetic_accelerator/proc/reload()
 	power_supply.give(500)
 	on_recharge()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -131,7 +131,7 @@
 /obj/item/gun/energy/kinetic_accelerator/emp_act(severity)
 	return
 
-/obj/item/gun/energy/kinetic_accelerator/proc/robocharge()
+/obj/item/gun/energy/kinetic_accelerator/robocharge()
 	return
 
 /obj/item/gun/energy/kinetic_accelerator/proc/reload()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds GPS coordinates under the status tab for cyborgs which have a GPS. Also fixes the mining cyborg's ability to fire their KA with no cooldown. 

Unfortunately I had to snowflake an `istype` check for KAs into the `robocharge()` proc . This proc is used when borgs fire energy weapons, and is used to subtract the appropriate power cost of the shot from their battery. This instantly recharges the borg's KA which can then be fired again immediately.

Since the KA is a subtype of energy weapon, and that proc needs to be where it is, I'm not sure if there is another fix for it. Open to any help/suggestions on this.

Fixes #12407
Closes #12384

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
For the first change: human miners carrying GPSs already have their GPS coordinates displayed under the status tab so I think its reasonable to give cyborg miners one as well. Second change is a bug fix.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Where the cyborg GPS text will be placed:

![GPS](https://user-images.githubusercontent.com/42044220/65653231-0d44fb80-dfda-11e9-8435-ead017381bcd.png)


## Changelog
:cl:
add: Added GPS coordinates under that status tab for cyborgs which have a GPS
fix: You can no longer fire mining cyborg's KA with no cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
