### PR TITLE
Singulo can now expand when placed directly by containment wall.

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -110,8 +110,12 @@
 
 
 /obj/singularity/process()
-	if(current_size >= STAGE_TWO)
+	if(allowed_size >= STAGE_TWO)
+		// Start moving even before we reach "true" stage two.
+		// If we are stage one and are sufficiently energetic to be allowed to 2,
+		//  it might mean we are stuck in a corner somewere. So move around to try to expand. 
 		move()
+	if(current_size >= STAGE_TWO)
 		pulse()
 		if(prob(event_chance))//Chance for it to run a special event TODO:Come up with one or two more that fit
 			event()


### PR DESCRIPTION
## What Does This PR Do
Singulo will now try to move around if it's sufficiently energetic to expand, but cannot expand without moving.
Fixes #12712 

## Why It's Good For The Game
See #12712 

## Images of changes
![2019-11-09_23-04-12](https://user-images.githubusercontent.com/7831163/68536130-d63a6780-0345-11ea-8f91-fd1dcb3bee23.gif)

## Changelog
:cl:
fix: fixed singulo being unable to expand when placed next to containment wall
/:cl: