### PR TITLE
Fix Re-admining self on test server (with legacy admin config)

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -64,7 +64,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		// strip out comments
 		var/comment_start = findtext(line, "#")
 		if(comment_start > 0)
-			line = copytext(line, comment_start)
+			line = copytext(line, 1, comment_start)
 
 		// Format is `ckey - rank`.
 		// Silently ignore all the lines that don't conform

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -698,15 +698,12 @@ var/list/admin_verbs_ticket = list(
 	var/datum/admins/D = admin_datums[ckey]
 	var/rank = null
 	if(config.admin_legacy_system)
-		//load text from file
-		var/list/Lines = file2list("config/admins.txt")
-		for(var/line in Lines)
-			var/list/splitline = splittext(line, " - ")
-			if(lowertext(splitline[1]) == ckey)
-				if(splitline.len >= 2)
-					rank = ckeyEx(splitline[2])
+
+		var/admins = parse_admins_config_file()
+		for(var/admin_ckey in admins)
+			if(lowertext(admin_ckey) == ckey)
+				rank = admins[admin_ckey]
 				break
-			continue
 	else
 		if(!dbcon.IsConnected())
 			message_admins("Warning, MySQL database is not connected.")


### PR DESCRIPTION
## What Does This PR Do
You can now readmin self after de-admining self on test server.

Moved the functionality to parse admins.txt to a dedicated function, and call that, instead of reimplementing the config parser each time it's needed (it's only two, but 50% of those happened to runtime on default example config).

## Why It's Good For The Game
bugfix; makes easier to test stuffs on local server