### PR TITLE
Places bought wizard items into your hand instead of on the floor

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -15,12 +15,12 @@
 /datum/spellbook_entry/proc/IsSpellAvailable() // For config prefs / gamemode restrictions - these are round applied
 	return 1
 
-/datum/spellbook_entry/proc/CanBuy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book) // Specific circumstances
+/datum/spellbook_entry/proc/CanBuy(mob/living/carbon/human/user, obj/item/spellbook/book) // Specific circumstances
 	if(book.uses<cost || limit == 0)
 		return 0
 	return 1
 
-/datum/spellbook_entry/proc/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book) //return 1 on success
+/datum/spellbook_entry/proc/Buy(mob/living/carbon/human/user, obj/item/spellbook/book) //return 1 on success
 	if(!S)
 		S = new spell_type()
 
@@ -58,7 +58,7 @@
 	to_chat(user, "<span class='notice'>You have learned [S.name].</span>")
 	return 1
 
-/datum/spellbook_entry/proc/CanRefund(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
+/datum/spellbook_entry/proc/CanRefund(mob/living/carbon/human/user, obj/item/spellbook/book)
 	if(!refundable)
 		return 0
 	if(!S)
@@ -68,7 +68,7 @@
 			return 1
 	return 0
 
-/datum/spellbook_entry/proc/Refund(var/mob/living/carbon/human/user, var/obj/item/spellbook/book) //return point value or -1 for failure
+/datum/spellbook_entry/proc/Refund(mob/living/carbon/human/user, obj/item/spellbook/book) //return point value or -1 for failure
 	var/area/wizard_station/A = locate()
 	if(!(user in A.contents))
 		to_chat(user, "<span clas=='warning'>You can only refund spells at the wizard lair</span>")
@@ -386,7 +386,7 @@
 	buy_word = "Summon"
 	var/item_path = null
 
-/datum/spellbook_entry/item/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
+/datum/spellbook_entry/item/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	user.put_in_hands(new item_path)
 	feedback_add_details("wizard_spell_learned", log_name)
 	return 1
@@ -415,7 +415,7 @@
 	log_name = "SO"
 	category = "Artefacts"
 
-/datum/spellbook_entry/item/scryingorb/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
+/datum/spellbook_entry/item/scryingorb/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	if(..())
 		if(!(XRAY in user.mutations))
 			user.mutations.Add(XRAY)
@@ -432,7 +432,7 @@
 	log_name = "SS"
 	category = "Artefacts"
 
-/datum/spellbook_entry/item/soulstones/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
+/datum/spellbook_entry/item/soulstones/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	. = ..()
 	if(.)
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/construct(null))
@@ -639,7 +639,7 @@
 				OB.limit++
 		qdel(O)
 
-/obj/item/spellbook/proc/GetCategoryHeader(var/category)
+/obj/item/spellbook/proc/GetCategoryHeader(category)
 	var/dat = ""
 	switch(category)
 		if("Offensive")
@@ -674,7 +674,7 @@
 			dat += "Items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
 	return dat
 
-/obj/item/spellbook/proc/wrap(var/content)
+/obj/item/spellbook/proc/wrap(content)
 	var/dat = ""
 	dat +="<html><head><title>Spellbook</title></head>"
 	dat += {"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -14,11 +14,13 @@
 
 /datum/spellbook_entry/proc/IsSpellAvailable() // For config prefs / gamemode restrictions - these are round applied
 	return 1
-/datum/spellbook_entry/proc/CanBuy(var/mob/living/carbon/human/user,var/obj/item/spellbook/book) // Specific circumstances
+
+/datum/spellbook_entry/proc/CanBuy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book) // Specific circumstances
 	if(book.uses<cost || limit == 0)
 		return 0
 	return 1
-/datum/spellbook_entry/proc/Buy(var/mob/living/carbon/human/user,var/obj/item/spellbook/book) //return 1 on success
+
+/datum/spellbook_entry/proc/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book) //return 1 on success
 	if(!S)
 		S = new spell_type()
 
@@ -56,7 +58,7 @@
 	to_chat(user, "<span class='notice'>You have learned [S.name].</span>")
 	return 1
 
-/datum/spellbook_entry/proc/CanRefund(var/mob/living/carbon/human/user,var/obj/item/spellbook/book)
+/datum/spellbook_entry/proc/CanRefund(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
 	if(!refundable)
 		return 0
 	if(!S)
@@ -66,7 +68,7 @@
 			return 1
 	return 0
 
-/datum/spellbook_entry/proc/Refund(var/mob/living/carbon/human/user,var/obj/item/spellbook/book) //return point value or -1 for failure
+/datum/spellbook_entry/proc/Refund(var/mob/living/carbon/human/user, var/obj/item/spellbook/book) //return point value or -1 for failure
 	var/area/wizard_station/A = locate()
 	if(!(user in A.contents))
 		to_chat(user, "<span clas=='warning'>You can only refund spells at the wizard lair</span>")
@@ -384,8 +386,8 @@
 	buy_word = "Summon"
 	var/item_path = null
 
-/datum/spellbook_entry/item/Buy(var/mob/living/carbon/human/user,var/obj/item/spellbook/book)
-	new item_path(get_turf(user))
+/datum/spellbook_entry/item/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
+	user.put_in_hands(new item_path)
 	feedback_add_details("wizard_spell_learned", log_name)
 	return 1
 
@@ -413,7 +415,7 @@
 	log_name = "SO"
 	category = "Artefacts"
 
-/datum/spellbook_entry/item/scryingorb/Buy(var/mob/living/carbon/human/user,var/obj/item/spellbook/book)
+/datum/spellbook_entry/item/scryingorb/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
 	if(..())
 		if(!(XRAY in user.mutations))
 			user.mutations.Add(XRAY)
@@ -430,7 +432,7 @@
 	log_name = "SS"
 	category = "Artefacts"
 
-/datum/spellbook_entry/item/soulstones/Buy(var/mob/living/carbon/human/user,var/obj/item/spellbook/book)
+/datum/spellbook_entry/item/soulstones/Buy(var/mob/living/carbon/human/user, var/obj/item/spellbook/book)
 	. = ..()
 	if(.)
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/construct(null))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -310,13 +310,13 @@
 		else
 			to_chat(src, "<span class='warning'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>")
 
-/mob/living/carbon/human/put_in_hands(obj/item/W)
-	if(!W)
-		return 0
-	if(put_in_active_hand(W))
-		return 1
-	else if(put_in_inactive_hand(W))
-		return 1
+/mob/living/carbon/human/put_in_hands(obj/item/I)
+	if(!I)
+		return FALSE
+	if(put_in_active_hand(I))
+		return TRUE
+	else if(put_in_inactive_hand(I))
+		return TRUE
 	else
 		. = ..()
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -311,9 +311,12 @@
 			to_chat(src, "<span class='warning'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>")
 
 /mob/living/carbon/human/put_in_hands(obj/item/W)
-	if(!W)		return 0
-	if(put_in_active_hand(W))			return 1
-	else if(put_in_inactive_hand(W))	return 1
+	if(!W)
+		return 0
+	if(put_in_active_hand(W))
+		return 1
+	else if(put_in_inactive_hand(W))
+		return 1
 	else
 		. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Attempts to place bought wizard items like the wand belt, scrying orb, or staves into any open hands you have. If you do not have any open hands, it will then place the item on the floor beneath you.

I also made some of the code more legible by adding proper spacing between text, and adding some line breaks in other procs I came across while making this PR.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Since vendors, chemistry dispensers, syndicate uplinks and so on already have this behavior, I thought it would be nice to have wizard items follow suit. I've gotten quite used to having the items put into my hand and dislike them being put on the floor all of the time.

## Changelog
:cl:
tweak: Bought items from the wizard spell book are first placed into any empty hands. If all hands are full, it places the item on the ground.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
