### PR TITLE
Massive Clown Nerfs - Unbuckle time while restrained is now equal to breakout time.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -771,13 +771,11 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
 
 /mob/living/carbon/resist_buckle()
-	var/breakouttime = 600
-
 	spawn(0)
 		resist_muzzle()
 	if(restrained())
 		var/obj/item/I = handcuffed
-		breakouttime = I.breakouttime
+		var/breakouttime = I.breakouttime
 		var/displaytime = breakouttime / 600
 		changeNext_move(CLICK_CD_BREAKOUT)
 		last_special = world.time + CLICK_CD_BREAKOUT

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -771,14 +771,19 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
 
 /mob/living/carbon/resist_buckle()
+	var/breakouttime = 600
+
 	spawn(0)
 		resist_muzzle()
 	if(restrained())
+		var/obj/item/I = handcuffed
+		breakouttime = I.breakouttime
+		var/displaytime = breakouttime / 600
 		changeNext_move(CLICK_CD_BREAKOUT)
 		last_special = world.time + CLICK_CD_BREAKOUT
 		visible_message("<span class='warning'>[src] attempts to unbuckle [p_them()]self!</span>", \
-					"<span class='notice'>You attempt to unbuckle yourself... (This will take around one minute and you need to stay still.)</span>")
-		if(do_after(src, 600, 0, target = src))
+					"<span class='notice'>You attempt to unbuckle yourself... (This will take around [displaytime] minute and you need to stay still.)</span>")
+		if(do_after(src, breakouttime, 0, target = src))
 			if(!buckled)
 				return
 			buckled.user_unbuckle_mob(src,src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -776,11 +776,11 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	if(restrained())
 		var/obj/item/I = handcuffed
 		var/breakouttime = I.breakouttime
-		var/displaytime = breakouttime / 600
+		var/displaytime = breakouttime / 10
 		changeNext_move(CLICK_CD_BREAKOUT)
 		last_special = world.time + CLICK_CD_BREAKOUT
 		visible_message("<span class='warning'>[src] attempts to unbuckle [p_them()]self!</span>", \
-					"<span class='notice'>You attempt to unbuckle yourself... (This will take around [displaytime] minute and you need to stay still.)</span>")
+					"<span class='notice'>You attempt to unbuckle yourself... (This will take around [displaytime] seconds and you need to stay still.)</span>")
 		if(do_after(src, breakouttime, 0, target = src))
 			if(!buckled)
 				return
@@ -839,10 +839,10 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 /mob/living/carbon/proc/cuff_resist(obj/item/I, breakouttime = 600, cuff_break = 0)
 	breakouttime = I.breakouttime
 
-	var/displaytime = breakouttime / 600
+	var/displaytime = breakouttime / 10
 	if(!cuff_break)
 		visible_message("<span class='warning'>[src] attempts to remove [I]!</span>")
-		to_chat(src, "<span class='notice'>You attempt to remove [I]... (This will take around [displaytime] minutes and you need to stand still.)</span>")
+		to_chat(src, "<span class='notice'>You attempt to remove [I]... (This will take around [displaytime] seconds and you need to stand still.)</span>")
 		if(do_after(src, breakouttime, 0, target = src))
 			if(I.loc != src || buckled)
 				return


### PR DESCRIPTION
## What Does This PR Do
Title.

## Why It's Good For The Game
Mostly to correct Toy Handcuffs. They have a breakout time of 0, meaning they're meant for jokes and if anyone wants to break free they can instantly. However if you bucklecuff someone with toy cuffs, they would have to break out in 60 seconds. This also very slightly nerfs things like zipties which have a 45 second breakout time compared to the handcuff's 60. 

EDIT: Meant to include this also slightly nerfs cable-restraints similar to zipties. 30 Second unbuckle time as opposed to 60.

(Please inform me of better ways to do this if there are any.)

## Changelog
:cl:
balance: Unbuckle time is now equal to breakout time.
/:cl:
