### PR TITLE
Removes obsolete admin verb: "show discord duplicates"

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -702,7 +702,7 @@ var/global/nologevent = 0
 		return 1
 	else
 		to_chat(usr, "<font color='red'>Error: Start Now: Game has already started.</font>")
-		return 
+		return
 
 /datum/admins/proc/toggleenter()
 	set category = "Server"
@@ -1090,28 +1090,3 @@ var/gamma_ship_location = 1 // 0 = station , 1 = space
 			continue
 		result[1]++
 	return result
-
-//Discord duplications
-/datum/admins/proc/discord_duplicates()
-	if(!usr.client.holder)
-		return
-	var/dat = "<html><head><title>Discord Duplicates</title></head>"
-	dat += "<body><p><i>Discord IDs with more than one ckey linked are shown below</i></i><table border=1 cellspacing=5><B><tr><th>Discord ID</th><th>CKEYs</th><th>Unlink</th></B>"
-	// If anyone reads this, I spent a whole 30 minutes writing just this fucking query. It is the messiest SQL statement I have ever written
-	// If anyone even thinks about touching this I will impale you on a railroad spike
-	// It hurts to wake up in the morning, -aa07
-	var/DBQuery/discord_ids = dbcon.NewQuery("SELECT a.* FROM [format_table_name("discord")] a JOIN (SELECT discord_id, ckey, COUNT(*) FROM [format_table_name("discord")] GROUP BY discord_id HAVING count(*) > 1 ) b ON a.discord_id = b.discord_id ORDER BY a.discord_id")
-	if(!discord_ids.Execute())
-		var/err = discord_ids.ErrorMsg()
-		log_game("SQL ERROR while selecting discord accounts. Error : \[[err]\]\n")
-		return
-	while(discord_ids.NextRow())
-		var/ckey = discord_ids.item[1]
-		var/id = discord_ids.item[2]
-		dat += "<tr><td><b>" + id + "</b></td>"
-		dat += "<td>" + ckey + "</td>"
-		dat += "<td><a href='?src=[UID()];force_discord_unlink=[ckey]'>Unlink</td></tr>"
-
-	dat += "</table></body></html>"
-
-	usr << browse(dat, "window=duplicates;size=500x480")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,7 +79,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/list_ssds_afks,
 	/client/proc/cmd_admin_headset_message,
 	/client/proc/spawn_floor_cluwne,
-	/client/proc/show_discord_duplicates, // This needs removing at some point, ingame discord linking got removed in #11359
 	/client/proc/toggle_panic_bunker
 )
 var/list/admin_verbs_ban = list(
@@ -1019,15 +1018,6 @@ var/list/admin_verbs_ticket = list(
 	log_admin("[key_name(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 	message_admins("[key_name_admin(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 
-/client/proc/show_discord_duplicates()
-	set name = "Show Duplicate Discord Links"
-	set category = "Admin"
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	holder.discord_duplicates()
-
 /client/proc/toggle_panic_bunker()
 	set name = "Toggle Panic Bunker"
 	set category = "Admin"
@@ -1036,7 +1026,7 @@ var/list/admin_verbs_ticket = list(
 	if(!check_rights(R_ADMIN))
 		return
 
-	GLOB.panic_bunker_enabled = !GLOB.panic_bunker_enabled 
+	GLOB.panic_bunker_enabled = !GLOB.panic_bunker_enabled
 
 	log_admin("[key_name(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")
 	message_admins("[key_name_admin(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")


### PR DESCRIPTION
## What Does This PR Do
Removes the obsolete "show duplicate discord links" admin verb.
This verb showed data from the old game/discord link system used by Affected's Boxen bot, and hasn't been used for awhile now.
https://github.com/ParadiseSS13/Paradise/pull/11359 removed most of it, but this verb was missed. 

## Why It's Good For The Game
Reduces the number of obsolete/useless admin verbs.

## Changelog
:cl:
del: Removed admin-only "show duplicate discord links" verb.
/:cl: