### PR TITLE
Removes Creatable Video Cameras

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -35447,7 +35447,6 @@
 /area/library)
 "bmF" = (
 /obj/structure/cult/archives,
-/obj/item/videocam,
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -420,6 +420,8 @@
 	r_pocket = /obj/item/barcodescanner
 	l_hand = /obj/item/storage/bag/books
 	pda = /obj/item/pda/librarian
+	backpack_contents = list(
+		/obj/item/videocam = 1)
 
 /datum/job/barber
 	title = "Barber"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -872,14 +872,6 @@
 	build_path = /obj/item/assembly/mousetrap
 	category = list("initial", "Miscellaneous")
 
-/datum/design/videocam
-	name = "Video Camera"
-	id = "videocam"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 120, MAT_GLASS = 60)
-	build_path = /obj/item/videocam
-	category = list("initial", "Miscellaneous")
-
 /datum/design/logic_board
 	name = "Logic Circuit"
 	id = "logic_board"


### PR DESCRIPTION
I always said I was going to do this the moment it even became remotely semi-meta for security or command to carry around video-cams.

It was fine for a very long time, but this has started cropping up quite routinely.

Needless to say, video cams are horrendously toxic when used by security; TG had the same experience.

Any officer who carries them is pretty much immune from any shenanigans aside from extreme options--it also makes sec+AI even more omnipresent than they already are. The only real chance to do anything about them is EMP them---which just further entrenches the awful meta of "EMP everything as an antag just in case".

Is it realistic that in 2XXX all spess sec forces would have body/helmet cams? Yes, absolutely. Is it healthy for the game direction or game design? NOPE.

This is one of those things where immersion and realism need to take a back seat to game design and overall balance.

Librarian still has his, of course.

:cl: Fox McCloud
del: Can no longer print video cameras in the autolathe
/:cl: