### PR TITLE
Kidan Rebalance

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -204,7 +204,7 @@
 	strip_delay = 20			//	   but seperated to allow items to protect but not impair vision, like space helmets
 	put_on_delay = 25
 	resistance_flags = NONE
-	species_restricted = list("exclude","Kidan")
+
 /*
 SEE_SELF  // can see self, no matter what
 SEE_MOBS  // can see all mobs, no matter what

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -78,13 +78,13 @@
 
 		if("clack", "clacks")
 			if(iskidan(src))	//Only Kidan can clack and rightfully so.
-				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
+				on_CD = handle_emote_CD(30)			//proc located in code\modules\mob\emote.dm'
 			else								//Everyone else fails, skip the emote attempt
 				return
 
 		if("click", "clicks")
 			if(iskidan(src))	//Only Kidan can click and rightfully so.
-				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
+				on_CD = handle_emote_CD(30)			//proc located in code\modules\mob\emote.dm'
 			else								//Everyone else fails, skip the emote attempt
 				return
 
@@ -194,14 +194,14 @@
 
 		if("clack", "clacks")
 			var/M = handle_emote_param(param)
-
+			mineral_scan_pulse(get_turf(src), range = world.view)
 			message = "<B>[src]</B> clacks [p_their()] mandibles[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/effects/Kidanclack.ogg', 50, 1, frequency = get_age_pitch()) //Credit to DrMinky (freesound.org) for the sound.
 			m_type = 2
 
 		if("click", "clicks")
 			var/M = handle_emote_param(param)
-
+			mineral_scan_pulse(get_turf(src), range = world.view)
 			message = "<B>[src]</B> clicks [p_their()] mandibles[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/effects/Kidanclack2.ogg', 50, 1, frequency = get_age_pitch()) //Credit to DrMinky (freesound.org) for the sound.
 			m_type = 2

--- a/code/modules/mob/living/carbon/human/species/kidan.dm
+++ b/code/modules/mob/living/carbon/human/species/kidan.dm
@@ -7,8 +7,8 @@
 	unarmed_type = /datum/unarmed_attack/claws
 
 	brute_mod = 0.8
-	hunger_drain = 0.13
-	tox_mod = 1.2
+	hunger_drain = 0.15
+	tox_mod = 1.7
 
 	species_traits = list(IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS

--- a/code/modules/mob/living/carbon/human/species/kidan.dm
+++ b/code/modules/mob/living/carbon/human/species/kidan.dm
@@ -7,6 +7,8 @@
 	unarmed_type = /datum/unarmed_attack/claws
 
 	brute_mod = 0.8
+	hunger_drain = 0.13
+	tox_mod = 1.2
 
 	species_traits = list(IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS


### PR DESCRIPTION
## What Does This PR Do
Kidan can make minerals show up like in the mineral scanner everytime a kidan goes *click or *clack as an emote
Kidan can wear glasses
Kidan are 70% more injured by toxins
Kidan are 50% more hungry

## Why It's Good For The Game
It makes the species more interesting and viable to play, currently there is not much kidans on station because of how restrictive the glasses are.
They still cost 30 KP, so there is still a high barrier to playing them, but at least now people might actually see them as worth it.

Partially taken from #8580 credit to kyet where due

:cl:
add: Kidan can *click and *clack to locate minerals like a mining scanner
tweak: Kidan can wear glasses now
tweak: Kidan are 70% more injured by toxins
tweak: Kidan are 50% more hungry
/ :cl: