### PR TITLE
Changes the spray bottle in the full janitor belt to one with space cleaner in it

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -396,7 +396,7 @@
 	..()
 	new /obj/item/lightreplacer(src)
 	new /obj/item/holosign_creator(src)
-	new /obj/item/reagent_containers/spray(src)
+	new /obj/item/reagent_containers/spray/cleaner(src)
 	new /obj/item/soap(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)


### PR DESCRIPTION
## What Does This PR Do
Replaces the empty spray bottle in the full janitor belt to one with space cleaner in it.

## Why It's Good For The Game
The full jani belt is given to the ERT janitor and when one of them is called they'll need all the cleaning supplies they can get.

## Changelog
:cl:
fix: changed the empty spray bottle in the full jani belt to one with space cleaner in it
/:cl:
