### PR TITLE
New disease: Carpcough

### DIFF
--- a/code/datums/diseases/carpcough.dm
+++ b/code/datums/diseases/carpcough.dm
@@ -26,7 +26,7 @@
 					affected_mob.adjustBruteLoss(2)
 		if(4)
 			if(prob(10))
-				affected_mob.visible_message("<span class='danger'>[affected_mob] clutches his stomach.</span>", \
+				affected_mob.visible_message("<span class='danger'>[affected_mob] clutches [affected_mob.p_their()] stomach.</span>", \
 												"<span class='userdanger'>Your stomach hurts!</span>")
 			if(prob(5))
 				to_chat(affected_mob, "<span class='danger'>You feel something moving in your throat.</span>")
@@ -34,8 +34,7 @@
 				affected_mob.emote("cough")
 				affected_mob.visible_message("<span class='danger'>[affected_mob] coughs up an angry space carp!</span>", \
 													"<span class='userdanger'>You cough up an angry space carp!</span>")
-				new /mob/living/simple_animal/hostile/carp(affected_mob.loc)
-	return
+				new /mob/living/simple_animal/hostile/carp(get_turf(affected_mob))
 
 /datum/disease/carpcough/fake
 	name = "Localized Carpcough"

--- a/code/datums/diseases/carpcough.dm
+++ b/code/datums/diseases/carpcough.dm
@@ -31,6 +31,7 @@
 			if(prob(5))
 				to_chat(affected_mob, "<span class='danger'>You feel something moving in your throat.</span>")
 			if(prob(1))
+				affected_mob.emote("cough")
 				affected_mob.visible_message("<span class='danger'>[affected_mob] coughs up an angry space carp!</span>", \
 													"<span class='userdanger'>You cough up an angry space carp!</span>")
 				new /mob/living/simple_animal/hostile/carp(affected_mob.loc)

--- a/code/datums/diseases/carpcough.dm
+++ b/code/datums/diseases/carpcough.dm
@@ -1,0 +1,44 @@
+/datum/disease/carpcough
+	name = "Carpcough"
+	form = "Infection"
+	max_stages = 4
+	spread_text = "On contact"
+	spread_flags = CONTACT_GENERAL
+	cure_text = "Carpotoxin"
+	cures = list("carpotoxin")
+	agent = "Fishy Infection"
+	viable_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/human/monkey)
+	desc = "If left untreated subject will regurgitate aggressive space carp. And to make matters worse, the cure is almost as bad as the disease.."
+	severity = BIOHAZARD	//it is significantly harder to cure than beesease and spawns more dangerous mobs
+
+/datum/disease/carpcough/stage_act()
+	..()
+	switch(stage)
+		if(2)
+			if(prob(2))
+				to_chat(affected_mob, "<span class='notice'>You taste something fishy.</span>")
+		if(3)
+			if(prob(3))
+				affected_mob.emote("cough")
+			if(prob(2))
+				to_chat(affected_mob, "<span class='danger'>Your stomach suddenly hurts a lot. It feels like there's something sharp in there.</span>")
+				if(prob(20))
+					affected_mob.adjustBruteLoss(2)
+		if(4)
+			if(prob(10))
+				affected_mob.visible_message("<span class='danger'>[affected_mob] clutches his stomach.</span>", \
+												"<span class='userdanger'>Your stomach hurts!</span>")
+			if(prob(5))
+				to_chat(affected_mob, "<span class='danger'>You feel something moving in your throat.</span>")
+			if(prob(1))
+				affected_mob.visible_message("<span class='danger'>[affected_mob] coughs up an angry space carp!</span>", \
+													"<span class='userdanger'>You cough up an angry space carp!</span>")
+				new /mob/living/simple_animal/hostile/carp(affected_mob.loc)
+	return
+
+/datum/disease/carpcough/fake
+	name = "Localized Carpcough"
+	desc = "If left untreated subject will regurgitate aggressive space carp. And to make matters worse, the cure is almost as bad as the disease. Thankfully, this strain is not transmissable."
+	spread_flags = NON_CONTAGIOUS
+	spread_text = "Non-Contagious"
+	severity = DANGEROUS

--- a/paradise.dme
+++ b/paradise.dme
@@ -305,6 +305,7 @@
 #include "code\datums\diseases\beesease.dm"
 #include "code\datums\diseases\berserker.dm"
 #include "code\datums\diseases\brainrot.dm"
+#include "code\datums\diseases\carpcough.dm"
 #include "code\datums\diseases\cold.dm"
 #include "code\datums\diseases\cold9.dm"
 #include "code\datums\diseases\critical.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Inspired by a prayer of a player afflicted with anxiety, this adds a new disease: Carpcough. Carpcough, like anxiety or beesease makes you cough up a mob, namely space carp. The cure is also significantly harder, making this a very deadly disease. There is a non-transmissable version to use for admins, as well.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Smiting someone with spawning space carps around themselves sounds hilarious. Also another deadly disease is fun. Might also encourage people to farm some fish for carp toxin.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: A new, deadly disease: Carpcough
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
