### PR TITLE
Issue #12473: Lavaland Winter Dome Vehicle Fix

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -158,7 +158,7 @@
 /turf/simulated/floor/plating/asteroid/snow/atmosphere,
 /area/ruin/powered/snow_biodome)
 "aJ" = (
-/obj/vehicle/atv,
+/obj/vehicle/snowmobile,
 /turf/simulated/floor/plating/asteroid/snow/atmosphere,
 /area/ruin/powered/snow_biodome)
 "aK" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -158,12 +158,12 @@
 /turf/simulated/floor/plating/asteroid/snow/atmosphere,
 /area/ruin/powered/snow_biodome)
 "aJ" = (
-/obj/vehicle/snowmobile,
+/obj/vehicle/atv,
 /turf/simulated/floor/plating/asteroid/snow/atmosphere,
 /area/ruin/powered/snow_biodome)
 "aK" = (
 /obj/structure/table/wood,
-/obj/item/key/snowmobile,
+/obj/item/key,
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
 "aL" = (


### PR DESCRIPTION
## What Does This PR Do
Fixes #12473: Replaced the ATV in the Lavaland winter dome with a snowmobile since the ATV key changed to a snowmobile key and I assume that's what the intended effect was.

## Changelog
:cl:
tweak: replaced the Lavaland winter dome ATV with a snowmobile.
fix: The snowmobile key in the winterdome now accompanies an actual snowmobile instead of an incompatible vehicle.
/:cl: