### PR TITLE
Getting cluwned ignores species brain damage modifiers

### DIFF
--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -17,7 +17,7 @@
 		var/obj/item/organ/internal/brain/cluwne/idiot_brain = new
 		idiot_brain.insert(src, make_cluwne = 0)
 		idiot_brain.dna = dna.Clone()
-	setBrainLoss(80, ignore_brain_mod = TRUE)
+	setBrainLoss(80, use_brain_mod = FALSE)
 	set_nutrition(9000)
 	overeatduration = 9000
 	Confused(30)

--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -17,7 +17,7 @@
 		var/obj/item/organ/internal/brain/cluwne/idiot_brain = new
 		idiot_brain.insert(src, make_cluwne = 0)
 		idiot_brain.dna = dna.Clone()
-	setBrainLoss(80)
+	setBrainLoss(80, ignore_brain_mod = TRUE)
 	set_nutrition(9000)
 	overeatduration = 9000
 	Confused(30)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -39,7 +39,7 @@
 		update_stat("adjustBrainLoss")
 	return STATUS_UPDATE_STAT
 
-/mob/living/carbon/human/setBrainLoss(amount, updating = TRUE)
+/mob/living/carbon/human/setBrainLoss(amount, updating = TRUE, ignore_brain_mod = FALSE)
 	if(status_flags & GODMODE)
 		return STATUS_UPDATE_NONE	//godmode
 
@@ -47,7 +47,8 @@
 		var/obj/item/organ/internal/brain/sponge = get_int_organ(/obj/item/organ/internal/brain)
 		if(sponge)
 			if(dna.species && amount > 0)
-				amount = amount * dna.species.brain_mod
+				if(!ignore_brain_mod)
+					amount = amount * dna.species.brain_mod
 			sponge.damage = Clamp(amount, 0, 120)
 			if(sponge.damage >= 120)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -22,7 +22,7 @@
 	med_hud_set_status()
 	handle_hud_icons_health()
 
-/mob/living/carbon/human/adjustBrainLoss(amount, updating = TRUE)
+/mob/living/carbon/human/adjustBrainLoss(amount, updating = TRUE, ignore_brain_mod = FALSE)
 	if(status_flags & GODMODE)
 		return STATUS_UPDATE_NONE	//godmode
 
@@ -30,7 +30,8 @@
 		var/obj/item/organ/internal/brain/sponge = get_int_organ(/obj/item/organ/internal/brain)
 		if(sponge)
 			if(dna.species && amount > 0)
-				amount = amount * dna.species.brain_mod
+				if(!ignore_brain_mod)
+					amount = amount * dna.species.brain_mod
 			sponge.damage = Clamp(sponge.damage + amount, 0, 120)
 			if(sponge.damage >= 120)
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -22,7 +22,7 @@
 	med_hud_set_status()
 	handle_hud_icons_health()
 
-/mob/living/carbon/human/adjustBrainLoss(amount, updating = TRUE, ignore_brain_mod = FALSE)
+/mob/living/carbon/human/adjustBrainLoss(amount, updating = TRUE, use_brain_mod = TRUE)
 	if(status_flags & GODMODE)
 		return STATUS_UPDATE_NONE	//godmode
 
@@ -30,7 +30,7 @@
 		var/obj/item/organ/internal/brain/sponge = get_int_organ(/obj/item/organ/internal/brain)
 		if(sponge)
 			if(dna.species && amount > 0)
-				if(!ignore_brain_mod)
+				if(use_brain_mod)
 					amount = amount * dna.species.brain_mod
 			sponge.damage = Clamp(sponge.damage + amount, 0, 120)
 			if(sponge.damage >= 120)
@@ -40,7 +40,7 @@
 		update_stat("adjustBrainLoss")
 	return STATUS_UPDATE_STAT
 
-/mob/living/carbon/human/setBrainLoss(amount, updating = TRUE, ignore_brain_mod = FALSE)
+/mob/living/carbon/human/setBrainLoss(amount, updating = TRUE, use_brain_mod = TRUE)
 	if(status_flags & GODMODE)
 		return STATUS_UPDATE_NONE	//godmode
 
@@ -48,7 +48,7 @@
 		var/obj/item/organ/internal/brain/sponge = get_int_organ(/obj/item/organ/internal/brain)
 		if(sponge)
 			if(dna.species && amount > 0)
-				if(!ignore_brain_mod)
+				if(use_brain_mod)
 					amount = amount * dna.species.brain_mod
 			sponge.damage = Clamp(amount, 0, 120)
 			if(sponge.damage >= 120)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -283,7 +283,7 @@
 
 /obj/item/organ/internal/honktumor/cursed/on_life() //No matter what you do, no matter who you are, no matter where you go, you're always going to be a fat, stuttering dimwit.
 	..()
-	owner.setBrainLoss(80, ignore_brain_mod = TRUE)
+	owner.setBrainLoss(80, use_brain_mod = FALSE)
 	owner.set_nutrition(9000)
 	owner.overeatduration = 9000
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -283,7 +283,7 @@
 
 /obj/item/organ/internal/honktumor/cursed/on_life() //No matter what you do, no matter who you are, no matter where you go, you're always going to be a fat, stuttering dimwit.
 	..()
-	owner.setBrainLoss(80)
+	owner.setBrainLoss(80, ignore_brain_mod = TRUE)
 	owner.set_nutrition(9000)
 	owner.overeatduration = 9000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the brain damage caused from honk tumors and direct cluwning methods a flat 80 damage. It is no longer affected by species brain damage modifiers.

## Why It's Good For The Game
First of all, insta kills are bad mkaaay. Second, this allows slime people to experience the gloriousness of becoming a cluwne without dying immediately. You can now instead get beaten to death by your fellow crewmembers, HONK!!

 This also means that certain golems which take reduced brain damage will properly be turned into a stumbling idiot, as is intended with cluwning.

## Changelog
:cl:
tweak: The brain damage caused from honk tumors and direct cluwning methods is now a flat 80 damage. It is no longer affected by species brain damage modifiers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
