### PR TITLE
[DNM] Machinery processing refactor; Converts some machines to event-based processing

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -12,6 +12,12 @@
 #define IDLE_POWER_USE 1
 #define ACTIVE_POWER_USE 2
 
+// bitflags for a machine's processing preferences
+#define START_PROCESSING_ON_INIT 	1	// if the machine should start processing on Initialize()
+#define START_PROCESSING_MANUALLY 	2	// if the machine will start processing in the future, after Initialize(), such as when a certain condition is met
+#define NORMAL_PROCESS_SPEED		4	// normal processing speed
+#define FAST_PROCESS_SPEED			8	// fast processing speed
+
 //computer3 error codes, move lower in the file when it passes dev -Sayu
  #define PROG_CRASH      1  // Generic crash
  #define MISSING_PERIPHERAL  2  // Missing hardware

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -173,9 +173,7 @@
 			if(!.)
 				calling_holopad.atom_say("No answer received.")
 				calling_holopad.temp = ""
-
-	else if(!.)
-		qdel(src)
+				qdel(src) // the caller failed to make a connection, therefore, delete the holocall
 
 /datum/action/innate/end_holocall
 	name = "End Holocall"

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -43,8 +43,11 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 	switch(index)
 		if(SMARTFRIDGE_WIRE_THROW)
 			S.shoot_inventory = !S.shoot_inventory
+			if(S.shoot_inventory)
+				S.begin_processing()
 		if(SMARTFRIDGE_WIRE_ELECTRIFY)
 			S.seconds_electrified = 30
+			S.begin_processing()
 		if(SMARTFRIDGE_WIRE_IDSCAN)
 			S.scan_id = !S.scan_id
 	..()
@@ -54,6 +57,8 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 	switch(index)
 		if(SMARTFRIDGE_WIRE_THROW)
 			S.shoot_inventory = !mended
+			if(S.shoot_inventory)
+				S.begin_processing()
 		if(SMARTFRIDGE_WIRE_ELECTRIFY)
 			if(mended)
 				S.seconds_electrified = 0

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -248,9 +248,9 @@
 	var/default_timer = 4500
 	var/detonation_timer
 	var/announced = 0
+	processing_flags = START_PROCESSING_MANUALLY | FAST_PROCESS_SPEED
 
 /obj/machinery/doomsday_device/Destroy()
-	STOP_PROCESSING(SSfastprocess, src)
 	SSshuttle.emergencyNoEscape = 0
 	if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 		SSshuttle.emergency.mode = SHUTTLE_DOCKED
@@ -261,7 +261,7 @@
 /obj/machinery/doomsday_device/proc/start()
 	detonation_timer = world.time + default_timer
 	timing = 1
-	START_PROCESSING(SSfastprocess, src)
+	begin_processing()
 	SSshuttle.emergencyNoEscape = 1
 
 /obj/machinery/doomsday_device/proc/seconds_remaining()
@@ -278,7 +278,7 @@
 			priority_announcement.Announce("Hostile environment resolved. You have 3 minutes to board the Emergency Shuttle.", "Priority Announcement", 'sound/AI/shuttledock.ogg')
 		qdel(src)
 	if(!timing)
-		STOP_PROCESSING(SSfastprocess, src)
+		end_processing()
 		return
 	var/sec_left = seconds_remaining()
 	if(sec_left <= 0)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -23,6 +23,7 @@ var/bomb_set
 	use_power = NO_POWER_USE
 	var/previous_level = ""
 	var/datum/wires/nuclearbomb/wires = null
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/nuclearbomb/syndicate
 	is_syndicate = 1
@@ -47,7 +48,8 @@ var/bomb_set
 			spawn
 				explode()
 		SSnanoui.update_uis(src)
-	return
+	else
+		end_processing() // timer has been stopped, stop processing
 
 /obj/machinery/nuclearbomb/attackby(obj/item/O as obj, mob/user as mob, params)
 	if(istype(O, /obj/item/screwdriver))
@@ -297,6 +299,7 @@ var/bomb_set
 					if(!lighthack)
 						icon_state = "nuclearbomb2"
 					if(!safety)
+						begin_processing()
 						message_admins("[key_name_admin(usr)] engaged a nuclear bomb (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 						if(!is_syndicate)
 							set_security_level("delta")
@@ -347,6 +350,7 @@ var/bomb_set
 #define NUKERANGE 80
 /obj/machinery/nuclearbomb/proc/explode()
 	if(safety)
+		end_processing()
 		timing = 0
 		return
 	timing = -1.0

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -25,6 +25,7 @@
 	var/controls_inside = FALSE
 	idle_power_usage = 1250
 	active_power_usage = 2500
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 	light_color = LIGHT_COLOR_CYAN
 
@@ -81,6 +82,8 @@
 	go_out()
 
 /obj/machinery/sleeper/process()
+	if(!..())
+		return
 	if(filtering > 0)
 		if(beaker)
 			// To prevent runtimes from drawing blood from runtime, and to prevent getting IPC blood.
@@ -337,6 +340,7 @@
 			icon_state = "[base_icon]"
 			to_chat(M, "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
 			add_fingerprint(user)
+			begin_processing()
 			qdel(G)
 			return
 
@@ -389,6 +393,7 @@
 	occupant.forceMove(loc)
 	occupant = null
 	icon_state = "[base_icon]-open"
+	end_processing()
 	// eject trash the occupant dropped
 	for(var/atom/movable/A in contents - component_parts - list(beaker))
 		A.forceMove(loc)
@@ -488,6 +493,7 @@
 		icon_state = "[base_icon]"
 		to_chat(L, "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
 		add_fingerprint(user)
+		begin_processing()
 		if(user.pulling == L)
 			user.stop_pulling()
 		return

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -10,6 +10,7 @@
 	light_color = "#00FF00"
 	var/mob/living/carbon/human/occupant
 	var/known_implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/mindshield, /obj/item/implant/tracking, /obj/item/implant/health)
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/bodyscanner/Destroy()
 	go_out()
@@ -23,6 +24,8 @@
 		set_light(0)
 
 /obj/machinery/bodyscanner/process()
+	if(!..())
+		return
 	for(var/mob/M as mob in src) // makes sure that simple mobs don't get stuck inside a sleeper when they resist out of occupant's grasp
 		if(M == occupant)
 			continue
@@ -87,6 +90,7 @@
 		M.forceMove(src)
 		occupant = M
 		icon_state = "body_scanner_1"
+		begin_processing()
 		add_fingerprint(user)
 		qdel(TYPECAST_YOUR_SHIT)
 		return
@@ -129,6 +133,7 @@
 	occupant = H
 	icon_state = "bodyscanner"
 	add_fingerprint(user)
+	begin_processing()
 
 /obj/machinery/bodyscanner/attack_ai(user)
 	return attack_hand(user)
@@ -170,6 +175,7 @@
 	occupant.forceMove(loc)
 	occupant = null
 	icon_state = "body_scanner_0"
+	end_processing()
 	// eject trash the occupant dropped
 	for(var/atom/movable/A in contents - component_parts)
 		A.forceMove(loc)

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -11,6 +11,7 @@
 	pass_flags = PASSTABLE
 	var/obj/item/stock_parts/cell/charging = null
 	var/chargelevel = -1
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/cell_charger/deconstruct()
 	if(charging)
@@ -67,6 +68,7 @@
 			charging = I
 			user.visible_message("[user] inserts a cell into the charger.", "<span class='notice'>You insert a cell into the charger.</span>")
 			chargelevel = -1
+			begin_processing()
 			updateicon()
 	else if(iswrench(I))
 		if(charging)
@@ -84,6 +86,7 @@
 	charging.update_icon()
 	charging = null
 	chargelevel = -1
+	end_processing()
 	updateicon()
 
 /obj/machinery/cell_charger/attack_hand(mob/user)
@@ -120,7 +123,7 @@
 
 
 /obj/machinery/cell_charger/process()
-	if(!charging || !anchored || (stat & (BROKEN|NOPOWER)))
+	if(!..() || !charging || !anchored)
 		return
 
 	if(charging.percent() >= 100)

--- a/code/game/machinery/chiller.dm
+++ b/code/game/machinery/chiller.dm
@@ -8,6 +8,7 @@
 	desc = "If you can't take the heat, use one of these."
 	set_temperature = 20		// in celcius, add T0C for kelvin
 	var/cooling_power = 40000
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/space_heater/air_conditioner/New()
 	..()
@@ -97,7 +98,13 @@
 		user << browse("<HEAD><TITLE>Air Conditioner Control Panel</TITLE></HEAD><TT>[dat]</TT>", "window=aircond")
 		onclose(user, "aircond")
 	else
-		on = !on
+		if(!on)
+			on = TRUE
+			begin_processing()
+		else
+			on = FALSE
+			end_processing()
+
 		user.visible_message("<span class='notice'>[user] switches [on ? "on" : "off"] the [src].</span>","<span class='notice'>You switch [on ? "on" : "off"] the [src].</span>")
 		update_icon()
 	return
@@ -163,6 +170,8 @@
 	return 0
 
 /obj/machinery/space_heater/air_conditioner/process()
+	if(!..())
+		return
 	if(on)
 		if(cell && cell.charge > 0)
 			if(chill())

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -19,6 +19,7 @@
 	var/nextTick = OP_COMPUTER_COOLDOWN
 	var/healthAlarm = 50
 	var/oxy = 1 //oxygen beeping toggle
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/computer/operating/New()
 	..()
@@ -170,7 +171,10 @@
 
 
 /obj/machinery/computer/operating/process()
-
+	// when someone lays down on the linked operating table, the table begins processing, and also tells this computer to begin processing
+	// you can see this in OpTable.dm, line 105-106
+	if(!..())
+		return
 	if(table && table.check_victim())
 		if(verbose)
 			if(patientName!=table.victim.name)
@@ -186,3 +190,5 @@
 					playsound(src.loc, 'sound/machines/defib_saftyoff.ogg', 50, 0)
 				if(healthAnnounce && victim.health <= healthAlarm)
 					atom_say("[round(victim.health)]")
+	else
+		end_processing() // we don't have a linked table and there is no victim, end processing

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -10,6 +10,7 @@
 	interact_offline = 1
 	max_integrity = 350
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 30, "acid" = 30)
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 	var/on = 0
 	var/temperature_archived
 	var/mob/living/carbon/occupant = null
@@ -138,19 +139,20 @@
 				user.stop_pulling()
 
 /obj/machinery/atmospherics/unary/cryo_cell/process()
-	..()
-	if(autoeject)
-		if(occupant)
+	if(!..())
+		return
+
+	if(occupant)
+		if(autoeject)
 			if(!occupant.has_organic_damage() && !occupant.has_mutated_organs())
 				on = 0
 				go_out()
 				playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 
-	if(air_contents)
-		if(occupant)
+		if(air_contents)
 			process_occupant()
 
-	return 1
+	return TRUE
 
 /obj/machinery/atmospherics/unary/cryo_cell/process_atmos()
 	..()
@@ -426,6 +428,7 @@
 		occupant.bodytemperature = 261
 	occupant = null
 	update_icon()
+	end_processing()
 	// eject trash the occupant dropped
 	for(var/atom/movable/A in contents - component_parts - list(beaker))
 		A.forceMove(get_step(loc, SOUTH))
@@ -451,6 +454,7 @@
 //	M.metabslow = 1
 	add_fingerprint(usr)
 	update_icon()
+	begin_processing()
 	M.ExtinguishMob()
 	return 1
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -215,6 +215,7 @@
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/last_no_computer_message = 0
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 	// These items are preserved when the process() despawn proc occurs.
 	var/list/preserve_items = list(
@@ -292,6 +293,9 @@
 
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/machinery/cryopod/process()
+	if(!..())
+		return
+
 	if(occupant)
 		// Eject dead people
 		if(occupant.stat == DEAD)
@@ -460,6 +464,7 @@
 			occupant.ghostize(1)
 	QDEL_NULL(occupant)
 	name = initial(name)
+	end_processing()
 
 #undef CRYO_DESTROY
 #undef CRYO_PRESERVE
@@ -597,6 +602,7 @@
 	if(!E)
 		return
 	E.forceMove(src)
+	begin_processing()
 	time_till_despawn = initial(time_till_despawn) / willing_factor
 	if(orient_right)
 		icon_state = "[occupied_icon_state]-r"
@@ -688,6 +694,7 @@
 		to_chat(usr, "<span class='notice'>[on_enter_occupant_message]</span>")
 		to_chat(usr, "<span class='boldnotice'>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</span>")
 		occupant = usr
+		begin_processing()
 		time_entered = world.time
 
 		add_fingerprint(usr)
@@ -701,6 +708,7 @@
 
 	occupant.forceMove(get_turf(src))
 	occupant = null
+	end_processing()
 
 	if(orient_right)
 		icon_state = "[base_icon_state]-r"

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -35,6 +35,7 @@
 	var/crimes = "None"
 	var/time = 0
 	var/officer = "None"
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/door_timer/New()
  	GLOB.celltimers_list += src
@@ -170,7 +171,7 @@
 // if it's less than 0, open door, reset timer
 // update the door_timer window and the icon
 /obj/machinery/door_timer/process()
-	if(stat & (NOPOWER|BROKEN))
+	if(!..())
 		return
 	if(timing)
 		if(timeleft() <= 0)
@@ -208,7 +209,7 @@
 
 	// Set releasetime
 	releasetime = world.timeofday + timetoset
-	START_PROCESSING(SSmachines, src)
+	begin_processing()
 
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
 		if(door.density)
@@ -235,6 +236,8 @@
 /obj/machinery/door_timer/proc/timer_end()
 	if(stat & (NOPOWER|BROKEN))
 		return 0
+
+	end_processing()
 
 	// Reset vars
 	occupant = "None"

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -13,6 +13,7 @@
 	var/unlocked = FALSE
 	var/open = FALSE
 	var/brightness_on = 14
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/floodlight/get_cell()
 	return cell
@@ -32,13 +33,15 @@
 /obj/machinery/floodlight/process()
 	if(!cell && on)
 		on = FALSE
+		end_processing()
 		visible_message("<span class='warning'>[src] shuts down due to lack of power!</span>")
-		update_icon()
+		updateicon()
 		set_light(0)
 	if(on)
 		cell.charge -= use
 		if(cell.charge <= 0)
 			on = FALSE
+			end_processing()
 			updateicon()
 			set_light(0)
 			visible_message("<span class='warning'>[src] shuts down due to lack of power!</span>")
@@ -68,6 +71,7 @@
 
 	if(on)
 		on = FALSE
+		end_processing()
 		to_chat(user, "<span class='notice'>You turn off the light.</span>")
 		set_light(0)
 	else
@@ -76,6 +80,7 @@
 		if(cell.charge <= 0)
 			return
 		on = TRUE
+		begin_processing()
 		to_chat(user, "<span class='notice'>You turn on the light.</span>")
 		set_light(brightness_on)
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -17,9 +17,10 @@
 	var/frequency = 0
 	var/logic_id_tag = "default"					//Defines the ID tag to send logic signals to.
 	var/logic_connect = 0							//Set this to allow the switch to send out logic signals.
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 
-/obj/machinery/light_switch/New(turf/loc, var/w_dir=null)
+/obj/machinery/light_switch/New(turf/loc, w_dir=null)
 	..()
 	switch(w_dir)
 		if(NORTH)
@@ -141,8 +142,12 @@
 	..(severity)
 
 /obj/machinery/light_switch/process()
+	if(!..())
+		return
 	if(logic_connect && powered(LIGHT))		//We won't send signals while unpowered, but the last signal will remain valid for anything that received it before we went dark
 		handle_output()
+	else
+		end_processing()
 
 /obj/machinery/light_switch/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/detective_scanner))
@@ -162,7 +167,7 @@
 
 	return ..()
 
-/obj/machinery/light_switch/multitool_menu(var/mob/user, var/obj/item/multitool/P)
+/obj/machinery/light_switch/multitool_menu(mob/user, obj/item/multitool/P)
 	return {"
 	<ul>
 	<li><b>Light Circuit Connection:</b> <a href='?src=[UID()];toggle_light_connect=1'>[light_connect ? "On" : "Off"]</a></li>
@@ -170,9 +175,13 @@
 	<li><b>Logic ID Tag:</b> [format_tag("Logic ID Tag", "logic_id_tag")]</li>
 	</ul>"}
 
-/obj/machinery/light_switch/multitool_topic(var/mob/user,var/list/href_list,var/obj/O)
+/obj/machinery/light_switch/multitool_topic(mob/user, list/href_list, obj/O)
 	..()
 	if("toggle_light_connect" in href_list)
 		light_connect = !light_connect
 	if("toggle_logic" in href_list)
 		logic_connect = !logic_connect
+		if(logic_connect)
+			begin_processing()
+
+	update_multitool_menu(user)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -16,6 +16,7 @@
 	var/icon_state_charging = "recharger1"
 	var/icon_state_idle = "recharger0"
 	var/recharge_coeff = 1
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/recharger/New()
 	..()
@@ -63,6 +64,7 @@
 			G.forceMove(src)
 			charging = G
 			use_power = ACTIVE_POWER_USE
+			begin_processing()
 			update_icon()
 		else
 			to_chat(user, "<span class='notice'>[src] isn't connected to anything!</span>")
@@ -89,6 +91,7 @@
 		user.put_in_hands(charging)
 		charging = null
 		use_power = IDLE_POWER_USE
+		end_processing()
 		update_icon()
 
 /obj/machinery/recharger/attack_tk(mob/user)
@@ -100,7 +103,7 @@
 		update_icon()
 
 /obj/machinery/recharger/process()
-	if(stat & (NOPOWER|BROKEN) || !anchored)
+	if(!..() || !anchored)
 		return
 
 	using_power = FALSE

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -12,6 +12,7 @@
 	var/recharge_speed
 	var/recharge_speed_nutrition
 	var/repairs
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/recharge_station/New()
 	..()
@@ -49,7 +50,7 @@
 		recharge_speed_nutrition *= multiplier
 
 /obj/machinery/recharge_station/process()
-	if(!(NOPOWER|BROKEN))
+	if(!..())
 		return
 
 	if(src.occupant)
@@ -146,6 +147,7 @@
 		return
 	occupant.forceMove(loc)
 	occupant = null
+	end_processing()
 	build_icon()
 	use_power = IDLE_POWER_USE
 	return
@@ -280,6 +282,7 @@
 	user.forceMove(src)
 	occupant = user
 
+	begin_processing()
 	add_fingerprint(user)
 	build_icon()
 	update_use_power(1)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -141,6 +141,7 @@
 	var/list/deployed_shields = list()
 	var/is_open = FALSE //Whether or not the wires are exposed
 	var/locked = FALSE
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/shieldgen/Destroy()
 	QDEL_LIST(deployed_shields)
@@ -153,6 +154,7 @@
 		return //If it's already turned on, how did this get called?
 
 	active = 1
+	begin_processing()
 	update_icon()
 	anchored = 1
 
@@ -166,13 +168,14 @@
 		return //If it's already off, how did this get called?
 
 	active = 0
+	end_processing()
 	update_icon()
 
 	for(var/obj/machinery/shield/shield_tile in deployed_shields)
 		qdel(shield_tile)
 
 /obj/machinery/shieldgen/process()
-	if(malfunction && active)
+	if(active && malfunction)
 		if(deployed_shields.len && prob(5))
 			qdel(pick(deployed_shields))
 

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -12,6 +12,7 @@
 	var/open = 0
 	var/set_temperature = 50		// in celcius, add T0C for kelvin
 	var/heating_power = 40000
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/space_heater/get_cell()
 	return cell
@@ -105,7 +106,13 @@
 		onclose(user, "spaceheater")
 
 	else
-		on = !on
+		if(!on)
+			on = TRUE
+			begin_processing()
+		else
+			on = FALSE
+			end_processing()
+
 		user.visible_message("<span class='notice'>[user] switches [on ? "on" : "off"] [src].</span>","<span class='notice'>You switch [on ? "on" : "off"] [src].</span>")
 		update_icon()
 	return
@@ -154,6 +161,8 @@
 
 
 /obj/machinery/space_heater/process()
+	if(!..())
+		return
 	if(on)
 		if(cell && cell.charge > 0)
 			var/turf/simulated/L = loc

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -35,8 +35,6 @@
 	var/friendc = 0      // track if Friend Computer mode
 	var/ignore_friendc = 0
 
-	var/spookymode = 0
-
 	maptext_height = 26
 	maptext_width = 32
 	maptext_y = -1
@@ -62,11 +60,7 @@
 
 // timed process
 /obj/machinery/status_display/process()
-	if(stat & NOPOWER)
-		remove_display()
-		return
-	if(spookymode)
-		spookymode = 0
+	if(!..())
 		remove_display()
 		return
 	update()
@@ -79,18 +73,19 @@
 	..(severity)
 
 /obj/machinery/status_display/get_spooked()
-	spookymode = TRUE
+	remove_display()
+
+/obj/machinery/status_display/proc/ai_update()
+	if(friendc && !ignore_friendc)
+		set_picture("ai_friend")
+		return TRUE
 
 // set what is displayed
 /obj/machinery/status_display/proc/update()
-	if(friendc && !ignore_friendc)
-		set_picture("ai_friend")
-		return 1
-
 	switch(mode)
 		if(STATUS_DISPLAY_BLANK)	//blank
 			remove_display()
-			return 1
+			return TRUE
 		if(STATUS_DISPLAY_TRANSFER_SHUTTLE_TIME)				//emergency shuttle timer
 			var/use_warn = 0
 			if(SSshuttle.emergency && SSshuttle.emergency.timer)
@@ -104,7 +99,7 @@
 				message1 = "TIME"
 				message2 = station_time_timestamp("hh:mm")
 			update_display(message1, message2, use_warn)
-			return 1
+			return TRUE
 		if(STATUS_DISPLAY_MESSAGE)	//custom messages
 			var/line1
 			var/line2
@@ -127,13 +122,13 @@
 				if(index2 > message2_len)
 					index2 -= message2_len
 			update_display(line1, line2)
-			return 1
+			return TRUE
 		if(STATUS_DISPLAY_TIME)
 			message1 = "TIME"
 			message2 = station_time_timestamp("hh:mm")
 			update_display(message1, message2)
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /obj/machinery/status_display/examine(mob/user)
 	. = ..()
@@ -173,6 +168,7 @@
 	if(maptext)
 		maptext = ""
 
+// display receives a signal to update its screen to something else
 /obj/machinery/status_display/receive_signal(datum/signal/signal)
 	switch(signal.data["command"])
 		if("blank")
@@ -199,8 +195,6 @@
 	anchored = 1
 	density = 0
 
-	var/spookymode = 0
-
 	var/mode = 0	// 0 = Blank
 					// 1 = AI emoticon
 					// 2 = Blue screen of death
@@ -214,11 +208,7 @@
 		user.ai_statuschange()
 
 /obj/machinery/ai_status_display/process()
-	if(stat & NOPOWER)
-		overlays.Cut()
-		return
-	if(spookymode)
-		spookymode = 0
+	if(!..())
 		overlays.Cut()
 		return
 	update()
@@ -231,55 +221,56 @@
 	..(severity)
 
 /obj/machinery/ai_status_display/get_spooked()
-	spookymode = TRUE
+	overlays.Cut()
 
 /obj/machinery/ai_status_display/proc/update()
-	if(mode==0) //Blank
-		overlays.Cut()
-		return
+	switch(mode)
+		if(0) //Blank
+			overlays.Cut()
+			return
 
-	if(mode==1)	// AI emoticon
-		switch(emotion)
-			if("Very Happy")
-				set_picture("ai_veryhappy")
-			if("Happy")
-				set_picture("ai_happy")
-			if("Neutral")
-				set_picture("ai_neutral")
-			if("Unsure")
-				set_picture("ai_unsure")
-			if("Confused")
-				set_picture("ai_confused")
-			if("Sad")
-				set_picture("ai_sad")
-			if("Surprised")
-				set_picture("ai_surprised")
-			if("Upset")
-				set_picture("ai_upset")
-			if("Angry")
-				set_picture("ai_angry")
-			if("BSOD")
-				set_picture("ai_bsod")
-			if("Blank")
-				set_picture("ai_off")
-			if("Problems?")
-				set_picture("ai_trollface")
-			if("Awesome")
-				set_picture("ai_awesome")
-			if("Dorfy")
-				set_picture("ai_urist")
-			if("Facepalm")
-				set_picture("ai_facepalm")
-			if("Friend Computer")
-				set_picture("ai_friend")
-		return
+		if(1)	// AI emoticon
+			switch(emotion)
+				if("Very Happy")
+					set_picture("ai_veryhappy")
+				if("Happy")
+					set_picture("ai_happy")
+				if("Neutral")
+					set_picture("ai_neutral")
+				if("Unsure")
+					set_picture("ai_unsure")
+				if("Confused")
+					set_picture("ai_confused")
+				if("Sad")
+					set_picture("ai_sad")
+				if("Surprised")
+					set_picture("ai_surprised")
+				if("Upset")
+					set_picture("ai_upset")
+				if("Angry")
+					set_picture("ai_angry")
+				if("BSOD")
+					set_picture("ai_bsod")
+				if("Blank")
+					set_picture("ai_off")
+				if("Problems?")
+					set_picture("ai_trollface")
+				if("Awesome")
+					set_picture("ai_awesome")
+				if("Dorfy")
+					set_picture("ai_urist")
+				if("Facepalm")
+					set_picture("ai_facepalm")
+				if("Friend Computer")
+					set_picture("ai_friend")
+			return
 
-	if(mode==2)	// BSOD
-		set_picture("ai_bsod")
-		return
+		if(2)	// BSOD
+			set_picture("ai_bsod")
+			return
 
 
-/obj/machinery/ai_status_display/proc/set_picture(var/state)
+/obj/machinery/ai_status_display/proc/set_picture(state)
 	picture_state = state
 	if(overlays.len)
 		overlays.Cut()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -11,6 +11,7 @@
 	density = 0
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	processing_flags = START_PROCESSING_MANUALLY | FAST_PROCESS_SPEED
 
 	var/datum/wires/syndicatebomb/wires = null
 	var/minimum_timer = 90
@@ -47,7 +48,7 @@
 
 /obj/machinery/syndicatebomb/process()
 	if(!active)
-		STOP_PROCESSING(SSfastprocess, src)
+		end_processing()
 		detonation_timer = null
 		next_beep = null
 		countdown.stop()
@@ -81,7 +82,7 @@
 		if(defused && payload in src)
 			payload.defuse()
 			countdown.stop()
-			STOP_PROCESSING(SSfastprocess, src)
+			end_processing()
 
 /obj/machinery/syndicatebomb/New()
 	wires 	= new(src)
@@ -216,7 +217,7 @@
 
 /obj/machinery/syndicatebomb/proc/activate()
 	active = TRUE
-	START_PROCESSING(SSfastprocess, src)
+	begin_processing()
 	countdown.start()
 	next_beep = world.time + 10
 	detonation_timer = world.time + (timer_set * 10)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -21,6 +21,7 @@
 	var/drying = FALSE
 	var/visible_contents = TRUE
 	var/datum/wires/smartfridge/wires = null
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/smartfridge/New()
 	..()
@@ -202,10 +203,16 @@
 		return 1
 
 /obj/machinery/smartfridge/process()
-	if(stat & (BROKEN|NOPOWER))
+	if(!..())
 		return
+
+	if(seconds_electrified <= 0 && !shoot_inventory) //cutting the electrify wire will set `seconds_electrifed` to -1
+		end_processing()
+		return
+
 	if(seconds_electrified > 0)
 		seconds_electrified--
+
 	if(shoot_inventory && prob(2))
 		throw_item()
 

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -67,14 +67,16 @@
 	var/stack_amt = 50; //ammount to stack before releassing
 	input_dir = EAST
 	output_dir = WEST
-	speed_process = TRUE
 
 /obj/machinery/mineral/stacking_machine/process()
-	var/turf/T = get_step(src, input_dir)
-	if(T)
-		for(var/obj/item/stack/sheet/S in T)
-			process_sheet(S)
-			CHECK_TICK
+	if(!..())
+		return
+
+	for(var/obj/item/stack/sheet/S in input_turf)
+		process_sheet(S)
+		CHECK_TICK
+		
+	end_processing()
 
 /obj/machinery/mineral/stacking_machine/proc/process_sheet(obj/item/stack/sheet/inp)
 	if(!(inp.type in stack_list)) //It's the first of this sheet added

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -9,24 +9,26 @@
 	anchored = 1.0
 	input_dir = WEST
 	output_dir = EAST
-	speed_process = 1
 
 /obj/machinery/mineral/unloading_machine/process()
-	var/turf/T = get_step(src,input_dir)
-	if(T)
-		var/limit
-		for(var/obj/structure/ore_box/B in T)
-			for(var/obj/item/stack/ore/O in B)
-				B.contents -= O
-				unload_mineral(O)
-				limit++
-				if(limit>=10)
-					return
-				CHECK_TICK
-			CHECK_TICK
-		for(var/obj/item/I in T)
-			unload_mineral(I)
+	if(!..())
+		return
+
+	var/limit
+	for(var/obj/structure/ore_box/B in input_turf)
+		for(var/obj/item/stack/ore/O in B)
+			B.contents -= O
+			unload_mineral(O)
 			limit++
 			if(limit>=10)
 				return
 			CHECK_TICK
+		CHECK_TICK
+	for(var/obj/item/I in T)
+		unload_mineral(I)
+		limit++
+		if(limit>=10)
+			return
+		CHECK_TICK
+	
+	end_processing()

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -11,7 +11,7 @@
 	var/processing = FALSE
 	var/chosen = MAT_METAL //which material will be used to make coins
 	var/coinsToProduce = 10
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_MANUALLY | FAST_PROCESS_SPEED
 
 
 /obj/machinery/mineral/mint/New()
@@ -74,6 +74,7 @@
 	if(href_list["makeCoins"])
 		var/temp_coins = coinsToProduce
 		processing = TRUE
+		begin_processing()
 		icon_state = "coinpress1"
 		var/coin_mat = MINERAL_MATERIAL_AMOUNT * 0.2
 		var/datum/material/M = materials.materials[chosen]
@@ -90,6 +91,7 @@
 
 		icon_state = "coinpress0"
 		processing = FALSE
+		end_processing()
 		coinsToProduce = temp_coins
 	updateUsrDialog()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -885,6 +885,7 @@ var/list/ai_verbs_default = list(
 				SD.friendc = 1
 			else
 				SD.friendc = 0
+			SD.ai_update()
 	return
 
 //I am the icon meister. Bow fefore me.	//>fefore

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -16,6 +16,7 @@ var/global/list/rad_collectors = list()
 	var/active = 0
 	var/locked = 0
 	var/drainratio = 1
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 
 /obj/machinery/power/rad_collector/Initialize(mapload)
 	. = ..()
@@ -26,6 +27,8 @@ var/global/list/rad_collectors = list()
 	return ..()
 
 /obj/machinery/power/rad_collector/process()
+	if(!..())
+		return
 	if(P)
 		if(P.air_contents.toxins <= 0)
 			investigate_log("<font color='red'>out of fuel</font>.","singulo")
@@ -65,6 +68,7 @@ var/global/list/rad_collectors = list()
 		user.drop_item()
 		src.P = W
 		W.loc = src
+		begin_processing()
 		update_icons()
 	else if(istype(W, /obj/item/crowbar))
 		if(P && !src.locked)
@@ -111,6 +115,7 @@ var/global/list/rad_collectors = list()
 	Z.layer = initial(Z.layer)
 	Z.plane = initial(Z.plane)
 	src.P = null
+	end_processing()
 	if(active)
 		toggle_power()
 	else

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -7,6 +7,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 40
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	processing_flags = START_PROCESSING_MANUALLY | NORMAL_PROCESS_SPEED
 	var/obj/item/reagent_containers/beaker = null
 	var/desired_temp = T0C
 	var/on = FALSE
@@ -20,20 +21,21 @@
 	RefreshParts()
 
 /obj/machinery/chem_heater/process()
-	..()
-	if(stat & NOPOWER)
+	if(!..())
 		return
 	var/state_change = FALSE
 	if(on)
 		if(beaker)
 			if(!beaker.reagents.total_volume)
 				on = FALSE
+				end_processing()
 				SSnanoui.update_uis(src)
 				return
 			beaker.reagents.temperature_reagents(desired_temp)
 			beaker.reagents.temperature_reagents(desired_temp)
 			if(abs(beaker.reagents.chem_temp - desired_temp) <= 3)
 				on = FALSE
+				end_processing()
 			state_change = TRUE
 
 	if(state_change)
@@ -47,6 +49,7 @@
 		beaker = null
 		icon_state = "mixer0b"
 		on = FALSE
+		end_processing()
 		SSnanoui.update_uis(src)
 
 /obj/machinery/chem_heater/power_change()
@@ -108,7 +111,12 @@
 	if(href_list["toggle_on"])
 		if(!beaker.reagents.total_volume)
 			return FALSE
-		on = !on
+		if(!on)
+			on = TRUE
+			begin_processing()
+		else
+			on = FALSE
+			end_processing()
 		. = 1
 
 	if(href_list["adjust_temperature"])

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -124,9 +124,11 @@
 		to_chat(user, "<span class='notice'>You [active ? "deactivate": "activate"] the [src]</span>")
 	active = !active
 	if(active)
+		begin_processing()
 		animate(src, pixel_y = 2, time = 10, loop = -1)
 		anchored = 1
 	else
+		end_processing()
 		animate(src, pixel_y = 0, time = 10)
 		anchored = 0
 	update_icon()
@@ -144,7 +146,7 @@
 	name = "Meteor Shield Satellite"
 	desc = "Meteor Point Defense Satellite"
 	mode = "M-SHIELD"
-	speed_process = TRUE
+	processing_flags = START_PROCESSING_MANUALLY | FAST_PROCESS_SPEED
 	var/kill_range = 14
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Prerequisite PR: #11700

Putting a DNM on this because it's going to conflict to hell with the tool refactor and probably several other PRs since it modifies so many files.

## What Does This PR Do
This PR converts about 30 machines over "event-based processing" for lack of a better term. The idea is that these machines will now only begin processing when a certain criteria is met. For example, sleepers and cryotubes will now only process when there is an occupant, since there is no reason for them to be processing otherwise.

Replaces the `speed_process` var with a `processing_flags` var. Four different bitflags are meant to go here, which are:
```js
#define START_PROCESSING_ON_INIT     1
#define START_PROCESSING_MANUALLY    2
#define NORMAL_PROCESS_SPEED         4
#define FAST_PROCESS_SPEED           8
```
By default, all `obj/machinery` types start with these flags:
```js
processing_flags = START_PROCESSING_ON_INIT | NORMAL_PROCESS_SPEED
```
if you want to tell a machine to *not* start processing when the round starts, just replace the first flag with `START_PROCESSING_MANUALLY` instead. This allows it bypass the code in `/obj/machinery/Initialize()` that would normally tell it to immediately start processing. Then, simply find the places in the code in which you want to tell the machine to either being or end processing and use the `begin_processing()` and `end_processing()` procs respectively.

I won't explain absolutely everything I added here, but that was just a little introduction to the basics. Check out `machinery.dm` or `objs.dm` for more information on the procs available. If you have questions about specifics, just ask.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This will save a small amount of server resources, because the game won't have to pointlessly execute code when it doesn't need to.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Modifies a number of machines so that they will not constantly be processing even though there is no need for them to be. This will save some server resources. Back-end change only, there are no gameplay changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
