### PR TITLE
Rolls of Gauze and Ointments now heal 10 brute or burn respectively.

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -12,7 +12,7 @@
 	var/heal_brute = 0
 	var/heal_burn = 0
 	var/self_delay = 20
-	var/unique_handling = 0 //some things give a special prompt, do we want to bypass some checks in parent?
+	var/unique_handling = FALSE //some things give a special prompt, do we want to bypass some checks in parent?
 	var/stop_bleeding = 0
 	var/healverb = "bandage"
 
@@ -31,28 +31,20 @@
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_selected)
 
 		if(!H.can_inject(user, TRUE))
-			return 1
+			return TRUE
 
 		if(!affecting)
 			to_chat(user, "<span class='danger'>That limb is missing!</span>")
-			return 1
+			return TRUE
 
 		if(affecting.is_robotic())
 			to_chat(user, "<span class='danger'>This can't be used on a robotic limb.</span>")
-			return 1
-
-		if(stop_bleeding)
-			if(H.bleedsuppress)
-				to_chat(user, "<span class='warning'>[H]'s bleeding is already bandaged!</span>")
-				return 1
-			else if(!H.bleed_rate)
-				to_chat(user, "<span class='warning'>[H] isn't bleeding!</span>")
-				return 1
+			return TRUE
 
 		if(M == user && !unique_handling)
 			user.visible_message("<span class='notice'>[user] starts to apply [src] on [H]...</span>")
 			if(!do_mob(user, H, self_delay))
-				return 1
+				return TRUE
 		return
 
 	if(isanimal(M))
@@ -123,6 +115,7 @@
 	desc = "Some sterile gauze to wrap around bloody stumps."
 	icon_state = "gauze"
 	origin_tech = "biotech=2"
+	heal_brute = 10
 	stop_bleeding = 1800
 
 /obj/item/stack/medical/bruise_pack/attackby(obj/item/I, mob/user, params)
@@ -140,13 +133,13 @@
 
 /obj/item/stack/medical/bruise_pack/attack(mob/living/M, mob/user)
 	if(..())
-		return 1
+		return TRUE
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_selected)
 
-		if(affecting.open == 0)
+		if(affecting.open == FALSE)
 			affecting.germ_level = 0
 
 			if(stop_bleeding)
@@ -187,6 +180,7 @@
 	icon_state = "ointment"
 	origin_tech = "biotech=2"
 	healverb = "salve"
+	heal_burn = 10
 
 /obj/item/stack/medical/ointment/attack(mob/living/M, mob/user)
 	if(..())
@@ -196,7 +190,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_selected)
 
-		if(affecting.open == 0)
+		if(affecting.open == FALSE)
 			affecting.germ_level = 0
 
 			heal(H, user)


### PR DESCRIPTION
## What Does This PR Do
Changes the Rolls of Gauze and Ointments you can get out of the Emergency Medical Vendor to heal minor amounts of their respective damages. (Improvised Gauze is unchanged.)

Cleans up a few 1s and 0s to TRUEs and FALSEs in medical stacks code. (Let me know if I missed any.)

## Why It's Good For The Game
Previously, Rolls of Gauze stopped bleeding and prevented infections, and Ointment only prevented infections. Rolls of Gauze are highly situational, and Ointment is almost entirely worthless.

A long time ago, (6 years in fact!) with this commit 
https://github.com/ParadiseSS13/Paradise/commit/8735254b877ff966166e5c1199c3f2d45e5d7d68
the healing effect was removed from both. Now our medical system is wildly different from back then, and these items are currently almost entirely useless. 

Personally I think it's a bit of a waste to have emergency medical vendors all over station with effectively useless supplies in them. This however is clearly a pretty significant balance change, suddenly filling parts of the station with cheap and free healing meds, so that's the big debatable here.

I will say I think with this we can include future balance changes like changing medkits to have these supplies instead of the highly superior patches we have right now, but one balance change at a time perhaps. (Or perhaps not.)

Anyway, just wanted to get the idea out there, see what the heads and maintainers think. I had a few people push me to make a PR after I mentioned it so here it is.

## Images of changes
![demo_1](https://user-images.githubusercontent.com/47765135/68917906-2d6f7c00-073a-11ea-8ffa-b3ea918c925e.png)
![demo_2](https://user-images.githubusercontent.com/47765135/68917909-2ea0a900-073a-11ea-8c2f-0d46f4d39225.png)


## Changelog
:cl:
balance: Gauze and Ointment now heal for 10 brute/burn respectively.
/:cl:
