### PR TITLE
Cult Hotfix - Comments out Off_Station role check 

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -20,8 +20,8 @@ var/global/list/all_cults = list()
 		var/mob/living/carbon/human/H = mind.current
 		if(ismindshielded(H)) //mindshield protects against conversions unless removed
 			return FALSE
-/*	if(mind.offstation_role) //cant convert offstation roles such as ghost spawns
-		return FALSE */ //Commented out until we can figure out why offstation_role is getting set to TRUE on normal crew.
+/*	if(mind.offstation_role) cant convert offstation roles such as ghost spawns
+		return FALSE Commented out until we can figure out why offstation_role is getting set to TRUE on normal crew. */
 	if(issilicon(mind.current))
 		return FALSE //can't convert machines, that's ratvar's thing
 	if(isguardian(mind.current))

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -20,8 +20,8 @@ var/global/list/all_cults = list()
 		var/mob/living/carbon/human/H = mind.current
 		if(ismindshielded(H)) //mindshield protects against conversions unless removed
 			return FALSE
-/*	if(mind.offstation_role) cant convert offstation roles such as ghost spawns
-		return FALSE Commented out until we can figure out why offstation_role is getting set to TRUE on normal crew. */
+//	if(mind.offstation_role) cant convert offstation roles such as ghost spawns
+//		return FALSE Commented out until we can figure out why offstation_role is getting set to TRUE on normal crew
 	if(issilicon(mind.current))
 		return FALSE //can't convert machines, that's ratvar's thing
 	if(isguardian(mind.current))

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -20,8 +20,8 @@ var/global/list/all_cults = list()
 		var/mob/living/carbon/human/H = mind.current
 		if(ismindshielded(H)) //mindshield protects against conversions unless removed
 			return FALSE
-	if(mind.offstation_role) //cant convert offstation roles such as ghost spawns
-		return FALSE
+/*	if(mind.offstation_role) //cant convert offstation roles such as ghost spawns
+		return FALSE */ //Commented out until we can figure out why offstation_role is getting set to TRUE on normal crew.
 	if(issilicon(mind.current))
 		return FALSE //can't convert machines, that's ratvar's thing
 	if(isguardian(mind.current))


### PR DESCRIPTION
## What Does This PR Do
Comments out the Off_Station role check introduced by #12577 because as described in #12764 crew are randomly getting their offstation_role flag set to TRUE, causing them to be non-convertible to the cult.

## Why It's Good For The Game
Need functionality while this strange bug is looked into, nowhere in code is offstation_role set to TRUE except when initializing actual off station_roles. 

## Changelog
:cl:
fix: Potential Convertee's being unable to be converted.
/:cl: