### PR TITLE
Cult Fixes and Tweaks: Admins can cult anyone, Constructs get their comms back.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -225,9 +225,7 @@
 
 /datum/mind/proc/memory_edit_cult(mob/living/carbon/human/H)
 	. = _memory_edit_header("cult")
-	if(ismindshielded(H))
-		. += "<B>NO</B>|cultist"
-	else if(src in SSticker.mode.cult)
+	if(src in SSticker.mode.cult)
 		. += "<a href='?src=[UID()];cult=clear'>no</a>|<b><font color='red'>CULTIST</font></b>"
 		. += "<br>Give <a href='?src=[UID()];cult=tome'>tome</a>|<a href='?src=[UID()];cult=equip'>equip</a>."
 	else

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -182,7 +182,7 @@ var/global/list/all_cults = list()
 	if(!istype(cult_mind))
 		return 0
 	var/datum/game_mode/cult/cult_mode = SSticker.mode
-	if(!(cult_mind in cult) && is_convertable_to_cult(cult_mind))
+	if(!(cult_mind in cult))
 		cult += cult_mind
 		cult_mind.current.faction |= "cult"
 		var/datum/action/innate/cultcomm/C = new()

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -281,6 +281,8 @@
 
 /proc/init_construct(mob/living/simple_animal/hostile/construct/C, mob/living/simple_animal/shade/SH, obj/item/soulstone/SS, obj/structure/constructshell/T)
 	SH.mind.transfer_to(C)
+	var/datum/action/innate/cultcomm/CC = new()
+		CC.Grant(C) //We have to grant the cult comms again because they're lost during the mind transfer.
 	qdel(T)
 	qdel(SH)
 	to_chat(C, "<B>You are still bound to serve your creator, follow their orders and help them complete their goals at all costs.</B>")

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -281,8 +281,9 @@
 
 /proc/init_construct(mob/living/simple_animal/hostile/construct/C, mob/living/simple_animal/shade/SH, obj/item/soulstone/SS, obj/structure/constructshell/T)
 	SH.mind.transfer_to(C)
-	var/datum/action/innate/cultcomm/CC = new()
-		CC.Grant(C) //We have to grant the cult comms again because they're lost during the mind transfer.
+	if(iscultist(C))
+		var/datum/action/innate/cultcomm/CC = new()
+			CC.Grant(C) //We have to grant the cult comms again because they're lost during the mind transfer.
 	qdel(T)
 	qdel(SH)
 	to_chat(C, "<B>You are still bound to serve your creator, follow their orders and help them complete their goals at all costs.</B>")


### PR DESCRIPTION
## What Does This PR Do
Title.

The first part is achieved by removing a redundant is_convertible_to_cult check in the add_cultist proc, and by editing the traitor panel to not gray out 'make cultist' when the character has a mind shield.

In #12735 I changed constructs to just be mind transfers from shades. This resulted in everything transferring except the spell to speak over cult comms, which is tied to the body itself. We just check if the new construct is a cultist, and give it the comms if so.

## Why It's Good For The Game
Fixes good. Also removing that redundant check fixes really weird situations where someone would fail the is_convertible_to_cult check without a mind shield, like say a Chaplain. That would cause the player to hear the conversion sound, get text, but not actually be in the cult at all, leaving a very confused admin and player.

Also admins should be able to cult literally anyone, even through mind shields. It's adminbus.

## Changelog
:cl:
tweak: Admins can force anyone into the cult.
fix: Cult Constructs get their comms again.
/:cl:
