### PR TITLE
Ghosts can spawn from diona nymph pods

### DIFF
--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -14,28 +14,28 @@
 
 // If the nymph pods are fully grown, allow ghosts that click on them to spawn as a nymph (decreases yield by 1 and kills the plant when yield reaches 0)
 /obj/item/seeds/nymph/GhostAttackWhenPlanted(mob/dead/observer/O, obj/machinery/hydroponics/T)
-	if (!T.harvest) 
+	if(!T.harvest) 
 		to_chat(O, "The Diona nymph pod is not yet ready.")
 		return
-	if (T.dead)
+	if(T.dead)
 		to_chat(O, "The Diona nymph pod is dead!")
 		return
-	if (!(O in GLOB.respawnable_list))
+	if(!(O in GLOB.respawnable_list))
 		to_chat(O, "You are not permitted to rejoin the round.")
 		return
-	else if (cannotPossess(O))
+	else if(cannotPossess(O))
 		to_chat(O, "You have enabled antag HUD and are unable to re-enter the round.")
 		return
 	var/nymph_ask = alert("Become a Diona Nymph? You will not be able to be cloned!", "Diona Nymph Pod", "Yes", "No")
-	if (nymph_ask == "No" || !src || QDELETED(src))
+	if(nymph_ask == "No" || !src || QDELETED(src))
 		return
-	if (!(T.myseed == null) && yield > 0 && !T.dead)
+	if(!(T.myseed == null) && yield > 0 && !T.dead)
 		yield -= 1
 		var/mob/living/simple_animal/diona/D = new /mob/living/simple_animal/diona(get_turf(T))
 		D.key = O.key
 		GLOB.respawnable_list -= O
 		visible_message(D, "A new diona nymph emerges from the pod, its antennae waving excitedly.")
-		if (yield <= 0)
+		if(yield <= 0)
 			visible_message("The seed pod withers away, now merely an empty husk.")
 			T.plantdies()
 		spawn(5)

--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -12,6 +12,38 @@
 	yield = 1
 	reagents_add = list("plantmatter" = 0.1)
 
+// If the nymph pods are fully grown, allow ghosts that click on them to spawn as a nymph (decreases yield by 1 and kills the plant when yield reaches 0)
+/obj/item/seeds/nymph/GhostAttackWhenPlanted(mob/dead/observer/O, obj/machinery/hydroponics/T)
+	if (!T.harvest) 
+		to_chat(O, "The Diona nymph pod is not yet ready.")
+		return
+	if (T.dead)
+		to_chat(O, "The Diona nymph pod is dead!")
+		return
+	if (!(O in GLOB.respawnable_list))
+		to_chat(O, "You are not permitted to rejoin the round.")
+		return
+	else if (cannotPossess(O))
+		to_chat(O, "You have enabled antag HUD and are unable to re-enter the round.")
+		return
+	var/nymph_ask = alert("Become a Diona Nymph? You will not be able to be cloned!", "Diona Nymph Pod", "Yes", "No")
+	if (nymph_ask == "No" || !src || QDELETED(src))
+		return
+	if (!(T.myseed == null) && yield > 0 && !T.dead)
+		yield -= 1
+		var/mob/living/simple_animal/diona/D = new /mob/living/simple_animal/diona(get_turf(T))
+		D.key = O.key
+		GLOB.respawnable_list -= O
+		visible_message(D, "A new diona nymph emerges from the pod, its antennae waving excitedly.")
+		if (yield <= 0)
+			visible_message("The seed pod withers away, now merely an empty husk.")
+			T.plantdies()
+		spawn(5)
+			GLOB.respawnable_list += usr
+	else
+		to_chat(O, "Seed: [T.myseed.name], Yield: [yield], Dead: [T.dead]")
+		to_chat(O, "The seed pod is no longer functional. It has probably been used up or destroyed in some way.")
+
 /obj/item/reagent_containers/food/snacks/grown/nymph_pod
 	seed = /obj/item/seeds/nymph
 	name = "nymph pod"

--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -15,10 +15,10 @@
 // If the nymph pods are fully grown, allow ghosts that click on them to spawn as a nymph (decreases yield by 1 and kills the plant when yield reaches 0)
 /obj/item/seeds/nymph/GhostAttackWhenPlanted(mob/dead/observer/O, obj/machinery/hydroponics/T)
 	if(!T.harvest) 
-		to_chat(O, "The Diona nymph pod is not yet ready.")
+		to_chat(O, "[src] is not yet ready.")
 		return
 	if(T.dead)
-		to_chat(O, "The Diona nymph pod is dead!")
+		to_chat(O, "[src] is dead!")
 		return
 	if(!(O in GLOB.respawnable_list))
 		to_chat(O, "You are not permitted to rejoin the round.")
@@ -29,7 +29,7 @@
 	var/nymph_ask = alert("Become a Diona Nymph? You will not be able to be cloned!", "Diona Nymph Pod", "Yes", "No")
 	if(nymph_ask == "No" || !src || QDELETED(src))
 		return
-	if(!(T.myseed == null) && yield > 0 && !T.dead)
+	if(T.myseed && yield > 0 && !T.dead)
 		yield -= 1
 		var/mob/living/simple_animal/diona/D = new /mob/living/simple_animal/diona(get_turf(T))
 		D.key = O.key
@@ -41,7 +41,6 @@
 		spawn(5)
 			GLOB.respawnable_list += usr
 	else
-		to_chat(O, "Seed: [T.myseed.name], Yield: [yield], Dead: [T.dead]")
 		to_chat(O, "The seed pod is no longer functional. It has probably been used up or destroyed in some way.")
 
 /obj/item/reagent_containers/food/snacks/grown/nymph_pod

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -272,10 +272,10 @@
 		return
 	return
 
-// GHOST INTERACTIONS
+// GHOST INTERACTIONS - passes on a ghost click to the growing seed if present.
 /obj/machinery/hydroponics/attack_ghost(mob/dead/observer/O)
 	if(myseed)
-		myseed.GhostAttackWhenPlanted(O, src)
+		myseed.attack_ghost(O)
 
 /obj/machinery/hydroponics/update_icon()
 	//Refreshes the icon and sets the luminosity
@@ -810,6 +810,7 @@
 			to_chat(user, "<span class='notice'>You plant [O].</span>")
 			dead = 0
 			myseed = O
+			myseed.planted_tray = src
 			age = 1
 			plant_health = myseed.endurance
 			plant_hud_set_health()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -275,7 +275,7 @@
 // GHOST INTERACTIONS - passes on a ghost click to the growing seed if present.
 /obj/machinery/hydroponics/attack_ghost(mob/dead/observer/O)
 	if(myseed)
-		myseed.attack_ghost(O)
+		myseed.attack_ghost(O, src)
 
 /obj/machinery/hydroponics/update_icon()
 	//Refreshes the icon and sets the luminosity
@@ -810,7 +810,7 @@
 			to_chat(user, "<span class='notice'>You plant [O].</span>")
 			dead = 0
 			myseed = O
-			myseed.planted_tray = src
+			myseed.planted = TRUE
 			age = 1
 			plant_health = myseed.endurance
 			plant_hud_set_health()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -274,7 +274,7 @@
 
 // GHOST INTERACTIONS
 /obj/machinery/hydroponics/attack_ghost(mob/dead/observer/O)
-	if(myseed != null)
+	if(myseed)
 		myseed.GhostAttackWhenPlanted(O, src)
 
 /obj/machinery/hydroponics/update_icon()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -272,6 +272,11 @@
 		return
 	return
 
+// GHOST INTERACTIONS
+/obj/machinery/hydroponics/attack_ghost(mob/dead/observer/O)
+	if(myseed != null)
+		myseed.GhostAttackWhenPlanted(O, src)
+
 /obj/machinery/hydroponics/update_icon()
 	//Refreshes the icon and sets the luminosity
 	overlays.Cut()
@@ -466,8 +471,8 @@
 	harvest = 0
 	adjustPests(-10) // Pests die
 	if(!dead)
-		update_icon()
 		dead = 1
+		update_icon()
 	plant_hud_set_health()
 	plant_hud_set_status()
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -34,7 +34,7 @@
 
 	var/weed_rate = 1 //If the chance below passes, then this many weeds sprout during growth
 	var/weed_chance = 5 //Percentage chance per tray update to grow weeds
-	var/obj/machinery/hydroponics/planted_tray // Null if it hasn't been planted, contains a ref to the growing tray if it has.
+	var/planted = FALSE // FALSE if it hasn't been planted, TRUE if it has.
 
 /obj/item/seeds/New(loc, nogenes = 0)
 	..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -109,7 +109,9 @@
 	if(prob(traitmut))
 		add_random_traits(1, 1)
 
-
+// How the seeds react when touched by a ghost if planted in a hydroponics tray. Usually does nothing.
+/obj/item/seeds/proc/GhostAttackWhenPlanted(mob/dead/observer/O, obj/machinery/hydroponics/T)
+	return
 
 /obj/item/seeds/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(istype(Proj, /obj/item/projectile/energy/florayield))

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -34,6 +34,7 @@
 
 	var/weed_rate = 1 //If the chance below passes, then this many weeds sprout during growth
 	var/weed_chance = 5 //Percentage chance per tray update to grow weeds
+	var/obj/machinery/hydroponics/planted_tray // Null if it hasn't been planted, contains a ref to the growing tray if it has.
 
 /obj/item/seeds/New(loc, nogenes = 0)
 	..()
@@ -108,10 +109,6 @@
 	adjust_weed_chance(rand(-wcmut, wcmut))
 	if(prob(traitmut))
 		add_random_traits(1, 1)
-
-// How the seeds react when touched by a ghost if planted in a hydroponics tray. Usually does nothing.
-/obj/item/seeds/proc/GhostAttackWhenPlanted(mob/dead/observer/O, obj/machinery/hydroponics/T)
-	return
 
 /obj/item/seeds/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(istype(Proj, /obj/item/projectile/energy/florayield))


### PR DESCRIPTION
## What Does This PR Do
Allows ghosts to spawn as diona nymphs from harvestable diona nymph pods by clicking on them. Doing so reduces the yield of the plant and will eventually kill it.

## Why It's Good For The Game
Slightly improves the spawning conditions of the diona nymph, which when combined with [this PR](https://github.com/ParadiseSS13/Paradise/pull/12423) should make it a little easier to get started, assuming hydroponics actually grows the things (*scream).

## Changelog
:cl:
add: Ghosts can now spawn as diona nymphs from nymph plants that are ready to harvest.
/:cl: