### PR TITLE
Makes Wallrechargers Buildable

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -347,6 +347,19 @@ to destroy them and players will be able to make replacements.
 	frame_desc = "Requires 1 Capacitor"
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
 
+	/obj/item/circuitboard/recharger/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/screwdriver))
+		if(build_path == /obj/machinery/recharger)
+			build_path = /obj/machinery/recharger/wallcharger
+			name = "circuit board (WallRecharger)"
+			to_chat(user, "<span class='notice'>You set the Recharger Board to wall mode.</span>")
+		else
+			build_path = /obj/machinery/recharger
+			name = "circuit board (Recharger)"
+			to_chat(user, "<span class='notice'>You set Recharger Board to floor mode.</span>")
+		return
+	return ..()
+
 /obj/item/circuitboard/snow_machine
 	name = "circuit board (snow machine)"
 	build_path = /obj/machinery/snow_machine

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -347,7 +347,7 @@ to destroy them and players will be able to make replacements.
 	frame_desc = "Requires 1 Capacitor"
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
 
-	/obj/item/circuitboard/recharger/attackby(obj/item/I, mob/user, params)
+/obj/item/circuitboard/recharger/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver))
 		if(build_path == /obj/machinery/recharger)
 			build_path = /obj/machinery/recharger/wallcharger

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -351,7 +351,7 @@ to destroy them and players will be able to make replacements.
 	if(istype(I, /obj/item/screwdriver))
 		if(build_path == /obj/machinery/recharger)
 			build_path = /obj/machinery/recharger/wallcharger
-			name = "circuit board (WallRecharger)"
+			name = "circuit board (Wallrecharger)"
 			to_chat(user, "<span class='notice'>You set the Recharger Board to wall mode.</span>")
 		else
 			build_path = /obj/machinery/recharger


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This Pull request makes Wallrechargers Buildable.

## Why It's Good For The Game
So that we can build Rechargers like those in Brig that are on the wall, its mainly for ease of use of rechargers so that they dont take up a whole floor tile.

## Changelog
:cl:
adds: Wallrecharger Boards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
