### PR TITLE
Fixes bots not being trackable using the chat link as AI

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -146,7 +146,7 @@
 	access_card.access += access_robotics
 	set_custom_texts()
 	Radio = new/obj/item/radio/headset/bot(src)
-
+	Radio.follow_target = src
 	add_language("Galactic Common", 1)
 	add_language("Sol Common", 1)
 	add_language("Tradeband", 1)


### PR DESCRIPTION
## What Does This PR Do
Makes bots like beepsky trackable as ai when clicked on the name in chat when they say something

## Why It's Good For The Game
It's currently broken

## Changelog
:cl:
fix: Makes bots like beepsky trackable as when clicked on their name in chat
/:cl:
