### PR TITLE
Advanced Scanner print-outs now show if an organ is dead.

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -479,7 +479,7 @@
 			if(i.status & ORGAN_DEAD)
 				dead = "DEAD:"
 			switch(i.germ_level)
-				if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
+				if(1 to INFECTION_LEVEL_ONE + 200)
 					infection = "Mild Infection:"
 				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
 					infection = "Mild Infection+:"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -457,9 +457,9 @@
 					infected = "Acute Infection:"
 				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
 					infected = "Acute Infection+:"
-				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 400)
+				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 399)
 					infected = "Acute Infection++:"
-				if(INFECTION_LEVEL_THREE to INFINITY)
+				if(INFECTION_LEVEL_TWO + 400 to INFINITY)
 					infected = "Septic:"
 
 			var/unknown_body = 0
@@ -489,9 +489,9 @@
 					infection = "Acute Infection:"
 				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
 					infection = "Acute Infection+:"
-				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 400)
+				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 399)
 					infection = "Acute Infection++:"
-				if(INFECTION_LEVEL_THREE to INFINITY)
+				if(INFECTION_LEVEL_TWO + 400 to INFINITY)
 					infection = "Septic:"
 
 			dat += "<tr>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -425,6 +425,7 @@
 			var/AN = ""
 			var/open = ""
 			var/infected = ""
+			var/dead = ""
 			var/robot = ""
 			var/imp = ""
 			var/bled = ""
@@ -439,6 +440,8 @@
 				splint = "Splinted:"
 			if(e.status & ORGAN_BROKEN)
 				AN = "[e.broken_description]:"
+			if(e.status & ORGAN_DEAD)
+				dead = "DEAD:"
 			if(e.is_robotic())
 				robot = "Robotic:"
 			if(e.open)
@@ -467,13 +470,16 @@
 				imp += "Unknown body present:"
 			if(!AN && !open && !infected & !imp)
 				AN = "None:"
-			dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[e.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][internal_bleeding][lung_ruptured]</td>"
+			dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[e.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][internal_bleeding][lung_ruptured][dead]</td>"
 			dat += "</tr>"
 		for(var/obj/item/organ/internal/i in occupant.internal_organs)
 			var/mech = i.desc
 			var/infection = "None"
+			var/dead = ""
+			if(i.status & ORGAN_DEAD)
+				dead = "DEAD:"
 			switch(i.germ_level)
-				if(1 to INFECTION_LEVEL_ONE + 200)
+				if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
 					infection = "Mild Infection:"
 				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
 					infection = "Mild Infection+:"
@@ -483,11 +489,13 @@
 					infection = "Acute Infection:"
 				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
 					infection = "Acute Infection+:"
-				if(INFECTION_LEVEL_TWO + 300 to INFINITY)
+				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 400)
 					infection = "Acute Infection++:"
+				if(INFECTION_LEVEL_THREE to INFINITY)
+					infection = "Septic:"
 
 			dat += "<tr>"
-			dat += "<td>[i.name]</td><td>N/A</td><td>[i.damage]</td><td>[infection]:[mech]</td><td></td>"
+			dat += "<td>[i.name]</td><td>N/A</td><td>[i.damage]</td><td>[infection]:[mech][dead]</td><td></td>"
 			dat += "</tr>"
 		dat += "</table>"
 		if(occupant.disabilities & BLIND)


### PR DESCRIPTION
## What Does This PR Do
Fixes #6972 https://github.com/ParadiseSS13/Paradise/issues/6972. Advanced Scanner print outs will now properly report if an organ or limb is dead. It will also now properly report Septic organs, previously it only(for some reason) reported up to Acute Infection++. 

## Why It's Good For The Game
Print outs can be properly relied on for infection levels and limb/organ status so doctors don't have to 1. Constantly scan a patient/memorize what's dead or 2. Get a print out, be in a rush due to swamped medbay, and see the print out reports nothing is dead and thus they don't debride/revive the organs causing a lot of issues.

## Changelog
:cl: Mitchs98
fix: Advanced Scanner print outs now properly display dead organs and limbs.
fix: Advanced Scanners now properly show septic organs.
/:cl: