### PR TITLE
Prevents nanoui from flickering when opened in fancy mode

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -416,6 +416,11 @@ nanoui is used to open and update nano browser uis
 	if(!initial_data)
 		set_initial_data(src_object.ui_data(user, ui_key, state)) // Get the UI data.
 
+	// Preset the can_rezie and titlebar values on uis if the user has fancy uis set
+	// Prevents the ui from flickering when opened
+	if(user.client.prefs.nanoui_fancy)
+		set_window_options("focus=0;can_close=1;can_minimize=1;can_maximize=0;can_resize=0;titlebar=0;")
+
 	user << browse(get_html(), "window=[window_id];[window_size][window_options]")
 	winset(user, "mapwindow.map", "focus=true") // return keyboard focus to map
 	on_close_winset()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the weird flickering on nano when opened in fancy mode
https://cdn.discordapp.com/attachments/326831214667235328/636479291303002122/2019-10-23_01-18-24.mp4
We figured out this fix on tgui and it's generic enough to be brought over to the fancy nano you have here. It didn't apply to bay or vg because they don't use custom window decoration.

## Why It's Good For The Game
UIs feel more responsive.

## Changelog
:cl: actioninja
fix: Nanoui interfaces in fancy mode now open more cleanly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
