### PR TITLE
Fixes DNA Samplers not checking if target humanoid has DNA

### DIFF
--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -110,6 +110,9 @@ var/list/non_simple_animals = typecacheof(list(/mob/living/carbon/human/monkey,/
 	//humans
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
+		if(NO_DNA in H.dna.species.species_traits)
+			to_chat(user, "<span class='notice'>This humanoid doesn't have DNA.</span>")
+			return
 		if(dna[H.dna.uni_identity])
 			to_chat(user, "<span class='notice'>Humanoid data already present in local storage.</span>")
 			return


### PR DESCRIPTION
## What Does This PR Do
This PR addresses issue [#12737 ](https://github.com/ParadiseSS13/Paradise/issues/12737) which allowed for the DNA Sampler to take DNA from Machines and other human subspecies that lacked DNA.

## Changelog
:cl:
fix: DNA Samplers now check if the target species has DNA.
/:cl: