### PR TITLE
Announce to command when ERT request transmitted

### DIFF
--- a/code/modules/security_levels/keycard authentication.dm
+++ b/code/modules/security_levels/keycard authentication.dm
@@ -99,7 +99,7 @@
 	if(href_list["reset"])
 		reset()
 	if(href_list["ert"])
-		ert_reason = input(usr, "Reason for ERT Call:", "", "")
+		ert_reason = stripped_input(usr, "Reason for ERT Call:", "", "")
 
 	SSnanoui.update_uis(src)
 	add_fingerprint(usr)
@@ -168,7 +168,7 @@
 				atom_say("All Emergency Response Teams are dispatched and can not be called at this time.")
 				return
 			atom_say("ERT request transmitted!")
-			command_announcer.autosay("ERT request transmitted.")
+			command_announcer.autosay("ERT request transmitted. Reason: [ert_reason]", name)
 			print_centcom_report(ert_reason, station_time_timestamp() + " ERT Request")
 
 			var/fullmin_count = 0

--- a/code/modules/security_levels/keycard authentication.dm
+++ b/code/modules/security_levels/keycard authentication.dm
@@ -165,9 +165,10 @@
 			feedback_inc("alert_keycard_auth_stationRevoke",1)
 		if("Emergency Response Team")
 			if(is_ert_blocked())
-				to_chat(usr, "<span class='warning'>All Emergency Response Teams are dispatched and can not be called at this time.</span>")
+				atom_say("All Emergency Response Teams are dispatched and can not be called at this time.")
 				return
-			to_chat(usr, "<span class = 'notice'>ERT request transmitted.</span>")
+			atom_say("ERT request transmitted!")
+			command_announcer.autosay("ERT request transmitted.")
 			print_centcom_report(ert_reason, station_time_timestamp() + " ERT Request")
 
 			var/fullmin_count = 0


### PR DESCRIPTION
## What Does This PR Do
When ERT request is transmitted, it's broadcast on command radio and also spoken by the keycard authenticator, per Kyet's https://github.com/ParadiseSS13/Paradise/pull/13048#issuecomment-592753143

## Why It's Good For The Game
Better feedback to people involved in the ERT request. Also makes a little more sense than receiving a hard to see telepathic message that the request has been transmitted.

## Images of changes
![image](https://user-images.githubusercontent.com/26497062/75639994-191b9600-5be8-11ea-9068-278c97486780.png)

## Changelog
:cl:
tweak: ERT request transmitted announced to command
/:cl:
