### PR TITLE
Ghosts can browse though paper bundles.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2149,7 +2149,7 @@
 			var/data = ""
 			var/obj/item/paper_bundle/B = fax
 
-			for(var/page = 1, page <= B.amount + 1, page++)
+			for(var/page = 1, page <= B.contents.len, page++)
 				var/obj/pageobj = B.contents[page]
 				data += "<A href='?src=[UID()];AdminFaxViewPage=[page];paper_bundle=\ref[B]'>Page [page] - [pageobj.name]</A><BR>"
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -356,7 +356,6 @@
 		to_chat(user, "<span class='notice'>You clip the [P.name] to [(src.name == "paper") ? "the paper" : src.name].</span>")
 		src.loc = B
 		P.loc = B
-		B.amount++
 		B.update_icon()
 
 	else if(istype(P, /obj/item/pen) || istype(P, /obj/item/toy/crayon))

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -85,13 +85,13 @@
 				sleep(15)
 			else if(istype(copyitem, /obj/item/paper_bundle))
 				var/obj/item/paper_bundle/C = copyitem
-				if(toner < (C.amount + 1))
+				if(toner < (C.contents.len))
 					visible_message("<span class='notice'>A yellow light on [src] flashes, indicating there's not enough toner for the operation.</span>") // It is better to prevent partial bundle than to produce broken paper bundle
 					return
 				var/obj/item/paper_bundle/B = bundlecopy(copyitem)
 				if(!B)
 					return
-				sleep(15*B.amount)
+				sleep(15*B.contents.len)
 			else if(ass && ass.loc == loc)
 				copyass()
 				sleep(15)
@@ -291,11 +291,9 @@
 		else if(istype(W, /obj/item/photo))
 			W = photocopy(W)
 		W.forceMove(P)
-		P.amount++
-	if(!P.amount)
+	if(!P.contents.len)
 		qdel(P)
 		return null
-	P.amount--
 	P.forceMove(get_turf(src))
 	P.update_icon()
 	P.icon_state = "paper_words"


### PR DESCRIPTION
## What Does This PR Do
Allows ghosts to browse through paper bundles.
Fixes #3090

Living people still need to hold the bundle in hand to physically turn over the pages, but ghosts can now flip them over "virtually".

Also minor paper bundle refactor in general - we no longer need a separate `amount` variable which is basically `src.contents.len - 1` at all times, and we also don't need a separate "is this the first page, the last page or the middle page" variable, since we can calculate it when needed instead.


## Why It's Good For The Game
Ghosts have more fun.
Aghosts have more info to make informed decisions.

## Images of changes
N/A

## Changelog
:cl:
add: Ghosts can browse through paper bundles now
/:cl: