### PR TITLE
Added CC Stamp to Navy Officer's backpacks

### DIFF
--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -34,6 +34,9 @@
 		/obj/item/implant/dust
 	)
 	backpack = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/stamp/centcom = 1,
+	)
 	box = /obj/item/storage/box/centcomofficer
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus


### PR DESCRIPTION
## What Does This PR Do
Title.

## Why It's Good For The Game
During a chat with XProlithium, I was informed Navy Officers don't actually start with a Central Command stamp, nor is there one at Central Command proper. This tiny tiny quality of life change should save admins a few seconds of their lives if they ever feel like stamping a Fax.

## Changelog
:cl:
tweak: CC Stamps now spawn in Navy Officer's backpacks.
/:cl:
