### PR TITLE
Ratvar spear does burn damage

### DIFF
--- a/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
+++ b/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
@@ -258,3 +258,8 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	var/bonus_burn = 5
+
+/obj/item/clockwork/weapon/ratvarian_spear/attack(mob/living/M, mob/living/user, def_zone)
+	. = ..()
+	if(isliving(M))
+		M.apply_damage(bonus_burn, BURN, def_zone, used_weapon = src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #12570
However, I must admit my current naive solution has a bit of an issue in that the bonus burn damage isn't inflicted to the same zone as the brute. 

As far as I can tell there's really no way to fix that without snowflaking something into human defense code just for this specific item, or creating a dedicated 'deal multiple damage types at once' system which would amount to the same thing until more such items are created. 

If there is an obvious way to do it that I missed, that would of course be welcome, too.

Considering we're talking about a single, rarely seen lavaland loot item I don't think it's worth the effort and added complexity, though maints are of course free to disagree.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less bugs good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: ratvar spear now does burn damage on top of brute as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
