### PR TITLE
Universal Object Damage fixes.

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -8,6 +8,7 @@ var/const/SAFETY_COOLDOWN = 100
 	layer = MOB_LAYER+1 // Overhead
 	anchored = 1
 	density = 1
+	damage_deflection = 10
 	var/safety_mode = 0 // Temporarily stops machine if it detects a mob
 	var/icon_name = "grinder-o"
 	var/blood = 0

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -104,6 +104,7 @@
 	icon_opened = "toolclosetopen"
 
 /obj/structure/closet/toolcloset/New()
+	..()
 	if(prob(40))
 		new /obj/item/clothing/suit/storage/hazardvest(src)
 	if(prob(70))

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -8,6 +8,7 @@
 	max_integrity = 120
 	var/image/nest_overlay
 	comfort = 0
+	flags = NODECONSTRUCT
 
 /obj/structure/bed/nest/New()
 	nest_overlay = image('icons/mob/alien.dmi', "nestoverlay", layer=MOB_LAYER - 0.2)


### PR DESCRIPTION
## What Does This PR Do
Fixes #12617  - Set a NODECONSTRUCT flag which keeps them from being wrenched away + don't drop metal when destroyed.

Fixes #12786 - The initialize was missing the call to its parent function, so it never got an object integrity set anywhere.
 
Fixes #12588 - Gave it 10 damage_deflection, as the vast majority of items do < 10 damage when tossed into the recycler by disposals. Some will still hurt it but it shouldn't break through regular use.

## Why It's Good For The Game
Fixes good. 

## Changelog
:cl:
fix: Fixed issue where the recycler would break through normal use.
fix: Tool closets are no longer indestructible.
fix: Alien nests can no longer be wrenched and don't drop metal when destroyed.
/:cl:
