### PR TITLE
Fixed Reaper Cult not having it's own tome icon.

### DIFF
--- a/code/game/gamemodes/cult/cult_datums.dm
+++ b/code/game/gamemodes/cult/cult_datums.dm
@@ -79,7 +79,7 @@
 /datum/cult_info/death
 	name = "Cult of Mortality"
 	theme = "death"
-	tome_icon = "firetome"
+	tome_icon = "deathtome"
 
 	entity_name = "The Reaper"
 	entity_title1 = "The Silent One"


### PR DESCRIPTION
## What Does This PR Do
We had an unique icon the the death cult's tome, but we used the fire cult's tome for some reason. This is fixed.

## Why It's Good For The Game
The Ferryman put a lot of effort into making that spooky book, and by golly you're gonna appreciate it.

## Images of changes
![deathTome](https://user-images.githubusercontent.com/47765135/66101076-7351f580-e57b-11e9-8e87-fc16c1fdd2ce.png)


## Changelog
:cl:
fix: Incorrect icon path for reaper tome
/:cl: