### PR TITLE
Add fast item pickup to bandoliers and rapier holster

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -439,7 +439,7 @@
 	desc = "A bandolier for holding shotgun ammunition."
 	icon_state = "bandolier"
 	item_state = "bandolier"
-	storage_slots = 8
+	click_to_hand = TRUE
 	can_hold = list(
 		/obj/item/ammo_casing/shotgun
 		)
@@ -450,7 +450,6 @@
 
 /obj/item/storage/belt/bandolier/full/New()
 	..()
-	new /obj/item/ammo_casing/shotgun/beanbag(src)
 	new /obj/item/ammo_casing/shotgun/beanbag(src)
 	new /obj/item/ammo_casing/shotgun/beanbag(src)
 	new /obj/item/ammo_casing/shotgun/beanbag(src)
@@ -577,6 +576,7 @@
 	storage_slots = 1
 	w_class = WEIGHT_CLASS_BULKY
 	max_w_class = WEIGHT_CLASS_BULKY
+	click_to_hand = TRUE
 	can_hold = list(/obj/item/melee/rapier)
 
 /obj/item/storage/belt/rapier/update_icon()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -9,7 +9,7 @@
 	name = "storage"
 	icon = 'icons/obj/storage.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
-	var/silent = 0 // No message on putting items in
+	var/silent = FALSE // No message on putting items in
 	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
 	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_hold isn't set)
 	var/max_w_class = WEIGHT_CLASS_SMALL //Max size of objects that this object can store (in effect only if can_hold isn't set)
@@ -22,6 +22,7 @@
 	var/allow_quick_empty	//Set this variable to allow the object to have the 'empty' verb, which dumps all the contents on the floor.
 	var/allow_quick_gather	//Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
 	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile
+	var/click_to_hand = FALSE //Set this variable to TRUE to make clicking the storage item immediately pick up the first item in it, instead of opening storage
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
 
 /obj/item/storage/MouseDrop(obj/over_object as obj)
@@ -397,6 +398,13 @@
 			H.r_store = null
 			return
 
+
+	if(click_to_hand && src.loc == user)
+		for(var/obj/item/I in contents)
+			if(user.put_in_active_hand(I))
+				add_fingerprint(user)
+				return
+
 	src.orient2hud(user)
 	if(src.loc == user)
 		if(user.s_active)
@@ -407,7 +415,7 @@
 		for(var/mob/M in range(1))
 			if(M.s_active == src)
 				src.close(M)
-	src.add_fingerprint(user)
+	add_fingerprint(user)
 	return
 
 /obj/item/storage/verb/toggle_gathering_mode()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -399,14 +399,14 @@
 			return
 
 
-	if(click_to_hand && src.loc == user)
+	if(click_to_hand && loc == user)
 		for(var/obj/item/I in contents)
 			if(user.put_in_active_hand(I))
 				add_fingerprint(user)
 				return
 
-	src.orient2hud(user)
-	if(src.loc == user)
+	orient2hud(user)
+	if(loc == user)
 		if(user.s_active)
 			user.s_active.close(user)
 		src.show_to(user)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -124,7 +124,7 @@
 	new /obj/item/shield/riot/tele(src)
 	new /obj/item/melee/baton/loaded(src)
 	new /obj/item/storage/belt/security/sec(src)
-	new	/obj/item/storage/belt/bandolier(src)
+	new /obj/item/storage/belt/bandolier(src)
 	new /obj/item/gun/energy/gun/hos(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/reagent_containers/food/drinks/mug/hos(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -124,6 +124,7 @@
 	new /obj/item/shield/riot/tele(src)
 	new /obj/item/melee/baton/loaded(src)
 	new /obj/item/storage/belt/security/sec(src)
+	new	/obj/item/storage/belt/bandolier(src)
 	new /obj/item/gun/energy/gun/hos(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/reagent_containers/food/drinks/mug/hos(src)
@@ -164,6 +165,7 @@
 	new /obj/item/melee/baton/loaded(src)
 	new /obj/item/gun/energy/gun/advtaser(src)
 	new /obj/item/storage/belt/security/sec(src)
+	new /obj/item/storage/belt/bandolier(src)
 	new /obj/item/storage/box/holobadge(src)
 	new /obj/item/clothing/gloves/color/black/krav_maga/sec(src)
 


### PR DESCRIPTION
This PR changes the bandolier (shotgun ammo holster) and captain rapier holster to immediately pick up a shell/rapier if possible when you click on the storage item rather than opening its inventory. This makes them less clunky to use, and make the bandolier more valuable to a dedicated shotgun user loadout. The bandolier's inventory can still be opened using clickdrag.

The bandolier ammo capacity was reduced to 7, which is the same amount a shotgun and buckshot ammo boxes hold. The extra shell bothered me, and it balances the bandolier considering the significant buff the PR is otherwise.

This PR also adds a bandolier to the HOS and warden lockers, giving them an alternative to the security belt to equip when shit is going down.

:cl:
add: Bandoliers now immediately put a shotgun shell in your hand when clicked, rather than open the bandolier's contents.
add: The captain's rapier holster now immediately puts the rapier in your hand when clicked.
balance: Reduced the amount of shells the bandolier holds from 8 to 7
add: Added a bandolier to the HOS and warden lockers.
/:cl:
