### PR TITLE
Makes simple slimes ignore slime people when searching for targets again

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -84,6 +84,7 @@
 	var/single_gib_type = /obj/effect/decal/cleanable/blood/gibs
 	var/remains_type = /obj/effect/decal/remains/human //What sort of remains is left behind when the species dusts
 	var/base_color      //Used when setting species.
+	var/list/inherent_factions
 
 	//Used in icon caching.
 	var/race_key = 0
@@ -285,10 +286,18 @@
 		H.hud_used.update_locked_slots()
 	H.ventcrawler = ventcrawler
 
+	if(inherent_factions)
+		for(var/i in inherent_factions)
+			H.faction += i //Using +=/-= for this in case you also gain the faction from a different source.
+
 /datum/species/proc/on_species_loss(mob/living/carbon/human/H)
 	if(H.butcher_results) //clear it out so we don't butcher a actual human.
 		H.butcher_results = null
 	H.ventcrawler = initial(H.ventcrawler)
+
+	if(inherent_factions)
+		for(var/i in inherent_factions)
+			H.faction -= i
 
 /datum/species/proc/updatespeciescolor(mob/living/carbon/human/H) //Handles changing icobase for species that have multiple skin colors.
 	return

--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -108,13 +108,4 @@
 
 /datum/species/diona/pod //Same name and everything; we want the same limitations on them; we just want their regeneration to kick in at all times and them to have special factions
 	pod = TRUE
-
-/datum/species/diona/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
-	. = ..()
-	C.faction |= "plants"
-	C.faction |= "vines"
-
-/datum/species/diona/pod/on_species_loss(mob/living/carbon/C)
-	. = ..()
-	C.faction -= "plants"
-	C.faction -= "vines"
+	inherent_factions = list("plants", "vines")

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -5,6 +5,7 @@
 	icobase = 'icons/mob/human_races/r_shadow.dmi'
 	deform = 'icons/mob/human_races/r_shadow.dmi'
 	dangerous_existence = TRUE
+	inherent_factions = list("faithless")
 
 	unarmed_type = /datum/unarmed_attack/claws
 
@@ -49,14 +50,12 @@
 	if(grant_vision_toggle)
 		vision_toggle = new
 		vision_toggle.Grant(H)
-	H.faction |= "faithless"
 
 /datum/species/shadow/on_species_loss(mob/living/carbon/human/H)
 	..()
 	if(grant_vision_toggle && vision_toggle)
 		H.vision_type = null
 		vision_toggle.Remove(H)
-	H.faction -= "faithless"
 
 /datum/species/shadow/handle_life(mob/living/carbon/human/H)
 	var/light_amount = 0

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -13,6 +13,7 @@
 	icobase = 'icons/mob/human_races/r_slime.dmi'
 	deform = 'icons/mob/human_races/r_slime.dmi'
 	remains_type = /obj/effect/decal/remains/slime
+	inherent_factions = list("slime")
 
 	// More sensitive to the cold
 	cold_level_1 = 280

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -314,7 +314,7 @@
 
 				for(var/mob/living/L in view(7,src))
 
-					if(isslime(L) || isslimeperson(L) || L.stat == DEAD) // Ignore other slimes, slime people, and dead mobs
+					if(L.stat == DEAD) // Ignore dead mobs
 						continue
 
 					if(L in Friends) // No eating friends!

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -314,7 +314,7 @@
 
 				for(var/mob/living/L in view(7,src))
 
-					if(isslime(L) || L.stat == DEAD) // Ignore other slimes and dead mobs
+					if(isslime(L) || isslimeperson(L) || L.stat == DEAD) // Ignore other slimes, slime people, and dead mobs
 						continue
 
 					if(L in Friends) // No eating friends!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Simple slimes will ignore slime people when searching for targets, as they used to do.

EDIT: Updated to include species `inherent_factions` and gives slime people the "slime" faction. Since simple slimes have this faction, they will never attack other simple slimes, or slime people.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Restores a gameplay mechanic that was removed in the slime refactor (#12398) as an undocumented change.

Fixes #12518
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds in an inherent_factions var to all species. Gives slime people the "slime" faction
fix: Slimes will ignore slime people when searching for targets again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
