### PR TITLE
Makes AI able to click on turfs (flooring)

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -42,8 +42,8 @@
 
 	if(control_disabled || stat)
 		return
-
-	var/turf/pixel_turf = get_turf_pixel(A)
+	
+	var/turf/pixel_turf = isturf(A) ? A : get_turf_pixel(A)
 	if(isnull(pixel_turf))
 		return
 	if(!can_see(A))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1200,7 +1200,8 @@ var/list/ai_verbs_default = list(
 	if(isturf(loc)) //AI in core, check if on cameras
 		//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
 		//apc_override is needed here because AIs use their own APC when depowered
-		return (cameranet && cameranet.checkTurfVis(get_turf_pixel(A))) || apc_override
+		var/turf/T = isturf(A) ? A : get_turf_pixel(A)
+		return (cameranet && cameranet.checkTurfVis(T)) || apc_override
 	//AI is carded/shunted
 	//view(src) returns nothing for carded/shunted AIs and they have x-ray vision so just use get_dist
 	var/list/viewscale = getviewsize(client.view)


### PR DESCRIPTION
## What Does This PR Do
Makes AI able to click on turfs (flooring)
This will allow the AI to alt click on a turf to see the contents and set waypoints for bots.

I've tested clicking on hidden tiles and you still can't do that. It's still being catched by the safe guard

Fixes: #9100


## Why It's Good For The Game
It's a bug

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/74196595-dce6bc80-4c5d-11ea-885d-ea621c749a6e.png)


## Changelog
:cl:
fix: AIs can click on turfs (flooring) again. Allowing bots to be send to floors instead of just objects etc
/:cl:
