### PR TITLE
Vamps and cling on agent + cling/vamp rounds will spawn now

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -28,6 +28,7 @@
 		changelings += changeling
 		modePlayer += changelings
 		changeling.restricted_roles = restricted_jobs
+		changeling.special_role = SPECIAL_ROLE_CHANGELING
 		return ..()
 	else
 		return 0

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -32,6 +32,7 @@
 		slaved.masters += vampire
 		vampire.som = slaved //we MIGT want to mindslave someone
 		vampire.restricted_roles = restricted_jobs
+		vampire.special_role = SPECIAL_ROLE_VAMPIRE
 		..()
 		return 1
 	else


### PR DESCRIPTION
## What Does This PR Do
Vampires and clings on agent + them rounds will now get their special_status variable assigned. Which is used by the spawning code to see if they are antag or not.

Fixes #11739
Fixes #12643

## Why It's Good For The Game
No more lobby players who are vampires/clings

## Changelog
:cl:
fix: Vamps and clings in agent + them rounds will now always spawn
/:cl:

