### PR TITLE
Fixes a runtime when rejuvenating a borg

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -10,15 +10,11 @@
 	var/max_damage = 30
 	var/component_disabled = 0
 	var/mob/living/silicon/robot/owner
-
-// The actual device object that has to be installed for this.
-/datum/robot_component/var/external_type = null
-
-// The wrapped device(e.g. radio), only set if external_type isn't null
-/datum/robot_component/var/obj/item/wrapped = null
+	var/external_type = null // The actual device object that has to be installed for this.
+	var/obj/item/wrapped = null // The wrapped device(e.g. radio), only set if external_type isn't null
 
 /datum/robot_component/New(mob/living/silicon/robot/R)
-	src.owner = R
+	owner = R
 
 /datum/robot_component/proc/install()
 	go_online()
@@ -108,6 +104,13 @@
 /datum/robot_component/cell
 	name = "power cell"
 	max_damage = 50
+
+/datum/robot_component/cell/New(mob/living/silicon/robot/R)
+	. = ..()
+	// sets `external_type` to the borg's currently installed cell type
+	if(owner.cell)
+		var/obj/item/stock_parts/cell/C = owner.cell
+		external_type = C.type
 
 /datum/robot_component/cell/is_powered()
 	return ..() && owner.cell

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -142,6 +142,9 @@ var/list/robot_verbs_default = list(
 		mmi = new /obj/item/mmi/robotic_brain(src)	//Give the borg an MMI if he spawns without for some reason. (probably not the correct way to spawn a robotic brain, but it works)
 		mmi.icon_state = "boris"
 
+	if(!cell) // Make sure a new cell gets created *before* executing initialize_components(). The cell component needs an existing cell for it to get set up properly
+		cell = new /obj/item/stock_parts/cell/high(src)
+	
 	initialize_components()
 	//if(!unfinished)
 	// Create all the robot parts.
@@ -149,9 +152,6 @@ var/list/robot_verbs_default = list(
 		var/datum/robot_component/C = components[V]
 		C.installed = 1
 		C.wrapped = new C.external_type
-
-	if(!cell)
-		cell = new /obj/item/stock_parts/cell/high(src)
 
 	..()
 
@@ -602,7 +602,8 @@ var/list/robot_verbs_default = list(
 
 
 /mob/living/silicon/robot/attackby(obj/item/W, mob/user, params)
-	if(opened) // Are they trying to insert something?
+	// Check if the user is trying to insert another component like a radio, actuator, armor etc.
+	if(istype(W, /obj/item/robot_parts/robot_component) && opened)
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
 			if(!C.installed && istype(W, C.external_type))
@@ -637,7 +638,7 @@ var/list/robot_verbs_default = list(
 		user.visible_message("<span class='alert'>\The [user] fixes some of the burnt wires on \the [src] with \the [coil].</span>")
 
 	else if(istype(W, /obj/item/stock_parts/cell) && opened)	// trying to put a cell inside
-		var/datum/robot_component/C = components["power cell"]
+		var/datum/robot_component/cell/C = components["power cell"]
 		if(wiresexposed)
 			to_chat(user, "Close the panel first.")
 		else if(cell)
@@ -651,6 +652,7 @@ var/list/robot_verbs_default = list(
 			C.installed = 1
 			C.wrapped = W
 			C.install()
+			C.external_type = W.type // Update the cell component's `external_type` to the path of new cell
 			//This will mean that removing and replacing a power cell will repair the mount, but I don't care at this point. ~Z
 			C.brute_damage = 0
 			C.electronics_damage = 0
@@ -1419,6 +1421,8 @@ var/list/robot_verbs_default = list(
 		burn = borked_part.electronics_damage
 		borked_part.installed = 1
 		borked_part.wrapped = new borked_part.external_type
+		if(ispath(borked_part.external_type, /obj/item/stock_parts/cell)) // is the broken part a cell?
+			cell = new borked_part.external_type // borgs that have their cell destroyed have their `cell` var set to null. we need create a new cell for them based on their old cell type.
 		borked_part.heal_damage(brute,burn)
 		borked_part.install()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime when rejuvenating a borg. The `robot_component/cell`'s `external_type` var will no longer be null and now instead will hold the type path of the currently installed cell that the borg has. When you insert a new one, `external_type` gets updated to that new cell. This var is needed so the rejuvenate proc can tell which cell type it should put into the borg.

Fixes #13033
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime bad. Not being able to rejuvenate borgs properly bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Rejuvenating a borg now gives them back their old cell if it has been destroyed instead of leaving it null and creating a runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
