### PR TITLE
Actually fixes cultists getting multiple summon objectives

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -126,8 +126,8 @@ var/global/list/all_cults = list()
 	..()
 
 
-/datum/game_mode/cult/proc/memorize_cult_objectives(var/datum/mind/cult_mind)
-	for(var/obj_count = 1,obj_count <= objectives.len,obj_count++)
+/datum/game_mode/cult/proc/memorize_cult_objectives(datum/mind/cult_mind)
+	for(var/obj_count in 1 to objectives.len)
 		var/explanation
 		switch(objectives[obj_count])
 			if("survive")

--- a/code/game/gamemodes/cult/cult_objectives.dm
+++ b/code/game/gamemodes/cult/cult_objectives.dm
@@ -42,6 +42,8 @@
 	additional_phase()
 
 /datum/game_mode/cult/proc/additional_phase()
+	if(objectives.Find("eldergod") || objectives.Find("slaughter"))
+		return
 	current_objective++
 
 	message_admins("Picking a new Cult objective.")
@@ -62,6 +64,7 @@
 		message_admins("There are less than 4 cultists! [SSticker.cultdat.entity_name] objective unlocked.")
 		log_admin("There are less than 4 cultists! [SSticker.cultdat.entity_name] objective unlocked.")
 		gtfo_phase()
+		return
 
 	if(!sacrificed.len && (new_objective != "sacrifice"))
 		sacrifice_target = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Ok, this actually fixes cultists getting duplicates summoning objectives by just returning from a proc if they already have the "summon god" or "bring the slaughter" objective.

Also, apparently on the live server, cultists are having problems with their objectives just appearing blank. I have no idea why this is, because when I test this on my own server using multiple accounts and numerous cultists, I get objective 1 and 2 just fine, as evident by the picture below.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![cultobjectives](https://user-images.githubusercontent.com/42044220/66085041-bdb08380-e535-11e9-97ac-fdb33cc3d012.png)


## Changelog
:cl:
fix: Cultists no longer get more than one summon objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
