### PR TITLE
[DNM] Some more mindslave code fixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1662,7 +1662,7 @@
 	SSticker.mode.traitors += src
 
 	
-	var/datum/objective/protect/zealot_objective = new
+	var/datum/objective/protect/mindslave/zealot_objective = new
 	zealot_objective.target = missionary.mind
 	zealot_objective.owner = src
 	zealot_objective.explanation_text = "Obey every order from and protect [missionary.real_name], the [missionary.mind.assigned_role == missionary.mind.special_role ? (missionary.mind.special_role) : (missionary.mind.assigned_role)]."

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -8,7 +8,7 @@
 
 /datum/antagonist/mindslave/on_gain()
 	owner.special_role = special_role
-	// Will print the most recent objective which is probably going the mindslave objective
+	// Will print the most recent objective which is probably going to be the mindslave objective
 	to_chat(owner.current, "<b>New Objective:</b> [owner.objectives[owner.objectives.len].explanation_text]")
 	update_mindslave_icons_added()
 
@@ -17,8 +17,13 @@
 		var/datum/mindslaves/slaved = owner.som
 		slaved.serv -= owner
 		slaved.leave_serv_hud(owner)
-	antag_memory = ""
-	owner.special_role = null
+	if(LAZYLEN(owner.antag_datums) > 1) // If it was an antag who was mindslaved, they'll have more than 1 antag datum. We don't want this to be null
+		owner.special_role = owner.antag_datums[1].special_role // Set their special role to the role it was before they got mindslaved
+	else
+		owner.special_role = null
+	for(var/objective in owner.objectives) // Remove their mindslave objective while keeping others intact
+		if(istype(objective, /datum/objective/protect/mindslave))
+			remove_objective(objective)
 	update_mindslave_icons_removed()
 	..()
 

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -13,6 +13,7 @@
 	update_mindslave_icons_added()
 
 /datum/antagonist/mindslave/on_removal()
+	SSticker.mode.implanted.Remove(owner.current)
 	if(owner.som)
 		var/datum/mindslaves/slaved = owner.som
 		slaved.serv -= owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes mindslaves and zealot's not getting their objectives removed when they lose the mindslave status. 

Antags who are mindslaved now revert to their previous special role when they lose the mindslave status. For example, if a traitor gets mindslaved and then that status gets removed, their `special_role` won't be null, it will get reverted back to traitor.

Fixes  #12675


## Changelog
:cl:
fix: Fixes mindslaves and zealots not getting their objective removed when they lose the mindslave status
fix: Antagonists who are mindslaved now revert to their previous special role when they lose the mindslave status
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
