### PR TITLE
Some more bugfixes from the tool refactor

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -202,6 +202,8 @@
 	if(user.a_intent == INTENT_HARM)
 		return
 	. = TRUE
+	if(operating)
+		return
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	try_to_crowbar(I, user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -360,6 +360,7 @@
 					constructionStep = CONSTRUCTION_WIRES_EXPOSED
 					update_icon()
 				return
+		if(CONSTRUCTION_NOCIRCUIT)
 			if(istype(C, /obj/item/firelock_electronics))
 				user.visible_message("<span class='notice'>[user] starts adding [C] to [src]...</span>", \
 									 "<span class='notice'>You begin adding a circuit board to [src]...</span>")

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -442,7 +442,8 @@ Class Procs:
 	return FALSE
 
 /obj/machinery/default_unfasten_wrench(mob/user, obj/item/I, time)
-	if(..())
+	. = ..()
+	if(.)
 		power_change()
 
 /obj/machinery/proc/exchange_parts(mob/user, obj/item/storage/part_replacer/W)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -402,18 +402,19 @@ Class Procs:
 /obj/machinery/proc/default_deconstruction_crowbar(user, obj/item/I, ignore_panel = 0)
 	if(I.tool_behaviour != TOOL_CROWBAR)
 		return FALSE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.use_tool(src, user, 0, volume = 0))
 		return FALSE
 	if((panel_open || ignore_panel) && !(flags & NODECONSTRUCT))
 		deconstruct(TRUE)
 		to_chat(user, "<span class='notice'>You disassemble [src].</span>")
+		I.play_tool_sound(user, I.tool_volume)
 		return 1
 	return 0
 
 /obj/machinery/proc/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
 	if(I.tool_behaviour != TOOL_SCREWDRIVER)
 		return FALSE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.use_tool(src, user, 0, volume = 0))
 		return FALSE
 	if(!(flags & NODECONSTRUCT))
 		if(!panel_open)
@@ -424,17 +425,19 @@ Class Procs:
 			panel_open = 0
 			icon_state = icon_state_closed
 			to_chat(user, "<span class='notice'>You close the maintenance hatch of [src].</span>")
+		I.play_tool_sound(user, I.tool_volume)
 		return 1
 	return 0
 
 /obj/machinery/proc/default_change_direction_wrench(mob/user, obj/item/I)
 	if(I.tool_behaviour != TOOL_WRENCH)
 		return FALSE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.use_tool(src, user, 0, volume = 0))
 		return FALSE
 	if(panel_open)
 		dir = turn(dir,-90)
 		to_chat(user, "<span class='notice'>You rotate [src].</span>")
+		I.play_tool_sound(user, I.tool_volume)
 		return TRUE
 	return FALSE
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -307,13 +307,12 @@
 
 /obj/machinery/vending/wirecutter_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
-	wires.Interact(user)
+	if(I.use_tool(src, user, 0, volume = 0))
+		wires.Interact(user)
 
 /obj/machinery/vending/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.use_tool(src, user, 0, volume = 0))
 		return
 	default_unfasten_wrench(user, I, time = 60)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -293,7 +293,7 @@ a {
 		return FALSE
 	if(I.tool_behaviour != TOOL_WRENCH)
 		return FALSE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.tool_use_check(user, 0))
 		return FALSE
 	if(!(flags & NODECONSTRUCT))
 		to_chat(user, "<span class='notice'>Now [anchored ? "un" : ""]securing [name].</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -241,7 +241,7 @@
 		return
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 20, volume = I.tool_volume) && deconstruction_ready)
-		deconstruct(TRUE, 1)
+		deconstruct(TRUE)
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
 
 /obj/structure/table/wrench_act(mob/user, obj/item/I)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -114,36 +114,38 @@
 			return 0
 	..()
 
-/obj/item/gun/projectile/revolver/detective/attackby(obj/item/A, mob/user, params)
-	if(istype(A, /obj/item/screwdriver))
-		if(magazine.caliber == "38")
-			to_chat(user, "<span class='notice'>You begin to reinforce the barrel of [src]...</span>")
-			if(magazine.ammo_count())
-				afterattack(user, user)	//you know the drill
-				user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
-				return
-			if(do_after(user, 30 * A.toolspeed, target = src))
-				if(magazine.ammo_count())
-					to_chat(user, "<span class='warning'>You can't modify it!</span>")
-					return
-				magazine.caliber = "357"
-				desc = "The barrel and chamber assembly seems to have been modified."
-				to_chat(user, "<span class='notice'>You reinforce the barrel of [src]. Now it will fire .357 rounds.</span>")
-		else
-			to_chat(user, "<span class='notice'>You begin to revert the modifications to [src]...</span>")
-			if(magazine.ammo_count())
-				afterattack(user, user)	//and again
-				user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
-				return
-			if(do_after(user, 30 * A.toolspeed, target = src))
-				if(magazine.ammo_count())
-					to_chat(user, "<span class='warning'>You can't modify it!</span>")
-					return
-				magazine.caliber = "38"
-				desc = initial(desc)
-				to_chat(user, "<span class='notice'>You remove the modifications on [src]. Now it will fire .38 rounds.</span>")
+/obj/item/gun/projectile/revolver/detective/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	if(magazine.caliber == "38")
+		to_chat(user, "<span class='notice'>You begin to reinforce the barrel of [src]...</span>")
+		if(magazine.ammo_count())
+			afterattack(user, user)	//you know the drill
+			user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
+			return
+		if(!I.use_tool(src, user, 30, volume = I.tool_volume))
+			return
+		if(magazine.ammo_count())
+			to_chat(user, "<span class='warning'>You can't modify it!</span>")
+			return
+		magazine.caliber = "357"
+		desc = "The barrel and chamber assembly seems to have been modified."
+		to_chat(user, "<span class='notice'>You reinforce the barrel of [src]. Now it will fire .357 rounds.</span>")
 	else
-		return ..()
+		to_chat(user, "<span class='notice'>You begin to revert the modifications to [src]...</span>")
+		if(magazine.ammo_count())
+			afterattack(user, user)	//and again
+			user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
+			return
+		if(!I.use_tool(src, user, 30, volume = I.tool_volume))
+			return
+		if(magazine.ammo_count())
+			to_chat(user, "<span class='warning'>You can't modify it!</span>")
+			return
+		magazine.caliber = "38"
+		desc = initial(desc)
+		to_chat(user, "<span class='notice'>You remove the modifications on [src]. Now it will fire .38 rounds.</span>")
 
 /obj/item/gun/projectile/revolver/fingergun //Summoned by the Finger Gun spell, from advanced mimery traitor item
 	name = "\improper finger gun"


### PR DESCRIPTION
Title
- Fixes #12990
- Fixes #12994
- Fixes #12995
- Fixes #13010

:cl:
fix: Fixes some tools playing tool sounds twice.
fix: Disassembling a table using a screwdriver will leave behind a table frame
fix: You can once again construct firedoors
fix: Wrenching the ORM won't attack it any more
fix: You can once again modify the detective's revolver
tweak: Welding something will now flash your eyes constantly, until it completes or you stop welding
/:cl: