### PR TITLE
Reverts legacy autoban

### DIFF
--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -152,10 +152,9 @@ var/list/chatResources = list(
 				if(world.IsBanned(row["ckey"], row["ip"], row["compid"], FALSE))
 					found = row
 					break
-
+			//Add autoban using the DB_ban_record function
 			//Uh oh this fucker has a history of playing on a banned account!!
 			if (found.len > 0)
-				AddBan(owner.ckey, owner.computer_id, "Ban evasion on account: [found["ckey"]]", "System", 0, 0, owner.address)
 				message_admins("[key_name(src.owner)] has a cookie from a banned account! (Matched: [found["ckey"]], [found["ip"]], [found["compid"]])")
 				log_admin("[key_name(src.owner)] has a cookie from a banned account! (Matched: [found["ckey"]], [found["ip"]], [found["compid"]])")
 


### PR DESCRIPTION
Reverts autoban using legacy system causing issues 

_DB_ban_record_ is the real ban proc, however it doesn't call _add_note_ from a quick glance

:cl:
del: Reverted autoban using legacy system causing issues 
/ 🆑 