### PR TITLE
Admin Roles no longer appear on manifest and Central Command PDAs are hidden on the messenger.

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -373,9 +373,9 @@
 	if(character.mind.assigned_role == "Cyborg")
 		AnnounceCyborg(character, rank, join_message)
 	else
-		data_core.manifest_inject(character)
 		SSticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
 		if(!IsAdminJob(rank))
+			data_core.manifest_inject(character)
 			AnnounceArrival(character, rank, join_message)
 			AddEmploymentContract(character)
 

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -186,6 +186,12 @@
 	default_cartridge = /obj/item/cartridge/centcom
 	icon_state = "pda-h"
 
+/obj/item/pda/centcom/New()
+	..()
+	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
+	if(M)
+		M.m_hidden = 1
+		
 //Some spare PDAs in a box
 /obj/item/storage/box/PDAs
 	name = "spare PDAs"


### PR DESCRIPTION
## What Does This PR Do
Fixes #12746 

Also hides Central Command PDAs from the general messenger.

## Why It's Good For The Game
Admins are shy creatures and need to be hidden away or else they won't come out to play.

## Images of changes
![adminRolesGood](https://user-images.githubusercontent.com/47765135/69385769-7a010d00-0c8e-11ea-96d1-0d5c3892f5f2.png)

![hiddenPDAs](https://user-images.githubusercontent.com/47765135/69392747-09191f80-0ca5-11ea-88a9-dc8dc68f0b0d.png)

## Changelog
:cl:
fix: Admin Roles no longer appear on manifest.
tweak: Central Command PDA's no longer appear on the messenger list.
/:cl:
