### PR TITLE
Add debug glasses to glasses loadout

### DIFF
--- a/code/modules/client/preference/loadout/loadout_glasses.dm
+++ b/code/modules/client/preference/loadout/loadout_glasses.dm
@@ -22,3 +22,8 @@
 /datum/gear/glasses/prescription
 	display_name = "Prescription glasses"
 	path = /obj/item/clothing/glasses/regular
+
+/datum/gear/glasses/debug
+	display_name = "Debug Lighting glasses"
+	path = /obj/item/clothing/glasses/material/lighting
+	description = "WARNING: Glasses used for those with lighting issues"


### PR DESCRIPTION
## What Does This PR Do
Certain people often ask to have the neutron glasses or lighting glasses spawned in for them. This allows them to have it spawned in for them at round start.

## Why It's Good For The Game
Allows those with the issue to gain the glasses without requiring Game admins to spawn them in initially.

## Images of changes
![XwBm4wWiEs](https://user-images.githubusercontent.com/7946481/69286118-68513400-0bc0-11ea-92ab-b5438d3251de.png)


## Changelog
:cl:
add: debug lighting glasses to glasses loadout
/:cl:
