### PR TITLE
Makes tanks dispensed from tank storage units get placed into your hands

### DIFF
--- a/_maps/map_files/RandomZLevels/evil_santa.dmm
+++ b/_maps/map_files/RandomZLevels/evil_santa.dmm
@@ -650,7 +650,7 @@
 /area/awaymission/challenge/start)
 "bT" = (
 /obj/structure/dispenser/oxygen{
-	oxygentanks = 9
+	starting_oxygen_tanks = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -2432,7 +2432,7 @@
 	})
 "dy" = (
 /obj/structure/dispenser/oxygen{
-	oxygentanks = 9
+	starting_oxygen_tanks = 9
 	},
 /obj/machinery/light/small{
 	active_power_usage = 0;

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -23,14 +23,8 @@
 
 /obj/structure/dispenser/Destroy()
 	..()
-	remove_all_tanks()
-
-/obj/structure/dispenser/proc/remove_all_tanks()
-	for(var/P in stored_plasma_tanks)
-		qdel(P)
-
-	for(var/O in stored_oxygen_tanks)
-		qdel(O)
+	QDEL_LIST(stored_plasma_tanks)
+	QDEL_LIST(stored_oxygen_tanks)
 
 /obj/structure/dispenser/proc/initialize_tanks()
 	for(var/I in 1 to starting_plasma_tanks)

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -62,7 +62,7 @@
 /obj/structure/dispenser/attack_ghost(mob/user)
 	ui_interact(user)
 
-/obj/structure/dispenser/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
+/obj/structure/dispenser/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, master_ui = null, datum/topic_state/state = GLOB.default_state)
 	user.set_machine(src)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -24,9 +24,9 @@
 	update_icon()
 
 /obj/structure/dispenser/Destroy()
-	..()
 	QDEL_LIST(stored_plasma_tanks)
 	QDEL_LIST(stored_oxygen_tanks)
+	return ..()
 
 /obj/structure/dispenser/proc/initialize_tanks()
 	for(var/I in 1 to starting_plasma_tanks)
@@ -38,7 +38,7 @@
 		stored_oxygen_tanks.Add(O)
 
 /obj/structure/dispenser/update_icon()
-	overlays.Cut()
+	cut_overlays()
 	var/oxy_tank_amount = LAZYLEN(stored_oxygen_tanks)
 	switch(oxy_tank_amount)
 		if(1 to 3)

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -5,28 +5,40 @@
 	icon_state = "dispenser"
 	density = 1
 	anchored = 1.0
-	var/oxygentanks = 10
-	var/plasmatanks = 10
-	var/list/oxytanks = list()	//sorry for the similar var names
-	var/list/platanks = list()
+	var/starting_oxygen_tanks = 10 // The starting amount of oxygen tanks the dispenser gets when it's spawned
+	var/starting_plasma_tanks = 10 // Starting amount of plasma tanks
+	var/list/stored_oxygen_tanks = list() // List of currently stored oxygen tanks
+	var/list/stored_plasma_tanks = list() // And plasma tanks
 
 /obj/structure/dispenser/oxygen
-	plasmatanks = 0
+	starting_plasma_tanks = 0
 
 /obj/structure/dispenser/plasma
-	oxygentanks = 0
+	starting_oxygen_tanks = 0
 
 /obj/structure/dispenser/New()
 	..()
+	initialize_tanks()
 	update_icon()
+
+/obj/structure/dispenser/proc/initialize_tanks()
+	for(var/I in 1 to starting_plasma_tanks)
+		var/obj/item/tank/plasma/P = new(src)
+		stored_plasma_tanks.Add(P)
+
+	for(var/I in 1 to starting_oxygen_tanks)
+		var/obj/item/tank/oxygen/O = new(src)
+		stored_oxygen_tanks.Add(O)
 
 /obj/structure/dispenser/update_icon()
 	overlays.Cut()
-	switch(oxygentanks)
-		if(1 to 3)	overlays += "oxygen-[oxygentanks]"
+	var/oxy_tank_amount = stored_oxygen_tanks.len
+	switch(oxy_tank_amount)
+		if(1 to 3)	overlays += "oxygen-[oxy_tank_amount]"
 		if(4 to INFINITY) overlays += "oxygen-4"
-	switch(plasmatanks)
-		if(1 to 4)	overlays += "plasma-[plasmatanks]"
+	var/pla_tank_amount = stored_plasma_tanks.len
+	switch(pla_tank_amount)
+		if(1 to 4)	overlays += "plasma-[pla_tank_amount]"
 		if(5 to INFINITY) overlays += "plasma-5"
 
 /obj/structure/dispenser/attack_hand(mob/user)
@@ -38,7 +50,7 @@
 /obj/structure/dispenser/attack_ghost(mob/user)
 	ui_interact(user)
 
-/obj/structure/dispenser/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = GLOB.default_state)
+/obj/structure/dispenser/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
 	user.set_machine(src)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
@@ -47,17 +59,16 @@
 
 /obj/structure/dispenser/ui_data(user)
 	var/list/data = list()
-	data["o_tanks"] = oxygentanks
-	data["p_tanks"] = plasmatanks
+	data["o_tanks"] = stored_oxygen_tanks.len
+	data["p_tanks"] = stored_plasma_tanks.len
 	return data
 
 /obj/structure/dispenser/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/tank/oxygen) || istype(I, /obj/item/tank/air) || istype(I, /obj/item/tank/anesthetic))
-		if(oxygentanks < 10)
+		if(stored_oxygen_tanks.len < 10)
 			user.drop_item()
 			I.forceMove(src)
-			oxytanks.Add(I)
-			oxygentanks++
+			stored_oxygen_tanks.Add(I)
 			update_icon()
 			to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 		else
@@ -65,11 +76,10 @@
 		SSnanoui.update_uis(src)
 		return
 	if(istype(I, /obj/item/tank/plasma))
-		if(plasmatanks < 10)
+		if(stored_plasma_tanks.len < 10)
 			user.drop_item()
 			I.forceMove(src)
-			platanks.Add(I)
-			plasmatanks++
+			stored_plasma_tanks.Add(I)
 			update_icon()
 			to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 		else
@@ -88,40 +98,43 @@
 
 /obj/structure/dispenser/Topic(href, href_list)
 	if(..())
-		return 1
+		return TRUE
 
 	if(Adjacent(usr))
 		usr.set_machine(src)
+
+		// The oxygen tank button
 		if(href_list["oxygen"])
-			if(oxygentanks > 0)
-				var/obj/item/tank/oxygen/O
-				if(oxytanks.len == oxygentanks)
-					O = oxytanks[1]
-					oxytanks.Remove(O)
-				else
-					O = new /obj/item/tank/oxygen(loc)
-				O.loc = loc
-				to_chat(usr, "<span class='notice'>You take [O] out of [src].</span>")
-				oxygentanks--
-				update_icon()
+			if(!stored_oxygen_tanks.len) // No more tanks in the machine
+				return
+
+			var/obj/item/tank/O = stored_oxygen_tanks[1] // Get the first tank in the list
+			stored_oxygen_tanks.Remove(O) // remove it from the list since we are ejecting the tank
+
+			if(!usr.put_in_hands(O)) // Try to place it in the user's hands first
+				O.forceMove(loc) // If hands are full, place it at the location of the tank dispenser
+			to_chat(usr, "<span class='notice'>You take [O] out of [src].</span>")
+			update_icon()
+
+		// The plasma tank button
 		if(href_list["plasma"])
-			if(plasmatanks > 0)
-				var/obj/item/tank/plasma/P
-				if(platanks.len == plasmatanks)
-					P = platanks[1]
-					platanks.Remove(P)
-				else
-					P = new /obj/item/tank/plasma(loc)
-				P.loc = loc
-				to_chat(usr, "<span class='notice'>You take [P] out of [src].</span>")
-				plasmatanks--
-				update_icon()
+			if(!stored_plasma_tanks.len)
+				return
+
+			var/obj/item/tank/P = stored_plasma_tanks[1]
+			stored_plasma_tanks.Remove(P)
+
+			if(!usr.put_in_hands(P))
+				P.forceMove(loc)
+			to_chat(usr, "<span class='notice'>You take [P] out of [src].</span>")
+			update_icon()
+
 		add_fingerprint(usr)
 		updateUsrDialog()
 		SSnanoui.update_uis(src)
 	else
 		SSnanoui.close_user_uis(usr,src)
-	return 1
+	return TRUE
 
 /obj/structure/tank_dispenser/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -1,3 +1,5 @@
+#define MAX_TANK_STORAGE	10
+
 /obj/structure/dispenser
 	name = "tank storage unit"
 	desc = "A simple yet bulky storage device for gas tanks. Has room for up to ten oxygen tanks, and ten plasma tanks."
@@ -5,8 +7,8 @@
 	icon_state = "dispenser"
 	density = 1
 	anchored = 1.0
-	var/starting_oxygen_tanks = 10 // The starting amount of oxygen tanks the dispenser gets when it's spawned
-	var/starting_plasma_tanks = 10 // Starting amount of plasma tanks
+	var/starting_oxygen_tanks = MAX_TANK_STORAGE // The starting amount of oxygen tanks the dispenser gets when it's spawned
+	var/starting_plasma_tanks = MAX_TANK_STORAGE // Starting amount of plasma tanks
 	var/list/stored_oxygen_tanks = list() // List of currently stored oxygen tanks
 	var/list/stored_plasma_tanks = list() // And plasma tanks
 
@@ -37,14 +39,14 @@
 
 /obj/structure/dispenser/update_icon()
 	overlays.Cut()
-	var/oxy_tank_amount = stored_oxygen_tanks.len
+	var/oxy_tank_amount = LAZYLEN(stored_oxygen_tanks)
 	switch(oxy_tank_amount)
 		if(1 to 3)
 			overlays += "oxygen-[oxy_tank_amount]"
 		if(4 to INFINITY)
 			overlays += "oxygen-4"
 
-	var/pla_tank_amount = stored_plasma_tanks.len
+	var/pla_tank_amount = LAZYLEN(stored_plasma_tanks)
 	switch(pla_tank_amount)
 		if(1 to 4)
 			overlays += "plasma-[pla_tank_amount]"
@@ -69,8 +71,8 @@
 
 /obj/structure/dispenser/ui_data(user)
 	var/list/data = list()
-	data["o_tanks"] = stored_oxygen_tanks.len
-	data["p_tanks"] = stored_plasma_tanks.len
+	data["o_tanks"] = LAZYLEN(stored_oxygen_tanks)
+	data["p_tanks"] = LAZYLEN(stored_plasma_tanks)
 	return data
 
 /obj/structure/dispenser/attackby(obj/item/I, mob/user, params)
@@ -116,7 +118,7 @@
 
 /// Called when the user clicks on the oxygen or plasma tank UI buttons, and tries to withdraw a tank.
 /obj/structure/dispenser/proc/try_remove_tank(mob/living/user, list/tank_list)
-	if(!tank_list.len)
+	if(!LAZYLEN(tank_list))
 		return // There are no tanks left to withdraw.
 
 	var/obj/item/tank/T = tank_list[1]
@@ -130,7 +132,7 @@
 
 /// Called when the user clicks on the dispenser with a tank. Tries to insert the tank into the dispenser, and updates the UI if successful.
 /obj/structure/dispenser/proc/try_insert_tank(mob/living/user, list/tank_list, obj/item/tank/T)
-	if(!tank_list.len >= 10)
+	if(LAZYLEN(tank_list) >= MAX_TANK_STORAGE)
 		to_chat(user, "<span class='warning'>[src] is full.</span>")
 		return
 
@@ -151,3 +153,5 @@
 			I.forceMove(loc)
 		new /obj/item/stack/sheet/metal(loc, 2)
 	qdel(src)
+
+#undef MAX_TANK_STORAGE

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -21,6 +21,17 @@
 	initialize_tanks()
 	update_icon()
 
+/obj/structure/dispenser/Destroy()
+	..()
+	remove_all_tanks()
+
+/obj/structure/dispenser/proc/remove_all_tanks()
+	for(var/P in stored_plasma_tanks)
+		qdel(P)
+
+	for(var/O in stored_oxygen_tanks)
+		qdel(O)
+
 /obj/structure/dispenser/proc/initialize_tanks()
 	for(var/I in 1 to starting_plasma_tanks)
 		var/obj/item/tank/plasma/P = new(src)
@@ -34,12 +45,17 @@
 	overlays.Cut()
 	var/oxy_tank_amount = stored_oxygen_tanks.len
 	switch(oxy_tank_amount)
-		if(1 to 3)	overlays += "oxygen-[oxy_tank_amount]"
-		if(4 to INFINITY) overlays += "oxygen-4"
+		if(1 to 3)
+			overlays += "oxygen-[oxy_tank_amount]"
+		if(4 to INFINITY)
+			overlays += "oxygen-4"
+
 	var/pla_tank_amount = stored_plasma_tanks.len
 	switch(pla_tank_amount)
-		if(1 to 4)	overlays += "plasma-[pla_tank_amount]"
-		if(5 to INFINITY) overlays += "plasma-5"
+		if(1 to 4)
+			overlays += "plasma-[pla_tank_amount]"
+		if(5 to INFINITY)
+			overlays += "plasma-5"
 
 /obj/structure/dispenser/attack_hand(mob/user)
 	if(..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If you dispense a plasma or oxygen tank from a tank storage unit, the tank will first try to be place into your hand. If you're hands are full, it places it at the location of the unit, which is how it functions currently.

## Why It's Good For The Game
Small QoL improvement. Currently most, if not all vending-type machines work like this. Examples being the NanoMeds, chemistry machines, and every food, tool, or clothes vending machine.

## Changelog
:cl:
tweak: Tanks dispensed from tank storage units now get placed into your hands, if your hands are not full
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
