### PR TITLE
Increases the defib timer back to 5 minutes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -345,7 +345,7 @@
 #define MOUSE_OPACITY_OPAQUE 2
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 120
+#define DEFIB_TIME_LIMIT 300
 #define DEFIB_TIME_LOSS 60
 
 //different types of atom colorations


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Increases the defib timer back to 5 minutes, up from 2 minutes. This means you'll have 5 minutes after a patient dies before they are no longer able to be defib'd.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In my opinion, having a shorter defib timer does not make death more meaningful/impactful, it may in theory but it does not in practice. Currently, the timer is so short, that bodies often get dumped at medbay already unable to be defib'd. The bodies are then promptly whisked away to cloning, where the doctor presses 3 buttons and then sits around and waits for the body to be dumped out.

So what this actually does is place more importance on cloning, since often that is the only option.
I think it not only encourages doctors to be more lazy with the "just wait till they die and then clone" attitude. But also, for doctors who would like to be able to defib and put in the extra work on bringing patients back from that state often aren't able to get the chance, and are forced to clone instead.

I honestly don't think this will mess with the balance too much. The cloner is still there and it is a viable option. This just gives more room for the doctors to do actual doctor work of healing and fixing people, if they choose to.

One last note: I know that SR exists and can be seen as a sort of alternative to defibbing, but it's actually quite easy to make 90 pills of in the first 5-10 minutes of the round if you actually care to make it. This PR addresses the defib timer only.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Increases the the defib timer to 5 minutes, up from 2 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
