### PR TITLE
Wizard Apprentices pass the IsWizard check. Wizard rounds end when all Wizards and Apprentices are dead.

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -99,7 +99,7 @@
 				new_objective:target = H:mind
 				new_objective.explanation_text = "Protect [H.real_name], the wizard."
 				M.mind.objectives += new_objective
-				SSticker.mode.traitors += M.mind
+				SSticker.mode.apprentices += M.mind
 				M.mind.special_role = SPECIAL_ROLE_WIZARD_APPRENTICE
 				SSticker.mode.update_wiz_icons_added(M.mind)
 				M.faction = list("wizard")

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -1,5 +1,6 @@
 /datum/game_mode
 	var/list/datum/mind/wizards = list()
+	var/list/datum/mind/apprentices = list()
 
 /datum/game_mode/wizard
 	name = "wizard"
@@ -161,7 +162,7 @@
 // Checks if the game should end due to all wizards and apprentices being dead, or MMI'd/Borged
 /datum/game_mode/wizard/check_finished()
 	var/wizards_alive = 0
-	var/traitors_alive = 0
+	var/apprentices_alive = 0
 
 	// Wizards
 	for(var/datum/mind/wizard in wizards)
@@ -173,18 +174,18 @@
 			continue
 		wizards_alive++
 
-	// Apprentices - classified as "traitors"
+	// Apprentices
 	if(!wizards_alive)
-		for(var/datum/mind/traitor in traitors)
-			if(!istype(traitor.current,/mob/living/carbon))
+		for(var/datum/mind/apprentice in apprentices)
+			if(!istype(apprentice.current,/mob/living/carbon))
 				continue
-			if(traitor.current.stat==DEAD)
+			if(apprentice.current.stat==DEAD)
 				continue
-			if(istype(traitor.current, /obj/item/mmi)) // apprentice is in an MMI, don't count them as alive
+			if(istype(apprentice.current, /obj/item/mmi)) // apprentice is in an MMI, don't count them as alive
 				continue
-			traitors_alive++
+			apprentices_alive++
 
-	if(wizards_alive || traitors_alive || but_wait_theres_more)
+	if(wizards_alive || apprentices_alive || but_wait_theres_more)
 		return ..()
 	else
 		finished = 1
@@ -279,4 +280,4 @@ Made a proc so this is not repeated 14 (or more) times.*/
 		return 1
 
 /proc/iswizard(mob/living/M as mob)
-	return istype(M) && M.mind && SSticker && SSticker.mode && (M.mind in SSticker.mode.wizards)
+	return istype(M) && M.mind && SSticker && SSticker.mode && ((M.mind in SSticker.mode.wizards) || (M.mind in SSticker.mode.apprentices))


### PR DESCRIPTION
## What Does This PR Do
Title.

## Why It's Good For The Game
Apprentices not passing the IsWizard check causes a few checks to fail when you'd think they shouldn't. In example, a Soul Stone Shard cannot be used by an apprentice cause they don't pass the check. 

Previously, apprentices were listed as traitors, so instead they've been listed as apprentices. As a consequence, wizard no longer checks if there are any traitors left alive, which means wizard rounds will end even if there are survivalists alive due to summon guns or magic.

Personally I think this change would be appropriate, as summon guns and magic extends wizard rounds by a ton of time, when they're normally short and chaotic.

## Changelog 
:cl:
tweak: Wizard Apprentices pass the IsWizard check.
tweak: Wizard rounds end if all wizards and apprentices are dead, even if there's survivalists.
/:cl: