### PR TITLE
Gas Mix Mistake Fix

### DIFF
--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -645,7 +645,7 @@ What are the archived variables for?
 		((nitrogen < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.nitrogen) || (nitrogen > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.nitrogen)))
 		return 0
 	if((abs(carbon_dioxide-sample.carbon_dioxide) > MINIMUM_AIR_TO_SUSPEND) && \
-		((carbon_dioxide < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.carbon_dioxide) || (oxygen > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.carbon_dioxide)))
+		((carbon_dioxide < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.carbon_dioxide) || (carbon_dioxide > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.carbon_dioxide)))
 		return 0
 	if((abs(toxins-sample.toxins) > MINIMUM_AIR_TO_SUSPEND) && \
 		((toxins < (1-MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.toxins) || (toxins > (1+MINIMUM_AIR_RATIO_TO_SUSPEND)*sample.toxins)))


### PR DESCRIPTION
## What Does This PR Do
Fixes a mistake in the gas_mixture datum where the CO2 portion of sample comparison for group processing used the moles of oxygen in the sample instead of CO2.

## Why It's Good For The Game
It fixes what is just a blatant error in the code. It seems to fix a bug in which CO2 can sometimes disappear when being moved from pipelines to turf by injectors. Noticeably, the CO2 injector in the filter loop will not make all CO2 that comes through it disappear after the injector's pipeline has been emptied once.

## Changelog
:cl:
fix: CO2 comparison for group processing now uses CO2 from the sample instead of oxygen.
/:cl:
