### PR TITLE
Fix global narrate not using admin pencode

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -116,7 +116,7 @@
 
 	if(!msg)
 		return
-	msg = pencode_to_html(msg)
+	msg = admin_pencode_to_html(msg)
 	to_chat(world, "[msg]")
 	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
 	message_admins("<span class='boldnotice'>GlobalNarrate: [key_name_admin(usr)]: [msg]<BR></span>", 1)


### PR DESCRIPTION
## What Does This PR Do
admin pencode was left out of global narrate

## Why It's Good For The Game
Need to be able to global narrate "Narsie has risen!"
