### PR TITLE
Issue #12408 - Fixes drones requiring all-access to reboot.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -13,7 +13,8 @@
 	braintype = "Robot"
 	lawupdate = 0
 	density = 0
-	req_access = list(access_engine, access_robotics)
+	req_access = null
+	req_one_access = list(access_engine, access_robotics)
 	ventcrawler = 2
 	magpulse = 1
 	mob_size = MOB_SIZE_SMALL

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -13,7 +13,6 @@
 	braintype = "Robot"
 	lawupdate = 0
 	density = 0
-	req_access = null
 	req_one_access = list(access_engine, access_robotics)
 	ventcrawler = 2
 	magpulse = 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -65,8 +65,8 @@ var/list/robot_verbs_default = list(
 
 	var/wiresexposed = 0
 	var/locked = 1
-	var/list/req_one_access = null
-	var/list/req_access = list(access_robotics)
+	var/list/req_one_access = list(access_robotics)
+	var/list/req_access
 	var/ident = 0
 	//var/list/laws = list()
 	var/alarms = list("Motion"=list(), "Fire"=list(), "Atmosphere"=list(), "Power"=list(), "Camera"=list())
@@ -1304,7 +1304,7 @@ var/list/robot_verbs_default = list(
 	designation = "SpecOps"
 	lawupdate = 0
 	scrambledcodes = 1
-	req_access = list(access_cent_specops)
+	req_one_access = list(access_cent_specops)
 	ionpulse = 1
 	magpulse = 1
 	pdahide = 1
@@ -1354,7 +1354,7 @@ var/list/robot_verbs_default = list(
 	designation = "ERT"
 	lawupdate = 0
 	scrambledcodes = 1
-	req_access = list(access_cent_specops)
+	req_one_access = list(access_cent_specops)
 	ionpulse = 1
 
 	force_modules = list("Engineering", "Medical", "Security")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -65,6 +65,7 @@ var/list/robot_verbs_default = list(
 
 	var/wiresexposed = 0
 	var/locked = 1
+	var/list/req_one_access = null
 	var/list/req_access = list(access_robotics)
 	var/ident = 0
 	//var/list/laws = list()
@@ -891,6 +892,7 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/proc/allowed(obj/item/I)
 	var/obj/dummy = new /obj(null) // Create a dummy object to check access on as to avoid having to snowflake check_access on every mob
 	dummy.req_access = req_access
+	dummy.req_one_access = req_one_access
 
 	if(dummy.check_access(I))
 		qdel(dummy)


### PR DESCRIPTION
## What Does This PR Do
Fix Issue #12408 by adding req_one_access to robot access checks.

## Why It's Good For The Game
You can reboot drones without bothering the captain now.

## Changelog
:cl:
fix: Rebooting a drone no longer requires both engineering and robotics access.
/:cl: