### PR TITLE
Fixes all of the projectiles firing north

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -24,7 +24,7 @@
 	var/p_x = 16
 	var/p_y = 16 // the pixel location of the tile that the player clicked. Default is the center
 	var/speed = 1			//Amount of deciseconds it takes for projectile to travel
-	var/Angle = 0
+	var/Angle = null
 	var/spread = 0			//amount (in degrees) of projectile spread
 	var/legacy = FALSE			//legacy projectile system
 	animate_movement = 0


### PR DESCRIPTION
##  What Does This PR Do
Fixes the massive bug right now that bugged all projectiles (except Emitters) to fire "North" AKA Angle 0 regardless of dir or anything.

## Why It's Good For The Game
Self-explanatory


## Changelog
:cl:FreeStylaLT
fix: Projectiles firing north only
/:cl:
