### PR TITLE
Making Nanites also fix internal bleeding. 

### DIFF
--- a/code/modules/reagents/chemistry/reagents/admin.dm
+++ b/code/modules/reagents/chemistry/reagents/admin.dm
@@ -23,6 +23,7 @@
 			I.receive_damage(-5, FALSE)
 		for(var/obj/item/organ/external/E in H.bodyparts)
 			E.mend_fracture()
+			E.internal_bleeding = FALSE
 	M.SetEyeBlind(0, FALSE)
 	M.CureNearsighted(FALSE)
 	M.CureBlind(FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Makes nanites and adminordrazine fix internal bleeding. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This solves a few edge cases where the user bleeds out while using either two substances when they should be unkillable, in all seriousness it's also odd that highly advanced nanomachines that repair bones and organs somehow miss repairing blood vessels.

## Changelog
:cl:
Balance: adds mend internal bleeding to adminordrazine and nanites 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
