### PR TITLE
Fixes construction tool-related do_mob actions not working properly

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -316,7 +316,7 @@ This is always put in the attack log.
 
 	msg_admin_attack("[key_name_admin(user)] vs [key_name_admin(target)]: [what_done]", loglevel)
 
-/proc/do_mob(var/mob/user, var/mob/target, var/time = 30, var/uninterruptible = 0, progress = 1, datum/callback/extra_checks = null)
+/proc/do_mob(mob/user, mob/target, time = 30, uninterruptible = 0, progress = 1, list/extra_checks = list())
 	if(!user || !target)
 		return 0
 	var/user_loc = user.loc
@@ -349,7 +349,7 @@ This is always put in the attack log.
 			drifting = 0
 			user_loc = user.loc
 
-		if((!drifting && user.loc != user_loc) || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || user.lying || (extra_checks && !extra_checks.Invoke()))
+		if((!drifting && user.loc != user_loc) || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || user.lying || check_for_true_callbacks(extra_checks))
 			. = 0
 			break
 	if(progress)

--- a/code/game/objects/items/tools/tool_behaviour.dm
+++ b/code/game/objects/items/tools/tool_behaviour.dm
@@ -16,7 +16,7 @@
 		var/datum/callback/tool_check = CALLBACK(src, .proc/tool_check_callback, user, target, amount, extra_checks)
 
 		if(ismob(target))
-			if(!do_mob(user, target, delay, extra_checks = tool_check))
+			if(!do_mob(user, target, delay, extra_checks = list(tool_check)))
 				return
 
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Followup to #13177. By reversing the logic in that PR, it caused `do_mob`'s that deal with construction tools, such as repairing your own robo-limbs or crowbarring out brains from borgs to break similar to how wall deconstruction and such was broken.

This makes `do_mob`'s extra checks callbacks look for one of them being `TRUE` like I previously did for `do_after`. 

Tested with all construction tool-related progress bar type actions performed on mobs that I could think of including:

- repairing your own robo-limbs
- crowbarring out a brain from borg
- ghetto surgery tool steps

Hopefully this is the last fix I have to make cleaning up after my do_after refactor. Sorry I keep breaking crap.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13179
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes not being able to repair your own robo-limbs, deconstruct borgs or any other possibly broken actions that involve construction tools and mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
