### PR TITLE
Makes the FLW command ignore permissions if you're already an observer

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1551,13 +1551,12 @@
 		show_player_panel(M)
 
 	else if(href_list["adminplayerobservefollow"])
-		if(!check_rights(R_ADMIN|R_MOD))
-			return
-
-		var/mob/M = locateUID(href_list["adminplayerobservefollow"])
-
 		var/client/C = usr.client
-		if(!isobserver(usr))	C.admin_ghost()
+		if(!isobserver(usr))
+			if(!check_rights(R_ADMIN|R_MOD)) // Need to be mod or admin to aghost
+				return
+			C.admin_ghost()
+		var/mob/M = locateUID(href_list["adminplayerobservefollow"])
 		var/mob/dead/observer/A = C.mob
 		sleep(2)
 		A.ManualFollow(M)


### PR DESCRIPTION
## What Does This PR Do
Will make the FLW command on tickets and such ignore permissions if you're already a ghost

## Why It's Good For The Game
This way ghosted mentors can use the button as well. Since if the user is already a ghost it will behave like orbiting the mob. Which they can already do

## Changelog
:cl:
tweak: The FLW button on tickets etc now ignores permissions if you're already an observer
/:cl: