### PR TITLE
Fixes #12504 - empty medkit in depot

### DIFF
--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -247,7 +247,7 @@
 	// Loot schema: medkits, very useful devices (jammer, illegal upgrade, RCD), better quality ammo (AP, fire), basic weapons (pistol, empgrenade), high value ores (diamond, uranium)
 	result = list(/datum/nothing = 25,
 		/obj/item/jammer = 1,
-		/obj/item/storage/firstaid = 1,
+		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/storage/box/syndie_kit/bonerepair = 1,
 		/obj/item/gun/projectile/automatic/pistol = 1,
 		/obj/item/stock_parts/cell/bluespace = 1,


### PR DESCRIPTION
## What Does This PR Do
Fixes #12504 - a bug where a medkit in the syndie depot is spawned empty.

## Why It's Good For The Game
It is a fix.

:cl: Kyep
fix: Fixed the medkit spawning in the syndie depot being empty.
/:cl: