### PR TITLE
Underage Drinking Is Now Illegal

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -15,6 +15,25 @@
 	M.AdjustDizzy(dizzy_adj)
 	return ..()
 
+/datum/reagent/consumable/ethanol/on_mob_add(mob/living/carbon/M)
+	..()
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/H = M
+	if(H.age >= 21) // Yes. Its 21. This is Space America. That is canon now.
+		return
+	if(!cameranet.checkTurfVis(get_turf(M)))
+		return
+	for(var/datum/data/record/E in data_core.general)
+		if(E.fields["name"] == M.real_name)
+			for(var/datum/data/record/R in data_core.security)
+				if(R.fields["id"] == E.fields["id"])
+					R.fields["criminal"] = "*Arrest*"
+					R.fields["mi_crim"] = "Underage Drinking"
+					R.fields["comments"] += "Set to *Arrest* by Nanotrasen Alcohol Oversight Committee on [current_date_string] [station_time_timestamp()]."
+					update_all_mob_security_hud()
+				break
+
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, volume)
 	if(istype(O,/obj/item/paper))
 		if(istype(O,/obj/item/paper/contract/infernal))


### PR DESCRIPTION
We're Space America now.

Credit to Goon for the idea; I included their comment  because it's just too good to pass up.

Drinking alcohol will now incur an arrest with a minor crime of Underage Drinking if you're under the age of 21.

Being hidden from camera while or having no records makes you immune to this, of course.

For those who are asking why I didn't make this a `reaction_mob` on `INGEST`; it's in part so you can't cheese it, but also to avoid looping through the entire datacore every time someone takes a sip of any of the myriad of alcohol types.

:cl: Fox McCloud
add: Underage Drinking is now illegal. Welcome to Space America. This is canon now
/:cl: