### PR TITLE
slightly slow down hunters

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -14,7 +14,7 @@
 	..()
 
 /mob/living/carbon/alien/humanoid/hunter/movement_delay()
-	. = -1		//hunters are sanic
+	. = -0.5		//hunters are sanic but our movespeed is different!
 	. += ..()	//but they still need to slow down on stun
 
 /mob/living/carbon/alien/humanoid/hunter/handle_hud_icons_health()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This is the final proposed xeno nerf and likely to be the most controversial, so i'll spend a bit explaining my reasoning for this.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hunters are too fast and they don't give the victim enough time to react to them attacking, the issue is that this combined with their thermal vision makes it really hard to counter a xeno outside of having a mech and the fact that they can get in and out of places very easily helps contribute to how powerful xenos are especially considering that dragging someone away is no slower than grabbing them in the first place. slightly slowing them down will give crew more time to react to their approach and also allow them to give chase if their xeno hunting buddy happens to be taken down early in the fight
## Changelog
:cl:
balance: xeno speed is more inline with paradise movespeed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
