### PR TITLE
Allows for robotic hands, feet, and groin to undergo customization surgery.

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -545,7 +545,7 @@
 /datum/surgery/cybernetic_customization
 	name = "Cybernetic Appearance Customization"
 	steps = list(/datum/surgery_step/robotics/external/unscrew_hatch, /datum/surgery_step/robotics/external/customize_appearance)
-	possible_locs = list("head", "chest", "l_arm", "r_arm", "r_leg", "l_leg")
+	possible_locs = list("head", "chest", "l_arm", "l_hand", "r_arm", "r_hand", "r_leg", "r_foot", "l_leg", "l_foot", "groin")
 	requires_organic_bodypart = FALSE
 
 /datum/surgery/cybernetic_customization/can_start(mob/user, mob/living/carbon/human/target)


### PR DESCRIPTION
## What Does This PR Do
This PR allows Robotic Limb customization on hands, feet, and the groin. Fixes #10997.

## Why It's Good For The Game
These parts have unique models, but can only be change in character creation for IPCs or just before attaching a robotic limb. It's good to have these customizable through the means you would expect, the customization surgery.

## Changelog
:cl:
fix: Allows for robotic hands, feet, and groin to undergo customization surgery.
/:cl:
