### PR TITLE
[DNM] TEG Tweaks

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -112,9 +112,9 @@
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
 				var/carnot_limit = 1 - (cold_air.temperature / hot_air.temperature) //the theoretical limit of engine efficiency
 
-				var/inefficiency = 0.65 //0-1, how close to being a perfect Carnot engine is it?
+				var/thermocouple = 0.65 //0-1, how close to being a perfect Carnot engine is it? (this simulates the material efficiency of the thermocouple)
 
-				var/efficiency = carnot_limit * inefficiency //the percentage of thermal energy being exchanged that is turned into electrical power
+				var/efficiency = carnot_limit * thermocouple //the percentage of thermal energy being exchanged that is turned into electrical power
 
 				var/energy_transfer = delta_temperature * hot_air_heat_capacity * cold_air_heat_capacity / (hot_air_heat_capacity + cold_air_heat_capacity) //the amount of energy being taken from the hot loop
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -112,10 +112,10 @@
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
 				var/carnot_limit = 1 - (cold_air.temperature / hot_air.temperature) //the theoretical limit of engine efficiency
 
-                		var/inefficiency = 0.65 //0-1, how close to being a perfect Carnot engine is it?
+				var/inefficiency = 0.65 //0-1, how close to being a perfect Carnot engine is it?
 
 				var/efficiency = carnot_limit * inefficiency //the percentage of thermal energy being exchanged that is turned into electrical power
-				
+
 				var/energy_transfer = delta_temperature * hot_air_heat_capacity * cold_air_heat_capacity / (hot_air_heat_capacity + cold_air_heat_capacity) //the amount of energy being taken from the hot loop
 
 				var/heat = energy_transfer * (1 - efficiency) //the amount of energy being put into the cold loop

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -112,15 +112,15 @@
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
 				var/carnot_limit = 1 - (cold_air.temperature / hot_air.temperature) //the theoretical limit of engine efficiency
 
-                var/inefficiency = 0.65 //0-1, how close to being a perfect Carnot engine is it?
+                		var/inefficiency = 0.65 //0-1, how close to being a perfect Carnot engine is it?
 
-                var/efficiency = carnot_limit * inefficiency //the percentage of thermal energy being exchanged that is turned into electrical power
+				var/efficiency = carnot_limit * inefficiency //the percentage of thermal energy being exchanged that is turned into electrical power
+				
+				var/energy_transfer = delta_temperature * hot_air_heat_capacity * cold_air_heat_capacity / (hot_air_heat_capacity + cold_air_heat_capacity) //the amount of energy being taken from the hot loop
 
-                var/energy_transfer = delta_temperature * hot_air_heat_capacity * cold_air_heat_capacity / (hot_air_heat_capacity + cold_air_heat_capacity) //the amount of energy being taken from the hot loop
+				var/heat = energy_transfer * (1 - efficiency) //the amount of energy being put into the cold loop
 
-                var/heat = energy_transfer * (1 - efficiency) //the amount of energy being put into the cold loop
-
-                lastgen = energy_transfer * efficiency //the amount of power the TEG is generating
+				lastgen = energy_transfer * efficiency //the amount of power the TEG is generating
 
 				//log_debug("lastgen = [lastgen]; heat = [heat]; delta_temperature = [delta_temperature]; hot_air_heat_capacity = [hot_air_heat_capacity]; cold_air_heat_capacity = [cold_air_heat_capacity];")
 
@@ -206,13 +206,13 @@
 		t += "<div class='statusDisplay'>"
 
 		if(lastgen >= 1000000000)
-            t += "Output: [round(lastgen) / 1000000000] GW"
-        else if(lastgen >= 1000000)
-            t += "Output: [round(lastgen) / 1000000] MW"
-        else if(lastgen >= 1000)
-            t += "Output: [round(lastgen) / 1000] kW"
-        else
-            t += "Output: [round(lastgen)] W"
+			t += "Output: [round(lastgen) / 1000000000] GW"
+		else if(lastgen >= 1000000)
+			t += "Output: [round(lastgen) / 1000000] MW"
+		else if(lastgen >= 1000)
+			t += "Output: [round(lastgen) / 1000] kW"
+		else
+			t += "Output: [round(lastgen)] W"
 
 		t += "<BR>"
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -110,12 +110,17 @@
 			//log_debug("delta_temperature = [delta_temperature]; cold_air_heat_capacity = [cold_air_heat_capacity]; hot_air_heat_capacity = [hot_air_heat_capacity]")
 
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
-				var/efficiency = 0.65
+				var/carnot_limit = 1 - (cold_air.temperature / hot_air.temperature) //the theoretical limit of engine efficiency
 
-				var/energy_transfer = delta_temperature * hot_air_heat_capacity * cold_air_heat_capacity / (hot_air_heat_capacity + cold_air_heat_capacity)
+                var/inefficiency = 0.65 //0-1, how close to being a perfect Carnot engine is it?
 
-				var/heat = energy_transfer * (1 - efficiency)
-				lastgen = energy_transfer * efficiency
+                var/efficiency = carnot_limit * inefficiency //the percentage of thermal energy being turned into electrical power
+
+                var/energy_transfer = delta_temperature * hot_air_heat_capacity * cold_air_heat_capacity / (hot_air_heat_capacity + cold_air_heat_capacity) //the amount of energy being taken from the hot loop
+
+                var/heat = energy_transfer * (1 - efficiency) //the amount of energy being put into the cold loop
+
+                lastgen = energy_transfer * efficiency
 
 				//log_debug("lastgen = [lastgen]; heat = [heat]; delta_temperature = [delta_temperature]; hot_air_heat_capacity = [hot_air_heat_capacity]; cold_air_heat_capacity = [cold_air_heat_capacity];")
 
@@ -200,7 +205,14 @@
 
 		t += "<div class='statusDisplay'>"
 
-		t += "Output: [round(lastgen)] W"
+		if(lastgen >= 1000000000)
+            t += "Output: [round(lastgen) / 1000000000] GW"
+        else if(lastgen >= 1000000)
+            t += "Output: [round(lastgen) / 1000000] MW"
+        else if(lastgen >= 1000)
+            t += "Output: [round(lastgen) / 1000] kW"
+        else
+            t += "Output: [round(lastgen)] W"
 
 		t += "<BR>"
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -114,13 +114,13 @@
 
                 var/inefficiency = 0.65 //0-1, how close to being a perfect Carnot engine is it?
 
-                var/efficiency = carnot_limit * inefficiency //the percentage of thermal energy being turned into electrical power
+                var/efficiency = carnot_limit * inefficiency //the percentage of thermal energy being exchanged that is turned into electrical power
 
                 var/energy_transfer = delta_temperature * hot_air_heat_capacity * cold_air_heat_capacity / (hot_air_heat_capacity + cold_air_heat_capacity) //the amount of energy being taken from the hot loop
 
                 var/heat = energy_transfer * (1 - efficiency) //the amount of energy being put into the cold loop
 
-                lastgen = energy_transfer * efficiency
+                lastgen = energy_transfer * efficiency //the amount of power the TEG is generating
 
 				//log_debug("lastgen = [lastgen]; heat = [heat]; delta_temperature = [delta_temperature]; hot_air_heat_capacity = [hot_air_heat_capacity]; cold_air_heat_capacity = [cold_air_heat_capacity];")
 


### PR DESCRIPTION
## What Does This PR Do
Slightly modifies TEG power generation to reflect the theoretical maximum efficiency of heat engines(only significant at low temperature differentials).
Changes TEG power readout by showing output as W, kW, MW, and GW at appropriate thresholds and avoids displaying scientific notation.

Expands TEG code documentation.

## Why It's Good For The Game
TEG doesn't break laws of physics at low temperature differentials.
TEG UI will now always have a very easy to read display of its power output.

Thorough explanations are now embedded in TEG code.

## Changelog
:cl:
tweak: TEG no longer creates energy it shouldn't be able to.
tweak: TEG UI will no longer throw up ugly powers of 10 on the power display.
/:cl:
