### PR TITLE
Adds a station announcement to the AI receiving the malf upgrade

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -10,7 +10,7 @@
 
 	light_color = LIGHT_COLOR_PURPLE
 
-/obj/machinery/computer/aifixer/attackby(I as obj, user as mob, params)
+/obj/machinery/computer/aifixer/attackby(obj/item/I, mob/user, params)
 	if(occupant && istype(I, /obj/item/screwdriver))
 		if(stat & BROKEN)
 			..()
@@ -18,6 +18,14 @@
 			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge.</span>")
 		else
 			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge and it emits a warning beep!.</span>")
+	else if(istype(I, /obj/item/malf_upgrade) && isAntag(user)) //Allow antags to override the announcing of the malf upgrade installation, if they can pull it off without being noticed, they deserve it.
+		var/obj/item/malf_upgrade/M = I
+		if(M.announce_installation)
+			M.announce_installation = FALSE
+			to_chat(user, "<span class='warning'>You disable the installation announcement on \the [M].</span>")
+		else
+			to_chat(user, "<span class='warning'>The installation announcement on \the [M] is already disabled!</span>")
+			return ..() //Allows you to whack the console with the disk like non-antags would, to avoid people meta-ing "Oh, you're not an antag? Then hit the console with this disk".
 	else
 		return ..()
 

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -28,9 +28,9 @@
 	. = ..()
 	if(isAntag(user))
 		if(announce_installation)
-			. += "<span class='warning'>You're familiar with this kind of illegal tech. You think you can disable the installation announcement by reprogramming \the [src] on an AI system integrity restorer console.</span>"
+			. += "<span class='notice'>You're familiar with this kind of illegal tech. You think you can disable the installation announcement by reprogramming \the [src] on an AI system integrity restorer console.</span>"
 		else
-			. += "<span class='warning'>The installation announcement on \the [src] was disabled.</span>"
+			. += "<span class='notice'>The installation announcement on \the [src] is disabled.</span>"
 
 //Lipreading
 /obj/item/surveillance_upgrade

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -18,6 +18,7 @@
 	else
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with combat software!</span>")
 		AI.add_malf_picker()
+		GLOB.minor_announcement.Announce("ERROR ER0RR $R-  [AI] has been upgraded with combat software. Thank you for your- 0RRO$!R41.%%!!(%$^^__+ @#F0E4.")
 	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")
 	qdel(src)
 

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -4,9 +4,10 @@
 //Malf Picker
 /obj/item/malf_upgrade
 	name = "combat software upgrade"
-	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs."
+	desc = "A highly illegal, highly dangerous upgrade for artificial intelligence units, granting them a variety of powers as well as the ability to hack APCs. Will announce the upgrade to the entire station."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk3"
+	var/announce_installation = TRUE
 
 
 /obj/item/malf_upgrade/afterattack(mob/living/silicon/ai/AI, mob/user)
@@ -18,10 +19,18 @@
 	else
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with combat software!</span>")
 		AI.add_malf_picker()
-		GLOB.minor_announcement.Announce("ERROR ER0RR $R-  [AI] has been upgraded with combat software. Thank you for your- 0RRO$!R41.%%!!(%$^^__+ @#F0E4.")
+		if(announce_installation)
+			GLOB.minor_announcement.Announce("ERROR ER0RR $R-  [AI] has been upgraded with combat software. Thank you for your- 0RRO$!R41.%%!!(%$^^__+ @#F0E4.")
 	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")
 	qdel(src)
 
+/obj/item/malf_upgrade/examine(mob/user)
+	. = ..()
+	if(isAntag(user))
+		if(announce_installation)
+			. += "<span class='warning'>You're familiar with this kind of illegal tech. You think you can disable the installation announcement by reprogramming \the [src] on an AI system integrity restorer console.</span>"
+		else
+			. += "<span class='warning'>The installation announcement on \the [src] was disabled.</span>"
 
 //Lipreading
 /obj/item/surveillance_upgrade


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a minor station announcement to the AI receiving the malf upgrade that can be found on lavaland.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Whenever the miners get their hands on the malf upgrade, it usually ends up in command's hands, who tend to be all too happy to give it to the AI. The AI suddenly getting access to station wide xray cameras among other malf modules can absolutely ruin antags.
With this change, the AI basically gets a big target painted on it's head, reading "I'M REALLY POWERFUL NOW, PLEASE SUBVERT ME!".
Antags can use the upgrade on the AI system integrity restorer console first, which can be found in the RD office, or constructed using a board from the board printer, same as other consoles.
Doing so will disable the announcement when the disk is installed.
The announcement is also a good way to inform admins of the AI receiving the upgrade, should they choose to berate command for installing an upgrade that literally reads "Highly illegal, highly dangerous" without a good reason.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/46876120/77860595-7408d300-7210-11ea-8503-d4059163bf21.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Adds a station announcement to the AI receiving the malf upgrade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
