### PR TITLE
isSynthetic() proc now returns TRUE for silicon mobs

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -604,7 +604,7 @@
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
 			L.electrocute_act(0, src, 1, TRUE, TRUE)
-			if(isrobot(L) || L.isSynthetic())
+			if(L.isSynthetic())
 				L.Weaken(5)
 			qdel(src)
 	..()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -61,7 +61,7 @@ proc/get_radio_key_from_channel(var/channel)
 	return default_language
 
 /mob/living/proc/handle_speech_problems(list/message_pieces, var/verb)
-	var/robot = isSynthetic()
+	var/robot = ismachine()
 	for(var/datum/multilingual_say_piece/S in message_pieces)
 		if(S.speaking && S.speaking.flags & NO_STUTTER)
 			continue

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -61,7 +61,7 @@ proc/get_radio_key_from_channel(var/channel)
 	return default_language
 
 /mob/living/proc/handle_speech_problems(list/message_pieces, var/verb)
-	var/robot = ismachine()
+	var/robot = ismachine(src)
 	for(var/datum/multilingual_say_piece/S in message_pieces)
 		if(S.speaking && S.speaking.flags & NO_STUTTER)
 			continue

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -13,12 +13,15 @@
 	return 0
 
 /mob/proc/isSynthetic()
-	return 0
+	return FALSE
 
 /mob/living/carbon/human/isSynthetic()
 	if(ismachine(src))
 		return TRUE
 	return FALSE
+
+mob/living/silicon/isSynthetic()
+	return TRUE
 
 /mob/proc/get_screen_colour()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes all silicon mobs return TRUE when running isSynthetic() proc. The proc works the same way as before for human mobs, except returns FALSE instead of 0, which I believe is the Paradise standard.

With an actual difference between ismachine() and isSynthetic() procs, adjusts the code in a few places where it may matter.
Majority of isSynthetic() calls are made by /living/carbon/human mobs. Since this PR does not affect how the proc works for carbons, I did not touch them, even if nearly all the cases could be replaced with plain ismachine() procs.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Without this change, we might as well replace all instances of isSynthetic() with ismachine() and remove the former, because they do exactly the same thing. In fact, isSynthetic() does basically nothing outside of calling for ismachine().

I'd rather have this change, as I'm currently working on some minor changes and improvements to the cyborg rechargers. Having a proc that returns true for silicons and IPC would make the code significantly more readable and, if I'm not mistaken, efficient.

The only problem that may arise, as far as I can tell, is that changes to the swarmer trap make unfolded pAIs get affected by it (and AIs, but if AI somehow runs into a swarmer trap, this bit of code is the least broken part). They get properly stunned and can be destroyed by swarmers, but a pAI can technically be used to destroy swarmer minefields. I think using pAIs this way is so unlikely and inefficient it does not warrant addressing, but it can still be seen as a bug and if deemed as such, I will have to either make isSynthetic() call for isrobot() or exclude pAIs from swarmer traps manually. Oh, and Lavaland swarmers obviously hate pAIs, so it doesn't really affect miners.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: isSynthetic() and ismachine() are now two different procs
tweak: Unfolded pAIs are now affected by swamer traps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
