### PR TITLE
Clowns learns clownish on spawn

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -294,6 +294,7 @@
 		genemutcheck(H, COMICBLOCK, null, MUTCHK_FORCED)
 		H.dna.default_blocks.Add(COMICBLOCK)
 	H.check_mutations = TRUE
+	H.add_language("Clownish")
 
 //action given to antag clowns
 /datum/action/innate/toggle_clumsy


### PR DESCRIPTION
With a grant from clown planet, Nanotrasen is now teaching Clownish classes to all hired clowns.

Clowns now get clownish on spawning. 

The reason for this change is that clowns should be the one job on the station that oughta speak clownish, and that due to it I suspect a lot of people have clownish as their second language just because they play clown now and then. 

This change should hopefully see people using other languages, as they are guaranteed to know clownish when they do play clown.

![image](https://user-images.githubusercontent.com/22121511/71030429-a84cfd80-2111-11ea-8f9e-db14a3fa9fec.png)


:cl:
add: Clowns can now always speak clownish.
/:cl: