### PR TITLE
Makes LINDA Aggressive

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -25,11 +25,13 @@
 #define BREATH_PERCENTAGE		(BREATH_VOLUME/CELL_VOLUME)					//Amount of air to take a from a tile
 
 //EXCITED GROUPS
-#define MINIMUM_AIR_RATIO_TO_SUSPEND				0.005	//Minimum ratio of air that must move to/from a tile to suspend group processing
+#define EXCITED_GROUP_BREAKDOWN_CYCLES				4		//number of FULL air controller ticks before an excited group breaks down (averages gas contents across turfs)
+#define EXCITED_GROUP_DISMANTLE_CYCLES				16		//number of FULL air controller ticks before an excited group dismantles and removes its turfs from active
+#define MINIMUM_AIR_RATIO_TO_SUSPEND				0.1		//Ratio of air that must move to/from a tile to reset group processing
+#define MINIMUM_AIR_RATIO_TO_MOVE					0.001	//Minimum ratio of air that must move to/from a tile
 #define MINIMUM_AIR_TO_SUSPEND						(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND)	//Minimum amount of air that has to move before a group processing can be suspended
-#define MINIMUM_MOLES_DELTA_TO_MOVE					(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND) //Either this must be active
+#define MINIMUM_MOLES_DELTA_TO_MOVE					(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_MOVE) //Either this must be active
 #define MINIMUM_TEMPERATURE_TO_MOVE					(T20C+100)			//or this (or both, obviously)
-#define MINIMUM_TEMPERATURE_RATIO_TO_SUSPEND		0.012
 #define MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND		4		//Minimum temperature difference before group processing is suspended
 #define MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER		0.5		//Minimum temperature difference before the gas temperatures are just set to be equal
 #define MINIMUM_TEMPERATURE_FOR_SUPERCONDUCTION		(T20C+10)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -249,9 +249,10 @@ SUBSYSTEM_DEF(air)
 		var/datum/excited_group/EG = currentrun[currentrun.len]
 		currentrun.len--
 		EG.breakdown_cooldown++
-		if(EG.breakdown_cooldown == 10)
+		EG.dismantle_cooldown++
+		if(EG.breakdown_cooldown >= EXCITED_GROUP_BREAKDOWN_CYCLES)
 			EG.self_breakdown()
-		else if(EG.breakdown_cooldown >= 20)
+		else if(EG.dismantle_cooldown >= EXCITED_GROUP_DISMANTLE_CYCLES)
 			EG.dismantle()
 		if(MC_TICK_CHECK)
 			return

--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -368,20 +368,20 @@ What are the archived variables for?
 
 	var/delta_temperature = (temperature_archived - model.temperature)
 
-	if(((abs(delta_oxygen) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_oxygen) >= oxygen_archived*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
-		|| ((abs(delta_carbon_dioxide) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_carbon_dioxide) >= carbon_dioxide_archived*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
-		|| ((abs(delta_nitrogen) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_nitrogen) >= nitrogen_archived*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
-		|| ((abs(delta_toxins) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_toxins) >= toxins_archived*MINIMUM_AIR_RATIO_TO_SUSPEND)))
-		return 0
+	if(((abs(delta_oxygen) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_oxygen) >= oxygen_archived*MINIMUM_AIR_RATIO_TO_MOVE)) \
+		|| ((abs(delta_carbon_dioxide) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_carbon_dioxide) >= carbon_dioxide_archived*MINIMUM_AIR_RATIO_TO_MOVE)) \
+		|| ((abs(delta_nitrogen) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_nitrogen) >= nitrogen_archived*MINIMUM_AIR_RATIO_TO_MOVE)) \
+		|| ((abs(delta_toxins) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_toxins) >= toxins_archived*MINIMUM_AIR_RATIO_TO_MOVE)))
+		return TRUE
 	if(abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
-		return 0
+		return TRUE
 
 	for(var/gas in trace_gases)
 		var/datum/gas/trace_gas = gas
-		if(trace_gas.moles_archived > MINIMUM_AIR_TO_SUSPEND*4)
-			return 0
+		if(trace_gas.moles_archived > MINIMUM_MOLES_DELTA_TO_MOVE*4)
+			return TRUE
 
-	return 1
+	return FALSE
 
 /datum/gas_mixture/proc/check_turf_total(turf/model) //I want this proc to die a painful death
 	var/delta_oxygen = (oxygen - model.oxygen)
@@ -391,20 +391,20 @@ What are the archived variables for?
 
 	var/delta_temperature = (temperature - model.temperature)
 
-	if(((abs(delta_oxygen) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_oxygen) >= oxygen*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
-		|| ((abs(delta_carbon_dioxide) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_carbon_dioxide) >= carbon_dioxide*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
-		|| ((abs(delta_nitrogen) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_nitrogen) >= nitrogen*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
-		|| ((abs(delta_toxins) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_toxins) >= toxins*MINIMUM_AIR_RATIO_TO_SUSPEND)))
-		return 0
+	if(((abs(delta_oxygen) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_oxygen) >= oxygen*MINIMUM_AIR_RATIO_TO_MOVE)) \
+		|| ((abs(delta_carbon_dioxide) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_carbon_dioxide) >= carbon_dioxide*MINIMUM_AIR_RATIO_TO_MOVE)) \
+		|| ((abs(delta_nitrogen) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_nitrogen) >= nitrogen*MINIMUM_AIR_RATIO_TO_MOVE)) \
+		|| ((abs(delta_toxins) > MINIMUM_MOLES_DELTA_TO_MOVE) && (abs(delta_toxins) >= toxins*MINIMUM_AIR_RATIO_TO_MOVE)))
+		return TRUE
 	if(abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
-		return 0
+		return TRUE
 
 	for(var/gas in trace_gases)
 		var/datum/gas/trace_gas = gas
-		if(trace_gas.moles > MINIMUM_AIR_TO_SUSPEND*4)
-			return 0
+		if(trace_gas.moles > MINIMUM_MOLES_DELTA_TO_MOVE*4)
+			return TRUE
 
-	return 1
+	return FALSE
 
 /datum/gas_mixture/share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
 	if(!sharer)	return 0
@@ -638,46 +638,53 @@ What are the archived variables for?
 			sharer.temperature += heat/sharer.heat_capacity
 
 /datum/gas_mixture/compare(datum/gas_mixture/sample)
-	if((abs(oxygen-sample.oxygen) > MINIMUM_AIR_TO_SUSPEND) && \
-		((oxygen < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.oxygen) || (oxygen > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.oxygen)))
-		return 0
-	if((abs(nitrogen-sample.nitrogen) > MINIMUM_AIR_TO_SUSPEND) && \
-		((nitrogen < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.nitrogen) || (nitrogen > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.nitrogen)))
-		return 0
-	if((abs(carbon_dioxide-sample.carbon_dioxide) > MINIMUM_AIR_TO_SUSPEND) && \
-		((carbon_dioxide < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.carbon_dioxide) || (oxygen > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.carbon_dioxide)))
-		return 0
-	if((abs(toxins-sample.toxins) > MINIMUM_AIR_TO_SUSPEND) && \
-		((toxins < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.toxins) || (toxins > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.toxins)))
-		return 0
+	var/delta = abs(oxygen - sample.oxygen)
+	if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && delta > oxygen * MINIMUM_AIR_RATIO_TO_MOVE)
+		return TRUE
 
-	if(total_moles() > MINIMUM_AIR_TO_SUSPEND)
-		if((abs(temperature-sample.temperature) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND) && \
-			((temperature < (1-MINIMUM_TEMPERATURE_RATIO_TO_SUSPEND)*sample.temperature) || (temperature > (1+MINIMUM_TEMPERATURE_RATIO_TO_SUSPEND)*sample.temperature)))
-			return 0
+	delta = abs(nitrogen - sample.nitrogen)
+	if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && delta > nitrogen * MINIMUM_AIR_RATIO_TO_MOVE)
+		return TRUE
 
-	for(var/gas in sample.trace_gases)
-		var/datum/gas/trace_gas = gas
-		if(trace_gas.moles_archived > MINIMUM_AIR_TO_SUSPEND)
-			var/datum/gas/corresponding = locate(trace_gas.type) in trace_gases
-			if(corresponding)
-				if((abs(trace_gas.moles - corresponding.moles) > MINIMUM_AIR_TO_SUSPEND) && \
-					((corresponding.moles < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*trace_gas.moles) || (corresponding.moles > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*trace_gas.moles)))
-					return 0
-			else
-				return 0
+	delta = abs(carbon_dioxide - sample.carbon_dioxide)
+	if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && delta > carbon_dioxide * MINIMUM_AIR_RATIO_TO_MOVE)
+		return TRUE
+
+	delta = abs(toxins - sample.toxins)
+	if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && delta > toxins * MINIMUM_AIR_RATIO_TO_MOVE)
+		return TRUE
+
+	if(total_moles() > MINIMUM_MOLES_DELTA_TO_MOVE)
+		var/temp = temperature
+		var/sample_temp = sample.temperature
+
+		var/temperature_delta = abs(temp - sample_temp)
+		if(temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
+			return TRUE
 
 	for(var/gas in trace_gases)
 		var/datum/gas/trace_gas = gas
-		if(trace_gas.moles > MINIMUM_AIR_TO_SUSPEND)
-			var/datum/gas/corresponding = locate(trace_gas.type) in sample.trace_gases
-			if(corresponding)
-				if((abs(trace_gas.moles - corresponding.moles) > MINIMUM_AIR_TO_SUSPEND) && \
-					((trace_gas.moles < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*corresponding.moles) || (trace_gas.moles > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*corresponding.moles)))
-					return 0
-			else
-				return 0
-	return 1
+		var/datum/gas/corresponding = locate(trace_gas.type) in sample.trace_gases
+		if(corresponding)
+			delta = abs(trace_gas.moles - corresponding.moles)
+			if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && delta > trace_gas.moles * MINIMUM_AIR_RATIO_TO_MOVE)
+				return TRUE
+		else
+			if(trace_gas.moles > MINIMUM_MOLES_DELTA_TO_MOVE)
+				return TRUE
+
+	for(var/gas in sample.trace_gases)
+		var/datum/gas/trace_gas = gas
+		var/datum/gas/corresponding = locate(trace_gas.type) in trace_gases
+		if(corresponding)
+			delta = abs(trace_gas.moles - corresponding.moles)
+			if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && delta > trace_gas.moles * MINIMUM_AIR_RATIO_TO_MOVE)
+				return TRUE
+		else
+			if(trace_gas.moles > MINIMUM_MOLES_DELTA_TO_MOVE)
+				return TRUE
+
+	return FALSE
 
 
 


### PR DESCRIPTION
Requesting that @MrStonedOne take a look at this.

I realize you guys have datumized gases and we don't, but I figure we can get the code *relatively* the same, function wise.

Either case, this ports @MrStonedOne's LINDA update from eons ago that makes LINDA more aggressive about breaking down excited groups and evening out the gas among them. 

It means LINDA is, overall, less active and moves gas faster among a larger amount of turfs.

This also fixes planetary atmos--our code expects that if there *IS* a difference between two turfs with gas, it returns `FALSE`. When @Markolie ported planetary atmos, he didn't realize that TG has inverted that logic (and made is more readable IMO...who expects a `FALSE` return to mean 'Yep, there's a difference!"), ergo, the only time atmos was sharing its gas with turfs was when there *wasn't* a difference between turfs.

:cl: Fox McCloud
tweak: LINDA is much more aggressive at distributing gas between turfs in an excited group
/:cl: