### PR TITLE
Panic bunker threshold is configurable

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -90,5 +90,4 @@ GLOBAL_VAR(map_name) // Self explanatory
 
 var/global/datum/datacore/data_core = null // Station datacore, manifest, etc
 
-GLOBAL_VAR_INIT(panic_bunker_automatic, TRUE) // Is the panic bunker in automatic mode
 GLOBAL_VAR_INIT(panic_bunker_enabled, FALSE) // Is the panic bunker enabled

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -90,4 +90,5 @@ GLOBAL_VAR(map_name) // Self explanatory
 
 var/global/datum/datacore/data_core = null // Station datacore, manifest, etc
 
+GLOBAL_VAR_INIT(panic_bunker_automatic, TRUE) // Is the panic bunker in automatic mode
 GLOBAL_VAR_INIT(panic_bunker_enabled, FALSE) // Is the panic bunker enabled

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -90,4 +90,4 @@ GLOBAL_VAR(map_name) // Self explanatory
 
 var/global/datum/datacore/data_core = null // Station datacore, manifest, etc
 
-GLOBAL_VAR_INIT(panic_bunker_enabled, 0) // Is the panic bunker enabled
+GLOBAL_VAR_INIT(panic_bunker_enabled, FALSE) // Is the panic bunker enabled

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -57,6 +57,7 @@
 	var/allow_ai = 1					// allow ai job
 	var/respawn = 0
 	var/guest_jobban = 1
+	var/panic_bunker_threshold = 150	// above this player count threshold, never-before-seen players are blocked from connecting
 	var/usewhitelist = 0
 	var/mods_are_mentors = 0
 	var/load_jobs_from_txt = 0
@@ -502,6 +503,9 @@
 
 				if("guest_ban")
 					guests_allowed = 0
+
+				if("panic_bunker_threshold")
+					config.panic_bunker_threshold = text2num(value)
 
 				if("usewhitelist")
 					config.usewhitelist = 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -78,8 +78,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_advanced_interaction, /*toggle admin ability to interact with not only machines, but also atoms such as buttons and doors*/
 	/client/proc/list_ssds_afks,
 	/client/proc/cmd_admin_headset_message,
-	/client/proc/spawn_floor_cluwne,
-	/client/proc/toggle_panic_bunker
+	/client/proc/spawn_floor_cluwne
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -1017,16 +1016,3 @@ var/list/admin_verbs_ticket = list(
 
 	log_admin("[key_name(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 	message_admins("[key_name_admin(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
-
-/client/proc/toggle_panic_bunker()
-	set name = "Toggle Panic Bunker"
-	set category = "Admin"
-	set desc = "Disables new players connecting."
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	GLOB.panic_bunker_enabled = !GLOB.panic_bunker_enabled
-
-	log_admin("[key_name(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")
-	message_admins("[key_name_admin(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -78,8 +78,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_advanced_interaction, /*toggle admin ability to interact with not only machines, but also atoms such as buttons and doors*/
 	/client/proc/list_ssds_afks,
 	/client/proc/cmd_admin_headset_message,
-	/client/proc/spawn_floor_cluwne,
-	/client/proc/set_server_capacity
+	/client/proc/spawn_floor_cluwne
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -144,8 +143,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/set_ooc,
-	/client/proc/reset_ooc,
-	/client/proc/set_server_capacity
+	/client/proc/reset_ooc
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/cmd_admin_list_open_jobs,
@@ -1018,17 +1016,3 @@ var/list/admin_verbs_ticket = list(
 
 	log_admin("[key_name(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 	message_admins("[key_name_admin(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
-
-/client/proc/set_server_capacity()
-	set name = "Set Server Capacity"
-	set category = "Admin"
-	set desc = "Prevent new players connecting when over capacity."
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	var/capacity = input("Please input the new Server Capacity (player count)", "Set Server Capacity", 150) as num
-	config.panic_bunker_threshold = Clamp(capacity, 0, 500)
-
-	log_admin("[key_name(usr)] has set the Server Capacity to [capacity].")
-	message_admins("[key_name_admin(usr)] has set the Server Capacity to [capacity].")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -78,7 +78,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_advanced_interaction, /*toggle admin ability to interact with not only machines, but also atoms such as buttons and doors*/
 	/client/proc/list_ssds_afks,
 	/client/proc/cmd_admin_headset_message,
-	/client/proc/spawn_floor_cluwne
+	/client/proc/spawn_floor_cluwne,
+	/client/proc/set_server_capacity
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -143,7 +144,8 @@ var/list/admin_verbs_server = list(
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/set_ooc,
-	/client/proc/reset_ooc
+	/client/proc/reset_ooc,
+	/client/proc/set_server_capacity
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/cmd_admin_list_open_jobs,
@@ -1016,3 +1018,17 @@ var/list/admin_verbs_ticket = list(
 
 	log_admin("[key_name(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 	message_admins("[key_name_admin(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
+
+/client/proc/set_server_capacity()
+	set name = "Set Server Capacity"
+	set category = "Admin"
+	set desc = "Prevent new players connecting when over capacity."
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/capacity = input("Please input the new Server Capacity (player count)", "Set Server Capacity", 150) as num
+	config.panic_bunker_threshold = Clamp(capacity, 0, 500)
+
+	log_admin("[key_name(usr)] has set the Server Capacity to [capacity].")
+	message_admins("[key_name_admin(usr)] has set the Server Capacity to [capacity].")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,7 +79,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/list_ssds_afks,
 	/client/proc/cmd_admin_headset_message,
 	/client/proc/spawn_floor_cluwne,
-	/client/proc/set_server_capacity
+	/client/proc/toggle_panic_bunker_state,
+	/client/proc/toggle_panic_bunker_mode
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -144,8 +145,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/set_ooc,
-	/client/proc/reset_ooc,
-	/client/proc/set_server_capacity
+	/client/proc/reset_ooc
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/cmd_admin_list_open_jobs,
@@ -1019,16 +1019,28 @@ var/list/admin_verbs_ticket = list(
 	log_admin("[key_name(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 	message_admins("[key_name_admin(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 
-/client/proc/set_server_capacity()
-	set name = "Set Server Capacity"
+/client/proc/toggle_panic_bunker_state()
+	set name = "Toggle Panic Bunker State"
 	set category = "Admin"
-	set desc = "Prevent new players connecting when over capacity."
+	set desc = "Change panic bunker between Disabled and Enabled. Prevents new players connecting when Enabled."
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/capacity = input("Please input the new Server Capacity (player count)", "Set Server Capacity", 150) as num
-	config.panic_bunker_threshold = Clamp(capacity, 0, 500)
+	GLOB.panic_bunker_enabled = !GLOB.panic_bunker_enabled
 
-	log_admin("[key_name(usr)] has set the Server Capacity to [capacity].")
-	message_admins("[key_name_admin(usr)] has set the Server Capacity to [capacity].")
+	log_admin("[key_name(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")
+	message_admins("[key_name_admin(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")
+
+/client/proc/toggle_panic_bunker_mode()
+	set name = "Toggle Panic Bunker Mode"
+	set category = "Admin"
+	set desc = "Change panic bunker mode between Manual and Automatic."
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	GLOB.panic_bunker_automatic = !GLOB.panic_bunker_automatic
+
+	log_admin("[key_name(usr)] has set the panic bunker to [GLOB.panic_bunker_automatic  ? "automatic" : "manual"] mode.")
+	message_admins("[key_name(usr)] has set the panic bunker to [GLOB.panic_bunker_automatic  ? "automatic" : "manual"] mode.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,8 +79,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/list_ssds_afks,
 	/client/proc/cmd_admin_headset_message,
 	/client/proc/spawn_floor_cluwne,
-	/client/proc/toggle_panic_bunker_state,
-	/client/proc/toggle_panic_bunker_mode
+	/client/proc/set_server_capacity
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -145,7 +144,8 @@ var/list/admin_verbs_server = list(
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/set_ooc,
-	/client/proc/reset_ooc
+	/client/proc/reset_ooc,
+	/client/proc/set_server_capacity
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/cmd_admin_list_open_jobs,
@@ -1019,28 +1019,16 @@ var/list/admin_verbs_ticket = list(
 	log_admin("[key_name(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 	message_admins("[key_name_admin(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 
-/client/proc/toggle_panic_bunker_state()
-	set name = "Toggle Panic Bunker State"
+/client/proc/set_server_capacity()
+	set name = "Set Server Capacity"
 	set category = "Admin"
-	set desc = "Change panic bunker between Disabled and Enabled. Prevents new players connecting when Enabled."
+	set desc = "Prevent new players connecting when over capacity."
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	GLOB.panic_bunker_enabled = !GLOB.panic_bunker_enabled
+	var/capacity = input("Please input the new Server Capacity (player count)", "Set Server Capacity", 150) as num
+	config.panic_bunker_threshold = Clamp(capacity, 0, 500)
 
-	log_admin("[key_name(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")
-	message_admins("[key_name_admin(usr)] has [GLOB.panic_bunker_enabled  ? "activated" : "deactivated"] the panic bunker.")
-
-/client/proc/toggle_panic_bunker_mode()
-	set name = "Toggle Panic Bunker Mode"
-	set category = "Admin"
-	set desc = "Change panic bunker mode between Manual and Automatic."
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	GLOB.panic_bunker_automatic = !GLOB.panic_bunker_automatic
-
-	log_admin("[key_name(usr)] has set the panic bunker to [GLOB.panic_bunker_automatic  ? "automatic" : "manual"] mode.")
-	message_admins("[key_name(usr)] has set the panic bunker to [GLOB.panic_bunker_automatic  ? "automatic" : "manual"] mode.")
+	log_admin("[key_name(usr)] has set the Server Capacity to [capacity].")
+	message_admins("[key_name_admin(usr)] has set the Server Capacity to [capacity].")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -417,14 +417,13 @@
 	// Update the state of the panic bunker based on current playercount
 	var/threshold = config.panic_bunker_threshold
 
-	if(GLOB.panic_bunker_enabled)
-		if(playercount < threshold)
-			GLOB.panic_bunker_enabled = FALSE
-			message_admins("Panic bunker has been automatically disabled due to playercount dropping below Server Capacity [threshold]")
-	else
-		if(playercount > threshold)
-			GLOB.panic_bunker_enabled = TRUE
-			message_admins("Panic bunker has been automatically enabled due to playercount rising above Server Capacity [threshold]")
+	if((playercount > threshold) && (GLOB.panic_bunker_enabled == FALSE))
+		GLOB.panic_bunker_enabled = TRUE
+		message_admins("Panic bunker has been automatically enabled due to playercount rising above [threshold]")
+
+	if((playercount < threshold) && (GLOB.panic_bunker_enabled == TRUE))
+		GLOB.panic_bunker_enabled = FALSE
+		message_admins("Panic bunker has been automatically disabled due to playercount dropping below [threshold]")
 
 /client/proc/is_connecting_from_localhost()
 	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -414,9 +414,16 @@
 		if(M.client)
 			playercount += 1
 
-	if(playercount >= 150 && GLOB.panic_bunker_enabled == 0)
-		GLOB.panic_bunker_enabled = 1
-		message_admins("Panic bunker has been automatically enabled due to playercount surpassing 150")
+	// Update the state of the panic bunker based on current playercount
+	var/threshold = config.panic_bunker_threshold
+
+	if((playercount > threshold) && (GLOB.panic_bunker_enabled == FALSE))
+		GLOB.panic_bunker_enabled = TRUE
+		message_admins("Panic bunker has been automatically enabled due to playercount rising above [threshold]")
+
+	if((playercount < threshold) && (GLOB.panic_bunker_enabled == TRUE))
+		GLOB.panic_bunker_enabled = FALSE
+		message_admins("Panic bunker has been automatically disabled due to playercount dropping below [threshold]")
 
 /client/proc/is_connecting_from_localhost()
 	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses
@@ -549,8 +556,8 @@
 
 		// Check new peeps for panic bunker
 		if(GLOB.panic_bunker_enabled)
-			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
-			src << "Sorry but the server is currently not accepting connections from never before seen players. Please try again later."
+			var/threshold = config.panic_bunker_threshold
+			src << "Server is not accepting connections from never-before-seen players until player count is less than [threshold]. Please try again later."
 			del(src)
 			return // Dont insert or they can just go in again
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -415,16 +415,17 @@
 			playercount += 1
 
 	// Update the state of the panic bunker based on current playercount
+	// if the panic bunker is operating in automatic mode
 	var/threshold = config.panic_bunker_threshold
-
-	if(GLOB.panic_bunker_enabled)
-		if(playercount < threshold)
-			GLOB.panic_bunker_enabled = FALSE
-			message_admins("Panic bunker has been automatically disabled due to playercount dropping below Server Capacity [threshold]")
-	else
-		if(playercount > threshold)
-			GLOB.panic_bunker_enabled = TRUE
-			message_admins("Panic bunker has been automatically enabled due to playercount rising above Server Capacity [threshold]")
+	if(GLOB.panic_bunker_automatic)
+		if(GLOB.panic_bunker_enabled)
+			if(playercount < threshold)
+				GLOB.panic_bunker_enabled = FALSE
+				message_admins("Panic bunker has been automatically disabled due to playercount dropping below Server Capacity [threshold]")
+		else
+			if(playercount > threshold)
+				GLOB.panic_bunker_enabled = TRUE
+				message_admins("Panic bunker has been automatically enabled due to playercount rising above Server Capacity [threshold]")
 
 /client/proc/is_connecting_from_localhost()
 	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -417,13 +417,14 @@
 	// Update the state of the panic bunker based on current playercount
 	var/threshold = config.panic_bunker_threshold
 
-	if((playercount > threshold) && (GLOB.panic_bunker_enabled == FALSE))
-		GLOB.panic_bunker_enabled = TRUE
-		message_admins("Panic bunker has been automatically enabled due to playercount rising above [threshold]")
-
-	if((playercount < threshold) && (GLOB.panic_bunker_enabled == TRUE))
-		GLOB.panic_bunker_enabled = FALSE
-		message_admins("Panic bunker has been automatically disabled due to playercount dropping below [threshold]")
+	if(GLOB.panic_bunker_enabled)
+		if(playercount < threshold)
+			GLOB.panic_bunker_enabled = FALSE
+			message_admins("Panic bunker has been automatically disabled due to playercount dropping below Server Capacity [threshold]")
+	else
+		if(playercount > threshold)
+			GLOB.panic_bunker_enabled = TRUE
+			message_admins("Panic bunker has been automatically enabled due to playercount rising above Server Capacity [threshold]")
 
 /client/proc/is_connecting_from_localhost()
 	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -415,17 +415,16 @@
 			playercount += 1
 
 	// Update the state of the panic bunker based on current playercount
-	// if the panic bunker is operating in automatic mode
 	var/threshold = config.panic_bunker_threshold
-	if(GLOB.panic_bunker_automatic)
-		if(GLOB.panic_bunker_enabled)
-			if(playercount < threshold)
-				GLOB.panic_bunker_enabled = FALSE
-				message_admins("Panic bunker has been automatically disabled due to playercount dropping below Server Capacity [threshold]")
-		else
-			if(playercount > threshold)
-				GLOB.panic_bunker_enabled = TRUE
-				message_admins("Panic bunker has been automatically enabled due to playercount rising above Server Capacity [threshold]")
+
+	if(GLOB.panic_bunker_enabled)
+		if(playercount < threshold)
+			GLOB.panic_bunker_enabled = FALSE
+			message_admins("Panic bunker has been automatically disabled due to playercount dropping below Server Capacity [threshold]")
+	else
+		if(playercount > threshold)
+			GLOB.panic_bunker_enabled = TRUE
+			message_admins("Panic bunker has been automatically enabled due to playercount rising above Server Capacity [threshold]")
 
 /client/proc/is_connecting_from_localhost()
 	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -190,6 +190,9 @@ GUEST_JOBBAN
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
 GUEST_BAN
 
+## above this player count threshold, never-before-seen players are blocked from connecting
+PANIC_BUNKER_THRESHOLD 150
+
 ### IPINTEL:
 ### This allows you to detect likely proxies by checking ips against getipintel.net
 ## Rating to warn at: (0.90 is good, 1 is 100% likely to be a spammer/proxy, 0.8 is 80%, etc) anything equal to or higher then this number triggers an admin warning


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Updates auto panic bunker code.
* Make the threshold at which it turns on (currently 150) into a config setting (`panic_bunker_threshold`).
* Make it automatically turn off again if player count goes below the threshold while it is on.
* When a player is blocked by it, give them the message "Server is not accepting connections from never-before-seen players until player count is less than (number)".
* When a player is blocked by it, don't display a message to admins.

The text above is paraphrased from [Kyet's Changes Wanted](https://www.paradisestation.org/forum/topic/18118-kyets-changes-wanted/)

* Admin verb to control panic bunker state is removed; adjust the configuration value and rely on automation instead.
(Edited: Kyet's request did not specify removing the verb. I have moved it below the attribution to make it clear that this was an informative point about the changes in PR, not a part of the original request specification.)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Panic bunker is automated and configurable. That's a good thing, right?

## Changelog
:cl:
add: panic_bunker_threshold configuration value added
add: Panic bunker will activate/deactivate automatically based on player count
del: Removed Admin verb to manually control panic bunker
del: Removed message to admins for users blocked by panic bunker.
tweak: Changed message sent to never-before-seen users blocked by panic bunker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
