### PR TITLE
Training Wheels Come Off

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -113,7 +113,16 @@
 
 /datum/status_effect/regenerative_core/on_apply()
 	owner.status_flags |= IGNORESLOWDOWN
-	owner.revive()
+	owner.adjustBruteLoss(-25)
+	owner.adjustFireLoss(-25)
+	owner.remove_CC()
+	owner.bodytemperature = BODYTEMP_NORMAL
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		for(var/thing in H.bodyparts)
+			var/obj/item/organ/external/E = thing
+			E.internal_bleeding = FALSE
+			E.mend_fracture()
 	return TRUE
 
 /datum/status_effect/regenerative_core/on_remove()

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -579,8 +579,8 @@
 		adjustFireLoss(-60)
 		for(var/obj/item/organ/external/E in bodyparts)
 			if(prob(25))
-				if(E.mend_fracture())
-					E.perma_injury = 0
+				E.mend_fracture()
+
 		return
 	if(stat != DEAD)
 		if(weakened)

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -165,15 +165,8 @@
 	desc = "Wall-mounted Medical Equipment dispenser. This one seems just a tiny bit smaller."
 	req_access = list()
 
-	products = list(/obj/item/reagent_containers/food/pill/patch/styptic = 5,
-					/obj/item/reagent_containers/food/pill/patch/silver_sulf = 5,
-					/obj/item/reagent_containers/food/pill/charcoal = 2,
-					/obj/item/stack/medical/bruise_pack/advanced = 1,
-					/obj/item/stack/medical/ointment/advanced = 1,
-					/obj/item/reagent_containers/hypospray/autoinjector = 2,
-					/obj/item/stack/medical/splint = 1)
-	contraband = list(/obj/item/reagent_containers/food/pill/tox = 2,
-	                  /obj/item/reagent_containers/food/pill/morphine = 2)
+	products = list(/obj/item/stack/medical/splint = 2)
+	contraband = list()
 
 //Computer
 /obj/item/gps/computer

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -48,12 +48,7 @@
 			var/list/our_organs = H.bodyparts.Copy()
 			shuffle(our_organs)
 			for(var/obj/item/organ/external/L in our_organs)
-				if(istype(L))
-					if(L.brute_dam < L.min_broken_damage)
-						L.status &= ~ORGAN_BROKEN
-						L.status &= ~ORGAN_SPLINTED
-						H.handle_splints()
-						L.perma_injury = 0
+				if(L.mend_fracture())
 					break // We're only checking one limb here, bucko
 		if(prob(3))
 			H.say(pick("Thanks Mr. Skeltal", "Thank for strong bones", "Doot doot!"))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -476,7 +476,7 @@
 
 /mob/living/proc/remove_CC(should_update_canmove = TRUE)
 	SetWeakened(0, FALSE)
-	SetWeaken(0, FALSE)
+	SetStunned(0, FALSE)
 	SetParalysis(0, FALSE)
 	SetSleeping(0, FALSE)
 	setStaminaLoss(0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -474,6 +474,16 @@
 		human_mob.update_dna()
 	return
 
+/mob/living/proc/remove_CC(should_update_canmove = TRUE)
+	SetWeakened(0, FALSE)
+	SetWeaken(0, FALSE)
+	SetParalysis(0, FALSE)
+	SetSleeping(0, FALSE)
+	setStaminaLoss(0)
+	SetSlowed(0)
+	if(should_update_canmove)
+		update_canmove()
+
 /mob/living/proc/UpdateDamageIcon()
 	return
 

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -109,9 +109,7 @@
 		var/var/mob/living/carbon/human/H = target
 		for(var/obj/item/organ/external/E in H.bodyparts)
 			if(prob(10))
-				if(E.mend_fracture())
-					E.perma_injury = 0
-	return
+				E.mend_fracture()
 
 /obj/item/gun/medbeam/proc/on_beam_release(var/mob/living/target)
 	return

--- a/code/modules/reagents/chemistry/reagents/admin.dm
+++ b/code/modules/reagents/chemistry/reagents/admin.dm
@@ -22,8 +22,7 @@
 			var/obj/item/organ/internal/I = thing
 			I.receive_damage(-5, FALSE)
 		for(var/obj/item/organ/external/E in H.bodyparts)
-			if(E.mend_fracture())
-				E.perma_injury = 0
+			E.mend_fracture()
 	M.SetEyeBlind(0, FALSE)
 	M.CureNearsighted(FALSE)
 	M.CureBlind(FALSE)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -165,11 +165,8 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] has mended the damaged bones in [target]'s [affected.name] with \the [tool].</span>"  , \
 		"<span class='notice'> You have mended the damaged bones in [target]'s [affected.name] with \the [tool].</span>" )
-	affected.status &= ~ORGAN_BROKEN
-	affected.status &= ~ORGAN_SPLINTED
-	affected.perma_injury = 0
-	target.handle_splints()
-	return 1
+	affected.mend_fracture()
+	return TRUE
 
 /datum/surgery_step/finish_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -625,12 +625,17 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /obj/item/organ/external/proc/mend_fracture()
 	if(is_robotic())
-		return 0	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
-	if(brute_dam > min_broken_damage)
-		return 0	//will just immediately fracture again
+		return FALSE	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
+
+	if(!(status & ORGAN_BROKEN))
+		return FALSE
 
 	status &= ~ORGAN_BROKEN
-	return 1
+	status &= ~ORGAN_SPLINTED
+	perma_injury = 0
+	if(owner)
+		owner.handle_splints()
+	return TRUE
 
 /obj/item/organ/external/robotize(company, make_tough = 0, convert_all = 1)
 	..()


### PR DESCRIPTION
Lavaland has been around a while and people are starting to figure out how to play effectively--megafauna have been updated (with the exception of Legion) and rebalanced; it's time for the training wheels to come off, however. 

From TG

Changes made:
- Survival medical wall vendor doesn't have any medicine in it anymore; it now just has two sets of splints
- Using a regenerative core is no longer a full heal, instead it heals 25 burn, 25  brute, removes all CC, sets your body temperature back to normal, mends all internal bleeding, and fixes all broken bones
  - Implanting a regenerative core will still provide a full heal, but you can only ever have one implanted in you, and you'll actually have to get surgery to get this

Other:
- Refactors fracturing mending to be more consistent; it also doesn't require the limb to be under minimum broken damage to mend the fracture, as fractures aren't guaranteed anymore

:cl: Fox McCloud
tweak: Survival pod medical vendors only have 2 pairs of splints instead of a wide array of medicines
tweak: Hivelord core, when used on someone, no longer fully revives them; instead it heals 25 burn, 25 brute, resets body temperature, removes all CC, cures all internal bleeding, and mends all fractures (slowdown bonus still stays
/:cl: