### PR TITLE
Makes it so that IRC can't be cloned

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -359,12 +359,12 @@
 	if(scan_brain && !can_brainscan())
 		return
 	if(isnull(subject) || (!(ishuman(subject))) || (!subject.dna))
-		if(isalien(subject)) 
+		if(isalien(subject))
 			scantemp = "<span class=\"bad\">Error: Xenomorphs are not scannable.</span>"
 			SSnanoui.update_uis(src)
 			return
 		// can add more conditions for specific non-human messages here
-		else 
+		else
 			scantemp = "<span class=\"bad\">Error: Subject species is not scannable.</span>"
 			SSnanoui.update_uis(src)
 			return
@@ -372,7 +372,7 @@
 		var/obj/item/organ/internal/brain/Brn = subject.get_int_organ(/obj/item/organ/internal/brain)
 		if(istype(Brn))
 			if(NO_SCAN in Brn.dna.species.species_traits)
-				scantemp = "<span class=\"bad\">Error: [subject.dna.species.name_plural] are not scannable.</span>"
+				scantemp = "<span class=\"bad\">Error: [Brn.dna.species.name_plural] are not scannable.</span>"
 				SSnanoui.update_uis(src)
 				return
 	if(!subject.get_int_organ(/obj/item/organ/internal/brain))

--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -206,6 +206,7 @@
 	brainmob.stat = CONSCIOUS
 	brainmob.SetSilence(0)
 	brainmob.dna = new(brainmob)
+	brainmob.dna.species = new /datum/species/machine() // Else it will default to human. And we don't want to clone IRC humans now do we?
 	brainmob.dna.ResetSE()
 	brainmob.dna.ResetUI()
 	GLOB.dead_mob_list -= brainmob

--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -106,9 +106,18 @@
 		radio_action.ApplyIcon()
 
 /obj/item/mmi/robotic_brain/attempt_become_organ(obj/item/organ/external/parent, mob/living/carbon/human/H)
+	if(!H)
+		return FALSE
+
+	var/had_dna = TRUE
+	if(!brainmob.dna)
+		had_dna = FALSE
+		brainmob.dna = H.dna.Clone() // Take the new targets dna to ensure the created holder has the correct DNA
 	if(..())
 		if(imprinted_master)
 			to_chat(H, "<span class='biggerdanger'>You are permanently imprinted to [imprinted_master], obey [imprinted_master]'s every order and assist [imprinted_master.p_them()] in completing [imprinted_master.p_their()] goals at any cost.</span>")
+	else if(!had_dna)
+		brainmob.dna = null // Reset it for next use
 
 
 /obj/item/mmi/robotic_brain/proc/transfer_personality(mob/candidate)

--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -106,19 +106,9 @@
 		radio_action.ApplyIcon()
 
 /obj/item/mmi/robotic_brain/attempt_become_organ(obj/item/organ/external/parent, mob/living/carbon/human/H)
-	if(!H)
-		return FALSE
-
-	var/had_dna = TRUE
-	if(!brainmob.dna)
-		had_dna = FALSE
-		brainmob.dna = H.dna.Clone() // Take the new targets dna to ensure the created holder has the correct DNA
 	if(..())
 		if(imprinted_master)
 			to_chat(H, "<span class='biggerdanger'>You are permanently imprinted to [imprinted_master], obey [imprinted_master]'s every order and assist [imprinted_master.p_them()] in completing [imprinted_master.p_their()] goals at any cost.</span>")
-	else if(!had_dna)
-		brainmob.dna = null // Reset it for next use
-
 
 /obj/item/mmi/robotic_brain/proc/transfer_personality(mob/candidate)
 	searching = FALSE
@@ -215,6 +205,9 @@
 	brainmob.container = src
 	brainmob.stat = CONSCIOUS
 	brainmob.SetSilence(0)
+	brainmob.dna = new(brainmob)
+	brainmob.dna.ResetSE()
+	brainmob.dna.ResetUI()
 	GLOB.dead_mob_list -= brainmob
 	..()
 


### PR DESCRIPTION
## What Does This PR Do
Makes it so that IRC and such can't be cloned.
The made IRC had a holder brain that had a default species set. And the species was human....

## Why It's Good For The Game
Fixes a bug

## Changelog
:cl:
fix: IRCs can't be cloned
/:cl: