### PR TITLE
Adds borg deathgasp for IPCs, updates IPC deathgasp message

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -19,7 +19,8 @@
 	burn_mod = 2.28  // So they take 50% extra damage from brute/burn overall
 	tox_mod = 0
 	clone_mod = 0
-	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."
+	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."
+	death_sounds = list('sound/voice/borg_deathsound.ogg') //I've made this a list in the event we add more sounds for dead robots.
 
 	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING) //Computers that don't decay? What a lie!
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS


### PR DESCRIPTION
## What Does This PR Do
A recent PR made by Fox added deathgasp sounds to all crewmembers. Unfortunately, it didn't account for IPCs, and thusly I've made this PR to account for them in addition to updating my previously outdated deathgasp message for IPCs. They will now use the same deathgasp sound as cyborgs do.
Also I'm the robot person and it bothered me a lot. Beep.
This does _not_ cover *gasp, as I don't have any sound files that would be useful for that. Should someone be able to provide one that's suitable, I can always add it to this PR or later on!

## Why It's Good For The Game
Immersion. Robots don't gasp for breath before they die. Unless you're Cayde-6 from Destiny 2, I suppose.

Dobby is a free elf

## Changelog
:cl:
tweak: Adjusted IPCs to have a proper deathgasp sound, in addition to updating their deathgasp message.
/:cl: