### PR TITLE
Robotics QoL: Combat Mechs now start with maintenance protocols permitted.

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -2,7 +2,6 @@
 	force = 30
 	var/maxsize = 2
 	internal_damage_threshold = 50
-	maint_access = 0
 	armor = list(melee = 30, bullet = 30, laser = 15, energy = 20, bomb = 20, bio = 0, rad = 0, fire = 100, acid = 100)
 	destruction_sleep_duration = 2
 	var/am = "d3c2fbcadca903a41161ccc9df9cf948"


### PR DESCRIPTION
## What Does This PR Do
Combat mechs now start with maintenance protocols enabled to facilitate easy cell replacement.

## Why It's Good For The Game
Replacing the cell in a newly constructed combat mech is a pain in the butt involving entering and leaving the mech just to start. Just a small QoL tweak for the roboticist (plus it makes it possible for a nerd to forget to lock the maintenance protocol and have a mighty durand beaten by a cultist with an ID card, which is always amusing).

## Changelog
:cl:
tweak: Combat mechs now start with maintenance protocols permitted.
/:cl:
