### PR TITLE
Remove the snowflake power cells

### DIFF
--- a/code/game/machinery/chiller.dm
+++ b/code/game/machinery/chiller.dm
@@ -11,9 +11,7 @@
 
 /obj/machinery/space_heater/air_conditioner/New()
 	..()
-	cell = new(src)
-	cell.charge = 1000
-	cell.maxcharge = 1000
+	cell = new /obj/item/stock_parts/cell(src)
 	update_icon()
 	return
 

--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -53,9 +53,9 @@
 		. += "<span class='notice'>There are a pair of <b>bolts</b> in the defib unit housing securing the [src] to the wall.<span>"
 
 /obj/machinery/defibrillator_mount/process()
-	if(defib && defib.bcell && defib.bcell.charge < defib.bcell.maxcharge && is_operational())
+	if(defib && defib.cell && defib.cell.charge < defib.cell.maxcharge && is_operational())
 		use_power(200)
-		defib.bcell.give(180) //90% efficiency, slightly better than the cell charger's 87.5%
+		defib.cell.give(180) //90% efficiency, slightly better than the cell charger's 87.5%
 		update_icon()
 
 /obj/machinery/defibrillator_mount/update_icon()
@@ -64,7 +64,7 @@
 		add_overlay("defib")
 		if(defib.powered)
 			add_overlay(defib.safety ? "online" : "emagged")
-			var/ratio = defib.bcell.charge / defib.bcell.maxcharge
+			var/ratio = defib.cell.charge / defib.cell.maxcharge
 			ratio = CEILING(ratio * 4, 1) * 25
 			add_overlay("charge[ratio]")
 		if(clamps_locked)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -353,7 +353,7 @@ var/list/turret_icons
 					to_chat(user, "<span class='notice'>You remove the turret and salvage some components.</span>")
 					if(installation)
 						var/obj/item/gun/energy/Gun = new installation(loc)
-						Gun.power_supply.charge = gun_charge
+						Gun.cell.charge = gun_charge
 						Gun.update_icon()
 					if(prob(50))
 						new /obj/item/stack/sheet/metal(loc, rand(1,4))
@@ -857,7 +857,7 @@ var/list/turret_icons
 					to_chat(user, "<span class='notice'>\the [I] is stuck to your hand, you cannot put it in \the [src]</span>")
 					return
 				installation = I.type //installation becomes I.type
-				gun_charge = E.power_supply.charge //the gun's charge is stored in gun_charge
+				gun_charge = E.cell.charge //the gun's charge is stored in gun_charge
 				to_chat(user, "<span class='notice'>You add [I] to the turret.</span>")
 
 				if(istype(installation, /obj/item/gun/energy/laser/tag/blue) || istype(installation, /obj/item/gun/energy/laser/tag/red))
@@ -964,7 +964,7 @@ var/list/turret_icons
 			build_step = 3
 
 			var/obj/item/gun/energy/Gun = new installation(loc)
-			Gun.power_supply.charge = gun_charge
+			Gun.cell.charge = gun_charge
 			Gun.update_icon()
 			installation = null
 			gun_charge = 0

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -107,8 +107,8 @@
 	if(charging)
 		if(istype(charging, /obj/item/gun/energy))
 			var/obj/item/gun/energy/E = charging
-			if(E.power_supply.charge < E.power_supply.maxcharge)
-				E.power_supply.give(E.power_supply.chargerate * recharge_coeff)
+			if(E.cell.charge < E.cell.maxcharge)
+				E.cell.give(E.cell.chargerate * recharge_coeff)
 				E.on_recharge()
 				use_power(250)
 				using_power = TRUE
@@ -141,8 +141,8 @@
 
 		if(istype(charging, /obj/item/bodyanalyzer))
 			var/obj/item/bodyanalyzer/B = charging
-			if(B.power_supply)
-				if(B.power_supply.give(B.power_supply.chargerate))
+			if(B.cell)
+				if(B.cell.give(B.cell.chargerate))
 					use_power(200)
 					using_power = TRUE
 
@@ -155,8 +155,8 @@
 
 	if(istype(charging,  /obj/item/gun/energy))
 		var/obj/item/gun/energy/E = charging
-		if(E.power_supply)
-			E.power_supply.emp_act(severity)
+		if(E.cell)
+			E.cell.emp_act(severity)
 
 	else if(istype(charging, /obj/item/melee/baton))
 		var/obj/item/melee/baton/B = charging

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -116,8 +116,8 @@
 
 		if(istype(charging, /obj/item/melee/baton))
 			var/obj/item/melee/baton/B = charging
-			if(B.bcell)
-				if(B.bcell.give(B.bcell.chargerate))
+			if(B.cell)
+				if(B.cell.give(B.cell.chargerate))
 					use_power(200)
 					using_power = TRUE
 
@@ -160,8 +160,8 @@
 
 	else if(istype(charging, /obj/item/melee/baton))
 		var/obj/item/melee/baton/B = charging
-		if(B.bcell)
-			B.bcell.charge = 0
+		if(B.cell)
+			B.cell.charge = 0
 	..(severity)
 
 /obj/machinery/recharger/update_icon(using_power = FALSE)	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -182,8 +182,8 @@
 							D.charge_tick = 0
 					if(istype(O,/obj/item/melee/baton))
 						var/obj/item/melee/baton/B = O
-						if(B.bcell)
-							B.bcell.charge = B.bcell.maxcharge
+						if(B.cell)
+							B.cell.charge = B.cell.maxcharge
 					//Service
 					if(istype(O,/obj/item/reagent_containers/food/condiment/enzyme))
 						if(O.reagents.get_reagent_amount("enzyme") < 50)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -173,9 +173,9 @@
 							F.icon_state = "flash"
 					if(istype(O,/obj/item/gun/energy/disabler/cyborg))
 						var/obj/item/gun/energy/disabler/cyborg/D = O
-						if(D.power_supply.charge < D.power_supply.maxcharge)
+						if(D.cell.charge < D.cell.maxcharge)
 							var/obj/item/ammo_casing/energy/E = D.ammo_type[D.select]
-							D.power_supply.give(E.e_cost)
+							D.cell.give(E.e_cost)
 							D.on_recharge()
 							D.update_icon()
 						else

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -18,9 +18,7 @@
 
 /obj/machinery/space_heater/New()
 	..()
-	cell = new(src)
-	cell.charge = 1000
-	cell.maxcharge = 1000
+	cell = new /obj/item/stock_parts/cell(src)
 	update_icon()
 	return
 

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -62,6 +62,4 @@
 	ME.attach(src)
 
 /obj/mecha/combat/gygax/dark/add_cell()
-	cell = new /obj/item/stock_parts/cell/bluespace(src)
-	cell.charge = 30000
-	cell.maxcharge = 30000
+	cell = new /obj/item/stock_parts/cell/hyper(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -59,8 +59,6 @@
 
 /obj/mecha/combat/marauder/seraph/add_cell()
 	cell = new /obj/item/stock_parts/cell/bluespace(src)
-	cell.charge = 40000
-	cell.maxcharge = 40000
 
 /obj/mecha/combat/marauder/seraph/loaded/New()
 	..()//Let it equip whatever is needed.

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -600,7 +600,7 @@ REAGENT SCANNER
 	throw_speed = 5
 	throw_range = 10
 	origin_tech = "magnets=6;biotech=6"
-	var/obj/item/stock_parts/cell/power_supply
+	var/obj/item/stock_parts/cell/cell
 	var/cell_type = /obj/item/stock_parts/cell/upgraded
 	var/ready = TRUE // Ready to scan
 	var/time_to_use = 0 // How much time remaining before next scan is available.
@@ -609,7 +609,7 @@ REAGENT SCANNER
 	var/scan_cd = 60 SECONDS //how long before we can scan again
 
 /obj/item/bodyanalyzer/get_cell()
-	return power_supply
+	return cell
 
 /obj/item/bodyanalyzer/advanced
 	cell_type = /obj/item/stock_parts/cell/upgraded/plus
@@ -624,8 +624,8 @@ REAGENT SCANNER
 
 /obj/item/bodyanalyzer/New()
 	..()
-	power_supply = new cell_type(src)
-	power_supply.give(power_supply.maxcharge)
+	cell = new cell_type(src)
+	cell.give(cell.maxcharge)
 	update_icon()
 
 /obj/item/bodyanalyzer/proc/setReady()
@@ -635,7 +635,7 @@ REAGENT SCANNER
 
 /obj/item/bodyanalyzer/update_icon(printing = FALSE)
 	overlays.Cut()
-	var/percent = power_supply.percent()
+	var/percent = cell.percent()
 	if(ready)
 		icon_state = "bodyanalyzer_1"
 	else
@@ -657,7 +657,7 @@ REAGENT SCANNER
 		playsound(user.loc, 'sound/machines/buzz-sigh.ogg', 50, 1)
 		return
 
-	if(power_supply.charge >= usecharge)
+	if(cell.charge >= usecharge)
 		mobScan(M, user)
 	else
 		to_chat(user, "<span class='notice'>The scanner beeps angrily at you! It's out of charge!</span>")
@@ -691,7 +691,7 @@ REAGENT SCANNER
 				var/mob/living/silicon/robot/R = user
 				R.cell.use(usecharge)
 			else
-				power_supply.use(usecharge)
+				cell.use(usecharge)
 			ready = FALSE
 			update_icon(TRUE)
 			addtimer(CALLBACK(src, /obj/item/bodyanalyzer/.proc/setReady), scan_cd)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -20,11 +20,11 @@
 	var/safety = 1 //if you can zap people with the defibs on harm mode
 	var/powered = 0 //if there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
 	var/obj/item/twohanded/shockpaddles/paddles
-	var/obj/item/stock_parts/cell/high/bcell = null
+	var/obj/item/stock_parts/cell/high/cell = null
 	var/combat = 0 //can we revive through space suits?
 
 /obj/item/defibrillator/get_cell()
-	return bcell
+	return cell
 
 /obj/item/defibrillator/New() //starts without a cell for rnd
 	..()
@@ -35,7 +35,7 @@
 /obj/item/defibrillator/loaded/New() //starts with hicap
 	..()
 	paddles = make_paddles()
-	bcell = new(src)
+	cell = new(src)
 	update_icon()
 	return
 
@@ -49,8 +49,8 @@
 	. += "<span class='notice'>Ctrl-click to remove the paddles from the defibrillator.</span>"
 
 /obj/item/defibrillator/proc/update_power()
-	if(bcell)
-		if(bcell.charge < paddles.revivecost)
+	if(cell)
+		if(cell.charge < paddles.revivecost)
 			powered = 0
 		else
 			powered = 1
@@ -63,21 +63,21 @@
 		overlays += "[icon_state]-paddles"
 	if(powered)
 		overlays += "[icon_state]-powered"
-	if(!bcell)
+	if(!cell)
 		overlays += "[icon_state]-nocell"
 	if(!safety)
 		overlays += "[icon_state]-emagged"
 
 /obj/item/defibrillator/proc/update_charge()
 	if(powered) //so it doesn't show charge if it's unpowered
-		if(bcell)
-			var/ratio = bcell.charge / bcell.maxcharge
+		if(cell)
+			var/ratio = cell.charge / cell.maxcharge
 			ratio = Ceiling(ratio*4) * 25
 			overlays += "[icon_state]-charge[ratio]"
 
 /obj/item/defibrillator/CheckParts(list/parts_list)
 	..()
-	bcell = locate(/obj/item/stock_parts/cell) in contents
+	cell = locate(/obj/item/stock_parts/cell) in contents
 	update_icon()
 
 /obj/item/defibrillator/ui_action_click()
@@ -90,7 +90,7 @@
 /obj/item/defibrillator/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stock_parts/cell))
 		var/obj/item/stock_parts/cell/C = W
-		if(bcell)
+		if(cell)
 			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
 		else
 			if(C.maxcharge < paddles.revivecost)
@@ -98,14 +98,14 @@
 				return
 			user.drop_item()
 			W.loc = src
-			bcell = W
+			cell = W
 			to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
 
 	if(istype(W, /obj/item/screwdriver))
-		if(bcell)
-			bcell.update_icon()
-			bcell.loc = get_turf(src.loc)
-			bcell = null
+		if(cell)
+			cell.update_icon()
+			cell.loc = get_turf(src.loc)
+			cell = null
 			to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
 
 	update_icon()
@@ -120,7 +120,7 @@
 		to_chat(user, "<span class='notice'>You silently enable [src]'s safety protocols with the card.")
 
 /obj/item/defibrillator/emp_act(severity)
-	if(bcell)
+	if(cell)
 		deductcharge(1000 / severity)
 	if(safety)
 		safety = 0
@@ -182,15 +182,15 @@
 		var/M = get(paddles, /mob)
 		remove_paddles(M)
 	QDEL_NULL(paddles)
-	QDEL_NULL(bcell)
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/item/defibrillator/proc/deductcharge(var/chrgdeductamt)
-	if(bcell)
-		if(bcell.charge < (paddles.revivecost+chrgdeductamt))
+	if(cell)
+		if(cell.charge < (paddles.revivecost+chrgdeductamt))
 			powered = 0
 			update_icon()
-		if(bcell.use(chrgdeductamt))
+		if(cell.use(chrgdeductamt))
 			update_icon()
 			return 1
 		else
@@ -199,8 +199,8 @@
 
 /obj/item/defibrillator/proc/cooldowncheck(var/mob/user)
 	spawn(50)
-		if(bcell)
-			if(bcell.charge >= paddles.revivecost)
+		if(cell)
+			if(cell.charge >= paddles.revivecost)
 				user.visible_message("<span class='notice'>[src] beeps: Unit ready.</span>")
 				playsound(get_turf(src), 'sound/machines/defib_ready.ogg', 50, 0)
 			else
@@ -226,7 +226,7 @@
 /obj/item/defibrillator/compact/loaded/New()
 	..()
 	paddles = make_paddles()
-	bcell = new(src)
+	cell = new(src)
 	update_icon()
 	return
 
@@ -239,7 +239,7 @@
 /obj/item/defibrillator/compact/combat/loaded/New()
 	..()
 	paddles = make_paddles()
-	bcell = new /obj/item/stock_parts/cell/infinite(src)
+	cell = new /obj/item/stock_parts/cell/infinite(src)
 	update_icon()
 	return
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -13,7 +13,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 	var/stunforce = 7
 	var/status = 0
-	var/obj/item/stock_parts/cell/high/bcell = null
+	var/obj/item/stock_parts/cell/high/cell = null
 	var/hitcost = 1000
 	var/throw_hit_chance = 35
 
@@ -22,7 +22,7 @@
 	return FIRELOSS
 
 /obj/item/melee/baton/get_cell()
-	return bcell
+	return cell
 
 /obj/item/melee/baton/New()
 	..()
@@ -30,7 +30,7 @@
 	return
 
 /obj/item/melee/baton/Destroy()
-	QDEL_NULL(bcell)
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/item/melee/baton/throw_impact(atom/hit_atom)
@@ -40,7 +40,7 @@
 
 /obj/item/melee/baton/loaded/New() //this one starts with a cell pre-installed.
 	..()
-	bcell = new(src)
+	cell = new(src)
 	update_icon()
 	return
 
@@ -55,12 +55,12 @@
 			return 1
 		else
 			return 0
-	if(bcell)
-		if(bcell.charge < (hitcost+chrgdeductamt)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
+	if(cell)
+		if(cell.charge < (hitcost+chrgdeductamt)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
 			status = 0
 			update_icon()
 			playsound(loc, "sparks", 75, 1, -1)
-		if(bcell.use(chrgdeductamt))
+		if(cell.use(chrgdeductamt))
 			return 1
 		else
 			return 0
@@ -68,7 +68,7 @@
 /obj/item/melee/baton/update_icon()
 	if(status)
 		icon_state = "[base_icon]_active"
-	else if(!bcell)
+	else if(!cell)
 		icon_state = "[base_icon]_nocell"
 	else
 		icon_state = "[base_icon]"
@@ -77,15 +77,15 @@
 	. = ..()
 	if(isrobot(loc))
 		. += "<span class='notice'>This baton is drawing power directly from your own internal charge.</span>"
-	if(bcell)
-		. += "<span class='notice'>The baton is [round(bcell.percent())]% charged.</span>"
-	if(!bcell)
+	if(cell)
+		. += "<span class='notice'>The baton is [round(cell.percent())]% charged.</span>"
+	if(!cell)
 		. += "<span class='warning'>The baton does not have a power source installed.</span>"
 
 /obj/item/melee/baton/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stock_parts/cell))
 		var/obj/item/stock_parts/cell/C = W
-		if(bcell)
+		if(cell)
 			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
 		else
 			if(C.maxcharge < hitcost)
@@ -94,15 +94,15 @@
 			if(!user.unEquip(W))
 				return
 			W.loc = src
-			bcell = W
+			cell = W
 			to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
 			update_icon()
 
 	else if(istype(W, /obj/item/screwdriver))
-		if(bcell)
-			bcell.update_icon()
-			bcell.loc = get_turf(src.loc)
-			bcell = null
+		if(cell)
+			cell.update_icon()
+			cell.loc = get_turf(src.loc)
+			cell = null
 			to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
 			status = 0
 			update_icon()
@@ -121,13 +121,13 @@
 		else
 			status = 0
 			to_chat(user, "<span class='warning'>You do not have enough reserve power to charge the [src]!</span>")
-	else if(bcell && bcell.charge >= hitcost)
+	else if(cell && cell.charge >= hitcost)
 		status = !status
 		to_chat(user, "<span class='notice'>[src] is now [status ? "on" : "off"].</span>")
 		playsound(loc, "sparks", 75, 1, -1)
 	else
 		status = 0
-		if(!bcell)
+		if(!cell)
 			to_chat(user, "<span class='warning'>[src] does not have a power source!</span>")
 		else
 			to_chat(user, "<span class='warning'>[src] is out of charge.</span>")
@@ -203,13 +203,13 @@
 		H.forcesay(GLOB.hit_appends)
 
 /obj/item/melee/baton/emp_act(severity)
-	if(bcell)
+	if(cell)
 		deductcharge(1000 / severity)
 	..()
 
 /obj/item/melee/baton/wash(mob/user, atom/source)
-	if(bcell)
-		if(bcell.charge > 0 && status == 1)
+	if(cell)
+		if(cell.charge > 0 && status == 1)
 			flick("baton_active", source)
 			user.Stun(stunforce)
 			user.Weaken(stunforce)

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -205,7 +205,7 @@
 		if(inawaymission)
 			if(ismob(loc))
 				to_chat(loc, "<span class='danger'>Your [src] deactivates, as it is out of range from its power source.</span>")
-			power_supply.charge = 0
+			cell.charge = 0
 			inawaymission = 0
 			update_icon()
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -52,8 +52,7 @@
 		camera.network.Add("Engineering")
 
 	//They are unable to be upgraded, so let's give them a bit of a better battery.
-	cell.maxcharge = 10000
-	cell.charge = 10000
+	cell = new /obj/item/stock_parts/cell/high(src)
 
 	// NO BRAIN.
 	mmi = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -151,9 +151,7 @@ var/list/robot_verbs_default = list(
 		C.wrapped = new C.external_type
 
 	if(!cell)
-		cell = new /obj/item/stock_parts/cell(src)
-		cell.maxcharge = 7500
-		cell.charge = 7500
+		cell = new /obj/item/stock_parts/cell/high(src)
 
 	..()
 
@@ -1316,8 +1314,7 @@ var/list/robot_verbs_default = list(
 
 /mob/living/silicon/robot/deathsquad/New(loc)
 	..()
-	cell.maxcharge = 25000
-	cell.charge = 25000
+	cell = new /obj/item/stock_parts/cell/hyper(src)
 
 /mob/living/silicon/robot/deathsquad/init()
 	laws = new /datum/ai_laws/deathsquad
@@ -1370,8 +1367,7 @@ var/list/robot_verbs_default = list(
 
 /mob/living/silicon/robot/ert/New(loc, cyborg_unlock)
 	..(loc)
-	cell.maxcharge = 25000
-	cell.charge = 25000
+	cell = new /obj/item/stock_parts/cell/hyper(src)
 	var/rnum = rand(1,1000)
 	var/borgname = "ERT [rnum]"
 	name = borgname

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -17,8 +17,7 @@
 
 /mob/living/silicon/robot/syndicate/New(loc)
 	..()
-	cell.maxcharge = 25000
-	cell.charge = 25000
+	cell = new /obj/item/stock_parts/cell/hyper(src)
 
 /mob/living/silicon/robot/syndicate/init()
 	laws = new /datum/ai_laws/syndicate_override

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -384,15 +384,15 @@
 
 	if(!lasercolor)
 		var/obj/item/gun/energy/gun/advtaser/G = new /obj/item/gun/energy/gun/advtaser(Tsec)
-		G.power_supply.charge = 0
+		G.cell.charge = 0
 		G.update_icon()
 	else if(lasercolor == "b")
 		var/obj/item/gun/energy/laser/tag/blue/G = new /obj/item/gun/energy/laser/tag/blue(Tsec)
-		G.power_supply.charge = 0
+		G.cell.charge = 0
 		G.update_icon()
 	else if(lasercolor == "r")
 		var/obj/item/gun/energy/laser/tag/red/G = new /obj/item/gun/energy/laser/tag/red(Tsec)
-		G.power_supply.charge = 0
+		G.cell.charge = 0
 		G.update_icon()
 
 	if(prob(50))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -59,9 +59,7 @@
 	var/datum/job/cargo_tech/J = new/datum/job/cargo_tech
 	access_card.access = J.get_access()
 	prev_access = access_card.access
-	cell = new(src)
-	cell.charge = 2000
-	cell.maxcharge = 2000
+	cell = new /obj/item/stock_parts/cell/upgraded(src)
 
 	mulebot_count++
 	set_suffix(suffix ? suffix : "#[mulebot_count]")

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -244,10 +244,10 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 
 /mob/living/simple_animal/hostile/mimic/copy/ranged/OpenFire(the_target)
 	if(Zapgun)
-		if(Zapgun.power_supply)
+		if(Zapgun.cell)
 			var/obj/item/ammo_casing/energy/shot = Zapgun.ammo_type[Zapgun.select]
-			if(Zapgun.power_supply.charge >= shot.e_cost)
-				Zapgun.power_supply.use(shot.e_cost)
+			if(Zapgun.cell.charge >= shot.e_cost)
+				Zapgun.cell.use(shot.e_cost)
 				Zapgun.update_icon()
 				..()
 	else if(Zapstick)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -63,10 +63,7 @@
 	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot( loc )
 
 	// cyborgs produced by Robotize get an automatic power cell
-	O.cell = new(O)
-	O.cell.maxcharge = 7500
-	O.cell.charge = 7500
-
+	O.cell = new /obj/item/stock_parts/cell/high(O)
 
 	O.gender = gender
 	O.invisibility = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -205,7 +205,7 @@
 	has_electronics = 2 //installed and secured
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)
-		cell = new/obj/item/stock_parts/cell(src)
+		cell = new/obj/item/stock_parts/cell/upgraded(src)
 		cell.maxcharge = cell_type	// cell_type is maximum charge (old default was 1000 or 2500 (values one and two respectively)
 		cell.charge = start_charge * cell.maxcharge / 100 		// (convert percentage to actual value)
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/guns/energy.dmi'
 	fire_sound_text = "laser blast"
 
-	var/obj/item/stock_parts/cell/power_supply //What type of power cell this uses
+	var/obj/item/stock_parts/cell/cell //What type of power cell this uses
 	var/cell_type = /obj/item/stock_parts/cell
 	var/modifystate = 0
 	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
@@ -20,7 +20,7 @@
 	var/charge_delay = 4
 
 /obj/item/gun/energy/emp_act(severity)
-	power_supply.use(round(power_supply.charge / severity))
+	cell.use(round(cell.charge / severity))
 	if(chambered)//phil235
 		if(chambered.BB)
 			qdel(chambered.BB)
@@ -30,15 +30,15 @@
 	update_icon()
 
 /obj/item/gun/energy/get_cell()
-	return power_supply
+	return cell
 
 /obj/item/gun/energy/New()
 	..()
 	if(cell_type)
-		power_supply = new cell_type(src)
+		cell = new cell_type(src)
 	else
-		power_supply = new(src)
-	power_supply.give(power_supply.maxcharge)
+		cell = new(src)
+	cell.give(cell.maxcharge)
 	update_ammo_types()
 	on_recharge()
 	if(selfcharge)
@@ -66,14 +66,14 @@
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0
-		if(!power_supply)
+		if(!cell)
 			return // check if we actually need to recharge
 		var/obj/item/ammo_casing/energy/E = ammo_type[select]
 		if(use_external_power)
-			var/obj/item/stock_parts/cell/external = get_external_power_supply()
+			var/obj/item/stock_parts/cell/external = get_external_cell()
 			if(!external || !external.use(E.e_cost)) //Take power from the borg...
 				return								//Note, uses /10 because of shitty mods to the cell system
-		power_supply.give(100) //... to recharge the shot
+		cell.give(100) //... to recharge the shot
 		on_recharge()
 		update_icon()
 
@@ -91,14 +91,14 @@
 
 /obj/item/gun/energy/can_shoot()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	return power_supply.charge >= shot.e_cost
+	return cell.charge >= shot.e_cost
 
 /obj/item/gun/energy/newshot()
-	if(!ammo_type || !power_supply)
+	if(!ammo_type || !cell)
 		return
 	if(!chambered)
 		var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-		if(power_supply.charge >= shot.e_cost) //if there's enough power in the power_supply cell...
+		if(cell.charge >= shot.e_cost) //if there's enough power in the cell cell...
 			chambered = shot //...prepare a new shot based on the current ammo type selected
 			if(!chambered.BB)
 				chambered.newshot()
@@ -106,7 +106,7 @@
 /obj/item/gun/energy/process_chamber()
 	if(chambered && !chambered.BB) //if BB is null, i.e the shot has been fired...
 		var/obj/item/ammo_casing/energy/shot = chambered
-		power_supply.use(shot.e_cost)//... drain the power_supply cell
+		cell.use(shot.e_cost)//... drain the cell cell
 		robocharge()
 	chambered = null //either way, released the prepared shot
 	newshot()
@@ -131,7 +131,7 @@
 
 /obj/item/gun/energy/update_icon()
 	overlays.Cut()
-	var/ratio = Ceiling((power_supply.charge / power_supply.maxcharge) * charge_sections)
+	var/ratio = Ceiling((cell.charge / cell.maxcharge) * charge_sections)
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	var/iconState = "[icon_state]_charge"
 	var/itemState = null
@@ -142,7 +142,7 @@
 		iconState += "_[shot.select_name]"
 		if(itemState)
 			itemState += "[shot.select_name]"
-	if(power_supply.charge < shot.e_cost)
+	if(cell.charge < shot.e_cost)
 		overlays += "[icon_state]_empty"
 	else
 		if(!shaded_charge)
@@ -172,7 +172,7 @@
 			user.visible_message("<span class='suicide'>[user] melts [user.p_their()] face off with the [name]!</span>")
 			playsound(loc, fire_sound, 50, 1, -1)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-			power_supply.use(shot.e_cost)
+			cell.use(shot.e_cost)
 			update_icon()
 			return FIRELOSS
 		else
@@ -198,9 +198,9 @@
 		if(R && R.cell)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select] //Necessary to find cost of shot
 			if(R.cell.use(shot.e_cost)) 		//Take power from the borg...
-				power_supply.give(shot.e_cost)	//... to recharge the shot
+				cell.give(shot.e_cost)	//... to recharge the shot
 
-/obj/item/gun/energy/proc/get_external_power_supply()
+/obj/item/gun/energy/proc/get_external_cell()
 	if(istype(loc, /obj/item/rig_module))
 		var/obj/item/rig_module/module = loc
 		if(module.holder && module.holder.wearer)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -106,7 +106,7 @@
 		empty()
 
 /obj/item/gun/energy/kinetic_accelerator/proc/empty()
-	power_supply.use(500)
+	cell.use(500)
 	update_icon()
 
 /obj/item/gun/energy/kinetic_accelerator/proc/attempt_reload(recharge_time)
@@ -136,7 +136,7 @@
 	return
 
 /obj/item/gun/energy/kinetic_accelerator/proc/reload()
-	power_supply.give(500)
+	cell.give(500)
 	on_recharge()
 	if(!suppressed)
 		playsound(loc, 'sound/weapons/kenetic_reload.ogg', 60, 1)

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -39,8 +39,8 @@
 /obj/item/gun/energy/gun/mini/New()
 	gun_light = new /obj/item/flashlight/seclite(src)
 	..()
-	power_supply.maxcharge = 600
-	power_supply.charge = 600
+	cell.maxcharge = 600
+	cell.charge = 600
 
 /obj/item/gun/energy/gun/mini/update_icon()
 	..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -43,7 +43,7 @@
 /obj/item/gun/energy/decloner/update_icon()
 	..()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	if(power_supply.charge > shot.e_cost)
+	if(cell.charge > shot.e_cost)
 		overlays += "decloner_spin"
 
 // Flora Gun //
@@ -160,26 +160,26 @@
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)
 	. = ..()
-	if(power_supply)
-		. += "<span class='notice'>[src] is [round(power_supply.percent())]% charged.</span>"
+	if(cell)
+		. += "<span class='notice'>[src] is [round(cell.percent())]% charged.</span>"
 
 /obj/item/gun/energy/plasmacutter/attackby(obj/item/A, mob/user)
 	if(istype(A, /obj/item/stack/sheet/mineral/plasma))
-		if(power_supply.charge >= power_supply.maxcharge)
+		if(cell.charge >= cell.maxcharge)
 			to_chat(user,"<span class='notice'>[src] is already fully charged.")
 			return
 		var/obj/item/stack/sheet/S = A
 		S.use(1)
-		power_supply.give(1000)
+		cell.give(1000)
 		on_recharge()
 		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
 	else if(istype(A, /obj/item/stack/ore/plasma))
-		if(power_supply.charge >= power_supply.maxcharge)
+		if(cell.charge >= cell.maxcharge)
 			to_chat(user,"<span class='notice'>[src] is already fully charged.")
 			return
 		var/obj/item/stack/ore/S = A
 		S.use(1)
-		power_supply.give(500)
+		cell.give(500)
 		on_recharge()
 		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
 	else
@@ -489,7 +489,7 @@
 		M.update_inv_r_hand()
 
 /obj/item/gun/energy/temperature/proc/update_charge()
-	var/charge = power_supply.charge
+	var/charge = cell.charge
 	switch(charge)
 		if(900 to INFINITY)		overlays += "900"
 		if(800 to 900)			overlays += "800"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-Make all cyborgs, mechs, mulebots and drons now start with an power cell that corresponds to its electrical charge instead of a snowflake cell.  Resulting in less confusing and, in some cases, a little more electric charge.

-Replace all bcell and power_supply with cell
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less snowflake, less confusion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: regular cyborgs now start with 10kW of electric charge
balance: ert/death/syndi cyborgs now start with 30kW of electric charge
balance: mulebots now start with 2.5kW of electric charge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
