### PR TITLE
Fixes nukie shuttle computer being destructible & others

### DIFF
--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -4,6 +4,7 @@
 	shuttleId = "specops"
 	possible_destinations = "specops_home;specops_away;specops_custom"
 	resistance_flags = INDESTRUCTIBLE
+	flags = NODECONSTRUCT
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/ert
 	name = "specops navigation computer"
@@ -16,6 +17,7 @@
 	x_offset = 0
 	y_offset = 0
 	resistance_flags = INDESTRUCTIBLE
+	flags = NODECONSTRUCT
 	access_tcomms = FALSE
 	access_construction = FALSE
 	access_mining = FALSE

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -9,6 +9,7 @@
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_z3;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	flags = NODECONSTRUCT
 	var/challenge = FALSE
 	var/moved = FALSE
 

--- a/code/modules/shuttle/vox.dm
+++ b/code/modules/shuttle/vox.dm
@@ -4,6 +4,7 @@
 	shuttleId = "skipjack"
 	possible_destinations = "skipjack_away;skipjack_ne;skipjack_nw;skipjack_se;skipjack_sw;skipjack_z5;skipjack_custom"
 	resistance_flags = INDESTRUCTIBLE
+	flags = NODECONSTRUCT
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/vox
 	name = "skipjack navigation computer"
@@ -16,4 +17,5 @@
 	x_offset = -10
 	y_offset = -10
 	resistance_flags = INDESTRUCTIBLE
+	flags = NODECONSTRUCT
 	access_derelict = TRUE


### PR DESCRIPTION
Fixes the nukie shuttle computer and a whole other special bunch like ERT and Vox from being able to be deconstructed.
If they have the indestructible flag chances are they shouldn't be deconstructed with a screwdriver either.

fixes: #12991

the INDESTRUCTIBLE flag is for damage only and not deconstruction which is why it still could be deconstructed

:cl:
fix: Special shuttles such as those for nuclear operatives can no longer be deconstructed with tools.
/ :cl: