### PR TITLE
Paintable Lights

### DIFF
--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -45,6 +45,14 @@
 		if(do_after(user, cleanspeed, target = target))
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 			clean_turf(target)
+	else if(istype(target, /obj/item/light))
+		user.visible_message("<span class='warning'>[user] begins to clean \the [target.name] with [src].</span>")
+		if(do_after(user, cleanspeed, target = target) && target)	
+			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")		
+			var/obj/item/light/L = target
+			L.brightness_color = null
+			L.color = null
+			L.update()
 	else
 		user.visible_message("<span class='warning'>[user] begins to clean \the [target.name] with [src].</span>")
 		if(do_after(user, cleanspeed, target = target))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -618,7 +618,6 @@
 	var/brightness_power = 1
 	var/brightness_color
 	var/time_to_paint = 30  //amount of time it takes to paint a light
-	var/time_to_clean = 40 //amount of time it takes to clean a light
 
 /obj/item/light/ComponentInitialize()
 	. = ..()
@@ -631,16 +630,10 @@
 		var/obj/item/toy/crayon/spraycan/S = O
 		brightness_color =  S.colour
 		color = S.colour
-		visible_message("<span class='warning'>[M] paints the [src]!</span>")
+		visible_message("<span class='notice'>[M] paints the [src]!</span>")
 		update()
 		M.do_attack_animation(src)
-	//clean the light
-	else if(istype(O, /obj/item/soap) && do_after(M, time_to_clean, target = src))
-		brightness_color = null
-		color = null
-		visible_message("<span class='warning'>[M] cleans the [src]!</span>")
-		update()
-		M.do_attack_animation(src)
+	//cleaning is handled in soap.dm
 
 /obj/item/light/Crossed(mob/living/L)
 	if(istype(L) && has_gravity(loc))


### PR DESCRIPTION
## What Does This PR Do
Allows you to paint light bulbs with a spraycan. To clean it, use soap on the light bulb. 

The bulb must be removed from the fixture first.

## Why It's Good For The Game
You can add cool mood lighting to areas. If you paint it black it will be as if it is off. 

## Images of changes
![image](https://user-images.githubusercontent.com/20497797/77373908-cdb85b80-6d3f-11ea-8d3f-b3515a8f4630.png)

![image](https://user-images.githubusercontent.com/20497797/77373930-ddd03b00-6d3f-11ea-9fbf-25e5b8585cf9.png)


:cl:
add: Paintable lights. You can now paint lights by removing the bulb and using a spraycan on it. To clean, remove and use soap.
/ :cl: