### PR TITLE
Makes simple animals cut_overlays on regenerate_icons

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -74,12 +74,11 @@
 		else
 			our_color = pick(carp_colors)
 			add_atom_colour(carp_colors[our_color], FIXED_COLOUR_PRIORITY)
-		add_carp_overlay()
+		regenerate_icons()
 
 /mob/living/simple_animal/hostile/carp/proc/add_carp_overlay()
 	if(!random_color)
 		return
-	cut_overlays()
 	var/mutable_appearance/base_overlay = mutable_appearance(icon, "base_mouth")
 	base_overlay.appearance_flags = RESET_COLOR
 	add_overlay(base_overlay)
@@ -87,7 +86,6 @@
 /mob/living/simple_animal/hostile/carp/proc/add_dead_carp_overlay()
 	if(!random_color)
 		return
-	cut_overlays()
 	var/mutable_appearance/base_dead_overlay = mutable_appearance(icon, "base_dead_mouth")
 	base_dead_overlay.appearance_flags = RESET_COLOR
 	add_overlay(base_dead_overlay)
@@ -103,24 +101,22 @@
 
 /mob/living/simple_animal/hostile/carp/death(gibbed)
 	. = ..()
-	cut_overlays()
 	if(!random_color || gibbed)
 		return
-	add_dead_carp_overlay()
+	regenerate_icons()
 
 /mob/living/simple_animal/hostile/carp/revive()
 	..()
 	regenerate_icons()
 
 /mob/living/simple_animal/hostile/carp/regenerate_icons()
-	cut_overlays()
+	..()
 	if(!random_color)
 		return
 	if(stat != DEAD)
 		add_carp_overlay()
 	else
 		add_dead_carp_overlay()
-	..()
 
 /mob/living/simple_animal/hostile/carp/holocarp
 	icon_state = "holocarp"

--- a/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
@@ -50,10 +50,9 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/regenerate_icons()
-	cut_overlays()
+	..()
 	if(udder.reagents.total_volume == udder.reagents.maximum_volume)
 		add_overlay("gl_full")
-	..()
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/attackby(obj/item/O, mob/user, params)
 	if(stat == CONSCIOUS && istype(O, /obj/item/reagent_containers/glass))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -609,7 +609,7 @@
 		real_name = P.tagname
 
 /mob/living/simple_animal/regenerate_icons()
+	cut_overlays()
 	if(pcollar && collar_type)
-		cut_overlays()
 		add_overlay("[collar_type]collar")
 		add_overlay("[collar_type]tag")

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -121,7 +121,7 @@
 	set_colour(pick(slime_colours))
 
 /mob/living/simple_animal/slime/regenerate_icons()
-	cut_overlays()
+	..()
 	var/icon_text = "[colour] [is_adult ? "adult" : "baby"] slime"
 	icon_dead = "[icon_text] dead"
 	if(stat != DEAD)
@@ -130,7 +130,6 @@
 			add_overlay("aslime-[mood]")
 	else
 		icon_state = icon_dead
-	..()
 
 /mob/living/simple_animal/slime/movement_delay()
 	if(bodytemperature >= 330.23) // 135 F or 57.08 C


### PR DESCRIPTION
## What Does This PR Do
Makes simple_animals cut overlays when they regenerate icons

Fixes #12437

and maybe also #12826 but I couldn't repro it locally

I've tested all the animals I changed. Nothing weird found

## Why It's Good For The Game
Every simple animal that has overlays already does this and it is currently broken for corgi's

## Changelog
:cl:
fix: Removing fashion from corgi's now updates the overlays correctly
/:cl: