### PR TITLE
Changes the spray bottle admin attack log messages

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -72,11 +72,3 @@ obj/item/reagent_containers/proc/add_initial_reagents()
 			to_chat(user, "<span class='notice'>You fill [src] from [source].</span>")
 			return
 	..()
-
-// Returns a string that contains a list of reagents seperated with commas
-/obj/item/reagent_containers/proc/get_formatted_contents_string()
-	var/contents_string
-	for(var/R in reagents.reagent_list)
-		contents_string += "[R], "
-	contents_string = copytext(contents_string, 1, lentext(contents_string)-1)
-	return contents_string

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -72,3 +72,11 @@ obj/item/reagent_containers/proc/add_initial_reagents()
 			to_chat(user, "<span class='notice'>You fill [src] from [source].</span>")
 			return
 	..()
+
+// Returns a string that contains a list of reagents seperated with commas
+/obj/item/reagent_containers/proc/get_formatted_contents_string()
+	var/contents_string
+	for(var/R in reagents.reagent_list)
+		contents_string += "[R], "
+	contents_string = copytext(contents_string, 1, lentext(contents_string)-1)
+	return contents_string

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -51,7 +51,7 @@
 	user.newtonian_move(get_dir(A, user))
 
 	if(reagents.reagent_list.len == 1 && reagents.has_reagent("cleaner")) // Only show space cleaner logs if it's burning people from being too hot or cold
-		if((reagents.chem_temp < 300) && (reagents.chem_temp > 280)) // 280 is the cold threshold for slimes, 300 the hot threshold for drask
+		if(reagents.chem_temp < 300 && reagents.chem_temp > 280) // 280 is the cold threshold for slimes, 300 the hot threshold for drask
 			return
 
 	var/attack_log_type = ATKLOG_MOST

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -43,20 +43,22 @@
 		to_chat(user, "<span class='notice'>[src] is empty!</span>")
 		return
 
-	var/contents_log = get_formatted_contents_string()
+	var/contents_log = reagents.reagent_list.Join(", ")
 	spray(A)
 
 	playsound(loc, 'sound/effects/spray2.ogg', 50, 1, -6)
 	user.changeNext_move(CLICK_CD_RANGE*2)
 	user.newtonian_move(get_dir(A, user))
 
-	if(reagents.reagent_list.len == 1 && reagents.has_reagent("cleaner")) // Don't show logs for bottles spraying only space cleaner
-		return
+	if(reagents.reagent_list.len == 1 && reagents.has_reagent("cleaner")) // Only show space cleaner logs if it's burning people from being too hot or cold
+		if((reagents.chem_temp < 300) && (reagents.chem_temp > 280)) // 280 is the cold threshold for slimes, 300 the hot threshold for drask
+			return
 
 	var/attack_log_type = ATKLOG_MOST
 	if(reagents.has_reagent("sacid") || reagents.has_reagent("facid") || reagents.has_reagent("lube"))
 		attack_log_type = ATKLOG_FEW
 	msg_admin_attack("[key_name_admin(user)] used a spray bottle at [COORD(user)] - Contents: [contents_log] - Temperature: [reagents.chem_temp]K", attack_log_type)
+	log_game("[key_name(user)] used a spray bottle at [COORD(user)] - Contents: [contents_log] - Temperature: [reagents.chem_temp]K")
 	return
 
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -43,21 +43,20 @@
 		to_chat(user, "<span class='notice'>[src] is empty!</span>")
 		return
 
+	var/contents_log = get_formatted_contents_string()
 	spray(A)
 
 	playsound(loc, 'sound/effects/spray2.ogg', 50, 1, -6)
 	user.changeNext_move(CLICK_CD_RANGE*2)
 	user.newtonian_move(get_dir(A, user))
 
-	if(reagents.has_reagent("sacid"))
-		msg_admin_attack("[key_name_admin(user)] fired sulphuric acid from \a [src] at [COORD(user)].", ATKLOG_FEW)
-		log_game("[key_name(user)] fired sulphuric acid from \a [src] at [COORD(user)].")
-	if(reagents.has_reagent("facid"))
-		msg_admin_attack("[key_name_admin(user)] fired fluorosulfuric acid from \a [src] at [COORD(user)].", ATKLOG_FEW)
-		log_game("[key_name(user)] fired fluorosulfuric Acid from \a [src] at [COORD(user)].")
-	if(reagents.has_reagent("lube"))
-		msg_admin_attack("[key_name_admin(user)] fired space lube from \a [src] at [COORD(user)].")
-		log_game("[key_name(user)] fired space lube from \a [src] at [COORD(user)].")
+	if(reagents.reagent_list.len == 1 && reagents.has_reagent("cleaner")) // Don't show logs for bottles spraying only space cleaner
+		return
+
+	var/attack_log_type = ATKLOG_MOST
+	if(reagents.has_reagent("sacid") || reagents.has_reagent("facid") || reagents.has_reagent("lube"))
+		attack_log_type = ATKLOG_FEW
+	msg_admin_attack("[key_name_admin(user)] used a spray bottle at [COORD(user)] - Contents: [contents_log] - Temperature: [reagents.chem_temp]K", attack_log_type)
 	return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
I'm making this based on @TDSSS's requests in the discord coder chat.

Changes spray bottle attack logging to now include all the contents of the spray and the temperature of the spray. By default, this will appear to admins that have their attack log prefs set to MOST, ALMOST ALL, or ALL.

If the bottle contains Sacid, Facid or space lube, the logs will also show up for admins on the FEW preference in addition to the prefs above. Basically everything except the NO preference.

If the bottle contains nothing but space cleaner, no logs will be shown of the spray, *unless* the temperature is above 300 or below 280. This covers all species temperature thresholds.

~~Sidenote: I don't think the coordinates for this log are particularly useful and could be removed, but correct me if I'm wrong and they're actually useful for something.~~
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Images of changes
![spray](https://user-images.githubusercontent.com/42044220/68667401-80172100-050b-11ea-8b1d-6d2118e0d296.png)

## Changelog
:cl:
tweak: Changes how spray bottle logging works. Show's its contents and temperature in attack logs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
