### PR TITLE
stripped_input now actually uses the max length at all times

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -108,11 +108,10 @@
 
 // Used to get a sanitized input.
 /proc/stripped_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
-	var/name = input(user, message, title, default) as text|null
-	if(no_trim)
-		return copytext(html_encode(name), 1, max_length)
-	else
-		return trim(html_encode(name), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
+	var/name = html_encode(input(user, message, title, default) as text|null)
+	if(!no_trim)
+		name = trim(name) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
+	return copytext(name, 1, max_length)
 
 // Uses client.typing to check if the popup should appear or not
 /proc/typing_input(mob/user, message = "", title = "", default = "")


### PR DESCRIPTION
## What Does This PR Do
Makes stripped_input use the max_length parameter.

Fixes: #12973

## Why It's Good For The Game
Fixes an exploit where people could fill in unlimited characters to certain objects like picket signs.

## Changelog
:cl:
fix: stripped_input now uses the max_length parameter. Picket signs now have a limit
/:cl: