### PR TITLE
Re-balancing the Medical ERTs

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -231,6 +231,24 @@
 	new /obj/item/surgicaldrill(src)
 	new /obj/item/circular_saw(src)
 
+/obj/item/storage/firstaid/ert
+	name = "ERT Medical Kit"
+	desc = "A kit that contains numerous medical supplies for medical emergancies. Includes preloaded Patch pack and Pill bottle."
+	icon_state = "advfirstaid"
+	item_state = "firstaid-advanced"
+	med_bot_skin = "adv"
+
+/obj/item/storage/firstaid/ert/New()
+	..()
+	new /obj/item/stack/medical/bruise_pack/advanced(src)
+	new /obj/item/stack/medical/bruise_pack/advanced(src)
+	new /obj/item/stack/medical/ointment/advanced(src)
+	new /obj/item/stack/medical/ointment/advanced(src)
+	new /obj/item/storage/pill_bottle/ert/red(src)
+	new /obj/item/storage/pill_bottle/patch_pack/ert(src)
+	new /obj/item/healthanalyzer(src)
+
+
 /*
  * Pill Bottles
  */
@@ -296,6 +314,22 @@
 	new /obj/item/reagent_containers/food/pill/charcoal(src)
 	new /obj/item/reagent_containers/food/pill/charcoal(src)
 	new /obj/item/reagent_containers/food/pill/charcoal(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/salbutamol(src)
+	new /obj/item/reagent_containers/food/pill/salbutamol(src)
+	new /obj/item/reagent_containers/food/pill/salbutamol(src)
+
+/obj/item/storage/pill_bottle/ert/red
+	wrapper_color = COLOR_MAROON
+
+/obj/item/storage/pill_bottle/ert/red/New()
+	..()
+	new /obj/item/reagent_containers/food/pill/salicylic(src)
+	new /obj/item/reagent_containers/food/pill/charcoal(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/salbutamol(src)
 
 /obj/item/storage/pill_bottle/MouseDrop(obj/over_object as obj) // Best utilized if you're a cantankerous doctor with a Vicodin habit.
 	if(iscarbon(over_object))
@@ -380,3 +414,40 @@
 	new /obj/item/reagent_containers/food/pill/fakedeath(src)
 	new /obj/item/reagent_containers/food/pill/fakedeath(src)
 	new /obj/item/reagent_containers/food/pill/fakedeath(src)
+
+/obj/item/storage/pill_bottle/pentetic
+	name = "Pill bottle (Pentetic Acid)"
+	desc = "Contains pills used to counter toxins,poisons and radiation. Use with Caution."
+	wrapper_color = COLOR_GREEN
+
+/obj/item/storage/pill_bottle/pentetic/New()
+	..()
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+	new /obj/item/reagent_containers/food/pill/pentetic(src)
+
+/obj/item/storage/pill_bottle/patch_pack/ert
+	name = "Emergancy Patch Pack"
+	desc = "Contains various ready to use patches."
+
+/obj/item/storage/pill_bottle/patch_pack/ert/New()
+	..()
+	new /obj/item/reagent_containers/food/pill/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/food/pill/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/food/pill/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/food/pill/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/food/pill/patch/styptic(src)
+	new /obj/item/reagent_containers/food/pill/patch/styptic(src)
+	new /obj/item/reagent_containers/food/pill/patch/styptic(src)
+	new /obj/item/reagent_containers/food/pill/patch/styptic(src)
+	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)
+
+	 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -81,6 +81,12 @@
 	list_reagents = list("omnizine" = 30)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/item/reagent_containers/hypospray/safety/painkiller //ERT can do surgery at any time now
+	name = "high capacity medical hypospray"
+	desc = "A modifed medical hypospray for additonal capacity, prefilled with hydrocodone."
+	volume = 100
+	list_reagents = list("hydrocodone" = 100)
+
 /obj/item/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
@@ -93,6 +99,7 @@
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with expensive medical nanites for rapid healing."
+	possible_transfer_amounts = list(5,10,15)
 	volume = 100
 	list_reagents = list("nanites" = 100)
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -153,3 +153,9 @@
 	desc = "Used to treat cranial swelling."
 	icon_state = "pill19"
 	list_reagents = list("mannitol" = 20)
+
+/obj/item/reagent_containers/food/pill/pentetic
+	name = "Pentetic Acid pill"
+	desc = "Used to agrressively pruge toxins, impurities and radiation, but causes tissue damage in the process."
+	icon_state = "pill17"
+	list_reagents = list("pen_acid" = 20)

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -336,9 +336,7 @@
 
 	backpack_contents = list(
 		/obj/item/clothing/mask/surgical = 1,
-		/obj/item/storage/firstaid/toxin = 1,
-		/obj/item/storage/firstaid/brute = 1,
-		/obj/item/storage/firstaid/fire = 1,
+		/obj/item/storage/firstaid/ert = 1,
 		/obj/item/storage/box/autoinjectors = 1,
 		/obj/item/roller = 1,
 		/obj/item/clothing/shoes/magboots = 1,
@@ -358,13 +356,15 @@
 	belt = /obj/item/defibrillator/compact/loaded
 
 	l_pocket = /obj/item/reagent_containers/hypospray/combat/nanites
-	r_pocket = /obj/item/reagent_containers/hypospray/autoinjector
+	r_pocket = /obj/item/melee/classic_baton/telescopic
 
 	backpack_contents = list(
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/bodyanalyzer/advanced = 1,
 		/obj/item/extinguisher/mini = 1,
 		/obj/item/roller = 1,
+		/obj/item/reagent_containers/hypospray/safety/painkiller = 1,
+		/obj/item/storage/pill_bottle/pentetic = 1,
 		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/handheld_defibrillator = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This adjusts the load outs for the medical ERTs, adds some new items and adjusts others, with the following changes happening;

- Red level medical ERT loses the three med kits in favour of a modified advanced med kit that swaps out the injector and gauze for a patch pack filled with healing, burn and synthflesh patches, and pill bottle filled with salicylic acid, charcoal, mannitol and salbulamol pills.
These changes help to make the Red level medical ERT be a more effective mid tier, granting more overall healing potential than the amber while saving space and allowing it to preform surgery without having to go to med bay for additional supplies.

- Amber level medical ERT gains mannitol and salbutamol pills.
The addition of these pills help to keep people from going brain dead.

- Gamma level medical ERT gains a pill bottle filled with pentetic acid pills and a hypospray filled with hydrocodone, loses the emergency injector and gains a telescopic baton. By consequence the nanite hypospray now has adjustable output in 5, 10 and 15 unit injections.
These additions lets the Gamma level ERT deal with situations that the nanite hypospray would not appropriate, such as terror spider eggs, alien chest busters and excessive levels of poisonous chemicals. As well as letting them conserve those precious nanites. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
These changes helps to make the medical ERT less frustrating to play, especially at the higher alert levels, particular the red level ERT had severe inventory management issues with an over stuffed backpack, lacked resources and little, in the case of gamma no, ability to preform surgery out the gate due to a lack of painkillers, these changes allow them to do so.

## Changelog
:cl:
add: New Med kit for the red level medical ERT
add: New pre-loaded Patch pack and Pill bottles
add: New hypospray filled with painkillers
add: New pill - pentetic acid
tweak: Lets the nanite hypospray adjust the amount injected
tweak: Adds pills to the ERT pill bottle 
Balance: Changed the load outs for red and gamma level medical ERTs

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
