### PR TITLE
Reduces slime damage mod to 150% from 250%.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -20,7 +20,7 @@
 	cold_level_3 = 200
 	coldmod = 3
 
-	brain_mod = 2.5
+	brain_mod = 1.5
 
 	male_cough_sounds = list('sound/effects/slime_squish.ogg')
 	female_cough_sounds = list('sound/effects/slime_squish.ogg')


### PR DESCRIPTION
## What Does This PR Do
Reduces Slime Person brain damage mod to 150% from 250%.

## Why It's Good For The Game
Now that slimes use newcrit, they die ridiculously fast due to the oversized brain damage mod, which in turn makes it harder to defibrillate them in time. Since they have fewer organs, the important ones turn septic much faster making them harder to revive after death. This should hopefully give them a fighting chance while maintaining some of their previous flavour and vulnerability.

## Changelog
:cl:
balance: Slime brain damage multiplier reduced to 150% from 250%.
/:cl:
