### PR TITLE
Add affected wiki pages to the pull request template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,10 @@
 ## Images of changes
 <!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
 
+## Wiki pages that need to be updated
+<!-- If your PR changes something that is documented on the wiki, and players will notice, and be confused by, the change, then you need to ensure the wiki is updated.  -->
+<!--The first step to this, is having the affected wiki pages identified and listed here -->
+
 ## Changelog
 :cl:
 add: Added new things

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,8 @@
 ## Images of changes
 <!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
 
-## Wiki pages that need to be updated
-<!-- If your PR changes something that is documented on the wiki, and players will notice, and be confused by, the change, then you need to ensure the wiki is updated.  -->
-<!--The first step to this, is having the affected wiki pages identified and listed here -->
+## Does the wiki need to be updated
+<!-- If your PR changes something that is documented on the wiki, and players will notice, and be confused by the change, then please mention so. If it doesn't - feel free to delete this section -->
 
 ## Changelog
 :cl:


### PR DESCRIPTION
## What Does This PR Do
Modifies PR template to include affected wiki pages.

## Why It's Good For The Game
Per @Kyep's announcement:

>@ Github Contributors After each of your PRs are merged, check the relevant wiki pages to see if they need to be updated. If they do, it is your responsibility to ensure they're updated. You can update them yourself, or you can bring up the PR in #wiki-development so that a regular wiki editor can do the update. Either way, you need to take at least the first step in ensuring that changes you make are accurately reflected on the wiki. Not doing this leads to cases where new players read inaccurate info on the wiki, and mentors give out inaccurate info based on what is written on the wiki. Obviously, that is bad. While it is great that some mentors look at PRs as they are merged, ultimately it is PR authors who are responsible for ensuring that the changes they make are clearly documented and communicated. 

> In general, if your PR changes something that is documented on the wiki, and players will notice, and be confused by, the change, then you need to ensure the wiki is updated. This will be most common for changes to important game mechanics, like how to construct/deconstruct items, and job/species/antag mechanics

However that announcement is a one-off thing that's easy to forget, and very hard to discover for new contributors.
Requiring the list of affected wiki pages to be listed alongside PR (or at least reminding folks that it's a good idea) would be a good step towards having the wiki up-to-date.
Even if the PR author does not bother to update themselves, having the outdated pages mentioned *at all* would make it easier for someone else to fix those.