### PR TITLE
Goonchem: Addiction Rework

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -404,6 +404,7 @@
 		if(C.reagents)
 			C.reagents.clear_reagents()
 			QDEL_LIST(C.reagents.addiction_list)
+			C.reagents.addiction_threshold_accumulated.Cut()
 
 // rejuvenate: Called by `revive` to get the mob into a revivable state
 // the admin "rejuvenate" command calls `revive`, not this proc.

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -237,7 +237,7 @@ var/const/INGEST = 2
 
 	if(LAZYLEN(addiction_threshold_accumulated))
 		for(var/thing in addiction_threshold_accumulated)
-			if(reagent_list.Find(thing))
+			if(has_reagent(thing))
 				continue // if we have the reagent in our system, then don't deplete the addiction threshold
 			addiction_threshold_accumulated[thing] -= 0.01 // Otherwise very slowly deplete the buildup
 			if(addiction_threshold_accumulated[thing] <= 0)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -11,6 +11,7 @@ var/const/INGEST = 2
 	var/atom/my_atom = null
 	var/chem_temp = T20C
 	var/list/datum/reagent/addiction_list = new/list()
+	var/list/addiction_threshold_accumulated = new/list()
 	var/flags
 	var/list/reagents_generated_per_cycle = new/list()
 
@@ -233,6 +234,15 @@ var/const/INGEST = 2
 	if(M)
 		temperature_reagents(M.bodytemperature - 30)
 
+
+	if(LAZYLEN(addiction_threshold_accumulated))
+		for(var/thing in addiction_threshold_accumulated)
+			if(reagent_list.Find(thing))
+				continue // if we have the reagent in our system, then don't deplete the addiction threshold
+			addiction_threshold_accumulated[thing] -= 0.01 // Otherwise very slowly deplete the buildup
+			if(addiction_threshold_accumulated[thing] <= 0)
+				addiction_threshold_accumulated -= thing
+
 	// a bitfield filled in by each reagent's `on_mob_life` to find out which states to update
 	var/update_flags = STATUS_UPDATE_NONE
 	for(var/A in reagent_list)
@@ -291,17 +301,21 @@ var/const/INGEST = 2
 			if(R.addiction_stage < 5)
 				if(prob(5))
 					R.addiction_stage++
-			switch(R.addiction_stage)
-				if(1)
-					update_flags |= R.addiction_act_stage1(M)
-				if(2)
-					update_flags |= R.addiction_act_stage2(M)
-				if(3)
-					update_flags |= R.addiction_act_stage3(M)
-				if(4)
-					update_flags |= R.addiction_act_stage4(M)
-				if(5)
-					update_flags |= R.addiction_act_stage5(M)
+			if(M.reagents.has_reagent(R.id))
+				R.last_addiction_dose = world.timeofday
+				R.addiction_stage = 1
+			else
+				switch(R.addiction_stage)
+					if(1)
+						update_flags |= R.addiction_act_stage1(M)
+					if(2)
+						update_flags |= R.addiction_act_stage2(M)
+					if(3)
+						update_flags |= R.addiction_act_stage3(M)
+					if(4)
+						update_flags |= R.addiction_act_stage4(M)
+					if(5)
+						update_flags |= R.addiction_act_stage5(M)
 			if(prob(20) && (world.timeofday > (R.last_addiction_dose + ADDICTION_TIME))) //Each addiction lasts 8 minutes before it can end
 				to_chat(M, "<span class='notice'>You no longer feel reliant on [R.name]!</span>")
 				addiction_list.Remove(R)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -20,6 +20,9 @@
 	var/can_synth = TRUE //whether or not a mech syringe gun and synthesize this reagent
 	var/overdose_threshold = 0
 	var/addiction_chance = 0
+	var/addiction_chance_additional = 100 // If we want to lower the chance of addiction even more, set this
+	var/addiction_threshold = 0 // How much of a chem do we have to absorb before we can start rolling for its ill effects?
+	var/minor_addiction = FALSE
 	var/addiction_stage = 1
 	var/last_addiction_dose = 0
 	var/overdosed = FALSE // You fucked up and this is now triggering it's overdose effects, purge that shit quick.
@@ -53,12 +56,7 @@
 			var/can_become_addicted = M.reagents.reaction_check(M, src)
 
 			if(can_become_addicted)
-				if(prob(addiction_chance) && !is_type_in_list(src, M.reagents.addiction_list))
-					to_chat(M, "<span class='danger'>You suddenly feel invigorated and guilty...</span>")
-					var/datum/reagent/new_reagent = new type()
-					new_reagent.last_addiction_dose = world.timeofday
-					M.reagents.addiction_list.Add(new_reagent)
-				else if(is_type_in_list(src, M.reagents.addiction_list))
+				if(is_type_in_list(src, M.reagents.addiction_list))
 					to_chat(M, "<span class='notice'>You feel slightly better, but for how long?</span>")
 					for(var/A in M.reagents.addiction_list)
 						var/datum/reagent/AD = A
@@ -75,7 +73,19 @@
 
 /datum/reagent/proc/on_mob_life(mob/living/M)
 	current_cycle++
-	holder.remove_reagent(id, metabolization_rate * M.metabolism_efficiency * M.digestion_ratio) //By default it slowly disappears.
+	var/total_depletion_rate = metabolization_rate * M.metabolism_efficiency * M.digestion_ratio // Cache it
+
+	if(addiction_chance && !is_type_in_list(src, M.reagents.addiction_list))
+		M.reagents.addiction_threshold_accumulated[id] += total_depletion_rate
+		var/current_threshold_accumulated = M.reagents.addiction_threshold_accumulated[id]
+
+		if(addiction_threshold < current_threshold_accumulated && prob(addiction_chance) && prob(addiction_chance_additional))
+			to_chat(M, "<span class='danger'>You suddenly feel invigorated and guilty...</span>")
+			var/datum/reagent/new_reagent = new type()
+			new_reagent.last_addiction_dose = world.timeofday
+			M.reagents.addiction_list.Add(new_reagent)
+
+	holder.remove_reagent(id, total_depletion_rate) //By default it slowly disappears.
 	return STATUS_UPDATE_NONE
 
 /datum/reagent/proc/on_mob_death(mob/living/M)	//use this to have chems have a "death-triggered" effect
@@ -140,6 +150,8 @@
 	if(prob(8))
 		M.emote("shiver")
 	if(prob(4))
+		to_chat(M, "<span class='warning'>Your head hurts.</span>")
+	if(prob(4))
 		to_chat(M, "<span class='warning'>You begin craving [name]!</span>")
 	return STATUS_UPDATE_NONE
 
@@ -147,23 +159,32 @@
 	if(prob(8))
 		M.emote("twitch")
 	if(prob(4))
-		to_chat(M, "<span class='warning'>You have the strong urge for some [name]!</span>")
+		to_chat(M, "<span class='warning'>You have a pounding headache.</span>")
 	if(prob(4))
+		to_chat(M, "<span class='warning'>You have the strong urge for some [name]!</span>")
+	else if(prob(4))
 		to_chat(M, "<span class='warning'>You REALLY crave some [name]!</span>")
 	return STATUS_UPDATE_NONE
 
 /datum/reagent/proc/addiction_act_stage5(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	if(minor_addiction)
+		if(prob(6))
+			M.AdjustSlowed(3)
+			to_chat(M, "<span class='warning'>You feel [pick("tired", "exhausted", "sluggish")].</span>")
+	else
+		if(prob(6))
+			to_chat(M, "<span class='warning'>Your stomach lurches painfully!</span>")
+			M.visible_message("<span class='warning'>[M] gags and retches!</span>")
+			update_flags |= M.Stun(rand(2,4), FALSE)
+			update_flags |= M.Weaken(rand(2,4), FALSE)
 	if(prob(8))
-		M.emote("twitch")
-	if(prob(6))
-		to_chat(M, "<span class='warning'>Your stomach lurches painfully!</span>")
-		M.visible_message("<span class='warning'>[M] gags and retches!</span>")
-		update_flags |= M.Stun(rand(2,4), FALSE)
-		update_flags |= M.Weaken(rand(2,4), FALSE)
+		M.emote(pick("twitch", "twitch_s", "shiver"))
+	if(prob(4))
+		to_chat(M, "<span class='warning'>Your head is killing you!</span>")
 	if(prob(5))
 		to_chat(M, "<span class='warning'>You feel like you can't live without [name]!</span>")
-	if(prob(5))
+	else if(prob(5))
 		to_chat(M, "<span class='warning'>You would DIE for some [name] right now!</span>")
 	return update_flags
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -75,8 +75,14 @@
 	current_cycle++
 	var/total_depletion_rate = metabolization_rate * M.metabolism_efficiency * M.digestion_ratio // Cache it
 
+	handle_addiction(M, total_depletion_rate)
+
+	holder.remove_reagent(id, total_depletion_rate) //By default it slowly disappears.
+	return STATUS_UPDATE_NONE
+
+/datum/reagent/proc/handle_addiction(mob/living/M, consumption_rate)
 	if(addiction_chance && !is_type_in_list(src, M.reagents.addiction_list))
-		M.reagents.addiction_threshold_accumulated[id] += total_depletion_rate
+		M.reagents.addiction_threshold_accumulated[id] += consumption_rate
 		var/current_threshold_accumulated = M.reagents.addiction_threshold_accumulated[id]
 
 		if(addiction_threshold < current_threshold_accumulated && prob(addiction_chance) && prob(addiction_chance_additional))
@@ -84,9 +90,6 @@
 			var/datum/reagent/new_reagent = new type()
 			new_reagent.last_addiction_dose = world.timeofday
 			M.reagents.addiction_list.Add(new_reagent)
-
-	holder.remove_reagent(id, total_depletion_rate) //By default it slowly disappears.
-	return STATUS_UPDATE_NONE
 
 /datum/reagent/proc/on_mob_death(mob/living/M)	//use this to have chems have a "death-triggered" effect
 	return

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -6,6 +6,8 @@
 	reagent_state = LIQUID
 	nutriment_factor = 0 //So alcohol can fill you up! If they want to.
 	color = "#404030" // rgb: 64, 64, 48
+	addiction_chance = 1
+	addiction_threshold = 10
 	var/dizzy_adj = 3
 	var/alcohol_perc = 1 //percentage of ethanol in a beverage 0.0 - 1.0
 	taste_description = "liquid fire"

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -276,7 +276,10 @@
 	adj_sleepy = -2
 	adj_temp_hot = 25
 	overdose_threshold = 45
-	addiction_chance = 1 // It's true.
+	addiction_chance = 2 // It's true.
+	addiction_chance_additional = 20
+	addiction_threshold = 10
+	minor_addiction = TRUE
 	heart_rate_increase = 1
 	drink_icon = "glass_brown"
 	drink_name = "Glass of coffee"
@@ -367,6 +370,10 @@
 	adj_drowsy = -1
 	adj_sleepy = -3
 	adj_temp_hot = 20
+	addiction_chance = 1
+	addiction_chance_additional = 1
+	addiction_threshold = 10
+	minor_addiction = TRUE
 	drink_icon = "glass_brown"
 	drink_name = "Glass of Tea"
 	drink_desc = "A glass of hot tea. Perhaps a cup with a handle would have been smarter?"

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -35,7 +35,8 @@
 	reagent_state = LIQUID
 	color = "#9087A2"
 	metabolization_rate = 0.2
-	addiction_chance = 65
+	addiction_chance = 15
+	addiction_threshold = 10
 	heart_rate_decrease = 1
 	taste_description = "a synthetic high"
 
@@ -88,7 +89,9 @@
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 35
-	addiction_chance = 70
+	addiction_chance = 15
+	addiction_threshold = 10
+	minor_addiction = TRUE
 	heart_rate_increase = 1
 	taste_description = "calm"
 
@@ -154,7 +157,8 @@
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 20
-	addiction_chance = 50
+	addiction_chance = 10
+	addiction_threshold = 5
 	taste_description = "bitterness"
 
 /datum/reagent/crank/on_mob_life(mob/living/M)
@@ -227,7 +231,8 @@
 	reagent_state = LIQUID
 	color = "#0264B4"
 	overdose_threshold = 20
-	addiction_chance = 50
+	addiction_chance = 10
+	addiction_threshold = 10
 	taste_description = "very poor life choices"
 
 
@@ -299,7 +304,8 @@
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 20
-	addiction_chance = 60
+	addiction_chance = 10
+	addiction_threshold = 5
 	metabolization_rate = 0.6
 	heart_rate_increase = 1
 	taste_description = "speed"
@@ -360,7 +366,8 @@
 	reagent_state = SOLID
 	color = "#FAFAFA"
 	overdose_threshold = 20
-	addiction_chance = 80
+	addiction_chance = 15
+	addiction_threshold = 5
 	metabolization_rate = 0.6
 	taste_description = "WAAAAGH"
 
@@ -460,7 +467,8 @@
 	description = "Jenkem is a prison drug made from fermenting feces in a solution of urine. Extremely disgusting."
 	reagent_state = LIQUID
 	color = "#644600"
-	addiction_chance = 30
+	addiction_chance = 5
+	addiction_threshold = 5
 	taste_description = "the inside of a toilet... or worse"
 
 /datum/reagent/jenkem/on_mob_life(mob/living/M)
@@ -526,7 +534,9 @@
 	metabolization_rate = 0.2
 	overdose_threshold = 15
 	process_flags = ORGANIC | SYNTHETIC		//Flipping for everyone!
-	addiction_chance = 10
+	addiction_chance = 1
+	addiction_chance_additional = 20
+	addiction_threshold = 10
 	taste_description = "flips"
 
 /datum/reagent/fliptonium/on_mob_life(mob/living/M)
@@ -631,7 +641,8 @@
 	color = "#1BB1FF"
 	process_flags = SYNTHETIC
 	overdose_threshold = 20
-	addiction_chance = 60
+	addiction_chance = 10
+	addiction_threshold = 5
 	metabolization_rate = 0.6
 	taste_description = "wiper fluid"
 
@@ -684,7 +695,8 @@
 
 	process_flags = SYNTHETIC
 	overdose_threshold = 20
-	addiction_chance = 50
+	addiction_chance = 10
+	addiction_threshold = 5
 	taste_description = "silicon"
 
 

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -149,6 +149,10 @@
 	description = "This is what makes chilis hot."
 	reagent_state = LIQUID
 	color = "#B31008" // rgb: 179, 16, 8
+	addiction_chance = 1
+	addiction_chance_additional = 10
+	addiction_threshold = 2
+	minor_addiction = TRUE
 	taste_description = "<span class='warning'>HOTNESS</span>"
 	taste_mult = 1.5
 
@@ -651,6 +655,10 @@
 	reagent_state = LIQUID
 	color = "#B2B139"
 	overdose_threshold = 50
+	addiction_chance = 2
+	addiction_chance_additional = 10
+	addiction_threshold = 5
+	minor_addiction = TRUE
 	harmless = FALSE
 	taste_description = "cheese?"
 
@@ -667,7 +675,10 @@
 	description = "Hell, I don't even know if this IS cheese. Whatever it is, it ain't normal. If you want to, pour it out to make it solid."
 	reagent_state = SOLID
 	color = "#50FF00"
-	addiction_chance = 5
+	addiction_chance = 1
+	addiction_chance_additional = 10
+	addiction_threshold = 5
+	minor_addiction = TRUE
 	taste_description = "cheeeeeese...?"
 
 /datum/reagent/consumable/weird_cheese/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -6,7 +6,11 @@
 
 /datum/reagent/medicine/on_mob_life(mob/living/M)
 	current_cycle++
-	holder.remove_reagent(id, (metabolization_rate / M.metabolism_efficiency) * M.digestion_ratio) //medicine reagents stay longer if you have a better metabolism
+	var/total_depletion_rate = (metabolization_rate / M.metabolism_efficiency) * M.digestion_ratio // Cache it
+
+	handle_addiction(M, total_depletion_rate)
+
+	holder.remove_reagent(id, total_depletion_rate) //medicine reagents stay longer if you have a better metabolism
 	return STATUS_UPDATE_NONE
 
 /datum/reagent/medicine/hydrocodone

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -293,7 +293,9 @@
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
 	overdose_threshold = 30
-	addiction_chance = 5
+	addiction_chance = 1
+	addiction_chance_additional = 20
+	addiction_threshold = 5
 	harmless = FALSE
 	taste_description = "health"
 
@@ -440,7 +442,9 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
-	addiction_chance = 20
+	addiction_chance = 1
+	addiction_chance_additional = 20
+	addiction_threshold = 10
 	harmless = FALSE
 	taste_description = "oxygenation"
 
@@ -462,7 +466,9 @@
 	color = "#C8A5DC"
 	metabolization_rate = 0.3
 	overdose_threshold = 35
-	addiction_chance = 25
+	addiction_chance = 1
+	addiction_chance = 10
+	addiction_threshold = 10
 	harmless = FALSE
 	taste_description = "stimulation"
 
@@ -512,7 +518,8 @@
 	description = "Anti-allergy medication. May cause drowsiness, do not operate heavy machinery while using this."
 	reagent_state = LIQUID
 	color = "#5BCBE1"
-	addiction_chance = 10
+	addiction_chance = 1
+	addiction_threshold = 10
 	harmless = FALSE
 	taste_description = "antihistamine"
 
@@ -535,7 +542,8 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 20
-	addiction_chance = 50
+	addiction_chance = 10
+	addiction_threshold = 15
 	shock_reduction = 50
 	harmless = FALSE
 	taste_description = "a delightful numbing"
@@ -883,7 +891,9 @@
 	description = "This experimental plasma-based compound seems to regulate body temperature."
 	reagent_state = LIQUID
 	color = "#D782E6"
-	addiction_chance = 20
+	addiction_chance = 1
+	addiction_chance_additional = 10
+	addiction_threshold = 10
 	overdose_threshold = 50
 	taste_description = "warmth and stability"
 


### PR DESCRIPTION
Credit to goon for the idea and *most* of the implementation.

Reworks addiction to make it less of an avoidable mallus.

Currently, addiction only rolls for a chance to make you addicted when you initially swallow the reagent; if you can manage to get the reagent into your bloodstream some other way, you can bypass the issues with addiction completely.

Likewise, regardless of how much you take, even if it's 0.00001 units, you can still get addicted to it; likewise, if you're eating something with a low addiction chance in it (say a salad with omnizine), you increase your chances of getting addicted based on how many times you take a bite. This is...silly.

The last issue is that sometimes addiction withdrawl is awfully severe if you don't feed the addiction; this is warranted for the *vast* bulk of drugs, but for a few of the more silly/gimmick ones, it can be a bit annoying. There's now a lighter version of addiction--you'll still twitch and have a headache, but you'll no longer fall on the floor stunned--instead you'll just be slowed for a short duration.

As for how addiction works now:
Addiction is still probability based and rolled for each time you process reagents. You must cross a threshold for the amount of reagents you process before you can get addicted; while this amount is usually fairly low (5-10 typically), this avoids situations of suddenly getting addicted because you were exposed to 1 unit of meth. As you process these reagents, it'll keep track of how much you've processed---once you stop processing that reagent, the tally will ***very slowly*** deplete; resuming taking an addictive reagent during this time will start increasing the tally again.

All addiction probabilities have been adjusted to be much lower to compensate for this; typically it's about the duration of your drug use that is going to govern if you're addicted now as opposed to just being exposed, once, to the drug.

And yes, this means that cigarettes and other methods of smoking are now definitively addictive.

Some new things you can now get addicted to:
- alcohol (very very low addiction chance)
- tea (insanely low addiction chance; minor withdrawl)
- capsaicin
- fake cheese

Things that have minor addiction:
- coffee
- tea
- capsaicin
- fake cheese
- weird cheese
- nicotine

This should make addiction a bit more impactful for those who are cheesing it with alternative injection methods while also discouraging doping a ton of chemicals at once while still making minor "recreational"  (or emergency edge case) drug use more than viable.

:cl: Fox McCloud
tweak: addiction has been overhauled. It's more metabolism based than just ingesting it; having a reagent in your system longer is going to increase your chances of becoming addicted
tweak: some reagents have a new addictions, like ethanol, capsaicin, tea, and fake cheese
tweak: new more minor addiction that is less debilitating: coffee, tea, capsaicin, fake cheese, weird cheese, and nicotine all have minor addiction effects
/:cl: