### PR TITLE
Improved Pressure Check Utility On Air Alarms

### DIFF
--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -299,22 +299,6 @@
 				ONE_ATMOSPHERE*50
 			)
 
-	if(signal.data["adjust_internal_pressure"] != null)
-		internal_pressure_bound = between(
-			0,
-			internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]),
-			ONE_ATMOSPHERE*50
-		)
-
-	if(signal.data["adjust_external_pressure"] != null)
-
-
-		external_pressure_bound = between(
-			0,
-			external_pressure_bound + text2num(signal.data["adjust_external_pressure"]),
-			ONE_ATMOSPHERE*50
-		)
-
 	if(signal.data["init"] != null)
 		name = signal.data["init"]
 		return

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -853,7 +853,7 @@
 					if(isnull(newval))
 						return
 					if(href_list["command"]=="set_external_pressure" || href_list["command"]=="set_internal_pressure")
-						between(0, newval, ONE_ATMOSPHERE*50)
+						newval = between(0, newval, ONE_ATMOSPHERE*50)
 					val = newval
 
 				send_signal(device_id, list(href_list["command"] = val ) )

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -849,15 +849,11 @@
 				if(href_list["val"])
 					val=text2num(href_list["val"])
 				else
-					var/newval = input("Enter new pressure target, 0-5066.25 kPa:") as num|null
+					var/newval = input("Enter new pressure target, 0-[ONE_ATMOSPHERE*50]:") as num|null
 					if(isnull(newval))
 						return
-					else
-						if(href_list["command"]=="set_external_pressure" || href_list["command"]=="set_internal_pressure")
-							if(newval>ONE_ATMOSPHERE*50)
-								newval = ONE_ATMOSPHERE*50
-							if(newval<0)
-								newval = 0
+					if(href_list["command"]=="set_external_pressure" || href_list["command"]=="set_internal_pressure")
+						between(0, newval, ONE_ATMOSPHERE*50)
 					val = newval
 
 				send_signal(device_id, list(href_list["command"] = val ) )

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -849,7 +849,7 @@
 				if(href_list["val"])
 					val=text2num(href_list["val"])
 				else
-					var/newval = input("Enter new pressure target, 0-[ONE_ATMOSPHERE*50]:") as num|null
+					var/newval = input("Enter new pressure target, 0-[ONE_ATMOSPHERE*50] kPa:") as num|null
 					if(isnull(newval))
 						return
 					if(href_list["command"]=="set_external_pressure" || href_list["command"]=="set_internal_pressure")

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -834,8 +834,8 @@
 		var/device_id = href_list["id_tag"]
 		switch(href_list["command"])
 			if( "power",
-				"adjust_external_pressure",
 				"set_external_pressure",
+				"set_internal_pressure",
 				"checks",
 				"co2_scrub",
 				"tox_scrub",
@@ -849,14 +849,15 @@
 				if(href_list["val"])
 					val=text2num(href_list["val"])
 				else
-					var/newval = input("Enter new value") as num|null
+					var/newval = input("Enter new pressure target, 0-5066.25 kPa:") as num|null
 					if(isnull(newval))
 						return
-					if(href_list["command"]=="set_external_pressure")
-						if(newval>1000+ONE_ATMOSPHERE)
-							newval = 1000+ONE_ATMOSPHERE
-						if(newval<0)
-							newval = 0
+					else
+						if(href_list["command"]=="set_external_pressure" || href_list["command"]=="set_internal_pressure")
+							if(newval>ONE_ATMOSPHERE*50)
+								newval = ONE_ATMOSPHERE*50
+							if(newval<0)
+								newval = 0
 					val = newval
 
 				send_signal(device_id, list(href_list["command"] = val ) )

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -149,7 +149,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 				<div class="line">
 					<div class="statusLabel">External pressure target:</div>
 					<div class="statusValue">
-						{{:helper.smoothRound(value.external,3)}} kPa
+						{{:helper.smoothRound(value.external,4)}} kPa
 					</div>
 					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_external_pressure'})}}
 					{{:helper.link('Reset','refresh',{'id_tag':value.id_tag,'command':'set_external_pressure','val':101.325},null,'linkOn')}}
@@ -157,7 +157,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 				<div class="line">
 					<div class="statusLabel">Internal pressure target:</div>
 					<div class="statusValue">
-						{{:helper.smoothRound(value.internal,3)}} kPa 
+						{{:helper.smoothRound(value.internal,4)}} kPa 
 					</div>
 					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_internal_pressure'})}}
 					{{:helper.link('Reset','refresh',{'id_tag':value.id_tag,'command':'set_internal_pressure','val':0},null,'linkOn')}}

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -149,7 +149,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 				<div class="line">
 					<div class="statusLabel">External pressure target:</div>
 					<div class="statusValue">
-						{{:helper.smoothRound(value.external,4)}} kPa
+						{{:helper.smoothRound(value.external,3)}} kPa
 					</div>
 					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_external_pressure'})}}
 					{{:helper.link('Reset','refresh',{'id_tag':value.id_tag,'command':'set_external_pressure','val':101.325},null,'linkOn')}}
@@ -157,7 +157,7 @@ Used In File(s): /code/game/machinery/alarm.dm
 				<div class="line">
 					<div class="statusLabel">Internal pressure target:</div>
 					<div class="statusValue">
-						{{:helper.smoothRound(value.internal,4)}} kPa 
+						{{:helper.smoothRound(value.internal,3)}} kPa 
 					</div>
 					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_internal_pressure'})}}
 					{{:helper.link('Reset','refresh',{'id_tag':value.id_tag,'command':'set_internal_pressure','val':0},null,'linkOn')}}

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -154,6 +154,14 @@ Used In File(s): /code/game/machinery/alarm.dm
 					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_external_pressure'})}}
 					{{:helper.link('Reset','refresh',{'id_tag':value.id_tag,'command':'set_external_pressure','val':101.325},null,'linkOn')}}
 				</div>
+				<div class="line">
+					<div class="statusLabel">Internal pressure target:</div>
+					<div class="statusValue">
+						{{:helper.smoothRound(value.internal,4)}} kPa 
+					</div>
+					{{:helper.link('Set','gear',{'id_tag':value.id_tag,'command':'set_internal_pressure'})}}
+					{{:helper.link('Reset','refresh',{'id_tag':value.id_tag,'command':'set_internal_pressure','val':0},null,'linkOn')}}
+				</div>
 			</div>
 		{{empty}}
 			<i>No vent pumps located in this area.</i>


### PR DESCRIPTION
## What Does This PR Do
Adds to air alarms the ability to show and set vents' internal pressure target, from 0-50atm, which is the range of what signals can set vents' internal pressure targets to.

Changes the upper limit of air alarms' ability to set vents' external pressure targets from 1101.325kPa to 50atm, which is the limit of what signals can set vents' external pressure targets to.

Changes the setting prompt asking for pressure targets to include the bounds and the units, so you know what they are.

Replaces a bizarre combination of if statements in air alarm code with a between(), which does the exact same thing, but better.

Removes 2 redundant and completely unused signal commands(adjust) from vent code, and removes reference to 1 of them from air alarm code.

## Why It's Good For The Game
Enables the use of non-zero internal pressure targets without building an AAC, which is potentially useful for pumping vents, and completely necessary for any usage of internal pressure checks with siphoning vents.

Can set vents to be have much higher external pressure checks without the intervention of an AAC; potentially useful in the coming SM age.

Makes the input prompt for vents' pressure targets tell you what the minimum and maximum values are.

Replaces some genuinely terrible logic in air alarm code.

Gets rid of an unused piece of code, and all reference to it.

## Images of changes
![nyehehehehe](https://user-images.githubusercontent.com/56715097/71704495-c1f47300-2da8-11ea-83db-7b28e39b4cea.png)

## Changelog
:cl:
add: Can set internal pressure targets for vents from air alarms.
tweak: Changed the text of the input prompt of pressure checks to include their bounds and units.
tweak: Air alarms can set vents' external pressure checks up to 50atm, instead of up to 1000kPa+1atm.
tweak: Improved operations in air alarm code.
/:cl: