### PR TITLE
fix slime heart going invisible

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -3,6 +3,7 @@
 	desc = "A nausea-inducing hunk of twisting flesh and metal."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gland"
+	dead_icon = null
 	status = ORGAN_ROBOT
 	origin_tech = "materials=4;biotech=7;abductor=3"
 	beating = TRUE
@@ -17,6 +18,9 @@
 	var/mind_control_uses = 1
 	var/mind_control_duration = 1800
 	var/active_mind_control = FALSE
+
+/obj/item/organ/internal/heart/gland/update_icon()
+	return
 
 /obj/item/organ/internal/heart/gland/proc/ownerCheck()
 	if(ishuman(owner))

--- a/code/modules/surgery/organs/subtypes/slime.dm
+++ b/code/modules/surgery/organs/subtypes/slime.dm
@@ -3,6 +3,10 @@
 	name = "osmotic pressure regulator"
 	icon_state = "heart"
 	desc = "It appears to be some kind of biological pump that uses osmotic pressure to regulate water flow. It seems to work similar to a heart."
+	dead_icon = null
+
+/obj/item/organ/internal/heart/slime/update_icon()
+	return
 
 /obj/item/organ/internal/lungs/slime
 	icon = 'icons/obj/species_organs/slime.dmi'    


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
update_icon proc on the heart was making its icon go invisible, overriding the proc for slime heart fixes this. This was also an issue for abductor fleshy masses, they also went invisible after being bitten or necrotizing due to having the dead_icon being defined as [icon]-off which fleshy masses and slime hearts both don't have

fixes: #10918
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
being able to see organs is always nice.

## Changelog
:cl:
fix: slime heart and fleshy masses no longer go invisible after being removed through surgery or being eaten or necrotizing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
