### PR TITLE
ID computer can no longer encourage Magi/BS/NTR as job transfer options

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -53,6 +53,7 @@
 	var/exp_type = ""
 
 	var/disabilities_allowed = 1
+	var/transfer_allowed = TRUE // If false, ID computer will always discourage transfers to this job, even if player is eligible
 
 	var/admin_only = 0
 	var/spawn_ert = 0
@@ -265,6 +266,8 @@
 		PDA.name = "PDA-[H.real_name] ([PDA.ownjob])"
 
 /datum/job/proc/would_accept_job_transfer_from_player(mob/player)
+	if(!transfer_allowed)
+		return FALSE
 	if(!guest_jobbans(title)) // actually checks if job is a whitelisted position
 		return TRUE
 	if(!istype(player))

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -112,6 +112,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_command = 1
+	transfer_allowed = FALSE
 	minimal_player_age = 21
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_COURT, ACCESS_FORENSICS_LOCKERS,
 			            ACCESS_MEDICAL, ACCESS_ENGINE, ACCESS_CHANGE_IDS, ACCESS_EVA, ACCESS_HEADS,
@@ -155,6 +156,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_command = 1
+	transfer_allowed = FALSE
 	minimal_player_age = 21
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_COURT, ACCESS_FORENSICS_LOCKERS,
 			            ACCESS_MEDICAL, ACCESS_ENGINE, ACCESS_CHANGE_IDS, ACCESS_EVA, ACCESS_HEADS,
@@ -198,6 +200,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_legal = 1
+	transfer_allowed = FALSE
 	minimal_player_age = 30
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_COURT, ACCESS_FORENSICS_LOCKERS,
 			            ACCESS_MEDICAL, ACCESS_ENGINE, ACCESS_CHANGE_IDS, ACCESS_EVA, ACCESS_HEADS,


### PR DESCRIPTION
## What Does This PR Do
Prior to this PR, Magi/Blueshield/NTR were treated the same as other karma jobs - they could be shown as 'encouraged' (ie: green highlight) job transfer options under certain conditions (job slot is free, player has job unlocked, etc).
With this PR, these three jobs are now always shown as 'discouraged' job transfer options. IE, they can never be shown in green, they can only be shown in gray, with text that turns red if you mouse over it.

This is a purely cosmetic change. It does not stop you from assigning these jobs to an ID.
All it does is change the way these options are displayed, such that the ID computer never encourages you to pick these options anymore.

## Why It's Good For The Game
Last week, the heads made a decision to stop allowing job transfers to Magi/BS/NTR. Primarily because we did not want Captains giving these jobs to their allies, which would undermine the vital oversight these jobs are meant to provide.
Currently, the ID computer still treats them like other karma jobs, and encourages them in some cases.
With this PR, the ID computer stops encouraging things that are against SOP and which the heads have decided shouldn't happen.

:cl: Kyep
tweak: ID computer will no longer encourage job transfers to Magi/BS/NTR.
/:cl: