### PR TITLE
Fixes Soul Stone Shards, they can now poll deadchat if the original soul is gone.

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -377,7 +377,7 @@
 			break
 
 	if(!chosen_ghost)	//Failing that, we grab a ghost
-		var/list/consenting_candidates = pollCandidates("Would you like to play as a Shade?", "Cultist", null, ROLE_CULTIST, poll_time = 100)
+		var/list/consenting_candidates = pollCandidates("Would you like to play as a Shade?", ROLE_CULTIST, FALSE, poll_time = 100)
 		if(consenting_candidates.len)
 			chosen_ghost = pick(consenting_candidates)
 	if(!T)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -230,17 +230,20 @@
 				if(T.stat == 0)
 					to_chat(U, "<span class='danger'>Capture failed!</span>: Kill or maim the victim first!")
 				else
-					if(T.client == null)
-						to_chat(U, "<span class='userdanger'>Capture failed!</span>: The soul has already fled its mortal frame. You attempt to bring it back...")
-						C.getCultGhost(T,U)
+					if(!T.client_mobs_in_contents?.len)
+						to_chat(U, "<span class='warning'>They have no soul!</span>")
 					else
-						if(C.contents.len)
-							to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone is full! Use or free an existing soul to make room.")
+						if(T.client == null)
+							to_chat(U, "<span class='userdanger'>Capture failed!</span>: The soul has already fled its mortal frame. You attempt to bring it back...")
+							C.getCultGhost(T,U)
 						else
-							for(var/obj/item/W in T)
-								T.unEquip(W)
-							C.init_shade(T, U, vic = 1)
-							qdel(T)
+							if(C.contents.len)
+								to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone is full! Use or free an existing soul to make room.")
+							else
+								for(var/obj/item/W in T)
+									T.unEquip(W)
+								C.init_shade(T, U, vic = 1)
+								qdel(T)
 		if("SHADE")
 			var/mob/living/simple_animal/shade/T = target
 			var/obj/item/soulstone/C = src


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a line that prevented Soul Stone Shards from polling deadchat to be filled, if the original soul is unreachable. This also prevents using soul shards on mobs that have never had a ckyey, to prevent soul sharding monkeys for free constructs. 

## Why It's Good For The Game
Cultists should not be denied their filled soul stone just because their target has left the game. Ghost chat has another way to rejoin the game. Prevents a cheese strategy before it could be used.

## Changelog
:cl:
tweak: Soul Shards fail when used on mobs that have never had a ckey.
fix: Soul Stone Shards properly poll dead chat to be filled.
/:cl:


EDIT: I forgot to say: Big thanks to SteelSlayer and Faire82 for help with the ckey problem!