### PR TITLE
Terrors spiders can now spawn again. Logs the corrupt vent and continues

### DIFF
--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -15,6 +15,10 @@
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in GLOB.all_vent_pumps)
 		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
+			if(!temp_vent.parent)
+				// Issue happening more often with vents. Log and continue. Delete once solved
+				log_debug("spider_terror/start(), vent has no parent: [temp_vent], qdeled: [QDELETED(temp_vent)], loc: [temp_vent.loc]")
+				continue
 			if(temp_vent.parent.other_atmosmch.len > 50)
 				vents += temp_vent
 	var/spider_type


### PR DESCRIPTION
## What Does This PR Do
Checks if the parent is null. If so logs some data and continues.

Fixes: #13005 

## Why It's Good For The Game
Will allow terror spiders to spawn again as an event and will give data on the cause of the issue

## Changelog
:cl:
fix: Terror spiders will now spawn again when a corrupt vent is in the round. Vent data will be logged
/:cl: