### PR TITLE
fixes roundstart autotraitors

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -45,12 +45,12 @@
 
 	for(var/i = 0, i < num_traitors, i++)
 		var/datum/mind/traitor = pick(possible_traitors)
-		traitors += traitor
+		pre_traitors += traitor
 		possible_traitors.Remove(traitor)
 
-	for(var/datum/mind/traitor in traitors)
+	for(var/datum/mind/traitor in pre_traitors)
 		if(!traitor || !istype(traitor))
-			traitors.Remove(traitor)
+			pre_traitors.Remove(traitor)
 			continue
 		if(istype(traitor))
 			traitor.special_role = SPECIAL_ROLE_TRAITOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes roundstart traitors in the autotraitor gamemode not getting objectives or uplink codes. I'm using the same fix that I used for normal traitors in the datumize traitors PR which is using `pre_traitors` instead of `traitors` during the pre_setup phase of the gamemode. Anyway, yes I tested this in my own server and yes, it works.

Fixes  #12434

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes things work properly, saves admins from having to do more busy work of manually giving things to antags they should have automatically.


## Changelog
:cl:
fix: Fixes round-start autotraitors not getting their objectives and uplink codes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
