### PR TITLE
Exosuit fabricator nano-UI conversion

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -66193,7 +66193,6 @@
 "cjr" = (
 /obj/machinery/mecha_part_fabricator{
 	dir = 1;
-	id = "0";
 	name = "counterfeit fabricator";
 	req_access = "0"
 	},

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -1,3 +1,9 @@
+
+#define MECHFAB_MAIN_MENU		1
+#define MECHFAB_CATEGORY_MENU	2
+#define MECHFAB_SEARCH_MENU		3
+#define MECHFAB_MATERIALS_MENU	4
+
 /obj/machinery/mecha_part_fabricator
 	icon = 'icons/obj/robotics.dmi'
 	icon_state = "fab-idle"
@@ -8,39 +14,30 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 20
 	active_power_usage = 5000
-	var/time_coeff = 1
-	var/component_coeff = 1
+	var/time_coeff = 1.15  // Determines build time for parts
+	var/component_coeff = 1.20  // Determines cost of parts
 	var/datum/research/files
 	var/fabricator_type = MECHFAB
-	var/id
-	var/sync = 0
-	var/part_set
-	var/datum/design/being_built
-	var/list/queue = list()
-	var/processing_queue = 0
-	var/screen = "main"
-	var/temp
-	var/list/part_sets = list(
-								"Cyborg",
-								"Cyborg Repair",
-								"Ripley",
-								"Firefighter",
-								"Odysseus",
-								"Gygax",
-								"Durand",
-								"H.O.N.K",
-								"Reticence",
-								"Phazon",
-								"Exosuit Equipment",
-								"Cyborg Upgrade Modules",
-								"Medical",
-								"Misc"
-								)
+	var/temp_search
+	var/wait_message // Used for popping up a wait message when the user presses sync
+	var/wait_message_timer
+	var/datum/design/being_built // The design currently being built
+	var/list/queue = list()  // list of designs currently in the queue
+	var/screen = MECHFAB_MAIN_MENU  // Which screen the mechfab is at. 1 is main menu, 2 is category etc. From the #defines
+	var/selected_category  // Which category the mechfab is currently displaying. See list below
+	var/list/categories = list("Cyborg", "Cyborg Repair", "Cyborg Upgrade Modules", "Ripley", "Firefighter", "Odysseus", "Gygax", "Durand", \
+							   "H.O.N.K", "Reticence", "Phazon", "Exosuit Equipment", "Medical", "Misc")
 
 /obj/machinery/mecha_part_fabricator/New()
-	var/datum/component/material_container/materials = AddComponent(/datum/component/material_container,
-		list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE), 0,
-		FALSE, /obj/item/stack, CALLBACK(src, .proc/is_insertion_ready), CALLBACK(src, .proc/AfterMaterialInsert))
+	var/datum/component/material_container/materials = AddComponent(
+		/datum/component/material_container,
+		list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM, MAT_TRANQUILLITE, MAT_TITANIUM, MAT_BLUESPACE),
+		0,
+		FALSE,
+		/obj/item/stack,
+		CALLBACK(src, .proc/is_insertion_ready),
+		CALLBACK(src, .proc/AfterMaterialInsert)
+	)
 	materials.precise_insertion = TRUE
 	..()
 	component_parts = list()
@@ -78,82 +75,131 @@
 	GET_COMPONENT(materials, /datum/component/material_container)
 	materials.max_amount = (200000 + (T*50000))
 
-	//resources adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
-	T = 1.15
-	for(var/obj/item/stock_parts/micro_laser/Ma in component_parts)
-		T -= Ma.rating*0.15
-	component_coeff = T
+	// build time adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
+	for(var/obj/item/stock_parts/micro_laser/Ml in component_parts)
+		time_coeff = initial(time_coeff) - Ml.rating*0.15
 
-	//building time adjustment coefficient (1 -> 0.8 -> 0.6)
-	T = -1
-	for(var/obj/item/stock_parts/manipulator/Ml in component_parts)
-		T += Ml.rating
-	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(T))/5,0.01)
+	// resource cost adjustment coefficient (1 -> 0.8 -> 0.6 -> 0.4)
+	for(var/obj/item/stock_parts/manipulator/Ma in component_parts)
+		component_coeff = initial(component_coeff) - Ma.rating*0.20
 
+/obj/machinery/mecha_part_fabricator/interact(mob/user)
+	ui_interact(user)
 
-/obj/machinery/mecha_part_fabricator/proc/output_parts_list(set_name)
-	var/output = ""
-	for(var/v in files.known_designs)
-		var/datum/design/D = files.known_designs[v]
-		if(D.build_type & fabricator_type)
-			if(!(set_name in D.category))
-				continue
-			output += "<div class='part'>[output_part_info(D)]<br>\["
-			if(check_resources(D))
-				output += "<a href='?src=[UID()];part=[D.id]'>Build</a> | "
-			output += "<a href='?src=[UID()];add_to_queue=[D.id]'>Add to queue</a>\]\[<a href='?src=[UID()];part_desc=[D.id]'>?</a>\]</div>"
-	return output
+/obj/machinery/mecha_part_fabricator/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
+	user.set_machine(src)
+	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "mech_fabricator.tmpl", name, 900, 600)
+		ui.open()
 
-/obj/machinery/mecha_part_fabricator/proc/output_part_info(datum/design/D)
-	var/output = "[initial(D.name)] (Cost: [output_part_cost(D)]) [get_construction_time_w_coeff(D)/10] seconds"
-	return output
+/obj/machinery/mecha_part_fabricator/ui_data(mob/user, ui_key = "main", datum/topic_state/state = GLOB.default_state)
+	var/data[0]
 
-/obj/machinery/mecha_part_fabricator/proc/output_part_cost(datum/design/D)
-	var/i = 0
-	var/output
-	for(var/c in D.materials)
-		output += "[i?" | ":null][get_resource_cost_w_coeff(D, c)] [material2name(c)]"
-		i++
-	return output
+	files.RefreshResearch()
 
-/obj/machinery/mecha_part_fabricator/proc/output_available_resources()
-	var/output
 	GET_COMPONENT(materials, /datum/component/material_container)
-	for(var/mat_id in materials.materials)
-		var/datum/material/M = materials.materials[mat_id]
-		output += "<span class=\"res_name\">[M.name]: </span>[M.amount] cm&sup3;"
-		if(M.amount >= MINERAL_MATERIAL_AMOUNT)
-			output += "<span style='font-size:80%;'>- Remove \[<a href='?src=[UID()];remove_mat=1;material=[mat_id]'>1</a>\]"
-			if(M.amount >= (MINERAL_MATERIAL_AMOUNT * 10))
-				output += " | \[<a href='?src=[UID()];remove_mat=10;material=[mat_id]'>10</a>\]"
-			output += " | \[<a href='?src=[UID()];remove_mat=50;material=[mat_id]'>All</a>\]</span>"
-		output += "<br/>"
-	return output
+	data["screen"] = screen
+	data["total_amount"] = materials.total_amount
+	data["max_amount"] = materials.max_amount
+	data["wait_message"] = wait_message
 
-/obj/machinery/mecha_part_fabricator/proc/get_resources_w_coeff(datum/design/D)
+	switch(screen)
+		if(MECHFAB_MAIN_MENU)
+			data["uid"] = UID()
+			data["categories"] = categories
+
+		if(MECHFAB_CATEGORY_MENU)
+			var/list/designs = list()
+			for(var/I in files.known_designs)
+				var/datum/design/D = files.known_designs[I]
+				if(!(D.build_type & fabricator_type) || !(selected_category in D.category))
+					continue
+				var/list/current_design = list()
+				designs[++designs.len] = current_design
+				current_design["name"] = D.name
+				current_design["id"] = D.id
+				current_design["materials"] = design_cost_data(D)
+			data["designs"] = designs
+			data["selected_category"] = selected_category
+			data["designs_len"] = designs.len
+
+		if(MECHFAB_SEARCH_MENU)
+			var/list/designs = list()
+			for(var/I in files.known_designs)
+				var/datum/design/D = files.known_designs[I]
+				if(!(D.build_type & fabricator_type))
+					continue
+				if(findtext(D.name, temp_search))
+					var/list/current_design = list()
+					designs[++designs.len] = current_design
+					current_design["name"] = D.name
+					current_design["id"] = D.id
+					current_design["materials"] = design_cost_data(D)
+			data["designs"] = designs
+			data["search"] = temp_search
+			data["designs_len"] = designs.len
+
+		if(MECHFAB_MATERIALS_MENU)
+			var/list/materials_list = list()
+			var/list/mats = materials.materials // Materials list in the material_container component. Shortening the name to make it less abnoxious.
+			for(var/M in mats)
+				materials_list[++materials_list.len] = list("name" = mats[M].name, "id" = mats[M].id, "amount" = mats[M].amount)
+			data["loaded_materials"] = materials_list
+
+	data["processing"] = being_built ? "PROCESSING: [initial(being_built.name)]" : null
+	var/list/data_queue = list()
+	if(queue?.len)
+		for(var/datum/design/D in queue)
+			data_queue[++data_queue.len] = list("name" = initial(D.name), "can_build" = can_build(D))
+		data["queue"] = data_queue
+	else
+		data["queue"] = null
+
+	return data
+
+// Gets the cost of each material type from the design as a list
+/obj/machinery/mecha_part_fabricator/proc/design_cost_data(datum/design/D)
+	GET_COMPONENT(materials, /datum/component/material_container)
+	var/list/data = list()
+	var/material_name
+	var/material_amount
+
+	for(var/R in D.materials)
+		material_amount = get_resource_cost_w_coeff(D, R)
+		material_name = CallMaterialName(R) // Formatted name so it looks nice. Ex: Metal, Solid Plasma
+		data[++data.len] = list("name" = material_name, "amount" = material_amount, "is_red" = materials.amount(R) < material_amount)
+	return data
+
+// Returns true if the mech fab can build the specified design
+/obj/machinery/mecha_part_fabricator/proc/can_build(datum/design/D)
+	GET_COMPONENT(materials, /datum/component/material_container)
+	if(materials.has_materials(get_all_resources_w_coeff(D)))
+		return TRUE
+	return FALSE
+
+/obj/machinery/mecha_part_fabricator/proc/get_all_resources_w_coeff(datum/design/D)
 	var/list/resources = list()
 	for(var/R in D.materials)
 		resources[R] = get_resource_cost_w_coeff(D, R)
 	return resources
 
-/obj/machinery/mecha_part_fabricator/proc/check_resources(datum/design/D)
-	if(D.reagents_list.len) // No reagents storage - no reagent designs.
-		return FALSE
-	GET_COMPONENT(materials, /datum/component/material_container)
-	if(materials.has_materials(get_resources_w_coeff(D)))
-		return TRUE
-	return FALSE
+/obj/machinery/mecha_part_fabricator/proc/get_resource_cost_w_coeff(datum/design/D, resource, roundto = 1)
+	return round(D.materials[resource] * component_coeff, roundto)
+
+/obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(datum/design/D, roundto = 1) //aran
+	return round(initial(D.construction_time) * time_coeff, roundto)
 
 /obj/machinery/mecha_part_fabricator/proc/build_part(datum/design/D)
 	being_built = D
 	desc = "It's building \a [initial(D.name)]."
-	var/list/res_coef = get_resources_w_coeff(D)
+	var/list/res_coef = get_all_resources_w_coeff(D)
 
 	GET_COMPONENT(materials, /datum/component/material_container)
 	materials.use_amount(res_coef)
 	overlays += "fab-active"
 	use_power = ACTIVE_POWER_USE
-	updateUsrDialog()
+	SSnanoui.update_uis(src)
 	sleep(get_construction_time_w_coeff(D))
 	use_power = IDLE_POWER_USE
 	overlays -= "fab-active"
@@ -172,34 +218,26 @@
 	atom_say("[I] is complete.")
 	being_built = null
 
-	updateUsrDialog()
+	SSnanoui.update_uis(src)
 	return TRUE
 
-/obj/machinery/mecha_part_fabricator/proc/update_queue_on_page()
-	send_byjax(usr,"mecha_fabricator.browser","queue",list_queue())
-	return
-
-/obj/machinery/mecha_part_fabricator/proc/add_part_set_to_queue(set_name)
-	if(set_name in part_sets)
-		for(var/v in files.known_designs)
-			var/datum/design/D = files.known_designs[v]
-			if(D.build_type & fabricator_type)
-				if(set_name in D.category)
-					add_to_queue(D)
-
-/obj/machinery/mecha_part_fabricator/proc/add_to_queue(D)
+// Add a single part to the queue
+/obj/machinery/mecha_part_fabricator/proc/add_to_queue(datum/design/D)
 	if(!istype(queue))
 		queue = list()
-	if(D)
+	if(D && istype(D))
 		queue[++queue.len] = D
-	return queue.len
+		return TRUE
+	return FALSE
 
+// Removes an item from the queue at the specified index
 /obj/machinery/mecha_part_fabricator/proc/remove_from_queue(index)
-	if(!isnum(index) || !istype(queue) || (index<1 || index>queue.len))
+	if(!isnum(index) || !istype(queue) || (index < 1 || index > queue.len))
 		return FALSE
-	queue.Cut(index,++index)
+	queue.Cut(index, index + 1)
 	return TRUE
 
+// Starts building whatever is in the queue
 /obj/machinery/mecha_part_fabricator/proc/process_queue()
 	var/datum/design/D = queue[1]
 	if(!D)
@@ -208,43 +246,21 @@
 			return process_queue()
 		else
 			return
-	temp = null
 	while(D)
-		if(stat&(NOPOWER|BROKEN))
+		if(stat & (NOPOWER|BROKEN))
 			return FALSE
-		if(!check_resources(D))
+		if(!can_build(D))
 			atom_say("Not enough resources. Queue processing stopped.")
-			temp = {"<span class='alert'>Not enough resources to build next part.</span><br>
-						<a href='?src=[UID()];process_queue=1'>Try again</a> | <a href='?src=[UID()];clear_temp=1'>Return</a><a>"}
 			return FALSE
 		remove_from_queue(1)
 		build_part(D)
 		D = listgetindex(queue, 1)
 	atom_say("Queue processing finished successfully.")
 
-/obj/machinery/mecha_part_fabricator/proc/list_queue()
-	var/output = "<b>Queue contains:</b>"
-	if(!istype(queue) || !queue.len)
-		output += "<br>Nothing"
-	else
-		output += "<ol>"
-		var/i = 0
-		for(var/datum/design/D in queue)
-			i++
-			var/obj/part = D.build_path
-			output += "<li[!check_resources(D)?" style='color: #f00;'":null]>"
-			output += initial(part.name) + " - "
-			output += "[i>1?"<a href='?src=[UID()];queue_move=-1;index=[i]' class='arrow'>&uarr;</a>":null] "
-			output += "[i<queue.len?"<a href='?src=[UID()];queue_move=+1;index=[i]' class='arrow'>&darr;</a>":null] "
-			output += "<a href='?src=[UID()];remove_from_queue=[i]'>Remove</a></li>"
-
-		output += "</ol>"
-		output += "\[<a href='?src=[UID()];process_queue=1'>Process queue</a> | <a href='?src=[UID()];clear_queue=1'>Clear queue</a>\]"
-	return output
-
+// Syncs with the local R&D console in the area
 /obj/machinery/mecha_part_fabricator/proc/sync()
-	temp = "Updating local R&D database..."
-	updateUsrDialog()
+	add_wait_message("Syncing with local R&D database...", 30)
+	SSnanoui.update_uis(src) // To get the wait message to show up
 	sleep(30) //only sleep if called by user
 	var/area/localarea = get_area(src)
 
@@ -252,23 +268,24 @@
 		if(!RDC.sync)
 			continue
 		RDC.files.push_data(files)
-		temp = "Processed equipment designs.<br>"
-		//check if the tech coefficients have changed
-		temp += "<a href='?src=[UID()];clear_temp=1'>Return</a>"
-
-		updateUsrDialog()
+		SSnanoui.update_uis(src)
 		atom_say("Successfully synchronized with R&D server.")
-		return
 
-	temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=[UID()];clear_temp=1'>Return</a>"
-	updateUsrDialog()
-	return
+	SSnanoui.update_uis(src)
+	atom_say("Failed to sync with R&D server.")
+	return FALSE
 
-/obj/machinery/mecha_part_fabricator/proc/get_resource_cost_w_coeff(datum/design/D, resource, roundto = 1)
-	return round(D.materials[resource]*component_coeff, roundto)
+// The two procs below are copied exactly from the R&D console (rdconsole.dm). See documentation written there if you need to learn more
+/obj/machinery/mecha_part_fabricator/proc/add_wait_message(message, delay)
+	wait_message = message
+	wait_message_timer = addtimer(CALLBACK(src, .proc/clear_wait_message), delay, TIMER_UNIQUE | TIMER_STOPPABLE)
 
-/obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(datum/design/D, roundto = 1) //aran
-	return round(initial(D.construction_time)*time_coeff, roundto)
+/obj/machinery/mecha_part_fabricator/proc/clear_wait_message()
+	wait_message = ""
+	if(wait_message_timer)
+		deltimer(wait_message_timer)
+		wait_message_timer = 0
+	SSnanoui.update_uis(src)
 
 /obj/machinery/mecha_part_fabricator/attack_ghost(mob/user)
 	interact(user)
@@ -281,143 +298,91 @@
 		return 1
 	return interact(user)
 
-/obj/machinery/mecha_part_fabricator/interact(mob/user)
-	var/dat, left_part
-	if(..())
-		return
-	user.set_machine(src)
-	var/turf/exit = get_step(src,(dir))
-	if(exit.density)
-		atom_say("Error! Part outlet is obstructed.")
-		return
-	if(temp)
-		left_part = temp
-	else if(being_built)
-		var/obj/I = being_built.build_path
-		left_part = {"<TT>Building [initial(I.name)].<BR>
-							Please wait until completion...</TT>"}
-	else
-		switch(screen)
-			if("main")
-				left_part = output_available_resources()+"<hr>"
-				left_part += "<a href='?src=[UID()];sync=1'>Sync with R&D servers</a><hr>"
-				for(var/part_set in part_sets)
-					left_part += "<a href='?src=[UID()];part_set=[part_set]'>[part_set]</a> - \[<a href='?src=[UID()];partset_to_queue=[part_set]'>Add all parts to queue</a>\]<br>"
-			if("parts")
-				left_part += output_parts_list(part_set)
-				left_part += "<hr><a href='?src=[UID()];screen=main'>Return</a>"
-	dat = {"
-
-			  <title>[name]</title>
-				<style>
-				.res_name {font-weight: bold; text-transform: capitalize;}
-				.red {color: #f00;}
-				.part {margin-bottom: 10px;}
-				.arrow {text-decoration: none; font-size: 10px;}
-				body, table {height: 100%;}
-				td {vertical-align: top; padding: 5px;}
-				html, body {padding: 0px; margin: 0px;}
-				h1 {font-size: 18px; margin: 5px 0px;}
-				</style>
-				<script language='javascript' type='text/javascript'>
-				[JS_BYJAX]
-				</script>
-
-				<table style='width: 100%;'>
-				<tr>
-				<td style='width: 65%; padding-right: 10px;'>
-				[left_part]
-				</td>
-				<td style='width: 35%; background: #000;' id='queue'>
-				[list_queue()]
-				</td>
-				<tr>
-				</table>"}
-	var/datum/browser/popup = new(user, "mecha_fabricator", name, 1000, 600)
-	popup.set_content(dat)
-	popup.open(0)
-	onclose(user, "mecha_fabricator")
-	return
-
 /obj/machinery/mecha_part_fabricator/Topic(href, href_list)
 	if(..())
 		return 1
-	var/datum/topic_input/afilter = new /datum/topic_input(href,href_list)
-	if(href_list["part_set"])
-		var/tpart_set = afilter.getStr("part_set")
-		if(tpart_set)
-			if(tpart_set=="clear")
-				part_set = null
-			else
-				part_set = tpart_set
-				screen = "parts"
-	if(href_list["part"])
-		var/T = afilter.getStr("part")
-		for(var/v in files.known_designs)
-			var/datum/design/D = files.known_designs[v]
-			if(D.build_type & fabricator_type)
-				if(D.id == T)
-					if(!processing_queue)
-						build_part(D)
-					else
-						add_to_queue(D)
-					break
+
+	if(href_list["menu"]) // Main menu
+		screen = MECHFAB_MAIN_MENU
+
+	if(href_list["category"]) // Inside a "category": cyborg parts, medical etc.
+		selected_category = href_list["category"]
+		screen = MECHFAB_CATEGORY_MENU
+
+	if(href_list["search"])
+		if(href_list["to_search"])
+			temp_search = href_list["to_search"]
+		if(!temp_search)
+			return
+		screen = MECHFAB_SEARCH_MENU
+
 	if(href_list["add_to_queue"])
-		var/T = afilter.getStr("add_to_queue")
-		for(var/v in files.known_designs)
-			var/datum/design/D = files.known_designs[v]
-			if(D.build_type & fabricator_type)
-				if(D.id == T)
-					add_to_queue(D)
-					break
-		return update_queue_on_page()
+		var/design = href_list["add_to_queue"]
+		for(var/I in files.known_designs)
+			var/datum/design/D = files.known_designs[I]
+			if(!(D.build_type & fabricator_type))
+				continue
+			if(D.id == design)
+				add_to_queue(D)
+				break
+
+	if(href_list["category_add_all"])
+		for(var/I in files.known_designs)
+			var/datum/design/D = files.known_designs[I]
+			if((D.build_type & fabricator_type) && selected_category in D.category)
+				add_to_queue(D)
+
+	if(href_list["main_menu_add_all"])
+		selected_category = href_list["main_menu_add_all"]
+		for(var/I in files.known_designs)
+			var/datum/design/D = files.known_designs[I]
+			if((D.build_type & fabricator_type) && selected_category in D.category)
+				add_to_queue(D)
+		selected_category = null
+
 	if(href_list["remove_from_queue"])
-		remove_from_queue(afilter.getNum("remove_from_queue"))
-		return update_queue_on_page()
-	if(href_list["partset_to_queue"])
-		add_part_set_to_queue(afilter.get("partset_to_queue"))
-		return update_queue_on_page()
+		var/index = text2num(href_list["remove_from_queue"])
+		remove_from_queue(index)
+
 	if(href_list["process_queue"])
 		spawn(0)
-			if(processing_queue || being_built)
+			if(being_built)
 				return FALSE
-			processing_queue = 1
 			process_queue()
-			processing_queue = 0
-	if(href_list["clear_temp"])
-		temp = null
-	if(href_list["screen"])
-		screen = href_list["screen"]
-	if(href_list["queue_move"] && href_list["index"])
-		var/index = afilter.getNum("index")
-		var/new_index = index + afilter.getNum("queue_move")
-		if(isnum(index) && isnum(new_index))
-			if(IsInRange(new_index,1,queue.len))
-				queue.Swap(index,new_index)
-		return update_queue_on_page()
+
 	if(href_list["clear_queue"])
-		queue = list()
-		return update_queue_on_page()
+		queue.Cut()
+
+	if(href_list["curr_index"] && href_list["new_index"])
+		var/curr_index = text2num(href_list["curr_index"])
+		var/new_index = text2num(href_list["new_index"])
+		if(isnum(curr_index) && isnum(new_index))
+			if(IsInRange(curr_index, 1, queue.len) && IsInRange(new_index, 1, queue.len))
+				queue.Swap(curr_index, new_index)
+
 	if(href_list["sync"])
 		sync()
-	if(href_list["part_desc"])
-		var/T = afilter.getStr("part_desc")
-		for(var/v in files.known_designs)
-			var/datum/design/D = files.known_designs[v]
-			if(D.build_type & fabricator_type)
-				if(D.id == T)
-					var/obj/part = D.build_path
-					temp = {"<h1>[initial(part.name)] description:</h1>
-								[initial(part.desc)]<br>
-								<a href='?src=[UID()];clear_temp=1'>Return</a>
-								"}
-					break
 
-	if(href_list["remove_mat"] && href_list["material"])
+	if(href_list["material_storage"])
+		screen = MECHFAB_MATERIALS_MENU
+
+	if(href_list["remove_mat"])
 		GET_COMPONENT(materials, /datum/component/material_container)
-		materials.retrieve_sheets(text2num(href_list["remove_mat"]), href_list["material"])
+		var/desired_num_sheets
+		if(href_list["remove_mat_amount"] == "custom")
+			desired_num_sheets = input("How many sheets would you like to eject from the machine?", "How much?", 1) as null|num
+			if(!desired_num_sheets)
+				return
+		else
+			desired_num_sheets = text2num(href_list["remove_mat_amount"])
 
-	updateUsrDialog()
+		if(!isnum(desired_num_sheets))
+			CRASH("A non-number got passed to a mach fabricator's remove_mat section")
+		desired_num_sheets = max(0, desired_num_sheets) // If you input too high of a number, the mineral datum will take care of it either way
+		desired_num_sheets = round(desired_num_sheets) // No partial-sheet goofery
+		materials.retrieve_sheets(desired_num_sheets, href_list["remove_mat"])
+
+	SSnanoui.update_uis(src)
 	return
 
 /obj/machinery/mecha_part_fabricator/proc/AfterMaterialInsert(type_inserted, id_inserted, amount_inserted)
@@ -425,7 +390,7 @@
 	overlays += "fab-load-[stack_name]"
 	sleep(10)
 	overlays -= "fab-load-[stack_name]"
-	updateUsrDialog()
+	SSnanoui.update_uis(src)
 
 /obj/machinery/mecha_part_fabricator/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "fab-o", "fab-idle", W))
@@ -434,7 +399,7 @@
 	if(exchange_parts(user, W))
 		return
 
-	if(default_deconstruction_crowbar(user, W))
+	if(default_deconstruction_crowbar(W))
 		return TRUE
 
 	else
@@ -456,12 +421,7 @@
 /obj/machinery/mecha_part_fabricator/spacepod
 	name = "spacepod fabricator"
 	fabricator_type = PODFAB
-	part_sets = list(			"Pod_Weaponry",
-								"Pod_Armor",
-								"Pod_Cargo",
-								"Pod_Parts",
-								"Pod_Frame",
-								"Misc")
+	categories = list("Pod_Weaponry", "Pod_Armor", "Pod_Cargo", "Pod_Parts", "Pod_Frame", "Misc")
 	req_access = list(ACCESS_MECHANIC)
 
 /obj/machinery/mecha_part_fabricator/spacepod/New()
@@ -475,7 +435,14 @@
 	component_parts += new /obj/item/stock_parts/micro_laser(null)
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	RefreshParts()
+	files = new /datum/research(src) //Setup the research data holder.
+
+/obj/machinery/mecha_part_fabricator/spacepod/interact(mob/user)
+	. = ..()
 
 /obj/machinery/mecha_part_fabricator/robot
 	name = "Robotic Fabricator"
-	part_sets = list("Cyborg")
+	categories = list("Cyborg")
+
+/obj/machinery/mecha_part_fabricator/robot/interact(mob/user)
+	. = ..()

--- a/nano/templates/mech_fabricator.tmpl
+++ b/nano/templates/mech_fabricator.tmpl
@@ -1,0 +1,192 @@
+<!--
+Title: Mech Fabricator UI
+Used In File(s): code\game\mecha\mech_fabricator.dm
+-->
+
+<!--
+#define MECHFAB_MAIN_MENU		1
+#define MECHFAB_CATEGORY_MENU	2
+#define MECHFAB_SEARCH_MENU		3
+#define MECHFAB_MATERIALS_MENU	4
+-->
+
+<style type="text/css">
+	input[type=text], input[type=submit] {
+		border: 1px solid #161616;
+		background-color: #40628a;
+		color: #FFFFFF;
+		padding: 4px;
+	}
+	input[type=submit]:hover {
+		background-color: #507aac;
+	}
+</style>
+
+{{if data.screen == 1}}
+	<div class='item'>
+		{{:helper.link('Material Storage', 'arrow-up', {'material_storage': 1})}}
+		{{:helper.link('Sync with R&D Server', 'refresh', {'sync': 1})}}
+	</div>
+{{else data.screen == 2 || data.screen == 3}}
+	<div class='item'>
+		{{:helper.link('Main Menu', 'reply', {'menu' : 1})}}
+		{{:helper.link('Material Storage', 'arrow-up', {'material_storage': 1})}}
+		{{:helper.link('Sync with R&D Server', 'refresh', {'sync': 1})}}
+	</div>
+{{else data.screen == 4}}
+	<div class='item'>
+		{{:helper.link('Main Menu', 'reply', {'menu' : 1})}}
+		{{:helper.link('Sync with R&D Server', 'refresh', {'sync': 1})}}
+	</div>
+{{/if}}
+
+<table style='width:100%'><tr>
+	<td valign='top' style='margin-right: 300px'>
+		<div class='statusDisplay'>
+			{{if data.screen == 1}} <!-- MECHFAB_MAIN_MENU -->
+				<h3>Exosuit Fabricator Menu</h3>
+				<div class='itemLabelWidest'><table>
+					<tr>
+						<td><b>Total Material Amount:</b> {{:data.total_amount}} / {{:data.max_amount}} cm<sup>3</sup></td>
+					</tr>
+				</table></div>
+				<form action='byond://'>
+					<input type='hidden' name='src' value='{{:data.uid}}'>
+					<input type='hidden' name='search' value='1'>
+					<input type='text' name='to_search'>   <input type='submit' value='Search'>
+				</form>
+
+				<hr>
+				<table class='item'><tr>
+					{{for data.categories}}
+						{{if (index & 1) == 0 && index != 0}}
+							</tr><tr>
+						{{/if}}
+						<td>{{:helper.link(value, 'arrow-right', {'category': value})}} {{:helper.link('+All', '', {'main_menu_add_all' : value})}}</td>
+					{{/for}}
+				</tr></table>
+			{{else data.screen == 2 || data.screen == 3}}
+				{{if data.screen == 2}} <!-- MECHFAB_CATEGORY_MENU -->
+					<h3>Viewing Category {{:data.selected_category}}:</h3>
+				{{else data.screen == 3}} <!-- MECHFAB_SEARCH_MENU -->
+					<h3>Search Results for '{{:data.search}}':</h3>
+				{{/if}}
+				<div class='itemLabelWidest'><table>
+					<tr>
+						<td><b>Total Material Amount:</b> {{:data.total_amount}} / {{:data.max_amount}} cm<sup>3</sup></td>
+					</tr>
+				</table></div>
+				{{if data.screen != 3}}
+					<table>
+						<tr>
+							<td>{{:helper.link('Add all parts to queue', null, {'category_add_all' : 'category'})}}</td>
+						</tr>
+					</table>
+				{{/if}}
+
+				<hr>
+				<table>
+					{{if data.designs.length}}
+						{{for data.designs}}
+							<tr>
+								<td>
+									{{:helper.link(value.name, 'print', {'add_to_queue' : value.id})}}
+								</td>
+								<td>
+									{{for value.materials : material : i}}
+										{{if material.amount}}
+											 | 
+											{{if material.is_red}}
+												<span class='bad'>
+											{{/if}}
+											{{:material.amount}} {{:material.name}}
+											{{if material.is_red}}
+												</span>
+											{{/if}}
+										{{/if}}
+									{{/for}}
+								</td>
+							</tr>
+						{{/for}}
+					{{else}}
+						{{if data.screen == 2}}
+							<ol class='average'>No designs currently available</ol>
+						{{else data.screen == 3}}
+							<br>
+							<ol class='average'>No designs found</ol>
+						{{/if}}
+					{{/if}}
+				</table>
+			{{else data.screen == 4}}
+				<table>
+					<tr>
+						<h3>Material Storage:</h3>
+					</tr>
+					{{for data.loaded_materials}}
+						<div class='item'>
+							<div class='itemLabel'> - {{:value.amount}} of {{:value.name}}</div> <div class='itemLabelNarrow'>({{:Math.round((value.amount / 2000) * 10) / 10}} sheets)</div>
+							{{if value.amount >= 2000}}
+								{{:helper.link('1x', 'eject', {'remove_mat': value.id, 'remove_mat_amount': 1})}}
+								{{if value.amount >= 2000*5}}
+									{{:helper.link('5x', 'eject', {'remove_mat': value.id, 'remove_mat_amount': 5})}}
+								{{/if}}
+								{{:helper.link('C', 'eject', {'remove_mat': value.id, 'remove_mat_amount': 'custom'})}}
+								{{:helper.link('All', 'eject', {'remove_mat': value.id, 'remove_mat_amount': 50})}}
+							{{/if}}
+							</div>
+						</div>
+					{{/for}}
+				</table>
+			{{/if}}
+		</div>
+	</td>
+	{{if data.screen != 4}}
+		<td valign='top' style='width: 300px'>
+			<div class="statusDisplay">
+				<h3>Queue contains:</h3>
+				{{if data.queue}}
+					{{if data.processing}}
+						<ol class='good'>{{:data.processing}}</ol>
+					{{/if}}
+					<ol>
+						{{for data.queue}}
+							<li>
+								{{if !value.can_build}}
+									<span class='bad'>
+								{{/if}}
+								{{:value.name}}
+								{{if !value.can_build}}
+									</span>
+								{{/if}}
+								<div class='item'>
+									{{if index + 1 > 1}}
+										{{:helper.link('', 'arrow-up', {'curr_index' : index + 1, 'new_index' : index})}}
+									{{/if}}
+									{{if index + 1 < data.queue.length}}
+										{{:helper.link('', 'arrow-down', {'curr_index' : index + 1, 'new_index' : index + 2})}}
+									{{/if}}
+									{{:helper.link('Remove', 'times', {'remove_from_queue' : index + 1})}}
+								</div>
+							</li>
+						{{/for}}
+					</ol>
+					{{:helper.link('Process queue', 'print', {'process_queue' : 1})}} {{:helper.link('Clear queue', 'trash', {'clear_queue' : 1})}}
+				{{else}}
+					{{if data.processing}}
+						<ol class='good'>{{:data.processing}}</ol>
+					{{else}}
+						<ol class='average'>Nothing</ol>
+					{{/if}}
+				{{/if}}
+			</div>
+		</td>
+	{{/if}}
+</tr></table>
+
+{{if data.wait_message}}
+	<div class="mask">
+		<div class="maskContent">
+			<h1>{{:data.wait_message}}</h1>
+		</div>
+	</div>
+{{/if}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This converts the exosuit fabricator's UI to use nano UI, which functions similarly to the autolathe and R&D console UIs. Pardon the gif to show off the features. Apparently OBS can't pick up nanoUI, so I had to settle for a gif instead.

**The swapping of what the exofab's parts determine:**

For some reason the exofab's build time was determined by its manipulator and its resource cost was determined by its micro-laser. I'm not sure why this is the case, however this is the opposite for other fabricating machines (autolathe, protolathe, circuit imprinter, etc.). 

All of these use the *manipulator* to determine cost. So to keep it consistent, I've swapped the part functions on the exofab to be in line with these other machines. The exosuit fabricator's resource cost adjustment is now determined by its manipulator, and its time to build is determined by its micro-laser.

**The removal of the part description and build time features from the exofab:**

To be honest I've maybe used the part description feature about one time. I've never heard anyone talk about using this feature or complain that some of the descriptions are empty. So for the sake of keeping the UI clean I've removed this button.

Similar to the part description feature, I've removed the bit where the UI tells you how long it will take to build the part. It's nice to see the time to build I suppose, but its not that particularly useful and once again I think it would clutter the UI with not that useful information.

## Why It's Good For The Game
The exofab's UI was old, clunky, and lacked search bar. Now it's less annoying to use and to find what you need via the serach bar. If you're lacking a material for a given part, the missing material will show up red, making it easier to see what you need more of.

## Images of changes

Demo gif of the UI:

![GIF](https://user-images.githubusercontent.com/42044220/70615987-130eae00-1bd3-11ea-9d84-b0b97b520071.gif)

Main menu: https://i.imgur.com/buuVJVf.png
Category menu (misc): https://i.imgur.com/ZsauhOK.png
Material storage manu: https://i.imgur.com/dw20lNC.png


## Changelog
:cl:
tweak: The exosuit fabricator now uses nano-UI
tweak: The exosuit fabricator's resource cost adjustment is now determined by its manipulator and its time to build is determined by is micro-laser
del: Removed the time to build information from the exosuit fabricator UI
del: Removed the part description button from the exosuit fabricator UI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
