### PR TITLE
Added Pylon healing to Wizards

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -198,7 +198,7 @@ var/list/blacklisted_pylon_turfs = typecacheof(list(
 	if(last_heal <= world.time)
 		last_heal = world.time + heal_delay
 		for(var/mob/living/L in range(5, src))
-			if(iscultist(L) || istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
+			if(iscultist(L) || iswizard(L) || istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
 				if(L.health != L.maxHealth)
 					new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
 					if(ishuman(L))


### PR DESCRIPTION


## What Does This PR Do
This PR allows wizards to heal from cult pylons, which they can construct via the use of soulstones and the 'Create Shell' spell. 

## Why It's Good For The Game
It is strange that the wizard's constructs are healed, but not the wizard themselves, by pylons. This small buff gives consistency to the mechanics of the pylons. 

## Changelog
:cl:
balance: Allows wizards to be healed by cult pylons. 
/:cl:

