### PR TITLE
ID Computer Playtime Check For Head Jobs

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -623,8 +623,8 @@ SUBSYSTEM_DEF(jobs)
 				jobs_to_formats[job.title] = "disabled" // the job they already have is pre-selected
 			else if(!job.would_accept_job_transfer_from_player(M))
 				jobs_to_formats[job.title] = "linkDiscourage" // jobs which are karma-locked and not unlocked for this player are discouraged
-			else if(istype(M) && M.client && job.available_in_playtime(M.client))
-				jobs_to_formats[job.title] = "linkDiscourage" // jobs which are playtime-locked and not unlocked for this player are discouraged
+			else if((job.title in GLOB.command_positions) && istype(M) && M.client && job.available_in_playtime(M.client))
+				jobs_to_formats[job.title] = "linkDiscourage" // command jobs which are playtime-locked and not unlocked for this player are discouraged
 			else if(job.total_positions && !job.current_positions && job.title != "Civilian")
 				jobs_to_formats[job.title] = "linkEncourage" // jobs with nobody doing them at all are encouraged
 			else if(job.total_positions >= 0 && job.current_positions >= job.total_positions)

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -622,7 +622,9 @@ SUBSYSTEM_DEF(jobs)
 			if(tgtcard.assignment && tgtcard.assignment == job.title)
 				jobs_to_formats[job.title] = "disabled" // the job they already have is pre-selected
 			else if(!job.would_accept_job_transfer_from_player(M))
-				jobs_to_formats[job.title] = "linkDiscourage" // karma jobs they don't have available are discouraged
+				jobs_to_formats[job.title] = "linkDiscourage" // jobs which are karma-locked and not unlocked for this player are discouraged
+			else if(istype(M) && M.client && job.available_in_playtime(M.client))
+				jobs_to_formats[job.title] = "linkDiscourage" // jobs which are playtime-locked and not unlocked for this player are discouraged
 			else if(job.total_positions && !job.current_positions && job.title != "Civilian")
 				jobs_to_formats[job.title] = "linkEncourage" // jobs with nobody doing them at all are encouraged
 			else if(job.total_positions >= 0 && job.current_positions >= job.total_positions)


### PR DESCRIPTION
## Current System (Background Information)
When doing job transfers in the ID Computer, jobs are listed with either gray, white, or green text:
![simple_id_computer_job_states](https://user-images.githubusercontent.com/16434066/78463129-e3773a80-76c8-11ea-91ae-ecf4656257b6.png)

Gray text (which turns red on mouseover) means that a job transfer that is possible, but discouraged. This happens when:
- The job has no free slots.
- The job has been set to never allow incoming job transfers, by head of staff ruling (e.g: Magistrate)
- The job is a karma job, and the transferring player has not unlocked it. IE: this job transfer would have the player bypass the karma system.

Green text means the job transfer is encouraged. This happens when the job has absolutely nobody doing it. E.g. Engineer would show in green if there are 0/5 engineers, CE would show in green when there are 0/1 CEs, etc.

White text means the job did not qualify for either gray or green. In practice, this typically applies to jobs like Scientist, Engineer, Atmos Tech, Medical Doctor etc which allow incoming job transfers, are not karma jobs and usually have some people doing them, but also some free slots (e.g: 3/6 full).

All of the above color-coding is already in the game.

## What Does This PR Do
The ID computer will now consider playtime unlocks, in addition to the above factors, when deciding whether to encourage someone to be appointed to a command / head of department job.
Example: Before this PR, a player who did not have the Head of Security job unlocked, would still find the HoS job lit up in green when their ID card was put into the ID computer. Before this PR, the ID computer would actively encourage a player to transfer to a head job they haven't unlocked, and would not normally qualify to get.
Now, _the ID computer still allows those job transfers_. You can still select them. The ID computer simply shows them in gray now, rather than encouraging them by showing them in green or white. This PR makes the ID computer treat job playtime requirements for head jobs the same way it already treats job karma requirements for all jobs.


## Why It's Good For The Game

It discourages players who wouldn't normally qualify to play as a head job, from getting a job transfer to that job. 

For example, a couple of days ago, a player on their first shift EVER started as a botanist, then went to the HoP for a job transfer. Because there was no CMO, the CMO job is not karma locked, and the job transfer highlighting system ignores playtime, the CMO job showed in green. The bald first-shift-ever botanist got a job transfer to CMO. Obviously, that went very badly for medbay.
Under the new system, such a transfer would still be _possible_, but the ID computer would no longer _encourage_ such transfers by showing them in green or white. Instead, it would discourage transfers like that by showing the option in gray. _This PR does not prevent such transfers, it merely stops actively encouraging them._

:cl: Kyep
add: When doing a job transfer on the ID computer, head jobs are now shown in gray if the player being transferred has not unlocked that head job. This is similar to how karma-locked jobs are already shown in gray if the player has not unlocked them with karma. Playtime continues to be ignored for non-head jobs. Also, even jobs shown in gray are still possible to transfer to. Everything that was possible before is still possible, its just transfers to non-unlocked head jobs are not encouraged like they were before.
/:cl:
