### PR TITLE
Lowers illegal tech level of chameleon flag

### DIFF
--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -197,7 +197,7 @@
 	name = "Chameleon flag"
 	desc = "A poor recreation of the official NT flag. It seems to shimmer a little."
 	icon_state = "ntflag"
-	origin_tech = "syndicate=4;magnets=4"
+	origin_tech = "syndicate=1;magnets=4"
 	var/updated_icon_state = null
 	var/used = FALSE
 	var/obj/item/grenade/boobytrap = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When #10713 was merged to rework how the chameleon flag worked, it didn't reduce the tech level of the flag itself.

This means that since the chameleon flag was changed to start off empty and instead have any grenade loaded into it, it currently has a high enough illegal tech level to instantly bump illegals research up to 4, enough for the energy crossbow. This is pretty unbalanced given the new flag currently costs just 1TC, allowing any traitor with access to science to print one for just 7TC, less if they can skip the emag.

I only found this out recently when I heard someone discussing how they got lucky with finding a chameleon flag for R&D, now it's obvious why. This reduces the tech level to 1, the same as other 1TC items like the AI detector. The next cheapest item to get illegals to 4 for anyone wondering is the Stechkin pistol for 4TC - which has been at this price long before the flag was reworked.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents traitors with R&D access from getting a powerful weapon for basically nothing in terms of TC cost for the levels themselves.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Chameleon Flag's Illegal Tech level reduced from 4 to 1.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
