### PR TITLE
blacklists hellhounds from the xeno spawn pool

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hellhound.dm
@@ -8,7 +8,6 @@
 	icon_dead = "hellhound_dead"
 	icon_resting = "hellhound_rest"
 	mutations = list(BREATHLESS)
-	gold_core_spawnable = NO_SPAWN
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
@@ -126,4 +125,3 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	environment_smash = 2
-	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/hostile/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hellhound.dm
@@ -8,7 +8,7 @@
 	icon_dead = "hellhound_dead"
 	icon_resting = "hellhound_rest"
 	mutations = list(BREATHLESS)
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY


### PR DESCRIPTION
There are a lot of cool mobs in xenobiology and i'm always reluctant to remove anything from their spawn pool, since half the fun of being a xenobiologist is breeding cool mobs and sending them out to be friends or whatever, but hellhounds are kind of absurdly strong.

Aside from their hefty health, speed, and damage, they also come with a brutal AoE smoke attack that knocks out anyone who inhales it.  There's a reason that attack is otherwise left to certain end-game cult mobs-it's just not really fair.

I mean, yes, sure, it's counterable, just wear internals. But if you happen to not have internals on because, for whatever reason, you aren't expecting a hellhound attack and then suddenly get blitzed by one, you're dead. So unless we're encouraging people to have internals on at all times (which feels kind of iffy to me) then the 30-damage 250 health murder dog that knocks you out instantly doesn't feel like something the xenobiologist should have access to in line with the rest of their abilities. 

## Changelog
:cl:
del: Xenobiology can no longer produce hellhounds with gold slime cores.
/:cl:
