### PR TITLE
Fixes depot mobs reacting very slowly

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -148,8 +148,10 @@
 			// This prevents someone from aggroing a depot mob, then hiding in a locker, perfectly safe, while the mob stands there getting killed by their friends.
 			LoseTarget()
 
-/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/handle_automated_movement()
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/handle_automated_action()
 	. = ..()
+	if(!.)
+		return
 	if(!istype(depotarea))
 		return
 	if(seen_enemy)
@@ -183,6 +185,10 @@
 			pointed(body)
 	else
 		scan_cycles++
+
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/AIShouldSleep(var/list/possible_targets)
+	FindTarget(possible_targets, 1)
+	return FALSE
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/proc/raise_alert(var/reason)
 	if(istype(depotarea) && (!raised_alert || seen_revived_enemy) && !depotarea.used_self_destruct)


### PR DESCRIPTION
## What Does This PR Do
Improves the reaction speed of depot AI mobs.

## Why It's Good For The Game
Currently, their reaction speed is so slow that someone can walk into their room, open their locker, take their item, and run out, before they notice that a player is within their vision range.
This improves their reaction time, so that they will now notice much faster when a player enters their vision range.

:cl: Kyep
fix: Fixed depot mobs taking a long time to react to the presence of nearby hostiles.
/:cl: