### PR TITLE
Another spelling fix in surgery

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -1,7 +1,7 @@
-//Procedures in this file: Gneric surgery steps
-//////////////////////////////////////////////////////////////////
+//Procedures in this file: Generic surgery steps
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //						COMMON STEPS							//
-//////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/surgery_step/generic/
 	can_infect = 1
@@ -237,7 +237,7 @@
 /datum/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>", \
-	"<span class='warning'> Your hand slips, sawwing through the bone in [target]'s [affected.name] with \the [tool]!</span>")
+	"<span class='warning'> Your hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>")
 	affected.receive_damage(30)
 	affected.fracture()
 	return 0


### PR DESCRIPTION
```diff
-- KOM-RAD's hand slips, sawwing through the bone in Vampy The Vampiric Clown's right leg with the surgical saw!
++ KOM-RAD's hand slips, sawing through the bone in Vampy The Vampiric Clown's right leg with the surgical saw!
```

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Just fixes a small spelling error. `sawwing` -> `sawing`

## Why It's Good For The Game
Misspellings detract from immersion.

## Changelog
:cl:
spellcheck: fixed misspelling in surgery saw fail step
/:cl: