### PR TITLE
Make photos look the same as reality to colorblind people.

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -81,7 +81,16 @@
 		. += "<span class='notice'>It is too far away.</span>"
 
 /obj/item/photo/proc/show(mob/user as mob)
-	usr << browse_rsc(img, "tmp_photo.png")
+	var/icon/img_shown = new/icon(img)
+	var/colormatrix = user.get_screen_colour()
+	// Apply colorblindness effects, if any.
+	if(islist(colormatrix))
+		img_shown.MapColors(
+			colormatrix[1], colormatrix[2], colormatrix[3],
+			colormatrix[4], colormatrix[5], colormatrix[6],
+			colormatrix[7], colormatrix[8], colormatrix[9],
+		)
+	usr << browse_rsc(img_shown, "tmp_photo.png")
 	usr << browse("<html><head><title>[name]</title></head>" \
 		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
 		+ "<img src='tmp_photo.png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" \


### PR DESCRIPTION
## What Does This PR Do
Applies colorblind filter to viewed photos if the person viewing said photo is colorblind.
Fixes #11778 

## Why It's Good For The Game
Muh immershn.

## Images of changes
![dreamseeker_2019-11-05_07-26-47](https://user-images.githubusercontent.com/7831163/68187197-ed700280-ff9d-11e9-91ce-8772d14e13ef.png)


## Changelog
:cl:
fix: photos no longer appear in full color to colorblind people.
/:cl:
