### PR TITLE
Removes Loyalty Implant aspect of Mindshield Implants

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_loyalty.dm
+++ b/code/game/objects/items/weapons/implants/implant_loyalty.dm
@@ -1,0 +1,59 @@
+/obj/item/implant/loyalty
+	name = "loyalty implant"
+	desc = "Makes you loyal to Nanotrasen."
+	origin_tech = "materials=5;biotech=5;programming=7"
+	activated = 0
+
+/obj/item/implant/loyalty/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Nanotrasen Employee Management Implant<BR>
+				<b>Life:</b> Ten years.<BR>
+				<b>Important Notes:</b> Personnel injected with this device tend to be much more loyal to the company.<BR>
+				<HR>
+				<b>Implant Details:</b><BR>
+				<b>Function:</b> Contains a small pod of nanobots that manipulate the host's mental functions.<BR>
+				<b>Special Features:</b> Will prevent and cure most forms of brainwashing.<BR>
+				<b>Integrity:</b> Implant will last so long as the nanobots are inside the bloodstream."}
+	return dat
+
+
+/obj/item/implant/loyalty/implant(mob/target)
+	if(..())
+		if(target.mind in SSticker.mode.head_revolutionaries || is_shadow_or_thrall(target) || ismindshielded(target) || ismindslave(target))
+			target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
+			removed(target, 1)
+			qdel(src)
+			return -1
+		if(target.mind in SSticker.mode.revolutionaries)
+			SSticker.mode.remove_revolutionary(target.mind)
+		if(target.mind in SSticker.mode.cult)
+			to_chat(target, "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
+		else
+			to_chat(target, "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>")
+		return 1
+	return 0
+
+/obj/item/implant/loyalty/removed(mob/target, var/silent = 0)
+	if(..())
+		if(target.stat != DEAD && !silent)
+			to_chat(target, "<span class='boldnotice'>You feel a sense of liberation as Nanotrasen's grip on your mind fades away.</span>")
+		return 1
+	return 0
+
+
+/obj/item/implanter/loyalty
+	name = "implanter (loyalty)"
+
+/obj/item/implanter/loyalty/New()
+	imp = new /obj/item/implant/loyalty(src)
+	..()
+	update_icon()
+
+
+/obj/item/implantcase/loyalty
+	name = "implant case - 'loyalty'"
+	desc = "A glass case containing a loyalty implant."
+
+/obj/item/implantcase/loyalty/New()
+	imp = new /obj/item/implant/loyalty(src)
+	..()

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -12,23 +12,14 @@
 				<HR>
 				<b>Implant Details:</b><BR>
 				<b>Function:</b> Contains a small pod of nanobots that manipulate the host's mental functions.<BR>
-				<b>Special Features:</b> Will prevent and cure most forms of brainwashing.<BR>
+				<b>Special Features:</b> Will prevent most forms of brainwashing.<BR>
 				<b>Integrity:</b> Implant will last so long as the nanobots are inside the bloodstream."}
 	return dat
 
 
 /obj/item/implant/mindshield/implant(mob/target)
 	if(..())
-		if(target.mind in SSticker.mode.head_revolutionaries || is_shadow_or_thrall(target))
-			target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
-			removed(target, 1)
-			qdel(src)
-			return -1
-		if(target.mind in SSticker.mode.revolutionaries)
-			SSticker.mode.remove_revolutionary(target.mind)
-		if(target.mind in SSticker.mode.cult)
-			to_chat(target, "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
-		else
+		if(target.stat != DEAD)
 			to_chat(target, "<span class='notice'>Your mind feels hardened - more resistant to brainwashing.</span>")
 		return 1
 	return 0
@@ -36,7 +27,7 @@
 /obj/item/implant/mindshield/removed(mob/target, var/silent = 0)
 	if(..())
 		if(target.stat != DEAD && !silent)
-			to_chat(target, "<span class='boldnotice'>You feel a sense of liberation as Nanotrasen's grip on your mind fades away.</span>")
+			to_chat(target, "<span class='boldnotice'>Your mind feels vulnerable - more open to outside influences.</span>")
 		return 1
 	return 0
 

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -84,6 +84,13 @@
 	new /obj/item/implantcase/mindshield(src)
 	new /obj/item/implanter/mindshield(src)
 
+/obj/item/storage/lockbox/loyalty/New()
+	..()
+	new /obj/item/implantcase/loyalty(src)
+	new /obj/item/implantcase/loyalty(src)
+	new /obj/item/implantcase/loyalty(src)
+	new /obj/item/implanter/loyalty(src)
+
 /obj/item/storage/lockbox/clusterbang
 	name = "lockbox (clusterbang)"
 	desc = "You have a bad feeling about opening this."

--- a/paradise.dme
+++ b/paradise.dme
@@ -998,6 +998,7 @@
 #include "code\game\objects\items\weapons\implants\implant_explosive.dm"
 #include "code\game\objects\items\weapons\implants\implant_freedom.dm"
 #include "code\game\objects\items\weapons\implants\implant_krav_maga.dm"
+#include "code\game\objects\items\weapons\implants\implant_loyalty.dm"
 #include "code\game\objects\items\weapons\implants\implant_mindshield.dm"
 #include "code\game\objects\items\weapons\implants\implant_misc.dm"
 #include "code\game\objects\items\weapons\implants\implant_storage.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that Mindshields provides protection against brainwashing, and does not work like a loyalty implant or mind slave implant
Adds Loyalty Implants back into the game

## Why It's Good For The Game
Works as the name says and not as remove brainwashing implant, with loyalty implants taking over as the brainwashing part.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
del: Remove Mindshield implants reverting cultists, revs or shadowling thralls
tweak: Changed the Implant data for mindshields to only protect against brainwashing.
add: Adds back Loyalty Implants, Nanotrasens answer to the Syndicates Mindslave implants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
