### PR TITLE
Fixes teleport runes teleporting AI eye

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -314,6 +314,8 @@ var/list/teleport_runes = list()
 	var/movedsomething = 0
 	var/moveuserlater = 0
 	for(var/atom/movable/A in T)
+		if(isAIEye(A))
+			continue // no teleporting ai eyes thankyouverymuch
 		if(A == user)
 			moveuserlater = 1
 			movedsomething = 1

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -314,8 +314,8 @@ var/list/teleport_runes = list()
 	var/movedsomething = 0
 	var/moveuserlater = 0
 	for(var/atom/movable/A in T)
-		if(isAIEye(A))
-			continue // no teleporting ai eyes thankyouverymuch
+		if(!A.simulated)
+			continue  //unsimulated objects should not be teleported
 		if(A == user)
 			moveuserlater = 1
 			movedsomething = 1

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -314,8 +314,8 @@ var/list/teleport_runes = list()
 	var/movedsomething = 0
 	var/moveuserlater = 0
 	for(var/atom/movable/A in T)
-		if(!A.simulated)
-			continue  //unsimulated objects should not be teleported
+		if(A.move_resist == INFINITY)
+			continue  //object cant move, shouldnt teleport
 		if(A == user)
 			moveuserlater = 1
 			movedsomething = 1

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -8,9 +8,10 @@
 	status_flags = GODMODE  // You can't damage it.
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	see_in_dark = 8
-	invisibility = 101 // No one can see us
+	invisibility = 101  // No one can see us
 	sight = SEE_SELF
 	move_on_shuttle = 0
+	simulated = false;  //why wasnt this a thing before?
 
 /mob/camera/experience_pressure_difference()
 	return

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -11,7 +11,6 @@
 	invisibility = 101  // No one can see us
 	sight = SEE_SELF
 	move_on_shuttle = 0
-	simulated = FALSE;  //why wasnt this a thing before?
 
 /mob/camera/experience_pressure_difference()
 	return

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -11,7 +11,7 @@
 	invisibility = 101  // No one can see us
 	sight = SEE_SELF
 	move_on_shuttle = 0
-	simulated = false;  //why wasnt this a thing before?
+	simulated = FALSE;  //why wasnt this a thing before?
 
 /mob/camera/experience_pressure_difference()
 	return


### PR DESCRIPTION
## What Does This PR Do
Fixes #12507 
Stops cult teleport runes from teleporting ai/console eyes

## Why It's Good For The Game
AI previously would have their eye teleported to the other end of the teleport rune, causing them to see things they shouldnt be able to, and obviously, the ai eye isnt actually an object.

## Changelog
:cl:
fix: cult teleport rune teleporting ai eye
/:cl:
