### PR TITLE
Increases distance of accelerated particles back to how they were

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -5,20 +5,19 @@
 	icon_state = "particle"
 	anchored = TRUE
 	density = FALSE
-	var/movement_range = 10
+	var/movement_range = 11
 	var/energy = 10
-	var/speed = 1
 
 /obj/effect/accelerated_particle/weak
-	movement_range = 8
+	movement_range = 9
 	energy = 5
 
 /obj/effect/accelerated_particle/strong
-	movement_range = 15
+	movement_range = 16
 	energy = 15
 
 /obj/effect/accelerated_particle/powerful
-	movement_range = 20
+	movement_range = 21
 	energy = 50
 
 


### PR DESCRIPTION
Fixes #13183 - this was due to an oversight in the accelerated particle code making them delete themselves one turf earlier than how they used to.

Also removes unused speed var which was not used anywhere (I removed the code that cared about it in my earlier PR but nothing actually made use of that)

:cl:
fix: Fixes an oversight that made accelerated particles travel 1 less turf than they used to. The singularity will now act like it used to.
/:cl: