### PR TITLE
Issue #12466: IPC EMP Identity Loss Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -158,10 +158,14 @@
 	return
 
 /mob/living/carbon/human/proc/ChangeToHusk()
-	var/obj/item/organ/external/head/H = bodyparts_by_name["head"]
+
+	// If the target has no DNA to begin with, its DNA can't be damaged beyond repair.
+	if(NO_DNA in dna.species.species_traits)
+		return
 	if(HUSK in mutations)
 		return
 
+	var/obj/item/organ/external/head/H = bodyparts_by_name["head"]
 	if(istype(H))
 		H.disfigured = TRUE //makes them unknown without fucking up other stuff like admintools
 		if(H.f_style)


### PR DESCRIPTION
## What Does This PR Do
Fixes #12466: NO_DNA humans (IPCs) can no longer husk.

I'm pretty sure IPCs aren't meant to husk under any circumstances, but after taking massive burn damage from an EMP they husk and remain so after reviving.

## Changelog
:cl:
fix: NO_DNA humans (IPCs) no longer husk under any circumstances.
/:cl: