### PR TITLE
AI Cores are no longer able to fit in a locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -46,6 +46,10 @@
 	for(var/obj/structure/closet/closet in get_turf(src))
 		if(closet != src && closet.anchored != 1)
 			return FALSE
+	for(var/mob/living/silicon/ai/ai in get_turf(src))
+		if(ai)
+			return FALSE
+
 	return TRUE
 
 /obj/structure/closet/proc/dump_contents()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -46,9 +46,6 @@
 	for(var/obj/structure/closet/closet in get_turf(src))
 		if(closet != src && closet.anchored != 1)
 			return FALSE
-	for(var/mob/living/silicon/ai/ai in get_turf(src))
-		if(ai)
-			return FALSE
 
 	return TRUE
 
@@ -109,6 +106,8 @@
 		if(istype(M, /mob/living/simple_animal/bot/mulebot))
 			continue
 		if(M.buckled || M.anchored || M.has_buckled_mobs())
+			continue
+		if(isAI(M))
 			continue
 
 		M.forceMove(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR prevents AI Cores (the mob kind with the AI in it) from being closed in a locker.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This is to prevent the cheese that can be done with the lockers, in which a AI would be closed in a locker, and they would be easily teleported via the teleporter (which the teleporter does not allow at all for AI cores to go through it).

Also a consideration that AI cores are larger than the lockers themselves.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
N/A

## Changelog
:cl: Quantum-M
tweak: AI Cores (the mob kind with the AI) are no longer able to fit inside lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
