### PR TITLE
Fixes the construct reflect and refactors the reflect code doing it

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -16,20 +16,8 @@ emp_act
 		if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
 			visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
 							"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
-			// Find a turf near or on the original location to bounce to
-			if(P.starting)
-				var/new_x = P.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
-				var/new_y = P.starting.y + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
-				var/turf/curloc = get_turf(src)
-
-				// redirect the projectile
-				P.firer = src
-				P.original = locate(new_x, new_y, P.z)
-				P.starting = curloc
-				P.current = curloc
-				P.yo = new_y - curloc.y
-				P.xo = new_x - curloc.x
-				P.Angle = null
+			
+			P.reflect_back(src)
 
 			return -1 // complete projectile permutation
 

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -474,19 +474,9 @@
 		if(P.is_reflectable)
 			H.visible_message("<span class='danger'>The [P.name] gets reflected by [H]'s glass skin!</span>", \
 			"<span class='userdanger'>The [P.name] gets reflected by [H]'s glass skin!</span>")
-			if(P.starting)
-				var/new_x = P.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
-				var/new_y = P.starting.y + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
-				var/turf/curloc = get_turf(H)
+			
+			P.reflect_back(H)
 
-				// redirect the projectile
-				P.firer = src
-				P.original = locate(new_x, new_y, P.z)
-				P.starting = curloc
-				P.current = curloc
-				P.yo = new_y - curloc.y
-				P.xo = new_x - curloc.x
-				P.Angle = null
 			return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -132,19 +132,7 @@
 			visible_message("<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>", \
 							"<span class='userdanger'>The [P.name] gets reflected by [src]'s shell!</span>")
 
-			// Find a turf near or on the original location to bounce to
-			if(P.starting)
-				var/new_x = P.starting.x + pick(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3)
-				var/new_y = P.starting.y + pick(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3)
-				var/turf/curloc = get_turf(src)
-
-				// redirect the projectile
-				P.original = locate(new_x, new_y, P.z)
-				P.starting = curloc
-				P.current = curloc
-				P.firer = src
-				P.yo = new_y - curloc.y
-				P.xo = new_x - curloc.x
+			P.reflect_back(src, list(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3))
 
 			return -1 // complete projectile permutation
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -302,6 +302,21 @@
 				Range()
 			sleep(1)
 
+obj/item/projectile/proc/reflect_back(atom/source, list/position_modifiers = list(0, 0, 0, 0, 0, -1, 1, -2, 2))
+	if(starting)
+		var/new_x = starting.x + pick(position_modifiers)
+		var/new_y = starting.y + pick(position_modifiers)
+		var/turf/curloc = get_turf(source)
+
+		// redirect the projectile
+		firer = source
+		original = locate(new_x, new_y, z)
+		starting = curloc
+		current = curloc
+		yo = new_y - curloc.y
+		xo = new_x - curloc.x
+		Angle = null // Will be calculated in fire()
+
 obj/item/projectile/Crossed(atom/movable/AM, oldloc) //A mob moving on a tile with a projectile is hit by it.
 	..()
 	if(isliving(AM) && AM.density && !checkpass(PASSMOB))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -308,8 +308,12 @@ obj/item/projectile/proc/reflect_back(atom/source, list/position_modifiers = lis
 		var/new_y = starting.y + pick(position_modifiers)
 		var/turf/curloc = get_turf(source)
 
+		if(ismob(source))
+			firer = source // The reflecting mob will be the new firer
+		else
+			firer = null // Reflected by something other than a mob so firer will be null
+		
 		// redirect the projectile
-		firer = source
 		original = locate(new_x, new_y, z)
 		starting = curloc
 		current = curloc


### PR DESCRIPTION
## What Does This PR Do
Fixes #12782
Refactors other parts of the code who all do the same but just copy pasta'd the code. The construct code was one that didn't fully copy pasta all the code.

## Why It's Good For The Game
Less bugs more gut

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/70730009-882dd080-1d04-11ea-818f-a8afe5296706.png)


## Changelog
:cl:
fix: Constructs now correctly reflect energy and beam projectiles
/:cl:
