### PR TITLE
Fix single quotes showing up weird in names and announcement titles

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -130,7 +130,7 @@
 
 //Filters out undesirable characters from names
 /proc/reject_bad_name(var/t_in, var/allow_numbers=0, var/max_length=MAX_NAME_LEN)
-	// Decode so that names with characters like < are still rejected. Will be encoded again at the end
+	// Decode so that names with characters like < are still rejected
 	t_in = html_decode(t_in)
 	if(!t_in || length(t_in) > max_length)
 		return //Rejects the input if it is null or if it is longer than the max length allowed
@@ -192,7 +192,7 @@
 	for(var/bad_name in list("space","floor","wall","r-wall","monkey","unknown","inactive ai","plating"))	//prevents these common metagamey names
 		if(cmptext(t_out,bad_name))	return	//(not case sensitive)
 
-	return html_encode(t_out)
+	return t_out
 
 //checks text for html tags
 //if tag is not in whitelist (var/list/paper_tag_whitelist in global.dm)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -612,7 +612,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(type == "Custom")
 		type = clean_input("What would you like the report type to be?", "Report Type", "Encrypted Transmission")
 
-	var/customname = clean_input("Pick a title for the report.", "Title", MsgType[type])
+	var/customname = input(usr, "Pick a title for the report.", "Title", MsgType[type]) as text|null
 	if(!customname)
 		return
 	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What's the message?") as message|null


### PR DESCRIPTION
## What Does This PR Do
Fixes #12338

## Why It's Good For The Game
Fixes a display bug

## Changelog
:cl:
fix: single quotes showing up weird in names and announcement titles
/:cl: