### PR TITLE
Some changes suggested by lummox (anti-flood protection)

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -360,10 +360,10 @@
 	. = ..()	//calls mob.Login()
 
 
-	if(ckey in clientmessages)
-		for(var/message in clientmessages[ckey])
+	if(ckey in GLOB.clientmessages)
+		for(var/message in GLOB.clientmessages[ckey])
 			to_chat(src, message)
-		clientmessages.Remove(ckey)
+		GLOB.clientmessages.Remove(ckey)
 
 	if(SSinput.initialized)
 		set_macros()
@@ -413,7 +413,7 @@
 	for(var/mob/M in GLOB.player_list)
 		if(M.client)
 			playercount += 1
-	
+
 	if(playercount >= 150 && GLOB.panic_bunker_enabled == 0)
 		GLOB.panic_bunker_enabled = 1
 		message_admins("Panic bunker has been automatically enabled due to playercount surpassing 150")
@@ -553,7 +553,7 @@
 			src << "Sorry but the server is currently not accepting connections from never before seen players. Please try again later."
 			del(src)
 			return // Dont insert or they can just go in again
-		
+
 		var/DBQuery/query_insert = dbcon.NewQuery("INSERT INTO [format_table_name("player")] (id, ckey, firstseen, lastseen, ip, computerid, lastadminrank) VALUES (null, '[ckey]', Now(), Now(), '[sql_ip]', '[sql_computerid]', '[sql_admin_rank]')")
 		if(!query_insert.Execute())
 			var/err = query_insert.ErrorMsg()
@@ -774,7 +774,7 @@
 	// Change the way they should download resources.
 	if(config.resource_urls)
 		preload_rsc = pick(config.resource_urls)
-	else 
+	else
 		preload_rsc = 1 // If config.resource_urls is not set, preload like normal.
 	// Most assets are now handled through global_cache.dm
 	getFiles(

--- a/code/modules/client/message.dm
+++ b/code/modules/client/message.dm
@@ -4,6 +4,7 @@ proc/addclientmessage(var/ckey, var/message)
 	ckey = ckey(ckey)
 	if(!ckey || !message)
 		return
-	if(!(ckey in clientmessages))
-		clientmessages[ckey] = list()
-	clientmessages[ckey] += message
+	var/list/L = GLOB.clientmessages[ckey]
+	if(!L)
+		GLOB.clientmessages[ckey] = L = list()
+	L += message

--- a/code/modules/client/message.dm
+++ b/code/modules/client/message.dm
@@ -1,4 +1,4 @@
-var/list/clientmessages = list()
+GLOBAL_LIST_EMPTY(clientmessages)
 
 proc/addclientmessage(var/ckey, var/message)
 	ckey = ckey(ckey)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -25,7 +25,7 @@
 		else
 			log_admin("Client [ckey] was just autokicked for flooding keysends; likely abuse but potentially lagspike.")
 			message_admins("Client [ckey] was just autokicked for flooding keysends; likely abuse but potentially lagspike.")
-			QDEL_IN(src, 1)
+			qdel(src)
 			return
 
 	///Check if the key is short enough to even be a real key
@@ -33,7 +33,7 @@
 		to_chat(src, "<span class='userdanger'>Invalid KeyDown detected! You have been disconnected from the server automatically.</span>")
 		log_admin("Client [ckey] just attempted to send an invalid keypress. Keymessage was over [MAX_KEYPRESS_COMMANDLENGTH] characters, autokicking due to likely abuse.")
 		message_admins("Client [ckey] just attempted to send an invalid keypress. Keymessage was over [MAX_KEYPRESS_COMMANDLENGTH] characters, autokicking due to likely abuse.")
-		QDEL_IN(src, 1)
+		qdel(src)
 		return
 	//offset by 1 because the buffer address is 0 indexed because the math was simpler
 	keys_held[current_key_address + 1] = _key


### PR DESCRIPTION
## What Does This PR Do
Ports https://github.com/tgstation/tgstation/pull/48594
This:
- Changes the way keysend flood detection works, so that the flooding client is instantly booted. Without this, the kick takes long enough to come into effect that they can still flood the server and lag it until the kick actually happens.
- Rewrites a couple of minor things to be more like TG (using GLOB to indicate a global var, for example)
- Does NOT port the miscellaneous RD console change in the original PR, since we don't appear to have that code

## Why It's Good For The Game
Stops keysend flooders lagging the game until the server gets around to kicking them.

## Changelog
:cl: Kyep
fix: Improved protection against malicious clients flooding keysends
/:cl: