### PR TITLE
ERT activation announcement

### DIFF
--- a/code/modules/nano/modules/ert_manager.dm
+++ b/code/modules/nano/modules/ert_manager.dm
@@ -70,7 +70,7 @@
 		notify_ghosts("An ERT is being dispatched. Open positions: [slot_text]")
 		message_admins("[key_name_admin(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]", 1)
 		log_admin("[key_name(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]")
-		event_announcement.Announce("Attention, [station_name()]. We are attempting to activate an ERT. Standby.", "ERT Activation Attempt In Progress")
+		event_announcement.Announce("Attention, [station_name()]. We are attempting to assemble an ERT. Standby.", "ERT Protocol Activated")
 		autoclose = 1
 		ui_interact(usr)
 		trigger_armed_response_team(convert_ert_string(ert_type), commander_slots, security_slots, medical_slots, engineering_slots, janitor_slots, paranormal_slots, cyborg_slots)

--- a/code/modules/nano/modules/ert_manager.dm
+++ b/code/modules/nano/modules/ert_manager.dm
@@ -70,6 +70,7 @@
 		notify_ghosts("An ERT is being dispatched. Open positions: [slot_text]")
 		message_admins("[key_name_admin(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]", 1)
 		log_admin("[key_name(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]")
+		event_announcement.Announce("Attention, [station_name()]. We are attempting to activate an ERT. Standby.", "ERT Activation Attempt In Progress")
 		autoclose = 1
 		ui_interact(usr)
 		trigger_armed_response_team(convert_ert_string(ert_type), commander_slots, security_slots, medical_slots, engineering_slots, janitor_slots, paranormal_slots, cyborg_slots)


### PR DESCRIPTION
Adds an announcement when an ERT is attempting to be activated aka when ghosts are asked if they want to signup.

This is good because there is frequently a large time between when the ERT request is actually accepted and any feedback to the crew is given, thinking they will not get an ERT.

:cl:
add: ERT will now announce when it is attempting to activate (when ghosts are polled)
/ :cl: