### PR TITLE
Snow machine can be ordered on both cargo consoles, not just the supply console

### DIFF
--- a/code/modules/holiday/christmas.dm
+++ b/code/modules/holiday/christmas.dm
@@ -11,8 +11,8 @@
 		break
 	//The following spawn is necessary as both the timer and the shuttle systems initialise after the events system does, so we can't add stuff to the shuttle system as it doesn't exist yet and we can't use a timer
 	spawn(60 SECONDS)
-		var/datum/supply_packs/xmas = SSshuttle.supply_packs["[/datum/supply_packs/misc/snow_machine]"]
-		xmas.special_enabled = TRUE
+		var/datum/supply_packs/misc/snow_machine/xmas = SSshuttle.supply_packs["[/datum/supply_packs/misc/snow_machine]"]
+		xmas.special = FALSE
 
 /datum/holiday/xmas/handle_event()
 	spawnTree()


### PR DESCRIPTION
Title.

Previously you had to ask cargo to order the snow machine for you. This way makes more sense, as the snow machine's not exactly something dangerous you have to pass through command.

:cl:
tweak: Snow machines can now be bought at both the ordering and supply consoles. (During Christmas, of course!)
/:cl: