### PR TITLE
Issue #10614 - Changeling Revive Baldness Fix

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -57,6 +57,7 @@
 	user.update_blind_effects()
 	user.update_blurry_effects()
 	user.mind.changeling.regenerating = FALSE
+	user.UpdateAppearance() //Ensures that the user's appearance matches their DNA.
 
 	to_chat(user, "<span class='notice'>We have regenerated.</span>")
 


### PR DESCRIPTION
## What Does This PR Do
Issue #10614 Fix: Added UpdateAppearance() to changeling revive in order to prevent rapid-onset alopecia totalis.

## Why It's Good For The Game
Changelings going bald when reviving seems a little silly.

## Changelog
:cl:
fix: changelings no longer go bald after reviving.
/:cl:
