### PR TITLE
Allow observers to inspect storage contents by clicking it [Take 2]

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -408,7 +408,7 @@
 	src.add_fingerprint(user)
 	return
 
-/obj/item/storage/attack_ghost(mob/user as mob)
+/obj/item/storage/attack_ghost(mob/user)
 	show_to(user)
 	return ..()
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -32,7 +32,6 @@
 			return
 
 		if(over_object == M && Adjacent(M)) // this must come before the screen objects only block
-			orient2hud(M)          // dunno why it wasn't before
 			if(M.s_active)
 				M.s_active.close(M)
 			show_to(M)
@@ -108,6 +107,7 @@
 				return
 	if(user.s_active)
 		user.s_active.hide_from(user)
+	orient2hud()
 	user.client.screen -= src.boxes
 	user.client.screen -= src.closer
 	user.client.screen -= src.contents
@@ -132,7 +132,6 @@
 	if(src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 1, -5)
 
-	orient2hud(user)
 	if(user.s_active)
 		user.s_active.close(user)
 	show_to(user)
@@ -397,7 +396,6 @@
 			H.r_store = null
 			return
 
-	src.orient2hud(user)
 	if(src.loc == user)
 		if(user.s_active)
 			user.s_active.close(user)
@@ -409,6 +407,10 @@
 				src.close(M)
 	src.add_fingerprint(user)
 	return
+
+/obj/item/storage/attack_ghost(mob/user as mob)
+	show_to(user)
+	return ..()
 
 /obj/item/storage/verb/toggle_gathering_mode()
 	set name = "Switch Gathering Method"


### PR DESCRIPTION
## What Does This PR Do
Ghosts can now click on containers to see the contents.

This is a re-take of #12663 (which i accidentally closed, and can't reopen now turns out).
This time implemented the simplest way possible, with no needless component shenanigans.

## Why It's Good For The Game
Ghosts get a bit more involved in the round, and have a bit more fun (without screwing with the living)

## Images of changes
![pic](https://user-images.githubusercontent.com/7831163/67758689-10e2fc80-fa36-11e9-8568-6d9e164e66c5.png)

## Changelog
:cl:
add: Ghosts can inspect containers by clicking on them
/:cl: