### PR TITLE
Caps the health and damage of sentient animals

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -36,9 +36,7 @@
 	SA.universal_speak = 1
 	SA.sentience_act()
 	SA.can_collar = 1
-	SA.maxHealth = min(SA.maxHealth + 200, max(SA.maxHealth, 300))
-	SA.melee_damage_lower = min(SA.melee_damage_lower + 15, max(SA.melee_damage_lower, 20))
-	SA.melee_damage_upper = min(SA.melee_damage_upper + 15, max(SA.melee_damage_upper, 25))
+	SA.maxHealth = max(SA.maxHealth, 200)
 	SA.health = SA.maxHealth
 	SA.del_on_death = FALSE
 	greet_sentient(SA)

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -36,9 +36,9 @@
 	SA.universal_speak = 1
 	SA.sentience_act()
 	SA.can_collar = 1
-	SA.maxHealth += 200
-	SA.melee_damage_lower += 15
-	SA.melee_damage_upper += 15
+	SA.maxHealth = min(SA.maxHealth + 200, 300)
+	SA.melee_damage_lower = min(SA.melee_damage_lower + 15, 20)
+	SA.melee_damage_upper = min(SA.melee_damage_upper + 15, 25)
 	SA.health = SA.maxHealth
 	SA.del_on_death = FALSE
 	greet_sentient(SA)

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -36,9 +36,9 @@
 	SA.universal_speak = 1
 	SA.sentience_act()
 	SA.can_collar = 1
-	SA.maxHealth = min(SA.maxHealth + 200, 300)
-	SA.melee_damage_lower = min(SA.melee_damage_lower + 15, 20)
-	SA.melee_damage_upper = min(SA.melee_damage_upper + 15, 25)
+	SA.maxHealth = min(SA.maxHealth + 200, max(SA.maxHealth, 300))
+	SA.melee_damage_lower = min(SA.melee_damage_lower + 15, max(SA.melee_damage_lower, 20))
+	SA.melee_damage_upper = min(SA.melee_damage_upper + 15, max(SA.melee_damage_upper, 25))
 	SA.health = SA.maxHealth
 	SA.del_on_death = FALSE
 	greet_sentient(SA)


### PR DESCRIPTION
## What Does This PR Do
Caps the health of a sentient animal to 300, min damage to 20 and max damage to 25

## Why It's Good For The Game
Animals like Araneus are stronger than nukies when they get chosen for said event. It is rather lame to fight against due to them being that strong

## Changelog
:cl:
balance: Sentient animal event now has a max cap for the health and damage values
/:cl: