### PR TITLE
Add missing grey translator implant check

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -97,6 +97,9 @@
 	return real_name
 
 /mob/living/carbon/human/IsVocal()
+	var/obj/item/organ/internal/cyberimp/brain/speech_translator/translator = locate(/obj/item/organ/internal/cyberimp/brain/speech_translator) in internal_organs
+	if(translator && translator.active)
+		return TRUE
 	// how do species that don't breathe talk? magic, that's what.
 	var/breathes = (!(NO_BREATHE in dna.species.species_traits))
 	var/obj/item/organ/internal/L = get_organ_slot("lungs")


### PR DESCRIPTION
Add a missing translator implant check in say code. 

This missing check caused radios to stop working for greys when suffering oxygen damage, as the radio checked IsVocal without going through the usual say code. 

Due to this, while the grey is able to speak, they were unable to speak into the radio.

With this check in, the radio works properly.

:cl:
fix: Fixed greys with translator implant being unable to use their headset when suffering oxygen damage.
/:cl: