### PR TITLE
Fix prisoner implant z-level checking.

### DIFF
--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -71,8 +71,8 @@
 				health_display = "DEAD"
 			else if(total_loss)
 				health_display = "HURT ([total_loss])"
-			if(is_station_level(M.z) && !istype(M.loc, /turf/space))
-				loc_display = "[get_area(M)]"
+			if(is_station_level(Tr.z) && !istype(Tr.loc, /turf/space))
+				loc_display = "[get_area(Tr)]"
 			dat += "ID: [T.id] <BR>Subject: [M] <BR>Location: [loc_display] <BR>Health: [health_display] <BR>"
 			dat += "<A href='?src=[UID()];warn=\ref[T]'>(<font color=red><i>Message Holder</i></font>)</A> |<BR>"
 			dat += "********************************<BR>"

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -70,9 +70,10 @@ Frequency:
 			for(var/obj/item/implant/tracking/T in GLOB.tracked_implants)
 				if(!T.implanted || !T.imp_in)
 					continue
+				var/turf/Tr = get_turf(T)
 
-				if(T && T.z == z)
-					temp += "[T.id]: [T.imp_in.x], [T.imp_in.y], [T.imp_in.z]<BR>"
+				if(Tr && Tr.z == sr.z)
+					temp += "[T.id]: [Tr.x], [Tr.y], [Tr.z]<BR>"
 
 			temp += "<B>You are at \[[sr.x],[sr.y],[sr.z]\]</B>."
 			temp += "<BR><BR><A href='byond://?src=[UID()];refresh=1'>Refresh</A><BR>"


### PR DESCRIPTION
## What Does This PR Do
- Can no longer hide in a locker from prisoner computer tracking
  it now checks your turf's .z which is stable, instead of your own .z which gets set to 0 when you are in a locker
- locator no longer tracks implanted people across z-levels
  it now compares own turf z with implant turf z instead of comapring own z (0 when held) with implant z (0 when implanted).

Fixes #12707 

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: being in a locker no longer interferes with tracking implant tracking
fix: locator no longer locates tracking implants on other z levels.
/:cl: