### PR TITLE
Mining Outpost: Holopad Additions and One Camera Addition

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -924,6 +924,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "cn" = (
@@ -1007,6 +1008,11 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Shuttle Docking Foyer North";
+	dir = 8;
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -1428,11 +1434,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Shuttle Docking Foyer";
-	dir = 8;
-	network = list("Mining Outpost")
-	},
 /obj/machinery/newscaster{
 	pixel_x = 30;
 	pixel_y = 1
@@ -1442,6 +1443,11 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Shuttle Docking Foyer South";
+	dir = 8;
+	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
@@ -1897,6 +1903,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "eu" = (
@@ -2019,6 +2026,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "eD" = (
@@ -2396,6 +2404,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "fv" = (
@@ -2794,6 +2803,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "gj" = (
@@ -3056,6 +3066,7 @@
 	dir = 6
 	},
 /obj/effect/baseturf_helper/lava_land/surface,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/maintenance)
 "gJ" = (
@@ -4119,6 +4130,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "BD" = (
@@ -4266,6 +4278,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"Ww" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/mine/eva)
 "WO" = (
 /obj/effect/spawner/window,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20693,7 +20709,7 @@ ab
 bg
 bs
 bY
-bY
+Ww
 bU
 cp
 bf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds several holopads to the mining outpost, along with a additional camera to the lavaland mining outpost foyer.

The new camera is indicated as being the northern one, and the existing southern one renamed to be the southern one. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The holopads are to allow the AI to more directly communicate with the miners (especially if the telecomms is taken down in the lavaland level).

The additional camera is to allow the AI to open the mining shuttle door when it is docked at lavaland (previously with the cameras the mining outpost had, the AI could open the external airlocks, but could not see the mining shuttle airlock to open it, which requires mining access).

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/32376559/75088268-1940d500-5508-11ea-94be-b81be49c3687.png)
![image](https://user-images.githubusercontent.com/32376559/75088279-37a6d080-5508-11ea-836d-05cb6c750797.png)
![image](https://user-images.githubusercontent.com/32376559/75088285-4f7e5480-5508-11ea-961a-1f929e7cdecf.png)
![image](https://user-images.githubusercontent.com/32376559/75088291-5efd9d80-5508-11ea-8ae9-90cdca0b2548.png)


## Changelog
:cl: Quantum-M
add: Adds holopads to the lavaland mining outpost.
add: Adds one additional camera to the lavaland mining outpost foyer to allow the AI to see and open the mining shuttle when it's docked at lavaland.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
