### PR TITLE
Particle accelerator will irradiate mobs again; adds COMSIG_CROSSED_M…

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -107,6 +107,7 @@
 #define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (/atom, dir)
 #define COMSIG_MOVABLE_CROSS "movable_cross"					//from base of atom/movable/Cross(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (/atom/movable)
+#define COMSIG_CROSSED_MOVABLE "crossed_movable"				//when we cross over something (calling Crossed() on that atom)
 #define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"            //from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_UNCROSS "movable_uncross"				//from base of atom/movable/Uncross(): (/atom/movable)
 	#define COMPONENT_MOVABLE_BLOCK_UNCROSS 1

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -220,6 +220,7 @@
 // This is automatically called when something enters your square
 /atom/movable/Crossed(atom/movable/AM, oldloc)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
+	SEND_SIGNAL(AM, COMSIG_CROSSED_MOVABLE, src)
 
 /atom/movable/Bump(atom/A, yes) //the "yes" arg is to differentiate our Bump proc from byond's, without it every Bump() call would become a double Bump().
 	if(A && yes)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -457,12 +457,6 @@
 	popup.set_content(dat)
 	popup.open()
 
-
-/mob/living/carbon/human/Crossed(atom/movable/AM, oldloc)
-	var/mob/living/simple_animal/bot/mulebot/MB = AM
-	if(istype(MB))
-		MB.RunOver(src)
-
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(var/if_no_id = "No id", var/if_no_job = "No job")
 	var/obj/item/pda/pda = wear_id

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -65,6 +65,7 @@
 
 	mulebot_count++
 	set_suffix(suffix ? suffix : "#[mulebot_count]")
+	RegisterSignal(src, COMSIG_CROSSED_MOVABLE, .proc/human_squish_check)
 
 /mob/living/simple_animal/bot/mulebot/Destroy()
 	unload(0)
@@ -867,6 +868,11 @@
 		unload(get_dir(loc, A))
 	else
 		..()
+
+/mob/living/simple_animal/bot/mulebot/proc/human_squish_check(src, atom/movable/AM)
+	if(!ishuman(AM))
+		return
+	RunOver(AM)
 
 #undef SIGH
 #undef ANNOYED

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -22,30 +22,29 @@
 	energy = 50
 
 
-/obj/effect/accelerated_particle/New(loc)
-	..()
+/obj/effect/accelerated_particle/Initialize(loc)
+	. = ..()
+	addtimer(CALLBACK(src, .proc/propagate), 1)
+	RegisterSignal(src, COMSIG_CROSSED_MOVABLE, .proc/try_irradiate)
+	RegisterSignal(src, COMSIG_MOVABLE_CROSSED, .proc/try_irradiate)
+	QDEL_IN(src, movement_range)
 
-	addtimer(CALLBACK(src, .proc/move), 1)
-
-
-/obj/effect/accelerated_particle/Bump(atom/A)
-	if(A)
-		if(isliving(A))
-			toxmob(A)
-		else if(istype(A, /obj/machinery/the_singularitygen))
-			var/obj/machinery/the_singularitygen/S = A
-			S.energy += energy
-		else if(istype(A, /obj/singularity))
-			var/obj/singularity/S = A
-			S.energy += energy
-		else if(istype(A, /obj/structure/blob))
-			var/obj/structure/blob/B = A
-			B.take_damage(energy * 0.6)
-			movement_range = 0
-
-/obj/effect/accelerated_particle/Crossed(atom/A, oldloc)
+/obj/effect/accelerated_particle/proc/try_irradiate(src, atom/A)
 	if(isliving(A))
-		toxmob(A)
+		var/mob/living/L = A
+		L.apply_effect((energy * 6), IRRADIATE, 0)
+	else if(istype(A, /obj/machinery/the_singularitygen))
+		var/obj/machinery/the_singularitygen/S = A
+		S.energy += energy
+	else if(istype(A, /obj/structure/blob))
+		var/obj/structure/blob/B = A
+		B.take_damage(energy * 0.6)
+		movement_range = 0
+
+/obj/effect/accelerated_particle/Bump(obj/singularity/S)
+	if(!istype(S))
+		return ..()
+	S.energy += energy
 
 
 /obj/effect/accelerated_particle/ex_act(severity)
@@ -54,17 +53,7 @@
 /obj/effect/accelerated_particle/singularity_pull()
 	return
 
-
-
-/obj/effect/accelerated_particle/proc/toxmob(mob/living/M)
-	M.apply_effect((energy * 6), IRRADIATE, 0)
-
-/obj/effect/accelerated_particle/proc/move()
+/obj/effect/accelerated_particle/proc/propagate()
+	addtimer(CALLBACK(src, .proc/propagate), 1)
 	if(!step(src,dir))
 		forceMove(get_step(src, dir))
-	movement_range--
-	if(movement_range == 0)
-		qdel(src)
-	else
-		sleep(speed)
-		move()


### PR DESCRIPTION
**What does this PR do:**
Fixes the behaviour of charged particles not properly irradiating mobs, making the engine much less dangerous than it ought to be.

Also, adds a new signal, `COMSIG_CROSSED_MOVABLE`, for use when you want to call something when an atom crosses over something else. (for example, to check if a mulebot ran over a human)

Fixes #11847

:cl:
fix: the particle accelerator will now properly irradiate you.
/:cl: