### PR TITLE
Fixes double cult summon objectives

### DIFF
--- a/code/game/gamemodes/cult/cult_objectives.dm
+++ b/code/game/gamemodes/cult/cult_objectives.dm
@@ -66,7 +66,7 @@
 	if(!sacrificed.len && (new_objective != "sacrifice"))
 		sacrifice_target = null
 
-	if(new_objective == "eldergod")
+	if(new_objective == "eldergod" || new_objective == "slaughter")
 		second_phase()
 		return
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes cultists having both the "summon your  god" and "bring the slaughter" objectives at the same time, making them unable to greentext.

The problem was here:
```js
if(new_objective == "eldergod")
	second_phase()
	return
else
	objectives += new_objective
```
If the first choice for `new_objective` was "slaughter", the game would not have triggered the `second_phase()` proc. Which means this code would have been executed again and the cult ends up with a "bring the slaughter" and "summon your god" objective. Tested this for about 10 or so rounds by advancing to the final objective stage, and it properly gave me only 1 of these objectives.

Fixes  #12453

## Changelog
:cl:
fix: Cultists will no longer get multiple summoning objectives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
