### PR TITLE
Orange Watchlist Names

### DIFF
--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -12,6 +12,7 @@
 	var/mob/M
 	var/client/C
 	var/key
+	var/watchlisted = FALSE
 
 	if(!whom)
 		return "INVALID/(INVALID)"
@@ -39,6 +40,9 @@
 
 	. = ""
 
+	if(check_watchlist(key) && is_admin(src))
+		watchlisted = TRUE
+
 	if(key)
 		if(C && C.holder && C.holder.fakekey && !include_name)
 			if(include_link)
@@ -46,7 +50,10 @@
 			. += "Administrator"
 		else
 			if(include_link && C)
-				. += "<a href='?priv_msg=[C.UID()];type=[type]'>"
+				if(watchlisted)
+					. += "<a style='color: #FF0000;' href='?priv_msg=[C.UID()];type=[type]'>"
+				else
+					. += "<a href='?priv_msg=[C.UID()];type=[type]'>"
 			. += key
 
 		if(include_link)

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -51,7 +51,7 @@
 		else
 			if(include_link && C)
 				if(watchlisted)
-					. += "<a style='color: #FF0000;' href='?priv_msg=[C.UID()];type=[type]'>"
+					. += "<a style='color: #db9737;' href='?priv_msg=[C.UID()];type=[type]'>"
 				else
 					. += "<a href='?priv_msg=[C.UID()];type=[type]'>"
 			. += key

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -70,7 +70,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	if(M.client)
 
 		if(check_watchlist(M.ckey)
-			body += " played by <a style = 'color: #db9737;' href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
+			body += " played by <a style='color: #db9737;' href='?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
 		else
 			body += " played by <b>[M.client]</b> "
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -68,7 +68,12 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	var/body = "<html><head><title>Options for [M.key]</title></head>"
 	body += "<body>Options panel for <b>[M]</b>"
 	if(M.client)
-		body += " played by <b>[M.client]</b> "
+
+		if(check_watchlist(M.ckey) || TRUE)
+			body += " played by <a style = 'color: #FF0000;' href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
+		else
+			body += " played by <a href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
+
 		body += "\[<A href='?_src_=holder;editrights=rank;ckey=[M.ckey]'>[M.client.holder ? M.client.holder.rank : "Player"]</A>\] "
 		body += "\[<A href='?_src_=holder;getplaytimewindow=[M.UID()]'>" + M.client.get_exp_type(EXP_TYPE_CREW) + " as [EXP_TYPE_CREW]</a>\]"
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -70,7 +70,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	if(M.client)
 
 		if(check_watchlist(M.ckey)
-			body += " played by <a style='color: #db9737;' href='?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
+			body += " played by <a style = 'color: #db9737;' href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
 		else
 			body += " played by <b>[M.client]</b> "
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -69,8 +69,8 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	body += "<body>Options panel for <b>[M]</b>"
 	if(M.client)
 
-		if(check_watchlist(M.ckey) || TRUE)
-			body += " played by <a style = 'color: #FF0000;' href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
+		if(check_watchlist(M.ckey)
+			body += " played by <a style = 'color: #db9737;' href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
 		else
 			body += " played by <a href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -69,8 +69,8 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	body += "<body>Options panel for <b>[M]</b>"
 	if(M.client)
 
-		if(check_watchlist(M.ckey)
-			body += " played by <a style = 'color: #db9737;' href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
+		if(check_watchlist(M.ckey))
+			body += " played by <a style='color: #db9737;' href='?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
 		else
 			body += " played by <b>[M.client]</b> "
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -72,7 +72,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 		if(check_watchlist(M.ckey)
 			body += " played by <a style = 'color: #db9737;' href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
 		else
-			body += " played by <a href = '?_src_=holder;watchsearch=[M.ckey];'><b>[M.client]</b></a> "
+			body += " played by <b>[M.client]</b> "
 
 		body += "\[<A href='?_src_=holder;editrights=rank;ckey=[M.ckey]'>[M.client.holder ? M.client.holder.rank : "Player"]</A>\] "
 		body += "\[<A href='?_src_=holder;getplaytimewindow=[M.UID()]'>" + M.client.get_exp_type(EXP_TYPE_CREW) + " as [EXP_TYPE_CREW]</a>\]"


### PR DESCRIPTION
People placed on a watchlist will now have Orange names to alert admins. Mentors are unable to see the orange names

If the name is orange in the player panel you can click it to bring up the watchlist reason

I changed the color after taking the screenshots, they are now orange instead of red.
![image](https://user-images.githubusercontent.com/20497797/77686169-e5c3f100-6f72-11ea-9f8a-4531100a7ae3.png)
![image](https://user-images.githubusercontent.com/20497797/77686180-e9f00e80-6f72-11ea-8502-97641ba5d9a6.png)
![image](https://user-images.githubusercontent.com/20497797/77686283-11df7200-6f73-11ea-8e33-53e934cc7819.png)

This is the color:
![image](https://user-images.githubusercontent.com/20497797/77686779-d5604600-6f73-11ea-8915-b8c608c1308f.png)
:cl:
add:People on a watchlist will now have orange names to admins. Admins can click the name in the player panel to bring up the watchlist reason
/ :cl:
