### PR TITLE
Grants the Blueshield additional access

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -162,8 +162,9 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
 			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_blueshield)
-	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_construction, access_engine, access_maint_tunnels, access_research,
-			            access_RC_announce, access_keycard_auth, access_heads, access_blueshield, access_weapons)
+	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_surgery, access_construction, access_engine, access_minisat, access_maint_tunnels, access_research,
+			            access_RC_announce, access_keycard_auth, access_heads, access_ai_upload, access_teleporter, access_eva, access_tcomsat, access_gateway, access_heads_vault,
+			            access_blueshield, access_weapons)
 	outfit = /datum/outfit/job/blueshield
 
 /datum/outfit/job/blueshield


### PR DESCRIPTION
The Blueshield currently has a frustratingly limited amount of station access to start with.

In theory, this can be remedied in rounds by the HOP or Captain granting the Blueshield the extra access they need. 

In practice, to save time and because 1. The Blueshield cant be an antag and 2. The Blueshield is rarely completely incompetent due to server rules and karma requirements, the captain just chucks the spare ID at the blueshield to do with as they please.

This is, IC, a violation of SOP : only the acting captain is supposed to have captain level access. Not even the HOP is allowed to!

I, personally, dislike this current meta, which I've seen happen almost every round I am playing command or Blueshield (being handed the spare ID without even asking for it).

This would be less prevalent if the Blueshield had more access, as it would be less of a pain to give the BS any additional access they require instead of just AA, if they do require any.

This PR gives the Blueshield access to surgery and all command areas : Teleporter, AI upload, EVA, telecomms, gateway, vault and the AI satellite, with the exception of the actual head of staff offices.

While this is a technically a buff to Blueshield, please consider that nearly all Blueshields currently walk around with all access, so it isnt that large of one.

:cl:
balance: The Blueshield now has roundstart access to : Surgery, AI upload, EVA, Telecomms, Gateway, Teleporter, Vault, and the AI satellite.
/:cl:
