### PR TITLE
Fixes Tribute Rune not producing full soul stone + light refactor.

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -437,12 +437,6 @@ var/list/teleport_runes = list()
 	var/sacrifice_fulfilled
 	var/datum/game_mode/cult/cult_mode = SSticker.mode
 	if(T)
-		if(isdog(T)) // Doggos are the best, but not cats
-			for(var/M in invokers)
-				var/mob/living/L = M
-				to_chat(L, "<span class='cultlarge'>\"Even I have standards, such as they are!\"</span>")
-				if(L.reagents)
-					L.reagents.add_reagent("hell_water", 2)
 		if(T.mind)
 			sacrificed.Add(T.mind)
 			if(is_sacrifice_target(T.mind))
@@ -456,26 +450,29 @@ var/list/teleport_runes = list()
 				to_chat(M, "<span class='cultlarge'>\"Yes! This is the one I desire! You have done well.\"</span>")
 				cult_mode.additional_phase()
 			else
-				if(ishuman(T) || isrobot(T))
-					to_chat(M, "<span class='cultlarge'>\"I accept this sacrifice.\"</span>")
-				else
+				if(!isdog(T) && !ishuman(T) && !(isrobot(T)))
 					to_chat(M, "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>")
-		if(T.mind)
-			var/obj/item/soulstone/stone = new /obj/item/soulstone(get_turf(src))
-			stone.invisibility = INVISIBILITY_MAXIMUM //so it's not picked up during transfer_soul()
-			if(!stone.transfer_soul("VICTIM", T, usr)) //If it cannot be added
-				qdel(stone)
-			if(stone)
-				stone.invisibility = 0
-			if(!T)
-				rune_in_use = 0
-				return
-		if(isrobot(T))
-			playsound(T, 'sound/effects/EMPulse.ogg', 100, 1)
-			T.dust() //To prevent the MMI from remaining
-		else
+				else
+					if(isdog(T)) // Doggos are the best, but not cats
+						to_chat(M, "<span class='cultlarge'>\"Even I have standards, such as they are!\"</span>")
+						var/mob/living/L = M
+						if(L.reagents)
+							L.reagents.add_reagent("hell_water", 2)
+					else
+						if(T.client_mobs_in_contents?.len)
+							if(ishuman(T) || isrobot(T))
+								to_chat(M, "<span class='cultlarge'>\"I accept this sacrifice.\"</span>")
+						else
+							to_chat(M, "<span class='cultlarge'>\"This shell lacks a soul.\"</span>")
+		if(T.client_mobs_in_contents?.len)
+			if(ishuman(T) || isrobot(T))
+				var/obj/item/soulstone/stone = new /obj/item/soulstone(get_turf(src))
+				stone.invisibility = INVISIBILITY_MAXIMUM //so it's not picked up during transfer_soul()
+				stone.transfer_soul("FORCE", T, usr)
+				stone.invisibility = 0	
+		if(!isdog(T) && !ishuman(T) && !(isrobot(T)))
 			playsound(T, 'sound/magic/disintegrate.ogg', 100, 1)
-			T.gib()
+			T.gib()	
 	rune_in_use = 0
 
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #12494 

While a straight fix could have been much easier if I just gutted a lot of the rune, I also made it a point to maintain previously intended functionality. What I mean by this is, you can still sacrifice just about any mob, with a exception of dogs. However, I adjusted it so only humans and cyborgs produce and attempt to fill soul stones when sacrificed, and only when the said human or cyborg has had a ckey at one point in its existence. So no cheesy free cult ghosts by sacrificing PAI's or something like that.

I changed a few lines here and there in soul stone code, like lines deleting mobs before we're done with them. (causing cyborgs to spill out their internal bits you're never supposed to see)

## Why It's Good For The Game
Makes an intended feature *work* while accounting for potential exploits. I did extensive testing. Sacrificing objective still works, as that part of the code wasn't touched. Adjusted for strange edge cases like a client leaving and then rejoining mid ghost-chat poll for filling the soul stone.

In short, it makes the Sacrifice Rune work as intended, giving the one sacrificed a bit of a consolation prize by putting them in a soul stone and letting them do some cult stuff, or lets ghosts take their place if the player has already ghosted.

My coding is likely poor quality, and I would appreciate feedback. If owners think we should do without some of the features like Nar'Sie being a dog person, or sacrificing any and all mobs for a meager sacrifice flavor text, I am 100% willing to ditch those.

Edge cases I did not test: Cortical Borers in the sacrificee, and the sacrificee being antag banned.

## Changelog
:cl:
fix: Fixed sacrificing rune not producing filled soul stones.
/:cl:
