### PR TITLE
Fixes R&D Materials Exploit

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -357,7 +357,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							submenu = 0
 						if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
 							for(var/material in linked_destroy.loaded_item.materials)
-								linked_lathe.materials.insert_amount(min((linked_lathe.materials.max_amount - linked_lathe.materials.total_amount), (linked_destroy.loaded_item.materials[material]*(linked_destroy.decon_mod/10))), material)
+								var/can_insert = min((linked_lathe.materials.max_amount - linked_lathe.materials.total_amount), (min(linked_destroy.loaded_item.materials[material] * (linked_destroy.decon_mod / 10), linked_destroy.loaded_item.materials[material])))
+								linked_lathe.materials.insert_amount(can_insert, material)
 						linked_destroy.loaded_item = null
 					else
 						menu = 0

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -357,7 +357,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							submenu = 0
 						if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
 							for(var/material in linked_destroy.loaded_item.materials)
-								var/can_insert = min((linked_lathe.materials.max_amount - linked_lathe.materials.total_amount), (min(linked_destroy.loaded_item.materials[material] * (linked_destroy.decon_mod / 10), linked_destroy.loaded_item.materials[material])))
+								var/can_insert = min(linked_lathe.materials.max_amount - linked_lathe.materials.total_amount, linked_destroy.loaded_item.materials[material] * (linked_destroy.decon_mod / 10), linked_destroy.loaded_item.materials[material])
 								linked_lathe.materials.insert_amount(can_insert, material)
 						linked_destroy.loaded_item = null
 					else


### PR DESCRIPTION
Alternative to: https://github.com/ParadiseSS13/Paradise/pull/12604

Fixes R&D being able to exploit infinite materials.

Also shame on you guys for actively exploiting this and not reporting it.

It only further gives credence to my thesis that a decent amount of players only report bugs when it *negatively* impacts them, but are blithely happy to conveniently "forget" to report exploits/bugs in their favor.

:cl: Fox McCloud
fix: Fixes being able to exploit the destructive analyzer for unlimited materials
/:cl: