### PR TITLE
Fixes RPEDs not showing parts of machines

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -447,7 +447,7 @@ Class Procs:
 			var/obj/item/circuitboard/CB = locate(/obj/item/circuitboard) in component_parts
 			var/P
 			if(W.works_from_distance)
-				to_chat(user, display_parts().Join("\n"))
+				to_chat(user, display_parts(user))
 			for(var/obj/item/stock_parts/A in component_parts)
 				for(var/D in CB.req_components)
 					if(ispath(A.type, D))
@@ -466,7 +466,7 @@ Class Procs:
 							break
 			RefreshParts()
 		else
-			to_chat(user, display_parts().Join("\n"))
+			to_chat(user, display_parts(user))
 		if(shouldplaysound)
 			W.play_rped_sound()
 		return 1
@@ -477,6 +477,7 @@ Class Procs:
 	. = list("<span class='notice'>Following parts detected in the machine:</span>")
 	for(var/obj/item/C in component_parts)
 		. += "<span class='notice'>[bicon(C)] [C.name]</span>"
+	. = jointext(., "\n")
 
 /obj/machinery/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -447,7 +447,7 @@ Class Procs:
 			var/obj/item/circuitboard/CB = locate(/obj/item/circuitboard) in component_parts
 			var/P
 			if(W.works_from_distance)
-				display_parts(user)
+				to_chat(user, display_parts().Join("\n"))
 			for(var/obj/item/stock_parts/A in component_parts)
 				for(var/D in CB.req_components)
 					if(ispath(A.type, D))
@@ -466,7 +466,7 @@ Class Procs:
 							break
 			RefreshParts()
 		else
-			display_parts(user)
+			to_chat(user, display_parts().Join("\n"))
 		if(shouldplaysound)
 			W.play_rped_sound()
 		return 1

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -326,12 +326,12 @@
 	var/moved = 0
 	if(panel_open || W.works_from_distance)
 		if(W.works_from_distance)
-			to_chat(user, display_parts().Join("\n"))
+			to_chat(user, display_parts())
 		for(var/I in W)
 			if(istype(I, refill_canister))
 				moved += restock(I)
 	else
-		to_chat(user, display_parts().Join("\n"))
+		to_chat(user, display_parts(user))
 	if(moved)
 		to_chat(user, "[moved] items restocked.")
 		W.play_rped_sound()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -326,12 +326,12 @@
 	var/moved = 0
 	if(panel_open || W.works_from_distance)
 		if(W.works_from_distance)
-			display_parts(user)
+			to_chat(user, display_parts().Join("\n"))
 		for(var/I in W)
 			if(istype(I, refill_canister))
 				moved += restock(I)
 	else
-		display_parts(user)
+		to_chat(user, display_parts().Join("\n"))
 	if(moved)
 		to_chat(user, "[moved] items restocked.")
 		W.play_rped_sound()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -326,7 +326,7 @@
 	var/moved = 0
 	if(panel_open || W.works_from_distance)
 		if(W.works_from_distance)
-			to_chat(user, display_parts())
+			to_chat(user, display_parts(user))
 		for(var/I in W)
 			if(istype(I, refill_canister))
 				moved += restock(I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes RPEDs and bluespace RPEDs not properly displaying a list of machine parts to player's chat when you clicked on a machine with them.

The examine refactor changed the `display_parts()` proc to return a list of strings however it didn't work with the old code... now it does.

Fixes #12554

## Changelog
:cl:
fix: Fixes the RPED and bluespace RPED not displaying a list of parts in players chat when used on a machine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
