### PR TITLE
Adds examine text for people who have open surgical incisions

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -215,6 +215,12 @@
 				else if(E.status & ORGAN_SPLINTED)
 					wound_flavor_text["[E.limb_name]"] = "[p_they(TRUE)] [p_have()] a splint on [p_their()] [E.name]!\n"
 
+			if(E.open)
+				if(E.is_robotic())
+					msg += "<b>The maintenance hatch on [p_their()] [ignore_limb_branding(E.limb_name)] is open!</b>\n"
+				else
+					msg += "<b>[p_their(TRUE)] [ignore_limb_branding(E.limb_name)] has an open incision!</b>\n"
+
 			for(var/obj/item/I in E.embedded_objects)
 				msg += "<B>[p_they(TRUE)] [p_have()] \a [bicon(I)] [I] embedded in [p_their()] [E.name]!</B>\n"
 
@@ -403,3 +409,29 @@
 				return 0
 	else
 		return 0
+
+// Ignores robotic limb branding prefixes like "Morpheus Cybernetics"
+/proc/ignore_limb_branding(limb_name)
+	switch(limb_name)
+		if("chest")
+			. = "upper body"
+		if("groin")
+			. = "lower body"
+		if("head")
+			. = "head"
+		if("l_arm")
+			. = "left arm"
+		if("r_arm")
+			. = "right arm"
+		if("l_leg")
+			. = "left leg"
+		if("r_leg")
+			. = "right leg"
+		if("l_foot")
+			. = "left foot"
+		if("r_foot")
+			. = "right foot"
+		if("l_hand")
+			. = "left hand"
+		if("r_hand")
+			. = "right hand"

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -47,7 +47,7 @@
 	var/damage_msg = "<span class='warning'>You feel an intense pain</span>"
 	var/broken_description
 
-	var/open = 0
+	var/open = 0  // If the body part has an open incision from surgery
 	var/sabotaged = 0 //If a prosthetic limb is emagged, it will detonate when it fails.
 	var/encased       // Needs to be opened with a saw to access the organs.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Idea taken from this forum post: 
https://nanotrasen.se/forum/topic/17316-add-examine-text-for-surgically-opened-limbs/
@Spacemanspark 

Organic limbs and robotic limbs have distinct messages which you can see in the picture below. IPC limbs will have the robotic examine text.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As was said in the forum post, it would be nice for when roboticists are working on IPCs. They don't have a body scanner and it can be annoying if the patient has a bunch of open body parts. And in general, it makes sense that you should be able to see if someone has an open surgical cut or an open maintenance hatch, in the case of IPC/robolimbs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![E](https://user-images.githubusercontent.com/42044220/69391803-88a0f180-0c99-11ea-9d8a-ebb1c45001c2.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Adds examine text for people with open incisions from surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
