### PR TITLE
Prevent stacks from being consumed by redspace.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -312,7 +312,7 @@
 			// the two get merged, so the amount of items in the stack can increase from the 0 that it had before.
 			// Check the amount again, to be sure we're not qdeling healthy stacks.
 			qdel(src)
-			return TRUE
+		return TRUE
 	return FALSE
 
 /obj/item/stack/proc/merge(obj/item/stack/S) //Merge src into S, as much as possible

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -307,7 +307,10 @@
 		if(ismob(loc))
 			var/mob/living/L = loc // At this stage, stack code is so horrible and atrocious, I wouldn't be all surprised ghosts can somehow have stacks. If this happens, then the world deserves to burn.
 			L.unEquip(src, TRUE)
-		if(amount < 1)  // check again. Dropping the stuff could have incresed the amount in src (somehow...)
+		if(amount < 1)
+			// If you stand on top of a stack, and drop a - different - 0-amount stack on the floor,
+			// the two get merged, so the amount of items in the stack can increase from the 0 that it had before.
+			// Check the amount again, to be sure we're not qdeling healthy stacks.
 			qdel(src)
 			return TRUE
 	return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -296,6 +296,8 @@
 	else
 		return ..()
 
+// Returns TRUE if the stack amount is zero.
+// Also qdels the stack gracefully if it is.
 /obj/item/stack/proc/zero_amount()
 	if(amount < 1)
 		if(isrobot(loc))
@@ -305,8 +307,9 @@
 		if(ismob(loc))
 			var/mob/living/L = loc // At this stage, stack code is so horrible and atrocious, I wouldn't be all surprised ghosts can somehow have stacks. If this happens, then the world deserves to burn.
 			L.unEquip(src, TRUE)
-		qdel(src)
-		return TRUE
+		if(amount < 1)  // check again. Dropping the stuff could have incresed the amount in src (somehow...)
+			qdel(src)
+			return TRUE
 	return FALSE
 
 /obj/item/stack/proc/merge(obj/item/stack/S) //Merge src into S, as much as possible


### PR DESCRIPTION
## What Does This PR Do
Fixes #12606
I don't understand the code enough to tell you why it works.

Edit: I think I figured it out. To copy from my code comment:
If you stand on top of a stack, and drop a - different - 0-amount stack on the floor, the two get merged, so the amount of items in the stack can increase from the 0 that it had before. So we need to perform an extra zero check before qdeling, to make sure we're not accidentally nomming the healthy stack.


## Why It's Good For The Game
Floor tiles being lost forever never to be seen again is extremely sad.

## Images of changes
N/A

## Changelog
:cl:
fix: fixed items disappearing if you use it while standing on top of the stack of same type of items.
/:cl: