### PR TITLE
Makes Pants All Powerful

### DIFF
--- a/code/modules/clothing/under/pants.dm
+++ b/code/modules/clothing/under/pants.dm
@@ -1,7 +1,17 @@
 /obj/item/clothing/under/pants
 	gender = PLURAL
 	body_parts_covered = LOWER_TORSO|LEGS
-	displays_id = 0
+	displays_id = FALSE
+
+/obj/item/clothing/under/pants/equipped(mob/user, slot)
+	if(ishuman(user) && slot == slot_w_uniform)
+		var/mob/living/carbon/human/H = user
+		if(H.undershirt != "Nude")
+			var/additional_body_parts = UPPER_TORSO|ARMS
+			body_parts_covered |= additional_body_parts
+			return ..()
+	body_parts_covered = LOWER_TORSO|LEGS
+	..()
 
 /obj/item/clothing/under/pants/classicjeans
 	name = "classic jeans"


### PR DESCRIPTION
Simple change; if you equip pants and are wearing an undershirt, then they cover your arms and chest.

I realize that technically some undershirts don't cover the arms (like tank tops), but making a list of which shirts do which just for that would be absurd.

Doesn't really change much, except if you fireproof your pants while having an undershirt, it'll provide more fire protection.

:cl: Fox McCloud
tweak: wearing pants while wearing an undershirt means your arms and chest are covered
/:cl: