### PR TITLE
More storage alt-click storage fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -98,6 +98,7 @@
 		add_fingerprint(usr)
 		to_chat(usr, "<span class='warning'>It's locked!</span>")
 		return FALSE
+	return TRUE
 
 /obj/item/storage/secure/attack_self(mob/user as mob)
 	user.set_machine(src)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -88,6 +88,8 @@
 		if(user.s_active)
 			user.s_active.close(user)
 		show_to(user)
+		playsound(loc, "rustle", 50, 1, -5)
+		add_fingerprint(user)
 
 /obj/item/storage/proc/return_inv()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
What the title and CL says. I forget one little return statement and it breaks everything ugh :pensive: . I also double checked secure briefcases since they used the same code, and they are also working as intended. 

Also fixes another issue pointed out to me: alt-clicking to open a storage object didn't leave the user's fingerprints on it.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13144
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes not being able to open the inventory screen of wall safes and secure briefcases
fix: Opening a storage item via alt-click will properly add fingerprints from the user to the storage item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
