### PR TITLE
Removing a note from an airlock now puts it in your hands and talismans don't go on airlocks anymore

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -983,6 +983,15 @@ About the new airlock wires panel:
 		if(note)
 			to_chat(user, "<span class='warning'>There's already something pinned to this airlock! Use wirecutters or your hands to remove it.</span>")
 			return
+
+		if(!user.canUnEquip(C))
+			to_chat(user, "<span class='warning'>For some reason, you can't attach [C]!</span>")
+			return
+		
+		// QOL for cultists
+		if(!do_after_once(user, 10, target = src))
+			return
+		
 		if(!user.unEquip(C))
 			to_chat(user, "<span class='warning'>For some reason, you can't attach [C]!</span>")
 			return
@@ -1349,7 +1358,8 @@ About the new airlock wires panel:
 		else
 			user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
 			playsound(src, 'sound/items/wirecutter.ogg', 50, 1)
-		note.forceMove(get_turf(user))
+		if(!user.put_in_active_hand(note) && !user.put_in_inactive_hand(note))
+			note.forceMove(get_turf(user))
 		note = null
 		update_icon()
 		return TRUE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1349,8 +1349,7 @@ About the new airlock wires panel:
 		else
 			user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
 			playsound(src, 'sound/items/wirecutter.ogg', 50, 1)
-		if(!user.put_in_active_hand(note) && !user.put_in_inactive_hand(note))
-			note.forceMove(get_turf(user))
+		user.put_in_hands(note)
 		note = null
 		update_icon()
 		return TRUE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -979,19 +979,10 @@ About the new airlock wires panel:
 	else if(istype(C, /obj/item/pai_cable))	// -- TLE
 		var/obj/item/pai_cable/cable = C
 		cable.plugin(src, user)
-	else if(istype(C, /obj/item/paper) || istype(C, /obj/item/photo))
+	else if((istype(C, /obj/item/paper) && !istype(C, /obj/item/paper/talisman)) || istype(C, /obj/item/photo))
 		if(note)
 			to_chat(user, "<span class='warning'>There's already something pinned to this airlock! Use wirecutters or your hands to remove it.</span>")
 			return
-
-		if(!user.canUnEquip(C))
-			to_chat(user, "<span class='warning'>For some reason, you can't attach [C]!</span>")
-			return
-		
-		// QOL for cultists
-		if(!do_after_once(user, 10, target = src))
-			return
-		
 		if(!user.unEquip(C))
 			to_chat(user, "<span class='warning'>For some reason, you can't attach [C]!</span>")
 			return


### PR DESCRIPTION
## What Does This PR Do
As the title says

## Why It's Good For The Game
QOL mostly for players and cultists. Accidently putting a paper on the door is pain and never the goal.

## Changelog
:cl:
tweak: Cult talismans can't be placed on airlocks anymore
tweak: Removing a note from an airlock now puts it in your hands
/:cl: