### PR TITLE
primed nukes explode if blobbed

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -51,8 +51,7 @@ GLOBAL_VAR(bomb_set)
 		GLOB.bomb_set = 1 //So long as there is one nuke timing, it means one nuke is armed.
 		timeleft = max(timeleft - 2, 0) // 2 seconds per process()
 		if(timeleft <= 0)
-			spawn
-				explode()
+			INVOKE_ASYNC(src, .proc/explode)
 		SSnanoui.update_uis(src)
 	return
 
@@ -348,8 +347,7 @@ GLOBAL_VAR(bomb_set)
 	if(timing == -1.0)
 		return
 	if(timing)	//boom
-		spawn
-			explode()
+		INVOKE_ASYNC(src, .proc/explode)
 		return
 	qdel(src)
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -347,6 +347,10 @@ GLOBAL_VAR(bomb_set)
 /obj/machinery/nuclearbomb/blob_act(obj/structure/blob/B)
 	if(timing == -1.0)
 		return
+	if(timing)	//boom
+		spawn
+			explode()
+		return
 	qdel(src)
 
 /obj/machinery/nuclearbomb/tesla_act(power, explosive)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it so that when a blob eats an active, primed nuke that's counting down, it causes the nuke to explode.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nukes are set to end the round, a blob eating the nuke means the round drags on and since midround blobs don't have a win condition it just forces admins to send in a deathsquad with another nuke while all the ghosts watch.

It also removes a source of confusion regarding rules on is it allowed for blobs to rush nukes or not, since it makes it into a pretty bad idea now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: blobs eating active nukes makes them blow up early.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
