### PR TITLE
Instant Summons spell now respects no_drop and teleports the holder of the nodrop item to the wizard now

### DIFF
--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -52,73 +52,75 @@
 			marked_item = 		null
 
 		else	//Getting previously marked item
-			var/obj/item_to_retrive = marked_item
+			var/obj/item_to_retrieve = marked_item
 			var/infinite_recursion = 0 //I don't want to know how someone could put something inside itself but these are wizards so let's be safe
 
-			while(!isturf(item_to_retrive.loc) && infinite_recursion < 10) //if it's in something you get the whole thing.
-				if(ismob(item_to_retrive.loc)) //If its on someone, properly drop it
-					var/mob/M = item_to_retrive.loc
+			while(!isturf(item_to_retrieve.loc) && infinite_recursion < 10) //if it's in something you get the whole thing.
+				if(ismob(item_to_retrieve.loc)) //If its on someone, properly drop it
+					var/mob/M = item_to_retrieve.loc
 
 					if(issilicon(M)) //Items in silicons warp the whole silicon
 						M.loc.visible_message("<span class='warning'>[M] suddenly disappears!</span>")
 						M.loc = target.loc
 						M.loc.visible_message("<span class='caution'>[M] suddenly appears!</span>")
-						item_to_retrive = null
+						item_to_retrieve = null
 						break
 
-					M.unEquip(item_to_retrive)
-
+					if(!M.unEquip(item_to_retrieve))
+						to_chat(M, "<span class='warning'>You feel a force pulling at [item_to_retrieve]!</span>")
+						to_chat(target, "<span class='warning'>A force withholds [item_to_retrieve] to be recalled to you!</span>")
+						return
 					if(ishuman(M)) //Edge case housekeeping
 						var/mob/living/carbon/human/C = M
-						/*if(C.internal_bodyparts_by_name  && item_to_retrive in C.internal_bodyparts_by_name ) //This won't work, as we use organ datums instead of objects. --DZD
-							C.internal_bodyparts_by_name  -= item_to_retrive
+						/*if(C.internal_bodyparts_by_name  && item_to_retrieve in C.internal_bodyparts_by_name ) //This won't work, as we use organ datums instead of objects. --DZD
+							C.internal_bodyparts_by_name  -= item_to_retrieve
 							if(istype(marked_item, /obj/item/brain)) //If this code ever runs I will be happy
 								var/obj/item/brain/B = new /obj/item/brain(target.loc)
 								B.transfer_identity(C)
 								C.death()
 								add_attack_logs(target, C, "Magically debrained INTENT: [uppertext(target.a_intent)]")*/
-						if(C.stomach_contents && item_to_retrive in C.stomach_contents)
-							C.stomach_contents -= item_to_retrive
+						if(C.stomach_contents && item_to_retrieve in C.stomach_contents)
+							C.stomach_contents -= item_to_retrieve
 						for(var/X in C.bodyparts)
 							var/obj/item/organ/external/part = X
-							if(item_to_retrive in part.embedded_objects)
-								part.embedded_objects -= item_to_retrive
-								to_chat(C, "<span class='warning'>The [item_to_retrive] that was embedded in your [part] has mysteriously vanished. How fortunate!</span>")
+							if(item_to_retrieve in part.embedded_objects)
+								part.embedded_objects -= item_to_retrieve
+								to_chat(C, "<span class='warning'>The [item_to_retrieve] that was embedded in your [part] has mysteriously vanished. How fortunate!</span>")
 								if(!C.has_embedded_objects())
 									C.clear_alert("embeddedobject")
 								break
 
 				else
-					if(istype(item_to_retrive.loc,/obj/machinery/portable_atmospherics/)) //Edge cases for moved machinery
-						var/obj/machinery/portable_atmospherics/P = item_to_retrive.loc
+					if(istype(item_to_retrieve.loc,/obj/machinery/portable_atmospherics/)) //Edge cases for moved machinery
+						var/obj/machinery/portable_atmospherics/P = item_to_retrieve.loc
 						P.disconnect()
 						P.update_icon()
-					if(istype(item_to_retrive.loc, /obj/structure/disposalholder) || istype(item_to_retrive.loc, /obj/machinery/disposal))//fixes the breaking of disposals. No more bluespace connected disposal bins!
+					if(istype(item_to_retrieve.loc, /obj/structure/disposalholder) || istype(item_to_retrieve.loc, /obj/machinery/disposal))//fixes the breaking of disposals. No more bluespace connected disposal bins!
 						break
-					item_to_retrive = item_to_retrive.loc
+					item_to_retrieve = item_to_retrieve.loc
 
 				infinite_recursion += 1
 
-			if(!item_to_retrive)
+			if(!item_to_retrieve)
 				return
 
-			item_to_retrive.loc.visible_message("<span class='warning'>The [item_to_retrive.name] suddenly disappears!</span>")
+			item_to_retrieve.loc.visible_message("<span class='warning'>The [item_to_retrieve.name] suddenly disappears!</span>")
 
 
 			if(target.hand) //left active hand
-				if(!target.equip_to_slot_if_possible(item_to_retrive, slot_l_hand, 0, 1, 1))
-					if(!target.equip_to_slot_if_possible(item_to_retrive, slot_r_hand, 0, 1, 1))
+				if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, 0, 1, 1))
+					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_r_hand, 0, 1, 1))
 						butterfingers = 1
 			else			//right active hand
-				if(!target.equip_to_slot_if_possible(item_to_retrive, slot_r_hand, 0, 1, 1))
-					if(!target.equip_to_slot_if_possible(item_to_retrive, slot_l_hand, 0, 1, 1))
+				if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_r_hand, 0, 1, 1))
+					if(!target.equip_to_slot_if_possible(item_to_retrieve, slot_l_hand, 0, 1, 1))
 						butterfingers = 1
 			if(butterfingers)
-				item_to_retrive.loc = target.loc
-				item_to_retrive.loc.visible_message("<span class='caution'>The [item_to_retrive.name] suddenly appears!</span>")
+				item_to_retrieve.loc = target.loc
+				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears!</span>")
 				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
 			else
-				item_to_retrive.loc.visible_message("<span class='caution'>The [item_to_retrive.name] suddenly appears in [target]'s hand!</span>")
+				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears in [target]'s hand!</span>")
 				playsound(get_turf(target),'sound/magic/summonitems_generic.ogg',50,1)
 
 		if(message)

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -59,17 +59,13 @@
 				if(ismob(item_to_retrieve.loc)) //If its on someone, properly drop it
 					var/mob/M = item_to_retrieve.loc
 
-					if(issilicon(M)) //Items in silicons warp the whole silicon
-						M.loc.visible_message("<span class='warning'>[M] suddenly disappears!</span>")
-						M.loc = target.loc
+					if(issilicon(M) || !M.unEquip(item_to_retrieve)) //Items in silicons warp the whole silicon
+						M.visible_message("<span class='warning'>[M] suddenly disappears!</span>", "<span class='danger'>A force suddenly pulls you away!</span>")
+						M.forceMove(target.loc)
 						M.loc.visible_message("<span class='caution'>[M] suddenly appears!</span>")
 						item_to_retrieve = null
 						break
 
-					if(!M.unEquip(item_to_retrieve))
-						to_chat(M, "<span class='warning'>You feel a force pulling at [item_to_retrieve]!</span>")
-						to_chat(target, "<span class='warning'>A force withholds [item_to_retrieve] to be recalled to you!</span>")
-						return
 					if(ishuman(M)) //Edge case housekeeping
 						var/mob/living/carbon/human/C = M
 						/*if(C.internal_bodyparts_by_name  && item_to_retrieve in C.internal_bodyparts_by_name ) //This won't work, as we use organ datums instead of objects. --DZD


### PR DESCRIPTION
## What Does This PR Do
The Instant Summons spell now recalls the holder of the nodrop item to the wizards location.

Also a small refactor to fix a typo in the variable name

Fixes: #12051
Fixes: #12958

## Why It's Good For The Game
Not breaking the game is a good thing

## Changelog
:cl:
fix: The Instant Summons spell now recalls the holder of nodrop items to the wizard instead of duping the item
/:cl: