### PR TITLE
remove encased var from unbreakable limbs

### DIFF
--- a/code/modules/surgery/organs/subtypes/unbreakable.dm
+++ b/code/modules/surgery/organs/subtypes/unbreakable.dm
@@ -1,5 +1,6 @@
 /obj/item/organ/external/chest/unbreakable
 	cannot_break = TRUE
+	encased = null
 
 /obj/item/organ/external/groin/unbreakable
 	cannot_break = TRUE
@@ -30,6 +31,7 @@
 
 /obj/item/organ/external/head/unbreakable
 	cannot_break = TRUE
+	encased = null
 
 // Cannot dismember or break
 /obj/item/organ/external/chest/unbreakable/sturdy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
unbreakable limbs had ribs and a skull defined which means you had to saw through them during surgery even though this limbs couldn't break, this PR changes it so these limbs are no longer encased and you can do the boneless surgery on them(without the saw bone step)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Its better for immersion and allows for that variety that everyone loves so much

## Changelog
:cl:
tweak: species without bones no longer have ribs or a skull either
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
