### PR TITLE
Spectral Manifest Fixes and Balance.

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1041,6 +1041,8 @@ var/list/teleport_runes = list()
 	while(user in get_turf(src))
 		if(user.stat)
 			break
+		if(new_human.z != user.z)
+			break
 		user.apply_damage(0.1, BRUTE)
 		sleep(3)
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1033,6 +1033,7 @@ var/list/teleport_runes = list()
 	N.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	new_human.key = ghost_to_spawn.key
 	SSticker.mode.add_cultist(new_human.mind, 0)
+	new_human.mind.special_role = "Cultist"
 	summoned_guys |= new_human
 	ghosts++
 	to_chat(new_human, "<span class='cultitalic'><b>You are a servant of [SSticker.cultdat.entity_title3]. You have been made semi-corporeal by the cult of [SSticker.cultdat.entity_name], and you are to serve them at all costs.</b></span>")
@@ -1051,6 +1052,7 @@ var/list/teleport_runes = list()
 			new_human.unEquip(I)
 		summoned_guys -= new_human
 		ghosts--
+		SSticker.mode.remove_cultist(new_human.mind, 0)
 		new_human.dust()
 
 /obj/effect/rune/manifest/Destroy()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1032,8 +1032,8 @@ var/list/teleport_runes = list()
 	N.health = 20
 	N.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	new_human.key = ghost_to_spawn.key
-	SSticker.mode.add_cultist(new_human.mind, 0)
-	new_human.mind.special_role = "Cultist"
+	SSticker.mode.add_cultist(new_human.mind, FALSE)
+	new_human.mind.special_role = "SPECIAL_ROLE_CULTIST"
 	summoned_guys |= new_human
 	ghosts++
 	to_chat(new_human, "<span class='cultitalic'><b>You are a servant of [SSticker.cultdat.entity_title3]. You have been made semi-corporeal by the cult of [SSticker.cultdat.entity_name], and you are to serve them at all costs.</b></span>")
@@ -1041,7 +1041,7 @@ var/list/teleport_runes = list()
 	while(user in get_turf(src))
 		if(user.stat)
 			break
-		if(new_human.z != user.z)
+		if(!atoms_share_level(get_turf(new_human), get_turf(user)))
 			break
 		user.apply_damage(0.1, BRUTE)
 		sleep(3)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1054,7 +1054,7 @@ var/list/teleport_runes = list()
 			new_human.unEquip(I)
 		summoned_guys -= new_human
 		ghosts--
-		SSticker.mode.remove_cultist(new_human.mind, 0)
+		SSticker.mode.remove_cultist(new_human.mind, FALSE)
 		new_human.dust()
 
 /obj/effect/rune/manifest/Destroy()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1033,7 +1033,7 @@ var/list/teleport_runes = list()
 	N.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	new_human.key = ghost_to_spawn.key
 	SSticker.mode.add_cultist(new_human.mind, FALSE)
-	new_human.mind.special_role = "SPECIAL_ROLE_CULTIST"
+	new_human.mind.special_role = SPECIAL_ROLE_CULTIST
 	summoned_guys |= new_human
 	ghosts++
 	to_chat(new_human, "<span class='cultitalic'><b>You are a servant of [SSticker.cultdat.entity_title3]. You have been made semi-corporeal by the cult of [SSticker.cultdat.entity_name], and you are to serve them at all costs.</b></span>")


### PR DESCRIPTION
## What Does This PR Do
Fixes manifested specters not showing up with the (A) Antag marker in attack logs. 

Removes specters from the list of cultists upon death, fixing specters cluttering up the 'end of round cult list', and should result in a far more accurate list of remaining cultists at the end of the round. 

Tweaks the balance of Spectral Manifest rune, causing manifested specters to die if they leave the same Z-level as their summoner.

## Why It's Good For The Game
The first fix should give admins some peace, and the second fix should give people accurate representation of total cultists at the end of shift.

The tweak to making manifested specters die if their Z-level does not match their summoners is to slightly nerf the very effective tactic of setting up off station Z-level and swarming the station with specters that just teleport in from an extremely safe location. Now if you want to employ this strategy, you'll need a setup on station, which give security an actual chance to stop the specters at their source. 

## Changelog
:cl:
balance: Cult Specters now die if they leave the same Z-level as their summoner.
fix: Cult Specters properly log as antags.
fix: Cult Specters are properly removed from the cult on death.
/:cl: