### PR TITLE
Remove OOC enabling on round end during round in progress

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -52,7 +52,6 @@ SUBSYSTEM_DEF(vote)
 	voting.Cut()
 	current_votes.Cut()
 
-	if(auto_muted && !config.ooc_allowed)
 		auto_muted = 0
 		config.ooc_allowed = !( config.ooc_allowed )
 		to_chat(world, "<b>The OOC channel has been automatically enabled due to vote end.</b>")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -52,6 +52,7 @@ SUBSYSTEM_DEF(vote)
 	voting.Cut()
 	current_votes.Cut()
 
+	if(auto_muted && !config.ooc_allowed && !(config.auto_toggle_ooc_during_round && SSticker.current_state == GAME_STATE_PLAYING))
 		auto_muted = 0
 		config.ooc_allowed = !( config.ooc_allowed )
 		to_chat(world, "<b>The OOC channel has been automatically enabled due to vote end.</b>")


### PR DESCRIPTION
This PR adds a check to prevent OOC being enabled when a vote is called in the middle of a round and OOC is disabled for rounds in progress.

:cl:
fix: Fix OOC getting enabled during a round in progress in some cases
/:cl: