### PR TITLE
Issue #5066 - Abductor silencer now properly silences radios temporarily.

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -268,8 +268,9 @@
 	for(var/obj/I in all_items)
 		if(istype(I, /obj/item/radio))
 			var/obj/item/radio/r = I
+			I.emp_act(1)
 			r.listening = 0
-			if(!istype(I, /obj/item/radio/headset))
+			if(istype(I, /obj/item/radio/headset))
 				r.broadcasting = 0 //goddamned headset hacks
 
 /obj/item/abductor/mind_device

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -267,11 +267,9 @@
 
 	for(var/obj/I in all_items)
 		if(istype(I, /obj/item/radio))
-			var/obj/item/radio/r = I
-			I.emp_act(1)
-			r.listening = 0
-			if(istype(I, /obj/item/radio/headset))
-				r.broadcasting = 0 //goddamned headset hacks
+			var/obj/item/radio/R = I
+			R.listening = 0 // Prevents the radio from buzzing due to the EMP, preserving possible stealthiness.
+			R.emp_act(1)
 
 /obj/item/abductor/mind_device
 	name = "mental interface device"


### PR DESCRIPTION
## What Does This PR Do
Fixes #5066 - The silencer now does an emp_act on all the target's radios as well as turning broadcasting off, knocking them out for 10-20 seconds.

## Why It's Good For The Game
The silencer doesn't seem to have ever worked. Now it does.

## Changelog
:cl:
fix: The abductor's silencer now actually silences radios for 10-20 seconds.
/:cl:
