### PR TITLE
Fixes APCs Not Being Hackable

### DIFF
--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -11,13 +11,13 @@ var/const/APC_WIRE_AI_CONTROL = 8
 	switch(index)
 		if(APC_WIRE_IDSCAN)
 			return "ID Scan"
-		
+
 		if(APC_WIRE_MAIN_POWER1)
 			return "Primary Power"
-		
+
 		if(APC_WIRE_MAIN_POWER2)
 			return "Secondary Power"
-		
+
 		if(APC_WIRE_AI_CONTROL)
 			return "AI Control"
 
@@ -31,9 +31,9 @@ var/const/APC_WIRE_AI_CONTROL = 8
 
 /datum/wires/apc/CanUse(mob/living/L)
 	var/obj/machinery/power/apc/A = holder
-	if(A.wiresexposed)
-		return 1
-	return 0
+	if(A.panel_open && !A.opened)
+		return TRUE
+	return FALSE
 
 /datum/wires/apc/UpdatePulsed(index)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -77,7 +77,6 @@
 	var/lastused_environ = 0
 	var/lastused_total = 0
 	var/main_status = 0
-	var/wiresexposed = 0
 	powernet = 0		// set so that APCs aren't found as powernet nodes //Hackish, Horrible, was like this before I changed it :(
 	var/malfhack = 0 //New var for my changes to AI malf. --NeoFite
 	var/mob/living/silicon/ai/malfai = null //See above --NeoFite
@@ -364,7 +363,7 @@
 			update_state |= UPSTATE_OPENED2
 	else if(emagged || malfai)
 		update_state |= UPSTATE_BLUESCREEN
-	else if(wiresexposed)
+	else if(panel_open)
 		update_state |= UPSTATE_WIREEXP
 	if(update_state <= 1)
 		update_state |= UPSTATE_ALLGOOD
@@ -421,7 +420,7 @@
 			updating_icon = 0
 
 /obj/machinery/power/apc/get_spooked(second_pass = FALSE)
-	if(opened || wiresexposed)
+	if(opened || panel_open)
 		return
 	if(stat & (NOPOWER | BROKEN))
 		return
@@ -695,7 +694,7 @@
 	if(!(emagged || malfhack))		// trying to unlock with an emag card
 		if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
-		else if(wiresexposed)
+		else if(panel_open)
 			to_chat(user, "You must close the panel first.")
 		else if(stat & (BROKEN|MAINT))
 			to_chat(user, "Nothing happens.")
@@ -735,7 +734,7 @@
 	src.interact(user)
 
 /obj/machinery/power/apc/attack_ghost(mob/user)
-	if(wiresexposed)
+	if(panel_open)
 		wires.Interact(user)
 	return ui_interact(user)
 
@@ -743,7 +742,7 @@
 	if(!user)
 		return
 
-	if(wiresexposed)
+	if(panel_open)
 		wires.Interact(user)
 
 	return ui_interact(user)


### PR DESCRIPTION
Sorry about that guys. This was implemented towards the end of the refactor, and I was getting really weary of things.

Fixes: https://github.com/ParadiseSS13/Paradise/issues/12537

also fixes the APC icon not properly updating

:cl: Fox McCloud
fix: Fixes APCs not being hackable
/:cl: