### PR TITLE
Actually makes editorconfig use LF by default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
 
 [*.yml]
 indent_style = space


### PR DESCRIPTION
## What Does This PR Do
Actually updates the `.editorconfig` enforce LF on the editor. I had this commit ready, I just forgot to stage it during deconfliction, probably due to using `git stage *.dm` to avoid adding my log files and midi2piano build cache

Thanks flattest for pointing this out

No CL because this doesnt change any game file at all
