### PR TITLE
Gives sleepers and cryotubes the ability to auto-eject dead people

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -23,6 +23,7 @@
 	var/initial_bin_rating = 1
 	var/min_health = -25
 	var/controls_inside = FALSE
+	var/autoeject_dead = FALSE
 	idle_power_usage = 1250
 	active_power_usage = 2500
 
@@ -81,8 +82,19 @@
 	go_out()
 
 /obj/machinery/sleeper/process()
-	if(filtering > 0)
-		if(beaker)
+	for(var/mob/M as mob in src) // makes sure that simple mobs don't get stuck inside a sleeper when they resist out of occupant's grasp
+		if(M == occupant)
+			continue
+		else
+			M.forceMove(loc)
+
+	if(occupant)
+		if(autoeject_dead && occupant.is_dead())
+			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 40)
+			go_out()
+			return
+
+		else if((filtering > 0) && beaker)
 			// To prevent runtimes from drawing blood from runtime, and to prevent getting IPC blood.
 			if(!istype(occupant) || !occupant.dna || (NO_BLOOD in occupant.dna.species.species_traits))
 				filtering = 0
@@ -94,7 +106,6 @@
 					occupant.reagents.trans_to(beaker, 3)
 					occupant.transfer_blood_to(beaker, 1)
 
-	if(occupant)
 		for(var/A in occupant.reagents.addiction_list)
 			var/datum/reagent/R = A
 
@@ -105,12 +116,6 @@
 				to_chat(occupant, "<span class='notice'>You no longer feel reliant on [R.name]!</span>")
 				occupant.reagents.addiction_list.Remove(R)
 				qdel(R)
-
-	for(var/mob/M as mob in src) // makes sure that simple mobs don't get stuck inside a sleeper when they resist out of occupant's grasp
-		if(M == occupant)
-			continue
-		else
-			M.forceMove(loc)
 
 	updateDialog()
 	return
@@ -201,6 +206,7 @@
 	data["maxchem"] = max_chem
 	data["minhealth"] = min_health
 	data["dialysis"] = filtering
+	data["autoeject_dead"] = autoeject_dead
 	if(beaker)
 		data["isBeakerLoaded"] = 1
 		if(beaker.reagents)
@@ -255,12 +261,22 @@
 					inject_chemical(usr,href_list["chemical"],text2num(href_list["amount"]))
 				else
 					to_chat(usr, "<span class='danger'>This person is not in good enough condition for sleepers to be effective! Use another means of treatment, such as cryogenics!</span>")
+
 		if(href_list["removebeaker"])
 			remove_beaker()
+
 		if(href_list["togglefilter"])
 			toggle_filter()
+
 		if(href_list["ejectify"])
 			eject()
+
+		if(href_list["autoeject_dead_on"])
+			autoeject_dead = TRUE
+
+		if(href_list["autoeject_dead_off"])
+			autoeject_dead = FALSE
+
 		add_fingerprint(usr)
 	return 1
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -23,7 +23,7 @@
 	var/initial_bin_rating = 1
 	var/min_health = -25
 	var/controls_inside = FALSE
-	var/autoeject_dead = FALSE
+	var/auto_eject_dead = FALSE
 	idle_power_usage = 1250
 	active_power_usage = 2500
 
@@ -89,12 +89,12 @@
 			M.forceMove(loc)
 
 	if(occupant)
-		if(autoeject_dead && occupant.is_dead())
-			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 40)
+		if(auto_eject_dead && occupant.is_dead())
+			playsound(loc, 'sound/machines/buzz-sigh.ogg', 40)
 			go_out()
 			return
 
-		else if((filtering > 0) && beaker)
+		if(filtering > 0 && beaker)
 			// To prevent runtimes from drawing blood from runtime, and to prevent getting IPC blood.
 			if(!istype(occupant) || !occupant.dna || (NO_BLOOD in occupant.dna.species.species_traits))
 				filtering = 0
@@ -206,7 +206,7 @@
 	data["maxchem"] = max_chem
 	data["minhealth"] = min_health
 	data["dialysis"] = filtering
-	data["autoeject_dead"] = autoeject_dead
+	data["auto_eject_dead"] = auto_eject_dead
 	if(beaker)
 		data["isBeakerLoaded"] = 1
 		if(beaker.reagents)
@@ -271,11 +271,11 @@
 		if(href_list["ejectify"])
 			eject()
 
-		if(href_list["autoeject_dead_on"])
-			autoeject_dead = TRUE
+		if(href_list["auto_eject_dead_on"])
+			auto_eject_dead = TRUE
 
-		if(href_list["autoeject_dead_off"])
-			autoeject_dead = FALSE
+		if(href_list["auto_eject_dead_off"])
+			auto_eject_dead = FALSE
 
 		add_fingerprint(usr)
 	return 1

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -89,7 +89,7 @@
 			M.forceMove(loc)
 
 	if(occupant)
-		if(auto_eject_dead && occupant.is_dead())
+		if(auto_eject_dead && occupant.stat == DEAD)
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 40)
 			go_out()
 			return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -17,7 +17,8 @@
 	var/temperature_archived
 	var/mob/living/carbon/occupant = null
 	var/obj/item/reagent_containers/glass/beaker = null
-	var/auto_eject_prefs = 0
+	/// Holds two bitflags, AUTO_EJECT_DEAD and AUTO_EJECT_HEALTHY. Used to determine if the cryo cell will auto-eject dead and/or completely health patients.
+	var/auto_eject_prefs = NONE
 
 	var/next_trans = 0
 	var/current_heat_capacity = 50
@@ -442,6 +443,7 @@
 	for(var/atom/movable/A in contents - component_parts - list(beaker))
 		A.forceMove(get_step(loc, SOUTH))
 
+/// Called when either the occupant is dead and the AUTO_EJECT_DEAD flag is present, OR the occupant is alive, has no external damage, and the AUTO_EJECT_HEALTHY flag is present.
 /obj/machinery/atmospherics/unary/cryo_cell/proc/auto_eject(eject_flag)
 	on = FALSE
 	go_out()

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -97,11 +97,21 @@
 			{{:helper.link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
 		</div>
 	</div>
+
+	<div class="item">&nbsp;</div>
 	<div class="item">
 		<div class="itemLabel" style="width: 70%">
-			Auto-eject:
+			Auto-eject healthy patients:
 		</div>
 		<div class="itemContent" style="width: 30%;">
-			{{:helper.link('On', 'power-off', {'autoejectOn' : 1}, data.autoeject ? 'selected' : null)}}{{:helper.link('Off', 'close', {'autoejectOff' : 1}, data.autoeject ? null : 'selected')}}
+			{{:helper.link('On', 'power-off', {'autoeject_healthy_on' : 1}, data.autoeject_healthy ? 'selected' : null)}}{{:helper.link('Off', 'close', {'autoeject_healthy_off' : 0}, data.autoeject_healthy ? null : 'selected')}}
+		</div>
+	</div>
+	<div class="item">
+		<div class="itemLabel" style="width: 70%">
+			Auto-eject dead patients:
+		</div>
+		<div class="itemContent" style="width: 30%;">
+			{{:helper.link('On', 'power-off', {'autoeject_dead_on' : 1}, data.autoeject_dead ? 'selected' : null)}}{{:helper.link('Off', 'close', {'autoeject_dead_off' : 0}, data.autoeject_dead ? null : 'selected')}}
 		</div>
 	</div>

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -104,7 +104,7 @@
 			Auto-eject healthy patients:
 		</div>
 		<div class="itemContent" style="width: 30%;">
-			{{:helper.link('On', 'power-off', {'autoeject_healthy_on' : 1}, data.autoeject_healthy ? 'selected' : null)}}{{:helper.link('Off', 'close', {'autoeject_healthy_off' : 0}, data.autoeject_healthy ? null : 'selected')}}
+			{{:helper.link('On', 'power-off', {'auto_eject_healthy_on' : 1}, data.auto_eject_healthy ? 'selected' : null)}}{{:helper.link('Off', 'close', {'auto_eject_healthy_off' : 0}, data.auto_eject_healthy ? null : 'selected')}}
 		</div>
 	</div>
 	<div class="item">
@@ -112,6 +112,6 @@
 			Auto-eject dead patients:
 		</div>
 		<div class="itemContent" style="width: 30%;">
-			{{:helper.link('On', 'power-off', {'autoeject_dead_on' : 1}, data.autoeject_dead ? 'selected' : null)}}{{:helper.link('Off', 'close', {'autoeject_dead_off' : 0}, data.autoeject_dead ? null : 'selected')}}
+			{{:helper.link('On', 'power-off', {'auto_eject_dead_on' : 1}, data.auto_eject_dead ? 'selected' : null)}}{{:helper.link('Off', 'close', {'auto_eject_dead_off' : 0}, data.auto_eject_dead ? null : 'selected')}}
 		</div>
 	</div>

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -197,5 +197,15 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 		</div>
 	</div>
     {{/for}}
+
+	<div class="item">&nbsp;</div>
+	<div class="item">
+		<div class="itemLabel" style="width: 35%">
+			Auto-eject dead patients:
+		</div>
+		<div class="itemContent" style="width: 30%">
+			{{:helper.link('On', 'power-off', {'autoeject_dead_on' : 1}, data.autoeject_dead ? 'selected' : null)}}{{:helper.link('Off', 'close', {'autoeject_dead_off' : 0}, data.autoeject_dead ? null : 'selected')}}
+		</div>
+	</div>
 </div>
 

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -204,7 +204,7 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 			Auto-eject dead patients:
 		</div>
 		<div class="itemContent" style="width: 30%">
-			{{:helper.link('On', 'power-off', {'autoeject_dead_on' : 1}, data.autoeject_dead ? 'selected' : null)}}{{:helper.link('Off', 'close', {'autoeject_dead_off' : 0}, data.autoeject_dead ? null : 'selected')}}
+			{{:helper.link('On', 'power-off', {'auto_eject_dead_on' : 1}, data.auto_eject_dead ? 'selected' : null)}}{{:helper.link('Off', 'close', {'auto_eject_dead_off' : 0}, data.auto_eject_dead ? null : 'selected')}}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a button to medical sleepers and cryotubes, that when toggled on, auto-ejects dead occupants and plays a buzz noise when it's ejects them.

## Why It's Good For The Game
I think it's bad that cryotubes and sleepers have no visual indicator that the person inside is currently alive or dead. This at least gives people the option to auto-eject those dead patients so they don't spend lots of time sitting there dead while no one notices them.

You could argue this is a "git gud" issue for doctors, and that they need to pay attention more. However, I would say that when things get really hectic and you have doctors running all over, frantically trying to heal and perform surgery during a crisis, they can easily forget to check these two machines, *especially* the sleeper. I've seen players sit in these for upwards of 10-15 minutes, myself included, and that's just frustrating and annoying for the player stuck in the sleeper/cryotube.

## Images of changes
![c](https://user-images.githubusercontent.com/42044220/71116913-a8451000-219a-11ea-83b9-cca05bee18eb.png)
![s](https://user-images.githubusercontent.com/42044220/71116916-abd89700-219a-11ea-9f67-a504b5398144.png)


## Changelog
:cl:
add: Gives sleepers and cryotubes the ability to auto-eject dead people via a toggleable button on their interface.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
