### PR TITLE
Alphabetically sorts hairstyles & appearance things

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1308,7 +1308,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 					else //Not using the whitelist? Aliens for everyone!
 						new_species += GLOB.whitelisted_species
 
-					species = input("Please select a species", "Character Generation", null) in new_species
+					species = input("Please select a species", "Character Generation", null) in sortTim(new_species, /proc/cmp_text_asc)
 					var/datum/species/NS = GLOB.all_species[species]
 					if(!istype(NS)) //The species was invalid. Notify the user and fail out.
 						species = prev_species
@@ -1406,7 +1406,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						if(!(lang.flags & RESTRICTED))
 							new_languages += lang.name
 
-					language = input("Please select a secondary language", "Character Generation", null) in new_languages
+					language = input("Please select a secondary language", "Character Generation", null) in sortTim(new_languages, /proc/cmp_text_asc)
 
 				if("autohiss_mode")
 					if(S.autohiss_basic_map)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -323,7 +323,7 @@
 
 		valid_species += current_species_name
 
-	return valid_species
+	return sortTim(valid_species, /proc/cmp_text_asc)
 
 /mob/living/carbon/human/proc/generate_valid_hairstyles()
 	var/list/valid_hairstyles = new()
@@ -351,7 +351,7 @@
 			if(H.dna.species.name in S.species_allowed) //If the user's head is of a species the hairstyle allows, add it to the list.
 				valid_hairstyles += hairstyle
 
-	return valid_hairstyles
+	return sortTim(valid_hairstyles, /proc/cmp_text_asc)
 
 /mob/living/carbon/human/proc/generate_valid_facial_hairstyles()
 	var/list/valid_facial_hairstyles = new()
@@ -380,7 +380,7 @@
 			if(H.dna.species.name in S.species_allowed) //If the user's head is of a species the facial hair style allows, add it to the list.
 				valid_facial_hairstyles += facialhairstyle
 
-	return valid_facial_hairstyles
+	return sortTim(valid_facial_hairstyles, /proc/cmp_text_asc)
 
 /mob/living/carbon/human/proc/generate_valid_head_accessories()
 	var/list/valid_head_accessories = new()
@@ -395,7 +395,7 @@
 			continue
 		valid_head_accessories += head_accessory
 
-	return valid_head_accessories
+	return sortTim(valid_head_accessories, /proc/cmp_text_asc)
 
 /mob/living/carbon/human/proc/generate_valid_markings(var/location = "body")
 	var/list/valid_markings = new()
@@ -433,7 +433,7 @@
 					continue
 		valid_markings += marking
 
-	return valid_markings
+	return sortTim(valid_markings, /proc/cmp_text_asc)
 
 /mob/living/carbon/human/proc/generate_valid_body_accessories()
 	var/list/valid_body_accessories = new()
@@ -448,7 +448,7 @@
 			if(dna.species.name in A.allowed_species) //If the user is not of a species the body accessory style allows, skip it. Otherwise, add it to the list.
 				valid_body_accessories += B
 
-	return valid_body_accessories
+	return sortTim(valid_body_accessories, /proc/cmp_text_asc)
 
 /mob/living/carbon/human/proc/generate_valid_alt_heads()
 	var/list/valid_alt_heads = list()
@@ -463,7 +463,7 @@
 
 		valid_alt_heads += alternate_head
 
-	return valid_alt_heads
+	return sortTim(valid_alt_heads, /proc/cmp_text_asc)
 
 /mob/living/carbon/human/proc/scramble_appearance()
 	scramble(1, src, 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sorts all the hairstyles and accessories in alphabetical order.

this is a direct result of me getting angry because I couldn't find if there were dreadlocks or not.

![](https://i.imgur.com/dGcKEES.png)

goes with #13038

🆑 
tweak: Alphabetically sorts Appearance list items such as hairstyles
/ 🆑 