### PR TITLE
Prevent facehuggers from pouncing on masks that cover the mouth

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -129,6 +129,11 @@ var/const/MAX_ACTIVE_TIME = 400
 								"<span class='userdanger'>[src] smashes against [H]'s [H.head]!</span>")
 			Die()
 			return 0
+		else if(H.wear_mask && H.wear_mask.flags_cover & MASKCOVERSMOUTH)
+			H.visible_message("<span class='danger'>[src] smashes against [H]'s [H.wear_mask]!</span>", \
+								"<span class='userdanger'>[src] smashes against [H]'s [H.wear_mask]!</span>")
+			Die()
+			return 0
 	if(iscarbon(M))
 		var/mob/living/carbon/target = M
 		if(target.wear_mask)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
masks are now immune to facehugger cheese. also am ded please nerf
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It makes xenos have to actually do more than machine gun toss facehuggers at you to win and heavily slows down their snowball rate

## Changelog
:cl:
tweak: facehuggers can no longer tear off masks that cover mouths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
