### PR TITLE
Welded vents burst open under strong overpressure

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -197,20 +197,20 @@ GLOBAL_DATUM_INIT(pipe_icon_manager, /datum/pipe_icon_manager, new())
 
 //Called when an atmospherics object is unwrenched while having a large pressure difference
 //with it's locs air contents.
-/obj/machinery/atmospherics/proc/unsafe_pressure_release(var/mob/user,var/pressures)
+/obj/machinery/atmospherics/proc/unsafe_pressure_release(mob/user, pressures)
 	if(!user)
 		return
 
 	if(!pressures)
 		var/datum/gas_mixture/int_air = return_air()
 		var/datum/gas_mixture/env_air = loc.return_air()
-		pressures = int_air.return_pressure()-env_air.return_pressure()
+		pressures = int_air.return_pressure() - env_air.return_pressure()
 
-	var/fuck_you_dir = get_dir(src,user)
-	var/turf/general_direction = get_edge_target_turf(user,fuck_you_dir)
+	var/fuck_you_dir = get_dir(src, user)
+	var/turf/general_direction = get_edge_target_turf(user, fuck_you_dir)
 	user.visible_message("<span class='danger'>[user] is sent flying by pressure!</span>","<span class='userdanger'>The pressure sends you flying!</span>")
 	//Values based on 2*ONE_ATMOS (the unsafe pressure), resulting in 20 range and 4 speed
-	user.throw_at(general_direction,pressures/10,pressures/50)
+	user.throw_at(general_direction, pressures/10, pressures/50)
 
 /obj/machinery/atmospherics/deconstruct(disassembled = TRUE)
 	if(can_deconstruct)

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -38,6 +38,7 @@
 	var/pressure_checks_default = PRESSURE_CHECKS
 
 	var/welded = 0 // Added for aliens -- TLE
+	var/weld_burst_pressure = 50 * ONE_ATMOSPHERE	//the (internal) pressure at which welded covers will burst off
 
 	var/frequency = ATMOS_VENTSCRUB
 	var/datum/radio_frequency/radio_connection
@@ -78,7 +79,7 @@
 	..()
 	air_contents.volume = 1000
 
-/obj/machinery/atmospherics/unary/vent_pump/update_icon(var/safety = 0)
+/obj/machinery/atmospherics/unary/vent_pump/update_icon(safety = 0)
 	..()
 
 	plane = FLOOR_PLANE
@@ -137,6 +138,12 @@
 		return 0
 
 	if(welded)
+		if(air_contents.return_pressure() >= weld_burst_pressure && prob(5))	//the weld is on but the cover is welded shut, can it withstand the internal pressure?
+			visible_message("<span class='danger'>The welded cover of [src] bursts open!</span>")
+			for(var/mob/M in range(1, src))
+				unsafe_pressure_release(M, air_contents.return_pressure())	//let's send everyone flying
+			welded = FALSE
+			update_icon()
 		return 0
 
 	var/datum/gas_mixture/environment = loc.return_air()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it so that vents can burst open if they are welded, turned on and have a strong internal pressure. If there are 50 atmospheres worth of pressure or more in the pipe net, then welded vents have a chance of bursting open while on (I assume the vents actual...vents are able to withstand the pressure, hence why it only happens if it's toggled on).

A bursting vent sends people on or adjacent to it flying like unwrenching pipes does and dumps some of its content on its tile.

It is just a 5% chance to not every vent on station bursts at the same time the moment pressure ticks over the threshold.

For reference, 50 atmospheres of internal pressure, assuming the vent has a 1 square meter area, would exert 5 million Newton worth of force on the vent ( if my math and wolfram alpha are correct)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This introduces a (small) downside to welding vents which right now is consequence free. You can still weld vents but you have to either:
1. Have atmos lower the distro pressure, giving them something to do. This also comes with downsides like allowing people with the ventcrawling jumpsuit to get places faster, slower pressurisation of rooms, easier sabotage by pumping poison into distro.
2. Have someone with atmos access turn off vents with an air alarm. This takes more time and effort than just having twenty assistants with welders weld every vent they see.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
add: Welded vents that are on now burst open at more than 50 atmospheres of internal pressure.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
