### PR TITLE
Waterbreath Trait, Snowflake Removal

### DIFF
--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -62,6 +62,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 //mob traits
 #define TRAIT_PACIFISM			"pacifism"
+#define TRAIT_WATERBREATH       "waterbreathing"
 
 // common trait sources
 #define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -28,21 +28,21 @@
 /obj/machinery/poolcontroller/invisible/sea
 	name = "Sea Controller"
 	desc = "A controller for the underwater portion of the sea. Players shouldn't see this."
-	deep_water = TRUE	
+	deep_water = TRUE
 
-/obj/machinery/poolcontroller/Initialize(mapload) 
-	var/contents_loop = linked_area 
+/obj/machinery/poolcontroller/Initialize(mapload)
+	var/contents_loop = linked_area
 	if(!linked_area)
 		contents_loop = range(srange, src)
 
 	for(var/turf/T in contents_loop)
 		if(istype(T, /turf/simulated/floor/beach/water))
 			var/turf/simulated/floor/beach/water/W = T
-			W.linkedcontroller = src 
+			W.linkedcontroller = src
 			linkedturfs += T
 		else if(istype(T, /turf/unsimulated/beach/water))
 			var/turf/unsimulated/beach/water/W = T
-			W.linkedcontroller = src 
+			W.linkedcontroller = src
 			linkedturfs += T
 
 	. = ..()
@@ -121,7 +121,7 @@
 			return //Has internals, no drowning
 		if((NO_BREATHE in drownee.dna.species.species_traits) || (BREATHLESS in drownee.mutations))
 			return //doesn't breathe, no drowning
-		if(isskrell(drownee) || isneara(drownee))
+		if(HAS_TRAIT(drownee,TRAIT_WATERBREATH))
 			return //fish things don't drown
 
 		if(drownee.stat == DEAD)	//Dead spacemen don't drown more

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -131,6 +131,13 @@
 		"appendix" = /obj/item/organ/internal/appendix,
 		"eyes" =     /obj/item/organ/internal/eyes/skrell //Tajara monkey-forms are uniquely colourblind and have excellent darksight, which is why they need a subtype of their greater-form's organ..
 		)
+/datum/species/monkey/skrell/on_species_gain(mob/living/carbon/human/H)
+	..()
+	ADD_TRAIT(H, TRAIT_WATERBREATH, "species")
+
+/datum/species/monkey/skrell/on_species_loss(mob/living/carbon/human/H)
+	..()
+	REMOVE_TRAIT(H, TRAIT_WATERBREATH, "species")
 
 /datum/species/monkey/unathi
 	name = "Stok"

--- a/code/modules/mob/living/carbon/human/species/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/skrell.dm
@@ -12,6 +12,7 @@
 	herbivores on the whole and tend to be co-operative with the other species of the galaxy, although they rarely reveal \
 	the secrets of their empire to their allies."
 
+
 	species_traits = list(LIPS)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_BODY_MARKINGS
@@ -44,3 +45,11 @@
 		"is twisting their own neck!",
 		"makes like a fish and suffocates!",
 		"is strangling themselves with their own tendrils!")
+
+/datum/species/skrell/on_species_gain(mob/living/carbon/human/H)
+	..()
+	ADD_TRAIT(H, TRAIT_WATERBREATH, "species")
+
+/datum/species/skrell/on_species_loss(mob/living/carbon/human/H)
+	..()
+	REMOVE_TRAIT(H, TRAIT_WATERBREATH, "species")

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -72,6 +72,7 @@
 	grow.Grant(H)
 	recolor = new()
 	recolor.Grant(H)
+	ADD_TRAIT(H, TRAIT_WATERBREATH, "species")
 
 /datum/species/slime/on_species_loss(mob/living/carbon/human/H)
 	..()
@@ -79,6 +80,7 @@
 		grow.Remove(H)
 	if(recolor)
 		recolor.Remove(H)
+	REMOVE_TRAIT(H, TRAIT_WATERBREATH, "species")
 
 /datum/species/slime/handle_life(mob/living/carbon/human/H)
 	// Slowly shifting to the color of the reagents


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Creates a new trait that allows for breathing underwater which was given to Slimes, Skrell, and Neara, it also removes the snowflake from the poolcontroller code which was meant to allow Skrell and Neara to breath underwater.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The removal of snowflaking is for the better, it also returns the ability to be in water without internals to Slime People which was removed as part of their rework as well as creating a new trait for possible future use.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
N/A
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: new water breathing trait, Skrell, Slime People, and Neara now use the new waterbreathing trait 
tweak: cleaned out the snowflake code in poolcontroller.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
