### PR TITLE
Shade related Soul Stone fixes and tweak.

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -223,10 +223,6 @@
 		if("VICTIM")
 			var/mob/living/carbon/human/T = target
 			var/obj/item/soulstone/C = src
-			if(!C.can_use(U))
-				U.Paralyse(5)
-				to_chat(U, "<span class='userdanger'>Your body is wracked with debilitating pain!</span>")
-				return
 			if(T.stat == 0)
 				to_chat(U, "<span class='danger'>Capture failed!</span>: Kill or maim the victim first!")
 			else

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -7,10 +7,9 @@
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = SLOT_BELT
 	origin_tech = "bluespace=4;materials=5"
-	var/imprinted = "empty"
 
 	var/optional = FALSE //does this soulstone ask the victim whether they want to be turned into a shade
-	var/usability = TRUE // Can this soul stone be used by anyone, or only cultists/wizards?
+	var/usability = FALSE // Can this soul stone be used by anyone, or only cultists/wizards?
 	var/reusable = TRUE // Can this soul stone be used more than once?
 	var/spent = FALSE // If the soul stone can only be used once, has it been used?
 
@@ -224,46 +223,48 @@
 		if("VICTIM")
 			var/mob/living/carbon/human/T = target
 			var/obj/item/soulstone/C = src
-			if(C.imprinted != "empty")
-				to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone has already been imprinted with [C.imprinted]'s mind!")
+			if(!C.can_use(U))
+				U.Paralyse(5)
+				to_chat(U, "<span class='userdanger'>Your body is wracked with debilitating pain!</span>")
+				return
+			if(T.stat == 0)
+				to_chat(U, "<span class='danger'>Capture failed!</span>: Kill or maim the victim first!")
 			else
-				if(T.stat == 0)
-					to_chat(U, "<span class='danger'>Capture failed!</span>: Kill or maim the victim first!")
+				if(!T.client_mobs_in_contents?.len)
+					to_chat(U, "<span class='warning'>They have no soul!</span>")
 				else
-					if(!T.client_mobs_in_contents?.len)
-						to_chat(U, "<span class='warning'>They have no soul!</span>")
+					if(T.client == null)
+						to_chat(U, "<span class='userdanger'>Capture failed!</span>: The soul has already fled its mortal frame. You attempt to bring it back...")
+						C.getCultGhost(T,U)
 					else
-						if(T.client == null)
-							to_chat(U, "<span class='userdanger'>Capture failed!</span>: The soul has already fled its mortal frame. You attempt to bring it back...")
-							C.getCultGhost(T,U)
+						if(C.contents.len)
+							to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone is full! Use or free an existing soul to make room.")
 						else
-							if(C.contents.len)
-								to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone is full! Use or free an existing soul to make room.")
-							else
-								for(var/obj/item/W in T)
-									T.unEquip(W)
-								C.init_shade(T, U, vic = 1)
-								qdel(T)
+							for(var/obj/item/W in T)
+								T.unEquip(W)
+							C.init_shade(T, U, vic = 1)
+							qdel(T)
 		if("SHADE")
 			var/mob/living/simple_animal/shade/T = target
 			var/obj/item/soulstone/C = src
+			if(!C.can_use(U))
+				U.Paralyse(5)
+				to_chat(U, "<span class='userdanger'>Your body is wracked with debilitating pain!</span>")
+				return
 			if(T.stat == DEAD)
 				to_chat(U, "<span class='danger'>Capture failed!</span>: The shade has already been banished!")
 			else
 				if(C.contents.len)
 					to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone is full! Use or free an existing soul to make room.")
 				else
-					if(T.name != C.imprinted)
-						to_chat(U, "<span class='danger'>Capture failed!</span>: The soul stone has already been imprinted with [C.imprinted]'s mind!")
-					else
-						T.loc = C //put shade in stone
-						T.status_flags |= GODMODE
-						T.canmove = 0
-						T.health = T.maxHealth
-						T.faction |= "\ref[U]"
-						C.icon_state = "soulstone2"
-						to_chat(T, "Your soul has been recaptured by the soul stone, its arcane energies are reknitting your ethereal form")
-						to_chat(U, "<span class='notice'>Capture successful!</span>: [T.name]'s has been recaptured and stored within the soul stone.")
+					T.loc = C //put shade in stone
+					T.status_flags |= GODMODE
+					T.canmove = 0
+					T.health = T.maxHealth
+					T.faction |= "\ref[U]"
+					C.icon_state = "soulstone2"
+					to_chat(T, "Your soul has been recaptured by the soul stone, its arcane energies are reknitting your ethereal form")
+					to_chat(U, "<span class='notice'>Capture successful!</span>: [T.name]'s has been recaptured and stored within the soul stone.")
 		if("CONSTRUCT")
 			var/obj/structure/constructshell/T = target
 			var/obj/item/soulstone/C = src


### PR DESCRIPTION
## What Does This PR Do
Fixes #12495

Fixes unlisted issue where non-cultists and non-wizards can use cult-spawned and wizard-spawned Soul Stones.

Removes all Soul Stone references to the 'imprinted' variable that was defined, never set anywhere, but still checked for. Functionally, this means any empty Soul Stone can fit any shade in them now. 


## Why It's Good For The Game
Besides fixing two bugs, one restoring an intended feature, one fixing an unintended feature, the removal of 'imprinting' makes for a small quality of life change for Shade users, as they won't have to remember which Shade goes in which stone.

## Changelog
:cl:
tweak: Shades can be stored in any Soul Stone.
fix: Shades can once again be stored in Soul Stones.
fix: Non-cultists and Non-wizards can no longer use most Soul Stones.
/:cl:
