### PR TITLE
Tweaks to admin freeze and sleeping

### DIFF
--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -26,7 +26,7 @@ var/global/list/frozen_mob_list = list()
 /mob/living/var/frozen = null //used for preventing attacks on admin-frozen mobs
 /mob/living/var/admin_prev_sleeping = 0 //used for keeping track of previous sleeping value with admin freeze
 
-/mob/living/proc/admin_Freeze(var/client/admin, skip_overlays = FALSE)
+/mob/living/proc/admin_Freeze(client/admin, skip_overlays = FALSE)
 	if(istype(admin))
 		to_chat(src, "<b><font color= red>You have been frozen by [admin]</b></font>")
 		message_admins("<span class='notice'>[key_name_admin(admin)]</span> froze [key_name_admin(src)]")
@@ -34,24 +34,25 @@ var/global/list/frozen_mob_list = list()
 
 	var/obj/effect/overlay/adminoverlay/AO = new
 	if(skip_overlays)
-		src.overlays += AO
+		overlays += AO
 
-	anchored = 1
-	frozen = AO
+	canmove = FALSE
 	admin_prev_sleeping = sleeping
 	AdjustSleeping(20000)
+	frozen = AO
 	if(!(src in frozen_mob_list))
 		frozen_mob_list += src
 
-/mob/living/proc/admin_unFreeze(var/client/admin, skip_overlays = FALSE)
+/mob/living/proc/admin_unFreeze(client/admin, skip_overlays = FALSE)
 	if(istype(admin))
 		to_chat(src, "<b><font color= red>You have been unfrozen by [admin]</b></font>")
 		message_admins("<span class='notice'>[key_name_admin(admin)] unfroze [key_name_admin(src)]</span>")
 		log_admin("[key_name(admin)] unfroze [key_name(src)]")
 
-	anchored = 0
 	if(skip_overlays)
 		overlays -= frozen
+
+	canmove = TRUE
 	frozen = null
 	SetSleeping(admin_prev_sleeping)
 	admin_prev_sleeping = null

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -36,6 +36,7 @@ var/global/list/frozen_mob_list = list()
 	if(skip_overlays)
 		overlays += AO
 
+	anchored = TRUE
 	canmove = FALSE
 	admin_prev_sleeping = sleeping
 	AdjustSleeping(20000)
@@ -52,6 +53,7 @@ var/global/list/frozen_mob_list = list()
 	if(skip_overlays)
 		overlays -= frozen
 
+	anchored = FALSE
 	canmove = TRUE
 	frozen = null
 	SetSleeping(admin_prev_sleeping)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -344,7 +344,7 @@
 	return SetSleeping(max(sleeping, amount), updating, no_alert)
 
 /mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE)
-	if(frozen) // If the mob has been admin frozen, sleeping should not be changable
+	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
 		return FALSE
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!sleeping)) // We're not changing from + to 0 or vice versa

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -345,7 +345,7 @@
 
 /mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
-		return FALSE
+		return
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!sleeping)) // We're not changing from + to 0 or vice versa
 		updating = FALSE

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -344,6 +344,8 @@
 	return SetSleeping(max(sleeping, amount), updating, no_alert)
 
 /mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE)
+	if(frozen) // If the mob has been admin frozen, sleeping should not be changable
+		return FALSE
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!sleeping)) // We're not changing from + to 0 or vice versa
 		updating = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
While a mob is admin frozen, their sleeping variable is unable to be changed
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admin freeze should freeze indefinitely and should not be able to be cleared by effects that set sleeping to 0.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: While a mob is admin frozen, their sleeping variable is unable to be changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
