### PR TITLE
Increases bag space of ERTs and death squads

### DIFF
--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -68,7 +68,7 @@
 	jobtype = /datum/job/ntspecops
 	uniform = /obj/item/clothing/under/rank/centcom_commander
 	suit = /obj/item/clothing/suit/space/deathsquad/officer
-	back = /obj/item/storage/backpack/security
+	back = /obj/item/storage/backpack/ert/security
 	belt = /obj/item/storage/belt/military/assault
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -537,6 +537,7 @@
 	desc = "A spacious backpack with lots of pockets, used by members of the Nanotrasen Emergency Response Team."
 	icon_state = "ert_commander"
 	item_state = "backpack"
+	max_combined_w_class = 30
 	resistance_flags = FIRE_PROOF
 
 //Commander


### PR DESCRIPTION
## What Does This PR Do
Increases the bag space of ERT members to duffel bag sizes gives death squads the sec ERT backpacks thus increasing their bag space as well.

## Why It's Good For The Game
The ERT and Death squads have had inventory issues for a long time now. I say it's high time to fix that.

## Changelog
:cl:
balance: Increased bag space of ERT backpacks to duffel bag sizes
balance: gives death squads sec ERT backpacks increasing their bag space by proxy
/:cl: