### PR TITLE
New Lavaland Ruin And Language Book

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ancientlibrary.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ancientlibrary.dmm
@@ -1,0 +1,41 @@
+"a" = (/turf/simulated/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"b" = (/turf/simulated/wall/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"c" = (/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"d" = (/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"e" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"f" = (/obj/structure/table/holotable/wood,/obj/item/ancient_tome,/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"g" = (/obj/item/stack/sheet/wood,/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"h" = (/obj/structure/bookcase,/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"i" = (/mob/living/simple_animal/hostile/asteroid/goliath/beast,/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"j" = (/obj/structure/stone_tile/slab/burnt,/turf/simulated/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"k" = (/obj/structure/stone_tile/block/burnt,/turf/simulated/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"l" = (/obj/structure/stone_tile/block/cracked{dir = 4},/turf/simulated/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"m" = (/obj/structure/fluff/drake_statue/falling,/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"n" = (/obj/structure/stone_tile/block/cracked{dir = 8},/turf/simulated/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+"o" = (/obj/item/paper/crumpled/ancient_crumpled_1,/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"p" = (/obj/item/paper/crumpled/ancient_crumpled_2,/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"q" = (/obj/structure/necropolis_gate,/turf/simulated/floor/indestructible/boss,/area/ruin/unpowered/ash_walkers)
+"r" = (/obj/structure/stone_tile/block/cracked{dir = 1},/turf/simulated/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors/explored)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaa
+aaaabbbbbbbbbbbcccaa
+aaaabdddefedddbcccaa
+aaaabdddddddddbcccaa
+aaaabdddddddddbcccaa
+aaccbgghdddhhhbcccaa
+aaccbddoddddpdbcccaa
+aaccbdddddddddbcccaa
+aaccbhghdddgggbcccaa
+aaccbdddddddddbccaaa
+aaccbdddddddddbccaaa
+aaccbdddddddddbccaaa
+aaccbbbbbqbbbbbccaaa
+aacccccccccccccccaaa
+aacccccciccccccccaaa
+aaaccjkjcccjkjcccaaa
+aaacclmnccclmncccaaa
+aaaccjrjcccjrjcccaaa
+cccccccccccccccccaaa
+cccccccccccccccccccc
+"}

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -218,3 +218,11 @@ datum/map_template/ruin/lavaland/ash_walker
 	description = "Mystery to be solved."
 	suffix = "lavaland_surface_puzzle.dmm"
 	cost = 5
+
+/datum/map_template/ruin/lavaland/ancientarchives
+	name = "Ancient Archives"
+	id = "archives"
+	description = "An ancient archives from a long since fallen civilization, perhaps there may be something useful remaining"
+	suffix = "lavaland_surface_ancientlibrary.dmm"
+	allow_duplicates = FALSE
+	cost = 10

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -93,6 +93,19 @@
 	new /obj/effect/decal/cleanable/ash(get_turf(user))
 	qdel(src)
 
+/obj/item/ancient_tome
+	name = "Ancient Tome"
+	desc = "This book is really old, despite that you feel like reading it could teach you a thing or two."
+	icon = 'icons/obj/library.dmi'
+	icon_state = "book1"
+	w_class = 2
+
+/obj/item/ancient_tome/attack_self(mob/user)
+	user.add_language("Sinta'unathi")
+	to_chat(user, "Reading the book gave you a lot of insights to what seems to be the Unathi language, enough so that you feel confident in your ability to communicate with and understand it. Unfortunately, presumably due to the tome's age, it crumbles into a pile of dust after you're finished with it. Whoops.")
+	new /obj/effect/decal/cleanable/ash(get_turf(user))
+	qdel(src)
+
 //Potion of Flight: as we do not have the "Angel" species this currently does not work.
 
 /obj/item/reagent_containers/glass/bottle/potion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR introduces a new ruin and a new single use book that teaches the native language of the Unathi
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The new ruin contains a few scraps of paper to give some more flavor to Lavaland, the new book will teach the Unathi language which will allow for more potential interaction with ash walkers hopefully resulting in more fun with both parties

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![Screenshot (20)](https://user-images.githubusercontent.com/52841396/75069945-46699500-54c0-11ea-8ee4-b059c86c41d2.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: New ruin with flavor papers
add: New loot that teaches the Unathi language
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
