### PR TITLE
Fixes reflectors and a Projectile angle bug

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -12,9 +12,9 @@
 /obj/structure/reflector/bullet_act(obj/item/projectile/P)
 	var/turf/reflector_turf = get_turf(src)
 	var/turf/reflect_turf
-	var/new_dir = get_reflection(dir, P.dir)
 	if(!istype(P, /obj/item/projectile/beam))
 		return ..()
+	var/new_dir = get_reflection(dir, P.dir)
 	if(new_dir)
 		reflect_turf = get_step(reflect_turf, new_dir)
 	else
@@ -30,6 +30,10 @@
 	P.current = reflector_turf
 	P.yo = reflect_turf.y - reflector_turf.y
 	P.xo = reflect_turf.x - reflector_turf.x
+	P.ignore_source_check = TRUE		//If shot by a laser, will now hit the mob that fired it
+	var/reflect_angle = dir2angle(new_dir)
+	P.setAngle(reflect_angle)
+
 	new_dir = 0
 	return -1
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -254,6 +254,7 @@
 		shot_number = 0
 	P.setDir(dir)
 	P.starting = loc
+	P.Angle = null
 	P.fire()
 	return P
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -240,8 +240,7 @@
 			if(!paused)
 				if((!( current ) || loc == current))
 					current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
-
-				if(!Angle)
+				if(isnull(Angle))
 					Angle=round(Get_Angle(src,current))
 				if(spread)
 					Angle += (rand() - 0.5) * spread


### PR DESCRIPTION
## What Does This PR Do
- Fixes Reflectors not reflecting at all 
- - Reflected projectiles needed an angle to be set to them. This happens now.
- Fixes Reflectors (and anything else) reflecting incorrectly NORTH (angle 0) in projectile.dm
- - null angle and 0 angle were treated the same (as a non-existing angle), meaning it'd get reset. 0th angle, however, is the reflection to North.

## Why It's Good For The Game
Makes reflections, you know, work.
This bug is also integral to both #11311 and #12119 due to the SM relying on reflectors almost completely. Merge this before you merge any of those.

## Images of changes
https://streamable.com/tty26
Reflectors work properly now at all angles.

## Changelog
:cl: FreeStylaLT
fix: Reflectors not reflecting
fix: North reflections in general
/:cl: