### PR TITLE
Makes Bubblegum fightable

### DIFF
--- a/code/modules/mining/lavaland/loot/bubblegum_loot.dm
+++ b/code/modules/mining/lavaland/loot/bubblegum_loot.dm
@@ -5,14 +5,7 @@
 	..()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
-	var/loot = rand(1,3)
-	switch(loot)
-		if(1)
-			new /obj/item/mayhem(src)
-		if(2)
-			new /obj/item/blood_contract(src)
-		if(3)
-			new /obj/item/gun/magic/staff/spellblade(src)
+	new /obj/item/gun/magic/staff/spellblade(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -144,19 +144,19 @@ Difficulty: Hard
 			surround_with_hallucinations()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/triple_charge()
+	charge(delay = 9)
 	charge(delay = 6)
-	charge(delay = 4)
-	charge(delay = 2)
+	charge(delay = 3)
 	SetRecoveryTime(15)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge()
 	if(!BUBBLEGUM_SMASH || prob(33))
-		hallucination_charge_around(times = 6, delay = 8)
+		hallucination_charge_around(times = 6, delay = 12)
 		SetRecoveryTime(10)
 	else
-		hallucination_charge_around(times = 4, delay = 9)
-		hallucination_charge_around(times = 4, delay = 8)
-		hallucination_charge_around(times = 4, delay = 7)
+		hallucination_charge_around(times = 4, delay = 14)
+		hallucination_charge_around(times = 4, delay = 12)
+		hallucination_charge_around(times = 4, delay = 11)
 		triple_charge()
 		SetRecoveryTime(20)
 
@@ -164,12 +164,12 @@ Difficulty: Hard
 	for(var/i = 1 to 5)
 		INVOKE_ASYNC(src, .proc/hallucination_charge_around, 2, 8, 2, 0, 4)
 		if(ismob(target))
-			charge(delay = 6)
+			charge(delay = 9)
 		else
 			SLEEP_CHECK_DEATH(6)
 	SetRecoveryTime(20)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(atom/chargeat = target, delay = 3, chargepast = 2)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(atom/chargeat = target, delay = 5, chargepast = 2)
 	if(!chargeat)
 		return
 	var/chargeturf = get_turf(chargeat)
@@ -337,7 +337,7 @@ Difficulty: Hard
 		return FALSE
 	enrage_till = world.time + enrage_time
 	update_approach()
-	change_move_delay(3.75)
+	change_move_delay(5)
 	var/newcolor = rgb(149, 10, 10)
 	add_atom_colour(newcolor, TEMPORARY_COLOUR_PRIORITY)
 	var/datum/callback/cb = CALLBACK(src, .proc/blood_enrage_end)
@@ -365,7 +365,7 @@ Difficulty: Hard
 /obj/effect/decal/cleanable/blood/bubblegum/can_bloodcrawl_in()
 	return TRUE
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge_around(times = 4, delay = 6, chargepast = 0, useoriginal = 1, radius)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge_around(times = 4, delay = 9, chargepast = 0, useoriginal = 1, radius)
 	var/startingangle = rand(1, 360)
 	if(!target)
 		return
@@ -478,7 +478,7 @@ Difficulty: Hard
 	..()
 
 /obj/effect/temp_visual/dragon_swoop/bubblegum
-	duration = 10
+	duration = 15
 
 /obj/effect/temp_visual/bubblegum_hands
 	icon = 'icons/effects/bubblegum.dmi'
@@ -522,7 +522,7 @@ Difficulty: Hard
 	. = ..()
 	toggle_ai(AI_OFF)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/charge(atom/chargeat = target, delay = 3, chargepast = 2)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/charge(atom/chargeat = target, delay = 5, chargepast = 2)
 	..()
 	qdel(src)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -19,10 +19,9 @@ It may summon clones charging from all sides, one of these charges being bubbleg
 It can charge at its target, and also heavily damaging anything directly hit in the charge.
 If at half health it will start to charge from all sides with clones.
 
-When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a chest that can contain three things:
- 1. A bottle that, when activated, drives everyone nearby into a frenzy
- 2. A contract that marks for death the chosen target
- 3. A spellblade that can slice off limbs at range
+When Bubblegum dies, it leaves behind a chest that contains:
+ 1. A H.E.C.K. mining suit
+ 2. A spellblade that can slice off limbs at range
 
 Difficulty: Hard
 


### PR DESCRIPTION
## What Does This PR Do
This PR makes Bubblegum's attacks a little bit slower to account for paradise movement speed so that the fight is possible without a load of cheese. This doesn't make it an easy fight by any means, but possible with regular miner gear. Here's a video showcasing the changes: https://streamable.com/f724j

This PR now also removes the bottle of mayhem and blood contract from the loot pool (for now at least).

## Why It's Good For The Game
Bubblegum should be very hard to kill, but not almost impossible.

## Changelog
:cl: CornMyCob
tweak: Bubblegum attacks a bit slower, making him possible to kill
/:cl: