### PR TITLE
Processing refactor; Code and performance improvements

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -47,6 +47,7 @@
 	#define EXAMINE_POSITION_BEFORE 2
 	//End positions
 	#define COMPONENT_EXNAME_CHANGED 1
+#define COMSIG_ATOM_CREATED "atom_created"						///from base of atom/proc/Initialize(): sent any time a new atom is created
 #define COMSIG_ATOM_ENTERED "atom_entered"                      //from base of atom/Entered(): (atom/movable/entering, /atom)
 #define COMSIG_ATOM_EXITED "atom_exited"						//from base of atom/Exited(): (atom/movable/exiting, atom/newloc)
 #define COMSIG_ATOM_EXIT "atom_exit"							//from base of atom/Exit(): (/atom/movable/exiting, /atom/newloc)
@@ -83,8 +84,6 @@
 	#define COMPONENT_NO_ATTACK_HAND 1							//works on all 3.
 /////////////////
 
-#define COMSIG_ENTER_AREA "enter_area" 						//from base of area/Entered(): (/area)
-#define COMSIG_EXIT_AREA "exit_area" 							//from base of area/Exited(): (/area)
 
 #define COMSIG_CLICK "atom_click"								//from base of atom/Click(): (location, control, params, mob/user)
 #define COMSIG_CLICK_SHIFT "shift_click"						//from base of atom/ShiftClick(): (/mob)
@@ -96,8 +95,11 @@
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"			//from base of atom/MouseDrop_T: (/atom/from, /mob/user)
 
 // /area signals
+#define COMSIG_AREA_POWER_CHANGE "area_power_change"			///from base of area/proc/power_change()
 #define COMSIG_AREA_ENTERED "area_entered" 						//from base of area/Entered(): (atom/movable/M)
-#define COMSIG_AREA_EXITED "area_exited" 							//from base of area/Exited(): (atom/movable/M)
+#define COMSIG_AREA_EXITED "area_exited" 						//from base of area/Exited(): (atom/movable/M)
+#define COMSIG_ENTER_AREA "enter_area" 							//from base of area/Entered(): (/area)
+#define COMSIG_EXIT_AREA "exit_area" 							//from base of area/Exited(): (/area)
 
 // /turf signals
 #define COMSIG_TURF_CHANGE "turf_change"						//from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
@@ -160,6 +162,11 @@
 // /mob/living/simple_animal/hostile signals
 #define COMSIG_HOSTILE_ATTACKINGTARGET "hostile_attackingtarget"
 	#define COMPONENT_HOSTILE_NO_ATTACK 1
+
+// /obj/machinery signals
+#define COMSIG_MACHINERY_BROKEN "machinery_broken"					///from base of /obj/machinery/obj_break(): (damage_flags)
+#define COMSIG_MACHINERY_POWER_LOST "machinery_power_lost"			///from base of /obj/machinery/proc/power_change()
+#define COMSIG_MACHINERY_POWER_RESTORED "machinery_power_restored"	///from base of /obj/machinery/proc/power_change()
 
 // /obj signals
 #define COMSIG_OBJ_DECONSTRUCT "obj_deconstruct"				//from base of obj/deconstruct(): (disassembled)

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -12,6 +12,15 @@
 #define IDLE_POWER_USE 1
 #define ACTIVE_POWER_USE 2
 
+// These aren't just used for machines, all /obj can use these if they want to process.
+/// Bitflags for a object's preferences on when it should start processing. For use with an object's `process_start_flags` var.
+#define START_PROCESSING_ON_INIT	(1<<1) /// Indicates the machine will automatically start processing right after it's `Initialize()` is ran.
+#define START_PROCESSING_MANUALLY	(1<<2) /// Machines with this flag will not start processing when it's spawned. Use this if you want to manually control when a machine starts processing.
+
+/// Bitflags for a object's preferences on processing speed (subsystem) it should use. For use with an object's `process_speed_flags` var.
+#define NORMAL_PROCESS_SPEED	(1<<0) /// Uses a slow speed: `process()` will run roughly every 2 seconds. Used with SSmachines and SSobj
+#define FAST_PROCESS_SPEED		(1<<1) /// Uses a fast speed: `process()` will run roughly every 0.2 seconds. Used with SSfastprocess
+
 //computer3 error codes, move lower in the file when it passes dev -Sayu
  #define PROG_CRASH      1  // Generic crash
  #define MISSING_PERIPHERAL  2  // Missing hardware

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -159,13 +159,13 @@
 /datum/holocall/proc/Check()
 	for(var/I in dialed_holopads)
 		var/obj/machinery/hologram/holopad/H = I
-		if((H.stat & NOPOWER) || !H.anchored)
+		if(!H.anchored)
 			ConnectionFailure(H)
 
 	if(QDELETED(src))
 		return FALSE
 
-	. = !QDELETED(user) && !user.incapacitated() && !QDELETED(calling_holopad) && !(calling_holopad.stat & NOPOWER) && user.loc == calling_holopad.loc
+	. = (user.loc == calling_holopad.loc) && !user.incapacitated() && !QDELETED(user) && !QDELETED(calling_holopad)
 
 	if(.)
 		if(!connected_holopad)
@@ -174,7 +174,7 @@
 				calling_holopad.atom_say("No answer received.")
 				calling_holopad.temp = ""
 
-	else if(!.)
+	if(!.)
 		qdel(src)
 
 /datum/action/innate/end_holocall

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -165,7 +165,7 @@
 	if(QDELETED(src))
 		return FALSE
 
-	. = (user.loc == calling_holopad.loc) && !user.incapacitated() && !QDELETED(user) && !QDELETED(calling_holopad)
+	. = !QDELETED(user) && !QDELETED(calling_holopad) && (user.loc == calling_holopad.loc) && !user.incapacitated()
 
 	if(.)
 		if(!connected_holopad)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -294,11 +294,11 @@
 /area/space/powered(chan) //Nope.avi
 	return 0
 
-// called when power status changes
-
+/// Called when the area's power status changes. Sends the `AREA_POWER_CHANGE` signal.
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
+	SEND_SIGNAL(src, COMSIG_AREA_POWER_CHANGE)
 	updateicon()
 
 /area/proc/usage(var/chan)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -85,9 +85,6 @@
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	initialized = TRUE
 
-	if(loc)
-		SEND_SIGNAL(loc, COMSIG_ATOM_CREATED, src) // Sends a signal that the new atom `src`, has been created at `loc`.
-
 	if(color)
 		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -66,7 +66,8 @@
 		if(SSatoms.InitAtom(src, args))
 			// we were deleted
 			return
-
+		if(loc)
+			SEND_SIGNAL(loc, COMSIG_ATOM_CREATED, src) // Send a signal that a new atom was created at `loc`.
 
 //Called after New if the map is being loaded. mapload = TRUE
 //Called from base of New if the map is not being loaded. mapload = FALSE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -84,6 +84,9 @@
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	initialized = TRUE
 
+	if(loc)
+		SEND_SIGNAL(loc, COMSIG_ATOM_CREATED, src) // Sends a signal that the new atom `src`, has been created at `loc`.
+
 	if(color)
 		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -244,14 +244,14 @@
 	anchored = 1
 	density = 1
 	atom_say_verb = "blares"
-	speed_process = TRUE // Disgusting fix. Please remove once #12952 is merged
+	process_start_flag = START_PROCESSING_MANUALLY
+	process_speed_flag = FAST_PROCESS_SPEED
 	var/timing = 0
 	var/default_timer = 4500
 	var/detonation_timer
 	var/announced = 0
 
 /obj/machinery/doomsday_device/Destroy()
-	STOP_PROCESSING(SSfastprocess, src)
 	SSshuttle.emergencyNoEscape = 0
 	if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 		SSshuttle.emergency.mode = SHUTTLE_DOCKED
@@ -262,7 +262,7 @@
 /obj/machinery/doomsday_device/proc/start()
 	detonation_timer = world.time + default_timer
 	timing = 1
-	START_PROCESSING(SSfastprocess, src)
+	begin_processing()
 	SSshuttle.emergencyNoEscape = 1
 
 /obj/machinery/doomsday_device/proc/seconds_remaining()
@@ -279,7 +279,7 @@
 			GLOB.priority_announcement.Announce("Hostile environment resolved. You have 3 minutes to board the Emergency Shuttle.", "Priority Announcement", 'sound/AI/shuttledock.ogg')
 		qdel(src)
 	if(!timing)
-		STOP_PROCESSING(SSfastprocess, src)
+		end_processing()
 		return
 	var/sec_left = seconds_remaining()
 	if(sec_left <= 0)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -606,9 +606,11 @@
 
 /obj/machinery/cryopod/proc/take_occupant(var/mob/living/carbon/E, var/willing_factor = 1)
 	if(occupant)
+		to_chat(E, "<span class='boldnotice'>\The [src] is in use.</span>")
 		return
-	if(!E)
+	if(!E || E.is_grabbing())
 		return
+	E.stop_pulling()
 	E.forceMove(src)
 	begin_processing()
 	time_till_despawn = initial(time_till_despawn) / willing_factor
@@ -681,34 +683,7 @@
 	visible_message("[usr] starts climbing into [src].")
 
 	if(do_after(usr, 20, target = usr))
-
-		if(!usr || !usr.client)
-			return
-
-		if(occupant)
-			to_chat(usr, "<span class='boldnotice'>\The [src] is in use.</span>")
-			return
-
-		usr.stop_pulling()
-		usr.forceMove(src)
-		occupant = usr
-		time_till_despawn = initial(time_till_despawn) / willing_time_divisor
-
-		if(orient_right)
-			icon_state = "[occupied_icon_state]-r"
-		else
-			icon_state = occupied_icon_state
-
-		to_chat(usr, "<span class='notice'>[on_enter_occupant_message]</span>")
-		to_chat(usr, "<span class='boldnotice'>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</span>")
-		occupant = usr
-		begin_processing()
-		time_entered = world.time
-
-		add_fingerprint(usr)
-		name = "[name] ([usr.name])"
-
-	return
+		take_occupant(usr)
 
 /obj/machinery/cryopod/proc/go_out()
 	if(!occupant)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -605,10 +605,13 @@
 			to_chat(user, "<span class='notice'>You stop [L == user ? "climbing into the cryo pod." : "putting [L] into the cryo pod."]</span>")
 
 /obj/machinery/cryopod/proc/take_occupant(var/mob/living/carbon/E, var/willing_factor = 1)
+	if(!E)
+		return
 	if(occupant)
 		to_chat(E, "<span class='boldnotice'>\The [src] is in use.</span>")
 		return
-	if(!E || E.is_grabbing())
+	if(E.is_grabbing())
+		to_chat(E, "<span class='warning'>Only one lifeform is allowed inside [src] at a time!</span")
 		return
 	E.stop_pulling()
 	E.forceMove(src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -213,7 +213,8 @@ Class Procs:
 	..()
 
 /obj/machinery/default_welder_repair(mob/user, obj/item/I)
-	if(..())
+	. = ..()
+	if(.)
 		stat &= ~BROKEN
 
 //sets the use_power var and then forces an area power update

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -11,6 +11,8 @@
 	density = 0
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	process_start_flag = START_PROCESSING_MANUALLY
+	process_speed_flag = FAST_PROCESS_SPEED
 
 	var/datum/wires/syndicatebomb/wires = null
 	var/minimum_timer = 90
@@ -47,7 +49,7 @@
 
 /obj/machinery/syndicatebomb/process()
 	if(!active)
-		STOP_PROCESSING(SSfastprocess, src)
+		end_processing()
 		detonation_timer = null
 		next_beep = null
 		countdown.stop()
@@ -81,7 +83,7 @@
 		if(defused && (payload in src))
 			payload.defuse()
 			countdown.stop()
-			STOP_PROCESSING(SSfastprocess, src)
+			end_processing()
 
 /obj/machinery/syndicatebomb/New()
 	wires 	= new(src)
@@ -94,7 +96,6 @@
 /obj/machinery/syndicatebomb/Destroy()
 	QDEL_NULL(wires)
 	QDEL_NULL(countdown)
-	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 
 /obj/machinery/syndicatebomb/examine(mob/user)
@@ -235,7 +236,7 @@
 
 /obj/machinery/syndicatebomb/proc/activate()
 	active = TRUE
-	START_PROCESSING(SSfastprocess, src)
+	begin_processing()
 	countdown.start()
 	next_beep = world.time + 10
 	detonation_timer = world.time + (timer_set * 10)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -376,8 +376,6 @@
 	if(ismob(O))
 		mobpresent += 1
 		check_heat(O)
-	if(on)
-		begin_processing()
 
 /obj/machinery/shower/Uncrossed(atom/movable/O)
 	if(ismob(O))
@@ -395,7 +393,8 @@
 
 //Yes, showers are super powerful as far as washing goes.
 /obj/machinery/shower/proc/wash(atom/movable/O as obj|mob)
-	if(!on) return
+	if(!on)
+		return
 
 	if(istype(O, /obj/item))
 		var/obj/item/I = O
@@ -487,7 +486,6 @@
 
 /obj/machinery/shower/process()
 	if(!on || !mobpresent)
-		end_processing()
 		return
 	for(var/mob/living/carbon/C in loc)
 		if(prob(33))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -248,6 +248,7 @@
 	density = 0
 	anchored = 1
 	use_power = NO_POWER_USE
+	process_start_flag = START_PROCESSING_MANUALLY
 	var/on = 0
 	var/obj/effect/mist/mymist = null
 	var/ismist = 0				//needs a var so we can make it linger~
@@ -288,6 +289,7 @@
 	on = !on
 	update_icon()
 	if(on)
+		begin_processing()
 		soundloop.start()
 		if(M.loc == loc)
 			wash(M)
@@ -297,6 +299,7 @@
 			G.clean_blood()
 			G.water_act(100, convertHeat(), src)
 	else
+		end_processing()
 		soundloop.stop()
 
 /obj/machinery/shower/attackby(obj/item/I as obj, mob/user as mob, params)
@@ -373,6 +376,8 @@
 	if(ismob(O))
 		mobpresent += 1
 		check_heat(O)
+	if(on)
+		begin_processing()
 
 /obj/machinery/shower/Uncrossed(atom/movable/O)
 	if(ismob(O))
@@ -482,6 +487,7 @@
 
 /obj/machinery/shower/process()
 	if(!on || !mobpresent)
+		end_processing()
 		return
 	for(var/mob/living/carbon/C in loc)
 		if(prob(33))

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -23,16 +23,18 @@
 	if(needs_item_input)
 		register_input_turf()
 		RegisterSignal(src, COMSIG_OBJ_SETANCHORED, .proc/on_set_anchored)
-		RegisterSignal(src, COMSIG_MACHINERY_BROKEN, .proc/unregister_input_turf, TRUE)
+		RegisterSignal(src, list(COMSIG_MACHINERY_BROKEN, COMSIG_MACHINERY_POWER_LOST), .proc/unregister_input_turf, TRUE)
+		RegisterSignal(src, COMSIG_MACHINERY_POWER_RESTORED, .proc/register_input_turf, TRUE)
 		output_turf = get_step(src, output_dir)
 
 /// The machine regained power, start listening for signals again.
 /obj/machinery/mineral/on_power_gain()
-	RegisterSignal(src, COMSIG_MACHINERY_POWER_RESTORED, .proc/register_input_turf, TRUE)
+	if(needs_item_input)
+		register_input_turf()
 
 /// If the there's no power to this machine, there's no reason to listen for signals.
 /obj/machinery/mineral/on_power_loss()
-	UnregisterSignal(src, COMSIG_MACHINERY_POWER_LOST, .proc/unregister_input_turf, TRUE)
+	unregister_input_turf()
 
 /// Gets the turf in the `input_dir` direction adjacent to the machine, and registers signals for ATOM_ENTERED and ATOM_CREATED. Calls the `pickup_item()` proc when it recieves these signals.
 /obj/machinery/mineral/proc/register_input_turf()

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -7,6 +7,8 @@
 	desc = "Controls a stacking machine... in theory."
 	density = FALSE
 	anchored = TRUE
+	process_start_flag = START_PROCESSING_MANUALLY
+	use_machinery_signals = TRUE
 	var/obj/machinery/mineral/stacking_machine/machine = null
 	var/machinedir = SOUTHEAST
 
@@ -60,21 +62,18 @@
 	desc = "A machine that automatically stacks acquired materials. Controlled by a nearby console."
 	density = TRUE
 	anchored = TRUE
+	needs_item_input = TRUE
+	input_dir = EAST
+	output_dir = WEST
 	var/obj/machinery/mineral/stacking_unit_console/CONSOLE
 	var/stk_types = list()
 	var/stk_amt   = list()
 	var/stack_list[0] //Key: Type.  Value: Instance of type.
 	var/stack_amt = 50; //ammount to stack before releassing
-	input_dir = EAST
-	output_dir = WEST
-	speed_process = TRUE
 
-/obj/machinery/mineral/stacking_machine/process()
-	var/turf/T = get_step(src, input_dir)
-	if(T)
-		for(var/obj/item/stack/sheet/S in T)
-			process_sheet(S)
-			CHECK_TICK
+/obj/machinery/mineral/stacking_machine/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+	if(istype(target, /obj/item/stack/sheet))
+		addtimer(CALLBACK(src, .proc/process_sheet, target), 2)
 
 /obj/machinery/mineral/stacking_machine/proc/process_sheet(obj/item/stack/sheet/inp)
 	if(!(inp.type in stack_list)) //It's the first of this sheet added

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -9,24 +9,12 @@
 	anchored = 1.0
 	input_dir = WEST
 	output_dir = EAST
-	speed_process = 1
+	needs_item_input = TRUE
+	use_machinery_signals = TRUE
 
-/obj/machinery/mineral/unloading_machine/process()
-	var/turf/T = get_step(src,input_dir)
-	if(T)
-		var/limit
-		for(var/obj/structure/ore_box/B in T)
-			for(var/obj/item/stack/ore/O in B)
-				B.contents -= O
-				unload_mineral(O)
-				limit++
-				if(limit>=10)
-					return
-				CHECK_TICK
-			CHECK_TICK
-		for(var/obj/item/I in T)
-			unload_mineral(I)
-			limit++
-			if(limit>=10)
-				return
-			CHECK_TICK
+/obj/machinery/mineral/unloading_machine/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+	if(istype(target, /obj/structure/ore_box))
+		for(var/ore in target)
+			addtimer(CALLBACK(src, .proc/unload_mineral, ore), 2)
+	else if(istype(target, /obj/item/stack/ore))
+		addtimer(CALLBACK(src, .proc/unload_mineral, target), 2)

--- a/code/modules/mining/mint.dm
+++ b/code/modules/mining/mint.dm
@@ -7,32 +7,28 @@
 	icon_state = "coinpress0"
 	density = TRUE
 	anchored = TRUE
+	needs_item_input = TRUE
+	use_machinery_signals = TRUE
 	var/newCoins = 0   //how many coins the machine made in it's last load
 	var/processing = FALSE
 	var/chosen = MAT_METAL //which material will be used to make coins
 	var/coinsToProduce = 10
-	speed_process = TRUE
+	var/datum/component/material_container/materials
 
 
 /obj/machinery/mineral/mint/New()
 	..()
-	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_URANIUM, MAT_DIAMOND, MAT_BANANIUM, MAT_TRANQUILLITE), MINERAL_MATERIAL_AMOUNT * 50, FALSE, /obj/item/stack)
+	materials = AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_URANIUM, MAT_DIAMOND, MAT_BANANIUM, MAT_TRANQUILLITE), MINERAL_MATERIAL_AMOUNT * 50, FALSE, /obj/item/stack)
 
-/obj/machinery/mineral/mint/process()
-	var/turf/T = get_step(src, input_dir)
-	if(!T)
-		return
-
-	GET_COMPONENT(materials, /datum/component/material_container)
-	for(var/obj/item/stack/sheet/O in T)
-		materials.insert_stack(O, O.amount)
+/obj/machinery/mineral/mint/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+	if(istype(target, /obj/item/stack))
+		addtimer(CALLBACK(materials, /datum/component/material_container.proc/insert_item, target), 2)
 
 /obj/machinery/mineral/mint/attack_hand(mob/user)
 	if(..())
 		return
 	var/dat = "<b>Coin Press</b><br>"
 
-	GET_COMPONENT(materials, /datum/component/material_container)
 	for(var/mat_id in materials.materials)
 		var/datum/material/M = materials.materials[mat_id]
 		if(!M.amount && chosen != mat_id)
@@ -63,9 +59,8 @@
 	usr.set_machine(src)
 	add_fingerprint(usr)
 	if(processing == 1)
-		to_chat(usr, "<span class='notice'>The machine is processing.</span>")
+		to_chat(usr, "<span class='notice'>[src] is currently processing.</span>")
 		return
-	GET_COMPONENT(materials, /datum/component/material_container)
 	if(href_list["choose"])
 		if(materials.materials[href_list["choose"]])
 			chosen = href_list["choose"]

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -615,6 +615,11 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		return FALSE
 	return TRUE
 
+/mob/living/carbon/is_grabbing()
+	if(locate(/obj/item/grab) in contents)
+		return TRUE
+	return FALSE
+
 /mob/living/carbon/restrained()
 	if(get_restraining_item())
 		return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -34,6 +34,14 @@
 		if(ranged_ability && prev_client)
 			ranged_ability.remove_mousepointer(prev_client)
 
+/**
+	Helper proc to check if this mob has another mob in an grab. If they do, an `/obj/item/grab` will be in their contents.
+	Only works on mobs with hands such as /carbon or /carbon/human.
+	Defined here so we don't have to cast mobs to carbon, or human, or silicon to be able to call the proc on them. Just override as needed.
+*/
+/mob/living/proc/is_grabbing()
+	return
+
 /mob/living/proc/OpenCraftingMenu()
 	return
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -104,15 +104,19 @@
 /obj/machinery/proc/removeStaticPower(value, powerchannel)
 	addStaticPower(-value, powerchannel)
 
-/obj/machinery/proc/power_change()		// called whenever the power settings of the containing area change
-										// by default, check equipment channel & set flag
-										// can override if needed
+/**
+	Called whnever the power status of the machine's area change.
+
+	If the machine gains power, the `NOPOWER` flag is removed from its `stat` var, and the `MACHINERY_POWER_RESTORED` signal is sent.
+	If the machine loses power, the `NOPOWER` flag is added from its `stat` var, and the `MACHINERY_POWER_LOST` signal is sent.
+*/
+/obj/machinery/proc/power_change()
 	if(powered(power_channel))
+		SEND_SIGNAL(src, COMSIG_MACHINERY_POWER_RESTORED)
 		stat &= ~NOPOWER
 	else
-
+		SEND_SIGNAL(src, COMSIG_MACHINERY_POWER_LOST)
 		stat |= NOPOWER
-	return
 
 // connect the machine to a powernet if a node cable is present on the turf
 /obj/machinery/power/proc/connect_to_network()

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -13,13 +13,11 @@
 	amount_per_transfer_from_this = 1
 	container_type = OPENCONTAINER
 	resistance_flags = ACID_PROOF
+	process_start_flag = START_PROCESSING_MANUALLY
+	process_speed_flag = FAST_PROCESS_SPEED
 	var/label_text
 	var/mode = IV_INJECT
 	var/mob/living/carbon/human/injection_target
-
-/obj/item/reagent_containers/iv_bag/Destroy()
-	end_processing()
-	return ..()
 
 /obj/item/reagent_containers/iv_bag/on_reagent_change()
 	update_icon()
@@ -40,14 +38,6 @@
 /obj/item/reagent_containers/iv_bag/attack_hand()
 	..()
 	update_icon()
-
-/obj/item/reagent_containers/iv_bag/proc/begin_processing(mob/target)
-	injection_target = target
-	START_PROCESSING(SSobj, src)
-
-/obj/item/reagent_containers/iv_bag/proc/end_processing()
-	injection_target = null
-	STOP_PROCESSING(SSobj, src)
 
 /obj/item/reagent_containers/iv_bag/process()
 	if(!injection_target)
@@ -100,6 +90,7 @@
 					return
 			L.visible_message("<span class='danger'>[user] removes [src]'s needle from [L]'s arm!</span>", \
 								"<span class='userdanger'>[user] removes [src]'s needle from [L]'s arm!</span>")
+			injection_target = null
 			end_processing()
 		else // Inserting the needle
 			if(!L.can_inject(user, TRUE))
@@ -114,7 +105,8 @@
 					return
 			L.visible_message("<span class='danger'>[user] inserts [src]'s needle into [L]'s arm!</span>", \
 									"<span class='userdanger'>[user] inserts [src]'s needle into [L]'s arm!</span>")
-			begin_processing(L)
+			injection_target = L
+			begin_processing()
 
 	else if(target.is_refillable() && is_drainable()) // Transferring from IV bag to other containers
 		if(!reagents.total_volume)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -124,9 +124,11 @@
 		to_chat(user, "<span class='notice'>You [active ? "deactivate": "activate"] the [src]</span>")
 	active = !active
 	if(active)
+		begin_processing()
 		animate(src, pixel_y = 2, time = 10, loop = -1)
 		anchored = 1
 	else
+		end_processing()
 		animate(src, pixel_y = 0, time = 10)
 		anchored = 0
 	update_icon()
@@ -144,7 +146,8 @@
 	name = "Meteor Shield Satellite"
 	desc = "Meteor Point Defense Satellite"
 	mode = "M-SHIELD"
-	speed_process = TRUE
+	process_start_flag = START_PROCESSING_MANUALLY
+	process_speed_flag = FAST_PROCESS_SPEED
 	var/kill_range = 14
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)
@@ -155,6 +158,7 @@
 
 /obj/machinery/satellite/meteor_shield/process()
 	if(!active)
+		end_processing()
 		return
 	for(var/obj/effect/meteor/M in GLOB.meteor_list)
 		if(M.z != z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Republish of #12952, but this one is a bit different and a bit more expanded. I've added a lot of documentation and comments for new code that hopefully explains things.

This refactors a bunch of machinery so it only starts processing when it needs to, and stops when there's no longer a need for it to run. Also adds in various useful signals and just general cleanup to certain bits of the code.

For now I've tried to tackle the machines which appear the most in game, such as solar panels, holopads, intercoms, lightswitches and so on. In the future, if and when this goes through, I'll probably look into fixing up some of the other ones.

Almost all of the changes in here are backend changes, but there is one tweak I made. You can no longer grab a mob and bring them into cyborg rechargers or sleepers with you. Only 1 mob will be allowed in these machines at a time. There was a bunch of pointless code running for these machines involving ejecting stuck mobs, and I figured, why are people allowed to do this in the first place?
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should increase the performance of the server a bit since we won't have a bunch of code pointlessly executing when it doesn't need to.

This PR fixes the weird teleporting bug with cyborg rechargers. I know this PR wont be merged for a while, so if someone wants to fix these sooner though, go ahead.
Fixes #13103
Fixes #13102
Fixes #12268
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You can no longer enter a sleeper, cyborg recharger, or cryopod while you have a mob in a grab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
