### PR TITLE
Make cult whispering use their real name

### DIFF
--- a/code/game/gamemodes/cult/cult_comms.dm
+++ b/code/game/gamemodes/cult/cult_comms.dm
@@ -38,7 +38,7 @@
 	if(istype(user, /mob/living/simple_animal/slaughter/cult)) //Harbringers of the Slaughter
 		my_message = "<span class='cultlarge'><b>Harbringer of the Slaughter:</b> [message]</span>"
 	else
-		my_message = "<span class='cultspeech'><b>[(ishuman(user) ? "Acolyte" : "Construct")] [user]:</b> [message]</span>"
+		my_message = "<span class='cultspeech'><b>[(ishuman(user) ? "Acolyte" : "Construct")] [user.real_name]:</b> [message]</span>"
 	for(var/mob/M in GLOB.player_list)
 		if(iscultist(M))
 			to_chat(M, my_message)


### PR DESCRIPTION
## What Does This PR Do
Makes cult whispering use their real name instead of their visible name

## Why It's Good For The Game
It's handy to know which cultist is talking. And not what ID they are wearing

## Changelog
:cl:
tweak: Cult whispering now uses your real name
/:cl:
