### PR TITLE
Fixes non-navy officers having navy officer uniforms

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -8862,10 +8862,6 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/under/rank/centcom/officer,
-/obj/item/clothing/under/rank/centcom/representative{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /turf/unsimulated/floor{
 	tag = "icon-floor";
 	icon_state = "floor"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -260,7 +260,6 @@
 	new /obj/item/clothing/accessory/holster(src)
 	new /obj/item/clothing/accessory/blue(src)
 	new /obj/item/clothing/shoes/jackboots/jacksandals(src)
-	new /obj/item/clothing/under/rank/centcom/blueshield(src)
 
 
 /obj/structure/closet/secure_closet/ntrep
@@ -285,7 +284,6 @@
 	new /obj/item/clothing/under/lawyer/oldman(src)
 	new /obj/item/clothing/under/lawyer/black(src)
 	new /obj/item/clothing/under/lawyer/female(src)
-	new /obj/item/clothing/under/rank/centcom/representative(src)
 	new /obj/item/clothing/head/ntrep(src)
 	new /obj/item/clothing/shoes/sandal/fancy(src)
 	new /obj/item/storage/box/tapes(src)
@@ -459,7 +457,6 @@
 	new /obj/item/clothing/gloves/color/white(src)
 	new /obj/item/clothing/shoes/centcom(src)
 	new /obj/item/clothing/under/suit_jacket/really_black(src)
-	new /obj/item/clothing/under/rank/centcom/magistrate(src)
 	new /obj/item/clothing/suit/judgerobe(src)
 	new /obj/item/clothing/head/powdered_wig(src)
 	new /obj/item/gavelblock(src)

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -112,45 +112,6 @@
 	item_color = "centcom"
 	displays_id = 0
 
-/obj/item/clothing/under/rank/centcom/blueshield
-	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Lieutenant\" and bears \"N.S.S. Cyberiad\" on the left shoulder."
-	name = "\improper Nanotrasen Navy Uniform"
-	icon_state = "officer"
-	item_state = "g_suit"
-	item_color = "officer"
-	displays_id = 0
-	flags_size = ONESIZEFITSALL
-
-/obj/item/clothing/under/rank/centcom/blueshield/New()
-	..()
-	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Lieutenant\" and bears [station_name()] on the left shoulder."
-
-/obj/item/clothing/under/rank/centcom/representative
-	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Ensign\" and bears \"N.S.S. Cyberiad\" on the left shoulder."
-	name = "\improper Nanotrasen Navy Uniform"
-	icon_state = "officer"
-	item_state = "g_suit"
-	item_color = "officer"
-	displays_id = 0
-	flags_size = ONESIZEFITSALL
-
-/obj/item/clothing/under/rank/centcom/representative/New()
-	..()
-	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Ensign\" and bears [station_name()] on the left shoulder."
-
-/obj/item/clothing/under/rank/centcom/magistrate
-	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Magistrate\" and bears \"N.S.S. Cyberiad\" on the left shoulder."
-	name = "\improper Nanotrasen Navy Uniform"
-	icon_state = "officer"
-	item_state = "g_suit"
-	item_color = "officer"
-	displays_id = 0
-	flags_size = ONESIZEFITSALL
-
-/obj/item/clothing/under/rank/centcom/magistrate/New()
-	..()
-	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Magistrate\" and bears [station_name()] on the left shoulder."
-
 /obj/item/clothing/under/rank/centcom/diplomatic
 	desc = "A very gaudy and official looking uniform of the Nanotrasen Diplomatic Corps."
 	name = "\improper Nanotrasen Diplomatic Uniform"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes navy officer uniform from jobs that are not navy officers.

## Why It's Good For The Game
The BS, Magistrate, and NTR; are not navy officers, so there is no reason why they should have navy officer uniforms. Navy officers have the authority to do pretty much anything including changing space law and terminating contracts directly. When navy officers rarely go on station they shouldn't be confused for regular crewmembers and vice versa.

Each of these jobs have their own uniform with their own name, description, and sprite already. There's no reason to just add the CC navy officer uniform anyways. This is equivalent to giving people a renamed captain uniform when they aren't a captain and then saying "but it's not a captain uniform!"

:cl:
tweak: Removes navy officer uniform from jobs that are not navy officers.
/ :cl: