### PR TITLE
Fixes spelling error in doppler array

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -143,7 +143,7 @@ var/list/doppler_arrays = list()
 
 	var/list/messages = list("Explosive disturbance detected.", \
 							 "Epicenter at: grid ([x0],[y0]). Temporal displacement of tachyons: [took] seconds.", \
-							 "Factual: Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range].")
+							 "Actual: Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range].")
 
 	// If the bomb was capped, say its theoretical size.
 	if(devastation_range < orig_dev_range || heavy_impact_range < orig_heavy_range || light_impact_range < orig_light_range)


### PR DESCRIPTION
Changes "factual" to "actual" in the doppler array explosion detector system


:cl:
spellcheck: "Factual" changed to Actual in the explosion doppler array detector system
/ 🆑 