### PR TITLE
[WIP] Removes all tool references from attackbys & other places; barsign fixes

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -244,12 +244,12 @@
 		broadcast_status()
 	update_icon()
 
-/obj/machinery/atmospherics/binary/dp_vent_pump/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
+/obj/machinery/atmospherics/binary/dp_vent_pump/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
-	return ..()
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/multitool_menu(var/mob/user,var/obj/item/multitool/P)
 	return {"

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -142,11 +142,11 @@
 				if(open)
 					close()
 
-/obj/machinery/atmospherics/binary/valve/digital/attackby(var/obj/item/W as obj, var/mob/user)
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	return ..()
+/obj/machinery/atmospherics/binary/valve/digital/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
 /obj/machinery/atmospherics/binary/valve/digital/multitool_menu(var/mob/user,var/obj/item/multitool/P)
 	return {"

--- a/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
@@ -176,15 +176,18 @@
 	</ul>
 "}
 
-/obj/machinery/atmospherics/unary/outlet_injector/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/multitool))
-		interact(user)
-		return 1
-	if(istype(W, /obj/item/wrench))
-		if(!(stat & NOPOWER) && on)
-			to_chat(user, "<span class='danger'>You cannot unwrench this [src], turn if off first.</span>")
-			return 1
+/obj/machinery/atmospherics/unary/outlet_injector/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	interact(user)
+
+/obj/machinery/atmospherics/unary/outlet_injector/wrench_act(mob/user, obj/item/I)
+	if(!(stat & NOPOWER) && on)
+		to_chat(user, "<span class='danger'>You cannot unwrench this [src], turn it off first.</span>")
+		return TRUE
 	return ..()
+
 
 /obj/machinery/atmospherics/unary/outlet_injector/interact(mob/user as mob)
 	update_multitool_menu(user)

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -344,21 +344,6 @@
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 100, TRUE)
 
 /obj/machinery/atmospherics/unary/vent_pump/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/screwdriver))
-		if(!welded)
-			if(open)
-				to_chat(user, "<span class='notice'>Now closing the vent.</span>")
-				if(do_after(user, 20 * W.toolspeed, target = src))
-					playsound(loc, W.usesound, 100, 1)
-					open = 0
-					user.visible_message("[user] screwdrivers the vent shut.", "You screwdriver the vent shut.", "You hear a screwdriver.")
-			else
-				to_chat(user, "<span class='notice'>Now opening the vent.</span>")
-				if(do_after(user, 20 * W.toolspeed, target = src))
-					playsound(loc, W.usesound, 100, 1)
-					open = 1
-					user.visible_message("[user] screwdrivers the vent open.", "You screwdriver the vent open.", "You hear a screwdriver.")
-		return
 	if(istype(W, /obj/item/paper))
 		if(!welded)
 			if(open)
@@ -369,15 +354,33 @@
 		else
 			to_chat(user, "The vent is welded.")
 		return 1
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	if(istype(W, /obj/item/wrench))
-		if(!(stat & NOPOWER) && on)
-			to_chat(user, "<span class='danger'>You cannot unwrench this [src], turn it off first.</span>")
-			return 1
+	else
+		return ..()
 
+/obj/machinery/atmospherics/unary/vent_pump/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!(stat & NOPOWER) && on)
+		to_chat(user, "<span class='danger'>You cannot unwrench this [src], turn it off first.</span>")
+		return
 	return ..()
+
+/obj/machinery/atmospherics/unary/vent_pump/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	update_multitool_menu(user)
+
+/obj/machinery/atmospherics/unary/vent_pump/screwdriver_act(mob/user, obj/item/I)
+	if(welded)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	to_chat(user, "<span class='notice'>Now [open ? "closing" : "opening"] [src].</span>")
+	if(!I.use_tool(src, user, 20, volume = I.tool_volume) || welded)
+		return
+	open = !open
+	user.visible_message("[user] screwdrivers [src] [open ? "open" : "shut"].", "You screwdriver [src] [open ? "open" : "shut"].", "You hear a screwdriver.")
 
 /obj/machinery/atmospherics/unary/vent_pump/welder_act(mob/user, obj/item/I)
 	. = TRUE
@@ -394,7 +397,6 @@
 			visible_message("<span class='notice'>[user] unwelds [src]!</span>",\
 				"<span class='notice'>You unweld [src]!</span>")
 		update_icon()
-
 
 /obj/machinery/atmospherics/unary/vent_pump/attack_hand()
 	if(!welded)

--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -392,15 +392,16 @@
 	pipe_image.plane = ABOVE_HUD_PLANE
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 100, TRUE)
 
-/obj/machinery/atmospherics/unary/vent_scrubber/attackby(var/obj/item/W as obj, var/mob/user as mob, params)
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	if(istype(W, /obj/item/wrench))
-		if(!(stat & NOPOWER) && on)
-			to_chat(user, "<span class='danger'>You cannot unwrench this [src], turn it off first.</span>")
-			return 1
+/obj/machinery/atmospherics/unary/vent_scrubber/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
+/obj/machinery/atmospherics/unary/vent_scrubber/wrench_act(mob/user, obj/item/I)
+	if(!(stat & NOPOWER) && on)
+		to_chat(user, "<span class='danger'>You cannot unwrench this [src], turn it off first.</span>")
+		return TRUE
 	return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/welder_act(mob/user, obj/item/I)

--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -36,8 +36,10 @@
 #define WELDER_FLOOR_WELD_SUCCESS_MESSAGE	to_chat(user, "<span class='notice'>You weld [src] to [get_turf(src)]!</span>")
 
 //Wrench messages
-#define WRENCH_ANCHOR_MESSAGE				user.visible_message("<span class='notice'>[user] tightens the bolts on [src]!</span>", "<span class='notice'>You tighten the bolts on [src]!</span>", "<span class='warning'>You hear ratcheting.</span>")
-#define WRENCH_UNANCHOR_MESSAGE				user.visible_message("<span class='notice'>[user] loosens the bolts on [src]!</span>", "<span class='notice'>You loosen the bolts on [src]!</span>", "<span class='warning'>You hear ratcheting.</span>")
+#define WRENCH_ATTEMPT_ANCHOR_MESSAGE		user.visible_message("<span class='notice'>[user] begins tightening the bolts on [src]...</span>", "<span class='notice'>You begin to tighten the bolts on [src]...</span>", "<span class='warning'>You hear ratcheting.</span>")
+#define WRENCH_ANCHOR_SUCCESS_MESSAGE		user.visible_message("<span class='notice'>[user] tightens the bolts on [src]!</span>", "<span class='notice'>You tighten the bolts on [src]!</span>", "<span class='warning'>You hear ratcheting.</span>")
+#define WRENCH_ATTEMPT_UNANCHOR_MESSAGE		user.visible_message("<span class='notice'>[user] begins loosening the bolts on [src]...</span>", "<span class='notice'>You begin to loosen the bolts on [src]...</span>", "<span class='warning'>You hear ratcheting.</span>")
+#define WRENCH_UNANCHOR_SUCCESS_MESSAGE		user.visible_message("<span class='notice'>[user] loosens the bolts on [src]!</span>", "<span class='notice'>You loosen the bolts on [src]!</span>", "<span class='warning'>You hear ratcheting.</span>")
 #define WRENCH_UNANCHOR_WALL_MESSAGE		user.visible_message("<span class='notice'>[user] unwrenches [src] from the wall!</span>", "<span class='notice'>You unwrench [src] from the wall!</span>", "<span class='warning'>You hear ratcheting.</span>")
 #define WRENCH_ANCHOR_TO_WALL_MESSAGE		user.visible_message("<span class='notice'>[user] affixes [src] to the wall!</span>", "<span class='notice'>You affix [src] to the wall!</span>", "<span class='warning'>You hear ratcheting.</span>")
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -58,7 +58,7 @@
 				else
 					return 1
 		var/obj/item/organ/external/O = M.get_organ(user.zone_selected)
-		if((is_sharp(src) || (isscrewdriver(src) && O.is_robotic())) && user.a_intent == INTENT_HELP)
+		if((is_sharp(src) || (tool_behaviour == TOOL_SCREWDRIVER && O.is_robotic())) && user.a_intent == INTENT_HELP)
 			if(!attempt_initiate_surgery(src, M, user))
 				return FALSE
 			else

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -148,15 +148,12 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 		holder.add_hiddenprint(L)
 		switch(href_list["action"])
 			if("cut") // Toggles the cut/mend status
-				if(istype(I, /obj/item/wirecutters) || L.can_admin_interact())
-					if(istype(I))
-						playsound(holder, I.usesound, 20, 1)
+				if((I.tool_behaviour == TOOL_WIRECUTTER && I.use_tool(src, user, 0, volume = I.tool_volume)) || L.can_admin_interact())
 					CutWireColour(colour)
 				else
 					to_chat(L, "<span class='error'>You need wirecutters!</span>")
 			if("pulse")
-				if(istype(I, /obj/item/multitool) || L.can_admin_interact())
-					playsound(holder, 'sound/weapons/empty.ogg', 20, 1)
+				if((I.tool_behaviour == TOOL_MULTITOOL && I.use_tool(src, user, 0, volume = I.tool_volume)) || L.can_admin_interact())
 					PulseColour(colour)
 				else
 					to_chat(L, "<span class='error'>You need a multitool!</span>")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -355,12 +355,6 @@
 /atom/proc/multitool_act(mob/living/user, obj/item/I)
 	return
 
-//Check if the multitool has an item in its data buffer
-/atom/proc/multitool_check_buffer(user, silent = FALSE)
-	if(!silent)
-		to_chat(user, "<span class='warning'>[src] has no data buffer!</span>")
-	return FALSE
-
 /atom/proc/screwdriver_act(mob/living/user, obj/item/I)
 	return
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -67,23 +67,25 @@
 			visible_message("You hear a quite click as the [src]'s floor bolts raise", "You hear a quite click")
 		return TRUE
 
-/obj/machinery/air_sensor/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	if(istype(W, /obj/item/wrench))
-		if(bolts)
-			to_chat(usr, "The [src] is bolted to the floor! You can't detach it like this.")
-			return 1
-		playsound(loc, W.usesound, 50, 1)
-		to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
-		if(do_after(user, 40 * W.toolspeed, target = src))
-			user.visible_message("[user] unfastens \the [src].", "<span class='notice'>You have unfastened \the [src].</span>", "You hear ratchet.")
-			new /obj/item/pipe_gsensor(src.loc)
-			qdel(src)
-			return 1
+/obj/machinery/air_sensor/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(bolts)
+		to_chat(user, "[src] is bolted to the floor! You can't detach it like this.")
 		return
-	return ..()
+	if(!I.tool_use_check(user, 0))
+		return
+	WRENCH_ATTEMPT_UNANCHOR_MESSAGE
+	if(!I.use_tool(src, user, 40, volume = I.tool_volume))
+		return
+	WRENCH_UNANCHOR_SUCCESS_MESSAGE
+	new /obj/item/pipe_gsensor(loc)
+	qdel(src)
+
+/obj/machinery/air_sensor/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
 /obj/machinery/air_sensor/process_atmos()
 	if(on)
@@ -179,12 +181,11 @@
 		sensors = list()
 	src.updateUsrDialog()
 
-/obj/machinery/computer/general_air_control/attackby(I as obj, user as mob, params)
-	if(istype(I, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	return ..()
-
+/obj/machinery/computer/general_air_control/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
 /obj/machinery/computer/general_air_control/receive_signal(datum/signal/signal)
 	if(!signal || signal.encryption) return
@@ -383,12 +384,11 @@
 
 	var/pressure_setting = ONE_ATMOSPHERE * 45
 
-/obj/machinery/computer/general_air_control/large_tank_control/attackby(I as obj, user as mob)
-	if(istype(I, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	return ..()
-
+/obj/machinery/computer/general_air_control/large_tank_control/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
 /obj/machinery/computer/general_air_control/large_tank_control/multitool_menu(mob/user, obj/item/multitool/P)
 	var/dat= {"
@@ -595,11 +595,11 @@
 	var/cutoff_temperature = 2000
 	var/on_temperature = 1200
 
-/obj/machinery/computer/general_air_control/fuel_injection/attackby(I as obj, user as mob, params)
-	if(istype(I, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	return ..()
+/obj/machinery/computer/general_air_control/fuel_injection/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
 /obj/machinery/computer/general_air_control/fuel_injection/process()
 	if(automation)

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -123,21 +123,21 @@
 
 	return ..()
 
-/obj/machinery/meter/attackby(var/obj/item/W as obj, var/mob/user as mob, params)
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
+/obj/machinery/meter/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
-	if(!istype(W, /obj/item/wrench))
-		return ..()
-	playsound(loc, W.usesound, 50, 1)
-	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
-	if(do_after(user, 40 * W.toolspeed, target = src))
-		user.visible_message( \
-			"[user] unfastens \the [src].", \
-			"<span class='notice'>You have unfastened \the [src].</span>", \
-			"You hear ratchet.")
-		deconstruct(TRUE)
+/obj/machinery/meter/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	WRENCH_ATTEMPT_UNANCHOR_MESSAGE
+	if(!I.use_tool(src, user, 40, volume = I.tool_volume))
+		return
+	WRENCH_UNANCHOR_SUCCESS_MESSAGE
+	deconstruct(TRUE)
 
 /obj/machinery/meter/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -66,23 +66,26 @@
 		return attack_hand(user)
 
 /obj/machinery/driver_button/attackby(obj/item/W, mob/user as mob, params)
+	if(!istype(W, /obj/item/detective_scanner))
+		return ..()
 
-	if(istype(W, /obj/item/detective_scanner))
+
+/obj/machinery/driver_button/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
 		return
+	WRENCH_ATTEMPT_UNANCHOR_MESSAGE
+	if(!I.use_tool(src, user, 30, volume = I.tool_volume))
+		return
+	WRENCH_UNANCHOR_WALL_MESSAGE
+	new/obj/item/mounted/frame/driver_button(get_turf(src))
+	qdel(src)
 
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-
-	if(istype(W, /obj/item/wrench))
-		playsound(get_turf(src), W.usesound, 50, 1)
-		if(do_after(user, 30 * W.toolspeed, target = src))
-			to_chat(user, "<span class='notice'>You detach \the [src] from the wall.</span>")
-			new/obj/item/mounted/frame/driver_button(get_turf(src))
-			qdel(src)
-		return 1
-
-	return ..()
+/obj/machinery/driver_button/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	update_multitool_menu(user)
 
 /obj/machinery/driver_button/multitool_menu(var/mob/user, var/obj/item/multitool/P)
 	return {"

--- a/code/game/machinery/chiller.dm
+++ b/code/game/machinery/chiller.dm
@@ -58,15 +58,19 @@
 		else
 			to_chat(user, "The hatch must be open to insert a power cell.")
 			return
-	else if(istype(I, /obj/item/screwdriver))
-		open = !open
-		user.visible_message("<span class='notice'>[user] [open ? "opens" : "closes"] the hatch on the [src].</span>", "<span class='notice'>You [open ? "open" : "close"] the hatch on the [src].</span>")
-		update_icon()
-		if(!open && user.machine == src)
-			user << browse(null, "window=aircond")
-			user.unset_machine()
 	else
 		return ..()
+
+/obj/machinery/space_heater/air_conditioner/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	open = !open
+	user.visible_message("<span class='notice'>[user] [open ? "opens" : "closes"] the hatch on [src].</span>", "<span class='notice'>You [open ? "open" : "close"] the hatch on [src].</span>")
+	update_icon()
+	if(!open && user.machine == src)
+		user << browse(null, "window=aircond")
+		user.unset_machine()
 
 /obj/machinery/space_heater/air_conditioner/attack_hand(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -398,10 +398,7 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(!I.multitool_check_buffer(user))
-		return
-	var/obj/item/multitool/M = I
-	M.set_multitool_buffer(user, src)
+	I.set_multitool_buffer(user, src)
 
 /obj/machinery/clonepod/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -10,16 +10,19 @@
 
 	light_color = LIGHT_COLOR_PURPLE
 
-/obj/machinery/computer/aifixer/attackby(I as obj, user as mob, params)
-	if(occupant && istype(I, /obj/item/screwdriver))
-		if(stat & BROKEN)
-			..()
-		if(stat & NOPOWER)
-			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge.</span>")
-		else
-			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge and it emits a warning beep!.</span>")
+/obj/machinery/computer/aifixer/screwdriver_act(mob/user, obj/item/I)
+	if(!occupant)
+		return
+	if(!(stat & BROKEN))
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(stat & NOPOWER)
+		to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge.</span>")
 	else
-		return ..()
+		to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge and it emits a warning beep!.</span>")
+
 
 /obj/machinery/computer/aifixer/attack_ai(var/mob/user as mob)
 	ui_interact(user)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -7,6 +7,7 @@
 	max_integrity = 100
 	var/state = 0
 	var/obj/item/circuitboard/circuit = null
+	var/allowed_board = "computer"
 	var/base_mineral = /obj/item/stack/sheet/metal
 
 /obj/structure/computerframe/deconstruct(disassembled = TRUE)
@@ -446,22 +447,7 @@
 
 /obj/structure/computerframe/attackby(obj/item/P as obj, mob/user as mob, params)
 	switch(state)
-		if(0)
-			if(istype(P, /obj/item/wrench))
-				playsound(loc, P.usesound, 50, 1)
-				if(do_after(user, 20 * P.toolspeed, target = src))
-					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
-					anchored = 1
-					state = 1
-				return
 		if(1)
-			if(istype(P, /obj/item/wrench))
-				playsound(loc, P.usesound, 50, 1)
-				if(do_after(user, 20 * P.toolspeed, target = src))
-					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
-					anchored = 0
-					state = 0
-				return
 			if(istype(P, /obj/item/circuitboard) && !circuit)
 				var/obj/item/circuitboard/B = P
 				if(B.board_type == "computer")
@@ -474,27 +460,7 @@
 				else
 					to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 				return
-			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
-				state = 2
-				icon_state = "2"
-				return
-			if(istype(P, /obj/item/crowbar) && circuit)
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You remove the circuit board.</span>")
-				state = 1
-				icon_state = "0"
-				circuit.loc = loc
-				circuit = null
-				return
 		if(2)
-			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
-				state = 1
-				icon_state = "1"
-				return
 			if(istype(P, /obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/C = P
 				if(C.amount >= 5)
@@ -512,14 +478,6 @@
 					to_chat(user, "<span class='warning'>You need five lengths of cable to wire the frame.</span>")
 				return
 		if(3)
-			if(istype(P, /obj/item/wirecutters))
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You remove the cables.</span>")
-				state = 2
-				icon_state = "2"
-				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
-				A.amount = 5
-				return
 			if(istype(P, /obj/item/stack/sheet/glass))
 				var/obj/item/stack/sheet/glass/G = P
 				if(G.amount >= 2)
@@ -536,31 +494,68 @@
 				else
 					to_chat(user, "<span class='warning'>You need two sheets of glass for this.</span>")
 				return
-		if(4)
-			if(istype(P, /obj/item/crowbar))
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
-				state = 3
-				icon_state = "3"
-				new /obj/item/stack/sheet/glass(loc, 2)
-				return
-			if(istype(P, /obj/item/screwdriver))
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
-				var/B = new circuit.build_path (loc)
-				if(circuit.powernet) B:powernet = circuit.powernet
-				if(circuit.id) B:id = circuit.id
-				if(circuit.records) B:records = circuit.records
-				if(circuit.frequency) B:frequency = circuit.frequency
-				if(istype(circuit,/obj/item/circuitboard/supplycomp))
-					var/obj/machinery/computer/supplycomp/SC = B
-					var/obj/item/circuitboard/supplycomp/C = circuit
-					SC.can_order_contraband = C.contraband_enabled
-				qdel(src)
-				return
 	if(user.a_intent == INTENT_HARM)
 		return ..()
 
+/obj/structure/computerframe/crowbar_act(mob/user, obj/item/I)
+	if(!(state == 1 && circuit) && state != 4)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(state == 1)
+		CROWBAR_PRY_CIRCUIT_SUCCESS_MESSAGE
+		state = 1
+		icon_state = "0"
+		circuit.loc = loc
+		circuit = null
+	else
+		to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
+		state = 3
+		icon_state = "3"
+		new /obj/item/stack/sheet/glass(loc, 2)
+
+/obj/structure/computerframe/screwdriver_act(mob/user, obj/item/I)
+	if(!(state in list(1, 2, 4)))
+		return
+	. = TRUE
+	if(!circuit)
+		to_chat(user, "<span class='warning'>[src] requires a circuitboard to function!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	switch(state)
+		if(1)
+			to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
+			state = 2
+			icon_state = "2"
+		if(2)
+			to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
+			state = 1
+			icon_state = "1"
+		if(4)
+			to_chat(user, "<span class='notice'>You connect the monitor.</span>")
+			var/B = new circuit.build_path (loc)
+			if(circuit.powernet) B:powernet = circuit.powernet
+			if(circuit.id) B:id = circuit.id
+			if(circuit.records) B:records = circuit.records
+			if(circuit.frequency) B:frequency = circuit.frequency
+			if(istype(circuit,/obj/item/circuitboard/supplycomp))
+				var/obj/machinery/computer/supplycomp/SC = B
+				var/obj/item/circuitboard/supplycomp/C = circuit
+				SC.can_order_contraband = C.contraband_enabled
+			qdel(src)
+
+/obj/structure/computerframe/wirecutter_act(mob/user, obj/item/I)
+	if(state != 3)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	WIRECUTTER_SNIP_MESSAGE
+	state = 2
+	icon_state = "2"
+	var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
+	A.amount = 5
 
 /obj/structure/computerframe/welder_act(mob/user, obj/item/I)
 	if(state)
@@ -574,114 +569,29 @@
 		deconstruct(TRUE)
 
 
+/obj/structure/computerframe/wrench_act(mob/user, obj/item/I)
+	if(state != 0 && state != 1)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	if(state == 1)
+		WRENCH_ATTEMPT_UNANCHOR_MESSAGE
+		if(!I.use_tool(src, user, 20, volume = I.tool_volume) || state != 1)
+			return
+		WRENCH_UNANCHOR_SUCCESS_MESSAGE
+		anchored == FALSE
+		state = 0
+	else
+		WRENCH_ATTEMPT_ANCHOR_MESSAGE
+		if(!I.use_tool(src, user, 20, volume = I.tool_volume) || state != 0)
+			return
+		WRENCH_ANCHOR_SUCCESS_MESSAGE
+		anchored == TRUE
+		state = 1
 
 /obj/structure/computerframe/HONKputer
 	name = "Bananium Computer-frame"
 	icon = 'icons/obj/machines/HONKputer.dmi'
+	allowed_board = "honkcomputer"
 	base_mineral = /obj/item/stack/sheet/mineral/bananium
-
-/obj/structure/computerframe/HONKputer/attackby(obj/item/P as obj, mob/user as mob, params)
-	switch(state)
-		if(0)
-			if(istype(P, /obj/item/wrench))
-				playsound(loc, P.usesound, 50, 1)
-				if(do_after(user, 20, target = src))
-					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
-					anchored = 1
-					state = 1
-		if(1)
-			if(istype(P, /obj/item/wrench))
-				playsound(loc, P.usesound, 50, 1)
-				if(do_after(user, 20 * P.toolspeed, target = src))
-					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
-					anchored = 0
-					state = 0
-			if(istype(P, /obj/item/circuitboard) && !circuit)
-				var/obj/item/circuitboard/B = P
-				if(B.board_type == "honkcomputer")
-					playsound(loc, P.usesound, 50, 1)
-					to_chat(user, "<span class='notice'>You place the circuit board inside the frame.</span>")
-					icon_state = "1"
-					circuit = P
-					user.drop_item()
-					P.loc = src
-				else
-					to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
-			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
-				state = 2
-				icon_state = "2"
-			if(istype(P, /obj/item/crowbar) && circuit)
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You remove the circuit board.</span>")
-				state = 1
-				icon_state = "0"
-				circuit.loc = loc
-				circuit = null
-			return
-		if(2)
-			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
-				state = 1
-				icon_state = "1"
-			if(istype(P, /obj/item/stack/cable_coil))
-				var/obj/item/stack/cable_coil/C = P
-				if(C.amount >= 5)
-					playsound(loc, C.usesound, 50, 1)
-					to_chat(user, "<span class='notice'>You start to add cables to the frame.</span>")
-					if(do_after(user, 20 * C.toolspeed, target = src))
-						if(state == 2 && C.amount >= 5 && C.use(5))
-							to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
-							state = 3
-							icon_state = "3"
-						else
-							to_chat(user, "<span class='warning'>At some point during construction you lost some cable. Make sure you have five lengths before trying again.</span>")
-							return
-				else
-					to_chat(user, "<span class='warning'>You need five lengths of cable to wire the frame.</span>")
-			return
-		if(3)
-			if(istype(P, /obj/item/wirecutters))
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You remove the cables.</span>")
-				state = 2
-				icon_state = "2"
-				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
-				A.amount = 5
-
-			if(istype(P, /obj/item/stack/sheet/glass))
-				var/obj/item/stack/sheet/glass/G = P
-				if(G.amount >= 2)
-					playsound(loc, G.usesound, 50, 1)
-					to_chat(user, "<span class='notice'>You start to add the glass panel to the frame.</span>")
-					if(do_after(user, 20 * G.toolspeed, target = src))
-						if(state == 3 && G.amount >= 2 && G.use(2))
-							to_chat(user, "<span class='notice'>You put in the glass panel.</span>")
-							state = 4
-							icon_state = "4"
-						else
-							to_chat(user, "<span class='warning'>At some point during construction you lost some glass. Make sure you have two sheets before trying again.</span>")
-							return
-				else
-					to_chat(user, "<span class='warning'>You need two sheets of glass for this.</span>")
-			return
-		if(4)
-			if(istype(P, /obj/item/crowbar))
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
-				state = 3
-				icon_state = "3"
-				new /obj/item/stack/sheet/glass(loc, 2)
-			if(istype(P, /obj/item/screwdriver))
-				playsound(loc, P.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
-				var/B = new circuit.build_path (loc)
-				if(circuit.powernet) B:powernet = circuit.powernet
-				if(circuit.id) B:id = circuit.id
-				if(circuit.records) B:records = circuit.records
-				if(circuit.frequency) B:frequency = circuit.frequency
-				qdel(src)
-			return
-	return ..()

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -386,29 +386,28 @@
 	icon_state = "bananium_board"
 	board_type = "honkcomputer"
 
-
-/obj/item/circuitboard/supplycomp/attackby(obj/item/I as obj, mob/user as mob, params)
-	if(istype(I,/obj/item/multitool))
-		var/catastasis = contraband_enabled
-		var/opposite_catastasis
-		if(catastasis)
-			opposite_catastasis = "STANDARD"
-			catastasis = "BROAD"
-		else
-			opposite_catastasis = "BROAD"
-			catastasis = "STANDARD"
-
-		switch( alert("Current receiver spectrum is set to: [catastasis]","Multitool-Circuitboard interface","Switch to [opposite_catastasis]","Cancel") )
-		//switch( alert("Current receiver spectrum is set to: " {(contraband_enabled) ? ("BROAD") : ("STANDARD")} , "Multitool-Circuitboard interface" , "Switch to " {(contraband_enabled) ? ("STANDARD") : ("BROAD")}, "Cancel") )
-			if("Switch to STANDARD","Switch to BROAD")
-				contraband_enabled = !contraband_enabled
-
-			if("Cancel")
-				return
-			else
-				to_chat(user, "DERP! BUG! Report this (And what you were doing to cause it) to Agouri")
+/obj/item/circuitboard/supplycomp/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	return ..()
+	var/catastasis = contraband_enabled
+	var/opposite_catastasis
+	if(catastasis)
+		opposite_catastasis = "STANDARD"
+		catastasis = "BROAD"
+	else
+		opposite_catastasis = "BROAD"
+		catastasis = "STANDARD"
+
+	switch( alert("Current receiver spectrum is set to: [catastasis]","Multitool-Circuitboard interface","Switch to [opposite_catastasis]","Cancel") )
+	//switch( alert("Current receiver spectrum is set to: " {(contraband_enabled) ? ("BROAD") : ("STANDARD")} , "Multitool-Circuitboard interface" , "Switch to " {(contraband_enabled) ? ("STANDARD") : ("BROAD")}, "Cancel") )
+		if("Switch to STANDARD","Switch to BROAD")
+			contraband_enabled = !contraband_enabled
+
+		if("Cancel")
+			return
+		else
+			to_chat(user, "DERP! BUG! Report this (And what you were doing to cause it) to Agouri")
 
 /obj/item/circuitboard/rdconsole/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(istype(I,/obj/item/card/id)||istype(I, /obj/item/pda))

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -93,17 +93,20 @@
 			to_chat(user, "You insert [W].")
 			SSnanoui.update_uis(src)
 			return
-	else if(istype(W, /obj/item/multitool))
-		var/obj/item/multitool/M = W
-		if(M.buffer && istype(M.buffer, /obj/machinery/clonepod))
-			var/obj/machinery/clonepod/P = M.buffer
-			if(P && !(P in pods))
-				pods += P
-				P.connected = src
-				P.name = "[initial(P.name)] #[pods.len]"
-				to_chat(user, "<span class='notice'>You connect [P] to [src].</span>")
 	else
 		return ..()
+
+/obj/machinery/computer/cloning/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(I.buffer && istype(I.buffer, /obj/machinery/clonepod))
+		var/obj/machinery/clonepod/P = I.buffer
+		if(P && !(P in pods))
+			pods += P
+			P.connected = src
+			P.name = "[initial(P.name)] #[pods.len]"
+			to_chat(user, "<span class='notice'>You connect [P] to [src].</span>")
 
 
 /obj/machinery/computer/cloning/attack_ai(mob/user as mob)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -11,6 +11,7 @@
 	integrity_failure = 100
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 20)
 	var/obj/item/circuitboard/circuit = null //if circuit==null, computer can't disassembly
+	var/obj/structure/computerframe/deconstructs_to = /obj/structure/computerframe
 	var/processing = 0
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
@@ -92,7 +93,7 @@
 	on_deconstruction()
 	if(!(flags & NODECONSTRUCT))
 		if(circuit) //no circuit, no computer frame
-			var/obj/structure/computerframe/A = new /obj/structure/computerframe(loc)
+			var/obj/structure/computerframe/A = new deconstructs_to(loc)
 			var/obj/item/circuitboard/M = new circuit(A)
 			A.setDir(dir)
 			A.circuit = M

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -12,6 +12,7 @@
 	var/message_cooldown = 0
 	var/state = STATE_DEFAULT
 	var/const/STATE_DEFAULT = 1
+	deconstructs_to = /obj/structure/computerframe/HONKputer
 
 /obj/machinery/computer/HONKputer/process()
 	if(..())
@@ -91,28 +92,3 @@
 	dat += "<BR>\[ [(src.state != STATE_DEFAULT) ? "<A HREF='?src=[UID()];operation=main'>Main Menu</A> | " : ""]<A HREF='?src=[user.UID()];mach_close=honkputer'>Close</A> \]"
 	user << browse(dat, "window=honkputer;size=400x500")
 	onclose(user, "honkputer")
-
-
-/obj/machinery/computer/HONKputer/attackby(obj/I, mob/user, params)
-	if(istype(I, /obj/item/screwdriver) && circuit)
-		var/obj/item/screwdriver/S = I
-		playsound(src.loc, S.usesound, 50, 1)
-		if(do_after(user, 20 * S.toolspeed, target = src))
-			var/obj/structure/computerframe/HONKputer/A = new /obj/structure/computerframe/HONKputer( src.loc )
-			var/obj/item/circuitboard/M = new circuit( A )
-			A.circuit = M
-			A.anchored = 1
-			for(var/obj/C in src)
-				C.loc = src.loc
-			if(src.stat & BROKEN)
-				to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-				new /obj/item/shard( src.loc )
-				A.state = 3
-				A.icon_state = "3"
-			else
-				to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-				A.state = 4
-				A.icon_state = "4"
-			qdel(src)
-	else
-		return ..()

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -90,46 +90,36 @@
 		set_light(brightness_on)
 		updateicon()
 
+/obj/machinery/floodlight/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I, 0)
+
+/obj/machinery/floodlight/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(open)
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	unlocked = !unlocked
+	to_chat(user, "You [unlocked ? "unscrew": "secure"] the battery panel.")
+	updateicon()
+
+/obj/machinery/floodlight/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!unlocked)
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(open)
+		open = FALSE
+		overlays = null
+		to_chat(user, "You crowbar the battery panel in place.")
+	else
+		open = TRUE
+		to_chat(user, "You remove the battery panel.")
+	updateicon()
+
 /obj/machinery/floodlight/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/wrench))
-		if(!anchored && !isinspace())
-			playsound(loc, W.usesound, 50, 1)
-			user.visible_message( \
-				"[user] tightens \the [src]'s casters.", \
-				"<span class='notice'> You have tightened \the [src]'s casters.</span>", \
-				"You hear ratchet.")
-			anchored = TRUE
-		else if(anchored)
-			playsound(loc, W.usesound, 50, 1)
-			user.visible_message( \
-				"[user] loosens \the [src]'s casters.", \
-				"<span class='notice'> You have loosened \the [src]'s casters.</span>", \
-				"You hear ratchet.")
-			anchored = FALSE
-		updateicon()
-		return
-	if(istype(W, /obj/item/screwdriver))
-		if(!open)
-			if(unlocked)
-				unlocked = FALSE
-				to_chat(user, "You screw the battery panel in place.")
-			else
-				unlocked = TRUE
-				to_chat(user, "You unscrew the battery panel.")
-		updateicon()
-		return
-	if(istype(W, /obj/item/crowbar))
-		if(unlocked)
-			if(open)
-				open = FALSE
-				overlays = null
-				to_chat(user, "You crowbar the battery panel in place.")
-			else
-				if(unlocked)
-					open = TRUE
-					to_chat(user, "You remove the battery panel.")
-		updateicon()
-		return
 	if(istype(W, /obj/item/stock_parts/cell))
 		if(open)
 			if(cell)
@@ -140,8 +130,8 @@
 				cell = W
 				to_chat(user, "You insert the power cell.")
 		updateicon()
-		return
-	return ..()
+	else
+		return ..()
 
 /obj/machinery/floodlight/extinguish_light()
 	on = 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -399,17 +399,16 @@ Class Procs:
 	if(!(flags & NODECONSTRUCT))
 		stat |= BROKEN
 
-/obj/machinery/proc/default_deconstruction_crowbar(user, obj/item/I, ignore_panel = 0)
+/obj/machinery/proc/default_deconstruction_crowbar(mob/user, obj/item/I, ignore_panel = 0)
 	if(I.tool_behaviour != TOOL_CROWBAR)
 		return FALSE
-	if(!I.use_tool(src, user, 0, volume = 0))
+	if(!(panel_open || ignore_panel) || (flags & NODECONSTRUCT))
 		return FALSE
-	if((panel_open || ignore_panel) && !(flags & NODECONSTRUCT))
-		deconstruct(TRUE)
-		to_chat(user, "<span class='notice'>You disassemble [src].</span>")
-		I.play_tool_sound(user, I.tool_volume)
-		return 1
-	return 0
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return FALSE
+	deconstruct(TRUE)
+	to_chat(user, "<span class='notice'>You disassemble [src].</span>")
+	return TRUE
 
 /obj/machinery/proc/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
 	if(I.tool_behaviour != TOOL_SCREWDRIVER)

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -14,25 +14,26 @@
 	settagwhitelist = list("id_tag")
 	var/drive_range = 50 //this is mostly irrelevant since current mass drivers throw into space, but you could make a lower-range mass driver for interstation transport or something I guess.
 
-/obj/machinery/mass_driver/attackby(obj/item/W, mob/user as mob)
+/obj/machinery/mass_driver/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	update_multitool_menu(user)
 
-	if(istype(W, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-
-	if(istype(W, /obj/item/screwdriver))
-		to_chat(user, "You begin to unscrew the bolts off the [src]...")
-		playsound(get_turf(src), W.usesound, 50, 1)
-		if(do_after(user, 30 * W.toolspeed, target = src))
-			var/obj/machinery/mass_driver_frame/F = new(get_turf(src))
-			F.dir = src.dir
-			F.anchored = 1
-			F.build = 4
-			F.update_icon()
-			qdel(src)
-		return 1
-
-	return ..()
+/obj/machinery/mass_driver/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	to_chat(user, "You begin to unscrew the bolts off the [src]...")
+	if(!I.use_tool(src, user, 30, volume = I.tool_volume))
+		return
+	to_chat(user, "You screw the bolts off [src]!")
+	var/obj/machinery/mass_driver_frame/F = new(get_turf(src))
+	F.dir = src.dir
+	F.anchored = 1
+	F.build = 4
+	F.update_icon()
+	qdel(src)
 
 /obj/machinery/mass_driver/multitool_menu(var/mob/user, var/obj/item/multitool/P)
 	return {"
@@ -100,27 +101,6 @@
 
 /obj/machinery/mass_driver_frame/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	switch(build)
-		if(0) // Loose frame
-			if(istype(W, /obj/item/wrench))
-				to_chat(user, "You begin to anchor \the [src] on the floor.")
-				playsound(get_turf(src), W.usesound, 50, 1)
-				if(do_after(user, 10 * W.toolspeed, target = src) && (build == 0))
-					to_chat(user, "<span class='notice'>You anchor \the [src]!</span>")
-					anchored = 1
-					build++
-					update_icon()
-				return 1
-			return
-		if(1) // Fixed to the floor
-			if(istype(W, /obj/item/wrench))
-				to_chat(user, "You begin to de-anchor \the [src] from the floor.")
-				playsound(get_turf(src), W.usesound, 50, 1)
-				if(do_after(user, 10 * W.toolspeed, target = src) && (build == 1))
-					build--
-					update_icon()
-					anchored = 0
-					to_chat(user, "<span class='notice'>You de-anchored \the [src]!</span>")
-				return 1
 		if(2) // Welded to the floor
 			if(istype(W, /obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/C = W
@@ -133,15 +113,6 @@
 					update_icon()
 			return
 		if(3) // Wired
-			if(istype(W, /obj/item/wirecutters))
-				to_chat(user, "You begin to remove the wiring from \the [src].")
-				if(do_after(user, 10 * W.toolspeed, target = src) && (build == 3))
-					new /obj/item/stack/cable_coil(loc,2)
-					playsound(get_turf(src), W.usesound, 50, 1)
-					to_chat(user, "<span class='notice'>You've removed the cables from \the [src].</span>")
-					build--
-					update_icon()
-				return 1
 			if(istype(W, /obj/item/stack/rods))
 				var/obj/item/stack/rods/R = W
 				to_chat(user, "You begin to complete \the [src]...")
@@ -153,24 +124,69 @@
 					update_icon()
 				return 1
 			return
-		if(4) // Grille in place
-			if(istype(W, /obj/item/crowbar))
-				to_chat(user, "You begin to pry off the grille from \the [src]...")
-				playsound(get_turf(src), W.usesound, 50, 1)
-				if(do_after(user, 30 * W.toolspeed, target = src) && (build == 4))
-					new /obj/item/stack/rods(loc,2)
-					build--
-					update_icon()
-				return 1
-			if(istype(W, /obj/item/screwdriver))
-				to_chat(user, "You finalize the Mass Driver...")
-				playsound(get_turf(src), W.usesound, 50, 1)
-				var/obj/machinery/mass_driver/M = new(get_turf(src))
-				M.dir = src.dir
-				qdel(src)
-				return 1
-			return
 	return ..()
+
+/obj/machinery/mass_driver_frame/crowbar_act(mob/user, obj/item/I)
+	if(build != 4)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	to_chat(user, "You begin to pry off the grille from [src]...")
+	if(!I.use_tool(src, user, 30, volume = I.tool_volume) || build != 4)
+		return
+	new /obj/item/stack/rods(drop_location(), 2)
+	build = 3
+	update_icon()
+
+/obj/machinery/mass_driver_frame/screwdriver_act(mob/user, obj/item/I)
+	if(build != 4)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	to_chat(user, "You finalize the Mass Driver...")
+	if(!I.use_tool(src, user, 50, volume = I.tool_volume) || build != 4)
+		return
+	var/obj/machinery/mass_driver/M = new(get_turf(src))
+	M.dir = dir
+	qdel(src)
+
+/obj/machinery/mass_driver_frame/wirecutter_act(mob/user, obj/item/I)
+	if(build != 3)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	to_chat(user, "You begin to remove the wiring from [src]...")
+	if(!I.use_tool(src, user, 10, volume = I.tool_volume) || build != 3)
+		return
+	new /obj/item/stack/cable_coil(drop_location(), 2)
+	WIRECUTTER_SNIP_MESSAGE
+	build = 2
+	update_icon()
+
+/obj/machinery/mass_driver_frame/wrench_act(mob/user, obj/item/I)
+	if(build != 0 && build != 1)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	if(build == 0)
+		to_chat(user, "You begin to anchor [src] on the floor.")
+		if(!I.use_tool(src, user, 10, volume = I.tool_volume) || build != 0)
+			return
+		WRENCH_ANCHOR_MESSAGE
+		anchored = TRUE
+		build = 1
+	else if(build == 1)
+		to_chat(user, "You begin to unanchor [src] on the floor.")
+		if(!I.use_tool(src, user, 10, volume = I.tool_volume) || build != 1)
+			return
+		WRENCH_UNANCHOR_MESSAGE
+		anchored = FALSE
+		build = 0
+	update_icon()		
 
 /obj/machinery/mass_driver_frame/welder_act(mob/user, obj/item/I)
 	if(build != 0 && build != 1 && build != 2)

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -91,13 +91,6 @@
 	if(T.intact)
 		return		// prevent intraction when T-scanner revealed
 
-	if(istype(I, /obj/item/screwdriver))
-		open = !open
-
-		user.visible_message("[user] [open ? "opens" : "closes"] the beacon's cover.", "<span class='notice'>You [open ? "open" : "close"] the beacon's cover.</span>")
-
-		updateicon()
-
 	else if(istype(I, /obj/item/card/id) || istype(I, /obj/item/pda))
 		if(open)
 			if(allowed(user))
@@ -110,6 +103,14 @@
 			to_chat(user, "<span class='warning'>You must open the cover first!</span>")
 	else
 		return ..()
+
+/obj/machinery/navbeacon/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	open = !open
+	user.visible_message("[user] [open ? "opens" : "closes"] the beacon's cover.", "<span class='notice'>You [open ? "open" : "close"] the beacon's cover.</span>")
+	updateicon()
 
 /obj/machinery/navbeacon/attack_ai(mob/user)
 	interact(user, 1)

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -56,13 +56,10 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(!I.multitool_check_buffer(user))
-		return
-	var/obj/item/multitool/M = I
 	if(panel_open)
-		M.set_multitool_buffer(user, src)
+		I.set_multitool_buffer(user, src)
 	else
-		linked_pad = M.buffer
+		linked_pad = I.buffer
 		to_chat(user, "<span class='notice'>You link the [src] to the one in the [I.name]'s buffer.</span>")
 
 /obj/machinery/quantumpad/screwdriver_act(mob/user, obj/item/I)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -49,7 +49,6 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		// 2 = high priority
 	var/screen = RCS_MAINMENU
 	var/silent = 0 // set to 1 for it not to beep all the time
-//	var/hackState = 0
 		// 0 = not hacked
 		// 1 = hacked
 	var/announcementConsole = 0
@@ -271,28 +270,6 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 
 					//err... hacking code, which has no reason for existing... but anyway... it was once supposed to unlock priority 3 messanging on that console (EXTREME priority...), but the code for that was removed.
 /obj/machinery/requests_console/attackby(obj/item/I, mob/user)
-	/*
-	if(istype(O, /obj/item/crowbar))
-		if(open)
-			open = 0
-			icon_state="req_comp0"
-		else
-			open = 1
-			if(hackState == 0)
-				icon_state="req_comp_open"
-			else if(hackState == 1)
-				icon_state="req_comp_rewired"
-	if(istype(O, /obj/item/screwdriver))
-		if(open)
-			if(hackState == 0)
-				hackState = 1
-				icon_state="req_comp_rewired"
-			else if(hackState == 1)
-				hackState = 0
-				icon_state="req_comp_open"
-		else
-			to_chat(user, "You can't do much with that.")*/
-
 	if(istype(I, /obj/item/card/id))
 		if(inoperable(MAINT))
 			return

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -181,37 +181,6 @@
 		updateUsrDialog()
 		return
 
-	attackby(var/obj/item/D as obj, var/mob/user as mob, params)
-		if(istype(D, /obj/item/screwdriver))
-			playsound(src.loc, D.usesound, 50, 1)
-			if(do_after(user, 20 * D.toolspeed, target = src))
-				if(src.stat & BROKEN)
-					to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-					var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-					new /obj/item/shard(loc)
-					var/obj/item/circuitboard/comm_server/M = new /obj/item/circuitboard/comm_server( A )
-					for(var/obj/C in src)
-						C.loc = src.loc
-					A.circuit = M
-					A.state = 3
-					A.icon_state = "3"
-					A.anchored = 1
-					qdel(src)
-				else
-					to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-					var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-					var/obj/item/circuitboard/comm_server/M = new /obj/item/circuitboard/comm_server( A )
-					for(var/obj/C in src)
-						C.loc = src.loc
-					A.circuit = M
-					A.state = 4
-					A.icon_state = "4"
-					A.anchored = 1
-					qdel(src)
-			updateUsrDialog()
-			return
-		return ..()
-
 	emag_act(user as mob)
 		if(!emagged)
 			playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -123,37 +123,6 @@
 		updateUsrDialog()
 		return
 
-	attackby(var/obj/item/D as obj, var/mob/user as mob, params)
-		if(istype(D, /obj/item/screwdriver))
-			playsound(src.loc, D.usesound, 50, 1)
-			if(do_after(user, 20 * D.toolspeed, target = src))
-				if(src.stat & BROKEN)
-					to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-					var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-					new /obj/item/shard(loc)
-					var/obj/item/circuitboard/comm_monitor/M = new /obj/item/circuitboard/comm_monitor( A )
-					for(var/obj/C in src)
-						C.loc = src.loc
-					A.circuit = M
-					A.state = 3
-					A.icon_state = "3"
-					A.anchored = 1
-					qdel(src)
-				else
-					to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-					var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-					var/obj/item/circuitboard/comm_monitor/M = new /obj/item/circuitboard/comm_monitor( A )
-					for(var/obj/C in src)
-						C.loc = src.loc
-					A.circuit = M
-					A.state = 4
-					A.icon_state = "4"
-					A.anchored = 1
-					qdel(src)
-			updateUsrDialog()
-			return
-		return ..()
-
 	emag_act(user as mob)
 		if(!emagged)
 			playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -539,19 +539,16 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(!I.multitool_check_buffer(user))
-		return
-	var/obj/item/multitool/M = I
 	if(!panel_open)
-		if(M.buffer && istype(M.buffer, /obj/machinery/teleport/station) && M.buffer != src)
+		if(I.buffer && istype(I.buffer, /obj/machinery/teleport/station) && I.buffer != src)
 			if(linked_stations.len < efficiency)
-				linked_stations.Add(M.buffer)
-				M.buffer = null
-				to_chat(user, "<span class='caution'>You upload the data from [M]'s buffer.</span>")
+				linked_stations.Add(I.buffer)
+				I.buffer = null
+				to_chat(user, "<span class='caution'>You upload the data from [I]'s buffer.</span>")
 			else
 				to_chat(user, "<span class='alert'>This station can't hold more information, try to use better parts.</span>")
 		return
-	M.set_multitool_buffer(user, src)
+	I.set_multitool_buffer(user, src)
 
 /obj/machinery/teleport/station/screwdriver_act(mob/user, obj/item/I)
 	if(default_deconstruction_screwdriver(user, "controller-o", "controller", I))

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -14,7 +14,6 @@
 	//6 = blood, open door
 	//7 = blood, closed door
 	//8 = blood, running
-	var/panel = 0
 	//0 = closed
 	//1 = open
 	var/hacked = 1 //Bleh, screw hacking, let's have it hacked by default.
@@ -193,12 +192,9 @@
 
 
 /obj/machinery/washing_machine/update_icon()
-	icon_state = "wm_[state][panel]"
+	icon_state = "wm_[state]0"
 
 /obj/machinery/washing_machine/attackby(obj/item/W as obj, mob/user as mob, params)
-	/*if(istype(W,/obj/item/screwdriver))
-		panel = !panel
-		to_chat(user, "<span class='notice'>you [panel ? </span>"open" : "close"] the [src]'s maintenance panel")*/
 	if(default_unfasten_wrench(user, W))
 		power_change()
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -87,6 +87,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	var/tool_enabled = TRUE //If we can turn on or off, are we currently active? Mostly for welders and this will normally be TRUE
 	var/tool_volume = 50 //How loud are we when we use our tool?
 	var/toolspeed = 1 // If this item is a tool, the speed multiplier
+	var/obj/machinery/buffer // simple machine buffer for device linkage. At the item level so things that aren't obj/item/multitool can also act as multitools
 
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:
@@ -679,3 +680,26 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	if(flags & SLOT_PDA)
 		owner.update_inv_wear_pda()
 
+//Multitool-speficic procs down below
+//Check if the item has a multitool buffer
+/obj/item/proc/multitool_check_buffer(user, message = TRUE)
+	if(I.tool_behaviour == TOOL_MULTITOOL)
+		return TRUE
+	if(message)
+		to_chat(user, "<span class='warning'>[src] has no data buffer!</span>")
+	return FALSE
+
+//Checks if a given typepath matches the buffer path
+/obj/item/proc/IsBufferA(typepath)
+	if(buffer)
+		return istype(buffer,typepath)
+
+//Loads a machine into memory, and returns TRUE if it does. Should do the relevant checks beforehand
+/obj/item/proc/set_multitool_buffer(mob/user, obj/machinery/M)
+	if(!ismachinery(M))
+		to_chat(user, "<span class='warning'>That's not a machine!</span>")
+		return
+	. = multitool_check_buffer(user)
+	if(.)
+		buffer = M
+		to_chat(user, "<span class='notice'>You load [M] into [src]'s internal buffer.</span>")

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -27,20 +27,22 @@
 	return 1
 
 /obj/item/flash/attackby(obj/item/W, mob/user, params)
-	if(can_overcharge)
-		if(istype(W, /obj/item/screwdriver))
-			if(battery_panel)
-				to_chat(user, "<span class='notice'>You close the battery compartment on the [src].</span>")
-				battery_panel = 0
-			else
-				to_chat(user, "<span class='notice'>You open the battery compartment on the [src].</span>")
-				battery_panel = 1
-		if(battery_panel && !overcharged)
-			if(istype(W, /obj/item/stock_parts/cell))
-				to_chat(user, "<span class='notice'>You jam the cell into battery compartment on the [src].</span>")
-				qdel(W)
-				overcharged = 1
-				overlays += "overcharge"
+	if(!istype(W, /obj/item/stock_parts/cell))
+		return ..()
+	if(can_overcharge && battery_panel && !overcharged)
+		to_chat(user, "<span class='notice'>You jam the cell into battery compartment on the [src].</span>")
+		qdel(W)
+		overcharged = TRUE
+		overlays += "overcharge"
+
+/obj/item/flash/screwdriver_act(mob/living/user, obj/item/I)
+	if(!can_overcharge)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	to_chat(user, "<span class='notice'>You [battery_panel ? "close" : "open"] the battery compartment on [src].</span>")
+	battery_panel = !battery_panel
 
 /obj/item/flash/random/New()
 	..()

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -47,23 +47,26 @@
 	laser_act(M, user)
 
 /obj/item/laser_pointer/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stock_parts/micro_laser))
-		if(!diode)
-			user.drop_item()
-			W.loc = src
-			diode = W
-			to_chat(user, "<span class='notice'>You install a [diode.name] in [src].</span>")
-		else
-			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+	if(!istype(W, /obj/item/stock_parts/micro_laser))
+		return ..()
+	if(!diode)
+		user.drop_item()
+		W.loc = src
+		diode = W
+		to_chat(user, "<span class='notice'>You install a [diode.name] in [src].</span>")
+	else
+		to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
 
-	else if(istype(W, /obj/item/screwdriver))
-		if(diode)
-			to_chat(user, "<span class='notice'>You remove the [diode.name] from the [src].</span>")
-			diode.loc = get_turf(src.loc)
-			diode = null
-			return
-		..()
-	return
+/obj/item/laser_pointer/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!diode)
+		to_chat(user, "<span class='notice'>[src] has no diode to remove.</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	to_chat(user, "<span class='notice'>You remove the [diode.name] from the [src].</span>")
+	diode.loc = get_turf(src.loc)
+	diode = null
 
 /obj/item/laser_pointer/afterattack(var/atom/target, var/mob/living/user, flag, params)
 	if(flag)	//we're placing the object on a table or in backpack

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -305,18 +305,25 @@
 
 
 /obj/item/tape/attackby(obj/item/I, mob/user)
-	if(ruined && istype(I, /obj/item/screwdriver))
-		to_chat(user, "<span class='notice'>You start winding the tape back in.</span>")
-		if(do_after(user, 120 * I.toolspeed, target = src))
-			to_chat(user, "<span class='notice'>You wound the tape back in!</span>")
-			fix()
-	else if(istype(I, /obj/item/pen))
-		var/title = stripped_input(usr,"What do you want to name the tape?", "Tape Renaming", name, MAX_NAME_LEN)
-		if(!title || !length(title))
-			name = initial(name)
-			return
-		name = "tape - [title]"
+	if(!istype(I, /obj/item/pen))
+		return ..()
+	var/title = stripped_input(usr,"What do you want to name the tape?", "Tape Renaming", name, MAX_NAME_LEN)
+	if(!title || !length(title))
+		name = initial(name)
+		return
+	name = "tape - [title]"
 
+/obj/item/tape/screwdriver_act(mob/user, obj/item/I)
+	if(!ruined)
+		return
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	to_chat(user, "<span class='notice'>You start winding the tape back in.</span>")
+	if(!I.use_tool(src, user, 120, volume = I.tool_volume) || !ruined)
+		return
+	to_chat(user, "<span class='notice'>You wound the tape back in!</span>")
+	fix()
 
 //Random colour tapes
 /obj/item/tape/random/New()

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -210,12 +210,6 @@
 		else
 			to_chat(user, "<span class='notice'>You need to attach a flash to it first!</span>")
 
-	if(istype(W, /obj/item/multitool))
-		if(check_completion())
-			Interact(user)
-		else
-			to_chat(user, "<span class='warning'>The endoskeleton must be assembled before debugging can begin!</span>")
-
 	if(istype(W, /obj/item/mmi))
 		var/obj/item/mmi/M = W
 		if(check_completion())
@@ -322,6 +316,15 @@
 		to_chat(user, "<span class='warning'>You need to use a multitool to name [src]!</span>")
 	return
 
+/obj/item/robot_parts/robot_suit/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	if(check_completion())
+		Interact(user)
+	else
+		to_chat(user, "<span class='warning'>The endoskeleton must be assembled before debugging can begin!</span>")
+
 /obj/item/robot_parts/robot_suit/proc/Interact(mob/user)
 			var/t1 = "Designation: <A href='?src=[UID()];Name=1'>[(created_name ? "[created_name]" : "Default Cyborg")]</a><br>\n"
 			t1 += "Master AI: <A href='?src=[UID()];Master=1'>[(forced_ai ? "[forced_ai.name]" : "Automatic")]</a><br><br>\n"
@@ -340,7 +343,7 @@
 
 	var/mob/living/living_user = usr
 	var/obj/item/item_in_hand = living_user.get_active_hand()
-	if(!istype(item_in_hand, /obj/item/multitool))
+	if(item_in_hand.tool_behaviour != TOOL_MULTITOOL) || !I.use_tool(src, user, 0, volume = 0))
 		to_chat(living_user, "<span class='warning'>You need a multitool!</span>")
 		return
 

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -23,23 +23,6 @@
 	tool_behaviour = TOOL_MULTITOOL
 	hitsound = 'sound/weapons/tap.ogg'
 	var/shows_wire_information = FALSE // shows what a wire does if set to TRUE
-	var/obj/machinery/buffer // simple machine buffer for device linkage
-
-/obj/item/multitool/proc/IsBufferA(var/typepath)
-	if(!buffer)
-		return 0
-	return istype(buffer,typepath)
-
-/obj/item/multitool/multitool_check_buffer(user, silent = FALSE)
-	return TRUE
-
-/obj/item/multitool/proc/set_multitool_buffer(mob/user, obj/machinery/M)	//Loads a machine into memory, returns TRUE if it does
-	if(!ismachinery(M))
-		to_chat(user, "<span class='warning'>That's not a machine!</span>")
-		return
-	buffer = M
-	to_chat(user, "<span class='notice'>You load [M] into [src]'s internal buffer.</span>")
-	return TRUE
 
 // Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -88,28 +88,31 @@
 		toggle_paddles()
 
 /obj/item/defibrillator/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stock_parts/cell))
-		var/obj/item/stock_parts/cell/C = W
-		if(cell)
-			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
-		else
-			if(C.maxcharge < paddles.revivecost)
-				to_chat(user, "<span class='notice'>[src] requires a higher capacity cell.</span>")
-				return
-			user.drop_item()
-			W.loc = src
-			cell = W
-			to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
-
-	if(istype(W, /obj/item/screwdriver))
-		if(cell)
-			cell.update_icon()
-			cell.loc = get_turf(src.loc)
-			cell = null
-			to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
-
+	if(!istype(W, /obj/item/stock_parts/cell))
+		return ..()
+	var/obj/item/stock_parts/cell/C = W
+	if(cell)
+		to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+		return
+	if(C.maxcharge < paddles.revivecost)
+		to_chat(user, "<span class='notice'>[src] requires a higher capacity cell.</span>")
+		return
+	user.drop_item()
+	W.loc = src
+	cell = W
+	to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
 	update_icon()
-	return
+
+/obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/I)
+	if(!cell)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	cell.update_icon()
+	cell.loc = get_turf(src.loc)
+	cell = null
+	to_chat(user, "<span class='notice'>You remove the cell from [src].</span>")
 
 /obj/item/defibrillator/emag_act(user as mob)
 	if(safety)

--- a/code/game/objects/items/weapons/grenades/bananade.dm
+++ b/code/game/objects/items/weapons/grenades/bananade.dm
@@ -45,15 +45,20 @@ var/turf/T
 			qdel(I)
 		else
 			to_chat(usr, "<span class='notice'>The bananade is full, screwdriver it shut to lock it down.</span>")
-	if(istype(I, /obj/item/screwdriver))
-		if(fillamt)
-			var/obj/item/grenade/bananade/G = new /obj/item/grenade/bananade
-			user.unEquip(src)
-			user.put_in_hands(G)
-			G.deliveryamt = src.fillamt
-			to_chat(user, "<span  class='notice'>You lock the assembly shut, readying it for HONK.</span>")
-			qdel(src)
-		else
-			to_chat(usr, "<span class='notice'>You need to add banana peels before you can ready the grenade!.</span>")
 	else
 		to_chat(usr, "<span class='notice'>Only banana peels fit in this assembly, up to 9.</span>")
+
+/obj/item/grenade/bananade/casing/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!fillamt)
+		to_chat(user, "<span class='notice'>You need to add banana peels before you can ready the grenade!.</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/obj/item/grenade/bananade/G = new /obj/item/grenade/bananade
+	user.unEquip(src)
+	user.put_in_hands(G)
+	G.deliveryamt = src.fillamt
+	to_chat(user, "<span  class='notice'>You lock the assembly shut, readying it for HONK.</span>")
+	qdel(src)
+

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -88,23 +88,23 @@
 		M.unEquip(src)
 
 
-/obj/item/grenade/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/screwdriver))
-		switch(det_time)
-			if("1")
-				det_time = 10
-				to_chat(user, "<span class='notice'>You set the [name] for 1 second detonation time.</span>")
-			if("10")
-				det_time = 30
-				to_chat(user, "<span class='notice'>You set the [name] for 3 second detonation time.</span>")
-			if("30")
-				det_time = 50
-				to_chat(user, "<span class='notice'>You set the [name] for 5 second detonation time.</span>")
-			if("50")
-				det_time = 1
-				to_chat(user, "<span class='notice'>You set the [name] for instant detonation.</span>")
-		add_fingerprint(user)
-	..()
+/obj/item/grenade/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	switch(det_time)
+		if("1")
+			det_time = 10
+			to_chat(user, "<span class='notice'>You set the [name] for 1 second detonation time.</span>")
+		if("10")
+			det_time = 30
+			to_chat(user, "<span class='notice'>You set the [name] for 3 second detonation time.</span>")
+		if("30")
+			det_time = 50
+			to_chat(user, "<span class='notice'>You set the [name] for 5 second detonation time.</span>")
+		if("50")
+			det_time = 1
+			to_chat(user, "<span class='notice'>You set the [name] for instant detonation.</span>")
 
 /obj/item/grenade/attack_hand()
 	walk(src, null, null)

--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -74,18 +74,22 @@
 		I.forceMove(src)
 		to_chat(user, "<span class='notice'>You sneak the [sig] underneath the pressure plate and connect the trigger wire.</span>")
 		desc = "A trap used to catch bears and other legged creatures. <span class='warning'>There is a remote signaler hooked up to it.</span>"
-	if(istype(I, /obj/item/screwdriver))
-		if(IED)
-			IED.forceMove(get_turf(src))
-			IED = null
-			to_chat(user, "<span class='notice'>You remove the IED from the [src].</span>")
-			return
-		if(sig)
-			sig.forceMove(get_turf(src))
-			sig = null
-			to_chat(user, "<span class='notice'>You remove the signaler from the [src].</span>")
-			return
-	..()
+	return ..()
+
+/obj/item/restraints/legcuffs/beartrap/screwdriver_act(mob/user, obj/item/I)
+	if(!IED && !sig)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(IED)
+		IED.forceMove(get_turf(src))
+		IED = null
+		to_chat(user, "<span class='notice'>You remove the IED from the [src].</span>")
+	else if(sig)
+		sig.forceMove(get_turf(src))
+		sig = null
+		to_chat(user, "<span class='notice'>You remove the signaler from the [src].</span>")
 
 /obj/item/restraints/legcuffs/beartrap/Crossed(AM as mob|obj, oldloc)
 	if(armed && isturf(src.loc))

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -195,23 +195,26 @@
 			qdel(W)
 			qdel(src)
 			user.put_in_hands(newSaber)
-	else if(istype(W, /obj/item/multitool))
-		if(hacked == 0)
-			hacked = 1
-			item_color = "rainbow"
-			to_chat(user, "<span class='warning'>RNBW_ENGAGE</span>")
 
-			if(active)
-				icon_state = "swordrainbow"
-				// Updating overlays, copied from welder code.
-				// I tried calling attack_self twice, which looked cool, except it somehow didn't update the overlays!!
-				if(user.r_hand == src)
-					user.update_inv_r_hand()
-				else if(user.l_hand == src)
-					user.update_inv_l_hand()
+/obj/item/melee/energy/sword/saber/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(hacked)
+		to_chat(user, "<span class='warning'>It's already fabulous!</span>")
+		return
+	hacked = TRUE
+	item_color = "rainbow"
+	to_chat(user, "<span class='warning'>RNBW_ENGAGE</span>")
+	if(active)
+		icon_state = "swordrainbow"
+		// Updating overlays, copied from welder code.
+		// I tried calling attack_self twice, which looked cool, except it somehow didn't update the overlays!!
+		if(user.r_hand == src)
+			user.update_inv_r_hand()
+		else if(user.l_hand == src)
+			user.update_inv_l_hand()
 
-		else
-			to_chat(user, "<span class='warning'>It's already fabulous!</span>")
 
 /obj/item/melee/energy/sword/pirate
 	name = "energy cutlass"

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -43,19 +43,6 @@
 	if(W.type == type)
 		to_chat(user, "<span class='warning'>You're fairly certain that putting a pneumatic cannon inside another pneumatic cannon would cause a spacetime disruption.</span>")
 		return
-	if(istype(W, /obj/item/wrench))
-		switch(pressureSetting)
-			if(1)
-				pressureSetting = 2
-			if(2)
-				pressureSetting = 3
-			if(3)
-				pressureSetting = 1
-		to_chat(user, "<span class='notice'>You tweak \the [src]'s pressure output to [pressureSetting].</span>")
-		return
-	if(istype(W, /obj/item/screwdriver) && tank)
-		updateTank(tank, 1, user)
-		return
 	if(loadedWeightClass >= maxWeightClass)
 		to_chat(user, "<span class='warning'>\The [src] can't hold any more items!</span>")
 		return
@@ -75,6 +62,27 @@
 		IW.loc = src
 		return
 
+/obj/item/pneumatic_cannon/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!tank)
+		to_chat(user, "<span class='notice'>There's no tank to remove!</span>")
+		return
+	if(!I.tool_use_check(user, 0))
+		return
+	updateTank(tank, 1, user)
+
+/obj/item/pneumatic_cannon/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	switch(pressureSetting)
+		if(1)
+			pressureSetting = 2
+		if(2)
+			pressureSetting = 3
+		if(3)
+			pressureSetting = 1
+	to_chat(user, "<span class='notice'>You tweak \the [src]'s pressure output to [pressureSetting].</span>")
 
 /obj/item/pneumatic_cannon/afterattack(atom/target, mob/living/carbon/human/user, flag, params)
 	if(istype(target, /obj/item/storage)) //So you can store it in backpacks

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -83,35 +83,37 @@
 		. += "<span class='warning'>The baton does not have a power source installed.</span>"
 
 /obj/item/melee/baton/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stock_parts/cell))
-		var/obj/item/stock_parts/cell/C = W
-		if(cell)
-			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
-		else
-			if(C.maxcharge < hitcost)
-				to_chat(user, "<span class='notice'>[src] requires a higher capacity cell.</span>")
-				return
-			if(!user.unEquip(W))
-				return
-			W.loc = src
-			cell = W
-			to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
-			update_icon()
+	if(!istype(W, /obj/item/stock_parts/cell))
+		return ..()
+	var/obj/item/stock_parts/cell/C = W
+	if(cell)
+		to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+		return
+	if(C.maxcharge < hitcost)
+		to_chat(user, "<span class='notice'>[src] requires a higher capacity cell.</span>")
+		return
+	if(!user.unEquip(W))
+		return
+	W.loc = src
+	cell = W
+	to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
+	update_icon()
 
-	else if(istype(W, /obj/item/screwdriver))
-		if(cell)
-			cell.update_icon()
-			cell.loc = get_turf(src.loc)
-			cell = null
-			to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
-			status = 0
-			update_icon()
-			return
-		..()
-	return
+/obj/item/melee/baton/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!cell)
+		to_chat(user, "<span class='warning'>There's no cell to remove!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	cell.update_icon()
+	cell.loc = get_turf(src.loc)
+	cell = null
+	to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
+	status = 0
+	update_icon()
 
 /obj/item/melee/baton/attack_self(mob/user)
-
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/R = loc
 		if(R && R.cell &&  R.cell.charge >= (hitcost))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -296,7 +296,8 @@ a {
 	if(!I.tool_use_check(user, 0))
 		return FALSE
 	if(!(flags & NODECONSTRUCT))
-		to_chat(user, "<span class='notice'>Now [anchored ? "un" : ""]securing [name].</span>")
+		if(time) //If it takes time, display an initial message
+			to_chat(user, "<span class='notice'>Now [anchored ? "un" : ""]securing [name].</span>")
 		if(I.use_tool(src, user, time, volume = I.tool_volume))
 			to_chat(user, "<span class='notice'>You've [anchored ? "un" : ""]secured [name].</span>")
 			anchored = !anchored

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -33,6 +33,8 @@
 /obj/structure/sign/barsign/proc/set_sign(var/datum/barsign/sign)
 	if(!istype(sign))
 		return
+	if(panel_open || emagged || broken)
+		return
 	icon_state = sign.icon
 	name = sign.name
 	if(sign.desc)
@@ -62,33 +64,9 @@
 
 
 /obj/structure/sign/barsign/attack_hand(mob/user as mob)
-	if(!src.allowed(user))
-		to_chat(user, "<span class = 'info'>Access denied.</span>")
-		return
-	if(broken)
-		to_chat(user, "<span class ='danger'>The controls seem unresponsive.</span>")
-		return
-	pick_sign()
+	pick_sign(user)
 
-
-
-
-/obj/structure/sign/barsign/attackby(var/obj/item/I, var/mob/user)
-	if( istype(I, /obj/item/screwdriver))
-		if(!panel_open)
-			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-			set_sign(new /datum/barsign/hiddensigns/signoff)
-			panel_open = 1
-		else
-			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
-			if(!broken && !emagged)
-				set_sign(pick(barsigns))
-			else if(emagged)
-				set_sign(new /datum/barsign/hiddensigns/syndibarsign)
-			else
-				set_sign(new /datum/barsign/hiddensigns/empbarsign)
-			panel_open = 0
-
+/obj/structure/sign/barsign/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/stack/cable_coil) && panel_open)
 		var/obj/item/stack/cable_coil/C = I
 		if(emagged) //Emagged, not broken by EMP
@@ -103,10 +81,28 @@
 			broken = 0
 		else
 			to_chat(user, "<span class='warning'>You need at least two lengths of cable!</span>")
+	else if(istype(I, /obj/item/card/id))
+		pick_sign(user)
 	else
 		return ..()
 
-
+/obj/structure/sign/barsign/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(!panel_open)
+		to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
+		set_sign(new /datum/barsign/hiddensigns/signoff)
+		panel_open = TRUE
+	else
+		to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
+		panel_open = FALSE
+		if(!broken && !emagged)
+			set_sign(pick(barsigns))
+		else if(emagged)
+			set_sign(new /datum/barsign/hiddensigns/syndibarsign)
+		else
+			set_sign(new /datum/barsign/hiddensigns/empbarsign)
 
 /obj/structure/sign/barsign/emp_act(severity)
     set_sign(new /datum/barsign/hiddensigns/empbarsign)
@@ -129,20 +125,21 @@
 	emagged = 1
 	req_access = list(access_syndicate)
 
-
-
-
-/obj/structure/sign/barsign/proc/pick_sign()
+/obj/structure/sign/barsign/proc/pick_sign(mob/user)
+	if(!allowed(user))
+		to_chat(user, "<span class = 'info'>Access denied.</span>")
+		return
+	if(broken)
+		to_chat(user, "<span class ='danger'>The controls seem unresponsive.</span>")
+		return
+	if(panel_open || emagged)
+		return
 	var/picked_name = input("Available Signage", "Bar Sign") as null|anything in barsigns
 	if(!picked_name)
 		return
 	set_sign(picked_name)
 
-
-
 //Code below is to define useless variables for datums. It errors without these
-
-
 
 /datum/barsign
 	var/name = "Name"
@@ -150,10 +147,7 @@
 	var/desc = "desc"
 	var/hidden = 0
 
-
 //Anything below this is where all the specific signs are. If people want to add more signs, add them below.
-
-
 
 /datum/barsign/maltesefalcon
 	name = "Maltese Falcon"
@@ -415,4 +409,3 @@
 	name = "Bar Sign"
 	icon = "empty"
 	desc = "This sign doesn't seem to be on."
-

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -19,17 +19,32 @@
 	. = ..()
 	. += "<span class='notice'>Use a multitool to lock/unlock it.</span>"
 
+/obj/structure/closet/fireaxecabinet/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	if(locked)
+		to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
+		playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
+		if(!I.use_tool(src, user, 20, volume = 0))
+			return
+		locked = FALSE
+		to_chat(user, "<span class = 'caution'> You disable the locking modules.</span>")
+		update_icon()
+		return
+	if(localopened)
+		localopened = FALSE
+		update_icon_closing()
+		return
+	to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
+	if(!I.use_tool(src, user, 20, volume = 0))
+		return
+	locked = TRUE
+	to_chat(user, "<span class='caution'> You re-enable the locking modules.</span>")
+
 /obj/structure/closet/fireaxecabinet/attackby(var/obj/item/O as obj, var/mob/living/user as mob)  //Marker -Agouri
 	if(isrobot(user) || locked)
-		if(istype(O, /obj/item/multitool))
-			to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
-			playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
-			if(do_after(user, 20 * O.toolspeed, target = src))
-				locked = FALSE
-				to_chat(user, "<span class = 'caution'> You disable the locking modules.</span>")
-				update_icon()
-			return
-		else if(istype(O, /obj/item))
+		if(istype(O, /obj/item))
 			user.changeNext_move(CLICK_CD_MELEE)
 			var/obj/item/W = O
 			if(smashed || localopened)
@@ -76,18 +91,6 @@
 	else
 		if(smashed)
 			return
-		if(istype(O, /obj/item/multitool))
-			if(localopened)
-				localopened = FALSE
-				update_icon_closing()
-				return
-			else
-				to_chat(user, "<span class='warning'>Resetting circuitry...</span>")
-				playsound(user, 'sound/machines/lockenable.ogg', 50, 1)
-				if(do_after(user, 20 * O.toolspeed, target = src))
-					locked = TRUE
-					to_chat(user, "<span class = 'caution'> You re-enable the locking modules.</span>")
-				return
 		else
 			localopened = !localopened
 			if(localopened)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -85,8 +85,6 @@
 			W.forceMove(loc)
 	else if((istype(W, /obj/item/card/emag)||istype(W, /obj/item/melee/energy/blade)) && !broken)
 		emag_act(user)
-	else if(istype(W,/obj/item/stack/packageWrap) || istype(W,/obj/item/weldingtool))
-		return ..(W, user)
 	else if(user.a_intent != INTENT_HARM)
 		togglelock(user)
 	else

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -113,17 +113,23 @@
 		if(T.density)
 			to_chat(user, "<span class='warning'>[src] is blocked!</span>")
 			return
-		if(istype(W, /obj/item/screwdriver))
-			if(!istype(T, /turf/simulated/floor))
-				to_chat(user, "<span class='warning'>[src] bolts must be tightened on the floor!</span>")
-				return
-			user.visible_message("<span class='notice'>[user] tightens some bolts on the wall.</span>", "<span class='warning'>You tighten the bolts on the wall.</span>")
-			ChangeToWall()
 	else
 		to_chat(user, "<span class='warning'>You can't reach, close it first!</span>")
 
 	if(istype(W, /obj/item/gun/energy/plasmacutter) || istype(W, /obj/item/pickaxe/drill/diamonddrill) || istype(W, /obj/item/pickaxe/drill/jackhammer) || istype(W, /obj/item/melee/energy/blade))
 		dismantle(user, TRUE)
+
+/obj/structure/falsewall/screwdriver_act(mob/user, obj/item/I)
+	if(opening || !density)
+		return
+	. = TRUE
+	if(!istype(T, /turf/simulated/floor))
+		to_chat(user, "<span class='warning'>[src] bolts must be tightened on the floor!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	user.visible_message("<span class='notice'>[user] tightens some bolts on the wall.</span>", "<span class='warning'>You tighten the bolts on the wall.</span>")
+	ChangeToWall()
 
 /obj/structure/falsewall/welder_act(mob/user, obj/item/I)
 	if(!density)

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -42,32 +42,34 @@
 	resistance_flags = FLAMMABLE
 	var/sign_state = ""
 
-/obj/item/sign/attackby(obj/item/tool as obj, mob/user as mob)	//construction
-	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
-		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
-		if(direction == "Cancel")
+/obj/item/sign/screwdriver_act(mob/user, obj/item/I)
+	if(!isturf(user.loc))
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
+	if(direction == "Cancel")
+		return
+	if(QDELETED(src))
+		return
+	var/obj/structure/sign/S = new(user.loc)
+	switch(direction)
+		if("North")
+			S.pixel_y = 32
+		if("East")
+			S.pixel_x = 32
+		if("South")
+			S.pixel_y = -32
+		if("West")
+			S.pixel_x = -32
+		else
 			return
-		if(QDELETED(src))
-			return
-		var/obj/structure/sign/S = new(user.loc)
-		switch(direction)
-			if("North")
-				S.pixel_y = 32
-			if("East")
-				S.pixel_x = 32
-			if("South")
-				S.pixel_y = -32
-			if("West")
-				S.pixel_x = -32
-			else
-				return
-		S.name = name
-		S.desc = desc
-		S.icon_state = sign_state
-		to_chat(user, "You fasten \the [S] with your [tool].")
-		qdel(src)
-	else
-		return ..()
+	S.name = name
+	S.desc = desc
+	S.icon_state = sign_state
+	to_chat(user, "You fasten \the [S] with your [tool].")
+	qdel(src)
 
 /obj/structure/sign/double/map
 	name = "station map"

--- a/code/modules/arcade/arcade_base.dm
+++ b/code/modules/arcade/arcade_base.dm
@@ -59,13 +59,7 @@
 			to_chat(user, "Someone else is already playing this machine, please wait your turn!")
 		return
 
-/obj/machinery/arcade/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
-	if(istype(O, /obj/item/screwdriver) && anchored)
-		playsound(src.loc, O.usesound, 50, 1)
-		panel_open = !panel_open
-		to_chat(user, "You [panel_open ? "open" : "close"] the maintenance panel.")
-		update_icon()
-		return
+/obj/machinery/arcade/attackby(obj/item/O, mob/user, params)
 	if(!freeplay)
 		if(istype(O, /obj/item/card/id))
 			var/obj/item/card/id/C = O
@@ -77,10 +71,23 @@
 			if(pay_with_cash(C, user))
 				tokens += 1
 		return
-	if(panel_open && component_parts && istype(O, /obj/item/crowbar))
-		default_deconstruction_crowbar(user, O)
-		return
 	return ..()
+
+/obj/machinery/arcade/crowbar_act(mob/user, obj/item/I)
+	if(!panel_open || !component_parts)
+		return
+	. = TRUE
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/arcade/screwdriver_act(mob/user, obj/item/I)
+	if(!anchored)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	panel_open = !panel_open
+	to_chat(user, "You [panel_open ? "open" : "close"] the maintenance panel.")
+	update_icon()
 
 /obj/machinery/arcade/update_icon()
 	return

--- a/code/modules/arcade/prize_counter.dm
+++ b/code/modules/arcade/prize_counter.dm
@@ -31,30 +31,41 @@
 		icon_state = "prize_counter-on"
 	return
 
-/obj/machinery/prize_counter/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
-	if(istype(O, /obj/item/stack/tickets))
-		var/obj/item/stack/tickets/T = O
-		if(user.unEquip(T))		//Because if you can't drop it for some reason, you shouldn't be increasing the tickets var
-			tickets += T.amount
-			qdel(T)
-		else
-			to_chat(user, "<span class='warning'>\The [T] seems stuck to your hand!</span>")
+/obj/machinery/prize_counter/attackby(obj/item/O as obj, mob/user as mob, params)
+	if(!istype(O, /obj/item/stack/tickets))
+		return ..()
+	var/obj/item/stack/tickets/T = O
+	if(user.unEquip(T))		//Because if you can't drop it for some reason, you shouldn't be increasing the tickets var
+		tickets += T.amount
+		qdel(T)
+	else
+		to_chat(user, "<span class='warning'>\The [T] seems stuck to your hand!</span>")
+
+/obj/machinery/prize_counter/crowbar_act(mob/user, obj/item/I)
+	if(!panel_open || !component_parts)
 		return
-	if(istype(O, /obj/item/screwdriver) && anchored)
-		playsound(src.loc, O.usesound, 50, 1)
-		panel_open = !panel_open
-		to_chat(user, "You [panel_open ? "open" : "close"] the maintenance panel.")
-		update_icon()
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(panel_open)
-		if(istype(O, /obj/item/wrench))
-			default_unfasten_wrench(user, O)
-		if(component_parts && istype(O, /obj/item/crowbar))
-			if(tickets)		//save the tickets!
-				print_tickets()
-			default_deconstruction_crowbar(user, O)
+	if(tickets)		//save the tickets!
+		print_tickets()
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/prize_counter/screwdriver_act(mob/user, obj/item/I)
+	if(!anchored)
 		return
-	return ..()
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	panel_open = !panel_open
+	to_chat(user, "You [panel_open ? "open" : "close"] the maintenance panel.")
+	update_icon()
+
+/obj/machinery/prize_counter/wrench_act(mob/user, obj/item/I)
+	if(!panel_open)
+		return
+	. = TRUE
+	default_unfasten_wrench(user, I)
 
 /obj/machinery/prize_counter/attack_hand(mob/user as mob)
 	if(..())

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -14,24 +14,29 @@
 	QDEL_NULL(part2)
 	return ..()
 
-/obj/item/assembly/shock_kit/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/wrench) && !status)
-		var/turf/T = loc
-		if(ismob(T))
-			T = T.loc
-		part1.loc = T
-		part2.loc = T
-		part1.master = null
-		part2.master = null
-		part1 = null
-		part2 = null
-		qdel(src)
+/obj/item/assembly/shock_kit/wrench_act(mob/user, obj/item/I)
+	if(status)
 		return
-	if(istype(W, /obj/item/screwdriver))
-		status = !status
-		to_chat(user, "<span class='notice'>[src] is now [status ? "secured" : "unsecured"]!</span>")
-	add_fingerprint(user)
-	return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/turf/T = loc
+	if(ismob(T))
+		T = T.loc
+	part1.loc = T
+	part2.loc = T
+	part1.master = null
+	part2.master = null
+	part1 = null
+	part2 = null
+	qdel(src)
+
+/obj/item/assembly/shock_kit/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	status = !status
+	to_chat(user, "<span class='notice'>[src] is now [status ? "secured" : "unsecured"]!</span>")
 
 /obj/item/assembly/shock_kit/attack_self(mob/user as mob)
 	part1.attack_self(user, status)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -158,11 +158,9 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		return
 
 
-/obj/machinery/gateway/centerstation/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W,/obj/item/multitool))
-		to_chat(user, "The gate is already calibrated, there is no work for you to do here.")
-		return
-	return ..()
+/obj/machinery/gateway/centerstation/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	to_chat(user, "The gate is already calibrated, there is no work for you to do here.")
 
 /////////////////////////////////////Away////////////////////////
 
@@ -283,13 +281,12 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 			return 1
 	return 0
 
-/obj/machinery/gateway/centeraway/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W,/obj/item/multitool))
-		if(calibrated)
-			to_chat(user, "<span class='notice'>The gate is already calibrated, there is no work for you to do here.</span>")
-			return
-		else
-			to_chat(user, "<span class='boldnotice'>Recalibration successful!</span><span class='notice'>: This gate's systems have been fine tuned.  Travel to this gate will now be on target.</span>")
-			calibrated = 1
+/obj/machinery/gateway/centeraway/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	return ..()
+	if(calibrated)
+		to_chat(user, "<span class='notice'>The gate is already calibrated, there is no work for you to do here.</span>")
+		return
+	to_chat(user, "<span class='boldnotice'>Recalibration successful!</span><span class='notice'>: This gate's systems have been fine tuned.  Travel to this gate will now be on target.</span>")
+	calibrated = TRUE

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -19,16 +19,23 @@
 			prescription = 1
 			name = "prescription [name]"
 			return
-		if(prescription && istype(O, /obj/item/screwdriver))
-			var/obj/item/clothing/glasses/regular/G = locate() in src
-			if(!G)
-				G = new(get_turf(H))
-			to_chat(H, "You salvage the prescription lenses from \the [name].")
-			prescription = 0
-			name = initial(name)
-			H.put_in_hands(G)
-			return
 	return ..()
+
+/obj/item/clothing/glasses/screwdriver_act(mob/user, obj/item/I)
+	if(!prescription_upgradable)
+		return
+	if(prescription)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/obj/item/clothing/glasses/regular/G = locate() in src
+	if(!G)
+		G = new(get_turf(user))
+	to_chat(user, "You salvage the prescription lenses from \the [name].")
+	prescription = FALSE
+	name = initial(name)
+	user.put_in_hands(G)
 
 /obj/item/clothing/glasses/visor_toggling()
 	..()

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -305,33 +305,38 @@
 			else
 				to_chat(user, "<span class='notice'>It's broken.</span>")
 
-/obj/item/clothing/mask/gas/sechailer/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/screwdriver))
-		switch(aggressiveness)
-			if(1)
-				to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the second position.</span>")
-				aggressiveness = 2
-				phrase = 7
-			if(2)
-				to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the third position.</span>")
-				aggressiveness = 3
-				phrase = 13
-			if(3)
-				to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the fourth position.</span>")
-				aggressiveness = 4
-				phrase = 1
-			if(4)
-				to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the first position.</span>")
-				aggressiveness = 1
-				phrase = 1
-			if(5)
-				to_chat(user, "<span class='warning'>You adjust the restrictor but nothing happens, probably because its broken.</span>")
-	else if(istype(W, /obj/item/wirecutters))
-		if(aggressiveness != 5)
-			to_chat(user, "<span class='warning'>You broke it!</span>")
-			aggressiveness = 5
-	else
-		..()
+/obj/item/clothing/mask/gas/sechailer/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	switch(aggressiveness)
+		if(1)
+			to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the second position.</span>")
+			aggressiveness = 2
+			phrase = 7
+		if(2)
+			to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the third position.</span>")
+			aggressiveness = 3
+			phrase = 13
+		if(3)
+			to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the fourth position.</span>")
+			aggressiveness = 4
+			phrase = 1
+		if(4)
+			to_chat(user, "<span class='notice'>You set the aggressiveness restrictor to the first position.</span>")
+			aggressiveness = 1
+			phrase = 1
+		if(5)
+			to_chat(user, "<span class='warning'>You adjust the restrictor but nothing happens, probably because its broken.</span>")
+
+/obj/item/clothing/mask/gas/sechailer/wirecutter_act(mob/user, obj/item/I)
+	if(aggressiveness == 5)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	to_chat(user, "<span class='warning'>You broke it!</span>")
+	aggressiveness = 5
 
 /obj/item/clothing/mask/gas/sechailer/attack_self()
 	halt()

--- a/code/modules/crafting/guncrafting.dm
+++ b/code/modules/crafting/guncrafting.dm
@@ -36,14 +36,15 @@
 	icon = 'icons/obj/improvised.dmi'
 	icon_state = "ishotgunstep1"
 
-/obj/item/weaponcrafting/ishotgunconstruction/attackby(var/obj/item/I, mob/user as mob, params)
-	..()
-	if(istype(I, /obj/item/screwdriver))
-		var/obj/item/weaponcrafting/ishotgunconstruction2/C = new /obj/item/weaponcrafting/ishotgunconstruction2
-		user.unEquip(src)
-		user.put_in_hands(C)
-		to_chat(user, "<span class='notice'>You screw the pins into place, securing the pipe to the receiver.</span>")
-		qdel(src)
+/obj/item/weaponcrafting/ishotgunconstruction/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/obj/item/weaponcrafting/ishotgunconstruction2/C = new /obj/item/weaponcrafting/ishotgunconstruction2
+	user.unEquip(src)
+	user.put_in_hands(C)
+	to_chat(user, "<span class='notice'>You screw the pins into place, securing the pipe to the receiver.</span>")
+	qdel(src)
 
 /obj/item/weaponcrafting/ishotgunconstruction2
 	name = "very conspicuous metal construction"

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -63,38 +63,9 @@
 	if(operating)
 		return
 	if(!broken && dirty < 100)
-		if(default_deconstruction_screwdriver(user, open_icon, off_icon, O))
-			return
 		if(exchange_parts(user, O))
 			return
-	if(!broken && istype(O, /obj/item/wrench))
-		playsound(src, O.usesound, 50, 1)
-		if(anchored)
-			anchored = 0
-			to_chat(user, "<span class='alert'>\The [src] can now be moved.</span>")
-			return
-		else if(!anchored)
-			anchored = 1
-			to_chat(user, "<span class='alert'>\The [src] is now secured.</span>")
-			return
-
-	default_deconstruction_crowbar(user, O)
-
 	if(broken > 0)
-		if(broken == 2 && istype(O, /obj/item/screwdriver)) // If it's broken and they're using a screwdriver
-			user.visible_message("<span class='notice'>[user] starts to fix part of [src].</span>", "<span class='notice'>You start to fix part of [src].</span>")
-			if(do_after(user, 20 * O.toolspeed, target = src))
-				user.visible_message("<span class='notice'>[user] fixes part of [src].</span>", "<span class='notice'>You have fixed part of \the [src].</span>")
-				broken = 1 // Fix it a bit
-		else if(broken == 1 && istype(O, /obj/item/wrench)) // If it's broken and they're doing the wrench
-			user.visible_message("<span class='notice'>[user] starts to fix part of [src].</span>", "<span class='notice'>You start to fix part of [src].</span>")
-			if(do_after(user, 20 * O.toolspeed, target = src))
-				user.visible_message("<span class='notice'>[user] fixes [src].</span>", "<span class='notice'>You have fixed [src].</span>")
-				icon_state = off_icon
-				broken = 0 // Fix it!
-				dirty = 0 // just to be sure
-				container_type = OPENCONTAINER
-		else
 			to_chat(user, "<span class='alert'>It's broken!</span>")
 			return 1
 	else if(dirty==100) // The machine is all dirty so can't be used!
@@ -137,6 +108,36 @@
 		to_chat(user, "<span class='alert'>You have no idea what you can cook with this [O].</span>")
 		return 1
 	updateUsrDialog()
+
+/obj/machinery/kitchen_machine/crowbar_act(mob/user, obj/item/I)
+	if(operating)
+		return
+	. = TRUE
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/kitchen_machine/screwdriver_act(mob/user, obj/item/I)
+	if(operating || broken || dirty >= 100)
+		return
+	. = TRUE
+	default_deconstruction_screwdriver(user, open_icon, off_icon, I)
+
+/obj/machinery/kitchen_machine/wrench_act(mob/user, obj/item/I)
+	if(operating || broken > 1)
+		return
+	. = TRUE
+	if(!broken)
+		if(I.use_tool(src, user, 0, volume = I.tool_volume))
+			anchored = !anchored
+			to_chat(user, "<span class='alert'>\The [src] [anchored ? "is now secured" : "can now be moved"].</span>")
+		return
+	user.visible_message("<span class='notice'>[user] starts to fix part of [src].</span>", "<span class='notice'>You start to fix part of [src].</span>")
+	if(!I.use_tool(src, user, 20, volume = I.tool_volume))
+		return
+	user.visible_message("<span class='notice'>[user] fixes [src].</span>", "<span class='notice'>You have fixed [src].</span>")
+	icon_state = off_icon
+	broken = 0 // Fix it!
+	dirty = 0 // just to be sure
+	container_type = OPENCONTAINER
 
 /obj/machinery/kitchen_machine/proc/add_item(obj/item/I, mob/user)
 	if(!user.drop_item())

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -46,40 +46,10 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	required_grind = req_grind
 
 /obj/machinery/monkey_recycler/attackby(obj/item/O, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "grinder_open", "grinder", O))
-		return
 
 	if(exchange_parts(user, O))
 		return
 
-	if(default_unfasten_wrench(user, O))
-		power_change()
-		return
-
-	if(default_deconstruction_crowbar(user, O))
-		return
-
-	if(istype(O, /obj/item/multitool))
-		if(!panel_open)
-			cycle_through++
-			switch(cycle_through)
-				if(1)
-					cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/farwacube
-				if(2)
-					cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/wolpincube
-				if(3)
-					cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/stokcube
-				if(4)
-					cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/neaeracube
-				if(5)
-					cube_type = /obj/item/reagent_containers/food/snacks/monkeycube
-					cycle_through = 0
-			to_chat(user, "<span class='notice'>You change the monkeycube type to [initial(cube_type.name)].</span>")
-		else
-			var/obj/item/multitool/M = O
-			M.buffer = src
-			to_chat(user, "<span class='notice'>You log [src] in the [M]'s buffer.</span>")
-		return
 	if(stat != 0) //NOPOWER etc
 		return
 	if(istype(O, /obj/item/grab))
@@ -108,6 +78,41 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 			to_chat(user, "<span class='warning'>The machine only accepts monkeys!</span>")
 		return
 	return ..()
+
+/obj/machinery/monkey_recycler/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/monkey_recycler/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	default_deconstruction_screwdriver(user, "grinder_open", "grinder", I)
+
+/obj/machinery/monkey_recycler/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I)
+
+/obj/machinery/monkey_recycler/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(!panel_open)
+		cycle_through++
+		switch(cycle_through)
+			if(1)
+				cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/farwacube
+			if(2)
+				cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/wolpincube
+			if(3)
+				cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/stokcube
+			if(4)
+				cube_type = /obj/item/reagent_containers/food/snacks/monkeycube/neaeracube
+			if(5)
+				cube_type = /obj/item/reagent_containers/food/snacks/monkeycube
+				cycle_through = 0
+		to_chat(user, "<span class='notice'>You change the monkeycube type to [initial(cube_type.name)].</span>")
+	else
+		I.set_multitool_buffer(user, src)
+	return
 
 /obj/machinery/monkey_recycler/attack_hand(mob/user)
 	if(stat != 0) //NOPOWER etc

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -235,30 +235,38 @@
 *   Item Adding
 ********************/
 
-/obj/machinery/smartfridge/default_deconstruction_screwdriver(mob/user, obj/item/screwdriver/S)
-	. = ..(user, icon_state, icon_state, S)
-
+/obj/machinery/smartfridge/default_deconstruction_screwdriver(mob/user, obj/item/I)
+	. = ..(user, icon_state, icon_state, I)
+	if(!.)
+		return
 	overlays.Cut()
 	if(panel_open)
 		overlays += image(icon, "[initial(icon_state)]-panel")
 
+/obj/machinery/smartfridge/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/smartfridge/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(panel_open)
+		attack_hand(user)
+
+/obj/machinery/smartfridge/wirecutter_act(mob/user, obj/item/I)
+	. = TRUE
+	if(panel_open)
+		attack_hand(user)
+
+/obj/machinery/smartfridge/screwdriver_act(mob/living/user, obj/item/I)
+	. = TRUE
+	default_deconstruction_screwdriver(user, I)
+
+/obj/machinery/smartfridge/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I)
+
 /obj/machinery/smartfridge/attackby(obj/item/O, var/mob/user)
-	if(default_deconstruction_screwdriver(user, O))
-		return
-
 	if(exchange_parts(user, O))
-		return
-
-	if(default_unfasten_wrench(user, O))
-		power_change()
-		return
-
-	if(default_deconstruction_crowbar(user, O))
-		return
-
-	if(istype(O, /obj/item/multitool)||istype(O, /obj/item/wirecutters))
-		if(panel_open)
-			attack_hand(user)
 		return
 
 	if(stat & NOPOWER)

--- a/code/modules/logic/converter.dm
+++ b/code/modules/logic/converter.dm
@@ -48,15 +48,20 @@
 		attached_signaler = S
 		to_chat(user, "<span class='notice'>You attach \the [S] to the I/O connection port and secure it.</span>")
 		return
-	if(attached_signaler && istype(O, /obj/item/screwdriver))		//Makes sure we remove the attached signaler before we can open up and deconstruct the machine
-		var/obj/item/assembly/signaler/S = attached_signaler
-		attached_signaler = null
-		S.forceMove(get_turf(src))
-		S.holder = null
-		S.toggle_secure()
-		to_chat(user, "<span class='notice'>You unsecure and detach \the [S] from the I/O connection port.</span>")
-		return
 	return ..()
+
+/obj/machinery/logic_gate/convert/screwdriver_act(mob/user, obj/item/I)
+	if(tamperproof || !attached_signaler)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/obj/item/assembly/signaler/S = attached_signaler
+	attached_signaler = null
+	S.forceMove(get_turf(src))
+	S.holder = null
+	S.toggle_secure()
+	to_chat(user, "<span class='notice'>You unsecure and detach \the [S] from the I/O connection port.</span>")
 
 /obj/machinery/logic_gate/convert/multitool_menu(var/mob/user, var/obj/item/multitool/P)
 	var/logic_state_string

--- a/code/modules/logic/logic_base.dm
+++ b/code/modules/logic/logic_base.dm
@@ -202,17 +202,32 @@
 	if(tamperproof)
 		to_chat(user, "<span class='warning'>The [src] appears to be tamperproofed! You can't interact with it!</span>")
 		return 0
-	if(istype(O, /obj/item/multitool))
-		update_multitool_menu(user)
-		return 1
-	if(istype(O, /obj/item/screwdriver))
-		panel_open = !panel_open
-		to_chat(user, "<span class='notice'>You [panel_open ? "open" : "close"] the access panel.</span>")
-		return 1
-	if(panel_open && istype(O, /obj/item/crowbar))
-		default_deconstruction_crowbar(user, O)
-		return 1
 	return ..()
+
+/obj/machinery/logic_gate/crowbar_act(mob/user, obj/item/I)
+	if(tamperproof)
+		return
+	if(!panel_open)
+		return
+	. = TRUE
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/logic_gate/multitool_act(mob/user, obj/item/I)
+	if(tamperproof)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	update_multitool_menu(user)
+
+/obj/machinery/logic_gate/screwdriver_act(mob/user, obj/item/I)
+	if(tamperproof)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	panel_open = !panel_open
+	to_chat(user, "<span class='notice'>You [panel_open ? "open" : "close"] the access panel.</span>")
 
 //////////////////////////////////////
 //			Attack procs			//

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -172,36 +172,33 @@
 	else
 		return ..()
 
-/obj/structure/closet/crate/secure/loot/attackby(obj/item/W, mob/user)
-	if(locked)
-		if(istype(W, /obj/item/card/emag))
-			boom(user)
-			return 1
-		if(istype(W, /obj/item/multitool))
-			to_chat(user, "<span class='notice'>DECA-CODE LOCK REPORT:</span>")
-			if(attempts == 1)
-				to_chat(user, "<span class='warning'>* Anti-Tamper Bomb will activate on next failed access attempt.</span>")
-			else
-				to_chat(user, "<span class='notice'>* Anti-Tamper Bomb will activate after [attempts] failed access attempts.</span>")
-			if(lastattempt != null)
-				var/bulls = 0
-				var/cows = 0
-				var/list/banned = list()
-				for(var/i in 1 to codelen)
-					var/list/a = copytext(lastattempt, i, i + 1)
-					if(a in banned)
-						continue
-					var/g = findtext(code, a)
-					if(g)
-						banned += a
-						if(g == i)
-							++bulls
-						else
-							++cows
-
-				to_chat(user, "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>")
-			return 1
-	return ..()
+/obj/structure/closet/crate/secure/loot/multitool_act(mob/user, obj/item/I)
+	if(!locked)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	to_chat(user, "<span class='notice'>DECA-CODE LOCK REPORT:</span>")
+	if(attempts == 1)
+		to_chat(user, "<span class='warning'>* Anti-Tamper Bomb will activate on next failed access attempt.</span>")
+	else
+		to_chat(user, "<span class='notice'>* Anti-Tamper Bomb will activate after [attempts] failed access attempts.</span>")
+	if(lastattempt != null)
+		var/bulls = 0
+		var/cows = 0
+		var/list/banned = list()
+		for(var/i in 1 to codelen)
+			var/list/a = copytext(lastattempt, i, i + 1)
+			if(a in banned)
+				continue
+			var/g = findtext(code, a)
+			if(g)
+				banned += a
+				if(g == i)
+					++bulls
+				else
+					++cows
+		to_chat(user, "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>")
 
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user)
 	if(locked)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		return
 
 	if(wires && !primed)
-		if(istype(I, /obj/item/wirecutters) || istype(I, /obj/item/multitool) || istype(I, /obj/item/assembly/signaler))
+		if(istype(I, /obj/item/assembly/signaler))
 			wires.Interact(user)
 			return
 
@@ -241,13 +241,26 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		GibtoniteReaction(user)
 		return
 	if(primed)
-		if(istype(I, /obj/item/mining_scanner) || istype(I, /obj/item/t_scanner/adv_mining_scanner) || istype(I, /obj/item/multitool))
-			primed = 0
-			user.visible_message("The chain reaction was stopped! ...The ore's quality looks diminished.", "<span class='notice'>You stopped the chain reaction. ...The ore's quality looks diminished.</span>")
-			icon_state = "Gibtonite ore"
-			quality = GIBTONITE_QUALITY_LOW
+		if(istype(I, /obj/item/mining_scanner) || istype(I, /obj/item/t_scanner/adv_mining_scanner))
+			defuse(user)
 			return
 	..()
+
+/obj/item/twohanded/required/gibtonite/multitool_act(mob/user, obj/item/I)
+	if(!primed && wires && I.use_tool(src, user, 0, volume = 0))
+		wires.Interact(user)
+		return TRUE
+	if(primed && I.use_tool(src, user, 0, volume = I.tool_volume))
+		defuse(user)
+		return TRUE
+
+/obj/item/twohanded/required/gibtonite/wirecutter_act(mob/user, obj/item/I)
+	if(!wires || primed)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	wires.Interact(user)
 
 /obj/item/twohanded/required/gibtonite/attack_ghost(mob/user)
 	if(wires)
@@ -265,6 +278,14 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 
 /obj/item/twohanded/required/gibtonite/ex_act()
 	GibtoniteReaction(null, 1)
+
+/obj/item/twohanded/required/gibtonite/proc/defuse(mob/user)
+	if(!primed)
+		return
+	primed = FALSE
+	user.visible_message("The chain reaction was stopped! ...The ore's quality looks diminished.", "<span class='notice'>You stopped the chain reaction. ...The ore's quality looks diminished.</span>")
+	icon_state = "Gibtonite ore"
+	quality = GIBTONITE_QUALITY_LOW
 
 /obj/item/twohanded/required/gibtonite/proc/GibtoniteReaction(mob/user, triggered_by = 0)
 	if(!primed)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -303,13 +303,7 @@
 	show_controls(user)
 
 /mob/living/simple_animal/bot/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/screwdriver))
-		if(!locked)
-			open = !open
-			to_chat(user, "<span class='notice'>The maintenance panel is now [open ? "opened" : "closed"].</span>")
-		else
-			to_chat(user, "<span class='warning'>The maintenance panel is locked.</span>")
-	else if(istype(W, /obj/item/card/id) || istype(W, /obj/item/pda))
+	if(istype(W, /obj/item/card/id) || istype(W, /obj/item/pda))
 		if(bot_core.allowed(user) && !open && !emagged)
 			locked = !locked
 			to_chat(user, "Controls are now [locked ? "locked." : "unlocked."]")
@@ -359,6 +353,18 @@
 	else
 		return ..()
 
+/mob/living/simple_animal/bot/screwdriver_act(mob/user, obj/item/I)
+	if(user.a_intent != INTENT_HELP)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(!locked)
+		open = !open
+		to_chat(user, "<span class='notice'>The maintenance panel is now [open ? "opened" : "closed"].</span>")
+	else
+		to_chat(user, "<span class='warning'>The maintenance panel is locked.</span>")
+
 /mob/living/simple_animal/bot/welder_act(mob/user, obj/item/I)
 	if(user.a_intent != INTENT_HELP)
 		return
@@ -371,7 +377,7 @@
 	if(!open)
 		to_chat(user, "<span class='warning'>Unable to repair with the maintenance panel closed!</span>")
 		return
-	if(!I.use_tool(src, user, volume = I.tool_volume))
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	adjustBruteLoss(-10)
 	add_fingerprint(user)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -175,9 +175,7 @@
 
 /mob/living/simple_animal/bot/ed209/attackby(obj/item/W, mob/user, params)
 	..()
-	if(istype(W, /obj/item/weldingtool) && user.a_intent != INTENT_HARM) // Any intent but harm will heal, so we shouldn't get angry.
-		return
-	if(!istype(W, /obj/item/screwdriver) && (!target)) // Added check for welding tool to fix #2432. Welding tool behavior is handled in superclass.
+	if(!target)
 		if(W.force && W.damtype != STAMINA)//If force is non-zero and damage type isn't stamina.
 			retaliate(user)
 			if(lasercolor)//To make up for the fact that lasertag bots don't hunt

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -83,12 +83,7 @@
 	reached_target = 0
 
 /mob/living/simple_animal/bot/mulebot/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/screwdriver))
-		..()
-		if(open)
-			on = FALSE
-		update_controls()
-	else if(istype(I,/obj/item/stock_parts/cell) && open && !cell)
+	if(istype(I,/obj/item/stock_parts/cell) && open && !cell)
 		if(!user.drop_item())
 			return
 		var/obj/item/stock_parts/cell/C = I
@@ -97,25 +92,6 @@
 		visible_message("[user] inserts a cell into [src].",
 						"<span class='notice'>You insert the new cell into [src].</span>")
 		update_controls()
-	else if(istype(I, /obj/item/crowbar) && open && cell)
-		cell.add_fingerprint(usr)
-		cell.forceMove(loc)
-		cell = null
-		visible_message("[user] crowbars out the power cell from [src].",
-						"<span class='notice'>You pry the powercell out of [src].</span>")
-		update_controls()
-	else if(istype(I, /obj/item/wrench))
-		if(health < maxHealth)
-			adjustBruteLoss(-25)
-			updatehealth()
-			user.visible_message(
-				"<span class='notice'>[user] repairs [src]!</span>",
-				"<span class='notice'>You repair [src]!</span>"
-			)
-		else
-			to_chat(user, "<span class='notice'>[src] does not need a repair!</span>")
-	else if((istype(I, /obj/item/multitool) || istype(I, /obj/item/wirecutters)) && open)
-		return attack_hand(user)
 	else if(load && ismob(load))  // chance to knock off rider
 		if(prob(1 + I.force * 2))
 			unload(0)
@@ -128,6 +104,40 @@
 		..()
 	update_icon()
 	return
+
+/mob/living/simple_animal/bot/mulebot/crowbar_act(mob/user, obj/item/I)
+	if(user.a_intent != INTENT_HELP)
+		return
+	if(!open)
+		return
+	. = TRUE
+	if(!cell)
+		to_chat(user, "<span class='warning'>There isn't a cell to remove!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	cell.add_fingerprint(usr)
+	cell.forceMove(loc)
+	cell = null
+	visible_message("[user] crowbars out the power cell from [src].",
+					"<span class='notice'>You pry the powercell out of [src].</span>")
+	update_controls()
+
+/mob/living/simple_animal/bot/mulebot/multitool_act(mob/user, obj/item/I)
+	if(open)
+		attack_hand(user)
+		return TRUE
+
+/mob/living/simple_animal/bot/mulebot/screwdriver_act(mob/user, obj/item/I)
+	. = ..()
+	if(. && open)
+		on = FALSE
+		update_controls()
+
+/mob/living/simple_animal/bot/mulebot/wirecutter_act(mob/user, obj/item/I)
+	if(open)
+		attack_hand(user)
+		return TRUE
 
 /mob/living/simple_animal/bot/mulebot/emag_act(mob/user)
 	if(emagged < 1)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -179,13 +179,6 @@ Auto Patrol: []"},
 		retaliate(H)
 	return ..()
 
-/mob/living/simple_animal/bot/secbot/attackby(obj/item/W, mob/user, params)
-	..()
-	if(istype(W, /obj/item/weldingtool) && user.a_intent != INTENT_HARM) // Any intent but harm will heal, so we shouldn't get angry.
-		return
-	if(!istype(W, /obj/item/screwdriver) && (W.force) && (!target) && (W.damtype != STAMINA) ) // Added check for welding tool to fix #2432. Welding tool behavior is handled in superclass.
-		retaliate(user)
-
 /mob/living/simple_animal/bot/secbot/emag_act(mob/user)
 	..()
 	if(emagged == 2)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -314,49 +314,53 @@
 	if(istype(W, /obj/item/computer_hardware))
 		if(install_component(W, user))
 			return
-
-	if(istype(W, /obj/item/wrench))
-		if(all_components.len)
-			to_chat(user, "<span class='warning'>Remove all components from \the [src] before disassembling it.</span>")
-			return
-		new /obj/item/stack/sheet/metal(get_turf(loc), steel_sheet_cost)
-		physical.visible_message("\The [src] has been disassembled by [user].")
-		relay_qdel()
-		qdel(src)
-		return
-
-	if(istype(W, /obj/item/screwdriver))
-		if(!all_components.len)
-			to_chat(user, "<span class='warning'>This device doesn't have any components installed.</span>")
-			return
-		var/list/component_names = list()
-		for(var/h in all_components)
-			var/obj/item/computer_hardware/H = all_components[h]
-			component_names.Add(H.name)
-
-		var/choice = input(user, "Which component do you want to uninstall?", "Computer maintenance", null) as null|anything in component_names
-
-		if(!choice)
-			return
-
-		if(!Adjacent(user))
-			return
-
-		var/obj/item/computer_hardware/H = find_hardware_by_name(choice)
-
-		if(!H)
-			return
-
-		uninstall_component(H, user)
-		return
-
 	..()
+
+/obj/item/modular_computer/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!all_components.len)
+		to_chat(user, "<span class='warning'>This device doesn't have any components installed.</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/list/component_names = list()
+	for(var/h in all_components)
+		var/obj/item/computer_hardware/H = all_components[h]
+		component_names.Add(H.name)
+
+	var/choice = input(user, "Which component do you want to uninstall?", "Computer maintenance", null) as null|anything in component_names
+
+	if(!choice)
+		return
+
+	if(!Adjacent(user))
+		return
+
+	var/obj/item/computer_hardware/H = find_hardware_by_name(choice)
+
+	if(!H)
+		return
+
+	uninstall_component(H, user)
 
 /obj/item/modular_computer/welder_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
 	default_welder_repair(user, I)
+
+/obj/item/modular_computer/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(all_components.len)
+		to_chat(user, "<span class='warning'>Remove all components from \the [src] before disassembling it.</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	new /obj/item/stack/sheet/metal(get_turf(loc), steel_sheet_cost)
+	physical.visible_message("\The [src] has been disassembled by [user].")
+	relay_qdel()
+	qdel(src)
+	return
 
 // Used by processor to relay qdel() to machinery type.
 /obj/item/modular_computer/proc/relay_qdel()

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -34,13 +34,6 @@
 
 
 /obj/item/computer_hardware/attackby(obj/item/I, mob/living/user)
-	// Multitool. Runs diagnostics
-	if(istype(I, /obj/item/multitool))
-		to_chat(user, "***** DIAGNOSTICS REPORT *****")
-		diagnostics(user)
-		to_chat(user, "******************************")
-		return 1
-
 	// Cable coil. Works as repair method, but will probably require multiple applications and more cable.
 	if(istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/S = I
@@ -56,6 +49,14 @@
 		return 1
 
 	return ..()
+
+/obj/item/computer_hardware/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	to_chat(user, "***** DIAGNOSTICS REPORT *****")
+	diagnostics(user)
+	to_chat(user, "******************************")
 
 // Called on multitool click, prints diagnostic information to the user.
 /obj/item/computer_hardware/proc/diagnostics(var/mob/user)

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -71,10 +71,9 @@
 		return TRUE
 	return FALSE
 
-/obj/item/computer_hardware/ai_slot/attackby(obj/item/I, mob/living/user)
-	if(..())
+/obj/item/computer_hardware/ai_slot/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(istype(I, /obj/item/screwdriver))
-		to_chat(user, "<span class='notice'>You press down on the manual eject button with \the [I].</span>")
-		try_eject(0, user, 1)
-		return
+	to_chat(user, "<span class='notice'>You press down on the manual eject button with \the [I].</span>")
+	try_eject(0, user, 1)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -98,13 +98,12 @@
 		return TRUE
 	return FALSE
 
-/obj/item/computer_hardware/card_slot/attackby(obj/item/I, mob/living/user)
-	if(..())
+/obj/item/computer_hardware/card_slot/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(istype(I, /obj/item/screwdriver))
-		to_chat(user, "<span class='notice'>You press down on the manual eject button with \the [I].</span>")
-		try_eject(0,user)
-		return
+	to_chat(user, "<span class='notice'>You press down on the manual eject button with \the [I].</span>")
+	try_eject(0,user)
 
 /obj/item/computer_hardware/card_slot/examine(mob/user)
 	. = ..()

--- a/code/modules/paperwork/frames.dm
+++ b/code/modules/paperwork/frames.dm
@@ -56,34 +56,7 @@
 		qdel(D)
 
 /obj/item/picture_frame/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/screwdriver))
-		if(displayed)
-			playsound(src, I.usesound, 100, 1)
-			user.visible_message("<span class='warning'>[user] unfastens \the [displayed] out of \the [src].</span>", "<span class='warning'>You unfasten \the [displayed] out of \the [src].</span>")
-
-			if(istype(displayed, /obj/structure/sign/poster))
-				var/obj/structure/sign/poster/P = displayed
-				P.roll_and_drop(user.loc)
-			else
-				displayed.forceMove(user.loc)
-			displayed = null
-			name = initial(name)
-			update_icon()
-		else
-			to_chat(user, "<span class='notice'>There is nothing to remove from \the [src].</span>")
-	else if(istype(I, /obj/item/crowbar))
-		playsound(src, I.usesound, 100, 1)
-		user.visible_message("<span class='warning'>[user] breaks down \the [src].</span>", "<span class='warning'>You break down \the [src].</span>")
-		for(var/A in contents)
-			if(istype(A, /obj/structure/sign/poster))
-				var/obj/structure/sign/poster/P = A
-				P.roll_and_drop(user.loc)
-			else
-				var/obj/O = A
-				O.forceMove(user.loc)
-		displayed = null
-		qdel(src)
-	else if(istype(I, /obj/item/paper) || istype(I, /obj/item/photo) || istype(I, /obj/item/poster))
+	if(istype(I, /obj/item/paper) || istype(I, /obj/item/photo) || istype(I, /obj/item/poster))
 		if(!displayed)
 			user.unEquip(I)
 			insert(I)
@@ -92,6 +65,39 @@
 			to_chat(user, "<span class='notice'>\The [src] already contains \a [displayed].</span>")
 	else
 		return ..()
+
+/obj/item/picture_frame/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	user.visible_message("<span class='warning'>[user] breaks down \the [src].</span>", "<span class='warning'>You break down \the [src].</span>")
+	for(var/A in contents)
+		if(istype(A, /obj/structure/sign/poster))
+			var/obj/structure/sign/poster/P = A
+			P.roll_and_drop(user.loc)
+		else
+			var/obj/O = A
+			O.forceMove(user.loc)
+	displayed = null
+	qdel(src)
+
+/obj/item/picture_frame/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!displayed)
+		to_chat(user, "<span class='notice'>There is nothing to remove from \the [src].</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	user.visible_message("<span class='warning'>[user] unfastens \the [displayed] out of \the [src].</span>", "<span class='warning'>You unfasten \the [displayed] out of \the [src].</span>")
+
+	if(istype(displayed, /obj/structure/sign/poster))
+		var/obj/structure/sign/poster/P = displayed
+		P.roll_and_drop(user.loc)
+	else
+		displayed.forceMove(user.loc)
+	displayed = null
+	name = initial(name)
+	update_icon()
 
 /obj/item/picture_frame/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag && istype(target, /turf/simulated/wall))
@@ -210,18 +216,6 @@
 		icon_state = initial(icon_state)
 
 /obj/structure/sign/picture_frame/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/screwdriver))
-		playsound(src, I.usesound, 100, 1)
-		user.visible_message("<span class='warning'>[user] begins to unfasten \the [src] from the wall.</span>", "<span class='warning'>You begin to unfasten \the [src] from the wall.</span>")
-		if(do_after(user, 100 * I.toolspeed, target = src))
-			playsound(src, I.usesound, 100, 1)
-			user.visible_message("<span class='warning'>[user] unfastens \the [src] from the wall.</span>", "<span class='warning'>You unfasten \the [src] from the wall.</span>")
-			frame.forceMove(user.loc)
-			frame = null
-			if(explosive)
-				explosive.forceMove(user.loc)
-				explosive = null
-			qdel(src)
 	if(istype(I, /obj/item/grenade) || istype(I, /obj/item/grenade/plastic/c4))
 		if(explosive)
 			to_chat(user, "<span class='warning'>There is already a device attached behind \the [src], remove it first.</span>")
@@ -244,6 +238,21 @@
 		return 1
 	else
 		return ..()
+
+/obj/structure/sign/picture_frame/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	user.visible_message("<span class='warning'>[user] begins to unfasten \the [src] from the wall.</span>", "<span class='warning'>You begin to unfasten \the [src] from the wall.</span>")
+	if(!I.use_tool(src, user, 100, volume = I.tool_volume))
+		return
+	user.visible_message("<span class='warning'>[user] unfastens \the [src] from the wall.</span>", "<span class='warning'>You unfasten \the [src] from the wall.</span>")
+	frame.forceMove(user.loc)
+	frame = null
+	if(explosive)
+		explosive.forceMove(user.loc)
+		explosive = null
+	qdel(src)
 
 /obj/structure/sign/picture_frame/examine(mob/user, var/infix = "", var/suffix = "")
 	if(frame)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -41,39 +41,6 @@
 
 /obj/machinery/light_construct/attackby(obj/item/W as obj, mob/living/user as mob, params)
 	src.add_fingerprint(user)
-	if(istype(W, /obj/item/wrench))
-		if(src.stage == 1)
-			playsound(src.loc, W.usesound, 75, 1)
-			to_chat(usr, "You begin deconstructing [src].")
-			if(!do_after(usr, 30 * W.toolspeed, target = src))
-				return
-			new /obj/item/stack/sheet/metal( get_turf(src.loc), sheets_refunded )
-			user.visible_message("[user.name] deconstructs [src].", \
-				"You deconstruct [src].", "You hear a noise.")
-			playsound(src.loc, W.usesound, 75, 1)
-			qdel(src)
-		if(src.stage == 2)
-			to_chat(usr, "You have to remove the wires first.")
-			return
-
-		if(src.stage == 3)
-			to_chat(usr, "You have to unscrew the case first.")
-			return
-
-	if(istype(W, /obj/item/wirecutters))
-		if(src.stage != 2) return
-		src.stage = 1
-		switch(fixture_type)
-			if("tube")
-				src.icon_state = "tube-construct-stage1"
-			if("bulb")
-				src.icon_state = "bulb-construct-stage1"
-		new /obj/item/stack/cable_coil(get_turf(src.loc), 1, paramcolor = COLOR_RED)
-		user.visible_message("[user.name] removes the wiring from [src].", \
-			"You remove the wiring from [src].", "You hear a noise.")
-		playsound(loc, W.usesound, 100, 1)
-		return
-
 	if(istype(W, /obj/item/stack/cable_coil))
 		if(src.stage != 1) return
 		var/obj/item/stack/cable_coil/coil = W
@@ -88,32 +55,62 @@
 		user.visible_message("[user.name] adds wires to [src].", \
 			"You add wires to [src].")
 		return
-
-	if(istype(W, /obj/item/screwdriver))
-		if(src.stage == 2)
-			switch(fixture_type)
-				if("tube")
-					src.icon_state = "tube-empty"
-				if("bulb")
-					src.icon_state = "bulb-empty"
-			src.stage = 3
-			user.visible_message("[user.name] closes [src]'s casing.", \
-				"You close [src]'s casing.", "You hear a noise.")
-			playsound(src.loc, W.usesound, 75, 1)
-
-			switch(fixture_type)
-
-				if("tube")
-					newlight = new /obj/machinery/light/built(src.loc)
-				if("bulb")
-					newlight = new /obj/machinery/light/small/built(src.loc)
-
-			newlight.dir = src.dir
-			src.transfer_fingerprints_to(newlight)
-			qdel(src)
-			return
 	else
 		return ..()
+
+/obj/machinery/light_construct/screwdriver_act(mob/user, obj/item/I)
+	if(stage != 2)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	switch(fixture_type)
+		if("tube")
+			src.icon_state = "tube-empty"
+		if("bulb")
+			src.icon_state = "bulb-empty"
+	stage = 3
+	user.visible_message("[user.name] closes [src]'s casing.", "You close [src]'s casing.", "You hear a noise.")
+	switch(fixture_type)
+		if("tube")
+			newlight = new /obj/machinery/light/built(src.loc)
+		if("bulb")
+			newlight = new /obj/machinery/light/small/built(src.loc)
+	newlight.dir = dir
+	transfer_fingerprints_to(newlight)
+	qdel(src)
+
+/obj/machinery/light_construct/wirecutter_act(mob/user, obj/item/I)
+	if(stage != 2)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	stage = 1
+	switch(fixture_type)
+		if("tube")
+			icon_state = "tube-construct-stage1"
+		if("bulb")
+			icon_state = "bulb-construct-stage1"
+	new /obj/item/stack/cable_coil(get_turf(loc), 1, paramcolor = COLOR_RED)
+	user.visible_message("[user.name] removes the wiring from [src].", "You remove the wiring from [src].", "You hear a noise.")
+
+/obj/machinery/light_construct/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	switch(stage)
+		if(1)
+			if(!I.tool_use_check(user, 0))
+				return
+			to_chat(user, "You begin deconstructing [src].")
+			if(!I.use_tool(src, user, 30, volume = I.tool_volume))
+				return
+			new /obj/item/stack/sheet/metal( get_turf(src.loc), sheets_refunded )
+			user.visible_message("[user.name] deconstructs [src].", "You deconstruct [src].", "You hear a noise.")
+			qdel(src)
+		if(2)
+			to_chat(user, "You have to remove the wires first.")
+		if(3)
+			to_chat(user, "You have to unscrew the case first.")
 
 /obj/machinery/light_construct/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)
@@ -375,12 +372,7 @@
 
 	// attempt to stick weapon into light socket
 	else if(status == LIGHT_EMPTY)
-		if(istype(W, /obj/item/screwdriver)) //If it's a screwdriver open it.
-			playsound(src.loc, W.usesound, 75, 1)
-			user.visible_message("[user.name] opens [src]'s casing.", \
-				"You open [src]'s casing.", "You hear a noise.")
-			deconstruct()
-			return
+
 
 		to_chat(user, "You stick \the [W] into the light socket!")
 		if(has_power() && (W.flags & CONDUCT))
@@ -389,6 +381,16 @@
 				electrocute_mob(user, get_area(src), src, rand(0.7, 1), TRUE)
 	else
 		return ..()
+
+/obj/machinery/light/screwdriver_act(mob/user, obj/item/I)
+	if(status != LIGHT_EMPTY)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	user.visible_message("[user.name] opens [src]'s casing.", \
+		"You open [src]'s casing.", "You hear a noise.")
+	deconstruct()
 
 /obj/machinery/light/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -283,32 +283,43 @@
 		SSnanoui.update_uis(src)
 		return
 	else if(!active)
-		if(istype(O, /obj/item/wrench))
-
-			if(!anchored)
-				connect_to_network()
-				to_chat(user, "<span class='notice'>You secure the generator to the floor.</span>")
-			else
-				disconnect_from_network()
-				to_chat(user, "<span class='notice'>You unsecure the generator from the floor.</span>")
-
-			playsound(src.loc, O.usesound, 50, 1)
-			anchored = !anchored
-
-		else if(istype(O, /obj/item/screwdriver))
-			panel_open = !panel_open
-			playsound(src.loc, O.usesound, 50, 1)
-			if(panel_open)
-				to_chat(user, "<span class='notice'>You open the access panel.</span>")
-			else
-				to_chat(user, "<span class='notice'>You close the access panel.</span>")
-		else if(istype(O, /obj/item/storage/part_replacer) && panel_open)
+		if(istype(O, /obj/item/storage/part_replacer) && panel_open)
 			exchange_parts(user, O)
 			return
-		else if(istype(O, /obj/item/crowbar) && panel_open)
-			default_deconstruction_crowbar(user, O)
 	else
 		return ..()
+
+/obj/machinery/power/port_gen/pacman/crowbar_act(mob/user, obj/item/I)
+	if(active || !panel_open)
+		return
+	. = TRUE
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/power/port_gen/pacman/screwdriver_act(mob/user, obj/item/I)
+	if(active)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	panel_open = !panel_open
+	if(panel_open)
+		to_chat(user, "<span class='notice'>You open the access panel.</span>")
+	else
+		to_chat(user, "<span class='notice'>You close the access panel.</span>")
+
+/obj/machinery/power/port_gen/pacman/wrench_act(mob/user, obj/item/I)
+	if(active)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(!anchored)
+		connect_to_network()
+		to_chat(user, "<span class='notice'>You secure the generator to the floor.</span>")
+	else
+		disconnect_from_network()
+		to_chat(user, "<span class='notice'>You unsecure the generator from the floor.</span>")
+	anchored = !anchored
 
 /obj/machinery/power/port_gen/pacman/attack_hand(mob/user as mob)
 	..()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -50,10 +50,7 @@ var/global/list/rad_collectors = list()
 
 
 /obj/machinery/power/rad_collector/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/multitool))
-		to_chat(user, "<span class='notice'>The [W.name] detects that [last_power]W were recently produced.</span>")
-		return 1
-	else if(istype(W, /obj/item/analyzer) && P)
+	if(istype(W, /obj/item/analyzer) && P)
 		atmosanalyzer_scan(P.air_contents, user)
 	else if(istype(W, /obj/item/tank/plasma))
 		if(!src.anchored)
@@ -66,23 +63,7 @@ var/global/list/rad_collectors = list()
 		src.P = W
 		W.loc = src
 		update_icons()
-	else if(istype(W, /obj/item/crowbar))
-		if(P && !src.locked)
-			eject()
-			return 1
-	else if(istype(W, /obj/item/wrench))
-		if(P)
-			to_chat(user, "<span class='notice'>Remove the plasma tank first.</span>")
-			return 1
-		playsound(src.loc, W.usesound, 75, 1)
-		src.anchored = !src.anchored
-		user.visible_message("[user.name] [anchored? "secures":"unsecures"] the [src.name].", \
-			"You [anchored? "secure":"undo"] the external bolts.", \
-			"You hear a ratchet")
-		if(anchored)
-			connect_to_network()
-		else
-			disconnect_from_network()
+
 	else if(istype(W, /obj/item/card/id)||istype(W, /obj/item/pda))
 		if(src.allowed(user))
 			if(active)
@@ -96,6 +77,37 @@ var/global/list/rad_collectors = list()
 			return 1
 	else
 		return ..()
+
+
+/obj/machinery/power/rad_collector/crowbar_act(mob/user, obj/item/I)
+	if(!P || locked)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	eject()
+
+/obj/machinery/power/rad_collector/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(P)	
+		to_chat(user, "<span class='notice'>Remove the plasma tank first.</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	anchored = !anchored
+	user.visible_message("[user.name] [anchored? "secures":"unsecures"] the [src.name].", \
+		"You [anchored? "secure":"undo"] the external bolts.", \
+		"You hear a ratchet")
+	if(anchored)
+		connect_to_network()
+	else
+		disconnect_from_network()
+
+/obj/machinery/power/rad_collector/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	to_chat(user, "<span class='notice'>The [W.name] detects that [last_power]W were recently produced.</span>")
 
 /obj/machinery/power/rad_collector/obj_break(damage_flag)
 	if(!(stat & BROKEN) && !(flags & NODECONSTRUCT))

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -395,35 +395,29 @@
 
 	return data
 
-/obj/machinery/power/solar_control/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/screwdriver))
-		playsound(src.loc, I.usesound, 50, 1)
-		if(do_after(user, 20 * I.toolspeed, target = src))
-			if(src.stat & BROKEN)
-				to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-				var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-				new /obj/item/shard( src.loc )
-				var/obj/item/circuitboard/solar_control/M = new /obj/item/circuitboard/solar_control( A )
-				for(var/obj/C in src)
-					C.loc = src.loc
-				A.circuit = M
-				A.state = 3
-				A.icon_state = "3"
-				A.anchored = 1
-				qdel(src)
-			else
-				to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
-				var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-				var/obj/item/circuitboard/solar_control/M = new /obj/item/circuitboard/solar_control( A )
-				for(var/obj/C in src)
-					C.loc = src.loc
-				A.circuit = M
-				A.state = 4
-				A.icon_state = "4"
-				A.anchored = 1
-				qdel(src)
+/obj/machinery/power/solar_control/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	if(!I.use_tool(src, user, 20, volume = I.tool_volume))
+		return
+	var/obj/structure/computerframe/A = new /obj/structure/computerframe(loc)
+	var/obj/item/circuitboard/solar_control/M = new /obj/item/circuitboard/solar_control(A)
+	A.anchored = TRUE
+	A.circuit = M
+	for(var/obj/C in src)
+			C.loc = src.loc
+	
+	if(src.stat & BROKEN)
+		to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
+		new /obj/item/shard( src.loc )
+		A.state = 3
+		A.icon_state = "3"
 	else
-		return ..()
+		to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
+		A.state = 4
+		A.icon_state = "4"
+	qdel(src)
 
 /obj/machinery/power/solar_control/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -57,28 +57,30 @@
 				playsound(src, 'sound/weapons/gun_interactions/bulletinsert.ogg', 50, 1)
 			else
 				to_chat(user, "<span class='warning'>You fail to collect anything!</span>")
-	else
-		if(istype(I, /obj/item/screwdriver))
-			if(BB)
-				if(initial(BB.name) == "bullet")
-					var/tmp_label = ""
-					var/label_text = sanitize(input(user, "Inscribe some text into \the [initial(BB.name)]","Inscription",tmp_label))
-					if(length(label_text) > 20)
-						to_chat(user, "<span class='warning''>The inscription can be at most 20 characters long.</span>")
-					else
-						if(label_text == "")
-							to_chat(user, "<span class='notice'>You scratch the inscription off of [initial(BB)].</span>")
-							BB.name = initial(BB.name)
-						else
-							to_chat(user, "<span class='notice'>You inscribe \"[label_text]\" into \the [initial(BB.name)].</span>")
-							BB.name = "[initial(BB.name)] \"[label_text]\""
-				else
-					to_chat(user, "<span class='notice'>You can only inscribe a metal bullet.</span>")//because inscribing beanbags is silly
-
-			else
-				to_chat(user, "<span class='notice'>There is no bullet in the casing to inscribe anything into.</span>")
 		..()
 
+/obj/item/ammo_casing/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!BB)
+		to_chat(user, "<span class='notice'>There is no bullet in the casing to inscribe anything into.</span>")
+		return
+	if(initial(BB.name) != "bullet")
+		to_chat(user, "<span class='notice'>You can only inscribe a metal bullet.</span>")//because inscribing beanbags is silly
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	var/tmp_label = ""
+	var/label_text = sanitize(input(user, "Inscribe some text into \the [initial(BB.name)]","Inscription",tmp_label))
+	if(length(label_text) > 20)
+		to_chat(user, "<span class='warning''>The inscription can be at most 20 characters long.</span>")
+	else
+		if(label_text == "")
+			to_chat(user, "<span class='notice'>You scratch the inscription off of [initial(BB)].</span>")
+			BB.name = initial(BB.name)
+		else
+			to_chat(user, "<span class='notice'>You inscribe \"[label_text]\" into \the [initial(BB.name)].</span>")
+			BB.name = "[initial(BB.name)] \"[label_text]\""
+		
 //Boxes of ammo
 /obj/item/ammo_box
 	name = "ammo box (generic)"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -342,11 +342,7 @@
 /obj/item/ammo_casing/caseless/foam_dart/attackby(obj/item/A, mob/user, params)
 	..()
 	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
-	if(istype(A, /obj/item/screwdriver) && !modified)
-		modified = 1
-		FD.damage_type = BRUTE
-		update_icon()
-	else if((istype(A, /obj/item/pen)) && modified && !FD.pen)
+	if((istype(A, /obj/item/pen)) && modified && !FD.pen)
 		if(!user.unEquip(A))
 			return
 		harmful = TRUE
@@ -356,7 +352,16 @@
 		FD.damage = 5
 		FD.nodamage = 0
 		to_chat(user, "<span class='notice'>You insert [A] into [src].</span>")
-	return
+
+/obj/item/ammo_casing/caseless/foam_dart/screwdriver_act(mob/user, obj/item/I)
+	if(modified)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	modified = TRUE
+	BB.damage_type = BRUTE
+	update_icon()
 
 /obj/item/ammo_casing/caseless/foam_dart/attack_self(mob/living/user)
 	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB

--- a/code/modules/projectiles/guns/throw/crossbow.dm
+++ b/code/modules/projectiles/guns/throw/crossbow.dm
@@ -104,15 +104,19 @@
 			process_chamber()
 		else
 			to_chat(user, "<span class='notice'>[src] already has a cell installed.</span>")
-	else if(istype(W, /obj/item/screwdriver))
-		if(cell)
-			cell.loc = get_turf(src)
-			to_chat(user, "<span class='notice'>You jimmy [cell] out of [src] with [W].</span>")
-			cell = null
-		else
-			to_chat(user, "<span class='notice'>[src] doesn't have a cell installed.</span>")
 	else
 		..()
+
+/obj/item/gun/throw/crossbow/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!cell)
+		to_chat(user, "<span class='notice'>[src] doesn't have a cell installed.</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	cell.loc = get_turf(src)
+	to_chat(user, "<span class='notice'>You jimmy [cell] out of [src] with [I].</span>")
+	cell = null
 
 /obj/item/gun/throw/crossbow/verb/set_tension()
 	set name = "Adjust Tension"

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -323,9 +323,6 @@
 
 
 /obj/machinery/computer/pandemic/attackby(obj/item/I, mob/user, params)
-	if(default_unfasten_wrench(user, I))
-		power_change()
-		return
 	if(istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER))
 		if(stat & (NOPOWER|BROKEN))
 			return
@@ -340,9 +337,17 @@
 		to_chat(user, "<span class='notice'>You add the beaker to the machine.</span>")
 		updateUsrDialog()
 		icon_state = "mixer1"
-
-	else if(istype(I, /obj/item/screwdriver))
-		if(beaker)
-			beaker.forceMove(get_turf(src))
 	else
 		return ..()
+
+/obj/machinery/computer/pandemic/screwdriver_act(mob/user, obj/item/I)
+	if(!beaker)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	beaker.forceMove(get_turf(src))
+
+/obj/machinery/computer/pandemic/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I))

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -167,7 +167,7 @@
 		to_chat(user, "You can only attach the [nicetype] if the floor plating is removed.")
 		return
 
-	if(istype(I, /obj/item/wrench))
+	if(I.tool_behaviour == TOOL_WRENCH && I.use_tool(src, user, 0, volume = I.tool_volume))
 		if(anchored)
 			anchored = 0
 			if(ispipe)
@@ -205,7 +205,7 @@
 					to_chat(user, "There is already a [nicetype] at that location.")
 					return
 
-	if(istype(I, /obj/item/weldingtool))
+	if(I.tool_behaviour == TOOL_WELDER && I.tool_use_check(user, 0))
 		if(anchored)
 			if(I.tool_use_check(user, 0))
 				to_chat(user, "Welding the [nicetype] in place.")

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1305,22 +1305,12 @@
 				return
 			AM.throw_at(target, 3, 1)
 
-
-/obj/structure/disposaloutlet/attackby(var/obj/item/I, var/mob/user, params)
-	if(!I || !user)
+/obj/structure/disposaloutlet/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	src.add_fingerprint(user)
-	if(istype(I, /obj/item/screwdriver))
-		if(mode==0)
-			mode=1
-			playsound(src.loc, I.usesound, 50, 1)
-			to_chat(user, "You remove the screws around the power connection.")
-			return
-		else if(mode==1)
-			mode=0
-			playsound(src.loc, I.usesound, 50, 1)
-			to_chat(user, "You attach the screws around the power connection.")
-			return
+	mode = !mode
+	to_chat(user, "You [mode ? "remove": "attach"] the screws around the power connection.")
 
 /obj/structure/disposaloutlet/welder_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -62,7 +62,7 @@
 	src.add_fingerprint(usr)
 	if(href_list["pulse"])
 		var/temp_wire = href_list["wire"]
-		if(!istype(usr.get_active_hand(), /obj/item/multitool))
+		if(I.tool_behaviour != TOOL_MULTITOOL || !I.use_tool(src, usr, 0, volume = I.tool_volume))
 			to_chat(usr, "You need a multitool!")
 		else
 			if(src.wires[temp_wire])
@@ -80,7 +80,7 @@
 					src.shock(usr,50)
 					spawn(100) src.shocked = !src.shocked
 	if(href_list["cut"])
-		if(!istype(usr.get_active_hand(), /obj/item/wirecutters))
+		if(I.tool_behaviour != TOOL_WIRECUTTER || !I.use_tool(src, usr, 0, volume = I.tool_volume))
 			to_chat(usr, "You need wirecutters!")
 		else
 			var/temp_wire = href_list["wire"]

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -136,20 +136,33 @@
 	if(shocked)
 		shock(user,50)
 
-	if(istype(O, /obj/item/screwdriver))
-		default_deconstruction_screwdriver(user, "server_o", "server", O)
-		return 1
-
 	if(exchange_parts(user, O))
 		return 1
 
-	if(panel_open)
-		if(istype(O, /obj/item/crowbar))
 			griefProtection()
 			default_deconstruction_crowbar(user, O)
 			return 1
 	else
 		return ..()
+
+/obj/machinery/r_n_d/server/crowbar_act(mob/user, obj/item/I)
+	if(disabled)
+		return
+	if(!panel_open)
+		return
+	. = TRUE
+	if(shocked && shock(user,50))
+		return
+	griefProtection()
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/r_n_d/server/screwdriver_act(mob/user, obj/item/I)
+	if(disabled)
+		return
+	. = TRUE
+	if(shocked && shock(user,50))
+		return
+	default_deconstruction_screwdriver(user, "server_o", "server", I)
 
 /obj/machinery/r_n_d/server/attack_hand(mob/user as mob)
 	if(disabled)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -169,12 +169,8 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(!I.multitool_check_buffer(user))
-		return
-	var/obj/item/multitool/M = I
-	if(istype(M.buffer, /obj/machinery/monkey_recycler))
-		M.set_multitool_buffer(user, src)
-		connected_recycler = M.buffer
+	if(istype(I.buffer, /obj/machinery/monkey_recycler) && I.set_multitool_buffer(user, src))
+		connected_recycler = I.buffer
 		connected_recycler.connected += src
 
 /datum/action/innate/slime_place

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -37,32 +37,30 @@
 	desc = "Generates cannon pulse. Needs to be linked with a fusor. "
 	icon_state = "power_box"
 
-/obj/machinery/bsa/back/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/multitool))
-		var/obj/item/multitool/M = W
-		M.buffer = src
-		to_chat(user, "<span class='notice'>You store linkage information in [W]'s buffer.</span>")
-	else if(istype(W, /obj/item/wrench))
-		default_unfasten_wrench(user, W, 10)
-		return TRUE
-	else
-		return ..()
+/obj/machinery/bsa/back/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	I.set_multitool_buffer(user, src)
+
+/obj/machinery/bsa/back/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I, 10)
 
 /obj/machinery/bsa/front
 	name = "Bluespace Artillery Bore"
 	desc = "Do not stand in front of cannon during operation. Needs to be linked with a fusor."
 	icon_state = "emitter_center"
 
-/obj/machinery/bsa/front/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/multitool))
-		var/obj/item/multitool/M = W
-		M.buffer = src
-		to_chat(user, "<span class='notice'>You store linkage information in [W]'s buffer.</span>")
-	else if(istype(W, /obj/item/wrench))
-		default_unfasten_wrench(user, W, 10)
-		return TRUE
-	else
-		return ..()
+/obj/machinery/bsa/front/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	I.set_multitool_buffer(user, src)
+
+/obj/machinery/bsa/front/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I, 10)
 
 /obj/machinery/bsa/middle
 	name = "Bluespace Artillery Fusor"
@@ -71,23 +69,28 @@
 	var/obj/machinery/bsa/back/back
 	var/obj/machinery/bsa/front/front
 
-/obj/machinery/bsa/middle/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/multitool))
-		var/obj/item/multitool/M = W
-		if(M.buffer)
-			if(istype(M.buffer,/obj/machinery/bsa/back))
-				back = M.buffer
-				M.buffer = null
-				to_chat(user, "<span class='notice'>You link [src] with [back].</span>")
-			else if(istype(M.buffer,/obj/machinery/bsa/front))
-				front = M.buffer
-				M.buffer = null
-				to_chat(user, "<span class='notice'>You link [src] with [front].</span>")
-	else if(istype(W, /obj/item/wrench))
-		default_unfasten_wrench(user, W, 10)
-		return TRUE
+/obj/machinery/bsa/middle/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.buffer)
+		to_chat(user, "<span class='warning'>[I] has nothing in its buffer!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(I.IsBufferA(/obj/machinery/bsa/back))
+		back = I.buffer
+		I.buffer = null
+		to_chat(user, "<span class='notice'>You link [src] with [back].</span>")
+	else if(I.IsBufferA(/obj/machinery/bsa/front))
+		front = M.buffer
+		I.buffer = null
+		to_chat(user, "<span class='notice'>You link [src] with [front].</span>")
 	else
-		return ..()
+		to_chat(user, "<span class='warning'>Unable to link [I]'s buffer to [src]!</span>")
+
+
+/obj/machinery/bsa/middle/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I, 10)
 
 /obj/machinery/bsa/middle/proc/check_completion()
 	if(!front || !back)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -134,11 +134,11 @@
 /obj/machinery/satellite/update_icon()
 	icon_state = active ? "sat_active" : "sat_inactive"
 
-/obj/machinery/satellite/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/multitool))
-		to_chat(user, "<span class='notice'>// NTSAT-[id] // Mode : [active ? "PRIMARY" : "STANDBY"] //[emagged ? "DEBUG_MODE //" : ""]</span>")
-	else
-		return ..()
+/obj/machinery/satellite/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	to_chat(user, "<span class='notice'>// NTSAT-[id] // Mode : [active ? "PRIMARY" : "STANDBY"] //[emagged ? "DEBUG_MODE //" : ""]</span>")
 
 /obj/machinery/satellite/meteor_shield
 	name = "Meteor Shield Satellite"

--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -27,11 +27,14 @@
 		I.forceMove(src)
 		storedorgan = I
 		to_chat(user, "<span class='notice'>You insert the [I] into [src].</span>")
-	else if(istype(I, /obj/item/screwdriver))
-		if(!storedorgan)
-			to_chat(user, "<span class='notice'>There's no implant in [src] for you to remove.</span>")
-		else
-			storedorgan.forceMove(get_turf(user))
-			storedorgan = null
-			to_chat(user, "<span class='notice'>You remove the [storedorgan] from [src].</span>")
-			playsound(get_turf(user), I.usesound, 50, 1)
+
+/obj/item/autoimplanter/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!storedorgan)
+		to_chat(user, "<span class='notice'>There's no implant in [src] for you to remove.</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	storedorgan.forceMove(get_turf(user))
+	storedorgan = null
+	to_chat(user, "<span class='notice'>You remove the [storedorgan] from [src].</span>")

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -51,10 +51,7 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(!I.multitool_check_buffer(user))
-		return
-	var/obj/item/multitool/M = I
-	M.set_multitool_buffer(user, src)
+	I.set_multitool_buffer(user, src)
 
 /obj/machinery/telepad/crowbar_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -65,15 +65,19 @@
 			W.loc = src
 			user.visible_message("<span class='notice'>[user] inserts [W] into [src]'s GPS device slot.</span>")
 			updateUsrDialog()
-	else if(istype(W, /obj/item/multitool))
-		var/obj/item/multitool/M = W
-		if(M.buffer && istype(M.buffer, /obj/machinery/telepad))
-			telepad = M.buffer
-			M.buffer = null
-			to_chat(user, "<span class = 'caution'>You upload the data from the [W.name]'s buffer.</span>")
-			updateUsrDialog()
+
 	else
 		return ..()
+
+/obj/machinery/computer/telescience/multitool_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(I.buffer && I.IsBufferA(/obj/machinery/telepad))
+		telepad = I.buffer
+		I.buffer = null
+		to_chat(user, "<span class = 'caution'>You upload the data from the [W.name]'s buffer.</span>")
+		updateUsrDialog()
 
 /obj/machinery/computer/telescience/emag_act(user as mob)
 	if(!emagged)


### PR DESCRIPTION
(I worked #12912) into this PR to avoid having to deal with merge conflicts and such) 

- Removes all `obj/item/tool` checks from the code and refactors it to use the new tool procs. Hopefully there will be no 🐛 introduced here, but you never know 😄 
- Also stops you ruining the bartender's day with a screwdriver. Instead it will just open and close the maintenance panel

WIP until I hit all the tool references
:cl:
fix: Unscrewing a barsign won't drop it as an invisible regular sign any more
tweak: Attacking a barsign with an ID card will open the sign pick menu
tweak: You may now use a welder to heal mulebots (instead of a wrench, which is how it used to be fore some reason)
/:cl: