### PR TITLE
Adds radio channel logging

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -447,6 +447,10 @@ var/global/list/default_medbay_channels = list(
 		signal.frequency = connection.frequency // Quick frequency set
 
 	  //#### Sending the signal to all subspace receivers ####//
+		//log radio message if it is transmitted
+		var/log_message = "([channel]) [multilingual_to_message(message_pieces)]"
+		M.say_log += log_message
+		log_say(log_message, M)
 
 		for(var/obj/machinery/telecomms/receiver/R in telecomms_list)
 			spawn(0)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -273,7 +273,7 @@ proc/get_radio_key_from_channel(var/channel)
 				O.hear_talk(src, message_pieces, verb)
 
 	//Log of what we've said, plain message, no spans or junk
-	if(!message_mode) //only if we are not talking on a radio to avoid duplictes. as we handle radio logs in radio.dm. if we handled it here, we would log any attempt to talk on a radio channel as if they were speaking on it, even if they didn't have it. (i.e. a civillian typing :c hi command would show up as "(command) hi command")
+	if(!message_mode) //only if we are not talking on a radio to avoid duplicates. as we handle radio logs in radio.dm. if we handled it here, we would log any attempt to talk on a radio channel as if they were speaking on it, even if they didn't have it. (i.e. a civillian typing :c hi command would show up as "(command) hi command")
 		say_log += message
 		log_say(message, src)
 	return 1

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -273,8 +273,9 @@ proc/get_radio_key_from_channel(var/channel)
 				O.hear_talk(src, message_pieces, verb)
 
 	//Log of what we've said, plain message, no spans or junk
-	say_log += message
-	log_say(message, src)
+	if(!message_mode) //only if we are not talking on a radio to avoid duplictes. as we handle radio logs in radio.dm. if we handled it here, we would log any attempt to talk on a radio channel as if they were speaking on it, even if they didn't have it. (i.e. a civillian typing :c hi command would show up as "(command) hi command")
+		say_log += message
+		log_say(message, src)
 	return 1
 
 /obj/effect/speech_bubble


### PR DESCRIPTION
When speaking on a radio it will now log what channel was spoken.

![](https://i.imgur.com/3ApMBNy.png)

this does not affect cult or shadowling speak

:cl:
add: When speaking on a radio, the channel will be logged as well
/ :cl: