### PR TITLE
Implements A Couple Goon Reagents

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -19,7 +19,7 @@
 	var/image/icon_beaker = null //cached overlay
 	var/list/dispensable_reagents = list("hydrogen", "lithium", "carbon", "nitrogen", "oxygen", "fluorine",
 	"sodium", "aluminum", "silicon", "phosphorus", "sulfur", "chlorine", "potassium", "iron",
-	"copper", "mercury", "plasma", "radium", "water", "ethanol", "sugar", "iodine", "bromine", "silver")
+	"copper", "mercury", "plasma", "radium", "water", "ethanol", "sugar", "iodine", "bromine", "silver", "chromium")
 	var/list/upgrade_reagents = list("oil", "ash", "acetone", "saltpetre", "ammonia", "diethylamine", "fuel")
 	var/list/hacked_reagents = list("toxin")
 	var/hack_message = "You disable the safety safeguards, enabling the \"Mad Scientist\" mode."

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -130,7 +130,6 @@
 	color = "#A8A8A8" // rgb: 168, 168, 168
 	taste_description = "metal"
 
-
 /datum/reagent/silicon
 	name = "Silicon"
 	id = "silicon"
@@ -147,6 +146,12 @@
 	color = "#6E3B08" // rgb: 110, 59, 8
 	taste_description = "copper"
 
+/datum/reagent/chromium
+	name = "Chromium"
+	id = "chromium"
+	description = "A catalytic chemical element."
+	color = "#DCDCDC"
+	taste_description = "bitterness"
 
 /datum/reagent/iron
 	name = "Iron"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -383,6 +383,35 @@
 			H.adjustFireLoss(min(max(8, (volume - 5) * 3), 75))
 		to_chat(H, "<span class='warning'>The blueish acidic substance stings[volume < 5 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 
+/datum/reagent/acetic_acid
+	name = "acetic acid"
+	id = "acetic_acid"
+	description = "A weak acid that is the main component of vinegar and bad hangovers."
+	color = "#0080ff"
+	reagent_state = LIQUID
+
+/datum/reagent/acetic_acid/reaction_mob(mob/M, method = TOUCH, volume)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(method == TOUCH)
+			if(H.wear_mask || H.head)
+				return
+			if(volume >= 50 && prob(75))
+				var/obj/item/organ/external/affecting = H.get_organ("head")
+				if(affecting)
+					affecting.disfigure()
+				H.adjustBruteLoss(5)
+				H.adjustFireLoss(15)
+				H.emote("scream")
+			else
+				H.adjustBruteLoss(min(5, volume * 0.25))
+		else
+			to_chat(H, "<span class='warning'>The transparent acidic substance stings[volume < 25 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
+			if(volume >= 25)
+				H.adjustBruteLoss(2)
+				H.emote("scream")
+
+
 /datum/reagent/carpotoxin
 	name = "Carpotoxin"
 	id = "carpotoxin"
@@ -546,7 +575,7 @@
 	id = "formaldehyde"
 	description = "Formaldehyde is a common industrial chemical and is used to preserve corpses and medical samples. It is highly toxic and irritating."
 	reagent_state = LIQUID
-	color = "#DED6D0"
+	color = "#B44B00"
 	penetrates_skin = TRUE
 	taste_description = "bitterness"
 
@@ -555,6 +584,20 @@
 	update_flags |= M.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	if(prob(10))
 		M.reagents.add_reagent("histamine",rand(5,15))
+	return ..() | update_flags
+
+/datum/reagent/acetaldehyde
+	name = "Acetaldehyde"
+	id = "acetaldehyde"
+	description = "Acetaldehyde is a common industrial chemical. It is a severe irritant."
+	reagent_state = LIQUID
+	color = "#B44B00"
+	penetrates_skin = TRUE
+	taste_description = "apples"
+
+/datum/reagent/acetaldehyde/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
+	update_flags |= M.adjustFireLoss(1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/venom

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -389,6 +389,7 @@
 	description = "A weak acid that is the main component of vinegar and bad hangovers."
 	color = "#0080ff"
 	reagent_state = LIQUID
+	taste_description = "vinegar"
 
 /datum/reagent/acetic_acid/reaction_mob(mob/M, method = TOUCH, volume)
 	if(ishuman(M))

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -322,6 +322,23 @@
 	result_amount = 3
 	mix_message = "The solution crystallizes with a brief flare of light."
 
+/datum/chemical_reaction/acetaldehyde
+	name = "Acetaldehyde"
+	id = "acetaldehyde"
+	result = "acetaldehyde"
+	required_reagents = list("chromium" = 1, "oxygen" = 1, "copper" = 1, "ethanol" = 1)
+	result_amount = 3
+	min_temp = T0C + 275
+	mix_message = "It smells like a bad hangover in here."
+
+/datum/chemical_reaction/acetic_acid
+	name = "Acetic Acid"
+	id = "acetic_acid"
+	result = "acetic_acid"
+	required_reagents = list("acetaldehyde" = 1, "oxygen" = 1, "nitrogen" = 4)
+	result_amount = 3
+	mix_message = "It smells like vinegar and a bad hangover in here."
+
 /datum/chemical_reaction/ice
 	name = "Ice"
 	id = "ice"


### PR DESCRIPTION
Credit to Goon.

Just implements a few Goon reagents; nothing particularly exciting:

- Chromium. Inert and used to make other chems--found in dispenser
- Acetaldehyde. Chemical that acts as a very basic poison, can be used to make acetic acid
- Acetic Acid. Very very weak acid; easily blocked by masks or helmets; can't melt gear or objects.

New recipes:
- acetaldehyde: Chromium+ Oxygen + Copper +Ethanol + Heat
- Acetic Acid: Acetaldehyde + Oxygen +Nitrogen

Adds a bit more diversity to reagents and can act as a building block for others.

:cl: Fox McCloud
add: Implements a few new reagents: chromium, acetaldehyde, and acetic acid. Find chromium in a dispenser; acetaldehyde is a basic poison, and acetic acid is a super weak acid
add: Make acetaldehyde with chromium + oxygen + copper + ethanol + heat
add: Make acetic acid with acetaldehyde + oxygen + nitrogen
/:cl: