### PR TITLE
Maintenance drones no longer get a flash

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -27,9 +27,10 @@
 	..()
 
 
-/obj/item/robot_module/New()
+/obj/item/robot_module/New(loc, should_have_flash = TRUE)
 	..()
-	modules += new /obj/item/flash/cyborg(src)
+	if(should_have_flash)
+		modules += new /obj/item/flash/cyborg(src)
 	emag = new /obj/item/toy/sword(src)
 	emag.name = "Placeholder Emag Item"
 
@@ -539,7 +540,7 @@
 		/obj/item/stack/cable_coil/cyborg = 30
 		)
 
-/obj/item/robot_module/drone/New()
+/obj/item/robot_module/drone/New(loc, should_have_flash = FALSE)
 	..()
 	modules += new /obj/item/weldingtool/largetank/cyborg(src)
 	modules += new /obj/item/screwdriver/cyborg(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -38,7 +38,7 @@
 	QDEL_NULL(emag)
 	return ..()
 
-// By default, all robots will get the items in this proc, unless you override it for you specific module. See: ../robot_module/drone
+// By default, all robots will get the items in this proc, unless you override it for your specific module. See: ../robot_module/drone
 /obj/item/robot_module/proc/add_default_robot_items()
 	modules += new /obj/item/flash/cyborg(src)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -27,10 +27,9 @@
 	..()
 
 
-/obj/item/robot_module/New(loc, should_have_flash = TRUE)
+/obj/item/robot_module/New()
 	..()
-	if(should_have_flash)
-		modules += new /obj/item/flash/cyborg(src)
+	add_default_robot_items()
 	emag = new /obj/item/toy/sword(src)
 	emag.name = "Placeholder Emag Item"
 
@@ -38,6 +37,10 @@
 	QDEL_LIST(modules)
 	QDEL_NULL(emag)
 	return ..()
+
+// By default, all robots will get the items in this proc, unless you override it for you specific module. See: ../robot_module/drone
+/obj/item/robot_module/proc/add_default_robot_items()
+	modules += new /obj/item/flash/cyborg(src)
 
 /obj/item/robot_module/proc/fix_modules()
 	for(var/obj/item/I in modules)
@@ -540,7 +543,7 @@
 		/obj/item/stack/cable_coil/cyborg = 30
 		)
 
-/obj/item/robot_module/drone/New(loc, should_have_flash = FALSE)
+/obj/item/robot_module/drone/New()
 	..()
 	modules += new /obj/item/weldingtool/largetank/cyborg(src)
 	modules += new /obj/item/screwdriver/cyborg(src)
@@ -562,6 +565,9 @@
 		modules += W
 
 	fix_modules()
+
+/obj/item/robot_module/drone/add_default_robot_items()
+	return
 
 /obj/item/robot_module/drone/respawn_consumable(mob/living/silicon/robot/R)
 	var/obj/item/reagent_containers/spray/cleaner/C = locate() in modules


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
#12934 Made all `New()` procs call their parent, but in the case of drones, it gave them a flash. This removes their flash, because drones should not have them.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13053
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Maintenance drones no longer get a flash
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
