### PR TITLE
Fixes maintenance drone suicide (DNM, WIP)

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -167,10 +167,9 @@
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")
-		suiciding = 1
-		to_chat(viewers(src), "<span class='danger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>")
-		//put em at -175
-		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		suiciding = TRUE
+		visible_message("<span class='danger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>")
+		adjustBruteLoss(max(200 - getBruteLoss(200), 0))
 
 /mob/living/silicon/pai/verb/suicide()
 	set category = "pAI Commands"


### PR DESCRIPTION
Updates suicide.dm to fix maint drone suicide, stopping them from being in life-death limbo when suiciding. Fixes https://github.com/ParadiseSS13/Paradise/issues/11609
Will be updated to separate drones into their own suicide act instead of a subset of silicon/borgs/etc to be able to give them a unique message and be able to ghost the player. This will be updated when the PR is ready for further review!

## What Does This PR Do
Adjusts the damage done to silicon/robot when suiciding, allowing suicide to properly kill maintenance drones whilst still working on borgs.

## Why It's Good For The Game
Previously, maintenance drones who suicided (no available drone consoles, convenience, player needed to leave quickly, etc) were stuck in a life-death limbo of endless suicide, unable to ghost without giving up respawn rights. This is tested to fix that.

## Changelog
:cl:
fix: Fixes maint drone suicide.
/:cl: