### PR TITLE
Camera bug now lists cameras in alphabetical order

### DIFF
--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -78,10 +78,8 @@
 				continue
 			if(length(list("SS13","MINE")&camera.network))
 				bugged_cameras[camera.c_tag] = camera
-	sortList(bugged_cameras)
+	sortTim(bugged_cameras, /proc/cmp_text_asc)
 	return bugged_cameras
-
-
 
 /obj/item/camera_bug/proc/menu(var/list/cameras)
 	if(!cameras || !cameras.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The camera bug currently lists all the cameras on the station in a nonsensical order to the user, making it difficult to spy, monitor or disable specific cameras useful to traitors. This PR makes it display in alphabetical order instead which should make the item easier to use.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the item less frustrating for traitors to use.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The camera bug now lists all cameras in alphabetical order.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
