### PR TITLE
Fixes #13070 - cyborg energy guns breaking

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -98,7 +98,7 @@
 		return
 	if(!chambered)
 		var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-		if(cell.charge >= shot.e_cost) //if there's enough power in the cell cell...
+		if(cell.charge >= shot.e_cost) //if there's enough power in the WEAPON'S cell...
 			chambered = shot //...prepare a new shot based on the current ammo type selected
 			if(!chambered.BB)
 				chambered.newshot()
@@ -110,6 +110,11 @@
 		robocharge()
 	chambered = null //either way, released the prepared shot
 	newshot()
+
+/obj/item/gun/energy/process_fire(atom/target, mob/living/user, message = 1, params, zone_override, bonus_spread = 0)
+	if(!chambered && can_shoot())
+		process_chamber()
+	return ..()
 
 /obj/item/gun/energy/proc/select_fire(mob/living/user)
 	select++


### PR DESCRIPTION
## What Does This PR Do
Fixes #13070 
It is no longer possible for cyborg weapons to become permanently broken if you deplete your cell fully.
Inspired by this code on TG: https://github.com/tgstation/tgstation/blob/6401ba57081efb3db2f39320eeefeb13c1be4d8c/code/modules/projectiles/guns/energy.dm#L118

## Why It's Good For The Game
Stops cyborg weapons breaking permanently to the point they need a module reset to fix it.

## Changelog
:cl: Kyep
fix: fixed cyborg energy weapons permanently breaking in low-energy situations.
/:cl: