### PR TITLE
Fixes too many items in the conscription kit

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1422,7 +1422,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	name = "Shaft Miner Starter Kit"
 	cost = 30
 	access = access_qm
-	contains = list(/obj/item/storage/backpack/duffel/mining_conscript/noid)
+	contains = list(/obj/item/storage/backpack/duffel/mining_conscript)
 	containertype = /obj/structure/closet/crate/secure
 	containername = "shaft miner starter kit"
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -359,11 +359,11 @@
 	new /obj/item/ammo_box/magazine/m12g/buckshot(src)
 	new /obj/item/ammo_box/magazine/m12g/dragon(src)
 
-/obj/item/storage/backpack/duffel/mining_conscript/noid
+/obj/item/storage/backpack/duffel/mining_conscript/
 	name = "mining conscription kit"
 	desc = "A kit containing everything a crewmember needs to support a shaft miner in the field."
 
-/obj/item/storage/backpack/duffel/mining_conscript/noid/New()
+/obj/item/storage/backpack/duffel/mining_conscript/New()
 	..()
 	new /obj/item/pickaxe(src)
 	new /obj/item/clothing/glasses/meson(src)
@@ -371,7 +371,7 @@
 	new /obj/item/storage/bag/ore(src)
 	new /obj/item/clothing/under/rank/miner/lavaland(src)
 	new /obj/item/encryptionkey/headset_cargo(src)
-	new /obj/item/clothing/mask/gas(src)
+	new /obj/item/clothing/mask/gas/explorer(src)
 
 
 /obj/item/storage/backpack/duffel/syndie/ammo/smg

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -36,7 +36,7 @@
 		new /datum/data/mining_equipment("Fulton Pack",					/obj/item/extraction_pack,											1000),
 		new /datum/data/mining_equipment("Lazarus Injector",			/obj/item/lazarus_injector,											1000),
 		new /datum/data/mining_equipment("Silver Pickaxe",				/obj/item/pickaxe/silver,											1000),
-		new /datum/data/mining_equipment("Mining Conscription Kit",		/obj/item/storage/backpack/duffel/mining_conscript,					1500),
+		new /datum/data/mining_equipment("Mining Conscription Kit",		/obj/item/storage/backpack/duffel/mining_conscript/full,					1500),
 		new /datum/data/mining_equipment("Jetpack Upgrade",				/obj/item/tank/jetpack/suit,										2000),
 		new /datum/data/mining_equipment("Mining Hardsuit",				/obj/item/clothing/suit/space/hardsuit/mining,						2000),
 		new /datum/data/mining_equipment("Diamond Pickaxe",				/obj/item/pickaxe/diamond,											2000),
@@ -235,7 +235,7 @@
 			new /obj/item/extinguisher/mini(drop_location)
 			new /obj/item/twohanded/kinetic_crusher(drop_location)
 		if("Mining Conscription Kit")
-			new /obj/item/storage/backpack/duffel/mining_conscript(drop_location)
+			new /obj/item/storage/backpack/duffel/mining_conscript/full(drop_location)
 
 	qdel(voucher)
 
@@ -293,18 +293,13 @@
 		to_chat(user, "You upgrade [I] with mining access.")
 		qdel(src)
 
-/obj/item/storage/backpack/duffel/mining_conscript
+/obj/item/storage/backpack/duffel/mining_conscript/full
 	name = "mining conscription kit"
 	desc = "A kit containing everything a crewmember needs to support a shaft miner in the field."
 
-/obj/item/storage/backpack/duffel/mining_conscript/New()
+/obj/item/storage/backpack/duffel/mining_conscript/full/New()
 	..()
-	new /obj/item/clothing/glasses/meson(src)
-	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
-	new /obj/item/storage/bag/ore(src)
 	new /obj/item/clothing/suit/hooded/explorer(src)
-	new /obj/item/encryptionkey/headset_cargo(src)
-	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/card/id/mining_access_card(src)
 	new /obj/item/gun/energy/kinetic_accelerator(src)
 	new /obj/item/kitchen/knife/combat/survival(src)


### PR DESCRIPTION
Slight refactor to the conscription kit, so the full kit miners can get for points or the voucher is a subtype of the smaller one cargo can order, instead of the other way around, which caused the cargo one to actually have more stuff than the full one. Side effects are that the cargo one now uses the explorer mask, and the full one having a pickaxe and jumpsuit.
:cl:
fix:The mining conscription kit that can be ordered now has only the items that are intended.
tweak:The cargo conscription kit now has the explorer gas mask instead of a normal one
add:The conscription kit miner can get now have a pickaxe and mining jumpsuit
/:cl: