### PR TITLE
Updates links for new domain

### DIFF
--- a/config/example/motd.txt
+++ b/config/example/motd.txt
@@ -1,5 +1,5 @@
 <h1>Welcome to Space Station 13!</h1>
 
--<i>This server is running <a href="http://nanotrasen.se/">Paradise's</a> modification of the <a href="http://baystation12.net/">Baystation 12</a> and <a href="http://ss13.eu/">/tg/station13</a> SS13 code.</i>
+-<i>This server is running <a href="https://www.paradisestation.org">Paradise's</a> modification of the <a href="http://baystation12.net/">Baystation 12</a> and <a href="http://ss13.eu/">/tg/station13</a> SS13 code.</i>
 <br><br>
 <strong>GitHub:</strong> <a href="https://github.com/ParadiseSS13/Paradise">https://github.com/ParadiseSS13/Paradise</a>

--- a/config/example/rules.html
+++ b/config/example/rules.html
@@ -4,7 +4,7 @@
 
 <!--
 Example: paradise rules embed.
-<iframe width='100%' height='100%' src="http://nanotrasen.se/phpBB3/viewtopic.php?f=10&t=44" frameborder="0" id="main_frame"></iframe>
+<iframe width='100%' height='100%' src="http://www.example.com" frameborder="0" id="main_frame"></iframe>
 -->
 
 </body>

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -1005,7 +1005,7 @@ $(function() {
 			'<div class="highlightPopup" id="highlightPopup">' +
 				'<div>Choose up to '+opts.highlightLimit+' strings that will highlight the line when they appear in chat.<br>'+
 		    			'<input name="highlightRegex" id="highlightRegexEnable" type="checkbox">Enable Regex</input>'+
-		    		'<br><a href="" onclick="window.open(\'https://nanotrasen.se/wiki/index.php/Guide_to_Regex\')">See here for details</a></div>' +
+		    		'<br><a href="" onclick="window.open(\'https://www.paradisestation.org/wiki/index.php/Guide_to_Regex\')">See here for details</a></div>' +
 				'<form id="highlightTermForm">' +
 					termInputs +
 					'<div><input type="text" name="highlightColor" id="highlightColor" class="highlightColor" '+

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -25,7 +25,7 @@
 		<td valign='top'>
 			<div align='center'><font size='3'><b>Paradise Station</b></font></div>
 			
-			<p><div align='center'><font size='3'><a href="http://nanotrasen.se/phpBB3/index.php">Forum</a> | <a href="http://nanotrasen.se/wiki/index.php/Main_Page">Wiki</a> | <a href="https://github.com/ParadiseSS13/Paradise">Source</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="https://www.paradisestation.org/forum">Forum</a> | <a href="https://www.paradisestation.org/wiki/index.php/Main_Page">Wiki</a> | <a href="https://github.com/ParadiseSS13/Paradise">Source</a></font></div></p>
 			<font size='2'><b>Visit our Discord channel:</b><a href='https://discordapp.com/invite/nuqD478<'>-Click Here-</a></font>
 			</td>
 	</tr>


### PR DESCRIPTION
## What Does This PR Do
Updates some links on our github to point to our new domain.

## Why It's Good For The Game
Nanotrasen.se is depreciated - we now use ParadiseStation.org for everything.

## Changelog
:cl: Kyep
tweak: Updated github links to point to our new domain.
/:cl: