### PR TITLE
Lighter refactor + Reduces zippo lighter and gavel text and sound spam

### DIFF
--- a/code/game/objects/items/weapons/courtroom.dm
+++ b/code/game/objects/items/weapons/courtroom.dm
@@ -27,10 +27,12 @@
 	throwforce = 2.0
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
+	var/next_gavel_hit
 
 /obj/item/gavelblock/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/gavelhammer))
-		playsound(loc, 'sound/items/gavel.ogg', 100, 1)
-		user.visible_message("<span class='warning'>[user] strikes \the [src] with \the [I].</span>")
-	else
+	if(!istype(I, /obj/item/gavelhammer))
 		return
+	if(world.time > next_gavel_hit)
+		playsound(loc, 'sound/items/gavel.ogg', 100, 1)
+		next_gavel_hit = world.time + 5 SECONDS
+		user.visible_message("<span class='warning'>[user] strikes \the [src] with \the [I].</span>")

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -14,6 +14,7 @@
 	var/lit = FALSE
 	var/icon_on = "lighter-g-on"
 	var/icon_off = "lighter-g"
+	var/light_chance = 75
 
 /obj/item/lighter/random/New()
 	..()
@@ -39,7 +40,7 @@
 	hitsound = 'sound/items/welder.ogg'
 	attack_verb = list("burnt", "singed")
 
-	if(prob(75) || issilicon(user)) // Robots can never fail to light it.
+	if(prob(light_chance) || issilicon(user)) // Robots can never fail to light it.
 		to_chat(user, "<span class='notice'>You light [src].</span>")
 	else
 		var/mob/living/carbon/human/H = user
@@ -98,6 +99,7 @@
 	item_state = "zippo"
 	icon_on = "zippoon"
 	icon_off = "zippo"
+	light_chance = 100
 	var/next_on_message
 	var/next_off_message
 

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -1,29 +1,19 @@
-/////////
-//ZIPPO//
-/////////
+// Basic lighters
 /obj/item/lighter
 	name = "cheap lighter"
 	desc = "A cheap-as-free lighter."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "lighter-g"
 	item_state = "lighter-g"
-	var/icon_on = "lighter-g-on"
-	var/icon_off = "lighter-g"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 4
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	attack_verb = null
 	resistance_flags = FIRE_PROOF
-	var/lit = 0
-
-/obj/item/lighter/zippo
-	name = "zippo lighter"
-	desc = "The zippo."
-	icon_state = "zippo"
-	item_state = "zippo"
-	icon_on = "zippoon"
-	icon_off = "zippo"
+	var/lit = FALSE
+	var/icon_on = "lighter-g-on"
+	var/icon_off = "lighter-g"
 
 /obj/item/lighter/random/New()
 	..()
@@ -33,54 +23,46 @@
 	icon_state = icon_off
 
 /obj/item/lighter/attack_self(mob/living/user)
-	if(user.r_hand == src || user.l_hand == src || isrobot(user))
-		if(!lit)
-			lit = 1
-			w_class = WEIGHT_CLASS_BULKY
-			icon_state = icon_on
-			item_state = icon_on
-			force = 5
-			damtype = "fire"
-			hitsound = 'sound/items/welder.ogg'
-			attack_verb = list("burnt", "singed")
-			if(istype(src, /obj/item/lighter/zippo) )
-				user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
-				playsound(src.loc, 'sound/items/zippolight.ogg', 25, 1)
-			else
-				if(prob(75))
-					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src].</span>")
-				else
-					to_chat(user, "<span class='warning'>You burn yourself while lighting the lighter.</span>")
-					var/mob/living/M = user
-					if(ishuman(M))
-						var/mob/living/carbon/human/H = M
-						var/obj/item/organ/external/affecting = H.get_organ("[user.hand ? "l" : "r" ]_hand")
-						if(affecting.receive_damage( 0, 5 ))		//INFERNO
-							H.UpdateDamageIcon()
-					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src], [user.p_they()] however burn[user.p_s()] [user.p_their()] finger in the process.</span>")
-
-			set_light(2)
-			START_PROCESSING(SSobj, src)
-		else
-			lit = 0
-			w_class = WEIGHT_CLASS_TINY
-			icon_state = icon_off
-			item_state = icon_off
-			hitsound = "swing_hit"
-			force = 0
-			attack_verb = null //human_defense.dm takes care of it
-			if(istype(src, /obj/item/lighter/zippo) )
-				user.visible_message("<span class='rose'>You hear a quiet click, as [user] shuts off [src] without even looking at what [user.p_theyre()] doing. Wow.")
-				playsound(src.loc, 'sound/items/zippoclose.ogg', 25, 1)
-			else
-				user.visible_message("<span class='notice'>[user] quietly shuts off the [src].")
-
-			set_light(0)
-			STOP_PROCESSING(SSobj, src)
+	. = ..()
+	if(!lit)
+		turn_on_lighter(user)
 	else
-		return ..()
-	return
+		turn_off_lighter(user)
 
+/obj/item/lighter/proc/turn_on_lighter(mob/living/user)
+	lit = TRUE
+	w_class = WEIGHT_CLASS_BULKY
+	icon_state = icon_on
+	item_state = icon_on
+	force = 5
+	damtype = BURN
+	hitsound = 'sound/items/welder.ogg'
+	attack_verb = list("burnt", "singed")
+
+	if(prob(75) || issilicon(user)) // Robots can never fail to light it.
+		to_chat(user, "<span class='notice'>You light [src].</span>")
+	else
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/external/affecting = H.get_organ("[user.hand ? "l" : "r" ]_hand")
+		if(affecting.receive_damage( 0, 5 ))		//INFERNO
+			H.UpdateDamageIcon()
+		to_chat(user,"<span class='notice'>You light [src], but you burn your hand in the process.</span>")
+
+	set_light(2)
+	START_PROCESSING(SSobj, src)
+
+/obj/item/lighter/proc/turn_off_lighter(mob/living/user)
+	lit = FALSE
+	w_class = WEIGHT_CLASS_TINY
+	icon_state = icon_off
+	item_state = icon_off
+	hitsound = "swing_hit"
+	force = 0
+	attack_verb = null //human_defense.dm takes care of it
+
+	to_chat(user, "<span class='notice'>You shut off [src].")
+	set_light(0)
+	STOP_PROCESSING(SSobj, src)
 
 /obj/item/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!isliving(M))
@@ -107,6 +89,31 @@
 	if(location)
 		location.hotspot_expose(700, 5)
 	return
+
+// Zippo lighters
+/obj/item/lighter/zippo
+	name = "zippo lighter"
+	desc = "The zippo."
+	icon_state = "zippo"
+	item_state = "zippo"
+	icon_on = "zippoon"
+	icon_off = "zippo"
+	var/next_on_message
+	var/next_off_message
+
+/obj/item/lighter/zippo/turn_on_lighter(mob/living/user)
+	. = ..()
+	if(world.time > next_on_message)
+		user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
+		playsound(src.loc, 'sound/items/zippolight.ogg', 25, 1)
+		next_on_message = world.time + 5 SECONDS
+
+/obj/item/lighter/zippo/turn_off_lighter(mob/living/user)
+	. = ..()
+	if(world.time > next_off_message)
+		user.visible_message("<span class='rose'>You hear a quiet click, as [user] shuts off [src] without even looking at what [user.p_theyre()] doing. Wow.")
+		playsound(src.loc, 'sound/items/zippoclose.ogg', 25, 1)
+		next_off_message = world.time + 5 SECONDS
 
 //EXTRA LIGHTERS
 /obj/item/lighter/zippo/nt_rep

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -14,7 +14,6 @@
 	var/lit = FALSE
 	var/icon_on = "lighter-g-on"
 	var/icon_off = "lighter-g"
-	var/light_chance = 75
 
 /obj/item/lighter/random/New()
 	..()
@@ -40,7 +39,12 @@
 	hitsound = 'sound/items/welder.ogg'
 	attack_verb = list("burnt", "singed")
 
-	if(prob(light_chance) || issilicon(user)) // Robots can never fail to light it.
+	attempt_light(user)
+	set_light(2)
+	START_PROCESSING(SSobj, src)
+
+/obj/item/lighter/proc/attempt_light(mob/living/user)
+	if(prob(75) || issilicon(user)) // Robots can never burn themselves trying to light it.
 		to_chat(user, "<span class='notice'>You light [src].</span>")
 	else
 		var/mob/living/carbon/human/H = user
@@ -48,9 +52,6 @@
 		if(affecting.receive_damage( 0, 5 ))		//INFERNO
 			H.UpdateDamageIcon()
 		to_chat(user,"<span class='notice'>You light [src], but you burn your hand in the process.</span>")
-
-	set_light(2)
-	START_PROCESSING(SSobj, src)
 
 /obj/item/lighter/proc/turn_off_lighter(mob/living/user)
 	lit = FALSE
@@ -61,9 +62,12 @@
 	force = 0
 	attack_verb = null //human_defense.dm takes care of it
 
-	to_chat(user, "<span class='notice'>You shut off [src].")
+	show_off_message(user)
 	set_light(0)
 	STOP_PROCESSING(SSobj, src)
+
+/obj/item/lighter/proc/show_off_message(mob/living/user)
+	to_chat(user, "<span class='notice'>You shut off [src].")
 
 /obj/item/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!isliving(M))
@@ -99,7 +103,6 @@
 	item_state = "zippo"
 	icon_on = "zippoon"
 	icon_off = "zippo"
-	light_chance = 100
 	var/next_on_message
 	var/next_off_message
 
@@ -109,6 +112,8 @@
 		user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
 		playsound(src.loc, 'sound/items/zippolight.ogg', 25, 1)
 		next_on_message = world.time + 5 SECONDS
+	else
+		to_chat(user, "<span class='notice'>You light [src].</span>")
 
 /obj/item/lighter/zippo/turn_off_lighter(mob/living/user)
 	. = ..()
@@ -116,6 +121,14 @@
 		user.visible_message("<span class='rose'>You hear a quiet click, as [user] shuts off [src] without even looking at what [user.p_theyre()] doing. Wow.")
 		playsound(src.loc, 'sound/items/zippoclose.ogg', 25, 1)
 		next_off_message = world.time + 5 SECONDS
+	else
+		to_chat(user, "<span class='notice'>You shut off [src].")
+
+/obj/item/lighter/zippo/show_off_message(mob/living/user)
+	return
+
+/obj/item/lighter/zippo/attempt_light(mob/living/user)
+	return
 
 //EXTRA LIGHTERS
 /obj/item/lighter/zippo/nt_rep


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Basically what the changelog says. Adds a 5 second cooldown for the gavel and zippo lighter visible messages and sounds. Also refactors lighter code because it was gross.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents massive walls of text spam and sound spam.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Zippo lighter's visible message and on/off sound can now only be triggered once every 5 seconds.
tweak: Hitting a gavel block with a gavel now has a cooldown of 5 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
