### PR TITLE
Makes the Handheld Defib not sleep people who are not in crit.

### DIFF
--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -63,7 +63,9 @@
 				else
 					to_chat(user, "<span class='danger'>[H] doesn't respond!</span>")
 
-			H.AdjustParalysis(3)
+			if((H.health <= HEALTH_THRESHOLD_CRIT) || (H.undergoing_cardiac_arrest())) //Don't sleep if they aren't in crit
+				H.AdjustParalysis(3)
+
 			H.AdjustStunned(5)
 			H.AdjustWeakened(5)
 			H.AdjustStuttering(10)

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -52,6 +52,14 @@
 		if(H.stat == DEAD)
 			to_chat(user, "<span class='danger'>[H] doesn't respond at all!</span>")
 		else
+
+			if((H.health <= HEALTH_THRESHOLD_CRIT) || (H.undergoing_cardiac_arrest())) //Don't sleep if they aren't in crit
+				H.AdjustParalysis(3)
+
+			H.AdjustStunned(5)
+			H.AdjustWeakened(5)
+			H.AdjustStuttering(10)
+
 			H.set_heartattack(FALSE)
 			var/total_damage = H.getBruteLoss() + H.getFireLoss() + H.getToxLoss()
 			if(H.health <= HEALTH_THRESHOLD_CRIT)
@@ -63,12 +71,7 @@
 				else
 					to_chat(user, "<span class='danger'>[H] doesn't respond!</span>")
 
-			if((H.health <= HEALTH_THRESHOLD_CRIT) || (H.undergoing_cardiac_arrest())) //Don't sleep if they aren't in crit
-				H.AdjustParalysis(3)
 
-			H.AdjustStunned(5)
-			H.AdjustWeakened(5)
-			H.AdjustStuttering(10)
 			to_chat(H, "<span class='danger'>You feel a powerful jolt!</span>")
 			H.shock_internal_organs(100)
 


### PR DESCRIPTION
## What Does This PR Do

This changes the handheld defibrillator, from sleeping people who are not in crit when safeties are disabled..

## Why It's Good For The Game

Handheld defibrillators are items easily available to anyone, being found all over medical, or mass produced in science. If the defibrillator is emaged or emped, it used to apply Paralysis(3) to the target upon using it on them. If you have 3 defibs, you would be able to instantly and permanently sleep someone, preventing them from calling for help and stunning them in one hit. Worse, if you combine the defibrillator with a soul stone, you could instantly sleep and shard an officer by standing beside them, zapping, and switching hands. This PR makes it so the person must be in crit, or undergoing cardiac arrest, for the paralysis affect to be applied.

## Changelog
:cl:
balance: Handheld defibrillator only paralyses the target if they are in crit or undergoing cardiac arrest.
/:cl:
