### PR TITLE
Antags that have their job unavailable will now spawn according to their preferences

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -389,8 +389,11 @@ SUBSYSTEM_DEF(jobs)
 	// Antags, who have to get in, come first
 	for(var/mob/new_player/player in unassigned)
 		if(player.mind.special_role)
-			GiveRandomJob(player)
-			if(player in unassigned)
+			if(player.client.prefs.alternate_option != BE_ASSISTANT)
+				GiveRandomJob(player)
+				if(player in unassigned)
+					AssignRole(player, "Civilian")
+			else
 				AssignRole(player, "Civilian")
 
 	// Then we assign what we can to everyone else.


### PR DESCRIPTION
## What Does This PR Do
Being an antag now makes you a civ if no jobs are available and you have that preference turned on.

Fixes #12771

## Why It's Good For The Game
Best to listen to peoples preferences init?

## Changelog
:cl:
fix: Antags now will spawn as civilians if their selected jobs are unavailable and they have the spawn as civ when job unavailable preference turned on
/:cl: