### PR TITLE
Fixes the array index out of range in keyDown() due to players joining prior to SSInput is initialised

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -367,6 +367,8 @@
 
 	if(SSinput.initialized)
 		set_macros()
+	else
+		reset_keys_held()
 
 	donator_check()
 	check_ip_intel()

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -33,13 +33,16 @@
 			erase_output = "[erase_output];[macro_name].parent=null"
 	winset(src, null, erase_output)
 
-/client/proc/set_macros()
-	set waitfor = FALSE
-
+/client/proc/reset_keys_held()
 	//Reset and populate the rolling buffer
 	keys_held.Cut()
 	for(var/i in 1 to HELD_KEY_BUFFER_LENGTH)
 		keys_held += null
+
+/client/proc/set_macros()
+	set waitfor = FALSE
+
+	reset_keys_held()
 
 	erase_all_macros()
 


### PR DESCRIPTION
## What Does This PR Do
Should fix the runtime where keys_held is accessed using a wrong index due to the array not being made properly.
Runtime in bindings_client.dm,39: list index out of bounds: proc name: keyDown (/client/verb/keyDown)

## Why It's Good For The Game
Very eager players who join before SSInput is started now won't cause runtimes

## Changelog
:cl:
fix: Players who join before SSInput has started now won't cause runtimes anymore
/:cl: