### PR TITLE
Allow the Cloning Pod to accept monster meat as a source of biomass

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -99,14 +99,14 @@
 "m" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/stack/sheet/animalhide/lizard,
-/obj/item/reagent_containers/food/snacks/lizardmeat,
+/obj/item/reagent_containers/food/snacks/meat/lizardmeat,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/lizardmeat,
+/obj/item/reagent_containers/food/snacks/meat/lizardmeat,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -116,7 +116,7 @@
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/lizardmeat,
+/obj/item/reagent_containers/food/snacks/meat/lizardmeat,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -99,14 +99,14 @@
 "m" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/stack/sheet/animalhide/lizard,
-/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -116,7 +116,7 @@
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -99,14 +99,14 @@
 "m" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/stack/sheet/animalhide/lizard,
-/obj/item/reagent_containers/food/snacks/lizardmeat,
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/lizardmeat,
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat
 /obj/machinery/light{
 	dir = 1
 	},
@@ -116,7 +116,7 @@
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/lizardmeat,
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -99,14 +99,14 @@
 "m" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/stack/sheet/animalhide/lizard,
-/obj/item/reagent_containers/food/snacks/meat/lizardmeat,
+/obj/item/reagent_containers/food/snacks/lizardmeat,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/meat/lizardmeat,
+/obj/item/reagent_containers/food/snacks/lizardmeat,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -116,7 +116,7 @@
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/meat/lizardmeat,
+/obj/item/reagent_containers/food/snacks/lizardmeat,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -5598,7 +5598,7 @@
 	},
 /area/syndicate_depot/outer)
 "lZ" = (
-/obj/item/reagent_containers/food/snacks/spiderleg,
+/obj/item/reagent_containers/food/snacks/meat/spiderleg,
 /obj/structure/spider,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -5598,7 +5598,7 @@
 	},
 /area/syndicate_depot/outer)
 "lZ" = (
-/obj/item/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/reagent_containers/food/snacks/spiderleg,
 /obj/structure/spider,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -5598,7 +5598,7 @@
 	},
 /area/syndicate_depot/outer)
 "lZ" = (
-/obj/item/reagent_containers/food/snacks/spiderleg,
+/obj/item/reagent_containers/food/snacks/monstermeat/spiderleg
 /obj/structure/spider,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -5598,7 +5598,7 @@
 	},
 /area/syndicate_depot/outer)
 "lZ" = (
-/obj/item/reagent_containers/food/snacks/monstermeat/spiderleg
+/obj/item/reagent_containers/food/snacks/monstermeat/spiderleg,
 /obj/structure/spider,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -4,7 +4,19 @@
 //Potential replacement for genetics revives or something I dunno (?)
 
 #define CLONE_BIOMASS 150
+
 #define BIOMASS_BASE_AMOUNT 50 // How much biomass a BIOMASSABLE item gives the cloning pod
+
+// Not a comprehensive list: Further PRs should add appropriate items here.
+// Meat as usual, monstermeat covers goliath, xeno, spider, bear meat
+GLOBAL_LIST_INIT(cloner_biomass_items, list(\
+/obj/item/reagent_containers/food/snacks/meat,\
+/obj/item/reagent_containers/food/snacks/monstermeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/salmonmeat,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/tofurkey))
+
 #define MINIMUM_HEAL_LEVEL 40
 #define CLONE_INITIAL_DAMAGE 190
 #define BRAIN_INITIAL_DAMAGE 90 // our minds are too feeble for 190
@@ -307,7 +319,7 @@
 /obj/machinery/clonepod/process()
 	var/show_message = 0
 	for(var/obj/item/item in range(1, src))
-		if (item.BIOMASSABLE)
+		if(is_type_in_list(item, GLOB.cloner_biomass_items))
 			qdel(item)
 			biomass += BIOMASS_BASE_AMOUNT
 			show_message = 1
@@ -366,12 +378,12 @@
 		use_power(200)
 
 //Let's unlock this early I guess.  Might be too early, needs tweaking.
-/obj/machinery/clonepod/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
+/obj/machinery/clonepod/attackby(obj/item/item, mob/user, params)
+	if(exchange_parts(user, item))
 		return
 
-	if(I.GetID())
-		if(!check_access(I))
+	if(item.GetID())
+		if(!check_access(item))
 			to_chat(user, "<span class='danger'>Access Denied.</span>")
 			return
 		if(!(occupant || mess))
@@ -384,11 +396,11 @@
 			go_out()
 
 // A user can feed in biomass sources manually.
-	else if(I.BIOMASSABLE)
+	else if(is_type_in_list(item, GLOB.cloner_biomass_items))
 		if(user.drop_item())
-			to_chat(user, "<span class='notice'>[src] processes [I].</span>")
+			to_chat(user, "<span class='notice'>[src] processes [item].</span>")
 			biomass += BIOMASS_BASE_AMOUNT
-			qdel(I)
+			qdel(item)
 	else
 		return ..()
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -317,12 +317,12 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 
 //Grow clones to maturity then kick them out. FREELOADERS
 /obj/machinery/clonepod/process()
-	var/show_message = 0
+	var/show_message = FALSE
 	for(var/obj/item/item in range(1, src))
 		if(is_type_in_list(item, GLOB.cloner_biomass_items))
 			qdel(item)
 			biomass += BIOMASS_BASE_AMOUNT
-			show_message = 1
+			show_message = TRUE
 	if(show_message)
 		visible_message("[src] sucks in and processes the nearby biomass.")
 
@@ -378,12 +378,12 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 		use_power(200)
 
 //Let's unlock this early I guess.  Might be too early, needs tweaking.
-/obj/machinery/clonepod/attackby(obj/item/item, mob/user, params)
-	if(exchange_parts(user, item))
+/obj/machinery/clonepod/attackby(obj/item/I, mob/user, params)
+	if(exchange_parts(user, I))
 		return
 
-	if(item.GetID())
-		if(!check_access(item))
+	if(I.GetID())
+		if(!check_access(I))
 			to_chat(user, "<span class='danger'>Access Denied.</span>")
 			return
 		if(!(occupant || mess))
@@ -396,11 +396,11 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 			go_out()
 
 // A user can feed in biomass sources manually.
-	else if(is_type_in_list(item, GLOB.cloner_biomass_items))
+	else if(is_type_in_list(I, GLOB.cloner_biomass_items))
 		if(user.drop_item())
-			to_chat(user, "<span class='notice'>[src] processes [item].</span>")
+			to_chat(user, "<span class='notice'>[src] processes [I].</span>")
 			biomass += BIOMASS_BASE_AMOUNT
-			qdel(item)
+			qdel(I)
 	else
 		return ..()
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -4,7 +4,7 @@
 //Potential replacement for genetics revives or something I dunno (?)
 
 #define CLONE_BIOMASS 150
-#define BIOMASS_MEAT_AMOUNT 50
+#define BIOMASS_BASE_AMOUNT 50 // How much biomass a BIOMASSABLE item gives the cloning pod
 #define MINIMUM_HEAL_LEVEL 40
 #define CLONE_INITIAL_DAMAGE 190
 #define BRAIN_INITIAL_DAMAGE 90 // our minds are too feeble for 190
@@ -17,6 +17,7 @@
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "pod_0"
 	req_access = list(ACCESS_GENETICS) //For premature unlocking.
+
 	var/mob/living/carbon/human/occupant
 	var/heal_level //The clone is released once its health reaches this level.
 	var/obj/machinery/computer/cloning/connected = null //So we remember the connected clone machine.
@@ -302,13 +303,14 @@
 	attempting = 0
 	return 1
 
-//Grow clones to maturity then kick them out.  FREELOADERS
+//Grow clones to maturity then kick them out. FREELOADERS
 /obj/machinery/clonepod/process()
 	var/show_message = 0
-	for(var/obj/item/reagent_containers/food/snacks/meat/meat in range(1, src))
-		qdel(meat)
-		biomass += BIOMASS_MEAT_AMOUNT
-		show_message = 1
+	for(var/obj/item/item in range(1, src))
+		if (item.BIOMASSABLE)
+			qdel(item)
+			biomass += BIOMASS_BASE_AMOUNT
+			show_message = 1
 	if(show_message)
 		visible_message("[src] sucks in and processes the nearby biomass.")
 
@@ -381,11 +383,11 @@
 			to_chat(user, "<span class='notice'>You force an emergency ejection.</span>")
 			go_out()
 
-//Removing cloning pod biomass
-	else if(istype(I, /obj/item/reagent_containers/food/snacks/meat))
+// A user can feed in biomass sources manually.
+	else if(I.BIOMASSABLE)
 		if(user.drop_item())
 			to_chat(user, "<span class='notice'>[src] processes [I].</span>")
-			biomass += BIOMASS_MEAT_AMOUNT
+			biomass += BIOMASS_BASE_AMOUNT
 			qdel(I)
 	else
 		return ..()

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -8,21 +8,16 @@
 	desc = "A slab of meat"
 	icon_state = "meat"
 	filling_color = "#FF1C1C"
-	var/makes_cutlet = TRUE // Some meat cannot be cut into ordinary cutlets, but is accepted by the cloning pod.
-							// i.e. this is set to FALSE for most monster meat.
 	bitesize = 3
 	list_reagents = list("protein" = 3)
 	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
-		if(!makes_cutlet)
-			to_chat(user, "<span class ='notice'>You can't quite figure out how to make [src] into cutlets.</span>")
-			return
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-		to_chat(user, "You cut the meat into thin strips.")
+		to_chat(user, "You cut the meat in thin strips.")
 		qdel(src)
 	else
 		..()
@@ -82,47 +77,45 @@
 		new /obj/item/reagent_containers/food/snacks/raw_bacon(loc)
 		qdel(src)
 
-/obj/item/reagent_containers/food/snacks/meat/bearmeat
+/obj/item/reagent_containers/food/snacks/bearmeat
 	name = "bear meat"
 	desc = "A very manly slab of meat."
 	icon_state = "bearmeat"
 	filling_color = "#DB0000"
-	makes_cutlet = FALSE
+	bitesize = 3
 	list_reagents = list("protein" = 12, "morphine" = 5, "vitamin" = 2)
 	tastes = list("meat" = 1, "salmon" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/xenomeat
+/obj/item/reagent_containers/food/snacks/xenomeat
 	name = "meat"
 	desc = "A slab of meat. It's green!"
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
-	makes_cutlet = FALSE
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 1)
 	tastes = list("meat" = 1, "acid" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/spidermeat
+/obj/item/reagent_containers/food/snacks/spidermeat
 	name = "spider meat"
 	desc = "A slab of spider meat. Not very appetizing."
 	icon_state = "spidermeat"
-	makes_cutlet = FALSE
+	bitesize = 3
 	list_reagents = list("protein" = 3, "toxin" = 3, "vitamin" = 1)
 	tastes = list("cobwebs" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/lizardmeat
+/obj/item/reagent_containers/food/snacks/lizardmeat
 	name = "mutant lizard meat"
 	desc = "A peculiar slab of meat. It looks scaly and radioactive."
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
-	makes_cutlet = FALSE
+	bitesize = 3
 	list_reagents = list("protein" = 3, "toxin" = 3)
 	tastes = list("tough meat" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/spiderleg
+/obj/item/reagent_containers/food/snacks/spiderleg
 	name = "spider leg"
 	desc = "A still twitching leg of a giant spider. You don't really want to eat this, do you?"
 	icon_state = "spiderleg"
-	makes_cutlet = FALSE
 	list_reagents = list("protein" = 2, "toxin" = 2)
 	tastes = list("cobwebs" = 1, "creepy motion" = 1)
 
@@ -140,15 +133,14 @@
 	list_reagents = list("protein" = 2, "toxin" = 2)
 	tastes = list("cobwebs" = 1, "spider juice" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/goliath
+/obj/item/reagent_containers/food/snacks/goliath
 	name = "goliath meat"
 	desc = "A slab of goliath meat. It's not very edible now, but it cooks great in lava."
 	icon_state = "goliathmeat"
-	makes_cutlet = FALSE
 	list_reagents = list("protein" = 3, "toxin" = 5)
 	tastes = list("tough meat" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/goliath/burn()
+/obj/item/reagent_containers/food/snacks/goliath/burn()
 	visible_message("<span class='notice'>[src] finishes cooking!</span>")
 	new /obj/item/reagent_containers/food/snacks/goliath_steak(loc)
 	qdel(src)
@@ -251,7 +243,7 @@
 	trash = null
 	list_reagents = list("protein" = 6, "vitamin" = 2)
 	tastes = list("meat" = 1)
-
+	
 /obj/item/reagent_containers/food/snacks/fried_vox
 	name = "Kentucky Fried Vox"
 	desc = "Bucket of voxxy, yaya!"

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -11,6 +11,7 @@
 	bitesize = 3
 	list_reagents = list("protein" = 3)
 	tastes = list("meat" = 1)
+	var/BIOMASSABLE = TRUE // Can be fed into the cloning pod as biomass
 
 /obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
@@ -77,8 +78,22 @@
 		new /obj/item/reagent_containers/food/snacks/raw_bacon(loc)
 		qdel(src)
 
-/obj/item/reagent_containers/food/snacks/bearmeat
-	name = "bear meat"
+//////////////////////////
+//		Monster Meat	//
+//////////////////////////
+
+// Cannot be used in the usual meat-based food recipies but can be used as cloning pod biomass.
+
+/obj/item/reagent_containers/food/snacks/monstermeat
+	// Abstract object used for inheritance. I don't see why you would want one.
+	// It's just a convenience to set all monstermeats' BIOMASSABLE vars.
+	// DOES NOT SPAWN NATURALLY!
+	name = "abstract monster meat"
+	desc = "A slab of abstract monster meat. This shouldn't exist, contact a coder about this if you are seeing it in-game."
+	icon_state = "bearmeat"
+	var/BIOMASSABLE = TRUE // Can be fed into the cloning pod as biomass
+
+/obj/item/reagent_containers/food/snacks/monstermeat/bearmeat	name = "bear meat"
 	desc = "A very manly slab of meat."
 	icon_state = "bearmeat"
 	filling_color = "#DB0000"
@@ -86,8 +101,7 @@
 	list_reagents = list("protein" = 12, "morphine" = 5, "vitamin" = 2)
 	tastes = list("meat" = 1, "salmon" = 1)
 
-/obj/item/reagent_containers/food/snacks/xenomeat
-	name = "meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat	name = "meat"
 	desc = "A slab of meat. It's green!"
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
@@ -95,16 +109,14 @@
 	list_reagents = list("protein" = 3, "vitamin" = 1)
 	tastes = list("meat" = 1, "acid" = 1)
 
-/obj/item/reagent_containers/food/snacks/spidermeat
-	name = "spider meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/spidermeat	name = "spider meat"
 	desc = "A slab of spider meat. Not very appetizing."
 	icon_state = "spidermeat"
 	bitesize = 3
 	list_reagents = list("protein" = 3, "toxin" = 3, "vitamin" = 1)
 	tastes = list("cobwebs" = 1)
 
-/obj/item/reagent_containers/food/snacks/lizardmeat
-	name = "mutant lizard meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat	name = "mutant lizard meat"
 	desc = "A peculiar slab of meat. It looks scaly and radioactive."
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
@@ -112,8 +124,7 @@
 	list_reagents = list("protein" = 3, "toxin" = 3)
 	tastes = list("tough meat" = 1)
 
-/obj/item/reagent_containers/food/snacks/spiderleg
-	name = "spider leg"
+/obj/item/reagent_containers/food/snacks/monstermeat/spiderleg	name = "spider leg"
 	desc = "A still twitching leg of a giant spider. You don't really want to eat this, do you?"
 	icon_state = "spiderleg"
 	list_reagents = list("protein" = 2, "toxin" = 2)
@@ -126,21 +137,19 @@
 	list_reagents = list("nutriment" = 1, "porktonium" = 10)
 	tastes = list("bacon" = 1)
 
-/obj/item/reagent_containers/food/snacks/spidereggs
-	name = "spider eggs"
+/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs	name = "spider eggs"
 	desc = "A cluster of juicy spider eggs. A great side dish for when you don't care about your health."
 	icon_state = "spidereggs"
 	list_reagents = list("protein" = 2, "toxin" = 2)
 	tastes = list("cobwebs" = 1, "spider juice" = 1)
 
-/obj/item/reagent_containers/food/snacks/goliath
-	name = "goliath meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath	name = "goliath meat"
 	desc = "A slab of goliath meat. It's not very edible now, but it cooks great in lava."
 	icon_state = "goliathmeat"
 	list_reagents = list("protein" = 3, "toxin" = 5)
 	tastes = list("tough meat" = 1)
 
-/obj/item/reagent_containers/food/snacks/goliath/burn()
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath/burn()
 	visible_message("<span class='notice'>[src] finishes cooking!</span>")
 	new /obj/item/reagent_containers/food/snacks/goliath_steak(loc)
 	qdel(src)
@@ -243,7 +252,7 @@
 	trash = null
 	list_reagents = list("protein" = 6, "vitamin" = 2)
 	tastes = list("meat" = 1)
-	
+
 /obj/item/reagent_containers/food/snacks/fried_vox
 	name = "Kentucky Fried Vox"
 	desc = "Bucket of voxxy, yaya!"

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -11,7 +11,6 @@
 	bitesize = 3
 	list_reagents = list("protein" = 3)
 	tastes = list("meat" = 1)
-	var/BIOMASSABLE = TRUE // Can be fed into the cloning pod as biomass
 
 /obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
@@ -93,7 +92,8 @@
 	icon_state = "bearmeat"
 	var/BIOMASSABLE = TRUE // Can be fed into the cloning pod as biomass
 
-/obj/item/reagent_containers/food/snacks/monstermeat/bearmeat	name = "bear meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/bearmeat
+	name = "bear meat"
 	desc = "A very manly slab of meat."
 	icon_state = "bearmeat"
 	filling_color = "#DB0000"
@@ -101,7 +101,8 @@
 	list_reagents = list("protein" = 12, "morphine" = 5, "vitamin" = 2)
 	tastes = list("meat" = 1, "salmon" = 1)
 
-/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat	name = "meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
+	name = "meat"
 	desc = "A slab of meat. It's green!"
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
@@ -109,14 +110,16 @@
 	list_reagents = list("protein" = 3, "vitamin" = 1)
 	tastes = list("meat" = 1, "acid" = 1)
 
-/obj/item/reagent_containers/food/snacks/monstermeat/spidermeat	name = "spider meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/spidermeat
+	name = "spider meat"
 	desc = "A slab of spider meat. Not very appetizing."
 	icon_state = "spidermeat"
 	bitesize = 3
 	list_reagents = list("protein" = 3, "toxin" = 3, "vitamin" = 1)
 	tastes = list("cobwebs" = 1)
 
-/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat	name = "mutant lizard meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/lizardmeat
+	name = "mutant lizard meat"
 	desc = "A peculiar slab of meat. It looks scaly and radioactive."
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
@@ -124,7 +127,8 @@
 	list_reagents = list("protein" = 3, "toxin" = 3)
 	tastes = list("tough meat" = 1)
 
-/obj/item/reagent_containers/food/snacks/monstermeat/spiderleg	name = "spider leg"
+/obj/item/reagent_containers/food/snacks/monstermeat/spiderleg
+	name = "spider leg"
 	desc = "A still twitching leg of a giant spider. You don't really want to eat this, do you?"
 	icon_state = "spiderleg"
 	list_reagents = list("protein" = 2, "toxin" = 2)
@@ -137,13 +141,15 @@
 	list_reagents = list("nutriment" = 1, "porktonium" = 10)
 	tastes = list("bacon" = 1)
 
-/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs	name = "spider eggs"
+/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs
+	name = "spider eggs"
 	desc = "A cluster of juicy spider eggs. A great side dish for when you don't care about your health."
 	icon_state = "spidereggs"
 	list_reagents = list("protein" = 2, "toxin" = 2)
 	tastes = list("cobwebs" = 1, "spider juice" = 1)
 
-/obj/item/reagent_containers/food/snacks/monstermeat/goliath	name = "goliath meat"
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath
+	name = "goliath meat"
 	desc = "A slab of goliath meat. It's not very edible now, but it cooks great in lava."
 	icon_state = "goliathmeat"
 	list_reagents = list("protein" = 3, "toxin" = 5)

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -8,16 +8,21 @@
 	desc = "A slab of meat"
 	icon_state = "meat"
 	filling_color = "#FF1C1C"
+	var/makes_cutlet = TRUE // Some meat cannot be cut into ordinary cutlets, but is accepted by the cloning pod.
+							// i.e. this is set to FALSE for most monster meat.
 	bitesize = 3
 	list_reagents = list("protein" = 3)
 	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
+		if(!makes_cutlet)
+			to_chat(user, "<span class ='notice'>You can't quite figure out how to make [src] into cutlets.</span>")
+			return
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-		to_chat(user, "You cut the meat in thin strips.")
+		to_chat(user, "You cut the meat into thin strips.")
 		qdel(src)
 	else
 		..()
@@ -77,45 +82,47 @@
 		new /obj/item/reagent_containers/food/snacks/raw_bacon(loc)
 		qdel(src)
 
-/obj/item/reagent_containers/food/snacks/bearmeat
+/obj/item/reagent_containers/food/snacks/meat/bearmeat
 	name = "bear meat"
 	desc = "A very manly slab of meat."
 	icon_state = "bearmeat"
 	filling_color = "#DB0000"
-	bitesize = 3
+	makes_cutlet = FALSE
 	list_reagents = list("protein" = 12, "morphine" = 5, "vitamin" = 2)
 	tastes = list("meat" = 1, "salmon" = 1)
 
-/obj/item/reagent_containers/food/snacks/xenomeat
+/obj/item/reagent_containers/food/snacks/meat/xenomeat
 	name = "meat"
 	desc = "A slab of meat. It's green!"
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
+	makes_cutlet = FALSE
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 1)
 	tastes = list("meat" = 1, "acid" = 1)
 
-/obj/item/reagent_containers/food/snacks/spidermeat
+/obj/item/reagent_containers/food/snacks/meat/spidermeat
 	name = "spider meat"
 	desc = "A slab of spider meat. Not very appetizing."
 	icon_state = "spidermeat"
-	bitesize = 3
+	makes_cutlet = FALSE
 	list_reagents = list("protein" = 3, "toxin" = 3, "vitamin" = 1)
 	tastes = list("cobwebs" = 1)
 
-/obj/item/reagent_containers/food/snacks/lizardmeat
+/obj/item/reagent_containers/food/snacks/meat/lizardmeat
 	name = "mutant lizard meat"
 	desc = "A peculiar slab of meat. It looks scaly and radioactive."
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
-	bitesize = 3
+	makes_cutlet = FALSE
 	list_reagents = list("protein" = 3, "toxin" = 3)
 	tastes = list("tough meat" = 1)
 
-/obj/item/reagent_containers/food/snacks/spiderleg
+/obj/item/reagent_containers/food/snacks/meat/spiderleg
 	name = "spider leg"
 	desc = "A still twitching leg of a giant spider. You don't really want to eat this, do you?"
 	icon_state = "spiderleg"
+	makes_cutlet = FALSE
 	list_reagents = list("protein" = 2, "toxin" = 2)
 	tastes = list("cobwebs" = 1, "creepy motion" = 1)
 
@@ -133,14 +140,15 @@
 	list_reagents = list("protein" = 2, "toxin" = 2)
 	tastes = list("cobwebs" = 1, "spider juice" = 1)
 
-/obj/item/reagent_containers/food/snacks/goliath
+/obj/item/reagent_containers/food/snacks/meat/goliath
 	name = "goliath meat"
 	desc = "A slab of goliath meat. It's not very edible now, but it cooks great in lava."
 	icon_state = "goliathmeat"
+	makes_cutlet = FALSE
 	list_reagents = list("protein" = 3, "toxin" = 5)
 	tastes = list("tough meat" = 1)
 
-/obj/item/reagent_containers/food/snacks/goliath/burn()
+/obj/item/reagent_containers/food/snacks/meat/goliath/burn()
 	visible_message("<span class='notice'>[src] finishes cooking!</span>")
 	new /obj/item/reagent_containers/food/snacks/goliath_steak(loc)
 	qdel(src)
@@ -243,7 +251,7 @@
 	trash = null
 	list_reagents = list("protein" = 6, "vitamin" = 2)
 	tastes = list("meat" = 1)
-	
+
 /obj/item/reagent_containers/food/snacks/fried_vox
 	name = "Kentucky Fried Vox"
 	desc = "Bucket of voxxy, yaya!"

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -85,12 +85,12 @@
 
 /obj/item/reagent_containers/food/snacks/monstermeat
 	// Abstract object used for inheritance. I don't see why you would want one.
-	// It's just a convenience to set all monstermeats' BIOMASSABLE vars.
+	// It's just a convenience to set all monstermeats as biomass-able at once,
+	// in the GLOB.cloner_biomass_items list.
 	// DOES NOT SPAWN NATURALLY!
 	name = "abstract monster meat"
 	desc = "A slab of abstract monster meat. This shouldn't exist, contact a coder about this if you are seeing it in-game."
 	icon_state = "bearmeat"
-	var/BIOMASSABLE = TRUE // Can be fed into the cloning pod as biomass
 
 /obj/item/reagent_containers/food/snacks/monstermeat/bearmeat
 	name = "bear meat"

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -8,6 +8,7 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "carpotoxin" = 2, "vitamin" = 2)
 	tastes = list("white fish" = 1)
+	var/BIOMASSABLE = TRUE
 
 /obj/item/reagent_containers/food/snacks/salmonmeat
 	name = "raw salmon"
@@ -18,6 +19,7 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 2)
 	tastes = list("raw salmon" = 1)
+	var/BIOMASSABLE = TRUE
 
 /obj/item/reagent_containers/food/snacks/salmonsteak
 	name = "salmon steak"
@@ -39,6 +41,7 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 2)
 	tastes = list("catfish" = 1)
+	var/BIOMASSABLE = TRUE
 
 /obj/item/reagent_containers/food/snacks/fishfingers
 	name = "fish fingers"
@@ -114,7 +117,7 @@
 	trash = /obj/item/stack/rods
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "shrimpskewer"
-	bitesize = 3 
+	bitesize = 3
 	list_reagents = list("nutriment" = 8)
 	tastes = list("shrimp" = 4)
 

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -8,7 +8,6 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "carpotoxin" = 2, "vitamin" = 2)
 	tastes = list("white fish" = 1)
-	var/BIOMASSABLE = TRUE
 
 /obj/item/reagent_containers/food/snacks/salmonmeat
 	name = "raw salmon"
@@ -19,7 +18,6 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 2)
 	tastes = list("raw salmon" = 1)
-	var/BIOMASSABLE = TRUE
 
 /obj/item/reagent_containers/food/snacks/salmonsteak
 	name = "salmon steak"
@@ -41,7 +39,6 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 2)
 	tastes = list("catfish" = 1)
-	var/BIOMASSABLE = TRUE
 
 /obj/item/reagent_containers/food/snacks/fishfingers
 	name = "fish fingers"

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -273,6 +273,8 @@
 //		reagents.add_reagent("nutriment", 2)							//	this line of code for all the contents.
 //		bitesize = 3													//This is the amount each bite consumes.
 
+// Remember to add anything that should be accepted as biomass by the cloning pods into the GLOB.cloner_biomass_items list.
+// E.g: raw meat and other sources of protein.
 
 /obj/item/reagent_containers/food/snacks/badrecipe
 	name = "burned mess"

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -273,9 +273,6 @@
 //		reagents.add_reagent("nutriment", 2)							//	this line of code for all the contents.
 //		bitesize = 3													//This is the amount each bite consumes.
 
-// Remember to add anything that should be accepted as biomass by the cloning pods into the GLOB.cloner_biomass_items list.
-// E.g: raw meat and other sources of protein.
-
 /obj/item/reagent_containers/food/snacks/badrecipe
 	name = "burned mess"
 	desc = "Someone should be demoted from chef for this."

--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -112,7 +112,7 @@
 /datum/recipe/grill/wingfangchu
 	reagents = list("soysauce" = 5)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
 	)
 	result = /obj/item/reagent_containers/food/snacks/wingfangchu
 
@@ -228,11 +228,9 @@
 	result = /obj/item/reagent_containers/food/snacks/sushi_Tai
 
 /datum/recipe/grill/goliath
-	items = list(
-/obj/item/reagent_containers/food/snacks/goliath
-	)
+	items = list(/obj/item/reagent_containers/food/snacks/monstermeat/goliath)
 	result = /obj/item/reagent_containers/food/snacks/goliath_steak
-	
+
 /datum/recipe/grill/shrimp_skewer
 	items = list(
 		/obj/item/reagent_containers/food/snacks/shrimp,

--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -112,7 +112,7 @@
 /datum/recipe/grill/wingfangchu
 	reagents = list("soysauce" = 5)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
+		/obj/item/reagent_containers/food/snacks/xenomeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/wingfangchu
 
@@ -229,10 +229,10 @@
 
 /datum/recipe/grill/goliath
 	items = list(
-/obj/item/reagent_containers/food/snacks/meat/goliath
+/obj/item/reagent_containers/food/snacks/goliath
 	)
 	result = /obj/item/reagent_containers/food/snacks/goliath_steak
-
+	
 /datum/recipe/grill/shrimp_skewer
 	items = list(
 		/obj/item/reagent_containers/food/snacks/shrimp,

--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -112,7 +112,7 @@
 /datum/recipe/grill/wingfangchu
 	reagents = list("soysauce" = 5)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/wingfangchu
 
@@ -229,10 +229,10 @@
 
 /datum/recipe/grill/goliath
 	items = list(
-/obj/item/reagent_containers/food/snacks/goliath
+/obj/item/reagent_containers/food/snacks/meat/goliath
 	)
 	result = /obj/item/reagent_containers/food/snacks/goliath_steak
-	
+
 /datum/recipe/grill/shrimp_skewer
 	items = list(
 		/obj/item/reagent_containers/food/snacks/shrimp,

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -87,7 +87,7 @@
 /datum/recipe/microwave/xenoburger
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/reagent_containers/food/snacks/xenomeat
+		/obj/item/reagent_containers/food/snacks/meat/xenomeat
 	)
 	result = /obj/item/reagent_containers/food/snacks/xenoburger
 
@@ -630,7 +630,7 @@ datum/recipe/microwave/slimesandwich
 /datum/recipe/microwave/boiledspiderleg
 	reagents = list("water" = 10)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/spiderleg,
+		/obj/item/reagent_containers/food/snacks/meat/spiderleg,
 	)
 	result = /obj/item/reagent_containers/food/snacks/boiledspiderleg
 
@@ -638,7 +638,7 @@ datum/recipe/microwave/slimesandwich
 	reagents = list("sodiumchloride" = 1)
 	items = list(
 		/obj/item/reagent_containers/food/snacks/spidereggs,
-		/obj/item/reagent_containers/food/snacks/spidermeat,
+		/obj/item/reagent_containers/food/snacks/meat/spidermeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/spidereggsham
 

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -87,7 +87,7 @@
 /datum/recipe/microwave/xenoburger
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/reagent_containers/food/snacks/meat/xenomeat
+		/obj/item/reagent_containers/food/snacks/xenomeat
 	)
 	result = /obj/item/reagent_containers/food/snacks/xenoburger
 
@@ -630,7 +630,7 @@ datum/recipe/microwave/slimesandwich
 /datum/recipe/microwave/boiledspiderleg
 	reagents = list("water" = 10)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/meat/spiderleg,
+		/obj/item/reagent_containers/food/snacks/spiderleg,
 	)
 	result = /obj/item/reagent_containers/food/snacks/boiledspiderleg
 
@@ -638,7 +638,7 @@ datum/recipe/microwave/slimesandwich
 	reagents = list("sodiumchloride" = 1)
 	items = list(
 		/obj/item/reagent_containers/food/snacks/spidereggs,
-		/obj/item/reagent_containers/food/snacks/meat/spidermeat,
+		/obj/item/reagent_containers/food/snacks/spidermeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/spidereggsham
 

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -197,7 +197,7 @@
 /datum/recipe/microwave/cubancarp
 	items = list(
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/monstermeat/carpmeat,
+		/obj/item/reagent_containers/food/snacks/carpmeat,
 		/obj/item/reagent_containers/food/snacks/grown/chili
 	)
 	result = /obj/item/reagent_containers/food/snacks/cubancarp
@@ -297,7 +297,7 @@
 /datum/recipe/microwave/fishandchips
 	items = list(
 		/obj/item/reagent_containers/food/snacks/fries,
-		/obj/item/reagent_containers/food/snacks/monstermeat/carpmeat,
+		/obj/item/reagent_containers/food/snacks/carpmeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishandchips
 
@@ -636,16 +636,16 @@ datum/recipe/microwave/slimesandwich
 /datum/recipe/microwave/spidereggsham
 	reagents = list("sodiumchloride" = 1)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs
+		/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs,
 		/obj/item/reagent_containers/food/snacks/monstermeat/spidermeat
 	)
-	result = /obj/item/reagent_containers/food/snacks/monstermeat/spidereggsham
+	result = /obj/item/reagent_containers/food/snacks/spidereggsham
 
 /datum/recipe/microwave/sashimi
 	reagents = list("soysauce" = 5)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs
-		/obj/item/reagent_containers/food/snacks/monstermeat/carpmeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs,
+		/obj/item/reagent_containers/food/snacks/carpmeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/sashimi
 

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -87,8 +87,7 @@
 /datum/recipe/microwave/xenoburger
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,
-		/obj/item/reagent_containers/food/snacks/xenomeat
-	)
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat	)
 	result = /obj/item/reagent_containers/food/snacks/xenoburger
 
 /datum/recipe/microwave/fishburger
@@ -198,7 +197,7 @@
 /datum/recipe/microwave/cubancarp
 	items = list(
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/carpmeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/carpmeat,
 		/obj/item/reagent_containers/food/snacks/grown/chili
 	)
 	result = /obj/item/reagent_containers/food/snacks/cubancarp
@@ -298,7 +297,7 @@
 /datum/recipe/microwave/fishandchips
 	items = list(
 		/obj/item/reagent_containers/food/snacks/fries,
-		/obj/item/reagent_containers/food/snacks/carpmeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/carpmeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/fishandchips
 
@@ -630,23 +629,23 @@ datum/recipe/microwave/slimesandwich
 /datum/recipe/microwave/boiledspiderleg
 	reagents = list("water" = 10)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/spiderleg,
+		/obj/item/reagent_containers/food/snacks/monstermeat/spiderleg
 	)
 	result = /obj/item/reagent_containers/food/snacks/boiledspiderleg
 
 /datum/recipe/microwave/spidereggsham
 	reagents = list("sodiumchloride" = 1)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/spidereggs,
-		/obj/item/reagent_containers/food/snacks/spidermeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs
+		/obj/item/reagent_containers/food/snacks/monstermeat/spidermeat
 	)
-	result = /obj/item/reagent_containers/food/snacks/spidereggsham
+	result = /obj/item/reagent_containers/food/snacks/monstermeat/spidereggsham
 
 /datum/recipe/microwave/sashimi
 	reagents = list("soysauce" = 5)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/spidereggs,
-		/obj/item/reagent_containers/food/snacks/carpmeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/spidereggs
+		/obj/item/reagent_containers/food/snacks/monstermeat/carpmeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/sashimi
 

--- a/code/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -40,9 +40,9 @@
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
-		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
-		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
+		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/xenomeat,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
@@ -115,7 +115,7 @@
 /datum/recipe/oven/xemeatpie
 	items = list(
 		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
-		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
+		/obj/item/reagent_containers/food/snacks/xenomeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/xemeatpie
 

--- a/code/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -40,9 +40,9 @@
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
@@ -115,7 +115,7 @@
 /datum/recipe/oven/xemeatpie
 	items = list(
 		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
 	)
 	result = /obj/item/reagent_containers/food/snacks/xemeatpie
 

--- a/code/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -40,9 +40,9 @@
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
+		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
+		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
@@ -115,7 +115,7 @@
 /datum/recipe/oven/xemeatpie
 	items = list(
 		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
-		/obj/item/reagent_containers/food/snacks/xenomeat,
+		/obj/item/reagent_containers/food/snacks/meat/xenomeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/xemeatpie
 

--- a/code/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -40,9 +40,9 @@
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
-		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
-		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat,
+		/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -2,7 +2,7 @@
 	name = "alien"
 	icon_state = "alien_s"
 
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null
 	var/caste = ""

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -2,7 +2,7 @@
 	name = "alien"
 	icon_state = "alien_s"
 
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat= 5, /obj/item/stack/sheet/animalhide/xeno = 1)
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null
 	var/caste = ""

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -2,7 +2,7 @@
 	name = "alien"
 	icon_state = "alien_s"
 
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null
 	var/caste = ""

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -11,7 +11,7 @@
 	response_disarm = "shoves"
 	response_harm = "hits"
 	speed = 0
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 3, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat= 3, /obj/item/stack/sheet/animalhide/xeno = 1)
 	maxHealth = 125
 	health = 125
 	harm_intent_damage = 5
@@ -83,7 +83,7 @@
 	retreat_distance = 5
 	minimum_distance = 5
 	move_to_delay = 4
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 4, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat= 4, /obj/item/stack/sheet/animalhide/xeno = 1)
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
@@ -130,7 +130,7 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 10, /obj/item/stack/sheet/animalhide/xeno = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat= 10, /obj/item/stack/sheet/animalhide/xeno = 2)
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -11,7 +11,7 @@
 	response_disarm = "shoves"
 	response_harm = "hits"
 	speed = 0
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 3, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 3, /obj/item/stack/sheet/animalhide/xeno = 1)
 	maxHealth = 125
 	health = 125
 	harm_intent_damage = 5
@@ -83,7 +83,7 @@
 	retreat_distance = 5
 	minimum_distance = 5
 	move_to_delay = 4
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 4, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 4, /obj/item/stack/sheet/animalhide/xeno = 1)
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
@@ -130,7 +130,7 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 10, /obj/item/stack/sheet/animalhide/xeno = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 10, /obj/item/stack/sheet/animalhide/xeno = 2)
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -11,7 +11,7 @@
 	response_disarm = "shoves"
 	response_harm = "hits"
 	speed = 0
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 3, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 3, /obj/item/stack/sheet/animalhide/xeno = 1)
 	maxHealth = 125
 	health = 125
 	harm_intent_damage = 5
@@ -83,7 +83,7 @@
 	retreat_distance = 5
 	minimum_distance = 5
 	move_to_delay = 4
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 4, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 4, /obj/item/stack/sheet/animalhide/xeno = 1)
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
@@ -130,7 +130,7 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/xenomeat = 10, /obj/item/stack/sheet/animalhide/xeno = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/xenomeat = 10, /obj/item/stack/sheet/animalhide/xeno = 2)
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -13,7 +13,7 @@
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/bearmeat = 5, /obj/item/clothing/head/bearpelt = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/bearmeat= 5, /obj/item/clothing/head/bearpelt = 1)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -13,7 +13,7 @@
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/bearmeat = 5, /obj/item/clothing/head/bearpelt = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/bearmeat = 5, /obj/item/clothing/head/bearpelt = 1)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -13,7 +13,7 @@
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/bearmeat = 5, /obj/item/clothing/head/bearpelt = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/bearmeat = 5, /obj/item/clothing/head/bearpelt = 1)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -18,7 +18,7 @@
 	turns_per_move = 5
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/spidermeat = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/spidermeat = 2, /obj/item/reagent_containers/food/snacks/meat/spiderleg = 8)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
@@ -53,7 +53,7 @@
 	icon_state = "nurse"
 	icon_living = "nurse"
 	icon_dead = "nurse_dead"
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/spidermeat = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8, /obj/item/reagent_containers/food/snacks/spidereggs = 4)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/spidermeat = 2, /obj/item/reagent_containers/food/snacks/meat/spiderleg = 8, /obj/item/reagent_containers/food/snacks/spidereggs = 4)
 
 	maxHealth = 40
 	health = 40

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -18,7 +18,7 @@
 	turns_per_move = 5
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/spidermeat = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/spidermeat= 2, /obj/item/reagent_containers/food/snacks/monstermeat/spiderleg= 8)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
@@ -53,7 +53,7 @@
 	icon_state = "nurse"
 	icon_living = "nurse"
 	icon_dead = "nurse_dead"
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/spidermeat = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8, /obj/item/reagent_containers/food/snacks/spidereggs = 4)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/spidermeat= 2, /obj/item/reagent_containers/food/snacks/monstermeat/spiderleg= 8, /obj/item/reagent_containers/food/snacks/monstermeat/spidereggs= 4)
 
 	maxHealth = 40
 	health = 40

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -18,7 +18,7 @@
 	turns_per_move = 5
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/spidermeat = 2, /obj/item/reagent_containers/food/snacks/meat/spiderleg = 8)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/spidermeat = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
@@ -53,7 +53,7 @@
 	icon_state = "nurse"
 	icon_living = "nurse"
 	icon_dead = "nurse_dead"
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/spidermeat = 2, /obj/item/reagent_containers/food/snacks/meat/spiderleg = 8, /obj/item/reagent_containers/food/snacks/spidereggs = 4)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/spidermeat = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8, /obj/item/reagent_containers/food/snacks/spidereggs = 4)
 
 	maxHealth = 40
 	health = 40

--- a/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
@@ -89,7 +89,7 @@
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
 	crusher_loot = /obj/item/crusher_trophy/goliath_tentacle
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/goliath = 2, /obj/item/stack/sheet/animalhide/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/goliath = 2, /obj/item/stack/sheet/animalhide/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
 	loot = list()
 	stat_attack = UNCONSCIOUS
 	robust_searching = TRUE
@@ -113,7 +113,7 @@
 	pre_attack_icon = "Goliath_preattack"
 	throw_message = "does nothing to the rocky hide of the"
 	loot = list(/obj/item/stack/sheet/animalhide/goliath_hide) //A throwback to the asteroid days
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/goliath = 2, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/goliath = 2, /obj/item/stack/sheet/bone = 2)
 	crusher_drop_mod = 30
 	wander = FALSE
 	var/list/cached_tentacle_turfs

--- a/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
@@ -89,7 +89,7 @@
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
 	crusher_loot = /obj/item/crusher_trophy/goliath_tentacle
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/goliath = 2, /obj/item/stack/sheet/animalhide/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/goliath= 2, /obj/item/stack/sheet/animalhide/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
 	loot = list()
 	stat_attack = UNCONSCIOUS
 	robust_searching = TRUE
@@ -113,7 +113,7 @@
 	pre_attack_icon = "Goliath_preattack"
 	throw_message = "does nothing to the rocky hide of the"
 	loot = list(/obj/item/stack/sheet/animalhide/goliath_hide) //A throwback to the asteroid days
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/goliath = 2, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/goliath= 2, /obj/item/stack/sheet/bone = 2)
 	crusher_drop_mod = 30
 	wander = FALSE
 	var/list/cached_tentacle_turfs

--- a/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
@@ -89,7 +89,7 @@
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
 	crusher_loot = /obj/item/crusher_trophy/goliath_tentacle
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/goliath = 2, /obj/item/stack/sheet/animalhide/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/goliath = 2, /obj/item/stack/sheet/animalhide/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
 	loot = list()
 	stat_attack = UNCONSCIOUS
 	robust_searching = TRUE
@@ -113,7 +113,7 @@
 	pre_attack_icon = "Goliath_preattack"
 	throw_message = "does nothing to the rocky hide of the"
 	loot = list(/obj/item/stack/sheet/animalhide/goliath_hide) //A throwback to the asteroid days
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/goliath = 2, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/goliath = 2, /obj/item/stack/sheet/bone = 2)
 	crusher_drop_mod = 30
 	wander = FALSE
 	var/list/cached_tentacle_turfs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
It makes goliath meat and other exotic xeno meats (spider meat, bear meat, etc.) into instances of `/obj/reagent_containers/food/snacks/meat`, and therefore accepted by the cloning pod as biomass. Special case: they however cannot be made into cutlets, as other `meat` can.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It is currently very possible to construct a cloning setup on the mining outpost, but gathering biomass for a clone requires a stationside trip, since goliath meat is arbitratily not accepted as a biomass source by the cloning pods. This PR removes this issue! It also makes butchering xenos and spiders more useful.

## Changelog
:cl: Nokko
tweak: made the Cloning Pod accept goliath, xeno, spider, bear, and lizard meat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
