### PR TITLE
Fix borg unbuckling

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -31,6 +31,18 @@
 	if(buckled_mobs.len)
 		return TRUE
 
+/atom/movable/attack_robot(mob/living/user)
+	. = ..()
+	if(can_buckle && has_buckled_mobs() && Adjacent(user)) // attack_robot is called on all ranges, so the Adjacent check is needed
+		if(buckled_mobs.len > 1)
+			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
+			if(user_unbuckle_mob(unbuckled,user))
+				return 1
+		else
+			if(user_unbuckle_mob(buckled_mobs[1], user))
+				return 1
+
+
 //procs that handle the actual buckling and unbuckling
 /atom/movable/proc/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(!buckled_mobs)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -14,16 +14,16 @@
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
-				return 1
+				return TRUE
 		else
 			if(user_unbuckle_mob(buckled_mobs[1], user))
-				return 1
+				return TRUE
 
 /atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	if(can_buckle && istype(M) && istype(user))
 		if(user_buckle_mob(M, user))
-			return 1
+			return TRUE
 
 /atom/movable/proc/has_buckled_mobs()
 	if(!buckled_mobs)
@@ -37,10 +37,10 @@
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
-				return 1
+				return TRUE
 		else
 			if(user_unbuckle_mob(buckled_mobs[1], user))
-				return 1
+				return TRUE
 
 
 //procs that handle the actual buckling and unbuckling


### PR DESCRIPTION
Fix #12569

Buckling refactor removed the cyborg unbuckling proc as an undocumented/unintentional change, causing the bug.

This PR readds it, modified to fit the new buckling.

Cyborgs not being able to unbuckle really screws over secborgs and medborgs specifically, and it doesnt make sense that they can buckle others but not unbuckle.

:cl:
fix: Cyborgs are able to unbuckle others again.
/:cl: