### PR TITLE
Fix regex highlightning.

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -159,7 +159,7 @@ function escapeRegex(input){
 // Recursively highlights all text matching `term` in text nodes reachable from the given root `element`.
 // Returns the last (right-most, DOM-wise) element that was analyzed and potentially highglighted.
 function highlightRecursively(element, term) {
-	var regex = new RegExp(term, "gi")
+	var regex = new RegExp(term, "gi");
 	// if that's a text node - wrap found words in a highlighter span.
 	if (element.nodeType == Node.TEXT_NODE) {
 		// The underlying text element would (likely) be destroyed, and we'll be left with
@@ -179,20 +179,20 @@ function highlightRecursively(element, term) {
 			lastStop = newStop;
 		}
 		// Push the rest of the string.
-		newElements.push(document.createTextNode(element.textContent.substring(lastStop)))
+		newElements.push(document.createTextNode(element.textContent.substring(lastStop)));
 
 		// If we found any matches - replace the current text element with the bunch of new nodes we've just created
 		var lastInserted = element;
 		if (newElements.length > 0) {
 			for (var i = 0; i < newElements.length; i++){
-				lastInserted = element.parentNode.insertBefore(newElements[i], element)
+				lastInserted = element.parentNode.insertBefore(newElements[i], element);
 			}
 			element.parentNode.removeChild(element);
 		}
 		return lastInserted;
 	} else {
 		// If it's not a plain text node - recurse further.
-		var currentChild = element.childNodes[0]
+		var currentChild = element.childNodes[0];
 		while (currentChild){
 			currentChild = highlightRecursively(currentChild, term);
 			currentChild = currentChild.nextSibling;
@@ -1065,7 +1065,7 @@ $(function() {
 			count++;
 		}
 
-		opts.highlightRegexEnable = document.querySelector("#highlightRegexEnable").checked
+		opts.highlightRegexEnable = document.querySelector("#highlightRegexEnable").checked;
 		if (opts.highlightRegexEnable) {
 			// Check that all the patterns are valid regexes.
 			for(var i = 0; i < opts.highlightTerms.length; i++){

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -159,14 +159,22 @@ function escapeRegex(input){
 // Recursively highlights all text matching `term` in text nodes reachable from the given root `element`.
 // Returns the last (right-most, DOM-wise) element that was analyzed and potentially highglighted.
 function highlightRecursively(element, term) {
-	var regex = new RegExp(term, "gi");
+	var regex = new RegExp(term, "i");
 	// if that's a text node - wrap found words in a highlighter span.
 	if (element.nodeType == Node.TEXT_NODE) {
 		// The underlying text element would (likely) be destroyed, and we'll be left with
 		// a collection of smaller text nodes and highlighter spans. They'd be stored in this array.
 		var newElements = [];
 		var lastStop = 0;  // The end of the last found match.
-		while ((match = regex.exec(element.textContent)) !== null) {
+		// The loop is ugly.
+		// There are reasons for it, namely: BYOND does not support matchAll regex method, and the `regexp.exec()` which is
+		// "standard" workaround for older browsers does not respect sticky/global flags when matching .*, which
+		// means this thing never terminates.
+		while ((match = element.textContent.substring(lastStop).match(regex)) !== null) {
+			if (match[0].length == 0) {
+				// Matching on .* or other non-consuming pattern would get us here
+				break;
+			}
 			var start = match.index;
 			var newStop = match.index + match[0].length;
 			// push text between the end of the last match and start of this one


### PR DESCRIPTION
## What Does This PR Do
Fixes highlighting that was broken with the recent highlighting regex changes.
Conflicts with/reimplements #12690 (and, transitively, #12684)

Fixes #12676
Fixes #12657
Fixes #12656

You see, Cunningham's Law is true, as always - "the best way to ~~get the right answer~~ get a feature implemented on the internet is not to ~~ask a question~~ create a bug; it's to post the ~~wrong answer~~ suboptimal PR"
But that's, of course, a matter of personal taste - feel free to close this one if you like the other PR handles it better.

The prime difference is that this PR operates on DOM entities rather than on raw HTML, which makes it more robust to the weird layouts that you cannot really parse with a regex. Other changes (including the regex check being moved to when it's saved over when it's used) are more or less superficial.

Credits to @craftxbox for the original implementation.

## Why It's Good For The Game
I'm not sure why regex highlights are needed, but you currently get broken HTML if you use the feature at all, and that's bad user experience.

## Images of changes
![dreamseeker_2019-11-04_08-00-48](https://user-images.githubusercontent.com/7831163/68107000-52165900-fedb-11e9-8adc-01584600a351.png)


## Changelog
:cl:
fix: fixed highlighting messing up the chat
/:cl:

