### PR TITLE
Doomsday device fix

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -244,6 +244,7 @@
 	anchored = 1
 	density = 1
 	atom_say_verb = "blares"
+	speed_process = TRUE // Disgusting fix. Please remove once #12952 is merged
 	var/timing = 0
 	var/default_timer = 4500
 	var/detonation_timer


### PR DESCRIPTION
## What Does This PR Do
Makes the AI countdown work again.

Should be reverted/changed once #12952 gets merged

Fixes:  #12723

## Why It's Good For The Game
Bug fixes be good

## Changelog
:cl:
fix: Makes the AI doomsday device work again
/:cl:
