### PR TITLE
Mountable frame bugfixes and minor refactor

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -164,6 +164,34 @@
 	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, dir, newdir)
 	dir = newdir
 
+/*
+	Sets the atom's pixel locations based on the atom's `dir` variable, and what pixel offset arguments are passed into it
+	If no arguments are supplied, `pixel_x` or `pixel_y` will be set to 0
+	Used primarily for when players attach mountable frames to walls (APC frame, fire alarm frame, etc.)
+*/
+/atom/proc/set_pixel_offsets_from_dir(pixel_north = 0, pixel_south = 0, pixel_east = 0, pixel_west = 0)
+	switch(dir)
+		if(NORTH)
+			pixel_y = pixel_north
+		if(SOUTH)
+			pixel_y = pixel_south
+		if(EAST)
+			pixel_x = pixel_east
+		if(WEST)
+			pixel_x = pixel_west
+		if(NORTHEAST)
+			pixel_y = pixel_north
+			pixel_x = pixel_east
+		if(NORTHWEST)
+			pixel_y = pixel_north
+			pixel_x = pixel_west
+		if(SOUTHEAST)
+			pixel_y = pixel_south
+			pixel_x = pixel_east
+		if(SOUTHWEST)
+			pixel_y = pixel_south
+			pixel_x = pixel_west
+
 ///Handle melee attack by a mech
 /atom/proc/mech_melee_attack(obj/mecha/M)
 	return

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -83,7 +83,7 @@
 	idle_power_usage = 4
 	active_power_usage = 8
 	power_channel = ENVIRON
-	req_one_access = list(access_atmospherics, access_engine_equip)
+	req_one_access = list(ACCESS_ATMOSPHERICS, ACCESS_ENGINE_EQUIP)
 	max_integrity = 250
 	integrity_failure = 80
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 30)
@@ -132,7 +132,7 @@
 /obj/machinery/alarm/syndicate //general syndicate access
 	report_danger_level = FALSE
 	remote_control = FALSE
-	req_access = list(access_syndicate)
+	req_access = list(ACCESS_SYNDICATE)
 	req_one_access = list()
 
 /obj/machinery/alarm/monitor/server

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -226,7 +226,7 @@
 	if(SSradio)
 		SSradio.remove_object(src, frequency)
 	radio_connection = null
-	air_alarm_repository.update_cache(src)
+	GLOB.air_alarm_repository.update_cache(src)
 	QDEL_NULL(wires)
 	if(alarm_area && alarm_area.master_air_alarm == src)
 		alarm_area.master_air_alarm = null
@@ -240,7 +240,7 @@
 	if(name == "alarm")
 		name = "[alarm_area.name] Air Alarm"
 	apply_preset(1) // Don't cycle.
-	air_alarm_repository.update_cache(src)
+	GLOB.air_alarm_repository.update_cache(src)
 
 /obj/machinery/alarm/Initialize()
 	..()
@@ -657,7 +657,7 @@
 	data["danger"] = danger
 	return data
 
-/obj/machinery/alarm/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
+/obj/machinery/alarm/ui_data(mob/user, ui_key = "main", datum/topic_state/state = GLOB.default_state)
 	var/data[0]
 
 	var/list/href_list = state.href_list(user)
@@ -773,7 +773,7 @@
 
 	return thresholds
 
-/obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
+/obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = GLOB.default_state)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "air_alarm.tmpl", name, 570, 410, state = state)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -83,7 +83,7 @@
 	idle_power_usage = 4
 	active_power_usage = 8
 	power_channel = ENVIRON
-	req_one_access = list(ACCESS_ATMOSPHERICS, ACCESS_ENGINE_EQUIP)
+	req_one_access = list(access_atmospherics, access_engine_equip)
 	max_integrity = 250
 	integrity_failure = 80
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 30)
@@ -132,7 +132,7 @@
 /obj/machinery/alarm/syndicate //general syndicate access
 	report_danger_level = FALSE
 	remote_control = FALSE
-	req_access = list(ACCESS_SYNDICATE)
+	req_access = list(access_syndicate)
 	req_one_access = list()
 
 /obj/machinery/alarm/monitor/server
@@ -199,8 +199,8 @@
 		mode = AALARM_MODE_REPLACEMENT
 		apply_mode()
 
-/obj/machinery/alarm/New(var/loc, var/dir, var/building = 0)
-	..()
+/obj/machinery/alarm/New(loc, direction, building = 0)
+	. = ..()
 	GLOB.air_alarms += src
 	GLOB.air_alarms = sortAtom(GLOB.air_alarms)
 
@@ -211,12 +211,11 @@
 			src.loc = loc
 
 		if(dir)
-			src.dir = dir
+			setDir(direction)
 
 		buildstage = 0
 		wiresexposed = 1
-		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
-		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
+		set_pixel_offsets(-24, 24, -24, 24)
 		update_icon()
 		return
 
@@ -227,7 +226,7 @@
 	if(SSradio)
 		SSradio.remove_object(src, frequency)
 	radio_connection = null
-	GLOB.air_alarm_repository.update_cache(src)
+	air_alarm_repository.update_cache(src)
 	QDEL_NULL(wires)
 	if(alarm_area && alarm_area.master_air_alarm == src)
 		alarm_area.master_air_alarm = null
@@ -241,7 +240,7 @@
 	if(name == "alarm")
 		name = "[alarm_area.name] Air Alarm"
 	apply_preset(1) // Don't cycle.
-	GLOB.air_alarm_repository.update_cache(src)
+	air_alarm_repository.update_cache(src)
 
 /obj/machinery/alarm/Initialize()
 	..()
@@ -251,7 +250,7 @@
 
 /obj/machinery/alarm/proc/master_is_operating()
 	if(!alarm_area)
-		alarm_area = areaMaster
+		alarm_area = get_area(src)
 	if(!alarm_area)
 		log_runtime(EXCEPTION("Air alarm /obj/machinery/alarm lacks alarm_area and areaMaster vars during proc/master_is_operating()"), src)
 		return FALSE
@@ -658,7 +657,7 @@
 	data["danger"] = danger
 	return data
 
-/obj/machinery/alarm/ui_data(mob/user, ui_key = "main", datum/topic_state/state = GLOB.default_state)
+/obj/machinery/alarm/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	var/list/href_list = state.href_list(user)
@@ -774,7 +773,7 @@
 
 	return thresholds
 
-/obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = GLOB.default_state)
+/obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "air_alarm.tmpl", name, 570, 410, state = state)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -215,7 +215,7 @@
 
 		buildstage = 0
 		wiresexposed = 1
-		set_pixel_offsets(-24, 24, -24, 24)
+		set_pixel_offsets_from_dir(-24, 24, -24, 24)
 		update_icon()
 		return
 

--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -29,7 +29,7 @@
 		setDir(direction)
 
 	if(building)
-		set_pixel_offsets(30, -30, 30, -30)
+		set_pixel_offsets_from_dir(30, -30, 30, -30)
 
 /obj/machinery/defibrillator_mount/loaded/New() //loaded subtype for mapping use
 	..()

--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -26,11 +26,10 @@
 		loc = location
 
 	if(direction)
-		dir = direction
+		setDir(direction)
 
 	if(building)
-		pixel_x = (dir & 3)? 0 : (dir == 4 ? -30 : 30)
-		pixel_y = (dir & 3)? (dir == 1 ? -30 : 30) : 0
+		set_pixel_offsets(30, -30, 30, -30)
 
 /obj/machinery/defibrillator_mount/loaded/New() //loaded subtype for mapping use
 	..()
@@ -154,6 +153,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/mounted/frame/defib_mount/do_build(turf/on_wall, mob/user)
-	new /obj/machinery/defibrillator_mount(get_turf(src), get_dir(on_wall, user), 1)
+	new /obj/machinery/defibrillator_mount(get_turf(src), get_dir(user, on_wall), 1)
 	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 	qdel(src)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -136,8 +136,7 @@
 	Radio.config(list("Security" = 0))
 	Radio.follow_target = src
 
-	pixel_x = ((dir & 3)? (0) : (dir == 4 ? 32 : -32))
-	pixel_y = ((dir & 3)? (dir ==1 ? 32 : -32) : (0))
+	set_pixel_offsets_from_dir(32, -32, 32, -32)
 
 	spawn(20)
 		for(var/obj/machinery/door/window/brigdoor/M in GLOB.airlocks)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -315,8 +315,7 @@ FIRE ALARM
 		buildstage = 0
 		wiresexposed = TRUE
 		setDir(direction)
-		pixel_x = (dir & 3) ? 0 : (dir == 4 ? 26 : -26)
-		pixel_y = (dir & 3) ? (dir ==1 ? 24 : -24) : 0
+		set_pixel_offsets(26, -26, 26, -26)
 
 	if(is_station_contact(z) && show_alert_level)
 		if(GLOB.security_level)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -315,7 +315,7 @@ FIRE ALARM
 		buildstage = 0
 		wiresexposed = TRUE
 		setDir(direction)
-		set_pixel_offsets(26, -26, 26, -26)
+		set_pixel_offsets_from_dir(26, -26, 26, -26)
 
 	if(is_station_contact(z) && show_alert_level)
 		if(GLOB.security_level)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -309,13 +309,14 @@ FIRE ALARM
 	update_icon()
 
 /obj/machinery/firealarm/New(location, direction, building)
-	..()
+	. = ..()
 
 	if(building)
 		buildstage = 0
 		wiresexposed = TRUE
-		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
-		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
+		setDir(direction)
+		pixel_x = (dir & 3) ? 0 : (dir == 4 ? 26 : -26)
+		pixel_y = (dir & 3) ? (dir ==1 ? 24 : -24) : 0
 
 	if(is_station_contact(z) && show_alert_level)
 		if(GLOB.security_level)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -62,7 +62,7 @@
 
 /obj/item/radio/intercom/department/medbay/New()
 	..()
-	internal_channels = default_medbay_channels.Copy()
+	internal_channels = GLOB.default_medbay_channels.Copy()
 
 /obj/item/radio/intercom/department/security/New()
 	..()
@@ -270,4 +270,4 @@
 
 /obj/item/radio/intercom/locked/prison/New()
 	..()
-	wires.CutWireIndex(WIRE_TRANSMIT)
+	wires.CutWireIndex(RADIO_WIRE_TRANSMIT)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -68,7 +68,7 @@
 	..()
 	internal_channels = list(
 		num2text(PUB_FREQ) = list(),
-		num2text(SEC_I_FREQ) = list(access_security)
+		num2text(SEC_I_FREQ) = list(ACCESS_SECURITY)
 	)
 
 /obj/item/radio/intercom/syndicate
@@ -80,7 +80,7 @@
 
 /obj/item/radio/intercom/syndicate/New()
 	..()
-	internal_channels[num2text(SYND_FREQ)] = list(access_syndicate)
+	internal_channels[num2text(SYND_FREQ)] = list(ACCESS_SYNDICATE)
 
 /obj/item/radio/intercom/pirate
 	name = "pirate radio intercom"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -54,7 +54,7 @@
 	else
 		if(direction)
 			setDir(direction)
-			set_pixel_offsets(28, -28, 28, -28)
+			set_pixel_offsets_from_dir(28, -28, 28, -28)
 		b_stat=1
 		on = 0
 	GLOB.global_intercoms.Add(src)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -46,16 +46,15 @@
 	name = "station intercom (Security)"
 	frequency = SEC_I_FREQ
 
-/obj/item/radio/intercom/New(turf/loc, ndir, building = 3)
-	..()
+/obj/item/radio/intercom/New(turf/loc, direction, building = 3)
+	. = ..()
 	buildstage = building
 	if(buildstage)
 		START_PROCESSING(SSobj, src)
 	else
-		if(ndir)
-			pixel_x = (ndir & EAST|WEST) ? (ndir == EAST ? 28 : -28) : 0
-			pixel_y = (ndir & NORTH|SOUTH) ? (ndir == NORTH ? 28 : -28) : 0
-			dir=ndir
+		if(direction)
+			setDir(direction)
+			set_pixel_offsets(28, -28, 28, -28)
 		b_stat=1
 		on = 0
 	GLOB.global_intercoms.Add(src)
@@ -63,13 +62,13 @@
 
 /obj/item/radio/intercom/department/medbay/New()
 	..()
-	internal_channels = GLOB.default_medbay_channels.Copy()
+	internal_channels = default_medbay_channels.Copy()
 
 /obj/item/radio/intercom/department/security/New()
 	..()
 	internal_channels = list(
 		num2text(PUB_FREQ) = list(),
-		num2text(SEC_I_FREQ) = list(ACCESS_SECURITY)
+		num2text(SEC_I_FREQ) = list(access_security)
 	)
 
 /obj/item/radio/intercom/syndicate
@@ -81,7 +80,7 @@
 
 /obj/item/radio/intercom/syndicate/New()
 	..()
-	internal_channels[num2text(SYND_FREQ)] = list(ACCESS_SYNDICATE)
+	internal_channels[num2text(SYND_FREQ)] = list(access_syndicate)
 
 /obj/item/radio/intercom/pirate
 	name = "pirate radio intercom"
@@ -204,7 +203,7 @@
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/radio/intercom/welder_act(mob/user, obj/item/I)
-	if(!buildstage)
+	if(buildstage != 0)
 		return
 	. = TRUE
 	if(!I.tool_use_check(user, 3))
@@ -271,4 +270,4 @@
 
 /obj/item/radio/intercom/locked/prison/New()
 	..()
-	wires.CutWireIndex(RADIO_WIRE_TRANSMIT)
+	wires.CutWireIndex(WIRE_TRANSMIT)

--- a/code/game/objects/items/mountable_frames/fire_alarm.dm
+++ b/code/game/objects/items/mountable_frames/fire_alarm.dm
@@ -6,5 +6,5 @@
 	mount_reqs = list("simfloor", "nospace")
 
 /obj/item/mounted/frame/firealarm/do_build(turf/on_wall, mob/user)
-	new /obj/machinery/firealarm(get_turf(src), get_dir(on_wall, user), 1)
+	new /obj/machinery/firealarm(get_turf(src), get_dir(user, on_wall), 1)
 	qdel(src)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -17,11 +17,12 @@
 	var/opened = 0
 	var/material_drop = /obj/item/stack/sheet/metal
 
-/obj/structure/extinguisher_cabinet/New(turf/loc, ndir = null)
+/obj/structure/extinguisher_cabinet/New(turf/loc, direction = null)
 	..()
-	if(ndir)
-		pixel_x = (ndir & EAST|WEST) ? (ndir == EAST ? 28 : -28) : 0
-		pixel_y = (ndir & NORTH|SOUTH)? (ndir == WEST ? 28 : -28) : 0
+	if(direction)
+		setDir(direction)
+		pixel_x = (dir & 3) ? 0 : (dir == 4 ? 28 : -28)
+		pixel_y = (dir & 3) ? (dir == 1 ? 30 : -30) : 0
 	switch(extinguishertype)
 		if(NO_EXTINGUISHER)
 			return
@@ -165,9 +166,9 @@
 	else
 		icon_state = "extinguisher_empty"
 
-/obj/structure/extinguisher_cabinet/empty/New(turf/loc, ndir = null)
+/obj/structure/extinguisher_cabinet/empty/New(turf/loc, direction = null)
 	extinguishertype = NO_EXTINGUISHER
-	..()
+	return ..()
 
 #undef NO_EXTINGUISHER
 #undef NORMAL_EXTINGUISHER

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -21,7 +21,7 @@
 	..()
 	if(direction)
 		setDir(direction)
-		set_pixel_offsets(28, -28, 30, -30)
+		set_pixel_offsets_from_dir(28, -28, 30, -30)
 	switch(extinguishertype)
 		if(NO_EXTINGUISHER)
 			return
@@ -165,9 +165,8 @@
 	else
 		icon_state = "extinguisher_empty"
 
-/obj/structure/extinguisher_cabinet/empty/New(turf/loc, direction = null)
+/obj/structure/extinguisher_cabinet/empty
 	extinguishertype = NO_EXTINGUISHER
-	return ..()
 
 #undef NO_EXTINGUISHER
 #undef NORMAL_EXTINGUISHER

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -21,8 +21,7 @@
 	..()
 	if(direction)
 		setDir(direction)
-		pixel_x = (dir & 3) ? 0 : (dir == 4 ? 28 : -28)
-		pixel_y = (dir & 3) ? (dir == 1 ? 30 : -30) : 0
+		set_pixel_offsets(28, -28, 30, -30)
 	switch(extinguishertype)
 		if(NO_EXTINGUISHER)
 			return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -147,7 +147,7 @@
 	if(terminal)
 		terminal.connect_to_network()
 
-/obj/machinery/power/apc/New(turf/loc, ndir, building = 0)
+/obj/machinery/power/apc/New(turf/loc, direction, building = 0)
 	if(!armor)
 		armor = list("melee" = 20, "bullet" = 20, "laser" = 10, "energy" = 100, "bomb" = 30, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50)
 	..()
@@ -158,12 +158,11 @@
 	// offset 24 pixels in direction of dir
 	// this allows the APC to be embedded in a wall, yet still inside an area
 	if(building)
-		setDir(ndir)
-	tdir = dir		// to fix Vars bug
-	setDir(SOUTH)
+		setDir(direction) // We set this to direction only for pixel location determination.
 
-	pixel_x = (src.tdir & 3)? 0 : (src.tdir == 4 ? 24 : -24)
-	pixel_y = (src.tdir & 3)? (src.tdir ==1 ? 24 : -24) : 0
+	set_pixel_offsets_from_dir(24, -24, 24, -24) // Set pixel offsets based on `dir`
+	setDir(SOUTH) // APC's should always appear to *face* south.
+
 	if(building)
 		area = get_area(src)
 		area.apc |= src
@@ -425,11 +424,11 @@
 	if(stat & (NOPOWER | BROKEN))
 		return
 	if(!second_pass) //The first time, we just cut overlays
-		addtimer(CALLBACK(src, /obj/machinery/power/apc/proc.get_spooked, TRUE), 1)
+		addtimer(CALLBACK(src, .get_spooked, TRUE), 1)
 		cut_overlays()
 	else
 		flick("apcemag", src) //Second time we cause the APC to update its icon, then add a timer to update icon later
-		addtimer(CALLBACK(src, /obj/machinery/power/apc/proc.update_icon, TRUE), 10)
+		addtimer(CALLBACK(src, .proc/update_icon, TRUE), 10)
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 /obj/machinery/power/apc/attackby(obj/item/W, mob/living/user, params)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -424,11 +424,11 @@
 	if(stat & (NOPOWER | BROKEN))
 		return
 	if(!second_pass) //The first time, we just cut overlays
-		addtimer(CALLBACK(src, .get_spooked, TRUE), 1)
+		addtimer(CALLBACK(src, /obj/machinery/power/apc/proc.get_spooked, TRUE), 1)
 		cut_overlays()
 	else
 		flick("apcemag", src) //Second time we cause the APC to update its icon, then add a timer to update icon later
-		addtimer(CALLBACK(src, .proc/update_icon, TRUE), 10)
+		addtimer(CALLBACK(src, /obj/machinery/power/apc/proc.update_icon, TRUE), 10)
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 /obj/machinery/power/apc/attackby(obj/item/W, mob/living/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes this behavior, with these mountable frames: https://streamable.com/oqmpd

I also went ahead and cleaned up / refactored some duplicate code that was used with mountable frames to pick their pixel locations. 

## Why It's Good For The Game
Fixes #12598
Fixes #12610

## Changelog
:cl:
fix: Fixes extinguisher cabinets, intercom frames and fire alarm frames getting applied to walls with the incorrect orientation and location
fix: Fixes mounted intercom frames being unable to be welded from walls
fix: Fixes a runtime when placing an air alarm frame onto a wall
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
