### PR TITLE
Alphabetizes character creation options (Hair, clothes, etc)

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1464,6 +1464,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							if(species in SA.species_allowed) //If the user's head is of a species the hairstyle allows, add it to the list.
 								valid_hairstyles += hairstyle
 
+					sortTim(valid_hairstyles, /proc/cmp_text_asc) //this alphabetizes the list
 					var/new_h_style = input(user, "Choose your character's hair style:", "Character Preference") as null|anything in valid_hairstyles
 					if(new_h_style)
 						h_style = new_h_style
@@ -1485,6 +1486,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 							valid_head_accessory_styles += head_accessory_style
 
+						sortTim(valid_head_accessory_styles, /proc/cmp_text_asc)
 						var/new_head_accessory_style = input(user, "Choose the style of your character's head accessory:", "Character Preference") as null|anything in valid_head_accessory_styles
 						if(new_head_accessory_style)
 							ha_style = new_head_accessory_style
@@ -1542,7 +1544,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 										continue
 
 							valid_markings += markingstyle
-
+						sortTim(valid_markings, /proc/cmp_text_asc)
 						var/new_marking_style = input(user, "Choose the style of your character's head markings:", "Character Preference", m_styles["head"]) as null|anything in valid_markings
 						if(new_marking_style)
 							m_styles["head"] = new_marking_style
@@ -1566,7 +1568,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 								continue
 
 							valid_markings += markingstyle
-
+						sortTim(valid_markings, /proc/cmp_text_asc)
 						var/new_marking_style = input(user, "Choose the style of your character's body markings:", "Character Preference", m_styles["body"]) as null|anything in valid_markings
 						if(new_marking_style)
 							m_styles["body"] = new_marking_style
@@ -1596,7 +1598,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 									continue
 
 							valid_markings += markingstyle
-
+						sortTim(valid_markings, /proc/cmp_text_asc)
 						var/new_marking_style = input(user, "Choose the style of your character's tail markings:", "Character Preference", m_styles["tail"]) as null|anything in valid_markings
 						if(new_marking_style)
 							m_styles["tail"] = new_marking_style
@@ -1620,7 +1622,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 								continue
 							if(species in accessory.allowed_species)
 								possible_body_accessories += B
-
+					sortTim(possible_body_accessories, /proc/cmp_text_asc)
 					var/new_body_accessory = input(user, "Choose your body accessory:", "Character Preference") as null|anything in possible_body_accessories
 					if(new_body_accessory)
 						m_styles["tail"] = "None"
@@ -1668,7 +1670,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						else //If the user is not a species who can have robotic heads, use the default handling.
 							if(species in SA.species_allowed) //If the user's head is of a species the facial hair style allows, add it to the list.
 								valid_facial_hairstyles += facialhairstyle
-
+					sortTim(valid_facial_hairstyles, /proc/cmp_text_asc)
 					var/new_f_style = input(user, "Choose your character's facial-hair style:", "Character Preference")  as null|anything in valid_facial_hairstyles
 					if(new_f_style)
 						f_style = new_f_style
@@ -1684,6 +1686,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						if(!(species in SA.species_allowed))
 							continue
 						valid_underwear[underwear] = GLOB.underwear_list[underwear]
+					sortTim(valid_underwear, /proc/cmp_text_asc)
 					var/new_underwear = input(user, "Choose your character's underwear:", "Character Preference") as null|anything in valid_underwear
 					ShowChoices(user)
 					if(new_underwear)
@@ -1699,6 +1702,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						if(!(species in SA.species_allowed))
 							continue
 						valid_undershirts[undershirt] = GLOB.undershirt_list[undershirt]
+					sortTim(valid_undershirts, /proc/cmp_text_asc)
 					var/new_undershirt = input(user, "Choose your character's undershirt:", "Character Preference") as null|anything in valid_undershirts
 					ShowChoices(user)
 					if(new_undershirt)
@@ -1715,6 +1719,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						if(!(species in SA.species_allowed))
 							continue
 						valid_sockstyles[sockstyle] = GLOB.socks_list[sockstyle]
+					sortTim(valid_sockstyles, /proc/cmp_text_asc)
 					var/new_socks = input(user, "Choose your character's socks:", "Character Preference")  as null|anything in valid_sockstyles
 					ShowChoices(user)
 					if(new_socks)


### PR DESCRIPTION
## What Does This PR Do
Alphabetizes the options in character creation(Hair, clothing, body markings, etc) 

## Why It's Good For The Game
This makes it easier to find a hairstyle or shirt you're looking for and makes things cleaner in the options while also making it so that future hairstyles and what have you are already alphabetized.

## Changelog
:cl:
tweak: Hair styles, body markings, clothes, and other character customization options are now alphabetized.
/:cl:
