### PR TITLE
Makes yellow documents destructible

### DIFF
--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -33,6 +33,7 @@
 	name = "'Yellow' secret documents"
 	desc = "\"Top Secret\" documents printed on special copy-protected paper. It details sensitive Syndicate operational intelligence. These documents are marked \"Yellow\"."
 	icon_state = "docs_yellow"
+	resistance_flags = NONE
 
 /obj/item/documents/syndicate/yellow/trapped
 	desc = "\"Top Secret\" documents printed on special copy-protected paper. It details sensitive Syndicate operational intelligence. These documents are marked \"Yellow\", and have a thin film of clear material covering their surface."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Yellow documents (as found in the syndie depot) are now destructible again and will be blown up by the depot exploding (once #12539 goes in) as discussed in that PR. You can also burn them, throw them in lava etc.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You shouldn't be able to provoke a depot explosion to easily get secret documents from the wreckage. Nobody has yellow docs as a specific objective so you also don't screw over people too badly that way.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: yellow documents are no longer indestructible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
