### PR TITLE
Goonchem: Heparin Rework

### DIFF
--- a/code/datums/diseases/critical.dm
+++ b/code/datums/diseases/critical.dm
@@ -80,8 +80,8 @@
 	spread_text = "The patient is having a cardiac emergency"
 	max_stages = 3
 	spread_flags = SPECIAL
-	cure_text = "Atropine or Epinephrine"
-	cures = list("atropine", "epinephrine")
+	cure_text = "Atropine, Epinephrine, or Heparin"
+	cures = list("atropine", "epinephrine", "heparin")
 	cure_chance = 10
 	needs_all_cures = FALSE
 	viable_mobtypes = list(/mob/living/carbon/human)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1178,7 +1178,7 @@
 					/obj/item/reagent_containers/glass/bottle/salicylic = 4, /obj/item/reagent_containers/glass/bottle/potassium_iodide =3, /obj/item/reagent_containers/glass/bottle/saline = 5,
 					/obj/item/reagent_containers/glass/bottle/morphine = 4, /obj/item/reagent_containers/glass/bottle/ether = 4, /obj/item/reagent_containers/glass/bottle/atropine = 3,
 					/obj/item/reagent_containers/glass/bottle/oculine = 2, /obj/item/reagent_containers/glass/bottle/toxin = 4, /obj/item/reagent_containers/syringe/antiviral = 6,
-					/obj/item/reagent_containers/syringe/insulin = 6, /obj/item/reagent_containers/syringe/calomel = 10, /obj/item/reagent_containers/hypospray/autoinjector = 5, /obj/item/reagent_containers/food/pill/salbutamol = 10,
+					/obj/item/reagent_containers/syringe/insulin = 6, /obj/item/reagent_containers/syringe/calomel = 10, /obj/item/reagent_containers/syringe/heparin = 4, /obj/item/reagent_containers/hypospray/autoinjector = 5, /obj/item/reagent_containers/food/pill/salbutamol = 10,
 					/obj/item/reagent_containers/food/pill/mannitol = 10, /obj/item/reagent_containers/food/pill/mutadone = 5, /obj/item/stack/medical/bruise_pack/advanced = 4, /obj/item/stack/medical/ointment/advanced = 4, /obj/item/stack/medical/bruise_pack = 4,
 					/obj/item/stack/medical/splint = 4, /obj/item/reagent_containers/glass/beaker = 4, /obj/item/reagent_containers/dropper = 4, /obj/item/healthanalyzer = 4,
 					/obj/item/healthupgrade = 4, /obj/item/reagent_containers/hypospray/safety = 2, /obj/item/sensor_device = 2, /obj/item/pinpointer/crew = 2)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -305,10 +305,7 @@
 		msg += "[p_they(TRUE)] [p_are()] bandaged with something.\n"
 	else if(bleed_rate)
 		var/bleed_message = !isSynthetic() ? "bleeding" : "leaking"
-		if(reagents.has_reagent("heparin"))
-			msg += "<B>[p_they(TRUE)] [p_are()] [bleed_message] uncontrollably!</B>\n"
-		else
-			msg += "<B>[p_they(TRUE)] [p_are()] [bleed_message]!</B>\n"
+		msg += "<B>[p_they(TRUE)] [p_are()] [bleed_message]!</B>\n"
 
 	if(reagents.has_reagent("teslium"))
 		msg += "[p_they(TRUE)] [p_are()] emitting a gentle blue glow!\n"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -877,6 +877,43 @@
 	M.reagents.remove_reagent("sugar", 5)
 	return ..()
 
+/datum/reagent/heparin
+	name = "Heparin"
+	id = "heparin"
+	description = "An anticoagulant used in heart surgeries, and in the treatment of heart attacks and blood clots."
+	reagent_state = LIQUID
+	color = "#eee6da"
+	overdose_threshold = 20
+	taste_description = "bitterness"
+
+/datum/reagent/heparin/on_mob_life(mob/living/M)
+	M.reagents.remove_reagent("cholesterol", 2)
+	return ..()
+
+/datum/reagent/heparin/overdose_process(mob/living/carbon/M, severity)
+	var/list/overdose_info = ..()
+	var/effect = overdose_info[REAGENT_OVERDOSE_EFFECT]
+	var/update_flags = overdose_info[REAGENT_OVERDOSE_FLAGS]
+	if(severity == 1)
+		if(effect <= 2)
+			M.vomit(0, TRUE, FALSE)
+			M.blood_volume = max(M.blood_volume - rand(5, 10), 0)
+		else if(effect <= 4)
+			M.vomit(0, TRUE, FALSE)
+			M.blood_volume = max(M.blood_volume - rand(1, 2), 0)
+	else if(severity == 2)
+		if(effect <= 2)
+			M.visible_message("<span class='warning'>[M] is bleeding from [M.p_their()] very pores!</span>")
+			M.bleed(rand(10, 20))
+		else if(effect <= 4)
+			M.vomit(0, TRUE, FALSE)
+			M.blood_volume = max(M.blood_volume - rand(5, 10), 0)
+		else if(effect <= 8)
+			M.vomit(0, TRUE, FALSE)
+			M.blood_volume = max(M.blood_volume - rand(1, 2), 0)
+	return list(effect, update_flags)
+
+
 /datum/reagent/medicine/teporone
 	name = "Teporone"
 	id = "teporone"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -924,23 +924,6 @@
 				M.AdjustLoseBreath(1)
 	return ..() | update_flags
 
-/datum/reagent/heparin //Based on a real-life anticoagulant.
-	name = "Heparin"
-	id = "heparin"
-	description = "A powerful anticoagulant. Victims will bleed uncontrollably and suffer scaling bruising."
-	reagent_state = LIQUID
-	color = "#C8C8C8" //RGB: 200, 200, 200
-	metabolization_rate = 0.2 * REAGENTS_METABOLISM
-	taste_mult = 0
-
-/datum/reagent/heparin/on_mob_life(mob/living/M)
-	var/update_flags = STATUS_UPDATE_NONE
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.bleed_rate = min(H.bleed_rate + 2, 8)
-		update_flags |= H.adjustBruteLoss(1, FALSE)
-	return ..() | update_flags
-
 /datum/reagent/sarin
 	name = "Sarin"
 	id = "sarin"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -69,6 +69,13 @@
 	required_reagents = list("sodiumchloride" = 1, "water" = 1, "sugar" = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/heparin
+	name = "Heparin"
+	id = "Heparin"
+	result = "heparin"
+	required_reagents = list("sugar" = 1, "meatslurry" = 1, "phenol" = 1, "sacid" = 1)
+	result_amount = 2
+
 /datum/chemical_reaction/synthflesh
 	name = "Synthflesh"
 	id = "synthflesh"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -167,15 +167,6 @@
 	required_reagents = list("mutadone" = 3, "lithium" = 1)
 	result_amount = 4
 
-/datum/chemical_reaction/heparin
-	name = "Heparin"
-	id = "Heparin"
-	result = "heparin"
-	required_reagents = list("formaldehyde" = 1, "sodium" = 1, "chlorine" = 1, "lithium" = 1)
-	result_amount = 4
-	mix_message = "The mixture thins and loses all color."
-	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'
-
 /datum/chemical_reaction/rotatium
 	name = "Rotatium"
 	id = "Rotatium"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -194,6 +194,11 @@
 	desc = "Contains calomel, which be used to purge impurities, but is highly toxic itself."
 	list_reagents = list("calomel" = 15)
 
+/obj/item/reagent_containers/syringe/heparin
+	name = "Syringe (heparin)"
+	desc = "Contains heparin, a blood anticoagulant."
+	list_reagents = list("heparin" = 15)
+
 /obj/item/reagent_containers/syringe/bioterror
 	name = "bioterror syringe"
 	desc = "Contains several paralyzing reagents."

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -70,13 +70,15 @@
 			if(BP.internal_bleeding)
 				internal_bleeding_rate += 0.5
 
-		bleed_rate = max(bleed_rate - 0.5, temp_bleed)//if no wounds, other bleed effects (heparin) naturally decreases
+		bleed_rate = max(bleed_rate - 0.5, temp_bleed)//if no wounds, other bleed effects naturally decreases
+
+		var/additional_bleed = round(Clamp((reagents.get_reagent_amount("heparin") / 10), 0, 2), 1) //Heparin worsens existing bleeding
 
 		if(internal_bleeding_rate && !(status_flags & FAKEDEATH))
-			bleed_internal(internal_bleeding_rate)
+			bleed_internal(internal_bleeding_rate + additional_bleed)
 
 		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH))
-			bleed(bleed_rate)
+			bleed(bleed_rate + additional_bleed)
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/proc/bleed(amt)


### PR DESCRIPTION
Credit largely to Goon.

Reworks heparin from being an explicit poison to a medical chem. Likely to be expanded upon later by impacting blood clots and maybe tying into the blood system a little more.

Heparin is less directly a reagent meant exclusively for poisoning someone and is now a medical chem.

Here's what it'll do:
- Worsen existing internal and regular bleeding (but not cause bleeding on its own)
- If you overdose on it, the individual will vomit up blood or bleed excessively from their pores
- May stop heart failure

The recipe has also changed:
- meat slurry, phenol, sulfuric acid, and sugar

Medical will start with 4 syringes of it per vendor. 

:cl: Fox McCloud
tweak: reworked heparin. It's no longer explicitly a poison, but a medical chem. It can help with heart failure, but has the downside of making existing bleeding worse, and if overdosed, will cause the patient to lose quite a bit of blood
tweak: heparin has a new recipe: sulfuric+meat slurry+phenol+sugar
/:cl: