### PR TITLE
Fixes Blood Eat

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -247,10 +247,7 @@
 	user.visible_message("<span class='warning'>[user] raises [src] to [user.p_their()] mouth and tears into it with [user.p_their()] teeth!</span>", \
 						 "<span class='danger'>An unnatural hunger consumes you. You raise [src] to your mouth and devour it!</span>")
 	playsound(user, 'sound/misc/demon_consume.ogg', 50, 1)
-	for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
-		if(knownspell.type == /obj/effect/proc_holder/spell/bloodcrawl)
-			qdel(src)
-			return
+
 
 	if(user.bloodcrawl == 0)
 		user.visible_message("<span class='warning'>[user]'s eyes flare a deep crimson!</span>", \
@@ -259,10 +256,13 @@
 	else if(user.bloodcrawl == BLOODCRAWL)
 		to_chat(user, "You feel diffr-<span class = 'danger'> CONSUME THEM! </span>")
 		user.bloodcrawl = BLOODCRAWL_EAT
-	else
+	else if(user.bloodcrawl == BLOODCRAWL_EAT)
 		to_chat(user, "<span class='warning'>...and you don't feel any different.</span>")
 
 	user.drop_item()
+
+	if(istype(user.get_organ_slot(slot), /obj/item/organ/internal/heart/demon))
+		return
 	insert(user) //Consuming the heart literally replaces your heart with a demon heart. H A R D C O R E
 
 /obj/item/organ/internal/heart/demon/insert(mob/living/carbon/M, special = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This fixes a bug that prevented someone from obtaining the BLOODEAT power after consuming two demon hearts.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It fixes a bug that shouldn't exist in the first place
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
N/A
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: fixed a bug with eating demon hearts where it would remove your currently existing demon heart setting your bloodcrawl value to 0
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
