### PR TITLE
Issue #12420 - Guardian snapback null-space glitch fix

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -73,7 +73,8 @@
 		qdel()
 
 /mob/living/simple_animal/hostile/guardian/proc/snapback()
-	if(summoner)
+	// If the summoner dies instantly, the summoner's ghost may be drawn into null space as the protector is deleted. This check should prevent that.
+	if(summoner && loc && summoner.loc)
 		if(get_dist(get_turf(summoner),get_turf(src)) <= range)
 			return
 		else

--- a/code/game/gamemodes/miniantags/guardian/types/protector.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/protector.dm
@@ -41,7 +41,8 @@
 		toggle = TRUE
 
 /mob/living/simple_animal/hostile/guardian/protector/snapback() //snap to what? snap to the guardian!
-	if(summoner)
+	// If the summoner dies instantly, the summoner's ghost may be drawn into null space as the protector is deleted. This check should prevent that.
+	if(summoner && loc && summoner.loc)
 		if(get_dist(get_turf(summoner),get_turf(src)) <= range)
 			return
 		else


### PR DESCRIPTION
## What Does This PR Do
Fixes #12420 by ensuring that neither the guardian nor the summoner's location is null before doing the snapback.

## Changelog
:cl:
fix: fixed a rare glitch in which a guardian that is killed instantly (i.e by a wand of death) may draw its charge into null space.
/:cl: