### PR TITLE
Fix grey telepathy

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,5 +1,5 @@
 
-#define ILLEGAL_CHARACTERS_LIST list("<" = "", ">" = "", "^" = "", \
+#define ILLEGAL_CHARACTERS_LIST list("<" = "", ">" = "", \
 	"\[" = "", "]" = "", "{" = "", "}" = "")
 
 /mob/proc/say()


### PR DESCRIPTION
Fixes #13140
Grey telepathy is currently being filtered by the new forbidden characters because the key used for the language is ^

This removes the character from the forbidden characters list

:cl:
fix: Greys can now properly speak in grey telepathy again without being filtered
/:cl: