### PR TITLE
Fixes cling sting types not initialising

### DIFF
--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_EMPTY(sting_paths)
 		return
 	var/datum/changeling/changeling = usr.mind.changeling
 
-	if(!GLOB.sting_paths?.len)
+	if(!GLOB.sting_paths || !GLOB.sting_paths.len)
 		GLOB.sting_paths = init_subtypes(/datum/action/changeling)
 
 	var/dat = create_menu(changeling)

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_EMPTY(sting_paths)
 		return
 	var/datum/changeling/changeling = usr.mind.changeling
 
-	if(!GLOB.sting_paths)
+	if(!GLOB.sting_paths?.len)
 		GLOB.sting_paths = init_subtypes(/datum/action/changeling)
 
 	var/dat = create_menu(changeling)


### PR DESCRIPTION
## What Does This PR Do
Fixes: #13158

## Why It's Good For The Game
Makes cling be able to buy powers again

## Changelog
:cl:
fix: Cling sting types are now properly initialised again. Fixing clings not being able to buy powers
/:cl: