### PR TITLE
Automatic merge conflict labeling

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,0 +1,13 @@
+name: 'Merge Conflict Detection'
+on:
+  push:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'Merge Conflict'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What Does This PR Do
This PR adds in a GitHub action which will automatically run when a PR is merged. This action checks the mergability of a PR, and if it is conflicted, will add the appropriate label.

## Why It's Good For The ~~Game~~ **CODEBASE**
Allows maints to easily see at a glance whice PRs are conflicted and which ones arent

## Changelog
No CL because this is github only