### PR TITLE
Diona nymphs can eat veggies

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -182,3 +182,11 @@
 		user.put_in_hands(T)
 		to_chat(user, "<span class='notice'>You open [src]\'s shell, revealing \a [T].</span>")
 	qdel(src)
+
+// Diona Nymphs can eat these as well as weeds to gain nutrition.
+/obj/item/reagent_containers/food/snacks/grown/attack_animal(mob/living/simple_animal/M)
+	if(istype(M, /mob/living/simple_animal/diona))
+		var/mob/living/simple_animal/diona/D = M
+		D.consume(src)
+	else
+		..()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -189,4 +189,4 @@
 		var/mob/living/simple_animal/diona/D = M
 		D.consume(src)
 	else
-		..()
+		return ..()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -185,7 +185,7 @@
 
 // Diona Nymphs can eat these as well as weeds to gain nutrition.
 /obj/item/reagent_containers/food/snacks/grown/attack_animal(mob/living/simple_animal/M)
-	if(istype(M, /mob/living/simple_animal/diona))
+	if(isnymph(M))
 		var/mob/living/simple_animal/diona/D = M
 		D.consume(src)
 	else

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -97,14 +97,14 @@
 		if(nutrition >= nutrition_need) // Prevents griefing by overeating plant items without evolving.
 			to_chat(src, "<span class='warning'>You're too full to consume this! Perhaps it's time to grow bigger...</span>")
 		else
-			if(do_after(src, 20, target = A))
+			if(do_after_once(src, 20, target = A))
 				visible_message("[src] ravenously consumes [A].")
-				playsound(src.loc, 'sound/misc/demon_consume.ogg', 30, 0, frequency = 1.5)
+				playsound(loc, 'sound/misc/demon_consume.ogg', 30, 0, frequency = 1.5)
 				var/obj/item/reagent_containers/I = A
 				if(I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter") < 1)
-					nutrition += 2
+					adjust_nutrition(2)
 				else
-					nutrition += (I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter"))*2
+					adjust_nutrition((I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter"))*2)
 				qdel(A)
 	else
 		..()

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -93,15 +93,15 @@
 	if(isdiona(A) && (src in A.contents)) //can't attack your gestalt
 		visible_message("[src] wiggles around a bit.")
 	// Nymphs can consume grown food as well as weeds.
-	else if (istype(A, /obj/item/reagent_containers/food/snacks/grown))
-		if (nutrition >= nutrition_need) // Prevents griefing by overeating plant items without evolving.
+	else if(istype(A, /obj/item/reagent_containers/food/snacks/grown))
+		if(nutrition >= nutrition_need) // Prevents griefing by overeating plant items without evolving.
 			to_chat(src, "<span class='warning'>You're too full to consume this! Perhaps it's time to grow bigger...</span>")
 		else
 			if(do_after(src, 20, target = A))
 				visible_message("[src] ravenously consumes [A].")
 				playsound(src.loc, 'sound/misc/demon_consume.ogg', 30, 0, frequency = 1.5)
 				var/obj/item/reagent_containers/I = A
-				if (I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter") < 1)
+				if(I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter") < 1)
 					nutrition += 2
 				else
 					nutrition += (I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter"))*2

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -92,20 +92,6 @@
 /mob/living/simple_animal/diona/UnarmedAttack(var/atom/A)
 	if(isdiona(A) && (src in A.contents)) //can't attack your gestalt
 		visible_message("[src] wiggles around a bit.")
-	// Nymphs can consume grown food as well as weeds.
-	else if(istype(A, /obj/item/reagent_containers/food/snacks/grown))
-		if(nutrition >= nutrition_need) // Prevents griefing by overeating plant items without evolving.
-			to_chat(src, "<span class='warning'>You're too full to consume this! Perhaps it's time to grow bigger...</span>")
-		else
-			if(do_after_once(src, 20, target = A))
-				visible_message("[src] ravenously consumes [A].")
-				playsound(loc, 'sound/misc/demon_consume.ogg', 30, 0, frequency = 1.5)
-				var/obj/item/reagent_containers/I = A
-				if(I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter") < 1)
-					adjust_nutrition(2)
-				else
-					adjust_nutrition((I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter"))*2)
-				qdel(A)
 	else
 		..()
 
@@ -215,6 +201,20 @@
 
 	qdel(src)
 	return TRUE
+
+// Consumes plant matter other than weeds to evolve
+/mob/living/simple_animal/diona/proc/consume(obj/item/reagent_containers/food/snacks/grown/G)
+	if(nutrition >= nutrition_need) // Prevents griefing by overeating plant items without evolving.
+		to_chat(src, "<span class='warning'>You're too full to consume this! Perhaps it's time to grow bigger...</span>")
+	else
+		if(do_after_once(src, 20, target = G))
+			visible_message("[src] ravenously consumes [G].", "You ravenously devour [G].")
+			playsound(loc, 'sound/misc/demon_consume.ogg', 30, 0, frequency = 2.0)
+			if(G.reagents.get_reagent_amount("nutriment")+G.reagents.get_reagent_amount("plantmatter") < 1)
+				adjust_nutrition(2)
+			else
+				adjust_nutrition((G.reagents.get_reagent_amount("nutriment")+G.reagents.get_reagent_amount("plantmatter"))*2)
+			qdel(G)
 
 /mob/living/simple_animal/diona/proc/steal_blood()
 	if(stat != CONSCIOUS)

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -209,11 +209,11 @@
 	else
 		if(do_after_once(src, 20, target = G))
 			visible_message("[src] ravenously consumes [G].", "You ravenously devour [G].")
-			playsound(loc, 'sound/misc/demon_consume.ogg', 30, 0, frequency = 2.0)
-			if(G.reagents.get_reagent_amount("nutriment")+G.reagents.get_reagent_amount("plantmatter") < 1)
+			playsound(loc, 'sound/items/eatfood.ogg', 30, 0, frequency = 1.5)
+			if(G.reagents.get_reagent_amount("nutriment") + G.reagents.get_reagent_amount("plantmatter") < 1)
 				adjust_nutrition(2)
 			else
-				adjust_nutrition((G.reagents.get_reagent_amount("nutriment")+G.reagents.get_reagent_amount("plantmatter"))*2)
+				adjust_nutrition((G.reagents.get_reagent_amount("nutriment") + G.reagents.get_reagent_amount("plantmatter")) * 2)
 			qdel(G)
 
 /mob/living/simple_animal/diona/proc/steal_blood()

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -92,6 +92,20 @@
 /mob/living/simple_animal/diona/UnarmedAttack(var/atom/A)
 	if(isdiona(A) && (src in A.contents)) //can't attack your gestalt
 		visible_message("[src] wiggles around a bit.")
+	// Nymphs can consume grown food as well as weeds.
+	else if (istype(A, /obj/item/reagent_containers/food/snacks/grown))
+		if (nutrition >= nutrition_need) // Prevents griefing by overeating plant items without evolving.
+			to_chat(src, "<span class='warning'>You're too full to consume this! Perhaps it's time to grow bigger...</span>")
+		else
+			if(do_after(src, 20, target = A))
+				visible_message("[src] ravenously consumes [A].")
+				playsound(src.loc, 'sound/misc/demon_consume.ogg', 30, 0, frequency = 1.5)
+				var/obj/item/reagent_containers/I = A
+				if (I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter") < 1)
+					nutrition += 2
+				else
+					nutrition += (I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter"))*2
+				qdel(A)
 	else
 		..()
 


### PR DESCRIPTION
## What Does This PR Do
Pretty much what it says in the title. Gives Diona nymphs the option of eating vegetables instead of uprooting weeds in order to grow. Gained nutrition is based on the plant matter and/or nutriment content. Nymphs can't eat more than they need to evolve to prevent griefing by overeating botany products.

## Why It's Good For The Game
Adds an option for Diona nymphs in case weeds are not readily available (usually due to overzealous Earthsblood usage).

## Changelog
:cl:
add: Diona nymphs can now consume veggies as well as weeds in order to gain nutrition and grow.
/:cl:
