### PR TITLE
Traitor Special Role Fix

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -10,7 +10,6 @@
 // justice if someone's abusing your role
 #define ROLE_SYNDICATE			"Syndicate"
 #define ROLE_TRAITOR			"traitor"
-#define ROLE_MINDSLAVE			"mindslave"
 #define ROLE_OPERATIVE			"operative"
 #define ROLE_CHANGELING			"changeling"
 #define ROLE_WIZARD				"wizard"

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -52,8 +52,7 @@
 		if(!traitor || !istype(traitor))
 			pre_traitors.Remove(traitor)
 			continue
-		if(istype(traitor))
-			traitor.special_role = SPECIAL_ROLE_TRAITOR
+		if(istype(traitor))	
 			traitor.restricted_roles = restricted_jobs
 
 //	if(!traitors.len)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -49,7 +49,6 @@
 			break
 		var/datum/mind/traitor = pick(possible_traitors)
 		pre_traitors += traitor
-		traitor.special_role = SPECIAL_ROLE_TRAITOR
 		traitor.restricted_roles = restricted_jobs
 		possible_traitors.Remove(traitor)
 

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -3,7 +3,7 @@
 /datum/antagonist/mindslave
 	name = "Mindslave"
 	roundend_category = "mindslaves"
-	job_rank = ROLE_MINDSLAVE
+	job_rank = SPECIAL_ROLE_TRAITOR
 	var/special_role = SPECIAL_ROLE_TRAITOR
 
 /datum/antagonist/mindslave/on_gain()

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -4,7 +4,7 @@
 	name = "Mindslave"
 	roundend_category = "mindslaves"
 	job_rank = ROLE_MINDSLAVE
-	var/special_role = ROLE_MINDSLAVE
+	var/special_role = SPECIAL_ROLE_TRAITOR
 
 /datum/antagonist/mindslave/on_gain()
 	owner.special_role = special_role

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -6,7 +6,7 @@
 	name = "Traitor"
 	roundend_category = "traitors"
 	job_rank = ROLE_TRAITOR
-	var/special_role = ROLE_TRAITOR
+	var/special_role = SPECIAL_ROLE_TRAITOR
 	var/give_objectives = TRUE
 	var/should_give_codewords = TRUE
 	var/should_equip = TRUE


### PR DESCRIPTION

## What Does This PR Do
Fixes #12739 caused by the mislabeling of the special role for traitor and mindslaves, it also fixes the unlisted issue of traitors being unable to hijack the shuttle, as it also checks for the special roll. 

## Why It's Good For The Game
It fixes some awfully inconvenient bugs regarding traitors 

## Changelog
:cl:
fix: Fixed mislabeled traitor and mindslave special role.
/:cl:
