### PR TITLE
Cyborg recharger now throws occupants out when destroyed and heals IPCs even when they are not hungry

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/recharge_station/Destroy()
 	go_out()
-	. = ..()
+	return ..()
 
 /obj/machinery/recharge_station/New()
 	..()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -13,6 +13,10 @@
 	var/recharge_speed_nutrition
 	var/repairs
 
+/obj/machinery/recharge_station/Destroy()
+	go_out()
+	. = ..()
+
 /obj/machinery/recharge_station/New()
 	..()
 	component_parts = list()
@@ -140,8 +144,8 @@
 			var/mob/living/carbon/human/H = occupant
 			if(H.get_int_organ(/obj/item/organ/internal/cell) && H.nutrition < 450)
 				H.set_nutrition(min(H.nutrition + recharge_speed_nutrition, 450))
-				if(repairs)
-					H.heal_overall_damage(repairs, repairs, TRUE, 0, 1)
+			if(repairs)
+				H.heal_overall_damage(repairs, repairs, TRUE, 0, 1)
 
 /obj/machinery/recharge_station/proc/go_out()
 	if(!occupant)


### PR DESCRIPTION
## What Does This PR Do
As the title says:
Cyborg recharger now throws occupants out when destroyed and heals IPCs even when they are not hungry

## Why It's Good For The Game
One is a bug that puts people in null space and the other is just odd.

## Changelog
:cl:
tweak: Cyborg recharger stations now heal IPCs even if they are not hungry (and the station is upgraded)
fix: Cyborg recharger stations now throw the occupant out when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
