### PR TITLE
Fixes a runtime with revenants when they click on mobs

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -61,6 +61,8 @@
 
 // health + cyborg analyzer for ghosts
 /mob/living/attack_ghost(mob/dead/observer/user)
+	if(!istype(user))
+		return
 	if(user.client && user.health_scan)
 		if(issilicon(src) || ismachine(src))
 			robot_healthscan(user, src)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -61,7 +61,7 @@
 
 // health + cyborg analyzer for ghosts
 /mob/living/attack_ghost(mob/dead/observer/user)
-	if(!istype(user))
+	if(!istype(user)) // Make sure user is actually an observer. Revenents also use attack_ghost, but do not have the health_scan var.
 		return
 	if(user.client && user.health_scan)
 		if(issilicon(src) || ismachine(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Revenants use `/mob/living/attack_ghost(mob/dead/observer/user)` when they click on mobs, which passes itself as user. However there is no safety check to make sure that the user is actually an observer, which lead to runtimes about the revenant not having a `health_scan` var, which only observers should have.

## Why It's Good For The Game
Fixes runtimes

## Changelog
:cl:
fix: Fixes a runtime with revenants when they click on mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
