### PR TITLE
Welders no longer spam eye flashes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -172,6 +172,8 @@
 #define INVISIBILITY_ABSTRACT 101
 #define UNHEALING_EAR_DAMAGE 100
 
+#define EYE_FLASH_DURATION  25 //How long an eye flash (due to welders, explosions etc.) should last for
+
 //Human sub-species
 #define isshadowling(A) (is_species(A, /datum/species/shadow/ling))
 #define isshadowlinglesser(A) (is_species(A, /datum/species/shadow/ling/lesser))

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -29,7 +29,7 @@
 	var/deactivation_sound = 'sound/items/welderdeactivate.ogg'
 	var/light_intensity = 2
 	var/low_fuel_changes_icon = TRUE//More than one icon_state due to low fuel?
-	var/progress_flash_divisor = 10 //Length of time between each "eye flash"
+	var/progress_flash_divisor = 25 //Length of time between each "eye flash".
 
 /obj/item/weldingtool/Initialize(mapload)
 	..()
@@ -122,8 +122,8 @@
 /obj/item/weldingtool/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)
 	. = ..()
 	if(. && user)
-		if(progress_flash_divisor == 0)
-			user.flash_eyes(min(light_intensity, 1))
+		if(progress_flash_divisor <= 0)
+			user.add_flash_overlay(min(light_intensity, 1))
 			progress_flash_divisor = initial(progress_flash_divisor)
 		else
 			progress_flash_divisor--

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -29,7 +29,7 @@
 	var/deactivation_sound = 'sound/items/welderdeactivate.ogg'
 	var/light_intensity = 2
 	var/low_fuel_changes_icon = TRUE//More than one icon_state due to low fuel?
-	var/progress_flash_divisor = 25 //Length of time between each "eye flash".
+	var/progress_flash_divisor = EYE_FLASH_DURATION //Length of time between each "eye flash".
 
 /obj/item/weldingtool/Initialize(mapload)
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -755,7 +755,6 @@
 /mob/living/proc/can_use_vents()
 	return "You can't fit into that vent."
 
-#define EYE_FLASH_DURATION	25
 //called when the mob receives a bright flash
 /mob/living/proc/flash_eyes(intensity, override_blindness_check, affect_silicon, visual, type)
 	return add_flash_overlay(intensity, override_blindness_check, affect_silicon, visual, type)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -755,15 +755,16 @@
 /mob/living/proc/can_use_vents()
 	return "You can't fit into that vent."
 
+#define EYE_FLASH_DURATION	25
 //called when the mob receives a bright flash
-/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
+/mob/living/proc/flash_eyes(intensity, override_blindness_check, affect_silicon, visual, type)
 	return add_flash_overlay(intensity, override_blindness_check, affect_silicon, visual, type)
 
 //called in proc/flash_eyes(). Makes it so that the mob's screen goes white for the duration of welding, but eye damage and such is handled in flash_eyes()
-/mob/living/proc/add_flash_overlay(intensity, override_blindness_check, affect_silicon, visual, type = /obj/screen/fullscreen/flash)
+/mob/living/proc/add_flash_overlay(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
 	if(check_eye_prot() < intensity && (override_blindness_check || !(disabilities & BLIND)))
 		overlay_fullscreen("flash", type)
-		addtimer(CALLBACK(src, .proc/clear_fullscreen, "flash", 25), 25)
+		addtimer(CALLBACK(src, .proc/clear_fullscreen, "flash", 25), EYE_FLASH_DURATION)
 		return TRUE
 
 /mob/living/proc/check_eye_prot()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -757,10 +757,14 @@
 
 //called when the mob receives a bright flash
 /mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
+	return add_flash_overlay(intensity, override_blindness_check, affect_silicon, visual, type)
+
+//called in proc/flash_eyes(). Makes it so that the mob's screen goes white for the duration of welding, but eye damage and such is handled in flash_eyes()
+/mob/living/proc/add_flash_overlay(intensity, override_blindness_check, affect_silicon, visual, type = /obj/screen/fullscreen/flash)
 	if(check_eye_prot() < intensity && (override_blindness_check || !(disabilities & BLIND)))
 		overlay_fullscreen("flash", type)
 		addtimer(CALLBACK(src, .proc/clear_fullscreen, "flash", 25), 25)
-		return 1
+		return TRUE
 
 /mob/living/proc/check_eye_prot()
 	return 0


### PR DESCRIPTION
**What does this PR do:**

Tweaks the change added in #11700 for welders. Instead of spamming `flash_eyes()` every second, instead now it just adds the flash overlay every 2.5 seconds (which essentially makes your screen white all the time while welding). It also won't give you more and more damage over time.

**Obligatory picture:**
![image](https://user-images.githubusercontent.com/18459142/78295723-7e82df80-7524-11ea-9a9d-d41c0ef57112.png)

:cl:
tweak: Welders now apply the flash overlay without a copious amount of eye damage.
/:cl: