### PR TITLE
quickfix to stop people using the scanner inside it

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -140,6 +140,9 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
+	if(occupant == user)
+		return // you cant reach that
+
 	if(panel_open)
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 		return


### PR DESCRIPTION
## What Does This PR Do
fixes #12565 

## Why It's Good For The Game
you shouldnt be able to reach the body scanner panel and read it when inside the thing

## Changelog
:cl:
fix: quickfix to stop people using the scanner inside it
/:cl:
