### PR TITLE
Saying ~ gives brain damage

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -69,6 +69,10 @@ proc/get_radio_key_from_channel(var/channel)
 		if((HULK in mutations) && health >= 25)
 			S.message = "[uppertext(S.message)]!!!"
 			verb = pick("yells", "roars", "hollers")
+			
+		if(findtext(S.message, "~"))
+			adjustBrainLoss(10) 
+			to_chat(src, "<span class='warning'>You feel dumber for having spoken in such a mannerism.</span>")
 
 		if(slurring)
 			if(robot)


### PR DESCRIPTION
## What Does This PR Do
Anytime someone says ~ it gives them 10 brain damage

## Why It's Good For The Game
It will increase the RP atmosphere

credit to fox for the original code

:cl:
add: Using tildes (~) gives you brain damage
/ :cl: