### PR TITLE
Allow observers to inspect storage contents by clicking it.

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -57,7 +57,9 @@
 	examinate(A)
 
 /atom/proc/attack_ghost(mob/user as mob)
-	return
+	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_GHOST, user) & COMPONENT_NO_ATTACK_HAND)
+		return TRUE
+	return FALSE
 
 // health + cyborg analyzer for ghosts
 /mob/living/attack_ghost(mob/dead/observer/user)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -1,0 +1,17 @@
+
+/datum/component/storage
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+
+/datum/component/storage/concrete
+
+/datum/component/storage/Initialize(datum/component/storage/concrete/master)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_GHOST, .proc/show_to_ghost)
+
+/datum/component/storage/proc/show_to_ghost(datum/source, mob/dead/observer/M)
+	var/obj/item/storage/s = parent
+	if(istype(s))
+		return s.show_to(M)
+

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -23,6 +23,10 @@
 	var/allow_quick_gather	//Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
 	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
+	var/component_type = /datum/component/storage/concrete
+
+/obj/item/storage/ComponentInitialize()
+	AddComponent(component_type)
 
 /obj/item/storage/MouseDrop(obj/over_object as obj)
 	if(ishuman(usr)) //so monkeys can take off their backpacks -- Urist
@@ -32,7 +36,6 @@
 			return
 
 		if(over_object == M && Adjacent(M)) // this must come before the screen objects only block
-			orient2hud(M)          // dunno why it wasn't before
 			if(M.s_active)
 				M.s_active.close(M)
 			show_to(M)
@@ -108,6 +111,7 @@
 				return
 	if(user.s_active)
 		user.s_active.hide_from(user)
+	orient2hud()
 	user.client.screen -= src.boxes
 	user.client.screen -= src.closer
 	user.client.screen -= src.contents
@@ -132,7 +136,6 @@
 	if(src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 1, -5)
 
-	orient2hud(user)
 	if(user.s_active)
 		user.s_active.close(user)
 	show_to(user)
@@ -397,7 +400,6 @@
 			H.r_store = null
 			return
 
-	src.orient2hud(user)
 	if(src.loc == user)
 		if(user.s_active)
 			user.s_active.close(user)

--- a/paradise.dme
+++ b/paradise.dme
@@ -290,6 +290,7 @@
 #include "code\datums\components\spawner.dm"
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\waddling.dm"
+#include "code\datums\components\storage\storage.dm"
 #include "code\datums\diseases\_disease.dm"
 #include "code\datums\diseases\_MobProcs.dm"
 #include "code\datums\diseases\anxiety.dm"


### PR DESCRIPTION
## What Does This PR Do
Allows ghosts to see storage contents by clicking on the storage (boxes, toolboxes, belts etc).

From tg but not really.
tg's storage handling is much.. refactored from what it is on Paradise, and I'm not going to port all of it here in one go.

Just taking a few small parts in hopes we can maybe migrate there  gradually... (not really, but one can dream)

## Why It's Good For The Game
Ghosts get a bit more involved in the round, and have a bit more fun (without screwing with the living)

## Images of changes
![dreamseeker_2019-10-29_10-22-48](https://user-images.githubusercontent.com/7831163/67758689-10e2fc80-fa36-11e9-8568-6d9e164e66c5.png)

## Changelog
:cl:
add: Ghosts can inspect containers by clicking on them
/:cl:
