### PR TITLE
Make can_inject deterministic; fix odysseus syringes sometimes not working.

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -314,6 +314,7 @@
 	playsound(chassis, 'sound/items/syringeproj.ogg', 50, 1)
 	log_message("Launched [mechsyringe] from [src], targeting [target].")
 	var/mob/originaloccupant = chassis.occupant
+	var/original_target_zone = originaloccupant.zone_selected
 	spawn(0)
 		src = null //if src is deleted, still process the syringe
 		var/max_range = 6
@@ -330,7 +331,7 @@
 			if(M)
 				var/R
 				mechsyringe.visible_message("<span class=\"attack\"> [M] was hit by the syringe!</span>")
-				if(M.can_inject(null, TRUE))
+				if(M.can_inject(originaloccupant, TRUE, original_target_zone))
 					if(mechsyringe.reagents)
 						for(var/datum/reagent/A in mechsyringe.reagents.reagent_list)
 							R += A.id + " ("

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -396,7 +396,10 @@
 /datum/plant_gene/trait/stinging/on_throw_impact(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target) && G.reagents && G.reagents.total_volume)
 		var/mob/living/L = target
-		if(L.reagents && L.can_inject(null, FALSE))
+		// It would be nice to inject the body part the original thrower aimed at,
+		// but we don't have this kind of information here. So pick something at random.
+		var/target_zone = pick("chest", "chest", "chest", "l_leg", "r_leg", "l_arm", "r_arm", "head")
+		if(L.reagents && L.can_inject(null, FALSE, target_zone))
 			var/injecting_amount = max(1, G.seed.potency*0.2) // Minimum of 1, max of 20
 			var/fraction = min(injecting_amount/G.reagents.total_volume, 1)
 			G.reagents.reaction(L, INGEST, fraction)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1011,8 +1011,8 @@
 
 	if(!target_zone)
 		if(!user)
-			stack_trace("can_inject() called on a human mob with neither a user nor a targeting zone selected.")
-			return FALSE
+			. = FALSE
+			CRASH("can_inject() called on a human mob with neither a user nor a targeting zone selected.")
 		else
 			target_zone = user.zone_selected
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1007,7 +1007,7 @@
 	return
 
 /mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE)
-	. = 1
+	. = TRUE
 
 	if(!target_zone)
 		if(!user)
@@ -1016,26 +1016,25 @@
 		else
 			target_zone = user.zone_selected
 
-
 	if(PIERCEIMMUNE in dna.species.species_traits)
-		. = 0
+		. = FALSE
 
 	var/obj/item/organ/external/affecting = get_organ(target_zone)
 	var/fail_msg
 	if(!affecting)
-		. = 0
+		. = FALSE
 		fail_msg = "[p_they(TRUE)] [p_are()] missing that limb."
 	else if(affecting.is_robotic())
-		. = 0
+		. = FALSE
 		fail_msg = "That limb is robotic."
 	else
 		switch(target_zone)
 			if("head")
 				if(head && head.flags & THICKMATERIAL && !penetrate_thick)
-					. = 0
+					. = FALSE
 			else
 				if(wear_suit && wear_suit.flags & THICKMATERIAL && !penetrate_thick)
-					. = 0
+					. = FALSE
 	if(!. && error_msg && user)
 		if(!fail_msg)
 			fail_msg = "There is no exposed flesh or thin material [target_zone == "head" ? "on [p_their()] head" : "on [p_their()] body"] to inject into."

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1011,7 +1011,8 @@
 
 	if(!target_zone)
 		if(!user)
-			target_zone = pick("chest","chest","chest","left leg","right leg","left arm", "right arm", "head")
+			stack_trace("can_inject() called on a human mob with neither a user nor a targeting zone selected.")
+			return FALSE
 		else
 			target_zone = user.zone_selected
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #12857 by passing in targeting_zone that the mecha occupant aims at.
The problem here is that when neither targeting zone nor the user are passed to `can_inject()` , it picks a random zone (which is weird, since one would expect `can_inject()` to be deterministic), and many of those random choices are not really zones (`"left leg"` is not a zone, but `"l_leg"` is).
Anyhow, now all callers to `can_inject` pass in either non-null user or properly pass in targeting zone (or both).

Also added test for #12857  . It probably doesn't add much value at this point, but I think this time is as good as any to start building up a test suite.

Separately, my previous pr of #12697 was overly cautions with not closing the bugs it fixed, so I'll do it here:
Fixes: #12685
Fixes: #7132

## Why It's Good For The Game
Bugfix good
Automated testing good

## Images of the changes
![B8g9ZeWIaH](https://user-images.githubusercontent.com/7831163/71549725-2d5dcf80-29ba-11ea-8bc0-c03fa35e3eaa.gif)


## Changelog
:cl:
fix: Odysseus syringes now inject the victim consistently
/:cl: