### PR TITLE
Adds minor armor to combat gloves and jackboots

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -29,6 +29,7 @@
 	name = "combat gloves"
 	icon_state = "combat"
 	item_state = "swat_gl"
+	armor = list(melee = 5, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 10, rad = 0)
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
 	strip_delay = 80

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -102,6 +102,7 @@
 	can_cut_open = 1
 	icon_state = "jackboots"
 	item_state = "jackboots"
+	armor = list(melee = 10, bullet = 10, laser = 5, energy = 5, bomb = 0, bio = 10, rad = 0)
 	item_color = "hosred"
 	strip_delay = 50
 	put_on_delay = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds very minor armor to combat gloves and security jackboots.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Combat gloves and jackboots are both tough garments designed to provide some protection. If even a jumpsuit can provide minor melee armor, then tough boots should do too. It also is a reason to wear them over just any normal shoes from a vendor. In other words, it's for consistency, it is counter-intuitive for them to not provide at least some protection, even if it's not a game-changer or anything.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
add: minor armor to jackboots and combat gloves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
