### PR TITLE
Removes Dirty Floors

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -27,7 +27,6 @@
 /obj/item/mop/proc/clean(turf/simulated/A)
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("cleaner", 1) || reagents.has_reagent("holywater", 1))
 		A.clean_blood()
-		A.dirt = 0
 		for(var/obj/effect/O in A)
 			if(is_cleanable(O))
 				qdel(O)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -55,7 +55,6 @@
 
 /obj/item/soap/proc/clean_turf(turf/simulated/T)
 	T.clean_blood()
-	T.dirt = 0
 	for(var/obj/effect/O in T)
 		if(is_cleanable(O))
 			qdel(O)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -8,7 +8,6 @@
 	nitrogen = MOLES_N2STANDARD
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed
 	var/max_fire_temperature_sustained = 0 //The max temperature of the fire which it was subjected to
-	var/dirt = 0
 	var/dirtoverlay = null
 	var/unacidable = FALSE
 
@@ -73,17 +72,6 @@
 /turf/simulated/Entered(atom/A, atom/OL, ignoreRest = 0)
 	..()
 	if(!ignoreRest)
-		if(isliving(A) && prob(50))
-			dirt++
-
-		var/obj/effect/decal/cleanable/dirt/dirtoverlay = locate(/obj/effect/decal/cleanable/dirt) in src
-		if(dirt >= 100)
-			if(!dirtoverlay)
-				dirtoverlay = new/obj/effect/decal/cleanable/dirt(src)
-				dirtoverlay.alpha = 10
-			else if(dirt > 100)
-				dirtoverlay.alpha = min(dirtoverlay.alpha + 10, 200)
-
 		if(ishuman(A))
 			var/mob/living/carbon/human/M = A
 			if(M.lying)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1130,9 +1130,6 @@ var/list/robot_verbs_default = list(
 			var/turf/tile = loc
 			if(isturf(tile))
 				var/floor_only = TRUE
-				if(istype(tile, /turf/simulated))
-					var/turf/simulated/S = tile
-					S.dirt = 0
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
 						if(is_cleanable(A))

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -81,9 +81,6 @@
 
 		for(var/mob/living/simple_animal/slime/M in T)
 			M.adjustToxLoss(rand(5, 10))
-		if(istype(T, /turf/simulated))
-			var/turf/simulated/S = T
-			S.dirt = 0
 
 /datum/reagent/space_cleaner/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(iscarbon(M))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -194,8 +194,7 @@
 
 	for(var/obj/effect/decal/cleanable/M in view(2, E.loc))//germs from messes
 		if(AStar(E.loc, M.loc, /turf/proc/Distance, 2, simulated_only = 0))
-			if(!istype(M,/obj/effect/decal/cleanable/dirt))//dirt is too common
-				germs++
+			germs++
 
 	if(tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
 		germs += 30

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -49,9 +49,6 @@
 		var/turf/tile = loc
 		if(isturf(tile))
 			tile.clean_blood()
-			if(istype(tile, /turf/simulated/floor))
-				var/turf/simulated/floor/F = tile
-				F.dirt = 0
 			for(var/A in tile)
 				if(is_cleanable(A))
 					qdel(A)


### PR DESCRIPTION
Dirt doesn't add anything particularly fun to the game, and ever since we got blood trails and blood drips and what have you, the station is, more often than not, *covered* in blood.

Dirt is impossible to keep up with, as a janitor, particularly on high pop...not only that, but it's lagging the server and gumming up the garbage collector; taking thousands of deciseconds of deletion time.

With how much vomit, blood, clothing shreds, and other messes that the crew can make these days, dirt is just adding insult to injury and doesn't really let the janitor fixate on tasks he can actually handle.

Plus, did i mention it's literally lagging the server right now?

![img](https://i.gyazo.com/6ed7444693491e044598cc6aa3afcf10.png)

It only failed 50 times and it's already used up 3 seconds of calculation time. That's 60 deciseconds per delete---yikes.

:cl: Fox McCloud
del: Floors no longer get dirty by walking on them
/:cl: