### PR TITLE
Fixes cyborg energy weapons costing twice as much as intended

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -193,6 +193,9 @@
 	. = ..()
 
 /obj/item/gun/energy/proc/robocharge()
+	if(cell.charge == cell.maxcharge)
+		// No point in recharging a weapon's cell that is already at 100%. That would just waste borg cell power for no reason.
+		return
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/R = loc
 		if(R && R.cell)


### PR DESCRIPTION
## What Does This PR Do
Some cyborg energy weapons cost twice as much energy as they are meant to cost.
For example, if you look at the secborg's disabler, it has a listed e_cost of 250.
Yet, when you fire it, you lose 500 energy.
The reason for this is that there's no safety on robocharge(), its called a lot, and often "recharges" an already full weapon cell, wasting energy from the borg's cell.
This fixes robocharge() to have a safety, returning early and not drawing power from the borg's cell if the weapon's cell is already full.
Therefore, it stops cases where a borg's weapon costs twice as much to fire as was intended.

## Why It's Good For The Game
Fixes various borg energy weapons costing twice as much to fire as they should.

## Changelog
:cl: Kyep
fix: Fixed cases where a borg's energy weapons could cost twice as much energy to fire as they were intended to cost.
/:cl: