### PR TITLE
Chaplain Zippo Relocation

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -27893,7 +27893,6 @@
 /area/chapel/main)
 "aYA" = (
 /obj/structure/table,
-/obj/item/lighter/zippo/black,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 5
@@ -29916,6 +29915,7 @@
 	network = list("SS13")
 	},
 /obj/structure/table/wood,
+/obj/item/lighter/zippo/black,
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bcx" = (


### PR DESCRIPTION
## What Does This PR Do
Moves the chaplain's lighter from the public area of the chapel to inside the chaplain's office.

## Why It's Good For The Game
The chaplain is now less vulnerable to the heinous crime of zippo theft.

## Images of changes
![zippochange](https://user-images.githubusercontent.com/56715097/71289548-66070480-233b-11ea-8be2-d7073a90af97.png)

## Changelog
:cl:
tweak: Chaplain's zippo is now in the chaplain's office.
/:cl: