### PR TITLE
Removes CL tag we dont support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,6 @@
 add: Added new things
 del: Removed old things
 tweak: tweaked a few things
-balance: rebalanced something
 fix: fixed a few things
 wip: added a few works in progress
 soundadd: added a new sound thingy


### PR DESCRIPTION
## What Does This PR Do
Removes the `balance` tag from the PR template CL template. Our webhook processor does not support this tag, and every time it is used it ends up half-failing.

## Why It's Good For The Game
Non-functional CL items shouldnt be in the PR template