### PR TITLE
[needs review]Refactors cmd_admin_pm and adds autotake to adminhelps

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -157,7 +157,7 @@
 
 
 	var/emoji_msg = "<span class='emoji_enabled'>[msg]</span>"
-	recieve_message = "<span class='[recieve_span]'>[type] from-<b>[recieve_pm_type][ranked ? key_name(src, TRUE, type) : key_name_hidden(src, TRUE, type)]</b>: [emoji_msg]</span>"
+	recieve_message = "<span class='[recieve_span]'>[type] from-<b>[recieve_pm_type][C.holder ? key_name(src, TRUE, type) : key_name_hidden(src, TRUE, type)]</b>: [emoji_msg]</span>"
 	to_chat(C, recieve_message)
 	var/ping_link = check_rights(R_ADMIN, 0, mob) ? "(<a href='?src=[pm_tracker.UID()];ping=[C.key]'>PING</a>)" : ""
 	var/window_link = "(<a href='?src=[pm_tracker.UID()];newtitle=[C.key]'>WINDOW</a>)"


### PR DESCRIPTION
What Does This PR Do
Refactors cmd_admin_pm proc and adds an autotake and confirmation for admins to avoid duplicate PMing people

Fixes: #12454

## Images of changes

![](https://i.imgur.com/thX1Zr8.png)

after removing permissions from both accounts:
![](https://i.imgur.com/OCxtvov.png)


:cl:
tweak: Refactor'd cmd_admin_pm proc, aka admin PM code.
add: Autotake and double PM check for admins in case another admin has already responded to the player.
/ 🆑 