### PR TITLE
Fix odysseus syringes breaking when flying beyond max range.

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -316,40 +316,38 @@
 	var/mob/originaloccupant = chassis.occupant
 	spawn(0)
 		src = null //if src is deleted, still process the syringe
-		for(var/i=0, i<6, i++)
+		var/max_range = 6
+		for(var/i=0, i<max_range, i++)
 			if(!mechsyringe)
 				break
-			if(step_towards(mechsyringe,trg))
-				var/list/mobs = new
-				for(var/mob/living/carbon/M in mechsyringe.loc)
-					mobs += M
-				var/mob/living/carbon/M = safepick(mobs)
-				if(M)
-					var/R
-					mechsyringe.visible_message("<span class=\"attack\"> [M] was hit by the syringe!</span>")
-					if(M.can_inject(null, TRUE))
-						if(mechsyringe.reagents)
-							for(var/datum/reagent/A in mechsyringe.reagents.reagent_list)
-								R += A.id + " ("
-								R += num2text(A.volume) + "),"
-						add_attack_logs(originaloccupant, M, "Shot with [src] containing [R], transferred [mechsyringe.reagents.total_volume] units")
-						mechsyringe.icon_state = initial(mechsyringe.icon_state)
-						mechsyringe.icon = initial(mechsyringe.icon)
-						mechsyringe.reagents.reaction(M, INGEST)
-						mechsyringe.reagents.trans_to(M, mechsyringe.reagents.total_volume)
-						M.take_organ_damage(2)
-					break
-				else if(mechsyringe.loc == trg)
-					mechsyringe.icon_state = initial(mechsyringe.icon_state)
-					mechsyringe.icon = initial(mechsyringe.icon)
-					mechsyringe.update_icon()
-					break
-			else
-				mechsyringe.icon_state = initial(mechsyringe.icon_state)
-				mechsyringe.icon = initial(mechsyringe.icon)
-				mechsyringe.update_icon()
+			if(!step_towards(mechsyringe,trg))
+				break
+
+			var/list/mobs = new
+			for(var/mob/living/carbon/M in mechsyringe.loc)
+				mobs += M
+			var/mob/living/carbon/M = safepick(mobs)
+			if(M)
+				var/R
+				mechsyringe.visible_message("<span class=\"attack\"> [M] was hit by the syringe!</span>")
+				if(M.can_inject(null, TRUE))
+					if(mechsyringe.reagents)
+						for(var/datum/reagent/A in mechsyringe.reagents.reagent_list)
+							R += A.id + " ("
+							R += num2text(A.volume) + "),"
+					add_attack_logs(originaloccupant, M, "Shot with [src] containing [R], transferred [mechsyringe.reagents.total_volume] units")
+					mechsyringe.reagents.reaction(M, INGEST)
+					mechsyringe.reagents.trans_to(M, mechsyringe.reagents.total_volume)
+					M.take_organ_damage(2)
+				break
+			else if(mechsyringe.loc == trg)
 				break
 			sleep(1)
+		if(mechsyringe)
+			// Revert the syringe icon to normal one once it stops flying.
+			mechsyringe.icon_state = initial(mechsyringe.icon_state)
+			mechsyringe.icon = initial(mechsyringe.icon)
+			mechsyringe.update_icon()
 	return 1
 
 


### PR DESCRIPTION
## What Does This PR Do
Related: #12685 
Related: #7132 
Late edit: According to https://github.com/ParadiseSS13/Paradise/issues/12685#issuecomment-552586988 there is another case of syringes breaking that I did not explicitly test against. I think this PR should handle that as well, but not 100% confident.

Prior to this PR, the syringe gun icon would be reverted to horizontal only if:
 - it hits someone
 - it hits a wall and can't make any progress towards its destination
 - it reaches its destination

but it would stay in its projectile (vertical) icon if the target you are aiming for is out of range (i.e. 7 tiles away)

## Why It's Good For The Game
Bugfix. Syringes are now reusable.

## Images of changes
N/A

## Changelog
:cl:
fix: fixed syringe fired from odysseus syringe gun sprite being broken when flying beyond max range.
/:cl:
