### PR TITLE
Makes classic secHUD available to Magistrate

### DIFF
--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -29,7 +29,7 @@
 /datum/gear/sechud
 	display_name = "a classic security HUD"
 	path = /obj/item/clothing/glasses/hud/security
-	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Security Pod Pilot", "Internal Affairs Agent")
+	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Security Pod Pilot", "Internal Affairs Agent","Magistrate")
 
 /datum/gear/matches
 	display_name = "a box of matches"
@@ -42,7 +42,7 @@
 /datum/gear/doublecards
 	display_name = "a double deck of standard cards"
 	path = /obj/item/deck/doublecards
-	
+
 /datum/gear/tarot
 	display_name = "a deck of tarot cards"
 	path = /obj/item/deck/tarot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds magistrate to the classic security HUD whitelist in the character loadout.

## Why It's Good For The Game
IAA are already able to spawn with a classic security HUD, magistrates should be able to as well.

## Changelog
:cl:
tweak: Magistrates can now use the classic sechud in the loadout options.
/:cl:
