### PR TITLE
Emagproofs CC, adds admin warning if ert shuttle is moved by non-ert

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -5381,7 +5381,7 @@
 	},
 /area/syndicate_mothership)
 "nQ" = (
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/impassable{
 	id_tag = "GRAVPULTS";
 	name = "Gravity Catapults"
 	},
@@ -5391,7 +5391,7 @@
 	},
 /area/centcom/specops)
 "nR" = (
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/impassable{
 	id_tag = "GRAVPULTS";
 	name = "Gravity Catapults"
 	},
@@ -5409,6 +5409,10 @@
 /area/syndicate_mothership)
 "nT" = (
 /obj/machinery/door/poddoor{
+	id_tag = "ASSAULT";
+	name = "Assault Armor"
+	},
+/obj/machinery/door/poddoor/impassable{
 	id_tag = "ASSAULT";
 	name = "Assault Armor"
 	},
@@ -5854,9 +5858,8 @@
 	},
 /area/centcom/gamma)
 "oR" = (
-/obj/machinery/door/poddoor{
-	id_tag = "SPECOPS";
-	name = "Ready Room"
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "SPECOPS"
 	},
 /turf/unsimulated/floor{
 	icon_state = "vault";
@@ -5980,6 +5983,10 @@
 	req_access_txt = "114"
 	},
 /obj/machinery/door/poddoor{
+	id_tag = "specopsoffice";
+	name = "Super Privacy Shutters"
+	},
+/obj/machinery/door/poddoor/impassable{
 	id_tag = "specopsoffice";
 	name = "Super Privacy Shutters"
 	},
@@ -6118,7 +6125,7 @@
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/shuttle/gamma/space)
 "pv" = (
-/obj/machinery/door/poddoor{
+/obj/machinery/door/poddoor/impassable{
 	id_tag = "CCTELE";
 	name = "Specops Teleporter"
 	},
@@ -6365,7 +6372,7 @@
 /area/centcom/specops)
 "pX" = (
 /obj/machinery/door_control{
-	desc = "A remote control switch to block view of the singularity.";
+	desc = "A remote control switch to connect the ready room to the rest of Centcom.";
 	icon_state = "doorctrl0";
 	id = "SPECOPS";
 	name = "Ready Room";
@@ -12300,6 +12307,24 @@
 	icon_state = "white"
 	},
 /area/tdome)
+"HJ" = (
+/obj/machinery/door/poddoor{
+	id_tag = "CCGAMMA";
+	name = "Gamma Security"
+	},
+/obj/machinery/door/airlock/centcom{
+	name = "Gamma Armory";
+	opacity = 1;
+	req_access_txt = "114"
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "CCGAMMA";
+	name = "Gamma Security"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/centcom/gamma)
 "HR" = (
 /obj/structure/closet/secure_closet/freezer/meat{
 	req_access_txt = "112"
@@ -29642,7 +29667,7 @@ fm
 fm
 md
 md
-oO
+HJ
 fm
 pv
 sX

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -12307,24 +12307,6 @@
 	icon_state = "white"
 	},
 /area/tdome)
-"HJ" = (
-/obj/machinery/door/poddoor{
-	id_tag = "CCGAMMA";
-	name = "Gamma Security"
-	},
-/obj/machinery/door/airlock/centcom{
-	name = "Gamma Armory";
-	opacity = 1;
-	req_access_txt = "114"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "CCGAMMA";
-	name = "Gamma Security"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/centcom/gamma)
 "HR" = (
 /obj/structure/closet/secure_closet/freezer/meat{
 	req_access_txt = "112"
@@ -12540,6 +12522,20 @@
 	name = "plating"
 	},
 /area/centcom/control)
+"NH" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Gamma Armory";
+	opacity = 1;
+	req_access_txt = "114"
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "CCGAMMA";
+	name = "Gamma Security"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/centcom/gamma)
 "NI" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/unsimulated/floor{
@@ -29667,7 +29663,7 @@ fm
 fm
 md
 md
-HJ
+NH
 fm
 pv
 sX

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -5006,6 +5006,20 @@
 	name = "grass"
 	},
 /area/centcom/control)
+"nc" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Gamma Armory";
+	opacity = 1;
+	req_access_txt = "114"
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "CCGAMMA";
+	name = "Gamma Security"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/centcom/gamma)
 "nd" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/unsimulated/floor{
@@ -5408,10 +5422,6 @@
 	},
 /area/syndicate_mothership)
 "nT" = (
-/obj/machinery/door/poddoor{
-	id_tag = "ASSAULT";
-	name = "Assault Armor"
-	},
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "ASSAULT";
 	name = "Assault Armor"
@@ -5859,7 +5869,8 @@
 /area/centcom/gamma)
 "oR" = (
 /obj/machinery/door/poddoor/impassable{
-	id_tag = "SPECOPS"
+	id_tag = "SPECOPS";
+	name = "Ready Room"
 	},
 /turf/unsimulated/floor{
 	icon_state = "vault";
@@ -5981,10 +5992,6 @@
 	name = "Special Operations Command";
 	opacity = 1;
 	req_access_txt = "114"
-	},
-/obj/machinery/door/poddoor{
-	id_tag = "specopsoffice";
-	name = "Super Privacy Shutters"
 	},
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "specopsoffice";
@@ -12522,20 +12529,6 @@
 	name = "plating"
 	},
 /area/centcom/control)
-"NH" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Gamma Armory";
-	opacity = 1;
-	req_access_txt = "114"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "CCGAMMA";
-	name = "Gamma Security"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/centcom/gamma)
 "NI" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/unsimulated/floor{
@@ -29663,7 +29656,7 @@ fm
 fm
 md
 md
-NH
+nc
 fm
 pv
 sX

--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -9,7 +9,7 @@
 	if(href_list["move"])
 		var/authorized_roles = list(SPECIAL_ROLE_ERT, SPECIAL_ROLE_DEATHSQUAD)
 		if(!((usr.mind.assigned_role in authorized_roles) || is_admin(usr)))
-			message_admins("Potential ERT shuttle hijack, ert shuttle moved by unauthorized user: [key_name_admin(usr)]")
+			message_admins("Potential ERT shuttle hijack, ERT shuttle moved by unauthorized user: [key_name_admin(usr)]")
 	..()
 	
 

--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -5,6 +5,14 @@
 	possible_destinations = "specops_home;specops_away;specops_custom"
 	resistance_flags = INDESTRUCTIBLE
 
+/obj/machinery/computer/shuttle/ert/Topic(href, href_list)
+	if(href_list["move"])
+		var/authorized_roles = list(SPECIAL_ROLE_ERT, SPECIAL_ROLE_DEATHSQUAD)
+		if(!((usr.mind.assigned_role in authorized_roles) || is_admin(usr)))
+			message_admins("Potential ERT shuttle hijack, ert shuttle moved by unauthorized user: [key_name_admin(usr)]")
+	..()
+	
+
 /obj/machinery/computer/camera_advanced/shuttle_docker/ert
 	name = "specops navigation computer"
 	desc = "Used to designate a precise transit location for the specops shuttle."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This replaces the blast doors in CC with an emag-proof variant used in the syndicate base as well.

Edit: It also includes a message informing admins whenever a player that is not an ert, a deathsquad or himself an admin moves the ert shuttle, so they do not miss people sneaking into CC.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It stops a traitor that manages to steal an ert shuttle from raiding the gamma armory or firing the CC BSA.

Admins can now appropriately react to anyone attempting to attack CC via the shuttle if they miss it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
the blast doors look exactly the same as the normal version, so no visual changes.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: CC is now emag-proof
fix: Minor copy-paste error
tweak: admins are now messaged if a non-ert/DS player moves the ert shuttle.
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
