### PR TITLE
Walking through barriers now also lets a dragged carbon get through

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -57,7 +57,7 @@
 		return TRUE
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
-		if(allow_walk && C.m_intent == MOVE_INTENT_WALK)
+		if(allow_walk && (C.m_intent == MOVE_INTENT_WALK || C.pulledby.m_intent == MOVE_INTENT_WALK))
 			return TRUE
 
 /obj/structure/holosign/barrier/engineering

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -57,7 +57,7 @@
 		return TRUE
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
-		if(allow_walk && (C.m_intent == MOVE_INTENT_WALK || C.pulledby.m_intent == MOVE_INTENT_WALK))
+		if(allow_walk && (C.m_intent == MOVE_INTENT_WALK || (C.pulledby && C.pulledby.m_intent == MOVE_INTENT_WALK)))
 			return TRUE
 
 /obj/structure/holosign/barrier/engineering


### PR DESCRIPTION
## What Does This PR Do
Makes people able to drag carbons through barriers if the person dragging is on walking intent.
Won't make you able to drag simple mobs through barriers.


## Why It's Good For The Game
Less annoying for security trying to drag people out of forbidden zones

## Changelog
:cl:
tweak: Dragging carbons while walking will allow the dragged carbons to pass through sec barriers
/:cl: