### PR TITLE
Ports Floor Closet from Goonstation

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1247,6 +1247,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
+/datum/uplink_item/stealthy_tools/floor_closet
+	name = "Floor Closet"
+	desc = "A bluespace closet fitted with chameleon technology, disguising it as whatever floor it is closed on. However, it only holds as much as a normal closet."
+	reference = "FCLS"
+	item = /obj/structure/closet/floor_closet
+	cost = 4
+	surplus = 20
+
+
 // DEVICE AND TOOLS
 
 /datum/uplink_item/device_tools

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1249,7 +1249,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_tools/floor_closet
 	name = "Floor Closet"
-	desc = "A bluespace closet fitted with chameleon technology, disguising it as whatever floor it is closed on. However, it only holds as much as a normal closet."
+	desc = "A bluespace closet fitted with chameleon technology, disguising it as whatever floor it is closed on. However, due to the space occupied by said technology, it only holds as much as a normal closet."
 	reference = "FCLS"
 	item = /obj/structure/closet/floor_closet
 	cost = 4

--- a/code/game/objects/structures/crates_lockers/closets/floor_closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/floor_closet.dm
@@ -1,0 +1,32 @@
+/obj/structure/closet/floor_closet
+	name = "floor"
+	desc = "Where did this come from?"
+	density = 0
+	icon_state = "bluespace"
+	icon_closed = "bluespaceclosed"
+	icon_opened = "bluespaceopen"
+	storage_capacity = 30
+	var/materials = list(MAT_METAL = 5000, MAT_PLASMA = 2500, MAT_TITANIUM = 500, MAT_BLUESPACE = 500)
+
+
+/obj/structure/closet/floor_closet/close()
+	var/turf/T = get_turf(src)
+		if (T)
+			src.icon = T.icon
+			src.icon_closed = T.icon_state
+			src.desc = T.desc + " It looks odd."
+			src.plane = T.plane
+		else
+			src.icon = 'icons/obj/closet.dmi'
+			src.icon_closed = "closet"
+
+    . = ..()
+	return
+
+/obj/structure/closet/floor_closet/open()
+		if (src.welded)
+			return
+		src.icon = 'icons/obj/closet.dmi'
+		src.plane = initial(src.plane)
+		..()
+		return

--- a/code/game/objects/structures/crates_lockers/closets/floor_closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/floor_closet.dm
@@ -1,27 +1,38 @@
 /obj/structure/closet/floor_closet
-	name = "floor"
+	name = "floor(?)"
 	desc = "Where did this come from?"
 	density = 0
 	icon_state = "bluespace"
 	icon_closed = "bluespaceclosed"
 	icon_opened = "bluespaceopen"
-	storage_capacity = 30
+	plane = OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
+	storage_capacity = 30 //With the chameleon technology it doesn't hold as much as a normal one
 
 
 /obj/structure/closet/floor_closet/close()
-	. = ..()
 	var/turf/T = get_turf(src)
 	if (T)
 		src.icon = T.icon
 		src.icon_closed = T.icon_state
 		src.desc = T.desc + " It looks odd."
 		src.plane = T.plane
+		src.layer = T.layer
+		src.name = T.name
 	else
 		src.icon = 'icons/obj/closet.dmi'
 		src.icon_closed = "bluespaceclosed"
+	. = ..()
+	src.density = 0
 	return
+	
 
 /obj/structure/closet/floor_closet/open()
 	. = ..()
 	src.plane = initial(src.plane)
+	src.layer = initial(src.layer)
+	src.icon = initial(src.icon)
+	src.icon_opened = initial(src.icon_opened)
+	src.name = initial(src.name)
+	src.desc = initial(src.desc)
 	return TRUE

--- a/code/game/objects/structures/crates_lockers/closets/floor_closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/floor_closet.dm
@@ -6,27 +6,22 @@
 	icon_closed = "bluespaceclosed"
 	icon_opened = "bluespaceopen"
 	storage_capacity = 30
-	var/materials = list(MAT_METAL = 5000, MAT_PLASMA = 2500, MAT_TITANIUM = 500, MAT_BLUESPACE = 500)
 
 
 /obj/structure/closet/floor_closet/close()
+	. = ..()
 	var/turf/T = get_turf(src)
-		if (T)
-			src.icon = T.icon
-			src.icon_closed = T.icon_state
-			src.desc = T.desc + " It looks odd."
-			src.plane = T.plane
-		else
-			src.icon = 'icons/obj/closet.dmi'
-			src.icon_closed = "closet"
-
-    . = ..()
+	if (T)
+		src.icon = T.icon
+		src.icon_closed = T.icon_state
+		src.desc = T.desc + " It looks odd."
+		src.plane = T.plane
+	else
+		src.icon = 'icons/obj/closet.dmi'
+		src.icon_closed = "bluespaceclosed"
 	return
 
 /obj/structure/closet/floor_closet/open()
-		if (src.welded)
-			return
-		src.icon = 'icons/obj/closet.dmi'
-		src.plane = initial(src.plane)
-		..()
-		return
+	. = ..()
+	src.plane = initial(src.plane)
+	return TRUE

--- a/paradise.dme
+++ b/paradise.dme
@@ -1097,6 +1097,7 @@
 #include "code\game\objects\structures\crates_lockers\closets\crittercrate.dm"
 #include "code\game\objects\structures\crates_lockers\closets\fireaxe.dm"
 #include "code\game\objects\structures\crates_lockers\closets\fitness.dm"
+#include "code\game\objects\structures\crates_lockers\closets\floor_closet.dm"
 #include "code\game\objects\structures\crates_lockers\closets\gimmick.dm"
 #include "code\game\objects\structures\crates_lockers\closets\job_closets.dm"
 #include "code\game\objects\structures\crates_lockers\closets\l3closet.dm"


### PR DESCRIPTION

## What Does This PR Do
This PR ports the "Floor Closet" traitor item from Goonstation; the Floor Closet itself is a closet which takes the appearance of any floor that it is closed on, providing an excellent stealthy storage, or a means to hide yourself. The disguise isn't perfect though, as a careful right-click or even examine will show the suspiciousness. And, of course, like smugglers' satchels, you have to remember where you put it! Currently, it costs 4 TC, and is allowed for both traitors and nuke ops, and can appear in surplus crates rarely.

## Why It's Good For The Game
It provides a good, fun, halfway point between smugglers' satchels and storage implants, while not being too strong to be ridiculous.


## Changelog
:cl:
add: Ported Floor Closet from Goonstation. Stealthy ambushes or a secret stash, your choice!
/:cl:


