### PR TITLE
Terror queen spit is now blockable

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -335,8 +335,8 @@
 	damage_type = TOX
 	var/bonus_tox = 30
 
-/obj/item/projectile/terrorqueenspit/on_hit(mob/living/carbon/target)
-	if(ismob(target))
+/obj/item/projectile/terrorqueenspit/on_hit(mob/living/carbon/target, blocked = 0, hit_zone)
+	if(ismob(target) && blocked < 100)
 		var/mob/living/L = target
 		if(L.reagents)
 			if(L.can_inject(null, FALSE, "chest", FALSE))


### PR DESCRIPTION
## What Does This PR Do
Terror queens spit is now blockable like the message you get says it does.

## Why It's Good For The Game
It doesn't make sense to block something and still get hit by it

## Changelog
:cl:
fix: Queen terror spit is now blockable like the message says it is
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
