### PR TITLE
Fixes Freezers being invisible on shuttle turfs

### DIFF
--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -8,6 +8,7 @@
 	use_power = IDLE_POWER_USE
 	current_heat_capacity = 1000
 	layer = 3
+	plane = GAME_PLANE
 	max_integrity = 300
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 30)
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #11602
Fixes what was likely a missed plane issue with freezers making them invisible on things like shuttle turfs.

## Why It's Good For The Game
Things like the admin hospital ship have cryo cells and without being able to see the freezers people won't know where to start cooling them.

## Changelog
:cl:
fix: fixed freezers being invisible on shuttle turfs
/:cl: