### PR TITLE
Removed Facehuggers functioning as breath masks

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -15,7 +15,6 @@ var/const/MAX_ACTIVE_TIME = 400
 	w_class = WEIGHT_CLASS_TINY //note: can be picked up by aliens unlike most other items of w_class below 4
 	throw_range = 5
 	tint = 3
-	flags = AIRTIGHT
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
 	layer = MOB_LAYER
 	max_integrity = 100


### PR DESCRIPTION
## What Does This PR Do
It removes facehuggers working as breath masks.

## Why It's Good For The Game
It doesn't really make any sense mechanically or lore-wise, I feel like facehuggers working with internals happened from a copy+paste error at some point.

## Changelog
:cl:RobinFox
fix: Facehuggers no longer work as breath masks
/:cl:
