### PR TITLE
5 Minute Shuttle

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -13,10 +13,9 @@ SUBSYSTEM_DEF(shuttle)
 		//emergency shuttle stuff
 	var/obj/docking_port/mobile/emergency/emergency
 	var/obj/docking_port/mobile/emergency/backup/backup_shuttle
-	var/emergencyCallTime = 6000	//time taken for emergency shuttle to reach the station when called (in deciseconds)
+	var/emergencyCallTime = 3000	//time taken for emergency shuttle to reach the station when called (in deciseconds)
 	var/emergencyDockTime = 1800	//time taken for emergency shuttle to leave again once it has docked (in deciseconds)
 	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
-	var/emergency_sec_level_time = 0 // time sec level was last raised to red or higher
 	var/area/emergencyLastCallLoc
 	var/emergencyNoEscape
 
@@ -135,14 +134,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/area/signal_origin = get_area(user)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
-	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
-		var/extra_minutes = 0
-		var/priority_time = emergencyCallTime * 0.5
-		if(world.time - emergency_sec_level_time < priority_time)
-			extra_minutes = 5
-		emergency.request(null, 0.5 + extra_minutes / (emergencyCallTime / 600), signal_origin, html_decode(emergency_reason), 1)
-	else
-		emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
+	emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
 
 	log_game("[key_name(user)] has called the shuttle.")
 	message_admins("[key_name_admin(user)] has called the shuttle.")

--- a/code/modules/security_levels/security levels.dm
+++ b/code/modules/security_levels/security levels.dm
@@ -27,10 +27,6 @@ GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/secur
 
 	//Will not be announced if you try to set to the same level as it already is
 	if(level >= SEC_LEVEL_GREEN && level <= SEC_LEVEL_DELTA && level != GLOB.security_level)
-		if(level >= SEC_LEVEL_RED && GLOB.security_level < SEC_LEVEL_RED)
-			// Mark down this time to prevent shuttle cheese
-			SSshuttle.emergency_sec_level_time = world.time
-
 		// Reset gamma borgs if the new security level is lower than Gamma.
 		if(level < SEC_LEVEL_GAMMA)
 			for(var/M in GLOB.silicon_mob_list)


### PR DESCRIPTION
## What Does This PR Do
Makes the shuttle take 5 minutes to arrive on all code levels

Reverts: #8616
## Why It's Good For The Game
Courtesy of Kyet:
- removes incentive to keep the station on unnecessary red alert just for faster shuttle
- better aligns with what players want - when players want the round to end they generally want it to end now, or at least soon, instead of taking an extra 5m because its on green
- reduces chance that antags who wait until the shuttle is called to do their objectives will be able to greentext, which acts as a bit of a discouragement for antags doing this, which is good, because it makes rounds more interesting since antags will be trying to do their objectives throughout the shift instead of waiting for the end


:cl:
tweak: The shuttle will now always take 5 minutes
/ :cl:

