### PR TITLE
Make horsehead masks breathable and reduce horsemask curse cost

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -135,6 +135,7 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/horsemask
 	log_name = "HH"
 	category = "Offensive"
+	cost = 1
 
 /datum/spellbook_entry/disintegrate
 	name = "Disintegrate"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -304,9 +304,11 @@
 	desc = "A mask made of soft vinyl and latex, representing the head of a horse."
 	icon_state = "horsehead"
 	item_state = "horsehead"
-	flags = BLOCKHAIR
+	flags = BLOCKHAIR | AIRTIGHT
 	flags_inv = HIDEFACE
 	w_class = WEIGHT_CLASS_SMALL
+	gas_transfer_coefficient = 0.10
+	permeability_coefficient = 0.50
 	var/voicechange = 0
 	var/temporaryname = " the Horse"
 	var/originalname = ""


### PR DESCRIPTION
## What Does This PR Do
Small balance change to make Horsehead Masks breathable. For the suffering Vox and Plasmaman.

EDIT: Reduces the cost of Curse of the Horseman to 1 spellpoint for wizards.

## Why It's Good For The Game
Mostly because Curse of the Horseman. A joke spell that actually straight up kills Vox and Plasmaman. It's really unfun to experience that. I'm pretty sure you can even get the spell in a spellbook, which can mean a lot of accidental crew on crew murder with summon magic.

EDIT: With the nerf to its part of its main functionality, Curse of the Horseman should have its price reduced. Even before the nerf it was a bit too expensive for the effect, when you could just spend 2 Spellpoints on rod/disintegrate/jaunt/mutate and other much stronger options. It's cost now reflects what you might hope for a joke spell, and might see more use when a wizard has one point left over after deciding on most of his spells.

## Changelog
:cl:
balance: Horsehead Masks are now breathable.
balance: Curse of the Horseman now costs 1 spellpoint.
/:cl:
