### PR TITLE
Fixes crafting 0 stacks

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -313,6 +313,11 @@
 /mob/living/carbon/human/put_in_hands(obj/item/I)
 	if(!I)
 		return FALSE
+	if(istype(I, /obj/item/stack))
+		var/obj/item/stack/S = I
+		if(S.amount == 0)
+			qdel(I)
+			return FALSE
 	if(put_in_active_hand(I))
 		return TRUE
 	else if(put_in_inactive_hand(I))


### PR DESCRIPTION
## What Does This PR Do
Fixes crafting 0 stacks which crashed the server. My bad. Thanks @AffectedArc07 for helping with a quick fix.

## Why It's Good For The Game
Server crashing is bad.

## Changelog
:cl:
fix: Fixes crafting 0 stacks, which made the MC shit itself
/:cl: