### PR TITLE
Fixes some oversights with storage alt-clicking

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -83,13 +83,21 @@
 			to_chat(user, "You short out the lock on [src].")
 		return
 
+/obj/item/storage/secure/AltClick(mob/user)
+	if(!try_to_open())
+		return FALSE
+	return ..()
 
 /obj/item/storage/secure/MouseDrop(over_object, src_location, over_location)
+	if(!try_to_open())
+		return FALSE
+	return ..()
+
+/obj/item/storage/secure/proc/try_to_open()
 	if(locked)
 		add_fingerprint(usr)
 		to_chat(usr, "<span class='warning'>It's locked!</span>")
-		return 0
-	..()
+		return FALSE
 
 /obj/item/storage/secure/attack_self(mob/user as mob)
 	user.set_machine(src)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -83,7 +83,7 @@
 	return
 
 /obj/item/storage/AltClick(mob/user)
-	if(Adjacent(user))
+	if(Adjacent(user) && !user.incapacitated(FALSE, TRUE, TRUE))
 		orient2hud(user)
 		if(user.s_active)
 			user.s_active.close(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Follow up to #12863. Someone pointed out to me after the PR was merged that I had forgot to handle secure briefcase and secure wall safes (why are wall safes items :angry:).

This adds a check for alt-clicking on `/obj/item/storage/secure` type objects. It will deny you access if the item is locked, just like it does for mouse drag and drop. Also includes a check for incapacitated on alt-clicking storage items, so you can only open these items while *not* stunned, slept, etc.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds stuff that should have been included in the original PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: You can no longer alt-click wall safes and secure briefcases to open them while they are locked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
