### PR TITLE
List SSDs and AFKs panel fix; Global objectives list fix

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1,4 +1,4 @@
-var/global/list/all_objectives = list()
+GLOBAL_LIST_EMPTY(all_objectives)
 
 var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datum/theft_objective/steal - /datum/theft_objective/number - /datum/theft_objective/unique
 
@@ -10,13 +10,13 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 	var/completed = 0					//currently only used for custom objectives.
 	var/martyr_compatible = 0			//If the objective is compatible with martyr objective, i.e. if you can still do it while dead.
 
-/datum/objective/New(var/text)
-	all_objectives |= src
+/datum/objective/New(text)
+	GLOB.all_objectives += src
 	if(text)
 		explanation_text = text
 
 /datum/objective/Destroy()
-	all_objectives -= src
+	GLOB.all_objectives -= src
 	return ..()
 
 /datum/objective/proc/check_completion()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -380,7 +380,7 @@
 			cult_mode.bypass_phase()
 
 	//Update any existing objectives involving this mob.
-	for(var/datum/objective/O in all_objectives)
+	for(var/datum/objective/O in GLOB.all_objectives)
 		// We don't want revs to get objectives that aren't for heads of staff. Letting
 		// them win or lose based on cryo is silly so we remove the objective.
 		if(istype(O,/datum/objective/mutiny) && O.target == occupant.mind)
@@ -395,7 +395,7 @@
 					if(!O) return
 					O.find_target()
 					if(!(O.target))
-						all_objectives -= O
+						GLOB.all_objectives -= O
 						O.owner.objectives -= O
 						qdel(O)
 	if(occupant.mind && occupant.mind.assigned_role)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -989,12 +989,14 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(job_string in command_positions)
 			job_string = "<U>" + job_string + "</U>"
 		role_string = "-"
+		obj_count = 0
+		obj_string = ""
 		if(H.mind)
 			if(H.mind.special_role)
 				role_string = "<U>[H.mind.special_role]</U>"
 			if(!H.key && H.mind.key)
 				key_string = H.mind.key
-			for(var/datum/objective/O in all_objectives)
+			for(var/datum/objective/O in GLOB.all_objectives)
 				if(O.target == H.mind)
 					obj_count++
 			if(obj_count > 0)
@@ -1033,7 +1035,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 				role_string = "<U>[H.mind.special_role]</U>"
 			if(!H.key && H.mind.key)
 				key_string = H.mind.key
-			for(var/datum/objective/O in all_objectives)
+			for(var/datum/objective/O in GLOB.all_objectives)
 				if(O.target == H.mind)
 					obj_count++
 			if(obj_count > 0)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -568,7 +568,7 @@ var/list/intents = list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
 		//Fixes renames not being reflected in objective text
 		var/length
 		var/pos
-		for(var/datum/objective/objective in all_objectives)
+		for(var/datum/objective/objective in GLOB.all_objectives)
 			if(!mind || objective.target != mind)
 				continue
 			length = lentext(oldname)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes "List SSDs and AFKs panel" showing everyone as the target of an assassinate objective. Also fixes the global variable `all_objectives`, that stores all objectives in the game, so it actually shows up in the Globals vars of the MC.

Fixes #12599

## Changelog
:cl:
fix: Fixes the "List SSDs and AFKs panel" showing everyone as the target of an assassinate objective
fix: The global objectives list is now viewable in the MC Globals menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
