### PR TITLE
Allows robotic limbs to be healed by pylons

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -212,7 +212,7 @@ var/list/blacklisted_pylon_turfs = typecacheof(list(
 				if(L.health != L.maxHealth)
 					new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
 					if(ishuman(L))
-						L.heal_overall_damage(1, 1)
+						L.heal_overall_damage(1, 1, TRUE, 0, 1)
 					if(istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
 						var/mob/living/simple_animal/M = L
 						if(M.health < M.maxHealth)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -212,7 +212,7 @@ var/list/blacklisted_pylon_turfs = typecacheof(list(
 				if(L.health != L.maxHealth)
 					new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
 					if(ishuman(L))
-						L.heal_overall_damage(1, 1, TRUE, 0, 1)
+						L.heal_overall_damage(1, 1, TRUE, FALSE, TRUE)
 					if(istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
 						var/mob/living/simple_animal/M = L
 						if(M.health < M.maxHealth)


### PR DESCRIPTION
## What Does This PR Do
This PR allows pylons to heal robotic limbs the same as they heal organic limbs and cult constructs.

## Why It's Good For The Game
Cultists take a lot of chip damage from using runes and talismans, so this change would largely be a convenience for robot limbed cultist, one their organic limbed friends already have . Having robotic limbs already puts a cultist at a major disadvantage, such as having unholy water being unable to heal those limbs, and restricting you and your nearby allies from freely using EMP runes and talismans, lest you die from it.

Considering pylons heal through some sort of 'magic' and even heal metal based constructs, I see it as perfectly reasonable for pylons to heal robotic limbs as well.

## Changelog
:cl:
tweak: Pylons heal robotic limbs.
/:cl: