### PR TITLE
Increases ATM Withdrawl Limit

### DIFF
--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -237,9 +237,9 @@ log transactions
 						playsound(src, 'sound/machines/chime.ogg', 50, 1)
 
 						//remove the money
-						if(amount > 10000) // prevent crashes
+						if(amount > 100000) // prevent crashes
 							to_chat(usr, "<span class='notice'>The ATM's screen flashes, 'Maximum single withdrawl limit reached, defaulting to 10,000.'</span>")
-							amount = 10000
+							amount = 100000
 						withdraw_arbitrary_sum(amount)
 						authenticated_account.charge(amount, null, "Credit withdrawal", machine_id, authenticated_account.owner_name)
 					else

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -238,7 +238,7 @@ log transactions
 
 						//remove the money
 						if(amount > 100000) // prevent crashes
-							to_chat(usr, "<span class='notice'>The ATM's screen flashes, 'Maximum single withdrawl limit reached, defaulting to 10,000.'</span>")
+							to_chat(usr, "<span class='notice'>The ATM's screen flashes, 'Maximum single withdrawl limit reached, defaulting to 100,000.'</span>")
 							amount = 100000
 						withdraw_arbitrary_sum(amount)
 						authenticated_account.charge(amount, null, "Credit withdrawal", machine_id, authenticated_account.owner_name)


### PR DESCRIPTION
## What Does This PR Do
Increases the max limit for ATM withdrawls from 10k to 100k. It's not often people get over 10k, but with some admin run events and slot winnings it's relevant. Mostly for the admin event side of things. Now, the comment on the line I edited said that it was done that way to prevent crashes. I personally noticed no CPU spikes when testing locally, and don't really think it would affect anything personally. I could be wrong though.

## Why It's Good For The Game
Allows events that involve a lot of credits being spawned/deposited/stolen and what not to run a lot more smoothly, withdrawing 10k at once is a huge pain in the rear and becomes tedious fast.

## Changelog
:cl:
tweak: You can now withdraw up to 100k at a time from an ATM.
/:cl: