### PR TITLE
Filters say of illegal characters

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,5 +1,5 @@
 
-#define ILLEGAL_CHARACTERS_LIST list("~" = "", "<" = "", ">" = "", "^" = "", \
+#define ILLEGAL_CHARACTERS_LIST list("<" = "", ">" = "", "^" = "", \
 	"\[" = "", "]" = "", "{" = "", "}" = "")
 
 /mob/proc/say()

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,4 +1,7 @@
 
+#define ILLEGAL_CHARACTERS_LIST list("~" = "", "<" = "", ">" = "", "^" = "", \
+	"\[" = "", "]" = "", "{" = "", "}" = "")
+
 /mob/proc/say()
 	return
 
@@ -23,7 +26,7 @@
 		else if(response == "No")
 			return
 	*/
-
+	message = replace_characters(message, ILLEGAL_CHARACTERS_LIST)
 	set_typing_indicator(0)
 	usr.say(message)
 
@@ -206,3 +209,5 @@
 	for(var/datum/multilingual_say_piece/S in message_pieces)
 		. += S.message + " "
 	. = trim_right(.)
+
+#undef ILLEGAL_CHARACTERS_LIST


### PR DESCRIPTION
## What Does This PR Do
Makes the say verb filter out illegal characters that can break the chat or just shouldn't be used in character.

Current list: {}[]<>^

This is done on the say verb. Meaning that other ways of saying stuff (being drunk etc) are not affected. This only clears direct player input.

## Why It's Good For The Game
< and > will just stop your message from going through. The others are unwanted characters

## Changelog
:cl:
tweak: Certain characters are removed from your say input
fix: Accidently typing < or > now doesn't kill your message
/:cl: