### PR TITLE
Adds custom emote logging to VV

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -30,12 +30,10 @@
 
 // All mobs should have custom emote, really..
 /mob/proc/custom_emote(var/m_type=EMOTE_VISUAL,var/message = null)
-
 	if(stat || !use_me && usr == src)
 		if(usr)
 			to_chat(usr, "You are unable to emote.")
 		return
-
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
@@ -57,7 +55,10 @@
 
 	if(message)
 		log_emote(message, src)
-
+		if(isliving(src)) //isliving because these are defined on the mob/living level not mob
+			var/mob/living/L = src
+			L.say_log += "EMOTE: [input]" //say log too so it is easier on admins instead of having to merge the two with timestamps etc
+			L.emote_log += input //emote only log if an admin wants to search just for emotes they don't have to sift through the say
 		// Hearing gasp and such every five seconds is not good emotes were not global for a reason.
 		// Maybe some people are okay with that.
 		for(var/mob/M in GLOB.player_list)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -59,6 +59,7 @@
 	var/tesla_ignore = FALSE
 
 	var/list/say_log = list() //a log of what we've said, plain text, no spans or junk, essentially just each individual "message"
+	var/list/emote_log = list() //like say_log but for emotes
 
 	var/list/recent_tastes = list()
 	var/blood_volume = 0 //how much blood the mob has


### PR DESCRIPTION
Adds custom emote logs to VV for admins.
These will also display in say_log in addition to their own emote_log so that we don't have to spend ages figuring out when an emote was sent in what context to the rest of the speech.



:cl:
add: Adds custom emote logging in VV for admins which can be viewed under say_log and emote_log
/ :cl: