### PR TITLE
Added the PASS alarm, a device that plays a very loud noise whenever it hasn't been moved for a set amount of time

### DIFF
--- a/code/modules/assembly/pass.dm
+++ b/code/modules/assembly/pass.dm
@@ -1,0 +1,48 @@
+var/list/PASS_list = list()
+
+/obj/item/assembly/timer/pass
+	name = "Personal Alert Safety System"
+	desc = "A device that plays a very loud alarm if it isn't moved for 30 seconds."
+	icon_state = "timer"
+	var/lastloc = null
+	var/loca = null
+	var/alarm = 0
+	var/list/pass_sounds = list('sound/effects/alert.ogg' = 1)
+
+
+
+/obj/item/assembly/timer/pass/Initialize
+	. = ..()
+	AddComponent(/datum/component/squeak, pass_sounds, 100)
+
+/obj/item/assembly/timer/pass/New()
+	PASS_list.Add(src)
+
+/obj/item/assembly/timer/pass/Destroy()
+	PASS_list.Remove(src)
+	return ..()
+
+/obj/item/assembly/timer/pass/describe()
+	if(timing)
+		return "The PASS will go off in [time] seconds if not moved!"
+	return "The timer is set for [time] seconds."
+
+
+/obj/item/assembly/timer/pass/process()
+	if(alarm == 1)
+		playsound(loca,'sound/effects/alert.ogg', 150, 1)
+	if(timing && (time > 0))
+		loca = get_turf(src)
+		if(loca == lastloc)
+			time -= 2 // 2 seconds per process()
+		else
+			time = set_time
+			alarm = 0
+		lastloc = loca
+
+	if(timing && time <= 0)
+		timing = repeat
+		timer_end()
+		alarm = 1
+		time = set_time
+

--- a/code/modules/assembly/pass.dm
+++ b/code/modules/assembly/pass.dm
@@ -15,12 +15,6 @@ var/list/PASS_list = list()
 	. = ..()
 	AddComponent(/datum/component/squeak, pass_sounds, 100)
 
-/obj/item/assembly/timer/pass/New()
-	PASS_list.Add(src)
-
-/obj/item/assembly/timer/pass/Destroy()
-	PASS_list.Remove(src)
-	return ..()
 
 /obj/item/assembly/timer/pass/describe()
 	if(timing)

--- a/code/modules/assembly/pass.dm
+++ b/code/modules/assembly/pass.dm
@@ -1,5 +1,3 @@
-var/list/PASS_list = list()
-
 /obj/item/assembly/timer/pass
 	name = "Personal Alert Safety System"
 	desc = "A device that plays a very loud alarm if it isn't moved for 30 seconds."

--- a/code/modules/assembly/pass.dm
+++ b/code/modules/assembly/pass.dm
@@ -11,7 +11,7 @@ var/list/PASS_list = list()
 
 
 
-/obj/item/assembly/timer/pass/Initialize
+/obj/item/assembly/timer/pass/Initialize()
 	. = ..()
 	AddComponent(/datum/component/squeak, pass_sounds, 100)
 
@@ -33,8 +33,6 @@ var/list/PASS_list = list()
 			time = set_time
 			alarm = 0
 		lastloc = loca
-
 	if(timing && time <= 0)
 		alarm = 1
 		time = set_time
-

--- a/code/modules/assembly/pass.dm
+++ b/code/modules/assembly/pass.dm
@@ -16,10 +16,10 @@ var/list/PASS_list = list()
 	AddComponent(/datum/component/squeak, pass_sounds, 100)
 
 
-/obj/item/assembly/timer/pass/describe()
-	if(timing)
-		return "The PASS will go off in [time] seconds if not moved!"
-	return "The timer is set for [time] seconds."
+///obj/item/assembly/timer/pass/describe()
+//	if(timing)
+//		return "The PASS will go off in [time] seconds if not moved!"
+//	return "The timer is set for [time] seconds."
 
 
 /obj/item/assembly/timer/pass/process()

--- a/code/modules/assembly/pass.dm
+++ b/code/modules/assembly/pass.dm
@@ -35,8 +35,6 @@ var/list/PASS_list = list()
 		lastloc = loca
 
 	if(timing && time <= 0)
-		timing = repeat
-		timer_end()
 		alarm = 1
 		time = set_time
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -1261,6 +1261,7 @@
 #include "code\modules\assembly\igniter.dm"
 #include "code\modules\assembly\infrared.dm"
 #include "code\modules\assembly\mousetrap.dm"
+#include "code\modules\assembly\pass.dm"
 #include "code\modules\assembly\proximity.dm"
 #include "code\modules\assembly\shock_kit.dm"
 #include "code\modules\assembly\signaler.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It adds the PASS alarm. A special device that, when activated, continuously plays a very loud sound whenever it hasn't been moved for a set time period.

## Why It's Good For The Game
I'm not honestly sure what anyone would use this for. I'm sure an admin or someone will come up with a use eventually

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:RobinFox
add: The PASS alarm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
