### PR TITLE
R&D console board in tech storage is no longer public

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -72015,7 +72015,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/rdconsole/public{
+/obj/item/circuitboard/rdconsole{
 	pixel_x = -4
 	},
 /obj/item/circuitboard/rdserver{


### PR DESCRIPTION
## What Does This PR Do
- Replaces the public R&D console board in tech storage with the normal, non-public version

## Why It's Good For The Game
- Recently, we have had a lot of rounds where non-antag Eng/Cargo players use the public board in tech storage to construct their own private R&D lab, eventually producing all manner of things, including fully loaded combat mechs
- This is against the rules (we recently added something to explicitly state this in the advanced rules). However, it is still happening very regularly. I have seen it happen many times this week, including yesterday and today in different rounds.
- There is no reason to have a public R&D console board in tech storage. A normal R&D console board works just as well for the purpose of reconstructing a destroyed R&D. Antags can still make their own private R&D lab by emagging the resulting console to remove its access requirement, stealing science access, or simply tricking a scientist into unlocking the board for them.

## Changelog
:cl:
tweak: R&D console board in tech storage is no longer public access
/:cl:
