### PR TITLE
Dead mice squeak no tails

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -41,6 +41,10 @@
 		use_delay = use_delay_override
 
 /datum/component/squeak/proc/play_squeak()
+	if(ismob(parent))
+		var/mob/M = parent
+		if(M.stat == DEAD)
+			return
 	if(prob(squeak_chance))
 		if(!override_squeak_sounds)
 			playsound(parent, pickweight(default_squeak_sounds), volume, 1, -1)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -41,7 +41,7 @@
 	AddComponent(/datum/component/squeak, list('sound/creatures/mousesqueak.ogg' = 1), 100)
 
 /mob/living/simple_animal/mouse/handle_automated_action()
-	if(prob(chew_probability))
+	if(prob(chew_probability) && isturf(loc))
 		var/turf/simulated/floor/F = get_turf(src)
 		if(istype(F) && !F.intact)
 			var/obj/structure/cable/C = locate() in F


### PR DESCRIPTION
Fixes #11596. RIP undead mice everywhere.

:cl: Kyep
fix: Fixed dead mice still squeaking when stepped on.
fix: Fixed mice held in your hand, or a backpack, still chewing through cables.
/:cl:
