### PR TITLE
Restricts revive on a particular mob type

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -22,6 +22,7 @@
 	ventcrawler = 2
 	var/datum/mind/origin
 	var/egg_lain = 0
+	sentience_type = SENTIENCE_OTHER
 
 /mob/living/simple_animal/hostile/headslug/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
Changes a sentience type on a mob type to prevent an issue.
:cl:
fix:Fixes unexpected results from reviving a mob type.
/:cl: