### PR TITLE
Cherry Bombs now default to Throw

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -145,6 +145,9 @@
 	message_admins("[user] ([user.key ? user.key : "no key"]) primed a cherry bomb for detonation at [A] ([user.x], [user.y], [user.z]) <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>(JMP)</a>")
 	log_game("[user] ([user.key ? user.key : "no key"]) primed a cherry bomb for detonation at [A] ([user.x],[user.y],[user.z]).")
 	prime()
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		C.throw_mode_on()
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/deconstruct(disassembled = TRUE)
 	if(!disassembled)


### PR DESCRIPTION
## What Does This PR Do
Previously Cherry Bombs wouldn't automatically toggle throw, this is inconsistent with every other grenade item including Combustible Lemons. Fixes #12633 

## Why It's Good For The Game
You won't explode yourself if you don't press R in time, now this only happens if you don't throw in time.

## Changelog
:cl:
fix: You now default to throw when priming a Cherry Bomb.
/:cl: