### PR TITLE
Make spell buttons light up slowly when recharging

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -463,6 +463,7 @@
 /datum/action/spell_action
 	check_flags = 0
 	background_icon_state = "bg_spell"
+	var/recharge_text_color = "#FFFFFF"
 
 /datum/action/spell_action/New(Target)
 	..()
@@ -501,15 +502,17 @@
 	return 0
 
 /datum/action/spell_action/UpdateButtonIcon()
-	if(button && !..())
+	if(button && !(. = ..()))
 		var/obj/effect/proc_holder/spell/S = target
 		if(!istype(S))
 			return
 		var/progress = S.get_availability_percentage()
 		var/col_val_high = 72 * progress + 128
 		var/col_val_low = 200 * progress
+		button.maptext = "<div style=\"font-size:6pt;color:[recharge_text_color];font:'Small Fonts';text-align:center;\" valign=\"bottom\">[round_down((1-progress) * 100)]%</div>"
 		button.color = rgb(col_val_high, col_val_low, col_val_low, col_val_high)
-
+	else
+		button.maptext = null
 /*
 /datum/action/spell_action/alien
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -509,7 +509,7 @@
 		var/progress = S.get_availability_percentage()
 		var/col_val_high = 72 * progress + 128
 		var/col_val_low = 200 * progress
-		button.maptext = "<div style=\"font-size:6pt;color:[recharge_text_color];font:'Small Fonts';text-align:center;\" valign=\"bottom\">[round_down((1-progress) * 100)]%</div>"
+		button.maptext = "<div style=\"font-size:6pt;color:[recharge_text_color];font:'Small Fonts';text-align:center;\" valign=\"bottom\">[round_down(progress * 100)]%</div>"
 		button.color = rgb(col_val_high, col_val_low, col_val_low, col_val_high)
 	else
 		button.maptext = null

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -500,6 +500,16 @@
 		return spell.can_cast(owner)
 	return 0
 
+/datum/action/spell_action/UpdateButtonIcon()
+	if(button && !..())
+		var/obj/effect/proc_holder/spell/S = target
+		if(!istype(S))
+			return
+		var/progress = S.get_availability_percentage()
+		var/col_val_high = 72 * progress + 128
+		var/col_val_low = 200 * progress
+		button.color = rgb(col_val_high, col_val_low, col_val_low, col_val_high)
+
 /*
 /datum/action/spell_action/alien
 

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -230,12 +230,12 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 
 /obj/effect/proc_holder/spell/process()
 	charge_counter += 2
+	if(action)
+		action.UpdateButtonIcon()
 	if(charge_counter < charge_max)
 		return
 	STOP_PROCESSING(SSfastprocess, src)
 	charge_counter = charge_max
-	if(action)
-		action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = 1, mob/user = usr) //if recharge is started is important for the trigger spells
 	before_cast(targets)
@@ -338,6 +338,19 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 		else
 			target.vars[type] += amount //I bear no responsibility for the runtimes that'll happen if you try to adjust non-numeric or even non-existant vars
 	return
+
+/obj/effect/proc_holder/spell/proc/get_availability_percentage()
+	switch(charge_type)
+		if("recharge")
+			if(charge_counter == 0)
+				return 0
+			return charge_counter / charge_max
+		if("charges")
+			if(charge_counter)
+				return 1
+			return 0
+		if("holdervar")
+			return 1
 
 /obj/effect/proc_holder/spell/targeted //can mean aoe for mobs (limited/unlimited number) or one target mob
 	var/max_targets = 1 //leave 0 for unlimited targets in range, 1 for one selectable target in range, more for limited number of casts (can all target one guy, depends on target_ignore_prev) in range


### PR DESCRIPTION
## What Does This PR Do
Makes spell action buttons slowly light up while they are recharging. A percentage is also shown below

## Why It's Good For The Game
Adds visual feedback to the user to see when the ability will be available again.

## Images of changes
![lFdy4YptRJ](https://user-images.githubusercontent.com/15887760/79584188-5bccfb00-80ce-11ea-8aca-3a777e69008c.gif)



## Changelog
:cl:
add: Spell buttons now visually recharge by slowly regaining their color and a percentage completed is shown below
/:cl: