### PR TITLE
Give Heads of Staff Single-Use Autoimplanters instead of raw implants.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -42,4 +42,4 @@
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/clothing/head/soft(src)
 	new /obj/item/door_remote/quartermaster(src)
-	new /obj/item/autoimplanter/meson(src)
+	new /obj/item/autoimplanter/head/meson(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -42,4 +42,4 @@
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/clothing/head/soft(src)
 	new /obj/item/door_remote/quartermaster(src)
-	new /obj/item/organ/internal/cyberimp/eyes/meson(src)
+	new /obj/item/autoimplanter/meson(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -38,7 +38,7 @@
 	new /obj/item/door_remote/chief_engineer(src)
 	new /obj/item/rpd(src)
 	new /obj/item/reagent_containers/food/drinks/mug/ce(src)
-	new /obj/item/organ/internal/cyberimp/eyes/meson(src)
+	new /obj/item/autoimplanter/meson(src)
 	new /obj/item/clothing/accessory/medal/engineering(src)
 	new /obj/item/holosign_creator/atmos(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -38,7 +38,7 @@
 	new /obj/item/door_remote/chief_engineer(src)
 	new /obj/item/rpd(src)
 	new /obj/item/reagent_containers/food/drinks/mug/ce(src)
-	new /obj/item/autoimplanter/meson(src)
+	new /obj/item/autoimplanter/head/meson(src)
 	new /obj/item/clothing/accessory/medal/engineering(src)
 	new /obj/item/holosign_creator/atmos(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -191,7 +191,7 @@
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/flash(src)
 	new /obj/item/reagent_containers/hypospray/CMO(src)
-	new /obj/item/organ/internal/cyberimp/eyes/hud/medical(src)
+	new /obj/item/autoimplanter/cmo(src)
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/reagent_containers/food/drinks/mug/cmo(src)
 	new /obj/item/clothing/accessory/medal/medical(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -191,7 +191,7 @@
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/flash(src)
 	new /obj/item/reagent_containers/hypospray/CMO(src)
-	new /obj/item/autoimplanter/cmo(src)
+	new /obj/item/autoimplanter/head/cmo(src)
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/reagent_containers/food/drinks/mug/cmo(src)
 	new /obj/item/clothing/accessory/medal/medical(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -76,7 +76,7 @@
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/reagent_containers/food/drinks/mug/rd(src)
-	new /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic(src)
+	new /obj/item/autoimplanter/rd(src)
 	new /obj/item/clothing/accessory/medal/science(src)
 
 /obj/structure/closet/secure_closet/research_reagents

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -76,7 +76,7 @@
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/reagent_containers/food/drinks/mug/rd(src)
-	new /obj/item/autoimplanter/rd(src)
+	new /obj/item/autoimplanter/head/rd(src)
 	new /obj/item/clothing/accessory/medal/science(src)
 
 /obj/structure/closet/secure_closet/research_reagents

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -32,6 +32,7 @@
 	new /obj/item/storage/belt/rapier(src)
 	new /obj/item/gun/energy/gun(src)
 	new /obj/item/door_remote/captain(src)
+	new /obj/item/autoimplanter/hos(src)
 	new /obj/item/reagent_containers/food/drinks/mug/cap(src)
 	new /obj/item/tank/emergency_oxygen/double(src)
 
@@ -127,7 +128,7 @@
 	new /obj/item/gun/energy/gun/hos(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/reagent_containers/food/drinks/mug/hos(src)
-	new /obj/item/organ/internal/cyberimp/eyes/hud/security(src)
+	new /obj/item/autoimplanter/hos(src)
 	new /obj/item/clothing/accessory/medal/security(src)
 
 /obj/structure/closet/secure_closet/warden

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -32,7 +32,7 @@
 	new /obj/item/storage/belt/rapier(src)
 	new /obj/item/gun/energy/gun(src)
 	new /obj/item/door_remote/captain(src)
-	new /obj/item/autoimplanter/hos(src)
+	new /obj/item/autoimplanter/head/hos(src)
 	new /obj/item/reagent_containers/food/drinks/mug/cap(src)
 	new /obj/item/tank/emergency_oxygen/double(src)
 
@@ -128,7 +128,7 @@
 	new /obj/item/gun/energy/gun/hos(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/reagent_containers/food/drinks/mug/hos(src)
-	new /obj/item/autoimplanter/hos(src)
+	new /obj/item/autoimplanter/head/hos(src)
 	new /obj/item/clothing/accessory/medal/security(src)
 
 /obj/structure/closet/secure_closet/warden

--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -6,14 +6,19 @@
 	item_state = "walkietalkie"//left as this so as to intentionally not have inhands
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/weapons/circsawhit.ogg'
+	var/uses = -1  // -1 is infinite as far as we care
 	var/obj/item/organ/internal/cyberimp/storedorgan
 
 /obj/item/autoimplanter/attack_self(mob/user)//when the object it used...
+	if(uses == 0) // uses check before stored check here because a single use implanter probably wont have an implant in it after its been used up.
+		to_chat(user, "<span class='notice'>[src] appears to be permanently jammed.</span>")
+		return
 	if(!storedorgan)
 		to_chat(user, "<span class='notice'>[src] currently has no implant stored.</span>")
 		return
 	storedorgan.insert(user)//insert stored organ into the user
 	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
+	uses = uses > 0 ? uses-1 : uses
 	playsound(get_turf(user), usesound, 50, 1)
 	storedorgan = null
 
@@ -21,6 +26,9 @@
 	if(istype(I, /obj/item/organ/internal/cyberimp))
 		if(storedorgan)
 			to_chat(user, "<span class='notice'>[src] already has an implant stored.</span>")
+			return
+		if(uses == 0)
+			to_chat(user, "<span class='notice'>[src] appears to be permanently jammed.</span>")
 			return
 		if(!user.drop_item())
 			return
@@ -34,4 +42,32 @@
 			storedorgan.forceMove(get_turf(user))
 			storedorgan = null
 			to_chat(user, "<span class='notice'>You remove the [storedorgan] from [src].</span>")
+			if(uses > 0)
+				uses = uses - 1
+			if(!uses)
+				desc = "[initial(desc)] Looks like it's been used up."
 			playsound(get_turf(user), I.usesound, 50, 1)
+
+/obj/item/autoimplanter/cmo
+	name = "Medical HUD autoimplanter"
+	desc = "A single use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1 //only one time use!
+	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/hud/medical()
+
+/obj/item/autoimplanter/hos
+	name = "Security HUD autoimplanter"
+	desc = "A single use autosurgeon that contains a security heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1 
+	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/hud/security()
+
+/obj/item/autoimplanter/rd
+	name = "Diagnostic HUD autoimplanter"
+	desc = "A single use autosurgeon that contains a diagnostic heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1 
+	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic()
+
+/obj/item/autoimplanter/meson
+	name = "Meson scanner autoimplanter"
+	desc = "A single use autosurgeon that contains a meson scanner augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1 
+	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/meson()

--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -7,18 +7,27 @@
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/weapons/circsawhit.ogg'
 	var/uses = -1  // -1 is infinite as far as we care
+	var/implanttime = 5 //fast for syndicate, .5sec
 	var/obj/item/organ/internal/cyberimp/storedorgan
+	var/possible_implants = list() //can put implant type references in here to let the user pick which one they want
 
 /obj/item/autoimplanter/attack_self(mob/user)//when the object it used...
 	if(uses == 0) // uses check before stored check here because a single use implanter probably wont have an implant in it after its been used up.
 		to_chat(user, "<span class='notice'>[src] appears to be permanently jammed.</span>")
 		return
-	if(!storedorgan)
+	if(!storedorgan && length(possible_implants) > 0)
+		var/selectedimplant = input("Select what to program the implant as.","Program Implant",/obj/item/organ/internal/cyberimp/eyes/hud/medical) in possible_implants
+		storedorgan = new selectedimplant()
+		return
+	else if(!storedorgan)
 		to_chat(user, "<span class='notice'>[src] currently has no implant stored.</span>")
 		return
-	storedorgan.insert(user)//insert stored organ into the user
 	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
-	uses = uses > 0 ? uses-1 : uses
+	if(!do_mob(user,user,implanttime))
+		user.show_message("<spam class='notice'>The autoimplanter detected movement and safely closed up and retracted itself.</span>")
+		return
+	storedorgan.insert(user)//insert stored organ into the user
+	uses--
 	playsound(get_turf(user), usesound, 50, 1)
 	storedorgan = null
 
@@ -41,33 +50,37 @@
 		else
 			storedorgan.forceMove(get_turf(user))
 			storedorgan = null
-			to_chat(user, "<span class='notice'>You remove the [storedorgan] from [src].</span>")
+			to_chat(user, "<span class='notice'>You remove the [storedorgan.name] from [src].</span>")
 			if(uses > 0)
-				uses = uses - 1
+				uses--
 			if(!uses)
 				desc = "[initial(desc)] Looks like it's been used up."
+			else
+				desc = "[initial(desc)] It has [uses] uses left."
 			playsound(get_turf(user), I.usesound, 50, 1)
+/obj/item/autoimplanter/head
+	uses = 1 // only one time use!
+	implanttime = 300 // slow for nanotrasen, 30sec
 
-/obj/item/autoimplanter/cmo
-	name = "Medical HUD autoimplanter"
-	desc = "A single use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1 //only one time use!
+/obj/item/autoimplanter/head/Initialize()
+	name = "[storedorgan.name] autoimplanter"
+	desc = "A single use autoimplanter that contains a [storedorgan.name] augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+
+/obj/item/autoimplanter/head/cmo
 	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/hud/medical()
 
-/obj/item/autoimplanter/hos
-	name = "Security HUD autoimplanter"
-	desc = "A single use autosurgeon that contains a security heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1 
+/obj/item/autoimplanter/head/hos
 	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/hud/security()
 
-/obj/item/autoimplanter/rd
-	name = "Diagnostic HUD autoimplanter"
-	desc = "A single use autosurgeon that contains a diagnostic heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1 
+/obj/item/autoimplanter/head/rd
 	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic()
 
-/obj/item/autoimplanter/meson
-	name = "Meson scanner autoimplanter"
-	desc = "A single use autosurgeon that contains a meson scanner augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1 
+/obj/item/autoimplanter/head/meson
 	storedorgan = new /obj/item/organ/internal/cyberimp/eyes/meson()
+
+/obj/item/autoimplanter/head/blueshield
+	possible_implants = list(/obj/item/organ/internal/cyberimp/eyes/hud/medical,/obj/item/organ/internal/cyberimp/eyes/hud/security)
+
+/obj/item/autoimplanter/head/blueshield/Initialize()
+	name = "Programmable autoimplanter"
+	desc = "A single use autoimplanter that contains a programmable augment, able to be programmed permamently to either medical or security modes. A screwdriver can be used to remove it once programmed, but implants can't be placed back in."


### PR DESCRIPTION
## What Does This PR Do
Give Heads of Staff Single-Use Autoimplanters instead of raw implants.

## Why It's Good For The Game
Makes it easier for heads to use their implants, encouraging them to use them more rather than them sitting unused in most shifts.

## Changelog
:cl:
add: added pre-loaded autoimplanters with huds
add: functionality to have autoimplanters select between implants
add: var to restrict the amount of times an autoimplanter may be used
add: var to set the amount of time it takes for an autoimplanter to implant
tweak: replaced head's implants with autoimplanters
/:cl:

Do let me know if the captain having a hud on spawn isnt something that's wanted and i'll take it out.