### PR TITLE
Fixes a Minor Spelling Error In Busy Space

### DIFF
--- a/code/modules/busy_space/organizations.dm
+++ b/code/modules/busy_space/organizations.dm
@@ -439,7 +439,7 @@
 
 /datum/lore/organization/gov/synth
 	name = "Synthetic Union"
-	short_name = "Synthtica"
+	short_name = "Synthetica"
 	acronym = "SYN"
 	desc = "A defensive coalition of synthetics based out of New Canaan,\
 			 the Synthetic Union is an organization which aims to establish and consolidate synthetic rights across the galaxy.\


### PR DESCRIPTION
## What Does This PR Do
Changes the shortened name of the Synthetic Union as used in the busy space module from "Synthtica" to "Synthetica"

## Why It's Good For The Game
I'm almost 100% positive that it's supposed to be Synthetica.

## Changelog
:cl:
spellcheck: Fixes the spelling of Synthetica.
/:cl:
