### PR TITLE
Kudzu Mutativeness Fix

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -544,7 +544,7 @@
 	if(potency != null && potency > 0)
 		// ~1 mutativeness at 6 potency
 		// 4 mutativeness at 100 potency
-		mutativeness = sqrt(potency) * .4
+		mutativeness = sqrt(potency) * 0.4
 	if(production != null)
 		// 1 production is crazy powerful
 		var/spread_value = max(10 - production, 1)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -544,7 +544,7 @@
 	if(potency != null && potency > 0)
 		// 1 mutativeness at 10 potency
 		// 4 mutativeness at 100 potency
-		mutativeness = log(10, potency) ** 2
+		mutativeness = log(10, (potency - 1)) ** 2
 	if(production != null)
 		// 1 production is crazy powerful
 		var/spread_value = max(10 - production, 1)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -544,7 +544,7 @@
 	if(potency != null && potency > 0)
 		// 1 mutativeness at 10 potency
 		// 4 mutativeness at 100 potency
-		mutativeness = log(10, (potency - 1)) ** 2
+		mutativeness = log(10, (potency + 1)) ** 2
 	if(production != null)
 		// 1 production is crazy powerful
 		var/spread_value = max(10 - production, 1)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -542,9 +542,9 @@
 	START_PROCESSING(SSobj, src)
 	init_subtypes(/datum/spacevine_mutation/, mutations_list)
 	if(potency != null && potency > 0)
-		// 1 mutativeness at 10 potency
+		// ~1 mutativeness at 6 potency
 		// 4 mutativeness at 100 potency
-		mutativeness = log(10, (potency + 1)) ** 2
+		mutativeness = sqrt(potency) * .4
 	if(production != null)
 		// 1 production is crazy powerful
 		var/spread_value = max(10 - production, 1)


### PR DESCRIPTION
## What Does This PR Do
Changes the lower bound of kudzu mutativeness from infinity at 0 potency(math-breaking) and having 0 mutativeness at 1 potency to having 0 mutativeness at 0 potency, as mutativeness is a squared log of potency.

## Why It's Good For The Game
Kudzu with potency below 1 will now not have busted mutativeness. Kudzu at 0 potency will not mutate.

## Changelog
:cl:
fix: Changed some bad math to make kudzu at 0 potency to have infinite mutativeness.
/:cl: