### PR TITLE
Fixes a bunch of things related to traitor and mindslave objectives

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1666,9 +1666,8 @@
 	zealot_objective.target = missionary.mind
 	zealot_objective.owner = src
 	zealot_objective.explanation_text = "Obey every order from and protect [missionary.real_name], the [missionary.mind.assigned_role == missionary.mind.special_role ? (missionary.mind.special_role) : (missionary.mind.assigned_role)]."
-	var/datum/antagonist/mindslave/S = new()
-	S.add_objective(zealot_objective)
-	add_antag_datum(S)
+	objectives += zealot_objective
+	add_antag_datum(/datum/antagonist/mindslave)
 
 	var/datum/antagonist/traitor/T = missionary.mind.has_antag_datum(/datum/antagonist)
 	T.update_traitor_icons_added(missionary.mind)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -73,10 +73,14 @@
 					objective = "Make certain at least 80% of the station evacuates on the shuttle."
 
 			var/datum/objective/custom_objective = new(objective)
+			custom_objective.owner = N.mind
+			N.mind.objectives += custom_objective
+			var/datum/objective/escape/escape_objective = new
+			escape_objective.owner = N.mind
+			N.mind.objectives += escape_objective
+
 			var/datum/antagonist/traitor/T = new()
 			T.give_objectives = FALSE
-			T.add_objective(custom_objective)
-			T.add_objective(/datum/objective/escape)
 			N.mind.add_antag_datum(T)
 	
 			to_chat(M, "<B>You have joined the ranks of the Syndicate and become a traitor to the station!</B>")

--- a/code/game/objects/items/weapons/implants/implant_traitor.dm
+++ b/code/game/objects/items/weapons/implants/implant_traitor.dm
@@ -56,7 +56,6 @@
 			SSticker.mode.implanted.Add(mindslave_target.mind)
 			SSticker.mode.implanted[mindslave_target.mind] = user.mind
 			SSticker.mode.implanter[user.mind] = implanters
-			SSticker.mode.traitors += mindslave_target.mind
 			
 			to_chat(mindslave_target, "<span class='warning'><B>You're now completely loyal to [user.name]!</B> You now must lay down your life to protect [user.p_them()] and assist in [user.p_their()] goals at any cost.</span>")
 
@@ -64,10 +63,8 @@
 			MS.owner = mindslave_target.mind
 			MS.target = user.mind
 			MS.explanation_text = "Obey every order from and protect [user.real_name], the [user.mind.assigned_role == user.mind.special_role ? (user.mind.special_role) : (user.mind.assigned_role)]."
-			
-			var/datum/antagonist/mindslave/S = new()
-			S.add_objective(MS)
-			mindslave_target.mind.add_antag_datum(S)
+			mindslave_target.mind.objectives += MS
+			mindslave_target.mind.add_antag_datum(/datum/antagonist/mindslave)
 
 			var/datum/mindslaves/slaved = user.mind.som
 			mindslave_target.mind.som = slaved

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -502,6 +502,9 @@
 		if(SSticker.mode.traitors.len)
 			dat += check_role_table("Traitors", SSticker.mode.traitors)
 
+		if(SSticker.mode.implanted.len)
+			dat += check_role_table("Mindslaves", SSticker.mode.implanted)
+
 		if(SSticker.mode.shadows.len)
 			dat += check_role_table("Shadowlings", SSticker.mode.shadows)
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1985,9 +1985,9 @@
 					kill_objective.target = H.mind
 					kill_objective.owner = newtraitormind
 					kill_objective.explanation_text = "Assassinate [H.mind], the [H.mind.assigned_role]"
+					H.mind.objectives += kill_objective
 					var/datum/antagonist/traitor/T = new()
 					T.give_objectives = FALSE
-					T.add_objective(kill_objective)
 					to_chat(newtraitormind, "<span class='danger'>ATTENTION:</span> It is time to pay your debt to the Syndicate...")
 					to_chat(newtraitormind, "<B>Goal: <span class='danger'>KILL [H.real_name]</span>, currently in [get_area(H.loc)]</B>")
 					newtraitormind.add_antag_datum(T)

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -7,8 +7,9 @@
 	var/special_role = ROLE_MINDSLAVE
 
 /datum/antagonist/mindslave/on_gain()
-	// Handling mindslave objectives on top of other antag objective sucks, so Im just gonna do it like this
-	to_chat(owner.current, "<b>New Objective:</b> [objectives[objectives.len].explanation_text]")
+	owner.special_role = special_role
+	// Will print the most recent objective which is probably going the mindslave objective
+	to_chat(owner.current, "<b>New Objective:</b> [owner.objectives[owner.objectives.len].explanation_text]")
 	update_mindslave_icons_added()
 
 /datum/antagonist/mindslave/on_removal()
@@ -37,10 +38,10 @@
 			slave_mob.mutations.Add(CLUMSY)
 
 /datum/antagonist/mindslave/proc/add_objective(datum/objective/O)
-	objectives += O
+	owner.objectives += O
 
 /datum/antagonist/mindslave/proc/remove_objective(datum/objective/O)
-	objectives -= O
+	owner.objectives -= O
 
 /datum/antagonist/mindslave/proc/update_mindslave_icons_added()
 	var/datum/atom_hud/antag/traitorhud = huds[ANTAG_HUD_TRAITOR]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
More cleanup from the traitor datum PR. I had forgotten to switch mindslaves, as well as some other traitor types, back to using the mind instead of the antag datum to handle objectives. This fixes that. 

Also seperates mindslaves and traitors in the check antagonists panel. No longer will mindslaves and zealots show up in the traitor section.

Fixes #12489

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![checkantags](https://user-images.githubusercontent.com/42044220/66148457-8c3bc480-e5d6-11e9-8481-6ff69f8b21b6.png)

## Changelog
:cl:
tweak: Mindslaves now show up in their own "Mindslaves" section in the check antagonists panel
fix: Mindslaves will now get their objectives added to their notes and announced in their chat properly
fix: Mindslaves will now have the red (A) in admin attack logs, which shows that the attacker is an antag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
