### PR TITLE
Blocked Traders event triggers another major event

### DIFF
--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -18,6 +18,9 @@ var/global/list/unused_trade_stations = list("sol")
 		return
 	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED)
 		event_announcement.Announce("A trading shuttle from Jupiter Station has been denied docking permission due to the heightened security alert aboard [station_name()].", "Trader Shuttle Docking Request Refused")
+		// if the docking request was refused, fire another major event in 60 seconds
+		var/list/datum/event_container/EC = SSevents.event_containers[EVENT_LEVEL_MAJOR]
+		EC.next_event_time = world.time + (60 * 10)
 		return
 
 	var/list/spawnlocs = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
If the 'Traders' major event fires, but the alert level is red or higher, so the traders don't come, then set the timer until the next major event to 60 seconds.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This will mean that there's actually a disincentive to stay on red alert pointlessly, because trader event on under red alert is beneficial, but trader event on red alert or higher causes another (almost certainly harmful) event to fire that would not otherwise have fired. 

The text describing this change is copied verbatim from [Kyet's Changes Wanted](https://www.paradisestation.org/forum/topic/18118-kyets-changes-wanted/)

## Changelog
:cl:
tweak: Blocked Traders event triggers another major event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
