### PR TITLE
Revert "Move the handle_changeling proc call to the (new) life signal"

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -155,7 +155,6 @@
 
 // /mob/living/carbon signals
 #define COMSIG_CARBON_SOUNDBANG "carbon_soundbang"					//from base of mob/living/carbon/soundbang_act(): (list(intensity))
-#define COMSIG_CARBON_LIFE "carbon_life"							//from base of mob/living/carbon/Life() ()
 
 // /mob/living/simple_animal/hostile signals
 #define COMSIG_HOSTILE_ATTACKINGTARGET "hostile_attackingtarget"

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -383,9 +383,6 @@ var/list/sting_paths
 	var/mob/living/carbon/C = src		//only carbons have dna now, so we have to typecaste
 	mind.changeling.absorbed_dna |= C.dna.Clone()
 	mind.changeling.trim_dna()
-
-	RegisterSignal(C, COMSIG_CARBON_LIFE, CALLBACK(C, /mob/living/carbon/.proc/handle_changeling))
-
 	return 1
 
 //Used to dump the languages from the changeling datum into the actual mob.
@@ -424,8 +421,6 @@ var/list/sting_paths
 		if(hud_used)
 			hud_used.lingstingdisplay.icon_state = null
 			hud_used.lingstingdisplay.invisibility = 101
-			hud_used.lingchemdisplay.invisibility = 101
-		UnregisterSignal(src, COMSIG_CARBON_LIFE)
 
 /datum/changeling/proc/has_sting(datum/action/power)
 	for(var/datum/action/P in purchasedpowers)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -13,13 +13,13 @@
 		for(var/obj/item/organ/internal/O in internal_organs)
 			O.on_life()
 
+	handle_changeling()
 	handle_wetness(times_fired)
 
 	// Increase germ_level regularly
 	if(germ_level < GERM_LEVEL_AMBIENT && prob(30))	//if you're just standing there, you shouldn't get more germs beyond an ambient level
 		germ_level++
 
-	SEND_SIGNAL(src, COMSIG_CARBON_LIFE, seconds, times_fired)
 
 ///////////////
 // BREATHING //


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#12798

Clings got broken when they change into another body. Don't have the time myself to fix this so I'll put the revert up instead.

Issue is caused because the signal listens on the body where the cling spawns with. This is not changed on a mind tranfer or such. But should be done (signals maybe for that)