### PR TITLE
Pylons now create artificer cult walls instead of real cult walls.

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -226,7 +226,7 @@ var/list/blacklisted_pylon_turfs = typecacheof(list(
 			if(istype(T, /turf/simulated/floor))
 				T.ChangeTurf(/turf/simulated/floor/engine/cult)
 			if(istype(T, /turf/simulated/wall))
-				T.ChangeTurf(/turf/simulated/wall/cult)
+				T.ChangeTurf(/turf/simulated/wall/cult/artificer)
 		else
 			var/turf/simulated/floor/engine/cult/F = safepick(cultturfs)
 			if(F)


### PR DESCRIPTION
## What Does This PR Do
Title. The path for the wall that gets transformed is now set to the same path as artificer walls, which look the same but can't be harvested for resources. Effectively this means you can't farm runed metal from pylon transformed walling. 

## Why It's Good For The Game
With the really cool change that made pylons slowly corrupt the area around them, came an exploit that luckily no one's figured out and abused yet. Since it turned the walls into real cult walls, a simple welder could recover extra runed metal from them, allowing for infinite farms.

## Changelog
:cl:
tweak: Pylons now create artificer cult walls instead of real cult walls.
/:cl:
