### PR TITLE
Made megafauna have randomized stats between half and 2 times the default stats

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -47,6 +47,11 @@
 	for(var/action_type in attack_action_types)
 		var/datum/action/innate/megafauna_attack/attack_action = new action_type()
 		attack_action.Grant(src)
+	maxHealth = maxHealth*(rand(25,100)/50)
+	armour_penetration = armour_penetration*(rand(25,100)/50)
+	melee_damage_lower = melee_damage_lower*(rand(25,100)/50)
+	melee_damage_upper = melee_damage_upper*(rand(25,100)/50)
+	speed = speed*(rand(25,100)/50)
 
 /mob/living/simple_animal/hostile/megafauna/Destroy()
 	QDEL_NULL(internal_gps)


### PR DESCRIPTION
…rent values, decided per mob

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
On map initialization, it randomizes the damage, health, speed, and armor penetration of all megafauna to be somewhere between 1/2 and 2 times the stats stated in the mob's file.

## Why It's Good For The Game
There's too much of an established meta for experienced lavalanders. Some bosses are hillariously easy if you know the strategy (hierophants) and some are very lethal even if you've done it hundreds of times (colossus). Let's throw a wrench in the meta strats!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:RobinFox
balance: Gave all megafauna randomized stats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
