### PR TITLE
Colours MC subsystems based on state

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -181,7 +181,7 @@
 	if(can_fire)
 		title = "\[[state_letter()]][title]"
 
-	stat(title, statclick.update(msg))
+	stat(title, "[state_colour()][statclick.update(msg)]</font>")
 
 /datum/controller/subsystem/proc/state_letter()
 	switch(state)
@@ -196,6 +196,18 @@
 		if(SS_IDLE)
 			. = "  "
 
+/datum/controller/subsystem/proc/state_colour()
+	switch(state)
+		if(SS_RUNNING) // If its actively processing, colour it green
+			. = "<font color='#32a852'>"
+		if(SS_QUEUED) // If its in the running queue, but delayed, colour it orange
+			. = "<font color='#fcba03'>"
+		if(SS_PAUSED, SS_PAUSING) // If its being paused due to lag, colour it red
+			. = "<font color='#eb4034'>"
+		if(SS_SLEEPING) // If fire() slept, colour it blue
+			. = "<font color='#4287f5'>"
+		if(SS_IDLE) // Leave it default if the SS is idle
+			. = "<font>"
 //could be used to postpone a costly subsystem for (default one) var/cycles, cycles
 //for instance, during cpu intensive operations like explosions
 /datum/controller/subsystem/proc/postpone(cycles = 1)


### PR DESCRIPTION
## What Does This PR Do
This PR colours the statpanel for MC subsystems based on their current running state
![image](https://user-images.githubusercontent.com/25063394/77304504-7210b280-6cec-11ea-8d97-37f565778b15.png)

*Making a 200x200 explosion to simulate mass lag*
![wokC1xWf0C](https://user-images.githubusercontent.com/25063394/77304538-7c32b100-6cec-11ea-9e10-d0c29cad98cf.gif)

Subsystems which are actively processing fine, will colour green
Subsystems which are in the queue to be processed, but are delayed, will colour orange
Subsystems which have their processing paused due to lag, will colour red
Subsystems which are currently sleeping will be coloured blue

## Why It's Good For The Game
This allows admins who arent as experienced with the MC panel layout to get a rough idea of what is killing the server, so it can be relayed over. It is a lot easier to say "Oh yeah the lighting SS was red" than "The lighting SS had a letter next to it, I couldnt quite remember which one though"

## Changelog
:cl: AffectedArc07
add: Subsystems will now colour themselves based on their status
/:cl:
