### PR TITLE
Smite Fix & Improvements

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -88,6 +88,7 @@
 	name = "advanced pinpointer"
 	desc = "A larger version of the normal pinpointer, this unit features a helpful quantum entanglement detection system to locate various objects that do not broadcast a locator signal."
 	var/mode = 0  // Mode 0 locates disk, mode 1 locates coordinates.
+	var/modelocked = FALSE // If true, user cannot change mode.
 	var/turf/location = null
 	var/obj/target = null
 
@@ -119,6 +120,10 @@
 	set src in usr
 
 	if(usr.stat || usr.restrained())
+		return
+
+	if(modelocked)
+		to_chat(usr, "<span class='warning'>[src] is locked. It can only track one specific target.</span>")
 		return
 
 	active = 0


### PR DESCRIPTION
## What Does This PR Do
1) Fixes #13149 - admins smiting someone with a "crew traitor" smite will no longer cause the kill objective to be incorrectly assigned to the victim, instead of the character hunting them.
2) Tweaks the advanced pinpointers that event characters from smite/bless get, so that they always point at their target and can longer be accidentally broken by changing their mode.
3) Adds the 'dust' smite option for admins, which dusts the target.

## Why It's Good For The Game
1) is a fix for an obvious bug.
2) prevents event characters from accidentally breaking the clue that is meant to lead them to their target
3) adds an option useful for quick/easy cleanup of humanoid characters, without having to worry about remains, their inventory, etc.

## Changelog
:cl:
fix: Admins smiting a crew member with the "hunter" option now has the kill objective assigned correctly.
tweak: Event characters created by admin smite/bless now get pinpointers that always point at their target, and cannot be changed to point at anything else.
add: Added "dust" as a new smiting option for admins.
/:cl:
