### PR TITLE
Issue #12223 Ripley Ore Pickup Fix

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -82,7 +82,7 @@
 	drill.move_ores()
 
 /obj/item/mecha_parts/mecha_equipment/drill/proc/move_ores()
-	if(locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in chassis.equipment && istype(chassis, /obj/mecha/working/ripley))
+	if((locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in chassis.equipment) && istype(chassis, /obj/mecha/working/ripley))
 		var/obj/mecha/working/ripley/R = chassis //we could assume that it's a ripley because it has a clamp, but that's ~unsafe~ and ~bad practice~
 		R.collect_ore()
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #12223: the collect_ore() event now correctly fires when drilling, causing the Ripley to pick up all its trash.

## Changelog
:cl:
fix: The Ripley now collects all the ore it unearths after drilling. 
/:cl: