### PR TITLE
Maxcap Devastation Range Spelling Fix

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -32,7 +32,7 @@ var/Debug = 0	// global debug switch
 var/Debug2 = 1   // enables detailed job debug file in secrets
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
-var/MAX_EX_DEVESTATION_RANGE = 3
+var/MAX_EX_DEVASTATION_RANGE = 3
 var/MAX_EX_HEAVY_RANGE = 7
 var/MAX_EX_LIGHT_RANGE = 14
 var/MAX_EX_FLASH_RANGE = 14

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -785,7 +785,7 @@
 					if(BombCap > 128)
 						BombCap = 128
 
-					MAX_EX_DEVESTATION_RANGE = round(BombCap/4)
+					MAX_EX_DEVASTATION_RANGE = round(BombCap/4)
 					MAX_EX_HEAVY_RANGE = round(BombCap/2)
 					MAX_EX_LIGHT_RANGE = BombCap
 					MAX_EX_FLASH_RANGE = BombCap

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1181,7 +1181,7 @@ steam.start() -- spawns the effect
 
 			// Clamp all values to MAX_EXPLOSION_RANGE
 			if(round(amount/12) > 0)
-				devastation = min (MAX_EX_DEVESTATION_RANGE, devastation + round(amount/12))
+				devastation = min (MAX_EX_DEVASTATION_RANGE, devastation + round(amount/12))
 
 			if(round(amount/6) > 0)
 				heavy = min (MAX_EX_HEAVY_RANGE, heavy + round(amount/6))

--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -172,7 +172,7 @@
 
 		// Clamp all values to MAX_EXPLOSION_RANGE
 		if(round(amount/12) > 0)
-			devastation = min (MAX_EX_DEVESTATION_RANGE, devastation + round(amount/12))
+			devastation = min (MAX_EX_DEVASTATION_RANGE, devastation + round(amount/12))
 
 		if(round(amount/6) > 0)
 			heavy = min (MAX_EX_HEAVY_RANGE, heavy + round(amount/6))

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -11,7 +11,7 @@
 
 	if(!ignorecap)
 		// Clamp all values to MAX_EXPLOSION_RANGE
-		devastation_range = min (MAX_EX_DEVESTATION_RANGE, devastation_range)
+		devastation_range = min (MAX_EX_DEVASTATION_RANGE, devastation_range)
 		heavy_impact_range = min (MAX_EX_HEAVY_RANGE, heavy_impact_range)
 		light_impact_range = min (MAX_EX_LIGHT_RANGE, light_impact_range)
 		flash_range = min (MAX_EX_FLASH_RANGE, flash_range)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2723,15 +2723,15 @@
 				if(newBombCap > 128)
 					newBombCap = 128
 
-				MAX_EX_DEVESTATION_RANGE = round(newBombCap/4)
+				MAX_EX_DEVASTATION_RANGE = round(newBombCap/4)
 				MAX_EX_HEAVY_RANGE = round(newBombCap/2)
 				MAX_EX_LIGHT_RANGE = newBombCap
 				//I don't know why these are their own variables, but fuck it, they are.
 				MAX_EX_FLASH_RANGE = newBombCap
 				MAX_EX_FLAME_RANGE = newBombCap
 
-				message_admins("<span class='boldannounce'>[key_name_admin(usr)] changed the bomb cap to [MAX_EX_DEVESTATION_RANGE], [MAX_EX_HEAVY_RANGE], [MAX_EX_LIGHT_RANGE]</span>")
-				log_admin("[key_name(usr)] changed the bomb cap to [MAX_EX_DEVESTATION_RANGE], [MAX_EX_HEAVY_RANGE], [MAX_EX_LIGHT_RANGE]")
+				message_admins("<span class='boldannounce'>[key_name_admin(usr)] changed the bomb cap to [MAX_EX_DEVASTATION_RANGE], [MAX_EX_HEAVY_RANGE], [MAX_EX_LIGHT_RANGE]</span>")
+				log_admin("[key_name(usr)] changed the bomb cap to [MAX_EX_DEVASTATION_RANGE], [MAX_EX_HEAVY_RANGE], [MAX_EX_LIGHT_RANGE]")
 
 			if("flicklights")
 				feedback_inc("admin_secrets_fun_used",1)


### PR DESCRIPTION
## What Does This PR Do
Fixes the spelling of "devastation" in the variable that sets the maximum devastation range.

## Why It's Good For The Game
Devestation is not a word.

## Changelog
:cl:
spellcheck: Maxcap bombs are now devastating instead of devestating.
/:cl: