### PR TITLE
Fixes toxic comp not doing the right amount of toxin damage

### DIFF
--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -40,13 +40,13 @@ Bonus
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 
-		var/list/parts = H.get_damaged_organs(1,1, AFFECT_ORGANIC_ORGAN) //1,1 because it needs inputs.
+		var/list/parts = H.get_damaged_organs(TRUE, TRUE, AFFECT_ORGANIC_ORGAN) //1,1 because it needs inputs.
 
 		if(!parts.len)
 			return
 		var/healed = 0
 		for(var/obj/item/organ/external/E in parts)
-			healed = min(E.brute_dam, get_damage) + min(E.burn_dam, get_damage)
+			healed += min(E.brute_dam, get_damage) + min(E.burn_dam, get_damage)
 			E.heal_damage(get_damage, get_damage, 0, 0)
 		M.adjustToxLoss(healed)
 


### PR DESCRIPTION
## What Does This PR Do
Makes TC add the damage up. Instead of taking the last healed damage... sorry guys mistake on my part

## Why It's Good For The Game
It's a bug

## Changelog
:cl:
fix: Toxic compensation now deals the right amount of toxic damage. Instead of just the last healed damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
