### PR TITLE
is_hot refactor and heating tweaks

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1201,57 +1201,6 @@ var/global/list/common_tools = list(
 	if(istype(O, /obj/item/stack/cable_coil))
 		return 1
 	return 0
-
-/proc/is_hot(obj/item/W as obj)
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/O = W
-		if(O.isOn())
-			return 2500
-		else
-			return 0
-	if(istype(W, /obj/item/lighter))
-		var/obj/item/lighter/O = W
-		if(O.lit)
-			return 1500
-		else
-			return 0
-	if(istype(W, /obj/item/match))
-		var/obj/item/match/O = W
-		if(O.lit == 1)
-			return 1000
-		else
-			return 0
-	if(istype(W, /obj/item/clothing/mask/cigarette))
-		var/obj/item/clothing/mask/cigarette/O = W
-		if(O.lit)
-			return 1000
-		else
-			return 0
-	if(istype(W, /obj/item/candle))
-		var/obj/item/candle/O = W
-		if(O.lit)
-			return 1000
-		else
-			return 0
-	if(istype(W, /obj/item/flashlight/flare))
-		var/obj/item/flashlight/flare/O = W
-		if(O.on)
-			return 1000
-		else
-			return 0
-	if(istype(W, /obj/item/gun/energy/plasmacutter))
-		return 3800
-	if(istype(W, /obj/item/melee/energy))
-		var/obj/item/melee/energy/O = W
-		if(O.active)
-			return 3500
-		else
-			return 0
-	if(istype(W, /obj/item/assembly/igniter))
-		return 20000
-	else
-		return 0
-
 //Whether or not the given item counts as sharp in terms of dealing damage
 /proc/is_sharp(obj/O)
 	if(!O)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -12,9 +12,9 @@
 	return
 
 /obj/item/proc/pre_attackby(atom/A, mob/living/user, params) //do stuff before attackby!
-	if(is_hot(src) && A.reagents && !ismob(A))
+	if(is_hot() && A.reagents && !ismob(A))
 		to_chat(user, "<span class='notice'>You heat [A] with [src].</span>")
-		A.reagents.temperature_reagents(is_hot(src))
+		A.reagents.temperature_reagents(src.is_hot(), A.reagents.total_volume)	//higher volume means you heat it less
 	return TRUE //return FALSE to avoid calling attackby after this proc does stuff
 
 // No comment

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -14,7 +14,7 @@
 /obj/item/proc/pre_attackby(atom/A, mob/living/user, params) //do stuff before attackby!
 	if(is_hot() && A.reagents && !ismob(A))
 		to_chat(user, "<span class='notice'>You heat [A] with [src].</span>")
-		A.reagents.temperature_reagents(src.is_hot(), A.reagents.total_volume)	//higher volume means you heat it less
+		A.reagents.temperature_reagents(is_hot(), A.reagents.total_volume)	//higher volume means you heat it less
 	return TRUE //return FALSE to avoid calling attackby after this proc does stuff
 
 // No comment

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -783,7 +783,7 @@ var/global/list/multiverse = list()
 
 /obj/item/voodoo/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(target && cooldown < world.time)
-		if(is_hot(I))
+		if(I.is_hot())
 			to_chat(target, "<span class='userdanger'>You suddenly feel very hot</span>")
 			target.bodytemperature += 50
 			GiveHint(target)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -192,11 +192,11 @@
 	qdel(src)
 
 /obj/machinery/door/airlock/plasma/attackby(obj/C, mob/user, params)
-	if(is_hot(C) > 300)
+	if(C.is_hot() > 300)
 		message_admins("Plasma airlock ignited by [key_name_admin(user)] in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 		log_game("Plasma airlock ignited by [key_name(user)] in ([x],[y],[z])")
 		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
-		ignite(is_hot(C))
+		ignite(C.is_hot())
 	else
 		return ..()
 

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -54,6 +54,10 @@
 		return
 	return ..()
 
+/obj/item/candle/is_hot()
+	if(lit)
+		return 1270
+	return 0
 
 /obj/item/candle/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	if(!lit)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -224,6 +224,11 @@
 		src.damtype = "fire"
 		START_PROCESSING(SSobj, src)
 
+/obj/item/flashlight/flare/is_hot()
+	if(on)
+		return 1870
+	return 0
+
 // GLOWSTICKS
 
 /obj/item/flashlight/flare/glowstick

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -12,7 +12,7 @@
 
 /obj/item/flag/attackby(obj/item/W, mob/user, params)
 	. = ..()
-	if(is_hot(W) && !(resistance_flags & ON_FIRE))
+	if(W.is_hot() && !(resistance_flags & ON_FIRE))
 		user.visible_message("<span class='notice'>[user] lights [src] with [W].</span>", "<span class='notice'>You light [src] with [W].</span>", "<span class='warning'>You hear a low whoosh.</span>")
 		fire_act()
 
@@ -254,7 +254,7 @@
 		return ..()
 
 /obj/item/flag/chameleon/attackby(obj/item/W, mob/user, params)
-	if(is_hot(W) && !(resistance_flags & ON_FIRE) && boobytrap && trapper)
+	if(W.is_hot() && !(resistance_flags & ON_FIRE) && boobytrap && trapper)
 		var/turf/bombturf = get_turf(src)
 		var/area/A = get_area(bombturf)
 		message_admins("[key_name_admin(user)] has lit the [src] trapped with [boobytrap] by [key_name_admin(trapper)] at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name] (JMP)</a>.")

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -61,5 +61,5 @@
 		var/obj/item/tank/T = W
 		blow(T, user)
 		return
-	if(is_sharp(W) || is_hot(W) || is_pointed(W))
+	if(is_sharp(W) || W.is_hot() || is_pointed(W))
 		burst()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -217,7 +217,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	recipes = plasma_recipes
 
 /obj/item/stack/sheet/mineral/plasma/attackby(obj/item/W, mob/user, params)
-	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
+	if(W.is_hot() > 300)//If the temperature of the object is over 300, then ignite
 		message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user,"?")]) ([ADMIN_FLW(user,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma sheets ignited by [key_name(user)] in ([x],[y],[z])")
 		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -25,7 +25,7 @@
 	if(iswelder(W))
 		var/obj/item/weldingtool/WT = W
 
-		if(is_hot(W) && !mineralType)
+		if(W.is_hot() && !mineralType)
 			to_chat(user, "<span class='warning'>You can not reform this!</span>")
 			return
 

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -59,6 +59,10 @@ LIGHTERS ARE IN LIGHTERS.DM
 	else
 		return ..()
 
+/obj/item/clothing/mask/cigarette/is_hot()
+	if(lit)
+		return 1170
+	return 0
 
 /obj/item/clothing/mask/cigarette/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	..()

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -17,6 +17,11 @@
 	resistance_flags = FIRE_PROOF
 	var/lit = 0
 
+/obj/item/lighter/is_hot()
+	if(lit)
+		return 870
+	return 0
+
 /obj/item/lighter/zippo
 	name = "zippo lighter"
 	desc = "The zippo."
@@ -157,6 +162,11 @@
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "materials=1"
 	attack_verb = null
+
+/obj/item/match/is_hot()
+	if(lit)
+		return 870
+	return 0
 
 /obj/item/match/process()
 	var/turf/location = get_turf(src)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -76,6 +76,11 @@
 	add_fingerprint(user)
 	return
 
+/obj/item/melee/energy/is_hot()
+	if(active)
+		return 4100
+	return 0
+
 /obj/item/melee/energy/axe
 	name = "energy axe"
 	desc = "An energised battle axe."

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -363,6 +363,11 @@
 	user.visible_message("<span class='suicide'>[user] welds [user.p_their()] every orifice closed! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return FIRELOSS
 
+/obj/item/weldingtool/is_hot()
+	if(isOn())
+		return 6270	//according to quick google search
+	return 0
+	
 /obj/item/weldingtool/proc/update_torch()
 	overlays.Cut()
 	if(welding)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -287,6 +287,9 @@ a {
 /obj/proc/CanAStarPass()
 	. = !density
 
+/obj/proc/is_hot()	//is this object hot and can ignite or heat stuff, and if yes at what temp
+	return 0
+
 /obj/proc/on_mob_move(dir, mob/user)
 	return
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -240,7 +240,7 @@
 	canSmoothWith = list(/obj/structure/falsewall/plasma, /turf/simulated/wall/mineral/plasma, /turf/simulated/wall/mineral/alien)
 
 /obj/structure/falsewall/plasma/attackby(obj/item/W, mob/user, params)
-	if(is_hot(W) > 300)
+	if(W.is_hot() > 300)
 		message_admins("Plasma falsewall ignited by [key_name_admin(user)] in [ADMIN_VERBOSEJMP(T)]")
 		log_game("Plasma falsewall ignited by [key_name(user)] in [AREACOORD(T)]")
 		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -188,7 +188,7 @@
 	sheetType = /obj/item/stack/sheet/mineral/plasma
 
 /obj/structure/mineral_door/transparent/plasma/attackby(obj/item/W, mob/user)
-	if(is_hot(W))
+	if(W.is_hot())
 		message_admins("Plasma mineral door ignited by [key_name_admin(user)] in ([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)", 0, 1)
 		log_game("Plasma mineral door ignited by [key_name(user)] in ([x], [y], [z])")
 		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -131,11 +131,11 @@
 	..()
 
 /obj/structure/statue/plasma/attackby(obj/item/W, mob/user, params)
-	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
+	if(W.is_hot() > 300)//If the temperature of the object is over 300, then ignite
 		message_admins("[key_name_admin(user)] ignited a plasma statue at [COORD(loc)]")
 		log_game("[key_name(user)] ignited plasma a statue at [COORD(loc)]")
 		investigate_log("[key_name(user)] ignited a plasma statue at [COORD(loc)]", "atmos")
-		ignite(is_hot(W))
+		ignite(W.is_hot())
 		return
 	return ..()
 

--- a/code/game/turfs/simulated/floor/mineral.dm
+++ b/code/game/turfs/simulated/floor/mineral.dm
@@ -38,11 +38,11 @@
 		PlasmaBurn()
 
 /turf/simulated/floor/mineral/plasma/attackby(obj/item/W, mob/user, params)
-	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
+	if(W.is_hot() > 300)//If the temperature of the object is over 300, then ignite
 		message_admins("Plasma flooring was ignited by [key_name_admin(user)]([ADMIN_QUE(user,"?")]) ([ADMIN_FLW(user,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma flooring was <b>ignited by [key_name(user)] in ([x],[y],[z])")
 		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
-		ignite(is_hot(W))
+		ignite(W.is_hot())
 		return
 	..()
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -93,11 +93,11 @@
 	canSmoothWith = list(/turf/simulated/wall/mineral/plasma, /obj/structure/falsewall/plasma)
 
 /turf/simulated/wall/mineral/plasma/attackby(obj/item/W as obj, mob/user as mob)
-	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
+	if(W.is_hot() > 300)//If the temperature of the object is over 300, then ignite
 		message_admins("Plasma wall ignited by [key_name_admin(user)] in ([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Plasma wall ignited by [key_name(user)] in ([x], [y], [z])")
 		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
-		ignite(is_hot(W))
+		ignite(W.is_hot())
 		return
 	..()
 

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -43,3 +43,6 @@
 	activate()
 	add_fingerprint(user)
 	return
+
+/obj/item/assembly/igniter/is_hot()
+	return 20000

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -334,7 +334,7 @@
 	..()
 
 /obj/item/reagent_containers/food/drinks/bottle/molotov/attackby(obj/item/I, mob/user, params)
-	if(is_hot(I) && !active)
+	if(I.is_hot() && !active)
 		active = 1
 		var/turf/bombturf = get_turf(src)
 		var/area/bombarea = get_area(bombturf)

--- a/code/modules/food_and_drinks/drinks/drinks/shotglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/shotglass.dm
@@ -77,7 +77,7 @@
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/attackby(obj/item/W)
 	..()
-	if(is_hot(W))
+	if(W.is_hot())
 		fire_act()
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/attack_hand(mob/user, pickupfireoverride = TRUE)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -124,7 +124,7 @@
 		to_chat(user, "<span class='italics'>You add a rod to [src].")
 		var/image/U = image(icon='icons/obj/hydroponics/equipment.dmi',icon_state="bonfire_rod",pixel_y=16)
 		underlays += U
-	if(is_hot(W))
+	if(W.is_hot())
 		StartBurning()
 
 

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -173,7 +173,7 @@
 		attempt_signature(user)
 	else if(istype(P, /obj/item/stamp))
 		to_chat(user,"<span class='notice'>You stamp the paper with your rubber stamp, however the ink ignites as you release the stamp.</span>")
-	else if(is_hot(P))
+	else if(P.is_hot())
 		user.visible_message("<span class='danger'>[user] brings [P] next to [src], but [src] does not catch fire!</span>", "<span class='danger'>The [src] refuses to ignite!</span>")
 	else
 		return ..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -384,7 +384,7 @@
 
 		to_chat(user, "<span class='notice'>You stamp the paper with your rubber stamp.</span>")
 
-	if(is_hot(P))
+	if(P.is_hot())
 		if((CLUMSY in user.mutations) && prob(10))
 			user.visible_message("<span class='warning'>[user] accidentally ignites [user.p_them()]self!</span>", \
 								"<span class='userdanger'>You miss the paper and accidentally light yourself on fire!</span>")

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -71,7 +71,7 @@
 		internal_paper.attackby(P, user) //spoofed attack to update internal paper.
 		update_icon()
 
-	else if(is_hot(P))
+	else if(P.is_hot())
 		if(user.disabilities & CLUMSY && prob(10))
 			user.visible_message("<span class='warning'>[user] accidentally ignites [user.p_them()]self!</span>", \
 				"<span class='userdanger'>You miss [src] and accidentally light yourself on fire!</span>")

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -188,6 +188,9 @@
 /obj/item/gun/energy/plasmacutter/update_icon()
 	return
 
+/obj/item/gun/energy/plasmacutter/is_hot()
+	return 3800
+
 /obj/item/gun/energy/plasmacutter/adv
 	name = "advanced plasma cutter"
 	icon_state = "adv_plasmacutter"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR does two things. First, it turns is_hot from an unsorted helper proc to an object level proc to remove that horrible istype construct. Secondly, adjusts how things like heaters and welding tools heat up reagents in a container, namely the more reagents you are heating up the slower you heat them. I also tweaked the temperatures for some of those heating sources, correcting lighters, matches and cigarettes down and welding tools up.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes weird code, makes lighters less OP at heating chemicals, adds muh realism.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: refactor of is_hot
tweak: heating up reagents with hot items takes longer if more reagents are being heated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
