### PR TITLE
Surgery refactor. Use surgery_behaviour now [DNM]

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -1,5 +1,3 @@
-#define SURGERY_ABDUCTOR_INSERT				"abductor insert"
-
 #define SURGERY_SAW_BONE					"saw bone"
 #define SURGERY_RETRACT_BONE				"retract bone"
 #define SURGERY_MEND_BONE					"mend bones" // Mending and medicating bones

--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -1,0 +1,53 @@
+#define SURGERY_ABDUCTOR_INSERT				"abductor insert"
+
+#define SURGERY_SAW_BONE					"saw bone"
+#define SURGERY_RETRACT_BONE				"retract bone"
+#define SURGERY_MEND_BONE					"mend bones" // Mending and medicating bones
+#define SURGERY_SET_BONE					"set bones"
+#define SURGERY_MAKE_CAVITY					"make cavity"
+#define SURGERY_IMPLANT_CAVITY				"implant cavity"
+// Close cavity is the same as cauterize
+#define SURGERY_SLIME_CUT_FLESH				"slime cut flesh"
+#define SURGERY_SLIME_EXTRACT_CORE			"slime extract core"
+#define SURGERY_INSERT_PILL					"insert pill"
+#define SURGERY_MAKE_INCISION				"make incision"
+#define SURGERY_CLAMP_BLEEDERS				"clamp bleeders"
+#define SURGERY_RETRACT_SKIN				"retract skin"
+#define SURGERY_CAUTERIZE_INCISION			"cauterize incision"
+#define SURGERY_DRILL_BONE					"drill bone"
+#define SURGERY_AMPUTATE					"amputate"
+#define SURGERY_EXTRACT_IMPLANT				"extract implant"
+#define SURGERY_AUGMENT_ROBOTIC				"augment robotic"
+#define SURGERY_ATTACH_LIMB					"attach limb"
+#define SURGERY_CONNECT_LIMB 				"connect limb"
+#define SURGERY_ATTACH_ROBOTIC_LIMB			"attach robotic limb"
+#define SURGERY_IMPLANT_ORGAN_MANIP			"implant organ manip"
+#define SURGERY_EXTRACT_ORGAN_MANIP			"extract organ manip"
+#define SURGERY_HEAL_ORGAN_MANIP			"heal organ manip"
+#define SURGERY_CLEAN_ORGAN_MANIP			"clean organ manip"
+// #define SURGERY_CLOSE_ORGAN_MANIP			"close organ manip" Same as SURGERY_RETRACT_BONE
+#define SURGERY_MEND_INTERNAL_BLEEDING		"mend internal bleeding"
+// #define SURGERY_REMOVE_DEAD_TISSUE			"remove dead tissue" Same as MAKE_INCISION
+//#define SURGERY_TREAT_NECROSIS				"treat necrosis" Same as CLEAN_ORGAN
+#define SURGERY_DETHRALL					"dethrall"
+#define SURGERY_RESHAPE_FACE				"reshape face"
+
+// Alien surgery
+// #define SURGERY_SAW_CARAPACE				"saw carapace" Same as SAW_BONE
+// #define SURGERY_CUT_CARAPACE				"cut carapace" Same as MAKE_INCISION
+// #define SURGERY_RETRACT_CARAPACE			"retract carapace" Same as RETRACT_SKIN
+
+// RIGSUIT stuff
+#define SURGERY_CUT_SEALS					"cut seals"
+
+// Robotic surgery
+#define SURGERY_ROBOTIC_UNSCREW_HATCH		"unscrew hatch"
+#define SURGERY_ROBOTIC_OPEN_CLOSE_HATCH	"open close hatch"
+#define SURGERY_ROBOTIC_HEAL_BURN			"robotic heal burn"
+#define SURGERY_ROBOTIC_HEAL_BRUTE			"robotic heal brute"
+#define SURGERY_ROBOTIC_INSERT_MMI			"robotic insert mmi"
+#define SURGERY_ROBOTIC_EXTRACT_ORGAN		"robotic extract organ"
+#define SURGERY_ROBOTIC_MEND				"robotic mend"
+// #define SURGERY_ROBOTIC_INSERT_ORGAN		"robotic insert organ" same as SURGERY_IMPLANT_ORGAN_MANIP
+// #define SURGERY_ROBOTIC_AMPUTATE			"robotic amputate" SAME AS SURGERY_ROBOTIC_EXTRACT_ORGAN
+#define SURGERY_ROBOTIC_REPROGRAM			"robotic reprogram"

--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -3,7 +3,6 @@
 #define SURGERY_MEND_BONE					"mend bones" // Mending and medicating bones
 #define SURGERY_SET_BONE					"set bones"
 #define SURGERY_MAKE_CAVITY					"make cavity"
-#define SURGERY_IMPLANT_CAVITY				"implant cavity"
 // Close cavity is the same as cauterize
 #define SURGERY_SLIME_CUT_FLESH				"slime cut flesh"
 #define SURGERY_SLIME_EXTRACT_CORE			"slime extract core"

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -132,6 +132,7 @@
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
+	surgery_behaviours = list(SURGERY_AMPUTATE = 75)
 
 /obj/item/melee/arm_blade/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)

--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -25,7 +25,7 @@
 	time = 32
 	var/obj/item/organ/internal/IC = null
 
-/datum/surgery_step/internal/extract_organ/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/internal/extract_organ/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	for(var/obj/item/I in target.internal_organs)
 		// Allows for multiple subtypes of heart.
 		if(istype(I, /obj/item/organ/internal/heart))
@@ -34,7 +34,7 @@
 	user.visible_message("[user] starts to remove [target]'s organs.", "<span class='notice'>You start to remove [target]'s organs...</span>")
 	..()
 
-/datum/surgery_step/internal/extract_organ/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/internal/extract_organ/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/mob/living/carbon/human/AB = target
 	if(IC)
 		user.visible_message("[user] pulls [IC] out of [target]'s [target_zone]!", "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>")
@@ -48,27 +48,27 @@
 		to_chat(user, "<span class='warning'>You don't find anything in [target]'s [target_zone]!</span>")
 		return TRUE
 
-/datum/surgery_step/internal/extract_organ/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/internal/extract_organ/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='warning'>[user]'s hand slips, failing to extract anything!</span>", "<span class='warning'>Your hand slips, failing to extract anything!</span>")
 	return FALSE
 
 /datum/surgery_step/internal/gland_insert
 	name = "insert gland"
-	allowed_tools = list(/obj/item/organ/internal/heart/gland = 100)
+	allowed_surgery_behaviours = list(SURGERY_ABDUCTOR_INSERT)
 	time = 32
 
-/datum/surgery_step/internal/gland_insert/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/internal/gland_insert/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("[user] starts to insert [tool] into [target].", "<span class ='notice'>You start to insert [tool] into [target]...</span>")
 	..()
 
-/datum/surgery_step/internal/gland_insert/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/internal/gland_insert/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("[user] inserts [tool] into [target].", "<span class ='notice'>You insert [tool] into [target].</span>")
 	user.drop_item()
 	var/obj/item/organ/internal/heart/gland/gland = tool
 	gland.insert(target, 2)
 	return TRUE
 
-/datum/surgery_step/internal/gland_insert/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/internal/gland_insert/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='warning'>[user]'s hand slips, failing to insert the gland!</span>", "<span class='warning'>Your hand slips, failing to insert the gland!</span>")
 	return FALSE
 

--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -54,8 +54,13 @@
 
 /datum/surgery_step/internal/gland_insert
 	name = "insert gland"
-	allowed_surgery_behaviours = list(SURGERY_ABDUCTOR_INSERT)
+	allowed_surgery_behaviours = list(SURGERY_IMPLANT_ORGAN_MANIP)
 	time = 32
+
+/datum/surgery_step/internal/gland_insert/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
+	. = istype(tool, /obj/item/organ/internal/heart/gland)
+	if(!.)
+		to_chat(user, "<span class='warning'>You must implant a gland for science!</span>")
 
 /datum/surgery_step/internal/gland_insert/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("[user] starts to insert [tool] into [target].", "<span class ='notice'>You start to insert [tool] into [target]...</span>")

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -14,7 +14,6 @@
 	var/human_only = 0
 	var/active = 0
 	tough = TRUE //not easily broken by combat damage
-	surgery_behaviours = list(SURGERY_ABDUCTOR_INSERT = 100, SURGERY_IMPLANT_ORGAN_MANIP = 100)
 	var/mind_control_uses = 1
 	var/mind_control_duration = 1800
 	var/active_mind_control = FALSE

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -14,7 +14,7 @@
 	var/human_only = 0
 	var/active = 0
 	tough = TRUE //not easily broken by combat damage
-
+	surgery_behaviours = list(SURGERY_ABDUCTOR_INSERT = 100, SURGERY_IMPLANT_ORGAN_MANIP = 100)
 	var/mind_control_uses = 1
 	var/mind_control_duration = 1800
 	var/active_mind_control = FALSE

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -15,6 +15,7 @@
 	sharp = TRUE
 	var/drill_delay = 7
 	var/drill_level = DRILL_BASIC
+	surgery_behaviours = list(SURGERY_DRILL_BONE = 60)
 
 /obj/item/mecha_parts/mecha_equipment/drill/action(atom/target)
 	if(!action_checks(target))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -88,6 +88,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	var/tool_volume = 50 //How loud are we when we use our tool?
 	var/toolspeed = 1 // If this item is a tool, the speed multiplier
 
+	// An associative list. key = surgery step, value = chance of success
+	var/list/surgery_behaviours = list() // What kind of surgery steps can we do? In the initialize of item it will add SURGERY_IMPLANT_CAVITY
+
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:
 	sprite_sheets = list(

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -89,7 +89,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	var/toolspeed = 1 // If this item is a tool, the speed multiplier
 
 	// An associative list. key = surgery step, value = chance of success
-	var/list/surgery_behaviours = list() // What kind of surgery steps can we do? In the initialize of item it will add SURGERY_IMPLANT_CAVITY
+	var/list/surgery_behaviours = list() // What kind of surgery steps can we do?
 
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -19,6 +19,7 @@
 	var/overcharged = 0   //if overcharged the flash will set people on fire then immediately burn out (does so even if it doesn't blind them).
 	var/can_overcharge = TRUE //set this to FALSE if you don't want your flash to be overcharge capable
 	var/use_sound = 'sound/weapons/flash.ogg'
+	surgery_behaviours = list(SURGERY_DETHRALL = 100)
 
 /obj/item/flash/proc/clown_check(mob/user)
 	if(user && (CLUMSY in user.mutations) && prob(50))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -12,6 +12,7 @@
 	var/on = FALSE
 	var/brightness_on = 4 //luminosity when on
 	var/togglesound = 'sound/weapons/empty.ogg'
+	surgery_behaviours = list(SURGERY_DETHRALL = 40)
 
 /obj/item/flashlight/Initialize()
 	. = ..()
@@ -98,6 +99,7 @@
 	slot_flags = SLOT_BELT | SLOT_EARS
 	flags = CONDUCT
 	brightness_on = 2
+	surgery_behaviours = list(SURGERY_DETHRALL = 80)
 
 /obj/item/flashlight/seclite
 	name = "seclite"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -9,6 +9,7 @@
 	var/sabotaged = 0 //Emagging limbs can have repercussions when installed as prosthetics.
 	var/model_info = "Unbranded"
 	dir = SOUTH
+	surgery_behaviours = list(SURGERY_AUGMENT_ROBOTIC = 100, SURGERY_ATTACH_ROBOTIC_LIMB = 100)
 
 /obj/item/robot_parts/New(newloc, model)
 	..(newloc)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -117,6 +117,7 @@
 	origin_tech = "biotech=2"
 	heal_brute = 10
 	stop_bleeding = 1800
+	surgery_behaviours = list(SURGERY_HEAL_ORGAN_MANIP = 20)
 
 /obj/item/stack/medical/bruise_pack/attackby(obj/item/I, mob/user, params)
 	if(I.sharp)
@@ -166,6 +167,7 @@
 	icon_state = "traumakit"
 	heal_brute = 25
 	stop_bleeding = 0
+	surgery_behaviours = list(SURGERY_HEAL_ORGAN_MANIP = 100)
 
 
 

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -8,6 +8,7 @@
 	amount = 6
 	max_amount = 6
 	toolspeed = 1
+	surgery_behaviours = list(SURGERY_HEAL_ORGAN_MANIP = 100, SURGERY_ROBOTIC_MEND = 100)
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
 	if(!istype(M) || !istype(user))

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -21,6 +21,7 @@ var/global/list/datum/stack_recipe/rod_recipes = list ( \
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 	toolspeed = 1
 	usesound = 'sound/items/deconstruct.ogg'
+	surgery_behaviours = list(SURGERY_MAKE_CAVITY = 60)
 
 /obj/item/stack/rods/cyborg
 	materials = list()

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -18,6 +18,7 @@
 
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	tool_behaviour = TOOL_CROWBAR
+	surgery_behaviours = list(SURGERY_SLIME_EXTRACT_CORE = 100, SURGERY_RETRACT_BONE = 90, SURGERY_RETRACT_SKIN = 90, SURGERY_EXTRACT_IMPLANT = 65, SURGERY_ROBOTIC_OPEN_CLOSE_HATCH = 100)
 
 /obj/item/crowbar/red
 	icon_state = "crowbar_red"

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -21,6 +21,7 @@
 	origin_tech = "magnets=1;engineering=2"
 	toolspeed = 1
 	tool_behaviour = TOOL_MULTITOOL
+	surgery_behaviours = list(SURGERY_ROBOTIC_EXTRACT_ORGAN = 100, SURGERY_ROBOTIC_REPROGRAM = 100)
 	hitsound = 'sound/weapons/tap.ogg'
 	var/shows_wire_information = FALSE // shows what a wire does if set to TRUE
 	var/obj/machinery/buffer // simple machine buffer for device linkage

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -18,6 +18,7 @@
 	toolspeed = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	tool_behaviour = TOOL_SCREWDRIVER
+	surgery_behaviours = list(SURGERY_MEND_BONE = 90, SURGERY_DRILL_BONE = 20, SURGERY_ROBOTIC_UNSCREW_HATCH = 100, SURGERY_ROBOTIC_MEND = 70)
 	var/random_color = TRUE //if the screwdriver uses random coloring
 
 /obj/item/screwdriver/nuke

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -30,6 +30,7 @@
 	var/light_intensity = 2
 	var/low_fuel_changes_icon = TRUE//More than one icon_state due to low fuel?
 	var/progress_flash_divisor = 10 //Length of time between each "eye flash"
+	surgery_behaviours = list(SURGERY_CAUTERIZE_INCISION = 30, SURGERY_CUT_SEALS = 80, SURGERY_ROBOTIC_HEAL_BRUTE = 100)
 
 /obj/item/weldingtool/Initialize(mapload)
 	..()

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -19,6 +19,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	tool_behaviour = TOOL_WIRECUTTER
 	var/random_color = TRUE
+	surgery_behaviours = list(SURGERY_RESHAPE_FACE = 35)
 
 /obj/item/wirecutters/New(loc, param_color = null)
 	..()

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -16,6 +16,7 @@
 	toolspeed = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	tool_behaviour = TOOL_WRENCH
+	surgery_behaviours = list(SURGERY_SET_BONE = 90)
 
 /obj/item/wrench/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is beating [user.p_them()]self to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -38,6 +38,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 		"Vulpkanin" = 'icons/mob/species/vulpkanin/mask.dmi',
 		"Grey" = 'icons/mob/species/grey/mask.dmi'
 		)
+	surgery_behaviours = list(SURGERY_CAUTERIZE_INCISION = 90)
 
 
 /obj/item/clothing/mask/cigarette/New()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -34,6 +34,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	sharp = 0
 	var/max_contents = 1
+	surgery_behaviours = list(SURGERY_ROBOTIC_OPEN_CLOSE_HATCH = 50)
 
 /obj/item/kitchen/utensil/New()
 	if(prob(60))
@@ -70,6 +71,7 @@
 	name = "fork"
 	desc = "It's a fork. Sure is pointy."
 	icon_state = "fork"
+	surgery_behaviours = list(SURGERY_RETRACT_SKIN = 60, SURGERY_EXTRACT_ORGAN_MANIP = 70)
 
 /obj/item/kitchen/utensil/pfork
 	name = "plastic fork"
@@ -118,6 +120,7 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharp = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	surgery_behaviours = list(SURGERY_SLIME_CUT_FLESH = 65, SURGERY_MAKE_INCISION = 90, SURGERY_RESHAPE_FACE = 50, SURGERY_ROBOTIC_UNSCREW_HATCH = 50)
 	var/bayonet = FALSE	//Can this be attached to a gun?
 
 /obj/item/kitchen/knife/suicide_act(mob/user)

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -16,6 +16,7 @@
 	attack_verb = null
 	resistance_flags = FIRE_PROOF
 	var/lit = 0
+	surgery_behaviours = list(SURGERY_CAUTERIZE_INCISION = 60)
 
 /obj/item/lighter/zippo
 	name = "zippo lighter"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -17,6 +17,7 @@
 	light_power = 2
 	var/brightness_on = 2
 	var/colormap = list(red=LIGHT_COLOR_RED, blue=LIGHT_COLOR_LIGHTBLUE, green=LIGHT_COLOR_GREEN, purple=LIGHT_COLOR_PURPLE, rainbow=LIGHT_COLOR_WHITE)
+	surgery_behaviours = list(SURGERY_MAKE_INCISION = 6)
 
 /obj/item/melee/energy/attack(mob/living/target, mob/living/carbon/human/user)
 	var/nemesis_faction = FALSE
@@ -116,6 +117,7 @@
 	origin_tech = "combat=3;magnets=4;syndicate=4"
 	block_chance = 50
 	sharp = 1
+	surgery_behaviours = list(SURGERY_SLIME_CUT_FLESH = 75)
 	var/hacked = 0
 
 /obj/item/melee/energy/sword/New()
@@ -154,6 +156,7 @@
 	item_color = null
 	w_class = WEIGHT_CLASS_NORMAL
 	light_color = LIGHT_COLOR_WHITE
+	surgery_behaviours = list(SURGERY_SAW_BONE = 100, SURGERY_AMPUTATE = 100)
 
 /obj/item/melee/energy/sword/cyborg/saw/New()
 	..()

--- a/code/game/objects/items/weapons/scissors.dm
+++ b/code/game/objects/items/weapons/scissors.dm
@@ -9,6 +9,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("slices", "cuts", "stabs", "jabs")
 	toolspeed = 1
+	surgery_behaviours = list(SURGERY_MAKE_INCISION = 12)
 
 /obj/item/scissors/barber
 	name = "Barber's Scissors"

--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -16,6 +16,7 @@
 	max_integrity = 40
 	resistance_flags = ACID_PROOF
 	sharp = TRUE
+	surgery_behaviours = list(SURGERY_SLIME_CUT_FLESH = 45, SURGERY_MAKE_INCISION = 60)
 	var/cooldown = 0
 	var/icon_prefix
 	var/obj/item/stack/sheet/welded_type = /obj/item/stack/sheet/glass

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -547,6 +547,7 @@
 	origin_tech = "materials=6;syndicate=4"
 	attack_verb = list("sawed", "cut", "hacked", "carved", "cleaved", "butchered", "felled", "timbered")
 	sharp = TRUE
+	surgery_behaviours = list(SURGERY_MAKE_INCISION = 1)
 
 /obj/item/twohanded/chainsaw/update_icon()
 	if(wielded)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -52,6 +52,7 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
+	surgery_behaviours = list(SURGERY_MAKE_INCISION = 6)
 
 /obj/item/claymore/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is falling on the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -5,7 +5,7 @@
 	materials = list(MAT_METAL=100)
 	origin_tech = "combat=1;materials=2;engineering=1"
 	var/armed = FALSE
-
+	surgery_behaviours = list(SURGERY_CLAMP_BLEEDERS = 25, SURGERY_CONNECT_LIMB = 25)
 	bomb_name = "contact mine"
 
 /obj/item/assembly/mousetrap/examine(mob/user)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -11,6 +11,7 @@
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	var/const/duration = 13 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
 	var/isGlass = 1 //Whether the 'bottle' is made of glass or not so that milk cartons dont shatter when someone gets hit by it
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 80)
 
 /obj/item/reagent_containers/food/drinks/bottle/proc/smash(mob/living/target, mob/living/user, ranged = 0)
 

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -12,6 +12,7 @@
 	materials = list(MAT_GLASS=500)
 	max_integrity = 20
 	resistance_flags = ACID_PROOF
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 85)
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/egg)) //breaking eggs

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -476,6 +476,7 @@
 	filling_color = "#E00D34"
 	bitesize = 3
 	list_reagents = list("protein" = 4, "vitamin" = 4)
+	surgery_behaviours = list(SURGERY_IMPLANT_ORGAN_MANIP = 0) // For the message
 
 /obj/item/reagent_containers/food/snacks/appendix
 //yes, this is the same as meat. I might do something different in future

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -98,6 +98,7 @@
 	attack_verb = list("chopped", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharp = 1
+	surgery_behaviours = list(SURGERY_SAW_BONE = 90, SURGERY_AMPUTATE = 90)
 
 /obj/item/hatchet/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is chopping at [user.p_them()]self with the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -79,6 +79,7 @@
 	usesound = 'sound/weapons/drill.ogg'
 	origin_tech = "materials=2;powerstorage=2;engineering=3"
 	desc = "An electric mining drill for the especially scrawny."
+	surgery_behaviours = list(SURGERY_DRILL_BONE = 60)
 
 /obj/item/pickaxe/drill/cyborg
 	name = "cyborg mining drill"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -323,6 +323,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	var/name_by_cmineral = TRUE
 	var/cooldown = 0
 	var/credits = 10
+	surgery_behaviours = list(SURGERY_ROBOTIC_UNSCREW_HATCH = 50)
 
 /obj/item/coin/New()
 	pixel_x = rand(0,16)-8

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -6,7 +6,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	origin_tech = "biotech=3"
 	origin_tech = "biotech=2;programming=3;engineering=2"
-
+	surgery_behaviours = list(SURGERY_ROBOTIC_INSERT_MMI)
+	
 	//Revised. Brainmob is now contained directly within object of transfer. MMI in this case.
 	var/alien = 0
 	var/syndiemmi = 0 //Whether or not this is a Syndicate MMI

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	origin_tech = "biotech=3"
 	origin_tech = "biotech=2;programming=3;engineering=2"
-	surgery_behaviours = list(SURGERY_ROBOTIC_INSERT_MMI)
+	surgery_behaviours = list(SURGERY_ROBOTIC_INSERT_MMI = 100)
 	
 	//Revised. Brainmob is now contained directly within object of transfer. MMI in this case.
 	var/alien = 0

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -19,14 +19,6 @@
 	if(volume > 10) // Anything over 10 volume will make the mob wetter.
 		wetlevel = min(wetlevel + 1,5)
 
-/mob/living/carbon/attackby(obj/item/I, mob/user, params)
-	if(lying && surgeries.len)
-		if(user != src && user.a_intent == INTENT_HELP)
-			for(var/datum/surgery/S in surgeries)
-				if(S.next_step(user, src))
-					return 1
-	return ..()
-
 /mob/living/carbon/attack_hand(mob/living/carbon/human/user)
 	if(!iscarbon(user))
 		return
@@ -41,11 +33,6 @@
 		if(D.IsSpreadByTouch())
 			ContractDisease(D)
 
-	if(lying && surgeries.len)
-		if(user.a_intent == INTENT_HELP)
-			for(var/datum/surgery/S in surgeries)
-				if(S.next_step(user, src))
-					return 1
 	return 0
 
 /mob/living/carbon/attack_slime(mob/living/simple_animal/slime/M)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -33,6 +33,11 @@
 		if(D.IsSpreadByTouch())
 			ContractDisease(D)
 
+	if(lying && surgeries.len)
+		if(user.a_intent == INTENT_HELP)
+			for(var/datum/surgery/S in surgeries)
+				if(S.next_step(user, src))
+					return 1
 	return 0
 
 /mob/living/carbon/attack_slime(mob/living/simple_animal/slime/M)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -281,6 +281,12 @@
 
 	return G
 
+/mob/living/proc/surgery_act(mob/living/user, obj/item/I)
+	if(can_operate(src) && surgeries.len)
+		for(var/datum/surgery/S in surgeries)
+			if(S.next_step(user, src))
+				return TRUE
+
 /mob/living/attack_slime(mob/living/simple_animal/slime/M)
 	if(!SSticker)
 		to_chat(M, "You cannot attack people before the game has started.")

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -23,6 +23,7 @@
 	materials = list(MAT_METAL=10)
 	var/colour = "black"	//what colour the ink is!
 	pressure_resistance = 2
+	surgery_behaviours = list(SURGERY_MAKE_CAVITY = 90)
 
 /obj/item/pen/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='suicide'>[user] starts scribbling numbers over [user.p_them()]self with the [name]! It looks like [user.p_theyre()] trying to commit sudoku.</span>")
@@ -151,6 +152,7 @@
 	var/on = 0
 	var/brightness_on = 2
 	light_color = LIGHT_COLOR_RED
+	surgery_behaviours = list(SURGERY_MAKE_INCISION = 6)
 
 /obj/item/pen/edagger/attack_self(mob/living/user)
 	if(on)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -492,6 +492,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	usesound = 'sound/items/deconstruct.ogg'
 	toolspeed = 1
+	surgery_behaviours = list(SURGERY_CLAMP_BLEEDERS = 90, SURGERY_CONNECT_LIMB = 90, SURGERY_MEND_INTERNAL_BLEEDING = 90, SURGERY_ROBOTIC_HEAL_BURN = 100)
 
 /obj/item/stack/cable_coil/suicide_act(mob/user)
 	if(locate(/obj/structure/chair/stool) in user.loc)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -157,6 +157,7 @@
 	force = 12
 	sharp = 1
 	can_charge = 0
+	surgery_behaviours = list(SURGERY_CUT_SEALS = 100, SURGERY_ROBOTIC_HEAL_BRUTE = 50)
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -11,6 +11,7 @@
 	possible_transfer_amounts = list(5,10,15,25,30)
 	container_type = OPENCONTAINER
 	volume = 30
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 90)
 
 /obj/item/reagent_containers/glass/bottle/romerol
 	name = "romerol bottle"

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -10,6 +10,7 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 100)
 
 /obj/item/reagent_containers/dropper/on_reagent_change()
 	if(!reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -176,6 +176,7 @@
 	materials = list(MAT_GLASS=500)
 	var/obj/item/assembly_holder/assembly = null
 	var/can_assembly = 1
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 75)
 
 /obj/item/reagent_containers/glass/beaker/on_reagent_change()
 	update_icon()
@@ -348,6 +349,7 @@
 	slot_flags = SLOT_HEAD
 	resistance_flags = NONE
 	container_type = OPENCONTAINER
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 50)
 
 /obj/item/reagent_containers/glass/bucket/wooden
 	name = "wooden bucket"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -12,6 +12,7 @@
 	consume_sound = null
 	can_taste = FALSE
 	antable = FALSE
+	surgery_behaviours = list(SURGERY_INSERT_PILL = 100)
 
 /obj/item/reagent_containers/food/pill/New()
 	..()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -16,6 +16,7 @@
 	amount_per_transfer_from_this = 5
 	volume = 250
 	possible_transfer_amounts = null
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 60)
 
 
 /obj/item/reagent_containers/spray/afterattack(atom/A, mob/user)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -17,6 +17,7 @@
 	var/projectile_type = /obj/item/projectile/bullet/dart/syringe
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
 	container_type = TRANSPARENT
+	surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP = 100)
 
 /obj/item/reagent_containers/syringe/New()
 	..()

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -31,145 +31,128 @@
 //surgery steps
 /datum/surgery_step/glue_bone
 	name = "mend bone"
-
-	allowed_tools = list(
-	/obj/item/bonegel = 100,	\
-	/obj/item/screwdriver = 90
-	)
+	allowed_surgery_behaviours = list(SURGERY_MEND_BONE)
 	can_infect = 1
 	blood_level = 1
 
 	time = 24
 
-/datum/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		return affected && !affected.is_robotic() && !(affected.cannot_break)
 
-/datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the damaged bones in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the damaged bones in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 	..()
 
-/datum/surgery_step/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		user.visible_message("<span class='notice'> [user] applies some [tool] to [target]'s bone in [affected.name]</span>", \
-			"<span class='notice'> You apply some [tool] to [target]'s bone in [affected.name] with \the [tool].</span>")
+/datum/surgery_step/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='notice'> [user] applies some [tool] to [target]'s bone in [affected.name]</span>", \
+		"<span class='notice'> You apply some [tool] to [target]'s bone in [affected.name] with \the [tool].</span>")
 
-		return 1
+	return TRUE
 
-/datum/surgery_step/glue_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		user.visible_message("<span class='warning'> [user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
-		"<span class='warning'> Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
-		return 0
+/datum/surgery_step/glue_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, surgery_behaviour)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'> [user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
+	"<span class='warning'> Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
+	return FALSE
 
 /datum/surgery_step/set_bone
 	name = "set bone"
 
-	allowed_tools = list(
-	/obj/item/bonesetter = 100,	\
-	/obj/item/wrench = 90	\
-	)
+	allowed_surgery_behaviours = list(SURGERY_SET_BONE)
 
 	time = 32
 
-/datum/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	return affected && !affected.is_robotic()
 
-/datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to set the bone in [target]'s [affected.name] in place with \the [tool]." , \
 		"You are beginning to set the bone in [target]'s [affected.name] in place with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is going to make you pass out!")
 	..()
 
-/datum/surgery_step/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/set_bone/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(affected.status & ORGAN_BROKEN)
-		user.visible_message("<span class='notice'> [user] sets the bone in [target]'s [affected.name] in place with \the [tool].</span>", \
-			"<span class='notice'> You set the bone in [target]'s [affected.name] in place with \the [tool].</span>")
-		return 1
-	else
-		user.visible_message("<span class='notice'> [user] sets the bone in [target]'s [affected.name] in place with \the [tool].</span>", \
-			"<span class='notice'> You set the bone in [target]'s [affected.name] in place with \the [tool].</span>")
-		return 1
+	user.visible_message("<span class='notice'> [user] sets the bone in [target]'s [affected.name] in place with \the [tool].</span>", \
+		"<span class='notice'> You set the bone in [target]'s [affected.name] in place with \the [tool].</span>")
+	
+	return TRUE
 
-/datum/surgery_step/set_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/set_bone/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, damaging the bone in [target]'s [affected.name] with \the [tool]!</span>" , \
 		"<span class='warning'> Your hand slips, damaging the bone in [target]'s [affected.name] with \the [tool]!</span>")
 	affected.receive_damage(5)
-	return 0
+	return FALSE
 
 /datum/surgery_step/mend_skull
 	name = "mend skull"
 
-	allowed_tools = list(
-	/obj/item/bonesetter = 100,	\
-	/obj/item/wrench = 90		\
-	)
+	allowed_surgery_behaviours = list(SURGERY_MEND_BONE)
 
 	time = 32
 
-/datum/surgery_step/mend_skull/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/mend_skull/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	return affected && !affected.is_robotic() && affected.limb_name == "head"
 
-/datum/surgery_step/mend_skull/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/mend_skull/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("[user] is beginning piece together [target]'s skull with \the [tool]."  , \
 		"You are beginning piece together [target]'s skull with \the [tool].")
 	..()
 
-/datum/surgery_step/mend_skull/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/mend_skull/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] sets [target]'s [affected.encased] with \the [tool].</span>" , \
 		"<span class='notice'> You set [target]'s [affected.encased] with \the [tool].</span>")
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/mend_skull/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/mend_skull/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s face with \the [tool]!</span>"  , \
 		"<span class='warning'>Your hand slips, damaging [target]'s face with \the [tool]!</span>")
 	var/obj/item/organ/external/head/h = affected
 	h.receive_damage(10)
 	h.disfigure()
-	return 0
+	return FALSE
 
 /datum/surgery_step/finish_bone
 	name = "medicate bones"
 
-	allowed_tools = list(
-	/obj/item/bonegel = 100,	\
-	/obj/item/screwdriver = 90
-	)
+	allowed_surgery_behaviours = list(SURGERY_MEND_BONE)
 	can_infect = 1
 	blood_level = 1
 
 	time = 24
 
-/datum/surgery_step/finish_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/finish_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	return affected && !affected.is_robotic()
 
-/datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to finish mending the damaged bones in [target]'s [affected.name] with \the [tool].", \
 	"You start to finish mending the damaged bones in [target]'s [affected.name] with \the [tool].")
 	..()
 
-/datum/surgery_step/finish_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/finish_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] has mended the damaged bones in [target]'s [affected.name] with \the [tool].</span>"  , \
 		"<span class='notice'> You have mended the damaged bones in [target]'s [affected.name] with \the [tool].</span>" )
 	affected.mend_fracture()
 	return TRUE
 
-/datum/surgery_step/finish_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/finish_bone/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'> Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
-	return 0
+	return FALSE

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -58,7 +58,7 @@
 			return "abdominal"
 	return ""
 
-/datum/surgery_step/cavity/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'> Your hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!</span>")
@@ -66,66 +66,53 @@
 
 /datum/surgery_step/cavity/make_space
 	name = "make cavity space"
-	allowed_tools = list(
-	/obj/item/surgicaldrill = 100,	\
-	/obj/item/pen = 90,	\
-	/obj/item/stack/rods = 60
-	)
+	allowed_surgery_behaviours = list(SURGERY_MAKE_CAVITY)
 
 	time = 54
 
-/datum/surgery_step/cavity/make_space/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/make_space/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].", \
 	"You start making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool]." )
 	target.custom_pain("The pain in your chest is living hell!")
 	..()
 
-/datum/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] makes some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].</span>", \
 	"<span class='notice'> You make some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].</span>" )
 
-	return 1
+	return TRUE
 
 /datum/surgery_step/cavity/close_space
 	name = "close cavity space"
-	allowed_tools = list(
-	/obj/item/scalpel/laser = 100, \
-	/obj/item/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 90,	\
-	/obj/item/lighter = 60,			\
-	/obj/item/weldingtool = 30
-	)
+	allowed_surgery_behaviours = list(SURGERY_CAUTERIZE_INCISION)
 
 	time = 24
 
-/datum/surgery_step/cavity/close_space/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/close_space/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts mending [target]'s [get_cavity(affected)] cavity wall with \the [tool].", \
 	"You start mending [target]'s [get_cavity(affected)] cavity wall with \the [tool]." )
 	target.custom_pain("The pain in your chest is living hell!")
 	..()
 
-/datum/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] mends [target]'s [get_cavity(affected)] cavity walls with \the [tool].</span>", \
 	"<span class='notice'> You mend [target]'s [get_cavity(affected)] cavity walls with \the [tool].</span>" )
 
-	return 1
+	return TRUE
 
 
 /datum/surgery_step/cavity/place_item
 	name = "implant/extract object"
-	accept_hand = 1
-	accept_any_item = 1
+	accept_hand = TRUE
+	accept_any_item = TRUE
 	var/obj/item/IC = null
-	allowed_tools = list(/obj/item = 100)
-
 	time = 32
 
-
-/datum/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!ishuman(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -139,13 +126,13 @@
 			return 0
 	return ..()
 
-/datum/surgery_step/cavity/place_item/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/place_item/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/I in affected.contents)
 		if(!istype(I, /obj/item/organ))
 			IC = I
 			break
-	if(istype(tool,/obj/item/cautery))
+	if(surgery_behaviour == SURGERY_CAUTERIZE_INCISION)
 		to_chat(user, "<span class='notice'>You prepare to close the cavity wall.</span>")
 	else if(tool)
 		user.visible_message("[user] starts putting \the [tool] inside [target]'s [get_cavity(affected)] cavity.", \
@@ -158,32 +145,32 @@
 	target.custom_pain("The pain in your [target_zone] is living hell!")
 	..()
 
-/datum/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 
 	if(istype(tool, /obj/item/disk/nuclear))
 		to_chat(user, "<span class='warning'>Central command would kill you if you implanted the disk into someone.</span>")
-		return 0//fail
+		return FALSE //fail
 
 	var/obj/item/disk/nuclear/datdisk = locate() in tool
 	if(datdisk)
 		to_chat(user, "<span class='warning'>Central command would kill you if you implanted the disk into someone. Even if in a box. Especially in a box.</span>")
-		return 0//fail
+		return FALSE //fail
 
 	if(istype(tool,/obj/item/organ))
 		to_chat(user, "<span class='warning'>This isn't the type of surgery for organ transplants!</span>")
-		return 0//fail
+		return FALSE//fail
 
 	if(!user.canUnEquip(tool, 0))
 		to_chat(user, "<span class='warning'>[tool] is stuck to your hand, you can't put it in [target]!</span>")
-		return 0
+		return FALSE
 
-	if(istype(tool,/obj/item/cautery))
-		return 1//god this is ugly....
+	if(surgery_behaviour == SURGERY_CAUTERIZE_INCISION)
+		return TRUE
 	else if(tool)
 		if(IC)
 			to_chat(user, "<span class='notice'>There seems to be something in there already!</span>")
-			return 1
+			return TRUE
 		else
 			user.visible_message("<span class='notice'> [user] puts \the [tool] inside [target]'s [get_cavity(affected)] cavity.</span>", \
 			"<span class='notice'> You put \the [tool] inside [target]'s [get_cavity(affected)] cavity.</span>" )
@@ -194,13 +181,13 @@
 			user.drop_item()
 			affected.hidden = tool
 			tool.forceMove(affected)
-			return 1
+			return TRUE
 	else
 		if(IC)
 			user.visible_message("[user] pulls [IC] out of [target]'s [target_zone]!", "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>")
 			user.put_in_hands(IC)
 			affected.hidden = null
-			return 1
+			return TRUE
 		else
 			to_chat(user, "<span class='warning'>You don't find anything in [target]'s [target_zone].</span>")
-			return 0
+			return FALSE

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -137,9 +137,7 @@
 	else if(tool)
 		user.visible_message("[user] starts putting \the [tool] inside [target]'s [get_cavity(affected)] cavity.", \
 		"You start putting \the [tool] inside [target]'s [get_cavity(affected)] cavity." )
-	else if(IC)
-		user.visible_message("[user] checks for items in [target]'s [target_zone].", "<span class='notice'>You check for items in [target]'s [target_zone]...</span>")
-	else //no internal items..but we still need a message!
+	else
 		user.visible_message("[user] checks for items in [target]'s [target_zone].", "<span class='notice'>You check for items in [target]'s [target_zone]...</span>")
 
 	target.custom_pain("The pain in your [target_zone] is living hell!")

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -9,32 +9,32 @@
 /datum/surgery_step/slime/is_valid_target(mob/living/simple_animal/slime/target)
 	return istype(target, /mob/living/simple_animal/slime)
 
-/datum/surgery_step/slime/can_use(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool)
+/datum/surgery_step/slime/can_use(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	return istype(target) && target.stat == DEAD
 
 /datum/surgery_step/slime/cut_flesh
-	allowed_tools = list(/obj/item/scalpel = 100, /obj/item/melee/energy/sword = 75, /obj/item/kitchen/knife = 65, /obj/item/shard = 45)
+	allowed_surgery_behaviours = list(SURGERY_SLIME_CUT_FLESH)
 	time = 16
 
-/datum/surgery_step/slime/cut_flesh/begin_step(mob/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool)
+/datum/surgery_step/slime/cut_flesh/begin_step(mob/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool, surgery_behaviour)
 	user.visible_message("[user] starts cutting through [target]'s flesh with \the [tool].", "You start cutting through [target]'s flesh with \the [tool].")
 
-/datum/surgery_step/slime/cut_flesh/end_step(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool)
+/datum/surgery_step/slime/cut_flesh/end_step(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='notice'> [user] cuts through [target]'s flesh with \the [tool].</span>",
 	"<span class='notice'> You cut through [target]'s flesh with \the [tool], revealing its silky innards.</span>")
 	return TRUE
 
-/datum/surgery_step/slime/cut_flesh/fail_step(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool)
+/datum/surgery_step/slime/cut_flesh/fail_step(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='warning'> [user]'s hand slips, tearing [target]'s flesh with \the [tool]!</span>", \
 	"<span class='warning'> Your hand slips, tearing [target]'s flesh with \the [tool]!</span>")
 	return FALSE
 
 /datum/surgery_step/slime/extract_core
 	name = "extract core"
-	allowed_tools = list(/obj/item/hemostat = 100, /obj/item/crowbar = 100)
+	allowed_surgery_behaviours = list(SURGERY_SLIME_EXTRACT_CORE)
 	time = 16
 
-/datum/surgery_step/slime/extract_core/begin_step(mob/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool)
+/datum/surgery_step/slime/extract_core/begin_step(mob/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool, surgery_behaviour)
 	user.visible_message("<span class='notice'>[user] begins to extract a core from [target].</span>",
 						 "<span class='notice'>You begin to extract a core from [target]...</span>")
 
@@ -55,7 +55,7 @@
 		to_chat(user, "<span class='warning'>There aren't any cores left in [slime]!</span>")
 		return TRUE
 
-/datum/surgery_step/slime/extract_core/fail_step(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool)
+/datum/surgery_step/slime/extract_core/fail_step(mob/living/user, mob/living/simple_animal/slime/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='warning'> [user]'s hand slips, tearing [target]'s flesh with \the [tool]!</span>", \
 	"<span class='warning'> Your hand slips, tearing [target]'s flesh with \the [tool]!</span>")
 	return FALSE

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -12,23 +12,23 @@
 
 /datum/surgery_step/insert_pill
 	name = "insert pill"
-	allowed_tools = list(/obj/item/reagent_containers/food/pill = 100)
+	allowed_surgery_behaviours = list(SURGERY_INSERT_PILL)
 	time = 16
 
-/datum/surgery_step/insert_pill/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/insert_pill/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("[user] begins to wedge \the [tool] in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to wedge [tool] in [target]'s [parse_zone(target_zone)]...</span>")
 	..()
 
 /datum/surgery_step/insert_pill/end_step(mob/living/user, mob/living/carbon/target, target_zone, var/obj/item/reagent_containers/food/pill/tool, datum/surgery/surgery)
 	if(!istype(tool))
-		return 0
+		return FALSE
 
 	var/dental_implants = 0
 	for(var/obj/item/reagent_containers/food/pill in target.contents) // Can't give them more than 4 dental implants.
 		dental_implants++
 	if(dental_implants >= 4)
 		user.visible_message("[user] pulls \the [tool] back out of [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You pull \the [tool] back out of [target]'s [parse_zone(target_zone)], there wans't enough room...</span>")
-		return 0
+		return FALSE
 
 	user.drop_item()
 	tool.forceMove(target)
@@ -40,7 +40,7 @@
 	P.Grant(target)
 
 	user.visible_message("[user] wedges \the [tool] into [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You wedge [tool] into [target]'s [parse_zone(target_zone)].</span>")
-	return 1
+	return TRUE
 
 /datum/action/item_action/hands_free/activate_pill
 	name = "Activate Pill"

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -7,7 +7,7 @@
 	can_infect = 1
 	blood_level = 1
 
-/datum/surgery_step/open_encased/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return 0
@@ -22,15 +22,11 @@
 
 /datum/surgery_step/open_encased/saw
 	name = "saw bone"
-	allowed_tools = list(
-	/obj/item/circular_saw = 100, \
-	/obj/item/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/hatchet = 90
-	)
+	allowed_surgery_behaviours = list(SURGERY_SAW_BONE)
 
 	time = 54
 
-/datum/surgery_step/open_encased/saw/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/saw/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -41,7 +37,7 @@
 	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
-/datum/surgery_step/open_encased/saw/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/saw/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -50,9 +46,9 @@
 	user.visible_message("<span class='notice'> [user] has cut [target]'s [affected.encased] open with \the [tool].</span>",		\
 	"<span class='notice'> You have cut [target]'s [affected.encased] open with \the [tool].</span>")
 	affected.open = 2.5
-	return 1
+	return TRUE
 
-/datum/surgery_step/open_encased/saw/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/saw/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -64,20 +60,16 @@
 	affected.receive_damage(20)
 	affected.fracture()
 
-	return 0
+	return FALSE
 
 
 /datum/surgery_step/open_encased/retract
 	name = "retract bone"
-	allowed_tools = list(
-	/obj/item/scalpel/laser/manager = 100, \
-	/obj/item/retractor = 100, 	\
-	/obj/item/crowbar = 90
-	)
+	allowed_surgery_behaviours = list(SURGERY_RETRACT_BONE)
 
 	time = 24
 
-/datum/surgery_step/open_encased/retract/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/retract/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -89,7 +81,7 @@
 	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
-/datum/surgery_step/open_encased/retract/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/retract/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -101,9 +93,9 @@
 
 	affected.open = 3
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/open_encased/retract/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/retract/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -116,19 +108,15 @@
 	affected.receive_damage(20)
 	affected.fracture()
 
-	return 0
+	return FALSE
 
 /datum/surgery_step/open_encased/close
 	name = "unretract bone" //i suck at names okay? give me a new one
-	allowed_tools = list(
-	/obj/item/scalpel/laser/manager = 100, \
-	/obj/item/retractor = 100, 	\
-	/obj/item/crowbar = 90
-	)
+	allowed_surgery_behaviours = list(SURGERY_RETRACT_BONE)
 
 	time = 24
 
-/datum/surgery_step/open_encased/close/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/close/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -140,7 +128,7 @@
 	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
-/datum/surgery_step/open_encased/close/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/close/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -152,9 +140,9 @@
 
 	affected.open = 2.5
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/open_encased/close/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/close/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -167,18 +155,15 @@
 	affected.receive_damage(20)
 	affected.fracture()
 
-	return 0
+	return FALSE
 
 /datum/surgery_step/open_encased/mend
 	name = "mend bone"
-	allowed_tools = list(
-	/obj/item/bonegel = 100,	\
-	/obj/item/screwdriver = 90
-	)
+	allowed_surgery_behaviours = list(SURGERY_MEND_BONE)
 
 	time = 24
 
-/datum/surgery_step/open_encased/mend/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/mend/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -190,7 +175,7 @@
 	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
-/datum/surgery_step/open_encased/mend/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/open_encased/mend/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
 	if(!hasorgans(target))
 		return
@@ -202,4 +187,4 @@
 
 	affected.open = 2
 
-	return 1
+	return TRUE

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -6,7 +6,7 @@
 /datum/surgery_step/generic/
 	can_infect = 1
 
-/datum/surgery_step/generic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -20,87 +20,67 @@
 /datum/surgery_step/generic/cut_open
 	name = "make incision"
 
-	allowed_tools = list(
-	/obj/item/scalpel = 100,		\
-	/obj/item/kitchen/knife = 90,	\
-	/obj/item/shard = 60, 		\
-	/obj/item/scissors = 12,		\
-	/obj/item/twohanded/chainsaw = 1, \
-	/obj/item/claymore = 6, \
-	/obj/item/melee/energy/ = 6, \
-	/obj/item/pen/edagger = 6,  \
-	)
+	allowed_surgery_behaviours = list(SURGERY_MAKE_INCISION)
 
 	time = 16
 
-/datum/surgery_step/generic/cut_open/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		user.visible_message("[user] starts the incision on [target]'s [affected.name] with \the [tool].", \
-		"You start the incision on [target]'s [affected.name] with \the [tool].")
-		target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!")
-		..()
+/datum/surgery_step/generic/cut_open/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("[user] starts the incision on [target]'s [affected.name] with \the [tool].", \
+	"You start the incision on [target]'s [affected.name] with \the [tool].")
+	target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!")
+	..()
 
-/datum/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] has made an incision on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'> You have made an incision on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.open = 1
-	return 1
+	return TRUE
 
-/datum/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, slicing open [target]'s [affected.name] in a wrong spot with \the [tool]!</span>", \
 	"<span class='warning'> Your hand slips, slicing open [target]'s [affected.name] in a wrong spot with \the [tool]!</span>")
 	affected.receive_damage(10)
-	return 0
+	return FALSE
 
 /datum/surgery_step/generic/clamp_bleeders
 	name = "clamp bleeders"
-
-	allowed_tools = list(
-	/obj/item/scalpel/laser = 100, \
-	/obj/item/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 90, 	\
-	/obj/item/assembly/mousetrap = 25
-	)
+	allowed_surgery_behaviours = list(SURGERY_CLAMP_BLEEDERS)
 
 	time = 24
 
 
-/datum/surgery_step/generic/clamp_bleeders/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		user.visible_message("[user] starts clamping bleeders in [target]'s [affected.name] with \the [tool].", \
-		"You start clamping bleeders in [target]'s [affected.name] with \the [tool].")
-		target.custom_pain("The pain in your [affected.name] is maddening!")
-		..()
+/datum/surgery_step/generic/clamp_bleeders/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("[user] starts clamping bleeders in [target]'s [affected.name] with \the [tool].", \
+	"You start clamping bleeders in [target]'s [affected.name] with \the [tool].")
+	target.custom_pain("The pain in your [affected.name] is maddening!")
+	..()
 
-/datum/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] clamps bleeders in [target]'s [affected.name] with \the [tool]</span>.",	\
 	"<span class='notice'> You clamp bleeders in [target]'s [affected.name] with \the [tool].</span>")
 	spread_germs_to_organ(affected, user, tool)
-	return 1
+	return TRUE
 
-/datum/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, tearing blood vessels and causing massive bleeding in [target]'s [affected.name] with \the [tool]!</span>",	\
 	"<span class='warning'> Your hand slips, tearing blood vessels and causing massive bleeding in [target]'s [affected.name] with \the [tool]!</span>",)
 	affected.receive_damage(10)
-	return 0
+	return FALSE
 
 /datum/surgery_step/generic/retract_skin
 	name = "retract skin"
 
-	allowed_tools = list(
-	/obj/item/scalpel/laser/manager = 100, \
-	/obj/item/retractor = 100, 	\
-	/obj/item/crowbar = 90,	\
-	/obj/item/kitchen/utensil/fork = 60
-	)
+	allowed_surgery_behaviours = list(SURGERY_RETRACT_SKIN)
 
 	time = 24
 
-/datum/surgery_step/generic/retract_skin/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/retract_skin/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/msg = "[user] starts to pry open the incision on [target]'s [affected.name] with \the [tool]."
 	var/self_msg = "You start to pry open the incision on [target]'s [affected.name] with \the [tool]."
@@ -114,7 +94,7 @@
 	target.custom_pain("It feels like the skin on your [affected.name] is on fire!")
 	..()
 
-/datum/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/msg = "<span class='notice'> [user] keeps the incision open on [target]'s [affected.name] with \the [tool].</span>"
 	var/self_msg = "<span class='notice'> You keep the incision open on [target]'s [affected.name] with \the [tool].</span>"
@@ -126,9 +106,9 @@
 		self_msg = "<span class='notice'> You keep the incision open on [target]'s lower abdomen with \the [tool].</span>"
 	user.visible_message(msg, self_msg)
 	affected.open = 2
-	return 1
+	return TRUE
 
-/datum/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/msg = "<span class='warning'> [user]'s hand slips, tearing the edges of incision on [target]'s [affected.name] with \the [tool]!</span>"
 	var/self_msg = "<span class='warning'> Your hand slips, tearing the edges of incision on [target]'s [affected.name] with \the [tool]!</span>"
@@ -140,72 +120,61 @@
 		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s lower abdomen with \the [tool]!</span>"
 	user.visible_message(msg, self_msg)
 	target.apply_damage(12, BRUTE, affected, sharp = 1)
-	return 0
+	return FALSE
 
 /datum/surgery_step/generic/cauterize
 
 	name = "cauterize incision"
 
-	allowed_tools = list(
-	/obj/item/scalpel/laser = 100, \
-	/obj/item/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 90,	\
-	/obj/item/lighter = 60,			\
-	/obj/item/weldingtool = 30
-	)
+	allowed_surgery_behaviours = list(SURGERY_CAUTERIZE_INCISION)
 
 	time = 24
 
-/datum/surgery_step/generic/cauterize/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/cauterize/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to cauterize the incision on [target]'s [affected.name] with \the [tool]." , \
 	"You are beginning to cauterize the incision on [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("Your [affected.name] is being burned!")
 	..()
 
-/datum/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] cauterizes the incision on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'> You cauterize the incision on [target]'s [affected.name] with \the [tool].</span>")
 	affected.open = 0
 	affected.germ_level = 0
-	return 1
+	return TRUE
 
-/datum/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, leaving a small burn on [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'> Your hand slips, leaving a small burn on [target]'s [affected.name] with \the [tool]!</span>")
 	target.apply_damage(3, BURN, affected)
-	return 0
+	return FALSE
 
 //drill bone
 /datum/surgery_step/generic/drill
 	name = "drill bone"
-	allowed_tools = list(/obj/item/surgicaldrill = 100, /obj/item/pickaxe/drill = 60, /obj/item/mecha_parts/mecha_equipment/drill = 60, /obj/item/screwdriver = 20)
+	allowed_surgery_behaviours = list(SURGERY_DRILL_BONE)
 	time = 30
 
-/datum/surgery_step/generic/drill/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/generic/drill/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>")
 	..()
 
 /datum/surgery_step/generic/drill/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] drills into [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You drill into [target]'s [parse_zone(target_zone)].</span>")
-	return 1
+	return TRUE
 
 
 /datum/surgery_step/generic/amputate
 	name = "amputate limb"
 
-	allowed_tools = list(
-	/obj/item/circular_saw = 100, \
-	/obj/item/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/hatchet = 90, \
-	/obj/item/melee/arm_blade = 75
-	)
+	allowed_surgery_behaviours = list(SURGERY_AMPUTATE)
 
 	time = 100
 
-/datum/surgery_step/generic/amputate/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/amputate/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(target_zone == "eyes")	//there are specific steps for eye surgery
 		return 0
 	if(!hasorgans(target))
@@ -215,14 +184,14 @@
 		return 0
 	return !affected.cannot_amputate
 
-/datum/surgery_step/generic/amputate/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/amputate/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to amputate [target]'s [affected.name] with \the [tool]." , \
 	"You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool].")
 	target.custom_pain("Your [affected.amputation_point] is being ripped apart!")
 	..()
 
-/datum/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] amputates [target]'s [affected.name] at the [affected.amputation_point] with \the [tool].</span>", \
 	"<span class='notice'> You amputate [target]'s [affected.name] with \the [tool].</span>")
@@ -232,12 +201,12 @@
 	var/atom/movable/thing = affected.droplimb(1,DROPLIMB_SHARP)
 	if(istype(thing,/obj/item))
 		user.put_in_hands(thing)
-	return 1
+	return TRUE
 
-/datum/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'> Your hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!</span>")
 	affected.receive_damage(30)
 	affected.fracture()
-	return 0
+	return FALSE

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -36,11 +36,11 @@
 
 /datum/surgery_step/extract_implant
 	name = "extract implant"
-	allowed_tools = list(/obj/item/hemostat = 100, /obj/item/crowbar = 65)
+	allowed_surgery_behaviours = list(SURGERY_EXTRACT_IMPLANT)
 	time = 64
 	var/obj/item/implant/I = null
 
-/datum/surgery_step/extract_implant/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/extract_implant/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	I = locate(/obj/item/implant) in target
 	user.visible_message("[user] starts poking around inside [target]'s [affected.name] with \the [tool].", \
@@ -48,7 +48,7 @@
 	target.custom_pain("The pain in your [affected.name] is living hell!")
 	..()
 
-/datum/surgery_step/extract_implant/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/extract_implant/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	I = locate(/obj/item/implant) in target
 	if(I && (target_zone == "chest")) //implant removal only works on the chest.
@@ -76,4 +76,4 @@
 	else
 		user.visible_message("<span class='notice'> [user] could not find anything inside [target]'s [affected.name], and pulls \the [tool] out.</span>", \
 		"<span class='notice'>You could not find anything inside [target]'s [affected.name].</span>")
-	return 1
+	return TRUE

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -17,10 +17,10 @@
 
 /datum/surgery_step/augment
 	name = "augment limb with robotic part"
-	allowed_tools = list(/obj/item/robot_parts = 100)
+	allowed_surgery_behaviours = list(SURGERY_AUGMENT_ROBOTIC)
 	time = 32
 
-/datum/surgery_step/augment/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/augment/can_use(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/robot_parts/p = tool
 	if(p.part)
 		if(!(target_zone in p.part))
@@ -28,11 +28,11 @@
 			return 0
 	return 1
 
-/datum/surgery_step/augment/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/augment/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts augmenting [affected] with [tool].", "You start augmenting [affected] with [tool].")
 
-/datum/surgery_step/augment/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/augment/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/robot_parts/L = tool
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has finished augmenting [affected] with [tool].</span>",	\
@@ -54,4 +54,4 @@
 
 	affected.open = 0
 	affected.germ_level = 0
-	return 1
+	return TRUE

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -70,7 +70,7 @@
 
 /datum/surgery_step/limb/
 	can_infect = 0
-/datum/surgery_step/limb/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/can_use(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -81,11 +81,11 @@
 
 /datum/surgery_step/limb/attach
 	name = "attach limb"
-	allowed_tools = list(/obj/item/organ/external = 100)
+	allowed_surgery_behaviours = list(SURGERY_ATTACH_LIMB)
 
 	time = 32
 
-/datum/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/attach/can_use(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!..())
 		return 0
 	if(!istype(tool, /obj/item/organ/external))
@@ -110,30 +110,30 @@
 	return 1
 
 
-/datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, surgery_behaviour)
 	var/obj/item/organ/external/E = tool
 	user.visible_message("[user] starts attaching [E.name] to [target]'s [E.amputation_point].", \
 	"You start attaching [E.name] to [target]'s [E.amputation_point].")
 
-/datum/surgery_step/limb/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/attach/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/E = tool
 	user.visible_message("<span class='notice'>[user] has attached [target]'s [E.name] to the [E.amputation_point].</span>",	\
 	"<span class='notice'>You have attached [target]'s [E.name] to the [E.amputation_point].</span>")
 	attach_limb(user, target, E)
-	return 1
+	return TRUE
 
-/datum/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/attach/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/E = tool
 	user.visible_message("<span class='alert'>[user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
 	"<span class='alert'>Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
 	target.apply_damage(10, BRUTE, null, sharp = 1)
-	return 0
+	return FALSE
 
 
 /datum/surgery_step/limb/attach/proc/is_correct_limb(obj/item/organ/external/E)
 	if(E.is_robotic())
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /datum/surgery_step/limb/attach/proc/attach_limb(mob/living/user, mob/living/carbon/human/target, obj/item/organ/external/E)
 	user.unEquip(E)
@@ -169,49 +169,45 @@
 
 /datum/surgery_step/limb/connect
 	name = "connect limb"
-	allowed_tools = list(
-	/obj/item/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 90, 	\
-	/obj/item/assembly/mousetrap = 25
-	)
+	allowed_surgery_behaviours = list(SURGERY_CONNECT_LIMB)
 	can_infect = 1
 
 	time = 32
 
 
-/datum/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/connect/can_use(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!hasorgans(target))
 		return 0
 	return 1
 
-/datum/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, surgery_behaviour)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("[user] starts connecting tendons and muscles in [target]'s [E.amputation_point] with [tool].", \
 	"You start connecting tendons and muscle in [target]'s [E.amputation_point].")
 
-/datum/surgery_step/limb/connect/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/connect/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>",	\
 	"<span class='notice'>You have connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>")
 	target.update_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()
-	return 1
+	return TRUE
 
-/datum/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/connect/fail_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='alert'>[user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
 	"<span class='alert'>Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
 	target.apply_damage(10, BRUTE, null, sharp = 1)
-	return 0
+	return FALSE
 
 /datum/surgery_step/limb/mechanize
 	name = "apply robotic prosthetic"
-	allowed_tools = list(/obj/item/robot_parts = 100)
+	allowed_surgery_behaviours = list(SURGERY_AUGMENT_ROBOTIC)
 
 	time = 32
 
-/datum/surgery_step/limb/mechanize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/mechanize/can_use(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(..())
 		var/obj/item/robot_parts/p = tool
 		if(p.part)
@@ -220,11 +216,10 @@
 				return 0
 		return isnull(target.get_organ(target_zone))
 
-/datum/surgery_step/limb/mechanize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		user.visible_message("[user] starts attaching \the [tool] to [target].", \
-		"You start attaching \the [tool] to [target].")
+/datum/surgery_step/limb/mechanize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, surgery_behaviour)
+	user.visible_message("[user] starts attaching \the [tool] to [target].", "You start attaching \the [tool] to [target].")
 
-/datum/surgery_step/limb/mechanize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/mechanize/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/robot_parts/L = tool
 	user.visible_message("<span class='notice'>[user] has attached \the [tool] to [target].</span>",	\
 	"<span class='notice'>You have attached \the [tool] to [target].</span>")
@@ -251,10 +246,10 @@
 
 	qdel(tool)
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/limb/mechanize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/limb/mechanize/fail_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='alert'>[user]'s hand slips, damaging [target]'s flesh!</span>", \
 	"<span class='alert'>Your hand slips, damaging [target]'s flesh!</span>")
 	target.apply_damage(10, BRUTE, null, sharp = 1)
-	return 0
+	return FALSE

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -7,6 +7,7 @@
 	max_damage = 0
 	dir = SOUTH
 	organ_tag = "limb"
+	surgery_behaviours = list(SURGERY_ATTACH_LIMB = 100)
 
 	var/brute_mod = 1
 	var/burn_mod = 1

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -7,6 +7,7 @@
 	// DO NOT add slots with matching names to different zones - it will break internal_organs_slot list!
 	var/non_primary = 0
 	var/unremovable = FALSE //Whether it shows up as an option to remove during surgery.
+	surgery_behaviours = list(SURGERY_IMPLANT_ORGAN_MANIP = 100)
 
 /obj/item/organ/internal/New(mob/living/carbon/holder)
 	..()

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -60,30 +60,27 @@
 
 /datum/surgery_step/fix_vein
 	name = "mend internal bleeding"
-	allowed_tools = list(
-	/obj/item/FixOVein = 100, \
-	/obj/item/stack/cable_coil = 90
-	)
+	allowed_surgery_behaviours = list(SURGERY_MEND_INTERNAL_BLEEDING)
 	can_infect = 1
 	blood_level = 1
 
 	time = 32
 
-/datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(!affected)
 		return 0
 
 	return affected.internal_bleeding
 
-/datum/surgery_step/fix_vein/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_vein/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts patching the damaged vein in [target]'s [affected.name] with \the [tool]." , \
 	"You start patching the damaged vein in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("The pain in [affected.name] is unbearable!")
 	..()
 
-/datum/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] has patched the damaged vein in [target]'s [affected.name] with \the [tool].</span>", \
 		"<span class='notice'> You have patched the damaged vein in [target]'s [affected.name] with \the [tool].</span>")
@@ -93,30 +90,26 @@
 		var/mob/living/carbon/human/U = user
 		U.bloody_hands(target, 0)
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'> Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
 	affected.receive_damage(5, 0)
 
-	return 0
+	return FALSE
 
 /datum/surgery_step/fix_dead_tissue		//Debridement
 	name = "remove dead tissue"
-	allowed_tools = list(
-		/obj/item/scalpel = 100,		\
-		/obj/item/kitchen/knife = 90,	\
-		/obj/item/shard = 60, 		\
-	)
+	allowed_surgery_behaviours = list(SURGERY_MAKE_INCISION)
 
 	can_infect = 1
 	blood_level = 1
 
 	time = 16
 
-/datum/surgery_step/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!hasorgans(target))
 		return 0
 
@@ -129,47 +122,39 @@
 		return 0
 	return 1
 
-/datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts cutting away necrotic tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start cutting away necrotic tissue in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("The pain in [affected.name] is unbearable!")
 	..()
 
-/datum/surgery_step/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] has cut away necrotic tissue in [target]'s [affected.name] with \the [tool].</span>", \
 		"<span class='notice'> You have cut away necrotic tissue in [target]'s [affected.name] with \the [tool].</span>")
 	affected.open = 3
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/fix_dead_tissue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/fix_dead_tissue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'> Your hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>")
 	affected.receive_damage(20)
 
-	return 0
+	return FALSE
 
 /datum/surgery_step/treat_necrosis
 	name = "treat necrosis"
-	allowed_tools = list(
-		/obj/item/reagent_containers/dropper = 100,
-		/obj/item/reagent_containers/glass/bottle = 90,
-		/obj/item/reagent_containers/food/drinks/drinkingglass = 85,
-		/obj/item/reagent_containers/food/drinks/bottle = 80,
-		/obj/item/reagent_containers/glass/beaker = 75,
-		/obj/item/reagent_containers/spray = 60,
-		/obj/item/reagent_containers/glass/bucket = 50
-	)
+	allowed_surgery_behaviours = list(SURGERY_CLEAN_ORGAN_MANIP)
 
 	can_infect = 0
 	blood_level = 0
 
 	time = 24
 
-/datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!istype(tool, /obj/item/reagent_containers))
 		return 0
 
@@ -187,39 +172,39 @@
 		return 0
 	return 1
 
-/datum/surgery_step/treat_necrosis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the affected tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the affected tissue in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 	..()
 
-/datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if(!istype(tool, /obj/item/reagent_containers))
-		return 0
+		return FALSE
 
 	var/obj/item/reagent_containers/container = tool
-	var/mitocholide = 0
+	var/has_mitocholide = FALSE
 
 	if(container.reagents.has_reagent("mitocholide"))
-		mitocholide = 1
+		has_mitocholide = TRUE
 
 	var/trans = container.reagents.trans_to(target, container.amount_per_transfer_from_this)
 	if(trans > 0)
 		container.reagents.reaction(target, INGEST)	//technically it's contact, but the reagents are being applied to internal tissue
 
-		if(mitocholide)
+		if(has_mitocholide)
 			affected.status &= ~ORGAN_DEAD
 			target.update_body()
 
 		user.visible_message("<span class='notice'> [user] applies [trans] units of the solution to affected tissue in [target]'s [affected.name]</span>", \
 			"<span class='notice'> You apply [trans] units of the solution to affected tissue in [target]'s [affected.name] with \the [tool].</span>")
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if(!istype(tool, /obj/item/reagent_containers))
@@ -285,24 +270,24 @@
 
 /datum/surgery_step/internal/dethrall
 	name = "cleanse contamination"
-	allowed_tools = list(/obj/item/flash = 100, /obj/item/flashlight/pen = 80, /obj/item/flashlight = 40)
+	allowed_surgery_behaviours = list(SURGERY_DETHRALL)
 	blood_level = 0
 	time = 30
 
-/datum/surgery_step/internal/dethrall/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/internal/dethrall/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!..())
 		return 0
 	if(!is_thrall(target))
 		return 0
 	return 1
 
-/datum/surgery_step/internal/dethrall/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/internal/dethrall/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/braincase = target.named_organ_parent("brain")
 	user.visible_message("[user] reaches into [target]'s head with [tool].", "<span class='notice'>You begin aligning [tool]'s light to the tumor on [target]'s brain...</span>")
 	to_chat(target, "<span class='boldannounce'>A small part of your [braincase] pulses with agony as the light impacts it.</span>")
 	..()
 
-/datum/surgery_step/internal/dethrall/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/internal/dethrall/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(isshadowlinglesser(target)) //Empowered thralls cannot be deconverted
 		to_chat(target, "<span class='shadowling'><b><i>NOT LIKE THIS!</i></b></span>")
 		user.visible_message("<span class='warning'>[target] suddenly slams upward and knocks down [user]!</span>", \
@@ -321,7 +306,7 @@
 			S.Weaken(8)
 			S.apply_damage(20, BRUTE)
 			playsound(S, 'sound/effects/bang.ogg', 50, 1)
-		return 0
+		return FALSE
 	var/obj/item/organ/internal/brain/B = target.get_int_organ(/obj/item/organ/internal/brain)
 	var/obj/item/organ/external/E = target.get_organ(check_zone(B.parent_organ))
 	user.visible_message("[user] shines light onto the tumor in [target]'s [E]!", "<span class='notice'>You cleanse the contamination from [target]'s brain!</span>")
@@ -333,4 +318,4 @@
 	var/obj/item/organ/thing = new /obj/item/organ/internal/shadowtumor(get_turf(target))
 	thing.set_dna(target.dna)
 	user.put_in_hands(thing)
-	return 1
+	return TRUE

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -16,10 +16,10 @@
 
 /datum/surgery_step/reshape_face
 	name = "reshape face"
-	allowed_tools = list(/obj/item/scalpel = 100, /obj/item/kitchen/knife = 50, /obj/item/wirecutters = 35)
+	allowed_surgery_behaviours = list(SURGERY_RESHAPE_FACE)
 	time = 64
 
-/datum/surgery_step/reshape_face/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/reshape_face/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("[user] begins to alter [target]'s appearance.", "<span class='notice'>You begin to alter [target]'s appearance...</span>")
 
 /datum/surgery_step/reshape_face/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -48,7 +48,7 @@
 	return TRUE
 
 
-/datum/surgery_step/reshape_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/reshape_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/head/head = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, tearing skin on [target]'s face with [tool]!</span>", \
 						 "<span class='warning'> Your hand slips, tearing skin on [target]'s face with [tool]!</span>")

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -35,7 +35,7 @@
 	var/obj/item/organ/external/L = null
 
 
-/datum/surgery_step/remove_object/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/remove_object/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	L = surgery.organ_ref
 	if(L)
 		user.visible_message("[user] looks for objects embedded in [target]'s [parse_zone(user.zone_selected)].", "<span class='notice'>You look for objects embedded in [target]'s [parse_zone(user.zone_selected)]...</span>")
@@ -43,7 +43,7 @@
 		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
 
 
-/datum/surgery_step/remove_object/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/remove_object/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(L)
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
@@ -63,4 +63,4 @@
 	else
 		to_chat(user, "<span class='warning'>You can't find [target]'s [parse_zone(user.zone_selected)], let alone any objects embedded in it!</span>")
 
-	return 1
+	return TRUE

--- a/code/modules/surgery/rig_removal.dm
+++ b/code/modules/surgery/rig_removal.dm
@@ -17,18 +17,14 @@
 //Bay12 removal
 /datum/surgery_step/rigsuit
 	name="Cut Seals"
-	allowed_tools = list(
-		/obj/item/weldingtool = 80,
-		/obj/item/circular_saw = 60,
-		/obj/item/gun/energy/plasmacutter = 100
-		)
+	allowed_surgery_behaviours = list(SURGERY_CUT_SEALS)
 
 	can_infect = 0
 	blood_level = 0
 
 	time = 50
 
-/datum/surgery_step/hardsuit/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/hardsuit/can_use(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!istype(target))
 		return 0
 	if(tool.tool_behaviour == TOOL_WELDER)
@@ -38,22 +34,21 @@
 			return
 	return (target_zone == "chest") && istype(target.back, /obj/item/rig) && (target.back.flags&NODROP)
 
-/datum/surgery_step/rigsuit/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/rigsuit/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, surgery_behaviour)
 	user.visible_message("[user] starts cutting through the support systems of [target]'s [target.back] with \the [tool]." , \
 	"You start cutting through the support systems of [target]'s [target.back] with \the [tool].")
 	..()
 
-/datum/surgery_step/rigsuit/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-
+/datum/surgery_step/rigsuit/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/rig/rig = target.back
 	if(!istype(rig))
 		return
 	rig.reset()
 	user.visible_message("<span class='notice'>[user] has cut through the support systems of [target]'s [rig] with \the [tool].</span>", \
 		"<span class='notice'>You have cut through the support systems of [target]'s [rig] with \the [tool].</span>")
-	return 1
+	return TRUE
 
-/datum/surgery_step/rigsuit/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/rigsuit/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='danger'>[user]'s [tool] can't quite seem to get through the metal...</span>", \
 	"<span class='danger'>Your [tool] can't quite seem to get through the metal. It's weakening, though - try again.</span>")
-	return 0
+	return FALSE

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -48,7 +48,7 @@
 /datum/surgery_step/robotics
 	can_infect = 0
 
-/datum/surgery_step/robotics/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!istype(target))
 		return 0
 	if(!hasorgans(target))
@@ -60,7 +60,7 @@
 
 /datum/surgery_step/robotics/external
 
-/datum/surgery_step/robotics/external/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(!..())
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -70,143 +70,111 @@
 
 /datum/surgery_step/robotics/external/unscrew_hatch
 	name = "unscrew hatch"
-	allowed_tools = list(
-		/obj/item/screwdriver = 100,
-		/obj/item/coin = 50,
-		/obj/item/kitchen/knife = 50
-	)
+	allowed_surgery_behaviours = list(SURGERY_ROBOTIC_UNSCREW_HATCH)
 
 	time = 16
 
-/datum/surgery_step/robotics/external/unscrew_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/unscrew_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(!affected)
 			return 0
 		return 1
 
-/datum/surgery_step/robotics/external/unscrew_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/unscrew_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
 	"You start to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
-/datum/surgery_step/robotics/external/unscrew_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/unscrew_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] has opened the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'> You have opened the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.open = 1
-	return 1
+	return TRUE
 
-/datum/surgery_step/robotics/external/unscrew_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/unscrew_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to unscrew [target]'s [affected.name].</span>", \
 	"<span class='warning'> Your [tool] slips, failing to unscrew [target]'s [affected.name].</span>")
-	return 0
+	return FALSE
 
 /datum/surgery_step/robotics/external/open_hatch
 	name = "open hatch"
-	allowed_tools = list(
-		/obj/item/retractor = 100,
-		/obj/item/crowbar = 100,
-		/obj/item/kitchen/utensil/ = 50
-	)
+	allowed_surgery_behaviours = list(SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 
 	time = 24
 
-/datum/surgery_step/robotics/external/open_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/open_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(!affected)
 			return 0
 		return 1
 
-/datum/surgery_step/robotics/external/open_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/open_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].",
 	"You start to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
-/datum/surgery_step/robotics/external/open_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/open_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] opens the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	 "<span class='notice'> You open the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>" )
 	affected.open = 2
-	return 1
+	return TRUE
 
-/datum/surgery_step/robotics/external/open_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/open_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to open the hatch on [target]'s [affected.name].</span>",
 	"<span class='warning'> Your [tool] slips, failing to open the hatch on [target]'s [affected.name].</span>")
-	return 0
+	return FALSE
 
 /datum/surgery_step/robotics/external/close_hatch
 	name = "close hatch"
-	allowed_tools = list(
-		/obj/item/retractor = 100,
-		/obj/item/crowbar = 100,
-		/obj/item/kitchen/utensil = 50
-	)
+	allowed_surgery_behaviours = list(SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 
 	time = 24
 
-/datum/surgery_step/robotics/external/close_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/close_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(!affected)
-			return 0
-		return 1
+			return FALSE
+		return TRUE
 
-/datum/surgery_step/robotics/external/close_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/close_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] begins to close and secure the hatch on [target]'s [affected.name] with \the [tool]." , \
 	"You begin to close and secure the hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
-/datum/surgery_step/robotics/external/close_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/close_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] closes and secures the hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'> You close and secure the hatch on [target]'s [affected.name] with \the [tool].</span>")
 	affected.open = 0
-	return 1
+	return TRUE
 
-/datum/surgery_step/robotics/external/close_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/close_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>",
 	"<span class='warning'> Your [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>")
-	return 0
+	return FALSE
 
 /datum/surgery_step/robotics/external/repair
 	name = "repair damage internally"
-	allowed_tools = list()
-
-	var/list/implements_finish = list(
-		/obj/item/retractor = 100,
-		/obj/item/crowbar = 100,
-		/obj/item/kitchen/utensil = 50
-	)
-	var/list/implements_heal_burn = list(
-		/obj/item/stack/cable_coil = 100
-	)
-	var/list/implements_heal_brute = list(
-		/obj/item/weldingtool = 100,
-		/obj/item/gun/energy/plasmacutter = 50
-	)
-	var/current_type
+	allowed_surgery_behaviours = list(SURGERY_ROBOTIC_OPEN_CLOSE_HATCH, SURGERY_ROBOTIC_HEAL_BRUTE, SURGERY_ROBOTIC_HEAL_BURN)
 	time = 32
 
-/datum/surgery_step/robotics/external/repair/New()
-	..()
-	allowed_tools = implements_heal_burn + implements_heal_brute + implements_finish
-
-
-/datum/surgery_step/robotics/external/repair/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/repair/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(!affected)
 		return -1
 
-	if(implement_type in implements_heal_burn)
-		current_type = "burn"
+	if(surgery_behaviour == SURGERY_ROBOTIC_HEAL_BURN)
 		var/obj/item/stack/cable_coil/C = tool
 		if(!(affected.burn_dam > 0))
 			to_chat(user, "<span class='warning'>The [affected] does not have any burn damage!</span>")
@@ -220,8 +188,7 @@
 		user.visible_message("[user] begins to splice new cabling into [target]'s [affected.name]." , \
 		"You begin to splice new cabling into [target]'s [affected.name].")
 
-	else if(implement_type in implements_heal_brute)
-		current_type = "brute"
+	else if(surgery_behaviour == SURGERY_ROBOTIC_HEAL_BRUTE)
 		if(!(affected.brute_dam > 0 || affected.disfigured))
 			to_chat(user, "<span class='warning'>The [affected] does not require welding repair!</span>")
 			return -1
@@ -231,77 +198,62 @@
 		user.visible_message("[user] begins to patch damage to [target]'s [affected.name]'s support structure with \the [tool]." , \
 		"You begin to patch damage to [target]'s [affected.name]'s support structure with \the [tool].")
 
-	else if(implement_type in implements_finish)
-		current_type = "finish"
+	else if(surgery_behaviour == SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 		user.visible_message("[user] begins to close and secure the hatch on [target]'s [affected.name] with \the [tool]." , \
 		"You begin to close and secure the hatch on [target]'s [affected.name] with \the [tool].")
 	else
-		log_runtime(EXCEPTION("Invalid tool: '[implement_type]'"), src)
+		log_runtime(EXCEPTION("Invalid surgery behaviour: '[surgery_behaviour]', tool: '[tool]'"), src)
 		return -1
 	..()
 
-/datum/surgery_step/robotics/external/repair/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/repair/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	switch(current_type)
-		if("brute")
+	switch(surgery_behaviour)
+		if(SURGERY_ROBOTIC_HEAL_BRUTE)
 			user.visible_message("<span class='notice'> [user] finishes patching damage to [target]'s [affected.name] with \the [tool].</span>", \
 			"<span class='notice'> You finish patching damage to [target]'s [affected.name] with \the [tool].</span>")
 			affected.heal_damage(rand(30,50),0,1,1)
 			affected.disfigured = FALSE
-		if("burn")
+		if(SURGERY_ROBOTIC_HEAL_BURN)
 			user.visible_message("<span class='notice'> [user] finishes splicing cable into [target]'s [affected.name].</span>", \
 			"<span class='notice'> You finishes splicing new cable into [target]'s [affected.name].</span>")
 			affected.heal_damage(0,rand(30,50),1,1)
-		if("finish")
+		if(SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 			user.visible_message("<span class='notice'> [user] closes and secures the hatch on [target]'s [affected.name] with \the [tool].</span>", \
 			"<span class='notice'> You close and secure the hatch on [target]'s [affected.name] with \the [tool].</span>")
 			affected.open = 0
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
-/datum/surgery_step/robotics/external/repair/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/repair/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	switch(current_type)
-		if("brute")
+	switch(surgery_behaviour)
+		if(SURGERY_ROBOTIC_HEAL_BRUTE)
 			user.visible_message("<span class='warning'> [user]'s [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>",
 			"<span class='warning'> Your [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>")
 			target.apply_damage(rand(5,10), BURN, affected)
-		if("burn")
+		if(SURGERY_ROBOTIC_HEAL_BURN)
 			user.visible_message("<span class='warning'> [user] causes a short circuit in [target]'s [affected.name]!</span>",
 			"<span class='warning'> You cause a short circuit in [target]'s [affected.name]!</span>")
 			target.apply_damage(rand(5,10), BURN, affected)
-		if("finish")
+		if(SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 			user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>",
 			"<span class='warning'> Your [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>")
-	return 0
+	return FALSE
 
 ///////condenseing remove/extract/repair here.	/////////////
 /datum/surgery_step/robotics/manipulate_robotic_organs
 
 	name = "internal part manipulation"
-	allowed_tools = list(/obj/item/mmi = 100)
-	var/implements_extract = list(/obj/item/multitool = 100)
-	var/implements_mend = list(	/obj/item/stack/nanopaste = 100,/obj/item/bonegel = 30, /obj/item/screwdriver = 70)
-	var/implements_insert = list(/obj/item/organ/internal = 100)
-	var/implements_finish =list(/obj/item/retractor = 100,/obj/item/crowbar = 100,/obj/item/kitchen/utensil = 50)
-	var/current_type
-	var/obj/item/organ/internal/I = null
+	allowed_surgery_behaviours = list(SURGERY_ROBOTIC_OPEN_CLOSE_HATCH, SURGERY_IMPLANT_ORGAN_MANIP, SURGERY_ROBOTIC_MEND, SURGERY_ROBOTIC_EXTRACT_ORGAN, SURGERY_ROBOTIC_INSERT_MMI)
+	var/obj/item/organ/internal/organ_being_removed = null
 	var/obj/item/organ/external/affected = null
 	time = 32
 
-/datum/surgery_step/robotics/manipulate_robotic_organs/New()
-	..()
-	allowed_tools = allowed_tools + implements_extract + implements_mend + implements_insert + implements_finish
-
-
-
-
-/datum/surgery_step/robotics/manipulate_robotic_organs/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-
-	I = null
+/datum/surgery_step/robotics/manipulate_robotic_organs/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
+	organ_being_removed = null
 	affected = target.get_organ(target_zone)
-	if(implement_type in implements_insert)
-		current_type = "insert"
+	if(surgery_behaviour == SURGERY_IMPLANT_ORGAN_MANIP)
 		var/obj/item/organ/internal/I = tool
 
 		if(!I.is_robotic())
@@ -322,9 +274,7 @@
 		user.visible_message("[user] begins reattaching [target]'s [tool].", \
 		"You start reattaching [target]'s [tool].")
 		target.custom_pain("Someone's rooting around in your [affected.name]!")
-	else if(istype(tool,/obj/item/mmi))
-		current_type = "install"
-
+	else if(surgery_behaviour == SURGERY_ROBOTIC_INSERT_MMI)
 		if(target_zone != "chest")
 			to_chat(user, "<span class='notice'> You must target the chest cavity.</span>")
 
@@ -361,8 +311,7 @@
 		user.visible_message("[user] starts installing \the [tool] into [target]'s [affected.name].", \
 		"You start installing \the [tool] into [target]'s [affected.name].")
 
-	else if(implement_type in implements_extract)
-		current_type = "extract"
+	else if(surgery_behaviour == SURGERY_ROBOTIC_EXTRACT_ORGAN)
 		var/list/organs = target.get_organs_zone(target_zone)
 		if(!(affected && affected.is_robotic()))
 			return -1
@@ -375,19 +324,18 @@
 				organs -= O
 				organs[O.name] = O
 
-			I = input("Remove which organ?", "Surgery", null, null) as null|anything in organs
-			if(I && user && target && user.Adjacent(target) && user.get_active_hand() == tool)
-				I = organs[I]
-				if(!I) return -1
-				user.visible_message("[user] starts to decouple [target]'s [I] with \the [tool].", \
-				"You start to decouple [target]'s [I] with \the [tool]." )
+			organ_being_removed = input("Remove which organ?", "Surgery", null, null) as null|anything in organs
+			if(organ_being_removed && user && target && user.Adjacent(target) && user.get_active_hand() == tool)
+				organ_being_removed = organs[organ_being_removed]
+				if(!organ_being_removed) return -1
+				user.visible_message("[user] starts to decouple [target]'s [organ_being_removed] with \the [tool].", \
+				"You start to decouple [target]'s [organ_being_removed] with \the [tool]." )
 
 				target.custom_pain("The pain in your [affected.name] is living hell!")
 			else
 				return -1
 
-	else if(implement_type in implements_mend)
-		current_type = "mend"
+	else if(surgery_behaviour == SURGERY_ROBOTIC_MEND)
 		if(!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -405,17 +353,14 @@
 
 		target.custom_pain("The pain in your [affected.name] is living hell!")
 
-	else if(implement_type in implements_finish)
-		current_type = "finish"
+	else if(surgery_behaviour == SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 		user.visible_message("[user] begins to close and secure the hatch on [target]'s [affected.name] with \the [tool]." , \
 		"You begin to close and secure the hatch on [target]'s [affected.name] with \the [tool].")
 
-
 	..()
 
-/datum/surgery_step/robotics/manipulate_robotic_organs/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	if(current_type == "mend")
-
+/datum/surgery_step/robotics/manipulate_robotic_organs/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
+	if(surgery_behaviour == SURGERY_ROBOTIC_MEND)
 		if(!hasorgans(target))
 			return
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
@@ -425,7 +370,7 @@
 					"<span class='notice'> You repair [target]'s [I.name] with [tool].</span>" )
 					I.damage = 0
 					I.surgeryize()
-	else if(current_type == "insert")
+	else if(surgery_behaviour == SURGERY_IMPLANT_ORGAN_MANIP)
 		var/obj/item/organ/internal/I = tool
 
 		if(!user.canUnEquip(I, 0))
@@ -437,7 +382,7 @@
 		user.visible_message("<span class='notice'> [user] has reattached [target]'s [I].</span>" , \
 		"<span class='notice'> You have reattached [target]'s [I].</span>")
 
-	else if(current_type == "install")
+	else if(surgery_behaviour == SURGERY_ROBOTIC_INSERT_MMI)
 		user.visible_message("<span class='notice'> [user] has installed \the [tool] into [target]'s [affected.name].</span>", \
 		"<span class='notice'> You have installed \the [tool] into [target]'s [affected.name].</span>")
 
@@ -446,14 +391,14 @@
 		user.unEquip(tool)
 		M.attempt_become_organ(affected,target)
 
-	else if(current_type == "extract")
-		if(I && I.owner == target)
-			user.visible_message("<span class='notice'> [user] has decoupled [target]'s [I] with \the [tool].</span>" , \
-		"<span class='notice'> You have decoupled [target]'s [I] with \the [tool].</span>")
+	else if(surgery_behaviour == SURGERY_ROBOTIC_EXTRACT_ORGAN)
+		if(organ_being_removed && organ_being_removed.owner == target)
+			user.visible_message("<span class='notice'> [user] has decoupled [target]'s [organ_being_removed] with \the [tool].</span>" , \
+		"<span class='notice'> You have decoupled [target]'s [organ_being_removed] with \the [tool].</span>")
 
-			add_attack_logs(user, target, "Surgically removed [I.name]. INTENT: [uppertext(user.a_intent)]")
-			spread_germs_to_organ(I, user)
-			var/obj/item/thing = I.remove(target)
+			add_attack_logs(user, target, "Surgically removed [organ_being_removed.name]. INTENT: [uppertext(user.a_intent)]")
+			spread_germs_to_organ(organ_being_removed, user)
+			var/obj/item/thing = organ_being_removed.remove(target)
 			if(!istype(thing))
 				thing.forceMove(get_turf(target))
 			else
@@ -461,18 +406,18 @@
 		else
 			user.visible_message("[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
 				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
-	else if(current_type == "finish")
+	else if(surgery_behaviour == SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("<span class='notice'> [user] closes and secures the hatch on [target]'s [affected.name] with \the [tool].</span>", \
 		"<span class='notice'> You close and secure the hatch on [target]'s [affected.name] with \the [tool].</span>")
 		affected.open = 0
 		affected.germ_level = 0
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
-/datum/surgery_step/robotics/manipulate_robotic_organs/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/manipulate_robotic_organs/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 
-	if(current_type == "mend")
+	if(surgery_behaviour == SURGERY_ROBOTIC_MEND)
 		if(!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -487,33 +432,31 @@
 			if(I)
 				I.receive_damage(rand(3,5),0)
 
-	else if(current_type == "insert")
+	else if(surgery_behaviour == SURGERY_IMPLANT_ORGAN_MANIP)
 		user.visible_message("<span class='warning'> [user]'s hand slips, disconnecting \the [tool].</span>", \
 		"<span class='warning'> Your hand slips, disconnecting \the [tool].</span>")
 
-	else if(current_type == "extract")
+	else if(surgery_behaviour == SURGERY_ROBOTIC_EXTRACT_ORGAN)
 		user.visible_message("<span class='warning'> [user]'s hand slips, disconnecting \the [tool].</span>", \
 		"<span class='warning'> Your hand slips, disconnecting \the [tool].</span>")
 
-	else if(current_type == "install")
+	else if(surgery_behaviour == SURGERY_ROBOTIC_INSERT_MMI)
 		user.visible_message("<span class='warning'> [user]'s hand slips!</span>.", \
 		"<span class='warning'> Your hand slips!</span>")
-	else if(current_type == "finish")
+	else if(surgery_behaviour == SURGERY_ROBOTIC_OPEN_CLOSE_HATCH)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>",
 		"<span class='warning'> Your [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>")
-	return 0
+	return FALSE
 
 
 /datum/surgery_step/robotics/external/amputate
 	name = "remove robotic limb"
-
-	allowed_tools = list(
-	/obj/item/multitool = 100)
+	allowed_surgery_behaviours = list(SURGERY_ROBOTIC_EXTRACT_ORGAN)
 
 	time = 100
 
-/datum/surgery_step/robotics/external/amputate/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/amputate/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to decouple [target]'s [affected.name] with \the [tool].", \
 	"You start to decouple [target]'s [affected.name] with \the [tool]." )
@@ -521,7 +464,7 @@
 	target.custom_pain("Your [affected.amputation_point] is being ripped apart!")
 	..()
 
-/datum/surgery_step/robotics/external/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'> [user] has decoupled [target]'s [affected.name] with \the [tool].</span>" , \
 	"<span class='notice'> You have decoupled [target]'s [affected.name] with \the [tool].</span>")
@@ -533,13 +476,12 @@
 	if(istype(thing,/obj/item))
 		user.put_in_hands(thing)
 
-	return 1
+	return TRUE
 
-/datum/surgery_step/robotics/external/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-
+/datum/surgery_step/robotics/external/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	user.visible_message("<span class='warning'> [user]'s hand slips!</span>", \
 	"<span class='warning'> Your hand slips!</span>")
-	return 0
+	return FALSE
 
 /datum/surgery/cybernetic_customization
 	name = "Cybernetic Appearance Customization"
@@ -558,23 +500,23 @@
 
 /datum/surgery_step/robotics/external/customize_appearance
 	name = "reprogram limb"
-	allowed_tools = list(/obj/item/multitool = 100)
+	allowed_surgery_behaviours = list(SURGERY_ROBOTIC_REPROGRAM)
 	time = 48
 
-/datum/surgery_step/robotics/external/customize_appearance/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/customize_appearance/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(!affected)
 			return FALSE
 		return TRUE
 
-/datum/surgery_step/robotics/external/customize_appearance/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/customize_appearance/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] begins to reprogram the appearance of [target]'s [affected.name] with [tool]." , \
 	"You begin to reprogram the appearance of [target]'s [affected.name] with [tool].")
 	..()
 
-/datum/surgery_step/robotics/external/customize_appearance/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/customize_appearance/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/chosen_appearance = input(user, "Select the company appearance for this limb.", "Limb Company Selection") as null|anything in selectable_robolimbs
 	if(!chosen_appearance)
 		return FALSE
@@ -592,7 +534,7 @@
 	affected.open = 0
 	return TRUE
 
-/datum/surgery_step/robotics/external/customize_appearance/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/robotics/external/customize_appearance/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, surgery_behaviour)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to reprogram [target]'s [affected.name].</span>",
 	"<span class='warning'> Your [tool.name] slips, failing to reprogram [target]'s [affected.name].</span>")

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -7,6 +7,7 @@
 	flags = CONDUCT
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "materials=1;biotech=1"
+	surgery_behaviours = list(SURGERY_RETRACT_SKIN = 100, SURGERY_RETRACT_BONE = 100, SURGERY_RETRACT_CARAPACE = 100, SURGERY_ROBOTIC_OPEN_CLOSE_HATCH = 100)
 
 /obj/item/retractor/augment
 	desc = "Micro-mechanical manipulator for retracting stuff."
@@ -23,6 +24,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "pinched")
+	surgery_behaviours = list(SURGERY_SLIME_EXTRACT_CORE = 100, SURGERY_CLAMP_BLEEDERS = 100, SURGERY_EXTRACT_IMPLANT = 100, SURGERY_CONNECT_LIMB = 100, SURGERY_EXTRACT_ORGAN_MANIP = 100)
 
 /obj/item/hemostat/augment
 	desc = "Tiny servos power a pair of pincers to stop bleeding."
@@ -38,6 +40,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("burnt")
+	surgery_behaviours = list(SURGERY_CAUTERIZE_INCISION = 100)
 
 /obj/item/cautery/augment
 	desc = "A heated element that cauterizes wounds."
@@ -56,6 +59,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("drilled")
+	surgery_behaviours = list(SURGERY_MAKE_CAVITY = 100, SURGERY_DRILL_BONE = 100)
 
 /obj/item/surgicaldrill/suicide_act(mob/user)
 	to_chat(viewers(user), pick("<span class='suicide'>[user] is pressing [src] to [user.p_their()] temple and activating it! It looks like [user.p_theyre()] trying to commit suicide.</span>",
@@ -86,6 +90,7 @@
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	surgery_behaviours = list(SURGERY_SLIME_CUT_FLESH = 100, SURGERY_MAKE_INCISION = 100, SURGERY_RESHAPE_FACE = 100)
 
 /obj/item/scalpel/suicide_act(mob/user)
 	to_chat(viewers(user), pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>",
@@ -107,6 +112,7 @@
 	icon_state = "scalpel_laser1_on"
 	damtype = "fire"
 	hitsound = 'sound/weapons/sear.ogg'
+	surgery_behaviours = list(SURGERY_CLAMP_BLEEDERS = 100, SURGERY_SLIME_CUT_FLESH = 100, SURGERY_MAKE_INCISION = 100, SURGERY_CAUTERIZE_INCISION = 100, SURGERY_RESHAPE_FACE = 100)
 
 /obj/item/scalpel/laser/laser1 //lasers also count as catuarys
 	name = "laser scalpel"
@@ -131,6 +137,7 @@
 	desc = "A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps."
 	icon_state = "scalpel_manager_on"
 	toolspeed = 0.2
+	surgery_behaviours = list(SURGERY_CLAMP_BLEEDERS = 100, SURGERY_SLIME_CUT_FLESH = 100, SURGERY_MAKE_INCISION = 100, SURGERY_CAUTERIZE_INCISION = 100, SURGERY_RESHAPE_FACE = 100, SURGERY_RETRACT_SKIN = 100, SURGERY_RETRACT_BONE = 100, SURGERY_RETRACT_CARAPACE = 100)
 
 /obj/item/circular_saw
 	name = "circular saw"
@@ -149,6 +156,7 @@
 	materials = list(MAT_METAL=10000, MAT_GLASS=6000)
 	origin_tech = "biotech=1;combat=1"
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
+	surgery_behaviours = list(SURGERY_SAW_BONE = 100, SURGERY_AMPUTATE = 100, SURGERY_CUT_SEALS = 60)
 
 /obj/item/circular_saw/augment
 	desc = "A small but very fast spinning saw. Edges dulled to prevent accidental cutting inside of the surgeon."
@@ -165,6 +173,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 1.0
 	origin_tech = "materials=1;biotech=1"
+	surgery_behaviours = list(SURGERY_MEND_BONE = 100, SURGERY_ROBOTIC_MEND = 30)
 
 /obj/item/bonegel/augment
 	toolspeed = 0.5
@@ -177,6 +186,7 @@
 	throwforce = 1.0
 	origin_tech = "materials=1;biotech=1"
 	w_class = WEIGHT_CLASS_SMALL
+	surgery_behaviours = list(SURGERY_MEND_INTERNAL_BLEEDING = 100)
 
 /obj/item/FixOVein/augment
 	toolspeed = 0.5
@@ -192,6 +202,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("attacked", "hit", "bludgeoned")
 	origin_tech = "materials=1;biotech=1"
+	surgery_behaviours = list(SURGERY_SET_BONE = 100)
 
 /obj/item/bonesetter/augment
 	toolspeed = 0.5

--- a/paradise.dme
+++ b/paradise.dme
@@ -65,6 +65,7 @@
 #include "code\__DEFINES\station_goals.dm"
 #include "code\__DEFINES\status_effects.dm"
 #include "code\__DEFINES\subsystems.dm"
+#include "code\__DEFINES\surgery.dm"
 #include "code\__DEFINES\tools.dm"
 #include "code\__DEFINES\typeids.dm"
 #include "code\__DEFINES\vv.dm"


### PR DESCRIPTION
## What Does This PR Do
Makes surgery use surgery behaviours or items instead of paths. 

DNM because:
I want to rework surgery all at once. I'll keep this PR open to get tips and reviews etc. The surgery tool code won't change much but the surgery and surgery step code itself will change

## Why It's Good For The Game
Will make surgery easier to expand upon and add new surgery items

Smoke testing on most surgeries and surgery tools. Also used normal tools as ghetto surgery tools

## Changelog
No gameplay change