### PR TITLE
Issue #12331 - Stops bluespace anomaly from teleporting ghosts.

### DIFF
--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -45,9 +45,7 @@
 				for(var/atom/movable/A in range(12, FROM )) // iterate thru list of mobs in the area
 					if(istype(A, /obj/item/radio/beacon)) // don't teleport beacons because that's just insanely stupid
 						continue 
-					if(isobserver(A)) // don't teleport ghosts.
-						continue
-					if(A.anchored) 
+					if(A.anchored || A.move_resist == INFINITY)
 						continue
 					var/turf/newloc = locate(A.x + x_distance, A.y + y_distance, TO.z) // calculate the new place
 					if(!A.Move(newloc)) // if the atom, for some reason, can't move, FORCE them to move! :) We try Move() first to invoke any movement-related checks the atom needs to perform after moving

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -45,7 +45,7 @@
 				for(var/atom/movable/A in range(12, FROM )) // iterate thru list of mobs in the area
 					if(istype(A, /obj/item/radio/beacon)) // don't teleport beacons because that's just insanely stupid
 						continue 
-					if(istype(A, /mob/dead/observer)) // don't teleport ghosts.
+					if(isobserver(A)) // don't teleport ghosts.
 						continue
 					if(A.anchored) 
 						continue

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -43,9 +43,12 @@
 				var/y_distance = TO.y - FROM.y
 				var/x_distance = TO.x - FROM.x
 				for(var/atom/movable/A in range(12, FROM )) // iterate thru list of mobs in the area
-					if(istype(A, /obj/item/radio/beacon)) continue // don't teleport beacons because that's just insanely stupid
-					if(A.anchored) continue
-
+					if(istype(A, /obj/item/radio/beacon)) // don't teleport beacons because that's just insanely stupid
+						continue 
+					if(istype(A, /mob/dead/observer)) // don't teleport ghosts.
+						continue
+					if(A.anchored) 
+						continue
 					var/turf/newloc = locate(A.x + x_distance, A.y + y_distance, TO.z) // calculate the new place
 					if(!A.Move(newloc)) // if the atom, for some reason, can't move, FORCE them to move! :) We try Move() first to invoke any movement-related checks the atom needs to perform after moving
 						A.loc = locate(A.x + x_distance, A.y + y_distance, TO.z)


### PR DESCRIPTION
## What Does This PR Do
Couldn't reproduce #12331. Stopped the bluespace anomaly from teleporting ghosts anyway just in case.

## Why It's Good For The Game
Ghosts shouldn't be affected by most ingame events, and I'm pretty sure this was unintended.

## Changelog
:cl:
tweak: bluespace anomalies no longer teleport ghosts when their event fires.
/:cl: