### PR TITLE
disabled SSchat till multiline to_chats are fixed

### DIFF
--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(chat)
 	name = "Chat"
-	flags = SS_TICKER
+	flags = SS_TICKER|SS_NO_INIT
 	wait = 1
 	priority = FIRE_PRIORITY_CHAT
 	init_order = INIT_ORDER_CHAT


### PR DESCRIPTION
## What Does This PR Do
to_chat with calls that have multilines are broken. Like examine and adminwho
This turns the subsystem off again till it's fixed

## Why It's Good For The Game
Quick disabling so the server can continue while the issue is being looked at

![image](https://user-images.githubusercontent.com/15887760/76151823-6650a980-60b9-11ea-9ae0-11d482710781.png)
Current issue and the workaround


## Changelog
:cl:
del: SSchat is being turned off till the multiline to_chats are fixed
/:cl: