### PR TITLE
Ports TG world.IsBanned() arg update and anti-flood check

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -1,5 +1,5 @@
 //Blocks an attempt to connect before even creating our client datum thing.
-world/IsBanned(key, address, computer_id, check_ipintel = TRUE)
+world/IsBanned(key, address, computer_id, type, check_ipintel = TRUE)
 
 	if(!config.ban_legacy_system)
 		if(address)
@@ -11,11 +11,20 @@ world/IsBanned(key, address, computer_id, check_ipintel = TRUE)
 		log_adminwarn("Failed Login (invalid data): [key] [address]-[computer_id]")
 		return list("reason"="invalid login data", "desc"="Error: Could not check ban status, please try again. Error message: Your computer provided invalid or blank information to the server on connection (BYOND Username, IP, and Computer ID). Provided information for reference: Username: '[key]' IP: '[address]' Computer ID: '[computer_id]'. If you continue to get this error, please restart byond or contact byond support.")
 
+	if(type == "world")
+		return ..() //shunt world topic banchecks to purely to byond's internal ban system
+
 	if(text2num(computer_id) == 2147483647) //this cid causes stickybans to go haywire
 		log_adminwarn("Failed Login (invalid cid): [key] [address]-[computer_id]")
 		return list("reason"="invalid login data", "desc"="Error: Could not check ban status, Please try again. Error message: Your computer provided an invalid Computer ID.")
+
 	var/admin = 0
 	var/ckey = ckey(key)
+
+	var/client/C = GLOB.directory[ckey]
+	if (C && ckey == C.ckey && computer_id == C.computer_id && address == C.address)
+		return //don't recheck connected clients.
+
 	if((ckey in admin_datums) || (ckey in GLOB.deadmins))
 		var/datum/admins/A = admin_datums[ckey]
 		if(A && (A.rights & R_ADMIN))

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -149,7 +149,7 @@ var/list/chatResources = list(
 				var/list/row = connectionHistory[i]
 				if(!row || row.len < 3 || !(row["ckey"] && row["compid"] && row["ip"]))
 					return
-				if(world.IsBanned(row["ckey"], row["ip"], row["compid"], FALSE))
+				if(world.IsBanned(key=row["ckey"], address=row["ip"], computer_id=row["compid"], type=null, check_ipintel=FALSE))
 					found = row
 					break
 			//Add autoban using the DB_ban_record function


### PR DESCRIPTION
## What Does This PR Do
1) Ports https://github.com/tgstation/tgstation/pull/32384 - fixes our world/IsBanned not being updated to account for a BYOND change where the world/IsBanned proc now includes a 4th param, 'type'.
2) Ports https://github.com/tgstation/tgstation/pull/48583 - changes by MSO which prevent BYOND from degrading server performance during world topic calls. Anti-DOS measure.
3) Future-proofs calls to world/IsBanned by using explicitly named params to avoid this sort of thing happening again if it changes in future. This one was requested by Lummox.

## Why It's Good For The Game
1) Fixes our code not being up to date with changes to how BYOND works
2) DOS mitigation
3) Future-proofing code

## Changelog
:cl: Kyep
fix: Updated old backend code, prevented situation where performance could degrade
/:cl: