### PR TITLE
Ported Skittish trait from TG, added Skittish trait to Vox.

### DIFF
--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -63,6 +63,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //mob traits
 #define TRAIT_PACIFISM			"pacifism"
 #define TRAIT_WATERBREATH       "waterbreathing"
+#define TRAIT_SKITTISH			"skittish"
 
 // common trait sources
 #define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -287,6 +287,13 @@
 		user.visible_message("<span class='danger'>[user] stuffs [O] into [src]!</span>", "<span class='danger'>You stuff [O] into [src]!</span>")
 	add_fingerprint(user)
 
+/obj/structure/closet/CtrlShiftClick(mob/living/user)
+	if(!HAS_TRAIT(user, TRAIT_SKITTISH))
+		return ..()
+	if(!isturf(user.loc) || !Adjacent(user))
+		return
+	dive_into(user)
+
 /obj/structure/closet/attack_ai(mob/user)
 	if(isrobot(user) && Adjacent(user)) //Robots can open/close it, but not the AI
 		attack_hand(user)
@@ -453,3 +460,25 @@
 /obj/structure/closet/bluespace/close()
 	. = ..()
 	density = 0
+
+/obj/structure/closet/proc/dive_into(mob/living/user)
+	var/turf/T1 = get_turf(user)
+	var/turf/T2 = get_turf(src)
+	if(!opened)
+		if(locked)
+			togglelock(user, TRUE)
+		if(!open(user))
+			to_chat(user, "<span class='warning'>It won't budge!</span>")
+			return
+	step_towards(user, T2)
+	T1 = get_turf(user)
+	if(T1 == T2)
+		if(!close(user))
+			to_chat(user, "<span class='warning'>You can't get [src] to close!</span>")
+			return
+		togglelock(user)
+		T1.visible_message("<span class='warning'>[user] dives into [src]!</span>")
+
+/obj/structure/closet/proc/togglelock(mob/user)
+	return
+	

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -48,14 +48,14 @@
 				req_access += pick(get_all_accesses())
 	..()
 
-/obj/structure/closet/secure_closet/proc/togglelock(mob/user)
+/obj/structure/closet/secure_closet/togglelock(mob/user)
 	if(opened)
 		to_chat(user, "<span class='notice'>Close the locker first.</span>")
 		return
 	if(broken)
 		to_chat(user, "<span class='warning'>The locker appears to be broken.</span>")
 		return
-	if(user.loc == src)
+	if(user.loc == src && !HAS_TRAIT(user, TRAIT_SKITTISH))
 		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
 		return
 	if(allowed(user))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -260,7 +260,7 @@
 /obj/structure/closet/crate/secure/can_open()
 	return !locked
 
-/obj/structure/closet/crate/secure/proc/togglelock(mob/user)
+/obj/structure/closet/crate/secure/togglelock(mob/user)
 	if(src.opened)
 		to_chat(user, "<span class='notice'>Close the crate first.</span>")
 		return

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -104,6 +104,10 @@
 	H.update_icons()
 	ADD_TRAIT(H, TRAIT_SKITTISH, "species")
 
+/datum/species/vox/on_species_loss(mob/living/carbon/human/H)
+	..()
+	REMOVE_TRAIT(H, TRAIT_SKITTISH, "species")
+
 /datum/species/vox/updatespeciescolor(mob/living/carbon/human/H, owner_sensitive = 1) //Handling species-specific skin-tones for the Vox race.
 	if(H.dna.species.bodyflags & HAS_ICON_SKIN_TONE) //Making sure we don't break Armalis.
 		var/new_icobase = 'icons/mob/human_races/vox/r_vox.dmi' //Default Green Vox.

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -102,6 +102,7 @@
 	..()
 	updatespeciescolor(H)
 	H.update_icons()
+	ADD_TRAIT(H, TRAIT_SKITTISH, "species")
 
 /datum/species/vox/updatespeciescolor(mob/living/carbon/human/H, owner_sensitive = 1) //Handling species-specific skin-tones for the Vox race.
 	if(H.dna.species.bodyflags & HAS_ICON_SKIN_TONE) //Making sure we don't break Armalis.


### PR DESCRIPTION
## What Does This PR Do
Title. The Skittish trait allows the one possessing such trait to do two things. Ctrl+Shift+Left Clicking on a locker while next to it will let one instantly dive into the locker and lock it behind them, assuming it has a locker and the one in question has access. This trait also lets one open ID locked lockers from the inside assuming they have the right access. This trait was granted to Vox.

## Why It's Good For The Game
#12009 and #12343 Rebalanced Vox, and gave Vox some pretty minor upsides in turn for removal of space-proofness. Silent Footsteps while flavorful, are practically useless, and I wanted to give Vox a fun and appropriate trait. It's very niche and fun to use, and if it's worth being a round-start upside you can have on TG, I don't see it as woefully unbalanced. Vox are in a bit of worse state than most races with just taking 20% extra brute, an extremely common occurrence, with upsides that almost never come into play.

## Images of changes
Here's a poor demo. I can't really record on my device.

![bad_demo](https://user-images.githubusercontent.com/47765135/71325935-db044680-24c1-11ea-965d-23d50038e3b2.gif)



## Changelog
:cl: Cazdon
add: Skittish Trait - Allows one to dive into lockers and lock them behind them.
balance: Vox have the Skittish Trait
/:cl:
