### PR TITLE
Adds the job and antag status to the offer to ghost question

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -118,7 +118,10 @@
 	log_admin("[key_name(usr)] has offered control of ([key_name(M)]) to ghosts.")
 	var/minhours = input(usr, "Minimum hours required to play [M]?", "Set Min Hrs", 10) as num
 	message_admins("[key_name_admin(usr)] has offered control of ([key_name_admin(M)]) to ghosts with [minhours] hrs playtime")
-	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name ? M.real_name : M.name]?", poll_time = 100, min_hours = minhours)
+	var/question = "Do you want to play as [M.real_name ? M.real_name : M.name][M.job ? " ([M.job])" : ""]"
+	if(alert("Do you want to show the antag status?","Show antag status","Yes","No") == "Yes")
+		question += ", [M.mind?.special_role ? M.mind?.special_role : "No special role"]"
+	var/list/mob/dead/observer/candidates = pollCandidates("[question]?", poll_time = 100, min_hours = minhours)
 	var/mob/dead/observer/theghost = null
 
 	if(LAZYLEN(candidates))


### PR DESCRIPTION
## What Does This PR Do
Adds the job and, if chosen by the offering admin also the antag status to the offer to ghosts verb.

## Why It's Good For The Game
Makes it easier for ghosts to decide if they want to play a random character.

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/72153222-90ce0100-33ad-11ea-85bb-89363713dcae.png)


## Changelog
:cl:
tweak: The offer control to ghosts question now includes the job title and optionally the antag status if chosen so.
/:cl:
