### PR TITLE
T-ray scanner now shows plumbing only to the users, not nearby mobs.

### DIFF
--- a/code/ATMOSPHERICS/pipes/cap.dm
+++ b/code/ATMOSPHERICS/pipes/cap.dm
@@ -18,7 +18,7 @@
 
 /obj/machinery/atmospherics/pipe/cap/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_MAXIMUM : 0
 	update_icon()
 
 /obj/machinery/atmospherics/pipe/cap/pipeline_expansion()

--- a/code/ATMOSPHERICS/pipes/manifold.dm
+++ b/code/ATMOSPHERICS/pipes/manifold.dm
@@ -60,7 +60,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_MAXIMUM : 0
 
 /obj/machinery/atmospherics/pipe/manifold/pipeline_expansion()
 	return list(node1, node2, node3)

--- a/code/ATMOSPHERICS/pipes/manifold4w.dm
+++ b/code/ATMOSPHERICS/pipes/manifold4w.dm
@@ -133,7 +133,7 @@
 
 /obj/machinery/atmospherics/pipe/manifold4w/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_MAXIMUM : 0
 
 /obj/machinery/atmospherics/pipe/manifold4w/atmos_init()
 	..()

--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
@@ -164,4 +164,4 @@
 
 /obj/machinery/atmospherics/pipe/simple/hide(var/i)
 	if(level == 1 && istype(loc, /turf/simulated))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_MAXIMUM : 0

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -169,7 +169,6 @@
 
 #define STATUS_UPDATE_NONE 0
 #define STATUS_UPDATE_ALL (~0)
-#define INVISIBILITY_ABSTRACT 101
 #define UNHEALING_EAR_DAMAGE 100
 
 //Human sub-species

--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -20,7 +20,8 @@
 #define INVISIBILITY_AI_EYE 61
 #define SEE_INVISIBLE_OBSERVER_AI_EYE 61
 
-#define INVISIBILITY_MAXIMUM 100
+#define INVISIBILITY_MAXIMUM 100   // The maximum allowed for "real" objects.
+#define INVISIBILITY_ABSTRACT 101  // Only used for abstract objects (e.g. spacevine_controller), things that are not really there.
 
 //Some mob defines below
 #define AI_CAMERA_LUMINOSITY 6

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -333,6 +333,7 @@
 			for(var/client/C in group)
 				C.screen -= O
 
+// Temporarily overlay `show_to` clients' view with specified image. Image disappears after `duration` deciseconds.
 /proc/flick_overlay(image/I, list/show_to, duration)
 	for(var/client/C in show_to)
 		C.images += I

--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -63,5 +63,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //mob traits
 #define TRAIT_PACIFISM			"pacifism"
 
+// item traits
+#define TRAIT_T_RAY_VISIBLE     "t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1
+
 // common trait sources
+#define TRAIT_GENERIC "generic"
 #define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention

--- a/code/game/machinery/Beacon.dm
+++ b/code/game/machinery/Beacon.dm
@@ -40,7 +40,7 @@
 	return ..()
 
 /obj/machinery/bluespace_beacon/hide(var/intact)
-	invisibility = intact ? 101 : 0
+	invisibility = intact ? INVISIBILITY_MAXIMUM : 0
 	update_icon()
 
 // update the icon_state

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -44,7 +44,7 @@
 
 	// update the invisibility and icon
 /obj/machinery/magnetic_module/hide(intact)
-	invisibility = intact ? 101 : 0
+	invisibility = intact ? INVISIBILITY_MAXIMUM : 0
 	updateicon()
 
 	// update the icon_state

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -20,7 +20,7 @@ REAGENT SCANNER
 	materials = list(MAT_METAL=150)
 	origin_tech = "magnets=1;engineering=1"
 	var/scan_range = 1
-	var/pulse_duration = 10
+	var/pulse_duration = 10  // in deciseconds
 
 /obj/item/t_scanner/longer_pulse
 	pulse_duration = 50
@@ -37,7 +37,7 @@ REAGENT SCANNER
 		STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/t_scanner/proc/toggle_on()
+/obj/item/t_scanner/attack_self(mob/user)
 	on = !on
 	icon_state = copytext(icon_state, 1, length(icon_state))+"[on]"
 	if(on)
@@ -45,21 +45,15 @@ REAGENT SCANNER
 	else
 		STOP_PROCESSING(SSobj, src)
 
-/obj/item/t_scanner/attack_self(mob/user)
-	toggle_on()
-
 /obj/item/t_scanner/process()
 	if(!on)
 		STOP_PROCESSING(SSobj, src)
 		return null
 	scan()
 
+// Show the holder the T-ray layout within `scan_range` for the `pulse_duration` deciseconds.
 /obj/item/t_scanner/proc/scan()
-	t_ray_scan(src.loc, pulse_duration=pulse_duration, scan_range=scan_range)
-
-// Show the viewer the T-ray layout within `scan_range` for the `pulse_duration` deciseconds.
-/proc/t_ray_scan(mob/viewer, pulse_duration, scan_range)
-	var/flick_time = pulse_duration
+	var/mob/viewer = src.loc
 	if(!ismob(viewer) || !viewer.client)
 		return
 
@@ -78,8 +72,8 @@ REAGENT SCANNER
 				I.appearance = MA
 				t_ray_images += I
 	if(t_ray_images.len)
-		flick_overlay(t_ray_images, list(viewer.client), flick_time)
-	
+		flick_overlay(t_ray_images, list(viewer.client), pulse_duration)
+
 
 /proc/chemscan(mob/living/user, mob/living/M)
 	if(ishuman(M))

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -302,13 +302,15 @@
 
 /obj/item/storage/backpack/satchel_flat/hide(var/intact)
 	if(intact)
-		invisibility = 101
-		anchored = 1 //otherwise you can start pulling, cover it, and drag around an invisible backpack.
+		invisibility = INVISIBILITY_OBSERVER
+		anchored = TRUE //otherwise you can start pulling, cover it, and drag around an invisible backpack.
 		icon_state = "[initial(icon_state)]2"
+		ADD_TRAIT(src, TRAIT_T_RAY_VISIBLE, TRAIT_GENERIC)
 	else
 		invisibility = initial(invisibility)
-		anchored = 0
+		anchored = FALSE
 		icon_state = initial(icon_state)
+		REMOVE_TRAIT(src, TRAIT_T_RAY_VISIBLE, TRAIT_GENERIC)
 
 /obj/item/storage/backpack/satchel_flat/New()
 	..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -95,7 +95,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/hide(i)
 
 	if(level == 1 && isturf(loc))
-		invisibility = i ? 101 : 0
+		invisibility = i ? INVISIBILITY_MAXIMUM : 0
 	updateicon()
 
 /obj/structure/cable/proc/updateicon()

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -27,7 +27,7 @@
 
 /obj/machinery/power/terminal/hide(i)
 	if(i)
-		invisibility = 101
+		invisibility = INVISIBILITY_MAXIMUM
 		icon_state = "term-f"
 	else
 		invisibility = 0

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -69,7 +69,7 @@
 // hide called by levelupdate if turf intact status changes
 // change visibility status and force update of icon
 /obj/structure/disposalconstruct/hide(var/intact)
-	invisibility = (intact && level==1) ? 101: 0	// hide if floor is intact
+	invisibility = (intact && level==1) ? INVISIBILITY_MAXIMUM: 0	// hide if floor is intact
 	update()
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -762,7 +762,7 @@
 // hide called by levelupdate if turf intact status changes
 // change visibility status and force update of icon
 /obj/structure/disposalpipe/hide(var/intact)
-	invisibility = intact ? 101: 0	// hide if floor is intact
+	invisibility = intact ? INVISIBILITY_MAXIMUM: 0	// hide if floor is intact
 	update_icon()
 
 // update actual icon_state depending on visibility


### PR DESCRIPTION
## What Does This PR Do
From tg, more or less.

- Makes T-ray overlay only visible for the user, not for other people nearby.

- Minor refactor: the plumbing invisibility values are switched from numerical 101 (which is INVISIBILITY_ABSTRACT) to INVISIBILITY_MAXIMUM (which is 100). The INVISIBLITY_MAXIMUM seems to be the semantically correct value, but I don't think this would have any noticeable effect in game.

- The old code tries to reveal "invisible" monsters on scan, but I've never heard of scanner being actually used for this purpose. Probably because only such monsters are ninjas, which are currently admin-only...

Changes from tg:
- `for(var/turf/T in range(scan_range, viewer)) for(var/obj/O in T.contents)` instead of `for(var/obj/O in orange(scan_range, viewer)` . I don't know why but `range` iterates over turfs contents on /tg/, yet not on para...
- `range` instead of `orange`: because you are likely interested in seeing piping even on the tile you're currently standing

## Why It's Good For The Game
T-ray view is only really useful for the person holding the scanner, and people nearby are usually mildly annoyed by the flashing. This is especially bothersome when an unconscious engineer comes/is brought to medbay/cloning.

## Images of changes
N/A

## Changelog
:cl:
tweak: T-Ray imagery is now only visible to T-Ray scanner user, not to outside observers.
/:cl:


P.s.: as a future work items, one could introduce:
- Increase the T-Ray scanner range to make it easier to work with (now that it's unobtrusive to bystanders) (the range is 3 on tg, compared to 1 here)
- Add ability icon for toggling T-ray scanner
- Add T-ray goggles (combined with optical meson scanners probably?)
- Add T-ray ghost view

but these are all items for a different PR