### PR TITLE
fixes an issue with romerol

### DIFF
--- a/code/modules/mob/living/carbon/human/species/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species/zombies.dm
@@ -70,14 +70,6 @@
 	if(!H.InCritical() && prob(4))
 		playsound(H, pick(spooks), 50, TRUE, 10)
 
-//Congrats you somehow died so hard you stopped being a zombie
-/datum/species/zombie/infectious/handle_death(gibbed, mob/living/carbon/C)
-	. = ..()
-	var/obj/item/organ/internal/zombie_infection/infection
-	infection = C.get_organ_slot("zombie_infection")
-	if(infection)
-		qdel(infection)
-
 /datum/species/zombie/infectious/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
 	// Deal with the source of this zombie corruption


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
In preparation for kasparovy's set_species rework which is now ready for review, this fixes one of the issues with romerol so it can soon(hopefully) be enabled and people and admins can start messing with it(Just in time for halloween too!)

The handle_death proc was removing the infection organ, which is fine on TG where zombies can't actually die, but here our zombies die and revive on a timer.. so we need to not be dezombifying them when they die(since removing the organ removes the infection). Now that we have the trait framework though it might be possible to code in the NO_DEATH traits and stuff but that's out of scope for this one!
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps us get closer to romerol
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: zombies not properly reviving
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
