### PR TITLE
Increases char slots to 30

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -55,8 +55,8 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 		return max(0, days - C.player_age)
 	return 0
 
-#define MAX_SAVE_SLOTS 20 // Save slots for regular players
-#define MAX_SAVE_SLOTS_MEMBER 20 // Save slots for BYOND members
+#define MAX_SAVE_SLOTS 30 // Save slots for regular players
+#define MAX_SAVE_SLOTS_MEMBER 30 // Save slots for BYOND members
 
 #define TAB_CHAR 0
 #define TAB_GAME 1


### PR DESCRIPTION
## What Does This PR Do
Increases character save slots to 30 as per forum suggestion. Database implications should really be minimal, for the few players who want to have 20+ characters.

https://www.paradisestation.org/forum/topic/17837-add-ten-additional-character-slots/

## Why It's Good For The Game
More character slots for players who want lots of charcters.

## Changelog
:cl:
tweak: Increases character slots from 20 to 30
/:cl:
