### PR TITLE
Adds Leather to Biogenerator

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -117,7 +117,8 @@ GLOBAL_LIST_INIT(leather_recipes, list (
 	new/datum/stack_recipe("bandolier", /obj/item/storage/belt/bandolier, 5),
 	new/datum/stack_recipe("leather jacket", /obj/item/clothing/suit/jacket/leather, 7),
 	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2),
-	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10)))
+	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10),
+	new/datum/stack_recipe("hide mantle", /obj/item/clothing/suit/unathi/mantle, 4)))
 
 /obj/item/stack/sheet/leather/New(loc, new_amount, merge = TRUE)
 	recipes = GLOB.leather_recipes

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -108,6 +108,21 @@ GLOBAL_LIST_INIT(xeno_recipes, list (
 	icon_state = "sheet-leather"
 	origin_tech = "materials=2"
 
+GLOBAL_LIST_INIT(leather_recipes, list (
+	new/datum/stack_recipe("wallet", /obj/item/storage/wallet, 1),
+	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2),
+	new/datum/stack_recipe("botany gloves", /obj/item/clothing/gloves/botanic_leather, 3),
+	new/datum/stack_recipe("toolbelt", /obj/item/storage/belt/utility, 4),
+	new/datum/stack_recipe("leather satchel", /obj/item/storage/backpack/satchel, 5),
+	new/datum/stack_recipe("bandolier", /obj/item/storage/belt/bandolier, 5),
+	new/datum/stack_recipe("leather jacket", /obj/item/clothing/suit/jacket/leather, 7),
+	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2),
+	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10)))
+
+/obj/item/stack/sheet/leather/New(loc, new_amount, merge = TRUE)
+	recipes = GLOB.leather_recipes
+	return ..()
+
 /obj/item/stack/sheet/sinew
 	name = "watcher sinew"
 	icon = 'icons/obj/mining.dmi'

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -123,29 +123,13 @@
 	build_path = /obj/item/stack/sheet/cardboard
 	category = list("initial", "Organic Materials")
 
-/datum/design/wallet
-	name = "Wallet"
-	id = "wallet"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 100)
-	build_path = /obj/item/storage/wallet
-	category = list("initial","Leather and Cloth")
-
-/datum/design/botany_gloves
-	name = "Botanical gloves"
-	id = "botany_gloves"
+/datum/design/leather
+	name = "Sheet of Leather"
+	id = "leather"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 150)
-	build_path = /obj/item/clothing/gloves/botanic_leather
-	category = list("initial","Leather and Cloth")
-
-/datum/design/toolbelt
-	name = "Utility Belt"
-	id = "toolbelt"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
-	build_path = /obj/item/storage/belt/utility
-	category = list("initial","Leather and Cloth")
+	build_path = /obj/item/stack/sheet/leather
+	category = list("initial", "Organic Materials")
 
 /datum/design/hydrobelt
 	name = "Botanist belt"
@@ -179,44 +163,12 @@
 	build_path = /obj/item/storage/belt/janitor
 	category = list("initial","Leather and Cloth")
 
-/datum/design/bandolier
-	name = "Bandolier belt"
-	id = "bandolier"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
-	build_path = /obj/item/storage/belt/bandolier
-	category = list("initial","Leather and Cloth")
-
 /datum/design/s_holster
 	name = "Shoulder holster"
 	id = "s_holster"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 400)
 	build_path = /obj/item/clothing/accessory/holster
-	category = list("initial","Leather and Cloth")
-
-/datum/design/leather_satchel
-	name = "Leather satchel"
-	id = "leather_satchel"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 400)
-	build_path = /obj/item/storage/backpack/satchel
-	category = list("initial","Leather and Cloth")
-
-/datum/design/leather_jacket
-	name = "Leather jacket"
-	id = "leather_jacket"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
-	build_path = /obj/item/clothing/suit/jacket/leather
-	category = list("initial","Leather and Cloth")
-
-/datum/design/leather_overcoat
-	name = "Leather overcoat"
-	id = "leather_overcoat"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 1000)
-	build_path = /obj/item/clothing/suit/jacket/leather/overcoat
 	category = list("initial","Leather and Cloth")
 
 /datum/design/rice_hat


### PR DESCRIPTION
From TG.

Leather is *horrendously* difficult to come across, in game, requiring making corgis and butchering them endlessly, or mining to actually let you use their spare goliath hides (which they'll probably just leave at lavaland to be honest).

This allows Botany to produce leather, which allows them to actually make good on some of their Durathread crafting recipes, while also reducing bio-generator clutter.

On that note, wallets, botany gloves, utility belts, bandoliers, satchels, and both leather jackets have been removed from the biogenerator; they're now made with leather itself.

Leather sheets can currently make:
- Wallets
- Muzzles
- Botany gloves
- Utility Belts
- Leather satchels
- Bandoliers
- Leather jackets
- Leather Overcoats
- Lace up leather shoes
- Hide Mantles

:cl: Fox McCloud
add: Adds being able to make leather with the bio-generator
tweak: removed a lot of leather-related recipes from the bio-generator; these have been moved to leather crafting
add: can make hide mantles with leather
/:cl: