### PR TITLE
Fixes RUST-G loading on linux

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -1,5 +1,5 @@
 //location of the rust-g library
-#define RUST_G "rust_g"
+#define RUST_G (world.system_type == UNIX ? "./librust_g.so" : "./rust_g.dll")
 
 // On Linux/Unix systems the line endings are LF, on windows it's CRLF, admins that don't use notepad++
 // will get logs that are one big line if the system is Linux and they are using notepad.  This solves it by adding CR to every line ending


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so rust_g actually loads on linux (You still have to compile it yourself). Made due to a player having trouble hosting the code under linux.

## Why It's Good For The Game
Currently the server is unable to be hosted on linux, which is bad because that approach gives 3x lower init times, and a lot better performance. This allows the server to be hosted on linux. 

## Changelog
:cl: AffectedArc07
tweak: RUST-G now loads on linux
/:cl:
