### PR TITLE
Corpses on the shuttle no longer prevent hijack greentext.

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -174,36 +174,37 @@
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked()
 	for(var/mob/living/player in GLOB.player_list)
-		if(player.mind)
-			if(player.stat == DEAD)  // Corpses
+		if(!player.mind)
+			continue
+		if(player.stat == DEAD)  // Corpses
+			continue
+		if(iszombie(player))  // Walking corpses
+			continue
+		if(issilicon(player)) //Borgs are technically dead anyways
+			continue
+		if(isanimal(player)) //Poly does not own the shuttle
+			continue
+		if(ishuman(player)) //hostages allowed on the shuttle, check for restraints
+			var/mob/living/carbon/human/H = player
+			if(!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD) //new crit users who are in hard crit are considered dead
 				continue
-			if(iszombie(player))  // Walking corpses
+			if(H.handcuffed) //cuffs
 				continue
-			if(issilicon(player)) //Borgs are technically dead anyways
+			if(H.wear_suit && H.wear_suit.breakouttime) //straight jacket
 				continue
-			if(isanimal(player)) //Poly does not own the shuttle
+			if(istype(H.loc, /obj/structure/closet)) //locked/welded locker, all aboard the clown train honk honk
+				var/obj/structure/closet/C = H.loc
+				if(C.welded || C.locked)
+					continue
+		var/special_role = player.mind.special_role
+		if(special_role)
+			// There's a long list of special roles, but almost all of them are antags anyway.
+			// If you manage to escape with a pet slaughter demon - go for it! Greentext well earned!
+			if(special_role != SPECIAL_ROLE_EVENTMISC && special_role != SPECIAL_ROLE_ERT && special_role != SPECIAL_ROLE_DEATHSQUAD)
 				continue
-			if(ishuman(player)) //hostages allowed on the shuttle, check for restraints
-				var/mob/living/carbon/human/H = player
-				if(!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD) //new crit users who are in hard crit are considered dead
-					continue
-				if(H.handcuffed) //cuffs
-					continue
-				if(H.wear_suit && H.wear_suit.breakouttime) //straight jacket
-					continue
-				if(istype(H.loc, /obj/structure/closet)) //locked/welded locker, all aboard the clown train honk honk
-					var/obj/structure/closet/C = H.loc
-					if(C.welded || C.locked)
-						continue
-			var/special_role = player.mind.special_role
-			if(special_role)
-				// There's a long list of special roles, but almost all of them are antags anyway.
-				// If you manage to escape with a pet slaughter demon - go for it! Greentext well earned!
-				if(special_role != SPECIAL_ROLE_EVENTMISC && special_role != SPECIAL_ROLE_ERT && special_role != SPECIAL_ROLE_DEATHSQUAD)
-					continue
 
-			if(get_area(player) == areaInstance)
-				return FALSE
+		if(get_area(player) == areaInstance)
+			return FALSE
 
 	return TRUE
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -199,7 +199,7 @@
 			if(special_role)
 				// There's a long list of special roles, but almost all of them are antags anyway.
 				// If you manage to escape with a pet slaughter demon - go for it! Greentext well earned!
-				if(special_role != SPECIAL_ROLE_ERT && special_role != SPECIAL_ROLE_EVENTMISC)
+				if(special_role != SPECIAL_ROLE_EVENTMISC && special_role != SPECIAL_ROLE_ERT && special_role != SPECIAL_ROLE_DEATHSQUAD)
 					continue
 
 			if(get_area(player) == areaInstance)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -175,42 +175,35 @@
 /obj/docking_port/mobile/emergency/proc/is_hijacked()
 	for(var/mob/living/player in GLOB.player_list)
 		if(player.mind)
-			if(player.stat != DEAD || !iszombie(player))
-				if(issilicon(player)) //Borgs are technically dead anyways
+			if(player.stat == DEAD)  // Corpses
+				continue
+			if(iszombie(player))  // Walking corpses
+				continue
+			if(issilicon(player)) //Borgs are technically dead anyways
+				continue
+			if(isanimal(player)) //Poly does not own the shuttle
+				continue
+			if(ishuman(player)) //hostages allowed on the shuttle, check for restraints
+				var/mob/living/carbon/human/H = player
+				if(!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD) //new crit users who are in hard crit are considered dead
 					continue
-				if(isanimal(player)) //Poly does not own the shuttle
+				if(H.handcuffed) //cuffs
 					continue
-				if(ishuman(player)) //hostages allowed on the shuttle, check for restraints
-					var/mob/living/carbon/human/H = player
-					if(!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD) //new crit users who are in hard crit are considered dead
+				if(H.wear_suit && H.wear_suit.breakouttime) //straight jacket
+					continue
+				if(istype(H.loc, /obj/structure/closet)) //locked/welded locker, all aboard the clown train honk honk
+					var/obj/structure/closet/C = H.loc
+					if(C.welded || C.locked)
 						continue
-					if(H.handcuffed) //cuffs
-						continue
-					if(H.wear_suit && H.wear_suit.breakouttime) //straight jacket
-						continue
-					if(istype(H.loc, /obj/structure/closet)) //locked/welded locker, all aboard the clown train honk honk
-						var/obj/structure/closet/C = H.loc
-						if(C.welded || C.locked)
-							continue
-				var/special_role = player.mind.special_role
-				if(special_role)
-					if(special_role == SPECIAL_ROLE_TRAITOR) // traitors can hijack the shuttle
-						continue
+			var/special_role = player.mind.special_role
+			if(special_role)
+				// There's a long list of special roles, but almost all of them are antags anyway.
+				// If you manage to escape with a pet slaughter demon - go for it! Greentext well earned!
+				if(special_role != SPECIAL_ROLE_ERT && special_role != SPECIAL_ROLE_EVENTMISC)
+					continue
 
-					if(special_role == SPECIAL_ROLE_CHANGELING) // changelings as well
-						continue
-
-					if(special_role == SPECIAL_ROLE_VAMPIRE || special_role == SPECIAL_ROLE_VAMPIRE_THRALL) // for traitorvamp
-						continue
-
-					if(special_role == SPECIAL_ROLE_NUKEOPS) // so can nukeops, for the hell of it
-						continue
-
-					if(special_role == SPECIAL_ROLE_SYNDICATE_DEATHSQUAD) // and the syndie deathsquad i guess
-						continue
-
-				if(get_area(player) == areaInstance)
-					return FALSE
+			if(get_area(player) == areaInstance)
+				return FALSE
 
 	return TRUE
 


### PR DESCRIPTION
## What Does This PR Do
Corpses on the shuttle no longer prevent hijack greentext.
Slaughter demons and other special roles don't count against it either.
Instead of having a long list of roles that are allowed on the shuttle, it's easier to list *dis*allowed ones instead.
Probably fixes #12641
Fixes #12672


The live (ha!) code checks for aliveness as  `if(player.stat != DEAD || !iszombie(player))`, which.. happens to be true for corpses. It probably meant to be `if(player.stat != DEAD && !iszombie(player))`. So I fixed that.

The special role check is long and tries to list every possible traitor-relevant role as "acceptable". But really all the special roles are traitor-relevant anyway. What matters is that no crew escapes!
The only ones [from the list](https://github.com/ParadiseSS13/Paradise/blob/8b9f6632038bbc98f93ce1c0740c3d7ea5f0f9cc/code/__DEFINES/gamemode.dm#L19) that I can see as arguable are revolutionaries (but I'm happy to have them count against hijack, if that is the decision).  

Note: **I did not test the changes**, since that requires a fairly involved setup. However, I hope the logic is straightforward enough that simply reading the code would suffice.

## Why It's Good For The Game
Greentext good.

## Images of changes
N/A

## Changelog
:cl:
fix: corpses on the shuttle no longer count against hijack objective.
tweak: slaughter demons, borers, wizards, xenomorphs, etc on the shuttle no longer count against hijack objective
/:cl: