### PR TITLE
Antag objectives are now announced when a target cryos

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -394,11 +394,11 @@
 				spawn(1) //This should ideally fire after the occupant is deleted.
 					if(!O) return
 					O.find_target()
-					O.owner.announce_objectives()
 					if(!(O.target))
 						GLOB.all_objectives -= O
 						O.owner.objectives -= O
 						qdel(O)
+					O.owner.announce_objectives()
 	if(occupant.mind && occupant.mind.assigned_role)
 		//Handle job slot/tater cleanup.
 		var/job = occupant.mind.assigned_role

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -394,6 +394,7 @@
 				spawn(1) //This should ideally fire after the occupant is deleted.
 					if(!O) return
 					O.find_target()
+					O.owner.announce_objectives()
 					if(!(O.target))
 						GLOB.all_objectives -= O
 						O.owner.objectives -= O


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When an antagonist's target is cryo'd, it will now announce the updated objectives to them rather than having them check their notes.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less M/AHelps about where a traitor needs to find their new target when they get the alert.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Antagonists will now have their new assassination targets announced should their original target enter cryo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
