### PR TITLE
Makes the KA and energy guns use Initialize instead of New fixing the KA runtime

### DIFF
--- a/code/game/machinery/portable_tag_turret.dm
+++ b/code/game/machinery/portable_tag_turret.dm
@@ -13,8 +13,8 @@
 	lasercolor = "b"
 	installation = /obj/item/gun/energy/laser/tag/blue
 
-/obj/machinery/porta_turret/tag/New()
-	..()
+/obj/machinery/porta_turret/tag/Initialize(mapload)
+	. = ..()
 	icon_state = "[lasercolor]grey_target_prism"
 
 /obj/machinery/porta_turret/tag/weapon_setup(var/obj/item/gun/energy/E)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -87,8 +87,8 @@
 	lethal = 1
 	installation = /obj/item/gun/energy/laser
 
-/obj/machinery/porta_turret/New()
-	..()
+/obj/machinery/porta_turret/Initialize(mapload)
+	. = ..()
 	if(req_access && req_access.len)
 		req_access.Cut()
 	req_one_access = list(ACCESS_SECURITY, ACCESS_HEADS)
@@ -105,8 +105,8 @@
 	QDEL_NULL(spark_system)
 	return ..()
 
-/obj/machinery/porta_turret/centcom/New()
-	..()
+/obj/machinery/porta_turret/centcom/Initialize(mapload)
+	. = ..()
 	if(req_one_access && req_one_access.len)
 		req_one_access.Cut()
 	req_access = list(ACCESS_CENT_SPECOPS)
@@ -1015,8 +1015,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		depotarea.declare_started()
 	return ..(target)
 
-/obj/machinery/porta_turret/syndicate/New()
-	..()
+/obj/machinery/porta_turret/syndicate/Initialize(mapload)
+	. = ..()
 	if(req_one_access && req_one_access.len)
 		req_one_access.Cut()
 	req_access = list(ACCESS_SYNDICATE)

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -32,7 +32,7 @@
 			if(PA)
 				qdel(PA)
 			else
-				PA = new(src)
+				PA = new(user, src)
 				user.put_in_hands(PA)
 
 /obj/item/chrono_eraser/item_action_slot_check(slot, mob/user)
@@ -55,7 +55,7 @@
 	var/obj/structure/chrono_field/field = null
 	var/turf/startpos = null
 
-/obj/item/gun/energy/chrono_gun/New(var/obj/item/chrono_eraser/T)
+/obj/item/gun/energy/chrono_gun/Initialize(mapload, obj/item/chrono_eraser/T)
 	. = ..()
 	if(istype(T))
 		TED = T

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -32,8 +32,8 @@
 /obj/item/gun/energy/get_cell()
 	return cell
 
-/obj/item/gun/energy/New()
-	..()
+/obj/item/gun/energy/Initialize(mapload, ...)
+	. = ..()
 	if(cell_type)
 		cell = new cell_type(src)
 	else

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -36,9 +36,9 @@
 	can_flashlight = 0 // Can't attach or detach the flashlight, and override it's icon update
 	actions_types = list(/datum/action/item_action/toggle_gunlight)
 
-/obj/item/gun/energy/gun/mini/New()
+/obj/item/gun/energy/gun/mini/Initialize(mapload, ...)
 	gun_light = new /obj/item/flashlight/seclite(src)
-	..()
+	. = ..()
 	cell.maxcharge = 600
 	cell.charge = 600
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -341,8 +341,8 @@
 	var/emagged = 0			//ups the temperature cap from 500 to 1000, targets hit by beams over 500 Kelvin will burst into flames
 	var/dat = ""
 
-/obj/item/gun/energy/temperature/New()
-	..()
+/obj/item/gun/energy/temperature/Initialize(mapload, ...)
+	. = ..()
 	update_icon()
 	START_PROCESSING(SSobj, src)
 


### PR DESCRIPTION
## What Does This PR Do
Makes energy guns and such use Initialize instead of New. Which caused some issues

Fixes: #12344

## Why It's Good For The Game
Less runtimes on roundstart