### PR TITLE
Gives the Nuke Codes to the NTR

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -139,7 +139,8 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	l_pocket = /obj/item/lighter/zippo/nt_rep
 	pda = /obj/item/pda/heads/ntrep
 	backpack_contents = list(
-		/obj/item/melee/classic_baton/ntcane = 1
+		/obj/item/melee/classic_baton/ntcane = 1,
+		/obj/item/paper/nanotrasen/nuke_code = 1
 	)
 	implants = list(/obj/item/implant/mindshield)
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -439,6 +439,7 @@
 /*
  * Premade paper
  */
+ //Use New() if you want to add vars or procs to the info/header/footer etc
 /obj/item/paper/Court
 	name = "Judgement"
 	info = "For crimes against the station, the offender is sentenced to:<BR>\n<BR>\n"
@@ -501,9 +502,7 @@
 /obj/item/paper/fortune/update_icon()
 	..()
 	icon_state = initial(icon_state)
-/*
- * Premade paper
- */
+
 /obj/item/paper/Court
 	name = "Judgement"
 	info = "For crimes against the station, the offender is sentenced to:<BR>\n<BR>\n"
@@ -600,6 +599,14 @@
 	header = "<p><img style='display: block; margin-left: auto; margin-right: auto;' src='ntlogo.png' width='220' height='135' /></p><hr />"
 	info =  ""
 	
+/obj/item/paper/nanotrasen/nuke_code
+	name = "CLASSIFIED: Directive 7-12"
+	
+//New because we cant use vars or procs on compile
+/obj/item/paper/nanotrasen/nuke_code/New()
+	info = "<b>FOR YOUR EYES ONLY.</b> <br><br> To be used only as a last resort where any other option is inviable/failed and failure to contain shall cause more harm to Nanotrasen assets across the galaxy. <br> The nuclear code is: [get_nuke_code()] <br> Remember it, and destroy this paper."
+	update_icon()
+
 /obj/item/paper/central_command
 	name = "paper"
 	header ="<p><img style='display: block; margin-left: auto; margin-right: auto;' src='ntlogo.png' alt='' width='220' height='135' /></p><hr /><h3 style='text-align: center;font-family: Verdana;'><b> Nanotrasen Central Command</h3><p style='text-align: center;font-family:Verdana;'>Official Expedited Memorandum</p></b><hr />"


### PR DESCRIPTION
## What Does This PR Do
Gives the NTR a piece of paper with the nuke codes on it when they spawn

## Why It's Good For The Game
Allows for more player autonomy and more variable scenarios to create different stories.

- [ ] Make the line breaks on the paper actually work

:cl:
add: Nanotrasen Representatives now get the nuke codes when they spawn
/ :cl: