### PR TITLE
Traitor clown fixes

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -28,6 +28,7 @@
 		forge_traitor_objectives()
 	if(!silent)
 		greet()
+	apply_innate_effects()
 	update_traitor_icons_added()
 	finalize_traitor()
 
@@ -54,6 +55,7 @@
 	assigned_targets.Cut()
 	SSticker.mode.traitors -= owner
 	owner.special_role = null
+	remove_innate_effects()
 	update_traitor_icons_removed()
 
 	if(!silent && owner.current)
@@ -67,8 +69,10 @@
 	if(owner.assigned_role == "Clown")
 		var/mob/living/carbon/human/traitor_mob = owner.current
 		if(traitor_mob && istype(traitor_mob))
-			to_chat(traitor_mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
+			to_chat(traitor_mob, "<span class='warning'>Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.</span>")
 			traitor_mob.mutations.Remove(CLUMSY)
+			var/datum/action/innate/toggle_clumsy/A = new
+			A.Grant(traitor_mob)
 
 
 /datum/antagonist/traitor/remove_innate_effects()
@@ -76,7 +80,11 @@
 	if(owner.assigned_role == "Clown")
 		var/mob/living/carbon/human/traitor_mob = owner.current
 		if(traitor_mob && istype(traitor_mob))
+			to_chat(traitor_mob, "<span class='warning'>You lose your syndicate training and return to your own clumsy, clownish self.</span>")
 			traitor_mob.mutations.Add(CLUMSY)
+			for(var/datum/action/innate/A in traitor_mob.actions)
+				if(istype(A, /datum/action/innate/toggle_clumsy))
+					A.Remove(traitor_mob)
 
 // Adding/removing objectives in the owner's mind until we can datumize all antags. Then we can use the /datum/antagonist/objectives var to handle them
 // Change "owner.objectives" to "objectives" once objectives are handled in antag datums instead of the mind


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes traitor clowns not getting a toggle clumsy action button or getting their clumsy mutation removed upon gaining the traitor datum. Both of these changes were unintended.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #12766
Adds back in features that got unintentionally removed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes traitor clowns not getting a toggle clumsy action button
fix: Fixes traitor clowns not getting their clumsy mutation removed upon gaining the traitor datum
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
