### PR TITLE
Make paperwork popups use UID as a window id.

### DIFF
--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -78,10 +78,5 @@
 	if(href_list["read"])
 		var/obj/item/paper/P = locate(href_list["read"])
 		if((P && P.loc == src))
-			if(!( istype(usr, /mob/living/carbon/human) ))
-				usr << browse("<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY><TT>[stars(P.info)]</TT></BODY></HTML>", "window=[P.name]")
-				onclose(usr, "[P.name]")
-			else
-				usr << browse("<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY><TT>[P.info]</TT></BODY></HTML>", "window=[P.name]")
-				onclose(usr, "[P.name]")
+			P.show_content(usr)
 	return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2153,7 +2153,7 @@
 				var/obj/pageobj = B.contents[page]
 				data += "<A href='?src=[UID()];AdminFaxViewPage=[page];paper_bundle=\ref[B]'>Page [page] - [pageobj.name]</A><BR>"
 
-			usr << browse(data, "window=[B.name]")
+			usr << browse(data, "window=PaperBundle[B.UID()]")
 		else
 			to_chat(usr, "<span class='warning'>The faxed item is not viewable. This is probably a bug, and should be reported on the tracker: [fax.type]</span>")
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -80,7 +80,7 @@
 	else
 		data = "<div id='markdown'>[infolinks ? info_links : info]</div>[stamps]"
 	if(view)
-		var/datum/browser/popup = new(user, name, , paper_width, paper_height)
+		var/datum/browser/popup = new(user, "Paper[UID()]", , paper_width, paper_height)
 		popup.stylesheets = list()
 		popup.set_content(data)
 		if(!stars)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -63,13 +63,13 @@
 		qdel(W)
 	else
 		if(istype(W, /obj/item/pen) || istype(W, /obj/item/toy/crayon))
-			usr << browse("", "window=[name]") //Closes the dialog
+			usr << browse("", "window=PaperBundle[UID()]") //Closes the dialog
 		P = src[page]
 		P.attackby(W, user, params)
 
 
 	update_icon()
-	if(winget(usr, "[name]", "is-visible") == "true") // NOT MY FAULT IT IS A BUILT IN PROC PLEASE DO NOT HIT ME
+	if(winget(usr, "PaperBundle[UID()]", "is-visible") == "true") // NOT MY FAULT IT IS A BUILT IN PROC PLEASE DO NOT HIT ME
 		attack_self(usr) //Update the browsed page.
 	add_fingerprint(usr)
 	return
@@ -125,7 +125,7 @@
 	if(istype(src[page], /obj/item/paper))
 		var/obj/item/paper/P = W
 		dat += P.show_content(usr, view = 0)
-		usr << browse(dat, "window=[name]")
+		usr << browse(dat, "window=PaperBundle[UID()]")
 	else if(istype(src[page], /obj/item/photo))
 		var/obj/item/photo/P = W
 		usr << browse_rsc(P.img, "tmp_photo.png")
@@ -133,7 +133,7 @@
 		+ "<body style='overflow:hidden'>" \
 		+ "<div> <img src='tmp_photo.png' width = '180'" \
 		+ "[P.scribble ? "<div><br> Written on the back:<br><i>[P.scribble]</i>" : ""]"\
-		+ "</body></html>", "window=[name]")
+		+ "</body></html>", "window=PaperBundle[UID()]")
 
 /obj/item/paper_bundle/attack_self(mob/user as mob)
 	src.show_content(user)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -86,8 +86,8 @@
 		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
 		+ "<img src='tmp_photo.png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" \
 		+ "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]"\
-		+ "</body></html>", "window=book;size=[64*photo_size]x[scribble ? 400 : 64*photo_size]")
-	onclose(usr, "[name]")
+		+ "</body></html>", "window=Photo[UID()];size=[64*photo_size]x[scribble ? 400 : 64*photo_size]")
+	onclose(usr, "Photo[UID()]")
 	return
 
 /obj/item/photo/verb/rename()


### PR DESCRIPTION
## What Does This PR Do
Allows you to have multiple papers with the same title opened at once.
Fixes #7967
Probably fixes #4520
Fixes #5351 if interpreted a certain way.

I originally tried to fix #7967 by sanitizing window id, as passed to `browser`, and `browse`, but turns out that paper/paper bundle/photo are the only[*] items that can be renamed at which are susceptible to this kind of breakage. So it's cleaner to just fix those specifically.
Being able to open multiple "paper" popups at once is a nice side-bonus (it was weird how you can have "paper" and "renamed paper" at once before, but only as long as they have different names).

[*] there are also several bot-related files (e.g. code/modules/mob/living/silicon/ai/ai.dm) which use `href_list["mach_close"]` directly as a window id in their Topic call, but I couldn't figure out what was going on there, so I didn't touch those.

## Why It's Good For The Game
Unscrewed UI good.
Read two papers at once good (or at least consistent).

## Images of changes
![dreamseeker_2019-11-06_04-40-00](https://user-images.githubusercontent.com/7831163/68269167-a8f16f00-0050-11ea-9906-72d30b1a934e.png)


## Changelog
:cl:
fix: papers no longer screw up interface when renamed to start with quotes.
/:cl:
