### PR TITLE
Adds Calcium Zeolite and Tranexamic Acid

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -59,6 +59,8 @@ var/global/default_martial_art = new/datum/martial_art
 	var/max_blood = BLOOD_VOLUME_NORMAL // For stuff in the vessel
 	var/bleed_rate = 0
 	var/bleedsuppress = 0 //for stopping bloodloss
+	var/bleed_rate_modifier = 1 //bleeding rate modifiered via percentage, 1 = 100%
+	var/internal_bleed_rate_modifier = 1 //bleeding rate modifiered via percentage, 1 = 100%
 
 	var/check_mutations=0 // Check mutations on next life tick
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -106,6 +106,59 @@
 		if(!Org.is_robotic())
 			Org.rejuvenate()
 
+/datum/reagent/medicine/tran_acid
+	name = "Tranexamic acid"
+	id = "tran_acid"
+	description = "A specialised chemical used for the treatment of truamatic bleeding and to control bleeding during surgery."
+	reagent_state = LIQUID
+	color = "#fcec96"
+	overdose_threshold = 40
+	harmless = FALSE
+	taste_description = "time running out"
+
+// This reagent's effects are handled in handle blood  code
+
+/datum/reagent/medicine/quikclot
+	name = "Calicum Zeolite"
+	id = "quikclot"
+	description = "A naturally occuring mineral used for treating mass hemorrhage. Use with caution."
+	reagent_state = LIQUID
+	color = "#f3d7a4"
+	overdose_threshold = 15
+	harmless = FALSE
+	taste_description = "Bonemeal"
+
+// This reagent's effects are handled in handle blood code
+
+/datum/reagent/medicine/quikclot/overdose_process(mob/living/M, severity)
+	var/list/overdose_info = ..()
+	var/effect = overdose_info[REAGENT_OVERDOSE_EFFECT]
+	var/update_flags = overdose_info[REAGENT_OVERDOSE_FLAGS]
+	if(severity == 1)
+		if(effect <= 1)
+			M.visible_message("<span class='warning'>[M] suddenly and violently vomits!</span>")
+			M.fakevomit(no_text = 1)
+		else if(effect <= 3)
+			M.emote(pick("groan","moan"))
+		if(effect <= 8)
+			M.emote("collapse")
+	else if(severity == 2)
+		if(effect <= 2)
+			M.visible_message("<span class='warning'>[M] suddenly and violently vomits!</span>")
+			M.fakevomit(no_text = 1)
+		else if(effect <= 5)
+			M.visible_message("<span class='warning'>[M.name] staggers and drools!</span>")
+			M.Dizzy(2)
+			update_flags |= M.Weaken(3, FALSE)
+		if(effect <= 15)
+			M.emote("collapse")
+	if(prob(5))	
+		if(istype(M,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			if(!H.undergoing_cardiac_arrest())
+				H.set_heartattack(TRUE) //this is a powerful clotting factor, overdose and experience SCD
+	return list(effect, update_flags)
+
 /datum/reagent/medicine/cryoxadone
 	name = "Cryoxadone"
 	id = "cryoxadone"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -106,55 +106,6 @@
 		if(!Org.is_robotic())
 			Org.rejuvenate()
 
-/datum/reagent/medicine/tran_acid
-	name = "Tranexamic acid"
-	id = "tran_acid"
-	description = "A specialised chemical used for the treatment of truamatic bleeding and to control bleeding during surgery."
-	reagent_state = LIQUID
-	color = "#fcec96"
-	overdose_threshold = 40
-	taste_description = "time running out"
-// This reagent's effects are handled in handle_blood() code
-
-/datum/reagent/medicine/calzeo
-	name = "Calicum Zeolite"
-	id = "calzeo"
-	description = "A naturally occuring mineral used for treating mass hemorrhage. Use with caution."
-	reagent_state = LIQUID
-	color = "#f3d7a4"
-	overdose_threshold = 15
-	harmless = FALSE
-	taste_description = "Bonemeal"
-// This reagent's effects are handled in handle_blood() code
-
-/datum/reagent/medicine/calzeo/overdose_process(mob/living/M, severity)
-	var/list/overdose_info = ..()
-	var/effect = overdose_info[REAGENT_OVERDOSE_EFFECT]
-	var/update_flags = overdose_info[REAGENT_OVERDOSE_FLAGS]
-	if(severity == 1)
-		if(effect <= 1)
-			M.visible_message("<span class='warning'>[M] suddenly and violently vomits!</span>")
-			M.fakevomit(no_text = 1)
-		else if(effect <= 3)
-			M.emote(pick("groan", "moan"))
-		if(effect <= 8)
-			M.emote("collapse")
-	else if(severity == 2)
-		if(effect <= 2)
-			M.visible_message("<span class='warning'>[M] suddenly and violently vomits!</span>")
-			M.fakevomit(no_text = 1)
-		else if(effect <= 5)
-			M.visible_message("<span class='warning'>[M.name] staggers and drools!</span>")
-			M.Dizzy(2)
-			update_flags |= M.Weaken(3, FALSE)
-		if(effect <= 15)
-			M.emote("collapse")
-	if(prob(5))	
-		if(istype(M, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			H.set_heartattack(TRUE) //this is a powerful clotting factor, overdose and experience SCD
-	return list(effect, update_flags)
-
 /datum/reagent/medicine/cryoxadone
 	name = "Cryoxadone"
 	id = "cryoxadone"
@@ -1244,3 +1195,81 @@
 	update_flags |= M.adjustFireLoss(3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	update_flags |= M.adjustToxLoss(3*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
+
+//blood loss suppressing chems
+
+/datum/reagent/medicine/bleedsuppress
+	name = "bleedsuppression"
+	id = "bleedsuppression"
+	reagent_state = LIQUID
+	taste_description = "bitterness"
+	var/externalbleedslow = 1 //affects bleedrate 1 = 100%
+	var/internalbleedslow = 1 //affects internal bleed rate 1 = 100%
+
+/datum/reagent/medicine/bleedsuppress/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(externalbleedslow < H.bleed_rate_modifier) // this is to stop multiple chems from jockeying for the modifier
+			H.bleed_rate_modifier = externalbleedslow
+		if(internalbleedslow < H.internal_bleed_rate_modifier) //ditto
+			H.internal_bleed_rate_modifier = internalbleedslow
+	return ..() | update_flags
+
+/datum/reagent/medicine/bleedsuppress/on_mob_delete(mob/living/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.bleed_rate_modifier = 1
+		H.internal_bleed_rate_modifier = 1
+	..()
+
+/datum/reagent/medicine/bleedsuppress/tran_acid
+	name = "Tranexamic acid"
+	id = "tran_acid"
+	description = "A specialised chemical used for the treatment of truamatic bleeding and to control bleeding during surgery."
+	reagent_state = LIQUID
+	color = "#fcec96"
+	overdose_threshold = 40
+	taste_description = "time running out"
+	externalbleedslow = 0.3
+	internalbleedslow = 0.3
+
+/datum/reagent/medicine/bleedsuppress/calzeo
+	name = "Calicum Zeolite"
+	id = "calzeo"
+	description = "A naturally occuring mineral used for treating mass hemorrhage. Use with caution."
+	reagent_state = LIQUID
+	color = "#f3d7a4"
+	overdose_threshold = 15
+	harmless = FALSE
+	taste_description = "Bonemeal"
+	externalbleedslow = 0
+	internalbleedslow = 0
+
+/datum/reagent/medicine/bleedsuppress/calzeo/overdose_process(mob/living/M, severity)
+	var/list/overdose_info = ..()
+	var/effect = overdose_info[REAGENT_OVERDOSE_EFFECT]
+	var/update_flags = overdose_info[REAGENT_OVERDOSE_FLAGS]
+	if(severity == 1)
+		if(effect <= 1)
+			M.visible_message("<span class='warning'>[M] suddenly and violently vomits!</span>")
+			M.fakevomit(no_text = 1)
+		else if(effect <= 3)
+			M.emote(pick("groan", "moan"))
+		if(effect <= 8)
+			M.emote("collapse")
+	else if(severity == 2)
+		if(effect <= 2)
+			M.visible_message("<span class='warning'>[M] suddenly and violently vomits!</span>")
+			M.fakevomit(no_text = 1)
+		else if(effect <= 5)
+			M.visible_message("<span class='warning'>[M.name] staggers and drools!</span>")
+			M.Dizzy(2)
+			update_flags |= M.Weaken(3, FALSE)
+		if(effect <= 15)
+			M.emote("collapse")
+	if(prob(5))	
+		if(istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			H.set_heartattack(TRUE) //this is a powerful clotting factor, overdose and experience SCD
+	return list(effect, update_flags)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -150,7 +150,7 @@
 		if(effect <= 15)
 			M.emote("collapse")
 	if(prob(5))	
-		if(istype(M,/mob/living/carbon/human))
+		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			H.set_heartattack(TRUE) //this is a powerful clotting factor, overdose and experience SCD
 	return list(effect, update_flags)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -113,24 +113,21 @@
 	reagent_state = LIQUID
 	color = "#fcec96"
 	overdose_threshold = 40
-	harmless = FALSE
 	taste_description = "time running out"
+// This reagent's effects are handled in handle_blood() code
 
-// This reagent's effects are handled in handle blood  code
-
-/datum/reagent/medicine/quikclot
+/datum/reagent/medicine/calzeo
 	name = "Calicum Zeolite"
-	id = "quikclot"
+	id = "calzeo"
 	description = "A naturally occuring mineral used for treating mass hemorrhage. Use with caution."
 	reagent_state = LIQUID
 	color = "#f3d7a4"
 	overdose_threshold = 15
 	harmless = FALSE
 	taste_description = "Bonemeal"
+// This reagent's effects are handled in handle_blood() code
 
-// This reagent's effects are handled in handle blood code
-
-/datum/reagent/medicine/quikclot/overdose_process(mob/living/M, severity)
+/datum/reagent/medicine/calzeo/overdose_process(mob/living/M, severity)
 	var/list/overdose_info = ..()
 	var/effect = overdose_info[REAGENT_OVERDOSE_EFFECT]
 	var/update_flags = overdose_info[REAGENT_OVERDOSE_FLAGS]
@@ -139,7 +136,7 @@
 			M.visible_message("<span class='warning'>[M] suddenly and violently vomits!</span>")
 			M.fakevomit(no_text = 1)
 		else if(effect <= 3)
-			M.emote(pick("groan","moan"))
+			M.emote(pick("groan", "moan"))
 		if(effect <= 8)
 			M.emote("collapse")
 	else if(severity == 2)
@@ -155,8 +152,7 @@
 	if(prob(5))	
 		if(istype(M,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-			if(!H.undergoing_cardiac_arrest())
-				H.set_heartattack(TRUE) //this is a powerful clotting factor, overdose and experience SCD
+			H.set_heartattack(TRUE) //this is a powerful clotting factor, overdose and experience SCD
 	return list(effect, update_flags)
 
 /datum/reagent/medicine/cryoxadone

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -19,10 +19,10 @@
 	required_reagents = list("oil" = 1, "ethanol" = 1, "ammonia" = 1)
 	result_amount = 3
 
-/datum/chemical_reaction/quikclot
+/datum/chemical_reaction/calzeo
 	name = "Calcium Zeolite"
-	id = "quikclot"
-	result = "quikclot"
+	id = "calzeo"
+	result = "calzeo"
 	required_reagents = list("milk" = 1, "aluminum" = 1, "silicon" = 1, "plasma_dust" = 1, "water" = 1)
 	result_amount = 3
 	min_temp = T0C + 60

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -12,6 +12,23 @@
 	required_reagents = list("synthflesh" = 1, "cryoxadone" = 1, "plasma" = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/tran_acid
+	name = "Tranexamic acid"
+	id = "tran_acid"
+	result = "tran_acid"
+	required_reagents = list("oil" = 1, "ethanol" = 1, "ammonia" = 1)
+	result_amount = 3
+
+/datum/chemical_reaction/quikclot
+	name = "Calcium Zeolite"
+	id = "quikclot"
+	result = "quikclot"
+	required_reagents = list("milk" = 1, "aluminum" = 1, "silicon" = 1, "plasma_dust" = 1, "water" = 1)
+	result_amount = 3
+	min_temp = T0C + 60
+	mix_message = "The mixture yields a fine white powder."
+	mix_sound = 'sound/goonstation/misc/fuse.ogg'
+
 /datum/chemical_reaction/cryoxadone
 	name = "Cryoxadone"
 	id = "cryoxadone"

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -72,11 +72,17 @@
 
 		bleed_rate = max(bleed_rate - 0.5, temp_bleed)//if no wounds, other bleed effects (heparin) naturally decreases
 
-		if(internal_bleeding_rate && !(status_flags & FAKEDEATH))
-			bleed_internal(internal_bleeding_rate)
+		if(internal_bleeding_rate && !(status_flags & FAKEDEATH) && !reagents.has_reagent("quikclot"))
+			if(reagents.has_reagent("tran_acid"))
+				bleed_internal(internal_bleeding_rate * 0.3) 	//bleed_internal(internal_bleeding_rate - 0.7 * reagents.has_reagent("tran_acid") * internal_bleeding_rate) efficient alternative 
+			else
+				bleed_internal(internal_bleeding_rate)
 
-		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH))
-			bleed(bleed_rate)
+		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH) && !reagents.has_reagent("quikclot"))
+			if(reagents.has_reagent("tran_acid"))
+				bleed(bleed_rate * 0.3) 	//bleed(bleed_rate - 0.7 * reagents.has_reagent("tran_acid") * bleed_rate) efficent alternative 
+			else
+				bleed(bleed_rate)
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/proc/bleed(amt)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -79,7 +79,7 @@
 		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH))
 			bleed(bleed_rate) 
 
-/mob/living/carbon/human/proc/get_bleed_modifier()
+/mob/living/carbon/human/proc/get_bleed_modifier() //this allows the rate of bleeding to be modified by a percentage based on the chemicals present, there is probably a better way to do this
 	if(reagents.has_reagent("calzeo"))
 		return 0
 	else if(reagents.has_reagent("tran_acid"))

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -70,12 +70,7 @@
 			if(BP.internal_bleeding)
 				internal_bleeding_rate += 0.5
 
-		if(temp_bleed > 0 || bleed_rate > 0 )
-			if(temp_bleed)
-				bleed_rate = temp_bleed * get_bleed_modifier() //temp_bleed to bleed_rate
-			else
-				bleed_rate = max(0, bleed_rate - 0.5) //if no wounds, other bleed effects (heparin) naturally decreases and can not go below 0
-		
+		bleed_rate = max(0, bleed_rate - 0.5, temp_bleed * get_bleed_modifier()) //if no wounds, other bleed effects (heparin) naturally decreases and can not go below 0
 		internal_bleeding_rate *= get_bleed_modifier()
 
 		if(internal_bleeding_rate && !(status_flags & FAKEDEATH))

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -48,6 +48,7 @@
 				death()
 
 		var/temp_bleed = 0
+		var/temp_internal_bleed = 0 //purely here because of a floating point error
 		var/internal_bleeding_rate = 0
 		//Bleeding out
 		for(var/X in bodyparts)
@@ -68,23 +69,16 @@
 				temp_bleed += 0.5
 
 			if(BP.internal_bleeding)
-				internal_bleeding_rate += 0.5
+				temp_internal_bleed += 0.5
 
-		bleed_rate = max(0, bleed_rate - 0.5, temp_bleed * get_bleed_modifier()) //if no wounds, other bleed effects (heparin) naturally decreases and can not go below 0
-		internal_bleeding_rate *= get_bleed_modifier()
+		bleed_rate = max(0, bleed_rate - 0.5, temp_bleed * bleed_rate_modifier) //if no wounds, other bleed effects (heparin) naturally decreases and can not go below 0
+		internal_bleeding_rate = max(0, temp_internal_bleed * internal_bleed_rate_modifier) //can not go below 0
 
 		if(internal_bleeding_rate && !(status_flags & FAKEDEATH))
 			bleed_internal(internal_bleeding_rate)
 
 		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH))
-			bleed(bleed_rate) 
-
-/mob/living/carbon/human/proc/get_bleed_modifier() //this allows the rate of bleeding to be modified by a percentage based on the chemicals present, there is probably a better way to do this
-	if(reagents.has_reagent("calzeo"))
-		return 0
-	else if(reagents.has_reagent("tran_acid"))
-		return 0.3
-	return 1
+			bleed(bleed_rate)
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/proc/bleed(amt)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -70,19 +70,21 @@
 			if(BP.internal_bleeding)
 				internal_bleeding_rate += 0.5
 
-		bleed_rate = max(bleed_rate - 0.5, temp_bleed)//if no wounds, other bleed effects (heparin) naturally decreases
+		bleed_rate = max(bleed_rate - 0.5, temp_bleed * get_bleed_modifier()) //if no wounds, other bleed effects (heparin) naturally decreases
+		internal_bleeding_rate *= get_bleed_modifier()
 
-		if(internal_bleeding_rate && !(status_flags & FAKEDEATH) && !reagents.has_reagent("quikclot"))
-			if(reagents.has_reagent("tran_acid"))
-				bleed_internal(internal_bleeding_rate * 0.3) 	//bleed_internal(internal_bleeding_rate - 0.7 * reagents.has_reagent("tran_acid") * internal_bleeding_rate) efficient alternative 
-			else
-				bleed_internal(internal_bleeding_rate)
+		if(internal_bleeding_rate && !(status_flags & FAKEDEATH))
+			bleed_internal(internal_bleeding_rate)
 
-		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH) && !reagents.has_reagent("quikclot"))
-			if(reagents.has_reagent("tran_acid"))
-				bleed(bleed_rate * 0.3) 	//bleed(bleed_rate - 0.7 * reagents.has_reagent("tran_acid") * bleed_rate) efficent alternative 
-			else
-				bleed(bleed_rate)
+		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH))
+			bleed(bleed_rate) 
+
+/mob/living/carbon/human/proc/get_bleed_modifier()
+	if(reagents.has_reagent("calzeo"))
+		return 0
+	else if(reagents.has_reagent("tran_acid"))
+		return 0.3
+	return 1
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/proc/bleed(amt)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -70,7 +70,12 @@
 			if(BP.internal_bleeding)
 				internal_bleeding_rate += 0.5
 
-		bleed_rate = max(bleed_rate - 0.5, temp_bleed * get_bleed_modifier()) //if no wounds, other bleed effects (heparin) naturally decreases
+		if(temp_bleed > 0 || bleed_rate > 0 )
+			if(temp_bleed)
+				bleed_rate = temp_bleed * get_bleed_modifier() //temp_bleed to bleed_rate
+			else
+				bleed_rate = max(0, bleed_rate - 0.5) //if no wounds, other bleed effects (heparin) naturally decreases and can not go below 0
+		
 		internal_bleeding_rate *= get_bleed_modifier()
 
 		if(internal_bleeding_rate && !(status_flags & FAKEDEATH))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This adds a pair of bleed rate affecting chemicals and the code additions required to make it work, specifically handle_blood in blood.dm was added too as these two chemicals have no effects of their own other than overdose.

update: originally this relied on blood.dm using a proc to figure out what level of suppression it should use, now I moved it out of there because i didn't think it was it was a good idea now.
Added vars to human_defines.dm for bleed rate modifiers, which are used by the chems to modify the bleed rate. 
These chems respect the lowest modifier and reset on filtering out of the system. 
Done some specific fixes because of a weird floating point error involving internal_bleed_rate going to negatives.

-Tranexamic acid slows bleeding and internal bleeding significantly, however significant damage and instances of IB overcome it through sheer brute force, at least giving people time to get medical attention if nothing else.  Good to inject during surgery to reduce blood loss.

-Calcium Zeolite halts all bleeding entirely while it remains in system and has a low overdose threshold with nasty side effects and a small chance of the user getting a heart attack.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
These chemicals add some quality of life to doctors and crew, there's very little in the way to levitate internal bleeding outside of surgery, pumping fresh blood, saline glucose solution or iron.
This adds two chemicals, one cheap and accessible and one harder to get, that slow bleeding and internal bleeding so multiple crew do not end up in medical and die from bleeding out because a doctor could not or can not make it to them in time.

## Changelog
:cl:
add: Tranexamic acid, reagent and recipe.
add: Calcium Zeolite ,reagent and recipe. 
~~add: new proc called get_bleed_modifier which is affected by whether the two chems are in the system with the stronger one overriding the other.~~
add: new parent specifically for bleed suppressing chems 
change: changes how bleed_rate was calculated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->