### PR TITLE
Fixes cult sacrifice targeting offstation roles

### DIFF
--- a/code/game/gamemodes/cult/cult_objectives.dm
+++ b/code/game/gamemodes/cult/cult_objectives.dm
@@ -155,12 +155,12 @@
 /datum/game_mode/cult/proc/get_possible_sac_targets()
 	var/list/possible_sac_targets = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(player.mind && !is_convertable_to_cult(player.mind) && (player.stat != DEAD))
+		if(player.mind && !is_convertable_to_cult(player.mind) && (player.stat != DEAD) && (player.mind.offstation_role != TRUE) )
 			possible_sac_targets += player.mind
 	if(!possible_sac_targets.len)
 	//There are no living Unconvertables on the station. Looking for a Sacrifice Target among the ordinary crewmembers
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-			if(is_secure_level(player.z)) //We can't sacrifice people that are on the centcom z-level
+			if(is_secure_level(player.z) || player.mind.offstation_role == TRUE) //We can't sacrifice people that are on the centcom z-level or offstation roles
 				continue
 			if(player.mind && !(player.mind in cult) && (player.stat != DEAD))//make DAMN sure they are not dead
 				possible_sac_targets += player.mind

--- a/code/game/gamemodes/cult/cult_objectives.dm
+++ b/code/game/gamemodes/cult/cult_objectives.dm
@@ -155,12 +155,12 @@
 /datum/game_mode/cult/proc/get_possible_sac_targets()
 	var/list/possible_sac_targets = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(player.mind && !is_convertable_to_cult(player.mind) && (player.stat != DEAD) && (player.mind.offstation_role != TRUE) )
+		if(player.mind && !is_convertable_to_cult(player.mind) && (player.stat != DEAD) && (!player.mind.offstation_role) )
 			possible_sac_targets += player.mind
 	if(!possible_sac_targets.len)
 	//There are no living Unconvertables on the station. Looking for a Sacrifice Target among the ordinary crewmembers
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-			if(is_secure_level(player.z) || player.mind.offstation_role == TRUE) //We can't sacrifice people that are on the centcom z-level or offstation roles
+			if(is_secure_level(player.z) || player.mind.offstation_role) //We can't sacrifice people that are on the centcom z-level or offstation roles
 				continue
 			if(player.mind && !(player.mind in cult) && (player.stat != DEAD))//make DAMN sure they are not dead
 				possible_sac_targets += player.mind


### PR DESCRIPTION
Stops cult sacrifice from targeting offstation roles

Fixes: #12998 

:cl:
fix: Cult sacrifice objective will no longer target offstation roles
/ :cl: