### PR TITLE
Balance out Traitor Clown by adding more HONK

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -189,6 +189,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/fake_revolver
 	cost = 1
 	job = list("Clown")
+	
+/datum/uplink_item/jobspecific/honker
+	name = "H.O.N.K"
+	desc = "Produced by \"Tyranny of Honk, INC\", this exosuit is designed as heavy clown-support. Used to spread the fun and joy of life. HONK!"
+	reference = "HONK"
+	item = /obj/mecha/combat/honker/loaded
+	cost = 1
+	job = list("Clown")
 /*
 /datum/uplink_item/stealthy_weapons/romerol_kit
 	name = "Romerol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives Traitor Clowns the ability to spread the fun and joy of life

## Why It's Good For The Game
Not every tool required needs to be lethal and not every tool needs to be S-Class contraband, sometimes you do not need a person killing everyone, but a common enemy in a HONK Mech!

## Images of changes
![image](https://user-images.githubusercontent.com/21987702/71047685-e27fc480-213c-11ea-9340-bac19a87de33.png)

## Changelog
:cl:
add: Add a honker to the syndicate uplink when mindrole "Clown"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
