### PR TITLE
Racial Loadout Items Placement Fix

### DIFF
--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -1,6 +1,7 @@
 /datum/gear/racial
 	sort_category = "Racial"
 	subtype_path = /datum/gear/racial
+	slot = slot_glasses
 	cost = 2
 
 
@@ -40,4 +41,5 @@
 /datum/gear/racial/footwraps
 	display_name = "cloth footwraps"
 	path = /obj/item/clothing/shoes/footwraps
+	slot = slot_shoes
 	cost = 1


### PR DESCRIPTION
Tajaran veils in the loadout will now automatically fill the glasses slot and move items already there at spawn to the backpack.
Cloth footwraps in the loadout will now automatically fill the shoes slot and move items already there at spawn to the backpack.