### PR TITLE
Adds extools debugger support

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -4,6 +4,7 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 
 /world/New()
 	SetupLogs()
+	enable_debugger() // Enable the extools debugger
 	log_world("World loaded at [time_stamp()]")
 	log_world("[GLOB.vars.len - GLOB.gvars_datum_in_built_vars.len] global variables")
 
@@ -468,3 +469,10 @@ proc/establish_db_connection()
 		return 1
 
 #undef FAILED_DB_CONNECTION_CUTOFF
+
+// Proc to enable the extools debugger, which allows breakpoints, live var checking, and many other useful tools
+// The DLL is injected into the env by visual studio code. If not running VSCode, the proc will not call the initialization
+/world/proc/enable_debugger()
+    var/dll = world.GetConfig("env", "EXTOOLS_DLL")
+    if (dll)
+        call(dll, "debug_initialize")()


### PR DESCRIPTION
## What Does This PR Do
This PR adds support for the extools debugger, part of the SpacemanDMM VSCode extension. This allows coders to add breakpoints, view full stacktraces with file navigation, view world variables from within vscode, and many other features

![image](https://user-images.githubusercontent.com/25063394/75342466-6917f700-588e-11ea-91b2-e05d0486ac53.png)

## Why It's Good For The Game
This allows coders to debug new and existing code in a much better way than our current tools can.

## Changelog
:cl: AffectedArc07
add: Added support for the VSCode extools debugger
/:cl:
