### PR TITLE
Fixes the KA runtime

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -109,6 +109,8 @@
 		empty()
 
 /obj/item/gun/energy/kinetic_accelerator/proc/empty()
+	if(!cell)
+		return
 	cell.use(500)
 	update_icon()
 


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so KAs no longer runtime on server init.

## Why It's Good For The Game
We shouldnt be getting runtimes on startup

## Changelog
:cl: 
tweak: KAs no longer runtime the server on spawn
/:cl:
