### PR TITLE
Runtime Transparency/Summary

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -140,6 +140,9 @@
 /proc/log_asset(text)
 	WRITE_LOG(GLOB.world_asset_log, "ASSET: [text]")
 
+/proc/log_runtime_summary(text)
+	WRITE_LOG(GLOB.runtime_summary_log, "[text]")
+
 /**
  * Standardized method for tracking startup times.
  */

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -12,6 +12,8 @@ GLOBAL_VAR(world_href_log)
 GLOBAL_PROTECT(world_href_log)
 GLOBAL_VAR(world_asset_log)
 GLOBAL_PROTECT(world_asset_log)
+GLOBAL_VAR(runtime_summary_log)
+GLOBAL_PROTECT(runtime_summary_log)
 
 var/list/jobMax = list()
 var/list/admin_log = list (  )

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -414,6 +414,13 @@ var/failed_old_db_connections = 0
 	start_log(GLOB.world_runtime_log)
 	start_log(GLOB.world_qdel_log)
 
+	// This log follows a special format and this path should NOT be used for anything else
+	GLOB.runtime_summary_log = "data/logs/runtime_summary.log"
+	if(fexists(GLOB.runtime_summary_log))
+		fdel(GLOB.runtime_summary_log)
+	start_log(GLOB.runtime_summary_log)
+	// And back to sanity
+
 	if(fexists(GLOB.config_error_log))
 		fcopy(GLOB.config_error_log, "[GLOB.log_directory]/config_error.log")
 		fdel(GLOB.config_error_log)

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -44,6 +44,9 @@ var/total_runtimes_skipped = 0
 	error_last_seen[erroruid] = world.time
 	error_cooldown[erroruid] = cooldown
 
+	// This line will log a runtime summary to a file which can be publicly distributed without sending player data
+	log_runtime_summary("Runtime in [e.file],[e.line]: [e]")
+	
 	// The detailed error info needs some tweaking to make it look nice
 	var/list/srcinfo = null
 	var/list/usrinfo = null


### PR DESCRIPTION
## What Does This PR Do
Makes a separate file, `data/logs/runtime_summary.log` which logs all the runtimes in a round which allows anyone to view server runtimes to fix them, without giving away any ckeys involved with what happened

## Why It's Good For The Game
Allows more people to tackle runtimes

## Images of changes
![image](https://user-images.githubusercontent.com/25063394/71854305-9ab5e280-30d5-11ea-9ad3-9eda720d834d.png)
Does this count?

## Changelog
:cl:
add: Adds a runtime summary log, which shows a brief summary of runtimes which happened in the round
/:cl:

