### PR TITLE
Makes personal crafting for all recipes work again.

### DIFF
--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -109,19 +109,28 @@
 		return TRUE
 	var/list/possible_tools = list()
 	var/list/tools_used = list()
+	var/list/other_tools = list()
 	for(var/obj/item/I in user.contents)
 		if(istype(I, /obj/item/storage))
 			for(var/obj/item/SI in I.contents)
 				if(SI.tool_behaviour) //Only add things that we could actually use as a tool
 					possible_tools += SI
+				else
+					other_tools += SI.type				
 		if(I.tool_behaviour)
 			possible_tools += I
+		else
+			other_tools += I.type
 	possible_tools |= contents["other"]
+	other_tools |= contents["other"]
 	main_loop:
 		for(var/A in R.tools)
 			for(var/obj/item/I in possible_tools)
 				if(A == I.tool_behaviour)
 					tools_used += I
+					continue main_loop
+			for(var/I in other_tools)
+				if(ispath(I,A))
 					continue main_loop
 			return FALSE
 	for(var/obj/item/T in tools_used)

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -105,36 +105,47 @@
 			.["other"][I.type] += 1
 
 /datum/personal_crafting/proc/check_tools(mob/user, datum/crafting_recipe/R, list/contents)
-	if(!R.tools.len)
+	if(!R.tools.len) //does not run if no tools are needed
 		return TRUE
 	var/list/possible_tools = list()
 	var/list/tools_used = list()
-	var/list/other_tools = list()
-	for(var/obj/item/I in user.contents)
+	for(var/obj/item/I in user.contents) // searchs the inventory of the mob
 		if(istype(I, /obj/item/storage))
 			for(var/obj/item/SI in I.contents)
-				if(SI.tool_behaviour) //Only add things that we could actually use as a tool
+				if(SI.tool_behaviour) //filters for tool behaviours
 					possible_tools += SI
-				else
-					other_tools += SI.type				
 		if(I.tool_behaviour)
 			possible_tools += I
-		else
-			other_tools += I.type
-	possible_tools |= contents["other"]
-	other_tools |= contents["other"]
-	main_loop:
+
+	possible_tools |= contents["other"] // This checks tool behaviours
+	main_loop: // checks if all tools found are usable with the recipe
 		for(var/A in R.tools)
 			for(var/obj/item/I in possible_tools)
 				if(A == I.tool_behaviour)
 					tools_used += I
 					continue main_loop
-			for(var/I in other_tools)
-				if(ispath(I,A))
-					continue main_loop
 			return FALSE
 	for(var/obj/item/T in tools_used)
 		if(!T.tool_start_check(user, 0)) //Check if all our tools are valid for their use
+			return FALSE
+	return TRUE
+
+/datum/personal_crafting/proc/check_pathtools(mob/user, datum/crafting_recipe/R, list/contents)
+	if(!R.pathtools.len) //does not run if no tools are needed
+		return TRUE
+	var/list/other_possible_tools = list()
+	for(var/obj/item/I in user.contents) // searchs the inventory of the mob
+		if(istype(I, /obj/item/storage))
+			for(var/obj/item/SI in I.contents)
+				other_possible_tools += SI.type	// filters type paths
+		other_possible_tools += I.type
+	
+	other_possible_tools |= contents["other"] // This check for type paths
+	main_loop: // checks if all tools found are usable with the recipe
+		for(var/A in R.pathtools)
+			for(var/I in other_possible_tools)
+				if(ispath(I,A))
+					continue main_loop
 			return FALSE
 	return TRUE
 
@@ -143,21 +154,25 @@
 	var/send_feedback = 1
 	if(check_contents(R, contents))
 		if(check_tools(user, R, contents))
-			if(do_after(user, R.time, target = user))
-				contents = get_surroundings(user)
-				if(!check_contents(R, contents))
-					return ", missing component."
-				if(!check_tools(user, R, contents))
-					return ", missing tool."
-				var/list/parts = del_reqs(R, user)
-				var/atom/movable/I = new R.result (get_turf(user.loc))
-				I.CheckParts(parts, R)
-				if(isitem(I))
-					user.put_in_hands(I)
-				if(send_feedback)
-					feedback_add_details("object_crafted","[I.type]")
-				return 0
-			return "."
+			if(check_pathtools(user, R, contents))
+				if(do_after(user, R.time, target = user))
+					contents = get_surroundings(user)
+					if(!check_contents(R, contents))
+						return ", missing component."
+					if(!check_tools(user, R, contents))
+						return ", missing tool."
+					if(!check_pathtools(user, R, contents))
+						return ", missing tool."
+					var/list/parts = del_reqs(R, user)
+					var/atom/movable/I = new R.result (get_turf(user.loc))
+					I.CheckParts(parts, R)
+					if(isitem(I))
+						user.put_in_hands(I)
+					if(send_feedback)
+						feedback_add_details("object_crafted","[I.type]")
+					return 0
+				return "."
+			return ", missing tool."
 		return ", missing tool."
 	return ", missing component."
 
@@ -422,12 +437,15 @@
 	catalyst_text = replacetext(catalyst_text, ",", "", -1)
 	data["catalyst_text"] = catalyst_text
 
-	for(var/a in R.tools)
+	for(var/a in R.pathtools)
 		if(ispath(a, /obj/item))
 			var/obj/item/b = a
 			tool_text += " [initial(b.name)],"
 		else
 			tool_text += " [a],"
+	for(var/a in R.tools)
+		var/b = a
+		tool_text += " [b],"
 	tool_text = replacetext(tool_text, ",", "", -1)
 	data["tool_text"] = tool_text
 

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -103,9 +103,8 @@
 				if(RC.is_drainable())
 					for(var/datum/reagent/A in RC.reagents.reagent_list)
 						.["other"][A.type] += A.volume
-			.["other"][I.type] += 1
-	for(var/obj/item/B in get_environment(user))
-		.["toolsother"][B] += 1
+			.["other"][I.type] += 1 
+		.["toolsother"][I] += 1
 
 /datum/personal_crafting/proc/check_tools(mob/user, datum/crafting_recipe/R, list/contents)
 	if(!R.tools.len) //does not run if no tools are needed
@@ -152,7 +151,7 @@
 			return FALSE
 	return TRUE
 
-/datum/personal_crafting/proc/construct_item(mob/user, datum/crafting_recipe/R)
+/datum/personal_crafting/proc/construct_item(mob/user, datum/crafting_recipe/R) 
 	var/list/contents = get_surroundings(user)
 	var/send_feedback = 1
 	if(check_contents(R, contents))

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -89,7 +89,8 @@
 
 /datum/personal_crafting/proc/get_surroundings(mob/user)
 	. = list()
-	.["other"] = list()
+	.["other"] = list() //paths go in here
+	.["toolsother"] = list() // items go in here
 	for(var/obj/item/I in get_environment(user))
 		if(I.flags_2 & HOLOGRAM_2)
 			continue
@@ -103,13 +104,15 @@
 					for(var/datum/reagent/A in RC.reagents.reagent_list)
 						.["other"][A.type] += A.volume
 			.["other"][I.type] += 1
+	for(var/obj/item/B in get_environment(user))
+		.["toolsother"][B] += 1
 
 /datum/personal_crafting/proc/check_tools(mob/user, datum/crafting_recipe/R, list/contents)
 	if(!R.tools.len) //does not run if no tools are needed
 		return TRUE
 	var/list/possible_tools = list()
 	var/list/tools_used = list()
-	for(var/obj/item/I in user.contents) // searchs the inventory of the mob
+	for(var/obj/item/I in user.contents) //searchs the inventory of the mob
 		if(istype(I, /obj/item/storage))
 			for(var/obj/item/SI in I.contents)
 				if(SI.tool_behaviour) //filters for tool behaviours
@@ -117,7 +120,7 @@
 		if(I.tool_behaviour)
 			possible_tools += I
 
-	possible_tools |= contents["other"] // This checks tool behaviours
+	possible_tools |= contents["toolsother"] // this add contents to possible_tools
 	main_loop: // checks if all tools found are usable with the recipe
 		for(var/A in R.tools)
 			for(var/obj/item/I in possible_tools)
@@ -133,14 +136,14 @@
 /datum/personal_crafting/proc/check_pathtools(mob/user, datum/crafting_recipe/R, list/contents)
 	if(!R.pathtools.len) //does not run if no tools are needed
 		return TRUE
-	var/list/other_possible_tools = list()
+	var/list/other_possible_tools = list() 
 	for(var/obj/item/I in user.contents) // searchs the inventory of the mob
 		if(istype(I, /obj/item/storage))
 			for(var/obj/item/SI in I.contents)
 				other_possible_tools += SI.type	// filters type paths
 		other_possible_tools += I.type
 	
-	other_possible_tools |= contents["other"] // This check for type paths
+	other_possible_tools |= contents["other"] // this adds contents to the other_possible_tools
 	main_loop: // checks if all tools found are usable with the recipe
 		for(var/A in R.pathtools)
 			for(var/I in other_possible_tools)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -3,7 +3,8 @@
 	var/reqs[] = list() //type paths of items consumed associated with how many are needed
 	var/blacklist[] = list() //type paths of items explicitly not allowed as an ingredient
 	var/result //type path of item resulting from this craft
-	var/tools[] = list() //type paths of items needed but not consumed
+	var/tools[] = list() //tool behaviours of items needed but not consumed
+	var/pathtools[] = list() //type paths of items needed but not consumed
 	var/time = 30 //time in deciseconds
 	var/parts[] = list() //type paths of items that will be placed in the result
 	var/chem_catalysts[] = list() //like tools but for reagents
@@ -307,7 +308,7 @@
 	time = 15
 	reqs = list(/obj/item/stack/sheet/wood = 1,
 				/obj/item/stack/cable_coil = 5)
-	tools = list(/obj/item/kitchen/knife) // Gotta carve the wood into handles
+	pathtools = list(/obj/item/kitchen/knife) // Gotta carve the wood into handles
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -328,8 +329,7 @@
 				/obj/item/stack/cable_coil = 10,
 				/obj/item/stack/sheet/plastic = 3,
 				/obj/item/stack/sheet/wood = 5)
-	tools = list(TOOL_WELDER,
-				TOOL_SCREWDRIVER)
+	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER)
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -354,7 +354,7 @@
 	result = /obj/item/stack/tile/carpet/black
 	time = 20
 	reqs = list(/obj/item/stack/tile/carpet = 1)
-	tools = list(/obj/item/toy/crayon)
+	pathtools = list(/obj/item/toy/crayon)
 	category = CAT_MISC
 
 /datum/crafting_recipe/showercurtain
@@ -559,7 +559,7 @@
 	reqs = list(/datum/reagent/paint/red = 10,
 				/datum/reagent/paint/black = 30,
 				/obj/item/storage/toolbox = 1) //Paint in reagents so it doesnt take the container up, yet still take it from the beaker
-	tools = list(/obj/item/reagent_containers/glass/rag = 1) //need something to paint with it
+	pathtools = list(/obj/item/reagent_containers/glass/rag = 1) //need something to paint with it
 	category = CAT_MISC
 
 /datum/crafting_recipe/snowman
@@ -578,60 +578,59 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/heart
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 1)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red)//cutters act as makeshift scissors. I doubt the barber wants to have their scissors stolen when somone wants to decorate
+	tools = list(TOOL_WIRECUTTER) //cutters act as makeshift scissors. I doubt the barber wants to have their scissors stolen when somone wants to decorate
+	pathtools = list(/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_DECORATION
 
 /datum/crafting_recipe/paper_craft/single_eye
 	name = "Paper Eye"
 	result = /obj/item/decorations/sticky_decorations/flammable/singleeye
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
-				/obj/item/toy/crayon/blue)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen, /obj/item/toy/crayon/blue)
 	category = CAT_DECORATIONS
 	subcategory = CAT_DECORATION
 
 /datum/crafting_recipe/paper_craft/googlyeyes
 	name = "Paper Googly Eye"
 	result = /obj/item/decorations/sticky_decorations/flammable/googlyeyes
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_DECORATION
 
 /datum/crafting_recipe/paper_craft/clock
 	name = "Paper Clock"
 	result = /obj/item/decorations/sticky_decorations/flammable/paperclock
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_DECORATION
 
 /datum/crafting_recipe/paper_craft/jack_o_lantern
 	name = "Paper Jack o'Lantern"
 	result = /obj/item/decorations/sticky_decorations/flammable/jack_o_lantern
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
-				/obj/item/toy/crayon/orange,
-				/obj/item/toy/crayon/green)//pen ink is black
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen, 
+					/obj/item/toy/crayon/orange, 
+					/obj/item/toy/crayon/green)//pen ink is black
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/ghost
 	name = "Paper Ghost"
 	result = /obj/item/decorations/sticky_decorations/flammable/ghost
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen)//it's white paper why need a white crayon?
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen)//it's white paper why need a white crayon?
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/spider
 	name = "Paper Spider"
 	result = /obj/item/decorations/sticky_decorations/flammable/spider
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
-				/obj/item/toy/crayon/red)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen, 
+					/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -639,58 +638,59 @@
 	name = "Paper Spiderweb"
 	result = /obj/item/decorations/sticky_decorations/flammable/spiderweb
 	tools = list(TOOL_WIRECUTTER)
+	pathtools = list()
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/skull
 	name = "Paper Skull"
 	result = /obj/item/decorations/sticky_decorations/flammable/skull
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/skeleton
 	name = "Paper Skeleton"
 	result = /obj/item/decorations/sticky_decorations/flammable/skeleton
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/cauldron
 	name = "Paper Cauldron"
 	result = /obj/item/decorations/sticky_decorations/flammable/cauldron
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/snowman
 	name = "Paper Snowman"
 	result = /obj/item/decorations/sticky_decorations/flammable/snowman
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
-				/obj/item/toy/crayon/orange)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen, 
+					/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/christmas_stocking
 	name = "Paper Christmas Stocking"
 	result = /obj/item/decorations/sticky_decorations/flammable/christmas_stocking
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/christmas_tree
 	name = "Paper Christmas Tree"
 	result = /obj/item/decorations/sticky_decorations/flammable/christmas_tree
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red,
-				/obj/item/toy/crayon/yellow,
-				/obj/item/toy/crayon/blue,
-				/obj/item/toy/crayon/green)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red, 
+					/obj/item/toy/crayon/yellow, 
+					/obj/item/toy/crayon/blue, 
+					/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -698,32 +698,33 @@
 	name = "Paper Snowflake"
 	result = /obj/item/decorations/sticky_decorations/flammable/snowflake
 	tools = list(TOOL_WIRECUTTER)
+	pathtools = list()
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/candy_cane
 	name = "Paper Candy Cane"
 	result = /obj/item/decorations/sticky_decorations/flammable/candy_cane
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/mistletoe
 	name = "Paper Mistletoe"
 	result = /obj/item/decorations/sticky_decorations/flammable/mistletoe
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red,
-				/obj/item/toy/crayon/green)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red, 
+					/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/holly
 	name = "Paper Holly"
 	result = /obj/item/decorations/sticky_decorations/flammable/holly
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red,
-				/obj/item/toy/crayon/green)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red, 
+					/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -734,6 +735,7 @@
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
 	tools = list(TOOL_WIRECUTTER)
+	pathtools = list()
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -743,8 +745,8 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/red
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -754,8 +756,8 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/blue
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/blue)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/blue)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -765,8 +767,8 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/yellow
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/yellow)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/yellow)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -776,8 +778,8 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/purple
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/purple)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/purple)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -787,8 +789,8 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/green
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/green)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -798,8 +800,8 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/orange
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/orange)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -809,8 +811,8 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/black
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -820,17 +822,17 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/halloween
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
-				/obj/item/toy/crayon/orange)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen,
+					/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/arrowed_heart
 	name = "Paper Arrowed Heart"
 	result = /obj/item/decorations/sticky_decorations/flammable/arrowed_heart
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -840,24 +842,24 @@
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2,
 				/obj/item/stack/cable_coil = 2)
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/four_leaf_clover
 	name = "Paper Four Leaf Clover"
 	result = /obj/item/decorations/sticky_decorations/flammable/four_leaf_clover
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/green)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/pot_of_gold
 	name = "Paper Pot of Gold"
 	result = /obj/item/decorations/sticky_decorations/flammable/pot_of_gold
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen,
 				/obj/item/toy/crayon/red,
 				/obj/item/toy/crayon/yellow,
 				/obj/item/toy/crayon/orange,
@@ -871,8 +873,8 @@
 	name = "Paper Leprechaun Hat"
 	time = 10
 	result = /obj/item/decorations/sticky_decorations/flammable/leprechaun_hat
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen,
 				/obj/item/toy/crayon/yellow,
 				/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
@@ -881,8 +883,8 @@
 /datum/crafting_recipe/paper_craft/easter_bunny
 	name = "Paper Easter Bunny"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_bunny
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/pen,
 				/obj/item/toy/crayon/blue,
 				/obj/item/toy/crayon/purple)
 	category = CAT_DECORATIONS
@@ -891,40 +893,40 @@
 /datum/crafting_recipe/paper_craft/easter_egg_blue
 	name = "Blue Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/blue)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/blue)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/easter_egg_yellow
 	name = "Yellow Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/yellow
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/yellow)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/yellow)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/easter_egg_red
 	name = "Red Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/red
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/red)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/easter_egg_purple
 	name = "Purple Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/purple
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/purple)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/purple)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/easter_egg_orange
 	name = "Orange Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/orange
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/toy/crayon/orange)
+	tools = list(TOOL_WIRECUTTER)
+	pathtools = list(/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -1010,9 +1012,9 @@
 				/obj/item/stack/rods = 4,
 				/obj/item/stock_parts/cell = 1,
 				/obj/item/stack/cable_coil = 4)//thing is a wireframe construct with an electro magnetic hover field
-	tools = list(TOOL_WIRECUTTER,
-				/obj/item/pen,
-				TOOL_WELDER,
+	tools = list(TOOL_WIRECUTTER, 
+				TOOL_WELDER)
+	pathtools = list(/obj/item/pen,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -578,7 +578,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/heart
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 1)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red)//cutters act as makeshift scissors. I doubt the barber wants to have their scissors stolen when somone wants to decorate
 	category = CAT_DECORATIONS
 	subcategory = CAT_DECORATION
@@ -586,7 +586,7 @@
 /datum/crafting_recipe/paper_craft/single_eye
 	name = "Paper Eye"
 	result = /obj/item/decorations/sticky_decorations/flammable/singleeye
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/blue)
 	category = CAT_DECORATIONS
@@ -595,7 +595,7 @@
 /datum/crafting_recipe/paper_craft/googlyeyes
 	name = "Paper Googly Eye"
 	result = /obj/item/decorations/sticky_decorations/flammable/googlyeyes
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_DECORATION
@@ -603,7 +603,7 @@
 /datum/crafting_recipe/paper_craft/clock
 	name = "Paper Clock"
 	result = /obj/item/decorations/sticky_decorations/flammable/paperclock
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_DECORATION
@@ -611,7 +611,7 @@
 /datum/crafting_recipe/paper_craft/jack_o_lantern
 	name = "Paper Jack o'Lantern"
 	result = /obj/item/decorations/sticky_decorations/flammable/jack_o_lantern
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/orange,
 				/obj/item/toy/crayon/green)//pen ink is black
@@ -621,7 +621,7 @@
 /datum/crafting_recipe/paper_craft/ghost
 	name = "Paper Ghost"
 	result = /obj/item/decorations/sticky_decorations/flammable/ghost
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen)//it's white paper why need a white crayon?
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -629,7 +629,7 @@
 /datum/crafting_recipe/paper_craft/spider
 	name = "Paper Spider"
 	result = /obj/item/decorations/sticky_decorations/flammable/spider
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
@@ -638,14 +638,14 @@
 /datum/crafting_recipe/paper_craft/spiderweb
 	name = "Paper Spiderweb"
 	result = /obj/item/decorations/sticky_decorations/flammable/spiderweb
-	tools = list(/obj/item/wirecutters)
+	tools = list(TOOL_WIRECUTTER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/skull
 	name = "Paper Skull"
 	result = /obj/item/decorations/sticky_decorations/flammable/skull
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -653,7 +653,7 @@
 /datum/crafting_recipe/paper_craft/skeleton
 	name = "Paper Skeleton"
 	result = /obj/item/decorations/sticky_decorations/flammable/skeleton
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -661,7 +661,7 @@
 /datum/crafting_recipe/paper_craft/cauldron
 	name = "Paper Cauldron"
 	result = /obj/item/decorations/sticky_decorations/flammable/cauldron
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -669,7 +669,7 @@
 /datum/crafting_recipe/paper_craft/snowman
 	name = "Paper Snowman"
 	result = /obj/item/decorations/sticky_decorations/flammable/snowman
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
@@ -678,7 +678,7 @@
 /datum/crafting_recipe/paper_craft/christmas_stocking
 	name = "Paper Christmas Stocking"
 	result = /obj/item/decorations/sticky_decorations/flammable/christmas_stocking
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -686,7 +686,7 @@
 /datum/crafting_recipe/paper_craft/christmas_tree
 	name = "Paper Christmas Tree"
 	result = /obj/item/decorations/sticky_decorations/flammable/christmas_tree
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red,
 				/obj/item/toy/crayon/yellow,
 				/obj/item/toy/crayon/blue,
@@ -697,14 +697,14 @@
 /datum/crafting_recipe/paper_craft/snowflake
 	name = "Paper Snowflake"
 	result = /obj/item/decorations/sticky_decorations/flammable/snowflake
-	tools = list(/obj/item/wirecutters)
+	tools = list(TOOL_WIRECUTTER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
 /datum/crafting_recipe/paper_craft/candy_cane
 	name = "Paper Candy Cane"
 	result = /obj/item/decorations/sticky_decorations/flammable/candy_cane
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -712,7 +712,7 @@
 /datum/crafting_recipe/paper_craft/mistletoe
 	name = "Paper Mistletoe"
 	result = /obj/item/decorations/sticky_decorations/flammable/mistletoe
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red,
 				/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
@@ -721,7 +721,7 @@
 /datum/crafting_recipe/paper_craft/holly
 	name = "Paper Holly"
 	result = /obj/item/decorations/sticky_decorations/flammable/holly
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red,
 				/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
@@ -733,7 +733,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters)
+	tools = list(TOOL_WIRECUTTER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
 
@@ -743,7 +743,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/red
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -754,7 +754,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/blue
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/blue)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -765,7 +765,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/yellow
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/yellow)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -776,7 +776,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/purple
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/purple)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -787,7 +787,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/green
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -798,7 +798,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/orange
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -809,7 +809,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/black
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -820,7 +820,7 @@
 	result = /obj/item/decorations/sticky_decorations/flammable/tinsel/halloween
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
@@ -829,7 +829,7 @@
 /datum/crafting_recipe/paper_craft/arrowed_heart
 	name = "Paper Arrowed Heart"
 	result = /obj/item/decorations/sticky_decorations/flammable/arrowed_heart
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -840,7 +840,7 @@
 	reqs = list(/obj/item/paper = 1,
 				/obj/item/stack/tape_roll = 2,
 				/obj/item/stack/cable_coil = 2)
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -848,7 +848,7 @@
 /datum/crafting_recipe/paper_craft/four_leaf_clover
 	name = "Paper Four Leaf Clover"
 	result = /obj/item/decorations/sticky_decorations/flammable/four_leaf_clover
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -856,7 +856,7 @@
 /datum/crafting_recipe/paper_craft/pot_of_gold
 	name = "Paper Pot of Gold"
 	result = /obj/item/decorations/sticky_decorations/flammable/pot_of_gold
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/red,
 				/obj/item/toy/crayon/yellow,
@@ -871,7 +871,7 @@
 	name = "Paper Leprechaun Hat"
 	time = 10
 	result = /obj/item/decorations/sticky_decorations/flammable/leprechaun_hat
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/yellow,
 				/obj/item/toy/crayon/green)
@@ -881,7 +881,7 @@
 /datum/crafting_recipe/paper_craft/easter_bunny
 	name = "Paper Easter Bunny"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_bunny
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
 				/obj/item/toy/crayon/blue,
 				/obj/item/toy/crayon/purple)
@@ -891,7 +891,7 @@
 /datum/crafting_recipe/paper_craft/easter_egg_blue
 	name = "Blue Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/blue)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -899,7 +899,7 @@
 /datum/crafting_recipe/paper_craft/easter_egg_yellow
 	name = "Yellow Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/yellow
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/yellow)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -907,7 +907,7 @@
 /datum/crafting_recipe/paper_craft/easter_egg_red
 	name = "Red Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/red
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -915,7 +915,7 @@
 /datum/crafting_recipe/paper_craft/easter_egg_purple
 	name = "Purple Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/purple
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/purple)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -923,7 +923,7 @@
 /datum/crafting_recipe/paper_craft/easter_egg_orange
 	name = "Orange Paper Easter Egg"
 	result = /obj/item/decorations/sticky_decorations/flammable/easter_egg/orange
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -934,7 +934,7 @@
 	result = /obj/structure/decorative_structures/metal/statue/metal_angel
 	reqs = list(/obj/item/stack/sheet/metal = 10,
 				/obj/item/stack/sheet/mineral/gold = 6)
-	tools = list(/obj/item/weldingtool)
+	tools = list(TOOL_WELDER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS
 
@@ -945,7 +945,7 @@
 	reqs = list(/obj/item/stack/sheet/metal = 10,
 				/obj/item/stack/sheet/mineral/plasma = 3,
 				/obj/item/stack/sheet/mineral/gold = 8)
-	tools = list(/obj/item/weldingtool)
+	tools = list(TOOL_WELDER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS
 
@@ -955,7 +955,7 @@
 	result = /obj/structure/decorative_structures/metal/statue/sun
 	reqs = list(/obj/item/stack/sheet/metal = 6,
 				/obj/item/stack/sheet/mineral/gold = 4)
-	tools = list(/obj/item/weldingtool)
+	tools = list(TOOL_WELDER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS
 
@@ -966,7 +966,7 @@
 	reqs = list(/obj/item/stack/sheet/metal = 6,
 				/obj/item/stack/sheet/mineral/silver = 6,
 				/obj/item/stack/sheet/mineral/gold = 4)
-	tools = list(/obj/item/weldingtool)
+	tools = list(TOOL_WELDER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS
 
@@ -976,7 +976,7 @@
 	result = /obj/structure/decorative_structures/metal/statue/tesla
 	reqs = list(/obj/item/stack/sheet/metal = 4,
 				/obj/item/stack/sheet/glass = 8)
-	tools = list(/obj/item/weldingtool)
+	tools = list(TOOL_WELDER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS
 
@@ -987,7 +987,7 @@
 	reqs = list(/obj/item/stack/sheet/metal = 8,
 				/obj/item/stock_parts/cell = 3,
 				/obj/item/stack/cable_coil = 4)
-	tools = list(/obj/item/weldingtool)
+	tools = list(TOOL_WELDER)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS
 
@@ -1010,9 +1010,9 @@
 				/obj/item/stack/rods = 4,
 				/obj/item/stock_parts/cell = 1,
 				/obj/item/stack/cable_coil = 4)//thing is a wireframe construct with an electro magnetic hover field
-	tools = list(/obj/item/wirecutters,
+	tools = list(TOOL_WIRECUTTER,
 				/obj/item/pen,
-				/obj/item/weldingtool,
+				TOOL_WELDER,
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
@@ -95,7 +95,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/boiled_shrimp = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/Ebi_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -116,7 +116,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/fish_eggs/salmon = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/Ikura_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -137,7 +137,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/fried_tofu = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/Inari_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -158,7 +158,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/salmonmeat = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/Sake_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -179,7 +179,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/salmonsteak = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/SmokedSalmon_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -200,7 +200,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/fish_eggs/goldfish = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/Masago_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -221,7 +221,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/fish_eggs/shark = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/Tobiko_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -242,7 +242,7 @@
 		/obj/item/reagent_containers/food/snacks/sushi_Tobiko = 4,
 		/obj/item/reagent_containers/food/snacks/egg = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/TobikoEgg_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -253,7 +253,7 @@
 		/obj/item/reagent_containers/food/snacks/sushi_Tobiko = 4,
 		/obj/item/reagent_containers/food/snacks/egg = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/TobikoEgg_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI
@@ -274,7 +274,7 @@
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/catfishmeat = 4,
 	)
-	tools = list(/obj/item/kitchen/sushimat)
+	pathtools = list(/obj/item/kitchen/sushimat)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/Tai_maki
 	category = CAT_FOOD
 	subcategory = CAT_SUSHI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

fixes: https://github.com/ParadiseSS13/Paradise/issues/13031#issue-571330753

also converts remaining /obj/item/"tool" paths in recipes to tool behaviours.
splits the two types of tools into paths and tool_behaviours for cleaner and more readable lists with a different proc reading the new list.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
people can make sushi, decorations and fake toolboxes again!

## Changelog
:cl:
tweak: changes old tool paths to tool behaviours
add: new proc and list for recipes.
fix: fixes personal crafting using tools that are not tool_behaviours.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
