### PR TITLE
Chemistry bag QoL improvement

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -134,76 +134,88 @@
 		icon_state = "juicer0"
 
 /obj/machinery/reagentgrinder/attackby(obj/item/I, mob/user, params)
-		if(default_unfasten_wrench(user, I))
-				return
+	if(default_unfasten_wrench(user, I))
+		return
 
-		if(exchange_parts(user, I))
-				return
+	if(exchange_parts(user, I))
+		return
 
-		if(anchored && !beaker)
-				if(default_deconstruction_screwdriver(user, "juicer_open", "juicer0", I))
-						return
+	if(anchored && !beaker)
+		if(default_deconstruction_screwdriver(user, "juicer_open", "juicer0", I))
+			return
 
-				if(panel_open && istype(I, /obj/item/crowbar))
-						default_deconstruction_crowbar(I)
-						return
+		if(panel_open && istype(I, /obj/item/crowbar))
+			default_deconstruction_crowbar(I)
+			return
 
-		if (istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER) )
-				if(beaker)
-						to_chat(user, "<span class='warning'>There's already a container inside.</span>")
-				else if(panel_open)
-						to_chat(user, "<span class='warning'>Close the maintenance panel first.</span>")
-				else
-						if(!user.drop_item())
-								return 1
-						beaker =  I
-						beaker.loc = src
-						update_icon()
-						src.updateUsrDialog()
-				return 1 //no afterattack
+	if(istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER) )
+		if(beaker)
+			to_chat(user, "<span class='warning'>There's already a container inside.</span>")
+		else if(panel_open)
+			to_chat(user, "<span class='warning'>Close the maintenance panel first.</span>")
+		else
+			if(!user.drop_item())
+				return TRUE
+			beaker =  I
+			beaker.loc = src
+			update_icon()
+			updateUsrDialog()
+		return TRUE //no afterattack
 
-		if(is_type_in_list(I, dried_items))
-				if(istype(I, /obj/item/reagent_containers/food/snacks/grown))
-						var/obj/item/reagent_containers/food/snacks/grown/G = I
-						if(!G.dry)
-								to_chat(user, "<span class='warning'>You must dry that first!</span>")
-								return 1
+	if(is_type_in_list(I, dried_items))
+		if(istype(I, /obj/item/reagent_containers/food/snacks/grown))
+			var/obj/item/reagent_containers/food/snacks/grown/G = I
+			if(!G.dry)
+				to_chat(user, "<span class='warning'>You must dry that first!</span>")
+				return TRUE
 
-		if(holdingitems && holdingitems.len >= limit)
-				to_chat(usr, "The machine cannot hold anymore items.")
-				return 1
+	if(holdingitems && holdingitems.len >= limit)
+		to_chat(usr, "The machine cannot hold anymore items.")
+		return TRUE
 
-		//Fill machine with a bag!
-		if(istype(I, /obj/item/storage/bag))
-				var/obj/item/storage/bag/B = I
-				for (var/obj/item/reagent_containers/food/G in B.contents)
-						B.remove_from_storage(G, src)
-						holdingitems += G
-						if(holdingitems && holdingitems.len >= limit) //Sanity checking so the blender doesn't overfill
-								to_chat(user, "<span class='notice'>You fill the All-In-One grinder to the brim.</span>")
-								break
+	//Fill machine with a bag!
+	if(istype(I, /obj/item/storage/bag))
+		var/obj/item/storage/bag/B = I
+		if(!B.contents.len)
+			to_chat(user, "<span class='warning'>[B] is empty.</span>")
+			return FALSE
 
-				if(!I.contents.len)
-						to_chat(user, "<span class='notice'>You empty [I] into the All-In-One grinder.</span>")
+		var/original_contents_len = B.contents.len
 
-				src.updateUsrDialog()
-				return 1
+		for(var/obj/item/G in B.contents)
+			if(is_type_in_list(G, blend_items) || is_type_in_list(G, juice_items))
+				B.remove_from_storage(G, src)
+				holdingitems += G
+				if(holdingitems && holdingitems.len >= limit) //Sanity checking so the blender doesn't overfill
+					to_chat(user, "<span class='notice'>You fill the All-In-One grinder to the brim.</span>")
+					break
 
-		if (!is_type_in_list(I, blend_items) && !is_type_in_list(I, juice_items))
-				if(user.a_intent == INTENT_HARM)
-						return ..()
-				else
-						to_chat(user, "<span class='warning'>Cannot refine into a reagent!</span>")
-						return 1
+		if(B.contents.len == original_contents_len)
+			to_chat(user, "<span class='warning'>Nothing in [B] can be put into the All-In-One grinder.</span>")
+			return FALSE
+		else if(!B.contents.len)
+			to_chat(user, "<span class='notice'>You empty all of [B]'s contents into the All-In-One grinder.</span>")
+		else
+			to_chat(user, "<span class='notice'>You empty some of [B]'s contents into the All-In-One grinder.</span>")
 
-		if(user.drop_item())
-				I.loc = src
-				holdingitems += I
-				src.updateUsrDialog()
-				return 0
+		updateUsrDialog()
+		return TRUE
+
+	if(!is_type_in_list(I, blend_items) && !is_type_in_list(I, juice_items))
+		if(user.a_intent == INTENT_HARM)
+			return ..()
+		else
+			to_chat(user, "<span class='warning'>Cannot refine into a reagent!</span>")
+			return TRUE
+
+	if(user.drop_item())
+		I.loc = src
+		holdingitems += I
+		src.updateUsrDialog()
+		return FALSE
 
 /obj/machinery/reagentgrinder/attack_ai(mob/user)
-		return 0
+		return FALSE
 
 /obj/machinery/reagentgrinder/attack_hand(mob/user)
 		user.set_machine(src)
@@ -301,8 +313,8 @@
 /obj/machinery/reagentgrinder/proc/is_allowed(obj/item/reagent_containers/O)
 		for (var/i in blend_items)
 				if(istype(O, i))
-						return 1
-		return 0
+						return TRUE
+		return FALSE
 
 /obj/machinery/reagentgrinder/proc/get_allowed_by_id(obj/item/O)
 		for (var/i in blend_items)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -184,7 +184,7 @@
 								break
 
 				if(!I.contents.len)
-						to_chat(user, "<span class='notice'>You empty the plant bag into the All-In-One grinder.</span>")
+						to_chat(user, "<span class='notice'>You empty [I] into the All-In-One grinder.</span>")
 
 				src.updateUsrDialog()
 				return 1

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -155,7 +155,7 @@
 			to_chat(user, "<span class='warning'>Close the maintenance panel first.</span>")
 		else
 			if(!user.drop_item())
-				return TRUE
+				return FALSE
 			beaker =  I
 			beaker.loc = src
 			update_icon()
@@ -167,11 +167,11 @@
 			var/obj/item/reagent_containers/food/snacks/grown/G = I
 			if(!G.dry)
 				to_chat(user, "<span class='warning'>You must dry that first!</span>")
-				return TRUE
+				return FALSE
 
 	if(holdingitems && holdingitems.len >= limit)
 		to_chat(usr, "The machine cannot hold anymore items.")
-		return TRUE
+		return FALSE
 
 	//Fill machine with a bag!
 	if(istype(I, /obj/item/storage/bag))

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -176,7 +176,7 @@
 		//Fill machine with a bag!
 		if(istype(I, /obj/item/storage/bag))
 				var/obj/item/storage/bag/B = I
-				for (var/obj/item/reagent_containers/food/snacks/grown/G in B.contents)
+				for (var/obj/item/reagent_containers/food/G in B.contents)
 						B.remove_from_storage(G, src)
 						holdingitems += G
 						if(holdingitems && holdingitems.len >= limit) //Sanity checking so the blender doesn't overfill


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the chemistry bag able to transfer pills and patches to the all-in-one grinder.

EDIT: Staring at all the double indentation in this file gave me a headache so I changed all the double indentation to singles in this proc. The actual new/modified code is on line 177-202. Also this has the added benefit of allowing the plant bag transfer certain items that weren't transferable before, such as nettles and novaflowers.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Useful when you accidentally make the wrong dosage on pills/patches. If you want to grind them back down to liquid form and try again, you have to place them 1 by 1 into the grinder. Now you can easily transfer a bulk amount from the chemistry bag just like you can when using the plant bag.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Chemistry bags can now transfer their pills and patches to all-in-one grinders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
