### PR TITLE
Fixes Bubblegum Spawn Rate

### DIFF
--- a/code/game/turfs/simulated/floor/asteroid.dm
+++ b/code/game/turfs/simulated/floor/asteroid.dm
@@ -280,8 +280,6 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 				var/maybe_boss = pickweight(megafauna_spawn_list)
 				if(megafauna_spawn_list[maybe_boss])
 					randumb = maybe_boss
-					if(ispath(maybe_boss, /mob/living/simple_animal/hostile/megafauna/bubblegum)) //there can be only one bubblegum, so don't waste spawns on it
-						megafauna_spawn_list.Remove(maybe_boss)
 			else //this is not danger, don't spawn a boss, spawn something else
 				randumb = pickweight(mob_spawn_list)
 
@@ -293,8 +291,10 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 			if((ispath(randumb, /obj/structure/spawner/lavaland) || istype(H, /obj/structure/spawner/lavaland)) && get_dist(src, H) <= 2)
 				return //prevents tendrils spawning in each other's collapse range
 
+		if(ispath(randumb, /mob/living/simple_animal/hostile/megafauna/bubblegum)) //there can be only one bubblegum, so don't waste spawns on it
+			megafauna_spawn_list.Remove(randumb)
+
 		new randumb(T)
-	return
 
 #undef SPAWN_MEGAFAUNA
 #undef SPAWN_BUBBLEGUM


### PR DESCRIPTION
From TG.

The reason Bubblegum is so ridiculously obscenely rare is that if it rolls for Bubblegum, but the spawn would put him in range of another mob within 15 tiles, then he will not be spawned, but will be removed from the spawn list.

This means, of course, that him spawning is obscenely rare--this fixes that, while keeping the amount of Bubblegum spawns to `1`.

:cl: Fox McCloud
fix: Fixes Bubblegum spawning being ridiculously rare
/:cl: