### PR TITLE
Adds new crates to cargo

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -639,11 +639,11 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_packs/engineering/engine/field_gen
-	name = "Field Generator Crate"
+	name = "Containment Field Generator Crate"
 	contains = list(/obj/machinery/field/generator,
 					/obj/machinery/field/generator)
 	cost = 10
-	containername = "field generator crate"
+	containername = "containment field generator crate"
 
 /datum/supply_packs/engineering/engine/sing_gen
 	name = "Singularity Generator Crate"
@@ -962,7 +962,24 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "surgery crate"
 	access = access_medical
 
-
+/datum/supply_packs/medical/doctorpack
+	name = "Doctor Starter Pack"
+	contains = list(/obj/item/storage/backpack/medic,
+					/obj/item/storage/backpack/duffel/medical,
+					/obj/item/clothing/under/rank/medical,
+					/obj/item/clothing/suit/storage/labcoat,
+					/obj/item/clothing/shoes/white,
+					/obj/item/radio/headset/headset_med,
+					/obj/item/clothing/gloves/color/latex/nitrile,
+					/obj/item/defibrillator/loaded,
+					/obj/item/handheld_defibrillator,
+					/obj/item/storage/belt/medical,
+					/obj/item/clothing/glasses/hud/health,
+	 				/obj/item/clothing/shoes/sandal/white)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure
+	containername = "doctor starter pack"
+	access = access_medical
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -1097,6 +1114,23 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
     containertype = /obj/structure/closet/crate/secure/unknownchemicals
     containername = "grey-market chemical supply kit"
     contraband = 1
+
+datum/supply_packs/science/sciencepack
+	name = "Scientest Starter Pack"
+	contains = list(/obj/item/storage/backpack/science,
+					/obj/item/storage/backpack/satchel_tox,
+					/obj/item/clothing/under/rank/scientist,
+					/obj/item/clothing/under/rank/scientist/skirt,
+					/obj/item/clothing/suit/storage/labcoat/science,
+					/obj/item/clothing/shoes/white,
+					/obj/item/radio/headset/headset_sci,
+					/obj/item/tank/air,
+					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/shoes/sandal/white,)
+	cost = 25 //only the headset is hard to get here, compaired to the sec and medical packs
+	containertype = /obj/structure/closet/crate/secure
+	containername = "scientest starter pack"
+	access = access_research
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Organic /////////////////////////////////////////
@@ -1435,7 +1469,6 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 20
 	containername = "sandstone blocks crate"
 
-
 /datum/supply_packs/materials/plastic30
 	name = "30 Plastic Sheets Crate"
 	contains = list(/obj/item/stack/sheet/plastic)
@@ -1443,6 +1476,12 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 20
 	containername = "plastic sheets crate"
 
+/datum/supply_packs/materials/cloth30
+	name = "30 Cloth Sheets Crate"
+	contains = list(/obj/item/stack/sheet/cloth)
+	amount = 30
+	cost = 15
+	containername = "cloth sheets crate"
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -1958,6 +1997,19 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/stack/tile/grass/twentyfive,
 					/obj/item/stack/tile/wood/twentyfive)
 	containername = "fancy flooring crate"
+
+/datum/supply_packs/misc/barberpack
+	name = "Barber Starter Kit Crate"
+	cost = 30
+	contains = list(/obj/item/scissors/barber,
+					/obj/item/hair_dye_bottle,
+					/obj/item/reagent_containers/glass/bottle/reagent/hairgrownium,
+					/obj/item/reagent_containers/glass/bottle/reagent/hair_dye,
+					/obj/item/reagent_containers/glass/bottle/reagent,
+					/obj/item/reagent_containers/dropper,
+					/obj/item/clothing/mask/fakemoustache,
+					/obj/machinery/dye_generator) // Incase the first one blows up, no other way to get a second one
+	containername = "barber starter kit crate"
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Vending /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1949,6 +1949,15 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/sparkler,
 					/obj/item/sparkler)
 	containername = "pyrotechnics display crate"
+
+/datum/supply_packs/misc/carpet
+	name = "Fancy Flooring Crate"
+	cost = 20
+	contains = list(/obj/item/stack/tile/carpet/twentyfive,
+					/obj/item/stack/tile/carpet/black/twentyfive,
+					/obj/item/stack/tile/grass/twentyfive,
+					/obj/item/stack/tile/wood/twentyfive)
+	containername = "fancy flooring crate"
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Vending /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1881,6 +1881,20 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					)
 	special = TRUE
 
+/datum/supply_packs/misc/fireworks
+	name = "Pyrotechnics Display Crate"
+	cost = 10
+	contains = list(/obj/item/firework,
+					/obj/item/firework,
+					/obj/item/firework,
+					/obj/item/firework,
+					/obj/item/firework,
+					/obj/item/sparkler,
+					/obj/item/sparkler,
+					/obj/item/sparkler,
+					/obj/item/sparkler,
+					/obj/item/sparkler)
+	containername = "pyrotechnics display crate"
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Vending /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -747,7 +747,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "conveyor assembly crate"
 
 /datum/supply_packs/engineering/o2
-	name = "02 Canister"
+	name = "O2 Canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 	cost = 15
 	containername = "o2 canister crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1012,6 +1012,38 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
     containertype = /obj/structure/largecrate
     containername = "oil tank crate"
 
+/datum/supply_packs/science/chemsupply
+    name = "Chemical Supply Kit"
+    contains = list(/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem)
+    cost = 10
+    containertype = /obj/structure/closet/crate/secure/chemicals
+    containername = "chemical supply kit"
+
+/datum/supply_packs/science/greychemsupply
+    name = "Grey-market Chemical Supply Kit"
+    contains = list(/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_standard_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_chem,
+    				/obj/item/reagent_containers/glass/bottle/random_chem,
+    				/obj/item/reagent_containers/food/drinks/bottle/random_drink,
+    				/obj/item/reagent_containers/food/drinks/bottle/random_drink,
+    				/obj/item/reagent_containers/food/drinks/bottle/random_drink,
+    				/obj/item/storage/pill_bottle/random_meds)
+    cost = 10
+    containertype = /obj/structure/closet/crate/secure/unknownchemicals
+    containername = "grey-market chemical supply kit"
+    contraband = 1
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Organic /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -772,7 +772,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 
 /datum/supply_packs/engineering/air
 	name = "Air Canister"
-	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
+	contains = list(/obj/machinery/portable_atmospherics/canister/air)
 	cost = 15
 	containername = "air canister crate"
 	access = access_atmospherics
@@ -780,7 +780,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 
 /datum/supply_packs/engineering/co2
 	name = "CO2 Canister"
-	contains = list(/obj/machinery/portable_atmospherics/canister/sleeping_agent)
+	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
 	cost = 15
 	containername = "co2 canister crate"
 	access = access_atmospherics
@@ -1116,7 +1116,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
     contraband = 1
 
 datum/supply_packs/science/sciencepack
-	name = "Scientest Starter Pack"
+	name = "Scientist Starter Pack"
 	contains = list(/obj/item/storage/backpack/science,
 					/obj/item/storage/backpack/satchel_tox,
 					/obj/item/clothing/under/rank/scientist,
@@ -1129,7 +1129,7 @@ datum/supply_packs/science/sciencepack
 					/obj/item/clothing/shoes/sandal/white,)
 	cost = 25 //only the headset is hard to get here, compaired to the sec and medical packs
 	containertype = /obj/structure/closet/crate/secure
-	containername = "scientest starter pack"
+	containername = "scientist starter pack"
 	access = access_research
 
 //////////////////////////////////////////////////////////////////////////////

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -746,6 +746,60 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 15
 	containername = "conveyor assembly crate"
 
+/datum/supply_packs/engineering/o2
+	name = "02 Canister"
+	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
+	cost = 15
+	containername = "o2 canister crate"
+	access = access_atmospherics
+	containertype = /obj/structure/closet/crate/secure/engineering
+
+/datum/supply_packs/engineering/n2o
+	name = "N2O Canister"
+	contains = list(/obj/machinery/portable_atmospherics/canister/sleeping_agent)
+	cost = 15
+	containername = "n2o canister crate"
+	access = access_atmospherics
+	containertype = /obj/structure/closet/crate/secure/engineering
+
+/datum/supply_packs/engineering/n2
+	name = "N2 Canister"
+	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
+	cost = 15
+	containername = "n2 canister crate"
+	access = access_atmospherics
+	containertype = /obj/structure/closet/crate/secure/engineering
+
+/datum/supply_packs/engineering/air
+	name = "Air Canister"
+	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
+	cost = 15
+	containername = "air canister crate"
+	access = access_atmospherics
+	containertype = /obj/structure/closet/crate/secure/engineering
+
+/datum/supply_packs/engineering/co2
+	name = "CO2 Canister"
+	contains = list(/obj/machinery/portable_atmospherics/canister/sleeping_agent)
+	cost = 15
+	containername = "co2 canister crate"
+	access = access_atmospherics
+	containertype = /obj/structure/closet/crate/secure/engineering
+
+/datum/supply_packs/engineering/plasma
+	name = "Plasma Canister"
+	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
+	cost = 25 //It's plasma,more expencive
+	containername = "plasma canister crate"
+	access = access_atmospherics
+	containertype = /obj/structure/closet/crate/secure/engineering
+
+/datum/supply_packs/engineering/pacman
+	name = "P.A.C.M.A.N Crate"
+	contains  = list(/obj/machinery/power/port_gen/pacman) // no plasma in the crate, can't let cargo ship plasma back
+	cost = 20
+	containername = "p.a.c.m.a.n crate"
+	containertype = /obj/structure/closet/crate/engineering/electrical
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Medical /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -152,6 +152,17 @@
 	name = "variety pillbottle"
 	labelled = TRUE
 
+/obj/item/reagent_containers/food/drinks/bottle/random_standard_chem
+	name = "unlabelled chemical bottle"
+
+/obj/item/reagent_containers/glass/bottle/random_standard_chem/New()
+	..()
+	var/datum/reagent/R = pick(GLOB.standard_chemicals)
+	reagents.add_reagent(R, rand(2, 6)*5)
+	name = "unlabelled bottle"
+	pixel_x = rand(-10, 10)
+	pixel_y = rand(-10, 10)
+
 
 // -------------------------------------
 //    Containers full of unknown crap
@@ -162,37 +173,24 @@
 	desc = "Crate full of chemicals of unknown type and value from a 'trusted' source."
 	req_one_access = list(access_chemistry,access_research,access_qm) // the qm knows a guy, you see.
 
-/obj/structure/closet/crate/secure/unknownchemicals/New()
+/obj/structure/closet/crate/secure/unknownchemicals/full
+	name = "grey-market chemicals grab pack"
+	desc = "Crate full of chemicals of unknown type and value from a 'trusted' source."
+	req_one_access = list(access_chemistry,access_research,access_qm) // the qm knows a guy, you see.
+
+/obj/structure/closet/crate/secure/unknownchemicals/full/New()
 	..()
-	for(var/i in 1 to 7)
-		new/obj/item/reagent_containers/glass/bottle/random_base_chem(src)
 	for(var/i in 1 to 3)
+		new/obj/item/reagent_containers/glass/bottle/random_standard_chem(src)
 		new/obj/item/reagent_containers/glass/bottle/random_chem(src)
-	while(prob(50))
-		new/obj/item/reagent_containers/glass/bottle/random_reagent(src)
+		new/obj/item/reagent_containers/food/drinks/bottle/random_drink(src)
 
 	new/obj/item/storage/pill_bottle/random_meds(src)
-	while(prob(25))
-		new/obj/item/storage/pill_bottle/random_meds(src)
 
 /obj/structure/closet/crate/secure/chemicals
 	name = "chemical supply kit"
 	desc = "Full of basic chemistry supplies."
 	req_one_access = list(access_chemistry,access_research)
-
-/obj/structure/closet/crate/secure/chemicals/New()
-	..()
-	for(var/chem in GLOB.standard_chemicals)
-		var/obj/item/reagent_containers/glass/bottle/B = new(src)
-		B.reagents.add_reagent(chem, B.volume)
-		if(prob(85))
-			var/datum/reagent/r = GLOB.chemical_reagents_list[chem]
-			B.name	= "[r.name] bottle"
-//			B.identify_probability = 100
-		else
-			B.name	= "unlabelled bottle"
-			B.desc	= "Looks like the label fell off."
-//			B.identify_probability = 0
 //
 /*
 /obj/structure/closet/crate/bin/flowers

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -83,6 +83,9 @@
 	turf_type = /turf/simulated/floor/grass
 	resistance_flags = FLAMMABLE
 
+/obj/item/stack/tile/grass/twentyfive
+		amount = 25
+
 //Wood
 /obj/item/stack/tile/wood
 	name = "wood floor tiles"
@@ -94,6 +97,9 @@
 	turf_type = /turf/simulated/floor/wood
 	resistance_flags = FLAMMABLE
 
+/obj/item/stack/tile/wood/twentyfive
+		amount = 25
+
 //Carpets
 /obj/item/stack/tile/carpet
 	name = "carpet"
@@ -103,10 +109,16 @@
 	turf_type = /turf/simulated/floor/carpet
 	resistance_flags = FLAMMABLE
 
+/obj/item/stack/tile/carpet/twentyfive
+		amount = 25
+
 /obj/item/stack/tile/carpet/black
 	name = "black carpet"
 	icon_state = "tile-carpet-black"
 	turf_type = /turf/simulated/floor/carpet/black
+
+/obj/item/stack/tile/carpet/black/twentyfive
+		amount = 25
 
 //Plasteel
 /obj/item/stack/tile/plasteel

--- a/code/game/objects/items/weapons/fireworks.dm
+++ b/code/game/objects/items/weapons/fireworks.dm
@@ -11,6 +11,7 @@ obj/item/firework/attackby(obj/item/W,mob/user, params)
 		for(var/mob/M in viewers(user))
 			to_chat(M, "[user] lits \the [src]")
 		litzor = 1
+		set_light(2)
 		icon_state = "rocket_1"
 		S = new()
 		S.set_up(5,0,src.loc)
@@ -24,6 +25,7 @@ obj/item/sparkler
 	name = "sparkler"
 	icon = 'icons/obj/fireworks.dmi'
 	icon_state = "sparkler_0"
+	item_state = "flare"
 	var/litzor = 0
 
 obj/item/sparkler/attackby(obj/item/W,mob/user, params)
@@ -33,11 +35,13 @@ obj/item/sparkler/attackby(obj/item/W,mob/user, params)
 		for(var/mob/M in viewers(user))
 			to_chat(M, "[user] lits \the [src]")
 		litzor = 1
+		set_light(2)
 		icon_state = "sparkler_1"
-		var/b = rand(5,9)
+		item_state = "flare-on"
+		var/b = rand(9,19)
 		for(var/xy, xy<=b, xy++)
 			do_sparks(1, 0, loc)
-			sleep(10)
+			sleep(8)
 		qdel(src)
 /obj/crate/fireworks
 	name = "Fireworks!"

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -426,11 +426,13 @@
 	var/packs_list[0]
 	for(var/set_name in SSshuttle.supply_packs)
 		var/datum/supply_packs/pack = SSshuttle.supply_packs[set_name]
-		if(!pack.contraband && !pack.hidden && !pack.special && pack.group == cat)
+		if((!pack.contraband && !pack.hidden && !pack.special && pack.group == cat) || (!pack.contraband && !pack.hidden && (pack.special && pack.special_enabled) && pack.group == cat))
 			// 0/1 after the pack name (set_name) is a boolean for ordering multiple crates
 			packs_list.Add(list(list("name" = pack.name, "amount" = pack.amount, "cost" = pack.cost, "command1" = list("doorder" = "[set_name]0"), "command2" = list("doorder" = "[set_name]1"), "command3" = list("contents" = set_name))))
 
+
 	data["supply_packs"] = packs_list
+
 	if(content_pack)
 		var/pack_name = sanitize(content_pack.name)
 		data["contents_name"] = pack_name

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -430,7 +430,6 @@
 			// 0/1 after the pack name (set_name) is a boolean for ordering multiple crates
 			packs_list.Add(list(list("name" = pack.name, "amount" = pack.amount, "cost" = pack.cost, "command1" = list("doorder" = "[set_name]0"), "command2" = list("doorder" = "[set_name]1"), "command3" = list("contents" = set_name))))
 
-
 	data["supply_packs"] = packs_list
 	if(content_pack)
 		var/pack_name = sanitize(content_pack.name)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -426,13 +426,12 @@
 	var/packs_list[0]
 	for(var/set_name in SSshuttle.supply_packs)
 		var/datum/supply_packs/pack = SSshuttle.supply_packs[set_name]
-		if((!pack.contraband && !pack.hidden && !pack.special && pack.group == cat) || (!pack.contraband && !pack.hidden && (pack.special && pack.special_enabled) && pack.group == cat))
+		if(!pack.contraband && !pack.hidden && !pack.special && pack.group == cat)
 			// 0/1 after the pack name (set_name) is a boolean for ordering multiple crates
 			packs_list.Add(list(list("name" = pack.name, "amount" = pack.amount, "cost" = pack.cost, "command1" = list("doorder" = "[set_name]0"), "command2" = list("doorder" = "[set_name]1"), "command3" = list("contents" = set_name))))
 
 
 	data["supply_packs"] = packs_list
-
 	if(content_pack)
 		var/pack_name = sanitize(content_pack.name)
 		data["contents_name"] = pack_name


### PR DESCRIPTION
## What Does This PR Do
This PR adds many new crates to cargo for ordering. The point costs should be adjusted for some of them, and suggestions are welcome. New crates that are added are: 

2 chemistry crates with some random reagents / drinks, for experimentation, or making a suspicious bar without knowing what you are drinking.

A fireworks crate, full of 5 fireworks and sparklers for crew parties, sparklers and fireworks were slightly adjusted to give off light, and the sparkler now uses the flare sprite in hand

A P.A.C.M.A.N crate was added, for when power is needed in an area due to damage, and science is unable to build new ones.

Canister crates for every gas, for when atmospherics goes boom and you need some more air, plasma, or n20.

A fancy flooring crate, full of 25 of each carpet type, 25 grass tiles, and 25 wood tiles.

A cloth crate, for people who want to tailor, or if sec wants new blindfolds.

3 new starter pack crates, a medical starter pack, a science stater pack, and a barber starter pack crate. Mostly good for if you run out of departmental headsets for some reason, but the barber crate can replace the dye generator, as if it is destroyed currently there is no other way to get a second one.

This also renames field generator crates to containment field generator crates, to make it more clear what it is.

## Why It's Good For The Game
Adds more stuff for cargo to order that's interesting and not dangerous, helps things like the die vendor get replaced, or canisters if atmospherics goes boom.

## Images of changes

https://imgur.com/a/woEx9tZ

## Changelog
:cl:
add: Added cloth crate, carpet crate, fireworks crate, medical science and barber starter pack, gas canister crates, P.A.C.M.A.N crate, and 2 chemistry crates.
tweak: Renamed Field Generator Crate to Containment Field Generator Crate.
/:cl: