### PR TITLE
Adds logs for Krav Maga and Carp.

### DIFF
--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -82,6 +82,7 @@
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE)
 	D.Weaken(2)
+	add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Leg Sweep", ATKLOG_ALL)
 	return 1
 
 /datum/martial_art/krav_maga/proc/quick_choke(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)//is actually lung punch
@@ -90,6 +91,7 @@
 	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, 1, -1)
 	D.AdjustLoseBreath(5)
 	D.adjustOxyLoss(10)
+	add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Lung Punch", ATKLOG_ALL)
 	return 1
 
 /datum/martial_art/krav_maga/proc/neck_chop(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
@@ -98,6 +100,7 @@
 	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE)
 	D.AdjustSilence(10)
+	add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Neck Chop", ATKLOG_ALL)
 	return 1
 
 datum/martial_art/krav_maga/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -40,13 +40,13 @@
 		D.visible_message("<span class='warning'>[A] grabs [D]'s wrist and wrenches it sideways!</span>", \
 						  "<span class='userdanger'>[A] grabs your wrist and violently wrenches it to the side!</span>")
 		playsound(get_turf(A), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Wrist Wrench", ATKLOG_ALL)
 		if(prob(60))
 			A.say(pick("WRISTY TWIRLY!", "WE FIGHT LIKE MEN!", "YOU DISHONOR YOURSELF!", "POHYAH!", "WHERE IS YOUR BATON NOW?", "SAY UNCLE!"))
 		D.emote("scream")
 		D.drop_item()
 		D.apply_damage(5, BRUTE, pick("l_arm", "r_arm"))
 		D.Stun(3)
-		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Wrist Wrench", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -58,9 +58,9 @@
 		step_to(D,get_step(D,D.dir),1)
 		D.Weaken(4)
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
+		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Back Kick", ATKLOG_ALL)
 		if(prob(80))
 			A.say(pick("SURRPRIZU!","BACK STRIKE!","WOPAH!", "WATAAH", "ZOTA!", "Never turn your back to the enemy!"))
-			add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Back Kick", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -73,9 +73,9 @@
 		D.AdjustLoseBreath(3)
 		D.Stun(2)
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
+		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Stomach Knee", ATKLOG_ALL)
 		if(prob(80))
 			A.say(pick("HWOP!", "KUH!", "YAKUUH!", "KYUH!", "KNEESTRIKE!"))
-			add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Stomach Knee", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -87,10 +87,10 @@
 		D.apply_damage(20, BRUTE, "head")
 		D.drop_item()
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
+		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Head Kick", ATKLOG_ALL)
 		if(prob(60))
 			A.say(pick("OOHYOO!", "OOPYAH!", "HYOOAA!", "WOOAAA!", "SHURYUKICK!", "HIYAH!"))
 		D.Stun(4)
-		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Head Kick", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -103,9 +103,9 @@
 			D.death() //FINISH HIM!
 		D.apply_damage(50, BRUTE, "chest")
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 75, 1, -1)
+		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Elbow Drop", ATKLOG_ALL)
 		if(prob(80))
 			A.say(pick("BANZAIII!", "KIYAAAA!", "OMAE WA MOU SHINDEIRU!", "YOU CAN'T SEE ME!", "MY TIME IS NOW!", "COWABUNGA"))
-			add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Elbow Drop", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -46,6 +46,7 @@
 		D.drop_item()
 		D.apply_damage(5, BRUTE, pick("l_arm", "r_arm"))
 		D.Stun(3)
+		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Wrist Wrench", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -59,6 +60,7 @@
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
 		if(prob(80))
 			A.say(pick("SURRPRIZU!","BACK STRIKE!","WOPAH!", "WATAAH", "ZOTA!", "Never turn your back to the enemy!"))
+			add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Back Kick", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -73,6 +75,7 @@
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
 		if(prob(80))
 			A.say(pick("HWOP!", "KUH!", "YAKUUH!", "KYUH!", "KNEESTRIKE!"))
+			add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Stomach Knee", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -87,6 +90,7 @@
 		if(prob(60))
 			A.say(pick("OOHYOO!", "OOPYAH!", "HYOOAA!", "WOOAAA!", "SHURYUKICK!", "HIYAH!"))
 		D.Stun(4)
+		add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Head Kick", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 
@@ -101,6 +105,7 @@
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 75, 1, -1)
 		if(prob(80))
 			A.say(pick("BANZAIII!", "KIYAAAA!", "OMAE WA MOU SHINDEIRU!", "YOU CAN'T SEE ME!", "MY TIME IS NOW!", "COWABUNGA"))
+			add_attack_logs(A, D, "Melee attacked with martial-art [src] :  Elbow Drop", ATKLOG_ALL)
 		return 1
 	return basic_hit(A,D)
 


### PR DESCRIPTION
## What Does This PR Do
Adds attack logs for admins for Krav Maga as well as Carp's special moves. Fixes #12898 

## Why It's Good For The Game
Alerts admins if Warden's decide to go around murderboning prisoners with Krav Maga, also alerts admins if traitors decide to go around murderboning people in general outside of hijack(Less of an issue, but still a decent concern I guess?). CQC was ATKLOG_ALL, so I put the same for Krav Maga and Carp. I can change either if admins decide it's needed. No Changelog as these are entirely back-end changes.

🆑 Mitchs98
add: Krav maga is now logged
/🆑