### PR TITLE
UI For Air Injectors

### DIFF
--- a/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
@@ -167,60 +167,6 @@
 			icon_state = "[i == 1 && istype(loc, /turf/simulated) ? "h" : "" ]exposed"
 			on = 0
 		return*/
-/obj/machinery/atmospherics/unary/outlet_injector/attack_hand(mob/user)
-	if(..())
-		return
-
-	if(!allowed(user))
-		to_chat(user, "<span class='alert'>Access denied.</span>")
-		return
-
-	add_fingerprint(user)
-	ui_interact(user)
-
-/obj/machinery/atmospherics/unary/outlet_injector/attack_ghost(mob/user)
-	ui_interact(user)
-
-/obj/machinery/atmospherics/unary/outlet_injector/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
-	user.set_machine(src)
-	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
-	if(!ui)
-		ui = new(user, src, ui_key, "atmos_pump.tmpl", name, 310, 115, state = state)
-		ui.open()
-
-/obj/machinery/atmospherics/unary/outlet_injector/ui_data(mob/user)
-	var/list/data = list()
-	data["on"] = on
-	data["rate"] = round(volume_rate)
-	data["max_rate"] = round(MAX_TRANSFER_RATE)
-	return data
-
-/obj/machinery/atmospherics/unary/outlet_injector/Topic(href,href_list)
-	if(..())
-		return 1
-
-	if(href_list["power"])
-		on = !on
-		investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
-		. = TRUE
-	if(href_list["rate"])
-		var/rate = href_list["rate"]
-		if(rate == "max")
-			rate = MAX_TRANSFER_RATE
-			. = TRUE
-		else if(rate == "input")
-			rate = input("New transfer rate (0-[MAX_TRANSFER_RATE] L/s):", name, volume_rate) as num|null
-			if(!isnull(rate))
-				. = TRUE
-		else if(text2num(rate) != null)
-			rate = text2num(rate)
-			. = TRUE
-		if(.)
-			volume_rate = Clamp(rate, 0, MAX_TRANSFER_RATE)
-			investigate_log("was set to [volume_rate] L/s by [key_name(usr)]", "atmos")
-
-	update_icon()
-	SSnanoui.update_uis(src)
 
 /obj/machinery/atmospherics/unary/outlet_injector/multitool_menu(var/mob/user,var/obj/item/multitool/P)
 	return {"

--- a/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
@@ -167,6 +167,60 @@
 			icon_state = "[i == 1 && istype(loc, /turf/simulated) ? "h" : "" ]exposed"
 			on = 0
 		return*/
+/obj/machinery/atmospherics/unary/outlet_injector/attack_hand(mob/user)
+	if(..())
+		return
+
+	if(!allowed(user))
+		to_chat(user, "<span class='alert'>Access denied.</span>")
+		return
+
+	add_fingerprint(user)
+	ui_interact(user)
+
+/obj/machinery/atmospherics/unary/outlet_injector/attack_ghost(mob/user)
+	ui_interact(user)
+
+/obj/machinery/atmospherics/unary/outlet_injector/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
+	user.set_machine(src)
+	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "atmos_pump.tmpl", name, 310, 115, state = state)
+		ui.open()
+
+/obj/machinery/atmospherics/unary/outlet_injector/ui_data(mob/user)
+	var/list/data = list()
+	data["on"] = on
+	data["rate"] = round(volume_rate)
+	data["max_rate"] = round(MAX_TRANSFER_RATE)
+	return data
+
+/obj/machinery/atmospherics/unary/outlet_injector/Topic(href,href_list)
+	if(..())
+		return 1
+
+	if(href_list["power"])
+		on = !on
+		investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
+		. = TRUE
+	if(href_list["rate"])
+		var/rate = href_list["rate"]
+		if(rate == "max")
+			rate = MAX_TRANSFER_RATE
+			. = TRUE
+		else if(rate == "input")
+			rate = input("New transfer rate (0-[MAX_TRANSFER_RATE] L/s):", name, volume_rate) as num|null
+			if(!isnull(rate))
+				. = TRUE
+		else if(text2num(rate) != null)
+			rate = text2num(rate)
+			. = TRUE
+		if(.)
+			volume_rate = Clamp(rate, 0, MAX_TRANSFER_RATE)
+			investigate_log("was set to [volume_rate] L/s by [key_name(usr)]", "atmos")
+
+	update_icon()
+	SSnanoui.update_uis(src)
 
 /obj/machinery/atmospherics/unary/outlet_injector/multitool_menu(var/mob/user,var/obj/item/multitool/P)
 	return {"


### PR DESCRIPTION
## What Does This PR Do
Gives air injectors an on-click UI that can be used to toggle them on and off, and set their flow rate between 0-200l/s. Does not conflict with computer controls.

## Why It's Good For The Game
Air injectors can now be used without having to build a large tank control computer to turn them on and off, and without having to build an atmospherics automation console to change the flow rate.

Please merge this. For the love of atmos, merge this.

## Images of changes
![MAGIC](https://user-images.githubusercontent.com/56715097/71313309-c1e99000-2404-11ea-869b-30cb741c9118.png)

## Changelog
:cl:
tweak: Gave air injectors a nanoUI.
/:cl: