### PR TITLE
Fixes Explosions

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -346,7 +346,19 @@
 /obj/machinery/sleeper/ex_act(severity)
 	if(filtering)
 		toggle_filter()
+	if(occupant)
+		occupant.ex_act(severity)
 	..()
+
+/obj/machinery/sleeper/handle_atom_del(atom/A)
+	..()
+	if(A == occupant)
+		occupant = null
+		updateUsrDialog()
+		update_icon()
+	if(A == beaker)
+		beaker = null
+		updateUsrDialog()
 
 /obj/machinery/sleeper/emp_act(severity)
 	if(filtering)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -567,3 +567,9 @@
 
 /obj/item/storage/AllowDrop()
 	return TRUE
+
+/obj/item/storage/ex_act(severity)
+	for(var/atom/A in contents)
+		A.ex_act(severity)
+		CHECK_TICK
+	..()


### PR DESCRIPTION
I forgot  to include the `ex_act` for storage which calls `ex_act` on the contents of said storage, which boxes dumping their contents and leaving it mostly unharmed.

Also fixes sleepers making you immune to explosions.

Fixes: https://github.com/ParadiseSS13/Paradise/issues/12535

The yellow documents will ALWAYS survive, because they have the `INDESTRUCTIBLE` flag, as the vast bulk of objective items do.

:cl: Fox McCloud
fix: Fixes explosions not properly interacting with storage items
/:cl: