### PR TITLE
Bar Redesign

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -33761,6 +33761,9 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/gun/projectile/revolver/doublebarrel,
 /obj/machinery/light,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/item/crowbar,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bjL" = (
@@ -35063,6 +35066,10 @@
 	pixel_x = 0;
 	pixel_y = 25
 	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -35073,35 +35080,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/primary/central/ne)
-"bmj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters";
-	opacity = 0
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Kitchen";
-	req_access_txt = "25;28"
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "bmk" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -35649,6 +35627,10 @@
 	dir = 2;
 	pixel_y = 24
 	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -35668,7 +35650,11 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j1";
+	tag = "icon-pipe-j1 (EAST)"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -96517,7 +96503,7 @@
 	dir = 8;
 	icon_state = "left";
 	name = "Bar Door";
-	req_access_txt = "25;28";
+	req_access_txt = "25";
 	tag = "icon-left (WEST)"
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -133584,7 +133570,7 @@ bhW
 biV
 boO
 bdT
-bmj
+bdT
 bog
 bpN
 bog

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -95898,18 +95898,11 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"ebd" = (
-/turf/simulated/floor,
-/area/maintenance/fsmaint2)
-"gom" = (
-/obj/machinery/atm{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"eAA" = (
+/obj/machinery/gameboard,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -95937,6 +95930,17 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"gTC" = (
+/obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Bar Delivery";
+	req_access_txt = "25"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "hsy" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -95958,18 +95962,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
-"hIw" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
+"iqt" = (
+/obj/machinery/atm{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "izn" = (
@@ -96005,12 +96007,22 @@
 /area/toxins/launch{
 	name = "Toxins Launch Room"
 	})
-"jcL" = (
-/obj/structure/piano,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"jjd" = (
-/mob/living/carbon/human/monkey/punpun,
+"jml" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/book/manual/sop_service,
+/obj/item/book/manual/barman_recipes,
+/obj/item/stack/packageWrap,
+/obj/item/pen/blue{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -96044,56 +96056,7 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"jDX" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10;
-	level = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"jEj" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"jKX" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/ashtray/bronze{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/bar)
-"jQW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/bar)
-"jUm" = (
+"jwq" = (
 /obj/structure/chair/wood/wings{
 	tag = "icon-wooden_chair_wings (NORTH)";
 	icon_state = "wooden_chair_wings";
@@ -96107,7 +96070,214 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"kai" = (
+"jKj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/crew_quarters/dorms)
+"jOz" = (
+/obj/machinery/door/airlock{
+	name = "Bar Office";
+	req_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"jXh" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"kiW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"kOE" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space/nearstation)
+"lqH" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"lLC" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/plasteel,
+/area/atmos)
+"lNC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"mKb" = (
+/turf/simulated/floor,
+/area/maintenance/fsmaint2)
+"mMw" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"mRp" = (
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/wall,
+/area/crew_quarters/bar)
+"mSj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"mZb" = (
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"nMi" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area/space/nearstation)
+"ojT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	level = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"oGR" = (
+/obj/structure/table/wood,
+/obj/item/dice/d6,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"oZV" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "Medbay";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"pgx" = (
+/obj/effect/landmark/start{
+	name = "Bartender"
+	},
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"phV" = (
+/mob/living/carbon/human/monkey/punpun,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"prb" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
+/obj/item/ashtray/bronze{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"pwN" = (
+/obj/machinery/door_control{
+	id = "adminshuttleblast";
+	name = "blast door control";
+	pixel_x = -30;
+	req_access_txt = "101"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"pGh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"pZO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area/space/nearstation)
+"qgG" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	req_access_txt = "101"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"qls" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -96130,85 +96300,7 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"kzm" = (
-/obj/machinery/gameboard,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"kOE" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
-"kQz" = (
-/obj/effect/landmark/start{
-	name = "Bartender"
-	},
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/bar)
-"lcm" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"ldq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"leD" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/book/manual/sop_service,
-/obj/item/book/manual/barman_recipes,
-/obj/item/stack/packageWrap,
-/obj/item/pen/blue{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/item/lighter/zippo,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/bar)
-"lFo" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 8;
-	location = "Bar"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/fsmaint2)
-"lLC" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"mrJ" = (
+"qyI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -96220,110 +96312,63 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"mMw" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
+"qOl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
-"mSj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/soda,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/crew_quarters/bar)
-"nMi" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/turf/space,
-/area/space/nearstation)
-"oZV" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "adminshuttle";
-	name = "Medbay";
-	opacity = 1;
-	req_access_txt = "101"
-	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/administration)
-"pwN" = (
-/obj/machinery/door_control{
-	id = "adminshuttleblast";
-	name = "blast door control";
-	pixel_x = -30;
-	req_access_txt = "101"
-	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/administration)
-"pAS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"pLB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
-"pZO" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/space,
-/area/space/nearstation)
-"qgG" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch";
-	req_access_txt = "101"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/administration)
-"qSH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
-	},
-/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "qUv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space/nearstation)
-"rBd" = (
-/obj/machinery/door/airlock{
-	name = "Bar Office";
-	req_access_txt = "25"
+"qWH" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10;
+	level = 1
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"qXP" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/pen/blue{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/crew_quarters/bar)
 "rEw" = (
 /obj/machinery/computer/shuttle/admin{
@@ -96333,6 +96378,15 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"rIY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "rSv" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
@@ -96341,10 +96395,10 @@
 	},
 /turf/space,
 /area/shuttle/administration)
-"rVP" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
+"rVq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "rYq" = (
 /obj/machinery/door/airlock/centcom{
@@ -96357,18 +96411,15 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"sqV" = (
-/obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
-	name = "Bar Delivery";
-	req_access_txt = "25"
+"sUK" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"sDP" = (
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
+"tsw" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
 	dir = 8;
@@ -96385,59 +96436,18 @@
 	icon_state = "bar"
 	},
 /area/crew_quarters/bar)
-"sKe" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+"ufg" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "bar"
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/crew_quarters/bar)
-"sUK" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/syndicate_sit)
-"sWZ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"ucZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/bar)
+/area/crew_quarters/kitchen)
 "uxy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -96460,18 +96470,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"uGl" = (
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/wall,
-/area/crew_quarters/bar)
-"vpD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/crew_quarters/bar)
 "vup" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -96479,6 +96477,13 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"vLh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "vUm" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -96487,45 +96492,60 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/constructionsite)
-"wom" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
+"wcc" = (
+/obj/machinery/power/apc{
 	dir = 1;
-	icon_state = "arrival"
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/area/crew_quarters/dorms)
-"wBg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"wNZ" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/blue{
-	pixel_x = 2;
-	pixel_y = 6
+"wiV" = (
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 8;
+	location = "Bar"
 	},
-/obj/item/pen/blue{
-	pixel_x = 2;
-	pixel_y = 6
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/turf/simulated/floor/plasteel,
+/area/maintenance/fsmaint2)
+"wmq" = (
+/obj/structure/piano,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"wHV" = (
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"wNz" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "wOS" = (
 /obj/structure/table,
@@ -96547,18 +96567,18 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
-"xmC" = (
+"xiB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xxW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/crew_quarters/bar)
-"xnl" = (
-/obj/structure/table/wood,
-/obj/item/dice/d6,
-/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "xAw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -96567,26 +96587,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"xBs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"xCP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	tag = "icon-intact (SOUTHEAST)";
@@ -130408,7 +130408,7 @@ bja
 bkM
 bcU
 bok
-jcL
+wmq
 brf
 brg
 buR
@@ -130652,7 +130652,7 @@ aUd
 aWG
 aWG
 bbk
-wom
+jKj
 beY
 aOI
 aGY
@@ -130663,14 +130663,14 @@ djh
 btq
 bmq
 baK
-qSH
-pAS
+ojT
+rVq
 btf
-pAS
-xBs
+rVq
+kiW
 byD
 bAU
-kzm
+eAA
 aUS
 bAi
 bHt
@@ -130920,12 +130920,12 @@ bfs
 btq
 bja
 bkP
-jUm
+jwq
 bmq
 btg
-lcm
-lcm
-lcm
+wNz
+wNz
+wNz
 bAH
 btm
 aUS
@@ -131177,10 +131177,10 @@ aZV
 aYd
 bnQ
 bkO
-ldq
+xiB
 bmq
 brg
-jEj
+mZb
 brg
 brg
 bAV
@@ -131434,11 +131434,11 @@ bfk
 aZR
 brT
 brT
-xCP
+rIY
 bmq
 brg
 brg
-xnl
+oGR
 brg
 bmq
 bmq
@@ -131691,13 +131691,13 @@ dji
 aVG
 bom
 bom
-xCP
+rIY
 bmM
 btm
 btm
 btm
 buQ
-wBg
+lNC
 bzn
 bsN
 bAk
@@ -131948,7 +131948,7 @@ aUS
 aUS
 aUS
 aUS
-gom
+iqt
 bmq
 bmq
 bmq
@@ -132205,13 +132205,13 @@ aRL
 beF
 cWo
 aUS
-sWZ
+wcc
 bmq
 bmq
 bmq
 bmq
-leD
-sDP
+jml
+tsw
 bzo
 bze
 bAk
@@ -132468,7 +132468,7 @@ bmr
 bmr
 bmr
 buq
-xmC
+xxW
 bCI
 aUS
 bAk
@@ -132714,18 +132714,18 @@ aOI
 bjk
 bbb
 beM
-uGl
+mRp
 aRN
 bfl
 bjK
 aUS
-kai
-jKX
+qls
+prb
 bqi
 bqi
 bqi
-wNZ
-sKe
+qXP
+qOl
 bCB
 aUS
 bFj
@@ -132970,20 +132970,20 @@ bfv
 aOI
 bjw
 bbe
-ebd
-lFo
-sqV
-jDX
-hIw
-rBd
+mKb
+wiV
+gTC
+qWH
+wHV
+jOz
 bnm
-jQW
-bqk
-bqk
-kQz
-ucZ
-mrJ
 mSj
+bqk
+bqk
+pgx
+pGh
+qyI
+vLh
 aUS
 bAo
 bHy
@@ -133234,12 +133234,12 @@ bdT
 bdT
 aUS
 bnl
-rVP
-jjd
-rVP
-rVP
-vpD
-rVP
+lqH
+phV
+lqH
+lqH
+jXh
+lqH
 bxE
 aUS
 bAn
@@ -135810,7 +135810,7 @@ bro
 bro
 bro
 bwp
-pLB
+ufg
 bzh
 bAk
 bHA

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -36006,6 +36006,14 @@
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
+/obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Bar Shutters";
+	req_access_txt = "25";
+	tag = "icon-left (WEST)"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -36817,6 +36825,14 @@
 	dir = 4;
 	name = "Kitchen";
 	req_access_txt = "28"
+	},
+/obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Bar Shutters";
+	req_access_txt = "25";
+	tag = "icon-left (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -96232,6 +96248,11 @@
 /obj/item/taperecorder,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"nax" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/cakehat,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "nAM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -131054,10 +131075,10 @@ srd
 bkP
 jwq
 lpS
-btg
-wNz
-wNz
-wNz
+bmq
+bmq
+bmq
+bmq
 bAH
 gWZ
 aUS
@@ -131311,10 +131332,10 @@ bnQ
 bkO
 xiB
 btq
-brg
-mZb
-brg
-brg
+wNz
+btg
+wNz
+wNz
 bAV
 bmq
 iXm
@@ -131568,8 +131589,8 @@ brT
 brT
 rIY
 btq
-brg
-brg
+nax
+mZb
 oGR
 brg
 lNC

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -23538,6 +23538,11 @@
 /area/crew_quarters/dorms)
 "aQs" = (
 /obj/structure/closet/crate/can,
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 2";
+	dir = 2;
+	network = list("SS13")
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitecorner"
@@ -24349,9 +24354,6 @@
 	c_tag = "Bar Storage";
 	network = list("SS13")
 	},
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -24359,6 +24361,13 @@
 	dir = 0;
 	name = "station intercom (General)";
 	pixel_x = -28
+	},
+/obj/machinery/requests_console{
+	department = "Bar";
+	name = "Bar Requests Console";
+	departmentType = 2;
+	pixel_x = 0;
+	pixel_y = 30
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -24383,6 +24392,11 @@
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10;
+	level = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -31022,13 +31036,6 @@
 	icon_state = "black";
 	name = "formal wardrobe"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "beG" = (
@@ -31369,9 +31376,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -31382,6 +31386,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bfm" = (
@@ -31603,6 +31608,10 @@
 "bfC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	level = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -32496,6 +32505,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 0;
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bhs" = (
@@ -32845,13 +32858,16 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
 	initialize_directions = 11;
 	level = 1
 	},
 /obj/structure/kitchenspike,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	level = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -32863,6 +32879,9 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -33377,6 +33396,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -33391,11 +33413,6 @@
 	d2 = 4;
 	icon_state = "1-4";
 	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -33743,6 +33760,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/gun/projectile/revolver/doublebarrel,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bjL" = (
@@ -35074,13 +35092,6 @@
 	name = "Kitchen";
 	req_access_txt = "25;28"
 	},
-/obj/machinery/requests_console{
-	department = "Bar";
-	name = "Bar Requests Console";
-	departmentType = 2;
-	pixel_x = 0;
-	pixel_y = 30
-	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
 	pixel_y = -1
@@ -36288,10 +36299,10 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/closet/crate/freezer,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -37004,7 +37015,14 @@
 /area/crew_quarters/locker)
 "bqi" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "bar";
+	name = "Bar Privacy Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -37448,6 +37466,10 @@
 	c_tag = "Medbay Corridor West";
 	dir = 4;
 	network = list("SS13")
+	},
+/obj/machinery/newscaster{
+	pixel_x = -27;
+	pixel_y = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -41425,17 +41447,6 @@
 	icon_state = "whitecorner"
 	},
 /area/hallway/primary/starboard/west)
-"bzh" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 2";
-	dir = 2;
-	network = list("SS13")
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitecorner"
-	},
-/area/hallway/primary/starboard/west)
 "bzi" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -42042,13 +42053,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"bAv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/bar)
 "bAw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43085,6 +43089,20 @@
 	network = list("SS13")
 	},
 /obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/door_control{
+	id = "bar";
+	name = "Bar Shutters Control";
+	pixel_x = -6;
+	pixel_y = -24;
+	req_access_txt = "28"
+	},
+/obj/machinery/door_control{
+	id = "bariso";
+	name = "Bar Seclusion Button";
+	pixel_x = 6;
+	pixel_y = -24;
+	req_access_txt = "28"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -46840,10 +46858,6 @@
 	dir = 6
 	},
 /area/medical/reception)
-"bJQ" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "bJR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -50340,6 +50354,14 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
 	req_access_txt = "28"
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "bariso";
+	name = "Bar Privacy Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -91668,6 +91690,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	level = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "djl" = (
@@ -92505,7 +92531,6 @@
 	dir = 5;
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -92514,6 +92539,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -95941,6 +95973,13 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"gWZ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "hsy" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -96007,6 +96046,13 @@
 /area/toxins/launch{
 	name = "Toxins Launch Room"
 	})
+"iXm" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/bar)
 "jml" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -96176,6 +96222,31 @@
 /obj/item/taperecorder,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"nAM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	level = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
 "nMi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -96233,7 +96304,14 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "bar";
+	name = "Bar Privacy Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -96282,7 +96360,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -96295,6 +96372,14 @@
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "bar";
+	name = "Bar Privacy Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -96332,9 +96417,6 @@
 /turf/space,
 /area/space/nearstation)
 "qWH" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -96352,6 +96434,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "qXP" = (
@@ -96365,7 +96450,14 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "bar";
+	name = "Bar Privacy Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -96528,9 +96620,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "wHV" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -96539,6 +96628,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "wNz" = (
@@ -130927,7 +131021,7 @@ wNz
 wNz
 wNz
 bAH
-btm
+gWZ
 aUS
 cMK
 bHy
@@ -131184,8 +131278,8 @@ mZb
 brg
 brg
 bAV
-bJQ
-aUS
+bmq
+iXm
 bAk
 bHy
 bCZ
@@ -131440,9 +131534,9 @@ brg
 brg
 oGR
 brg
-bmq
-bmq
-bAv
+lNC
+bzn
+bsN
 bAk
 bHy
 bAk
@@ -131697,9 +131791,9 @@ btm
 btm
 btm
 buQ
-lNC
-bzn
-bsN
+btq
+bmq
+iXm
 bAk
 bHy
 bDA
@@ -131956,7 +132050,7 @@ bmq
 bmq
 btq
 bmq
-bAv
+bze
 bAk
 bHy
 bDb
@@ -132213,7 +132307,7 @@ bmq
 jml
 tsw
 bzo
-bze
+aUS
 bAk
 bHy
 bDb
@@ -134001,7 +134095,7 @@ bbh
 bdT
 bdM
 bhX
-biU
+nAM
 boS
 bdT
 bmt
@@ -135811,7 +135905,7 @@ bro
 bro
 bwp
 ufg
-bzh
+bzf
 bAk
 bHA
 bJb

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -23537,7 +23537,7 @@
 	},
 /area/crew_quarters/dorms)
 "aQs" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitecorner"
@@ -24345,20 +24345,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aRL" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+/obj/machinery/camera{
+	c_tag = "Bar Storage";
+	network = list("SS13")
 	},
-/obj/structure/chair/comfy/brown{
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
+/obj/item/radio/intercom{
+	dir = 0;
+	name = "station intercom (General)";
+	pixel_x = -28
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aRM" = (
 /obj/structure/table,
@@ -24372,14 +24374,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aRN" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/bar{
+	req_access_txt = "25"
+	},
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aRO" = (
 /obj/effect/decal/warning_stripes/southwest,
@@ -27576,18 +27581,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	level = 1
 	},
-/area/crew_quarters/bar)
-"aYe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/mob/living/carbon/human/monkey/punpun,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aYf" = (
 /obj/machinery/modular_computer/console/preset/command,
@@ -28516,9 +28514,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aZR" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aZS" = (
 /obj/machinery/cryopod/robot,
@@ -28925,30 +28928,13 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"baJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "baK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"baL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Office Maintenance";
-	req_access_txt = "25"
-	},
+"baM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28960,19 +28946,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"baM" = (
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "baN" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -28986,15 +28959,6 @@
 /obj/item/flashlight,
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
-"baP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "baQ" = (
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -29011,12 +28975,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -29088,13 +29046,12 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	initialize_directions = 11;
-	level = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	level = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -30123,10 +30080,16 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "bcU" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (NORTH)";
+	icon_state = "wooden_chair_wings";
+	dir = 1
 	},
-/obj/structure/chair/stool/bar,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bcV" = (
@@ -30192,23 +30155,6 @@
 	dir = 5
 	},
 /area/hallway/primary/port)
-"bda" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/crew_quarters/dorms)
 "bdb" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -30542,20 +30488,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"bdJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
-	pixel_y = 25
-	},
-/obj/structure/closet/chefcloset,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "bdK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30594,6 +30526,11 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	broadcasting = 0;
+	name = "station intercom (General)";
+	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -31088,25 +31025,14 @@
 	},
 /area/crew_quarters/toilet)
 "beF" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
+/obj/item/storage/secure/safe{
+	pixel_x = -22;
+	pixel_y = 0
 	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
-"beG" = (
-/obj/machinery/light,
-/turf/simulated/shuttle/floor,
-/area/shuttle/arrival/station)
-"beH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"beI" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
+/obj/structure/closet/gmcloset{
+	icon_closed = "black";
+	icon_state = "black";
+	name = "formal wardrobe"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -31117,6 +31043,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"beG" = (
+/obj/machinery/light,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "beJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -31296,12 +31226,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
 	dir = 2
@@ -31314,6 +31247,9 @@
 	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
@@ -31358,28 +31294,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
-"bfd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
-	},
-/area/crew_quarters/dorms)
 "bfe" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -31457,27 +31371,30 @@
 	},
 /area/crew_quarters/dorms)
 "bfk" = (
-/obj/machinery/requests_console{
-	department = "Bar";
-	name = "Bar Requests Console";
-	departmentType = 2;
+/obj/machinery/status_display{
 	pixel_x = 0;
-	pixel_y = 30
+	pixel_y = 32
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/beer,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bfl" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bfm" = (
 /obj/effect/decal/warning_stripes/north,
@@ -31574,16 +31491,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/boozeomat,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
-"bft" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bfu" = (
 /obj/machinery/door/airlock/external{
@@ -31728,6 +31637,11 @@
 	},
 /area/hydroponics)
 "bfE" = (
+/obj/machinery/light/small{
+	tag = "icon-bulb1 (EAST)";
+	icon_state = "bulb1";
+	dir = 4
+	},
 /mob/living/simple_animal/hostile/retaliate/goat,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -32594,9 +32508,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bhs" = (
 /obj/machinery/firealarm{
@@ -32951,6 +32863,7 @@
 	initialize_directions = 11;
 	level = 1
 	},
+/obj/structure/kitchenspike,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -33454,18 +33367,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
-"biS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 2;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "biT" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
@@ -33493,10 +33394,6 @@
 	},
 /area/crew_quarters/kitchen)
 "biV" = (
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -33514,6 +33411,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -33567,33 +33470,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"biZ" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage";
-	network = list("SS13")
-	},
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/dropper,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32;
-	pixel_y = 0
+"bja" = (
+/obj/structure/chair/wood/wings,
+/obj/effect/landmark/start{
+	name = "Civilian"
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"bja" = (
-/obj/structure/sink{
-	icon_state = "sink";
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
 /area/crew_quarters/bar)
 "bjb" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -33620,15 +33502,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
-"bjc" = (
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "bjd" = (
 /obj/structure/sink{
 	icon_state = "sink";
@@ -33651,10 +33524,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
-"bjf" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "bjg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
@@ -33681,20 +33550,6 @@
 /obj/item/radio/beacon,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"bjj" = (
-/obj/structure/closet/gmcloset{
-	icon_closed = "black";
-	icon_state = "black";
-	name = "formal wardrobe"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "bjk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -33706,9 +33561,6 @@
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
-"bjm" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "bjn" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -33885,15 +33737,25 @@
 	},
 /area/shuttle/escape)
 "bjK" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
 /obj/structure/table/wood,
-/obj/item/ashtray/bronze{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/storage/fancy/candle_box/eternal,
+/obj/item/storage/fancy/candle_box/eternal,
+/obj/item/storage/fancy/candle_box/eternal,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/turf/simulated/floor/carpet,
+/obj/item/stack/sheet/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/gun/projectile/revolver/doublebarrel,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bjL" = (
 /obj/structure/chair,
@@ -34465,10 +34327,14 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bkM" = (
-/obj/machinery/slot_machine,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/table/wood,
+/obj/item/radio/intercom{
+	dir = 0;
+	name = "station intercom (General)";
+	pixel_x = -28
 	},
+/obj/item/dice/d20,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bkN" = (
 /obj/structure/disposalpipe/segment{
@@ -34477,17 +34343,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bkO" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bkP" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/item/deck/cards,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bkQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -34787,13 +34655,6 @@
 	name = "Comemmorative Plaque"
 	},
 /area/hallway/secondary/entry)
-"blt" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "blu" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -35223,7 +35084,18 @@
 /obj/machinery/door/window{
 	dir = 4;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access_txt = "25;28"
+	},
+/obj/machinery/requests_console{
+	department = "Bar";
+	name = "Bar Requests Console";
+	departmentType = 2;
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -35515,9 +35387,7 @@
 	},
 /area/hallway/secondary/exit)
 "bmM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bmN" = (
@@ -35776,17 +35646,33 @@
 	c_tag = "Bar East";
 	network = list("SS13")
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/crew_quarters/bar)
 "bnm" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/crew_quarters/bar)
 "bnn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36002,12 +35888,8 @@
 	},
 /area/hallway/primary/central/nw)
 "bnQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bnR" = (
 /obj/machinery/computer/atmos_alert,
@@ -36094,14 +35976,6 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
-"boc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "bod" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -36186,7 +36060,6 @@
 	},
 /area/crew_quarters/kitchen)
 "bok" = (
-/obj/structure/piano,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -36198,15 +36071,8 @@
 	},
 /area/hallway/secondary/exit)
 "bom" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/machinery/slot_machine,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bon" = (
 /obj/machinery/camera{
@@ -36237,18 +36103,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
-"bop" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start{
-	name = "Bartender"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "boq" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
@@ -36293,15 +36147,6 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
-"bot" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "bou" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/sink{
@@ -36411,24 +36256,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"boH" = (
-/obj/machinery/door/window{
-	base_state = "left";
-	dir = 4;
-	icon_state = "left";
-	name = "Bar Door";
-	req_access_txt = "25"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "boI" = (
 /obj/machinery/door/airlock/external{
 	aiControlDisabled = 0;
@@ -36457,18 +36284,10 @@
 	},
 /area/hallway/secondary/entry)
 "boM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
-/turf/simulated/floor/carpet,
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/dropper,
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "boN" = (
 /obj/machinery/gibber,
@@ -36484,6 +36303,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -36523,7 +36343,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "boS" = (
-/obj/structure/closet/crate/freezer,
+/obj/structure/closet/chefcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -36908,21 +36728,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel,
 /area/bridge)
-"bpC" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/blue{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/pen/blue{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "bpD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -37210,9 +37015,11 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bqi" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/utensil/fork,
-/turf/simulated/floor/wood,
+/obj/structure/table/reinforced,
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/crew_quarters/bar)
 "bqj" = (
 /obj/machinery/door/airlock/maintenance{
@@ -37224,12 +37031,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bqk" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
-	icon_state = "wooden_chair_wings";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bql" = (
 /obj/structure/cable{
@@ -37351,9 +37158,27 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bqy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/chair/stool/bar,
+/obj/machinery/status_display{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bqz" = (
@@ -37630,40 +37455,16 @@
 	},
 /area/hallway/secondary/entry)
 "brf" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
+/obj/structure/chair/wood/wings,
 /obj/machinery/camera{
-	c_tag = "Bar West";
+	c_tag = "Medbay Corridor West";
 	dir = 4;
 	network = list("SS13")
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brg" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
-	icon_state = "wooden_chair_wings";
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"brh" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"bri" = (
-/obj/structure/table/wood,
-/obj/item/dice/d20,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brj" = (
@@ -37884,11 +37685,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"brH" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/cakehat,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "brI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37978,31 +37774,6 @@
 "brU" = (
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
-"brV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"brW" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"brX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "brY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -38545,25 +38316,17 @@
 /turf/simulated/wall,
 /area/hallway/primary/starboard/east)
 "btf" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"btg" = (
+/obj/structure/chair/wood{
 	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"btg" = (
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -38593,22 +38356,9 @@
 /turf/simulated/floor/wood,
 /area/library)
 "btm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/chair/wood/wings,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"btn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/wood,
-/obj/item/dice,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"bto" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "btp" = (
@@ -38620,18 +38370,6 @@
 "btq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"btr" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2;
-	pixel_y = 6
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -38685,26 +38423,6 @@
 	icon_state = "swall_f9"
 	},
 /area/shuttle/transport)
-"btw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/wood/wings,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"btx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "bty" = (
 /obj/machinery/light/spot{
 	tag = "icon-tube1 (NORTH)";
@@ -39106,13 +38824,19 @@
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "buq" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/obj/item/clothing/head/that{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/flask/barflask,
+/obj/item/reagent_containers/food/drinks/flask/barflask,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/crew_quarters/bar)
 "bur" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -39345,11 +39069,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
-"buN" = (
-/obj/structure/table/wood,
-/obj/item/candle,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "buO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39374,11 +39093,11 @@
 	},
 /area/hydroponics)
 "buQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (NORTH)";
-	icon_state = "wooden_chair_wings";
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Civilian"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -40095,13 +39814,12 @@
 /area/hallway/secondary/exit)
 "bwl" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bar Office";
-	req_access_txt = "25"
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "bwm" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -40489,10 +40207,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bwX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -40502,6 +40216,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Office Maintenance";
+	req_access_txt = "25"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bwY" = (
@@ -40709,7 +40427,15 @@
 	},
 /area/bridge)
 "bxx" = (
-/obj/machinery/computer/arcade,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxy" = (
@@ -40801,12 +40527,10 @@
 	},
 /area/bridge)
 "bxE" = (
-/obj/machinery/atm{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/item/twohanded/required/kirbyplants,
-/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxF" = (
 /obj/structure/extinguisher_cabinet{
@@ -41399,11 +41123,7 @@
 /turf/simulated/wall,
 /area/quartermaster/office)
 "byD" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "byE" = (
@@ -41723,7 +41443,6 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitecorner"
@@ -41783,13 +41502,20 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bzo" = (
-/obj/machinery/light,
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/phone{
+	attack_verb = list("bounced a check off","checked-out","tipped");
+	desc = "Also known as a cash register, or, more commonly, \"robbery magnet\". It's old and rusty, clearly non-functional and decorative only.";
+	icon = 'icons/obj/machines/pos.dmi';
+	icon_state = "pos";
+	name = "point of sale"
 	},
-/turf/simulated/floor/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/crew_quarters/bar)
 "bzp" = (
 /obj/structure/cable{
@@ -43301,16 +43027,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bCB" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
 /obj/machinery/light/small,
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
-	icon_state = "wooden_chair_wings";
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bCC" = (
 /obj/item/folder/blue,
@@ -43374,8 +43096,10 @@
 	dir = 1;
 	network = list("SS13")
 	},
-/obj/machinery/gameboard,
-/turf/simulated/floor/wood,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
 /area/crew_quarters/bar)
 "bCJ" = (
 /obj/structure/cable,
@@ -47130,10 +46854,6 @@
 /area/medical/reception)
 "bJQ" = (
 /obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bJR" = (
@@ -47179,34 +46899,11 @@
 	},
 /area/crew_quarters/toilet)
 "bJV" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/gun/projectile/revolver/doublebarrel,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/storage/fancy/candle_box/eternal,
-/obj/item/storage/fancy/candle_box/eternal,
-/obj/item/storage/fancy/candle_box/eternal,
-/obj/item/storage/secure/safe{
-	pixel_x = -22;
-	pixel_y = 0
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "bJW" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /turf/simulated/floor/plasteel{
@@ -85518,18 +85215,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"cWu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 8;
-	location = "Bar"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/maintenance/fsmaint2)
 "cWv" = (
 /obj/structure/table,
 /obj/item/toy/plushie/octopus,
@@ -85630,18 +85315,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"cWG" = (
-/obj/machinery/door/window/southleft{
-	tag = "icon-left (WEST)";
-	name = "Bar Delivery";
-	icon_state = "left";
-	dir = 8;
-	req_access_txt = "25";
-	base_state = "left"
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/bar)
 "cWH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -91980,64 +91653,34 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
-/obj/item/book/manual/sop_service,
-/obj/item/pen/blue{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/item/book/manual/barman_recipes,
-/obj/item/lighter/zippo,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
-"dji" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /obj/machinery/camera{
-	c_tag = "Bar North";
-	dir = 2;
+	c_tag = "Medbay Corridor West";
+	dir = 4;
 	network = list("SS13")
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/soda,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"djj" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/flask/barflask,
-/obj/item/reagent_containers/food/drinks/flask/barflask,
-/obj/machinery/status_display{
+"dji" = (
+/obj/machinery/vending/cigarette{
 	pixel_x = 0;
-	pixel_y = 32
+	pixel_y = 0
 	},
-/obj/item/clothing/head/that{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "djk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "djl" = (
 /obj/structure/table,
@@ -92049,12 +91692,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"djn" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "djo" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -92775,14 +92412,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
-"dkE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "dkF" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -92858,22 +92487,6 @@
 /area/aisat/maintenance{
 	name = "\improper AI Satellite Service"
 	})
-"dkL" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/phone{
-	attack_verb = list("bounced a check off","checked-out","tipped");
-	desc = "Also known as a cash register, or, more commonly, \"robbery magnet\". It's old and rusty, clearly non-functional and decorative only.";
-	icon = 'icons/obj/machines/pos.dmi';
-	icon_state = "pos";
-	name = "point of sale"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "dkM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -92900,10 +92513,21 @@
 	name = "\improper AI Satellite Atmospherics"
 	})
 "dkN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "dkO" = (
 /turf/simulated/floor/engine{
@@ -92926,20 +92550,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"dkR" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/kitchenspike,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "dkS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -94345,12 +93955,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/turret_protected/ai)
-"dnu" = (
-/obj/structure/kitchenspike,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "dnv" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -96306,6 +95910,21 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"ebd" = (
+/turf/simulated/floor,
+/area/maintenance/fsmaint2)
+"gom" = (
+/obj/machinery/atm{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "gMZ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -96351,6 +95970,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"hIw" = (
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "izn" = (
 /obj/machinery/atmospherics/unary/passive_vent{
 	dir = 1
@@ -96384,6 +96017,16 @@
 /area/toxins/launch{
 	name = "Toxins Launch Room"
 	})
+"jcL" = (
+/obj/structure/piano,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"jjd" = (
+/mob/living/carbon/human/monkey/punpun,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "jnJ" = (
 /obj/machinery/light/spot{
 	tag = "icon-tube1 (NORTH)";
@@ -96413,6 +96056,100 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"jDX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10;
+	level = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"jEj" = (
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"jKX" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag,
+/obj/item/ashtray/bronze{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"jQW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"jUm" = (
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (NORTH)";
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"kai" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"kzm" = (
+/obj/machinery/gameboard,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "kOE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
@@ -96420,6 +96157,61 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"kQz" = (
+/obj/effect/landmark/start{
+	name = "Bartender"
+	},
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"lcm" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"ldq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"leD" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/book/manual/sop_service,
+/obj/item/book/manual/barman_recipes,
+/obj/item/stack/packageWrap,
+/obj/item/pen/blue{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/lighter/zippo,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"lFo" = (
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 8;
+	location = "Bar"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/fsmaint2)
 "lLC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -96428,12 +96220,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"mrJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "mMw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
+"mSj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "nMi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -96462,6 +96273,23 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"pAS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"pLB" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -96479,10 +96307,36 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"qSH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	level = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "qUv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space/nearstation)
+"rBd" = (
+/obj/machinery/door/airlock{
+	name = "Bar Office";
+	req_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "rEw" = (
 /obj/machinery/computer/shuttle/admin{
 	name = "NTV Argos shuttle console"
@@ -96499,6 +96353,11 @@
 	},
 /turf/space,
 /area/shuttle/administration)
+"rVP" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "rYq" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
@@ -96510,6 +96369,49 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"sqV" = (
+/obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Bar Delivery";
+	req_access_txt = "25"
+	},
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"sDP" = (
+/obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Bar Door";
+	req_access_txt = "25;28";
+	tag = "icon-left (WEST)"
+	},
+/obj/effect/decal/warning_stripes/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"sKe" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "sUK" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -96518,6 +96420,36 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
+"sWZ" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"ucZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "uxy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -96540,6 +96472,18 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"uGl" = (
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/wall,
+/area/crew_quarters/bar)
+"vpD" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "vup" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -96555,6 +96499,46 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/constructionsite)
+"wom" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/crew_quarters/dorms)
+"wBg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"wNZ" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/pen/blue{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
 "wOS" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -96575,6 +96559,19 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
+"xmC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
+	},
+/area/crew_quarters/bar)
+"xnl" = (
+/obj/structure/table/wood,
+/obj/item/dice/d6,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "xAw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -96582,6 +96579,26 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"xBs" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"xCP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	tag = "icon-intact (SOUTHEAST)";
@@ -130403,10 +130420,10 @@ bja
 bkM
 bcU
 bok
-bmq
+jcL
 brf
-bmq
-bmq
+brg
+buR
 bmq
 bxx
 aUS
@@ -130647,25 +130664,25 @@ aUd
 aWG
 aWG
 bbk
-bcy
+wom
 beY
-aUS
-biZ
+aOI
+aGY
 bJV
-cWo
+aGY
 aUS
 djh
-dkE
-aZR
-bkM
-bmr
-brT
-btf
-btf
+btq
 bmq
+baK
+qSH
+pAS
+btf
+pAS
+xBs
 byD
-bmq
-bmq
+bAU
+kzm
 aUS
 bAi
 bHt
@@ -130904,25 +130921,25 @@ aUI
 aWK
 aZy
 bbn
-bda
-bfd
-aUS
-bjf
-baK
-beI
+bcy
+beW
+aMn
+aGY
+aGY
+aGY
 aUS
 bfs
-aYe
-boc
+btq
+bja
 bkP
-bmr
-brV
+jUm
+bmq
 btg
-bqi
-bmq
-buN
-bmq
-aVG
+lcm
+lcm
+lcm
+bAH
+btm
 aUS
 cMK
 bHy
@@ -131163,22 +131180,22 @@ aWK
 bbn
 bcy
 bfb
-aUS
-bjc
-baJ
-beH
+aOI
+aGY
+bjk
+bfB
 bwl
-bft
+aZV
 aYd
 bnQ
 bkO
-bmr
-bmM
+ldq
+bmq
+brg
+jEj
 brg
 brg
-bmq
-bqk
-bmq
+bAV
 bJQ
 aUS
 bAk
@@ -131420,21 +131437,21 @@ aWM
 bbo
 bcy
 bfj
-aUS
-bjj
+aOI
+aGY
 baM
-cWG
+aGY
 aUS
 bfk
 aZR
-bop
-bkO
-bmr
-bmM
+brT
+brT
+xCP
 bmq
-bmq
-bmq
-bmq
+brg
+brg
+xnl
+brg
 bmq
 bmq
 bAv
@@ -131677,22 +131694,22 @@ aZz
 aUJ
 aSD
 bfi
-aUS
-aUS
-baL
-cWu
+aOI
+aOI
+baM
+aGY
 aUS
 dji
-biS
+aVG
 bom
-bkO
-bmr
+bom
+xCP
 bmM
 btm
-brh
-btn
+btm
+btm
 buQ
-aZV
+wBg
 bzn
 bsN
 bAk
@@ -131939,17 +131956,17 @@ aOI
 baS
 beJ
 aUS
-djj
-dkL
-boH
-bpC
-bmr
-bmM
-btw
-bri
-bto
-buR
+aUS
+aUS
+aUS
+aUS
+gom
 bmq
+bmq
+bmq
+bmq
+bmq
+btq
 bmq
 bAv
 bAk
@@ -132193,20 +132210,20 @@ aSD
 bfo
 bhe
 aOI
-baP
+aGY
 bkN
 aUS
 aRL
 beF
-bot
-bjm
-bmq
-brW
-btq
+cWo
+aUS
+sWZ
 bmq
 bmq
 bmq
 bmq
+leD
+sDP
 bzo
 bze
 bAk
@@ -132456,14 +132473,14 @@ bwX
 djk
 dkN
 boM
-dkN
+aUS
 bqy
-brX
-btx
+bmr
+bmr
+bmr
+bmr
 buq
-buq
-buq
-bAU
+xmC
 bCI
 aUS
 bAk
@@ -132709,18 +132726,18 @@ aOI
 bjk
 bbb
 beM
-aUS
+uGl
 aRN
 bfl
 bjK
-blt
-bmq
-bmq
+aUS
+kai
+jKX
 bqi
-brH
-btr
 bqi
-bAH
+bqi
+wNZ
+sKe
 bCB
 aUS
 bFj
@@ -132965,20 +132982,20 @@ bfv
 aOI
 bjw
 bbe
-bdT
-bdT
-bdT
-bdT
-bdT
-bdT
+ebd
+lFo
+sqV
+jDX
+hIw
+rBd
 bnm
-bmq
+jQW
 bqk
 bqk
-bqk
-bqk
-bAV
-bmq
+kQz
+ucZ
+mrJ
+mSj
 aUS
 bAo
 bHy
@@ -133223,18 +133240,18 @@ bpE
 bjo
 bbd
 bdT
-dhV
-djn
-dkR
-dnu
 bdT
+bdT
+bdT
+bdT
+aUS
 bnl
-bmq
-bmq
-bmq
-bmq
-bmq
-bmq
+rVP
+jjd
+rVP
+rVP
+vpD
+rVP
 bxE
 aUS
 bAn
@@ -133737,7 +133754,7 @@ aOI
 aQI
 bbh
 bdT
-bdJ
+dhV
 bfC
 biU
 boN
@@ -135805,7 +135822,7 @@ bro
 bro
 bro
 bwp
-bdT
+pLB
 bzh
 bAk
 bHA

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -27591,14 +27591,11 @@
 	},
 /area/hallway/primary/fore)
 "aYd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6;
 	level = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aYf" = (
@@ -34356,6 +34353,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bkP" = (
@@ -34364,6 +34362,7 @@
 	dir = 4
 	},
 /obj/item/deck/cards,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bkQ" = (
@@ -35365,6 +35364,9 @@
 /area/hallway/secondary/exit)
 "bmM" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bmN" = (
@@ -35650,11 +35652,10 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (EAST)"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -35874,6 +35875,7 @@
 /area/hallway/primary/central/nw)
 "bnQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bnR" = (
@@ -37170,6 +37172,9 @@
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -95916,6 +95921,14 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"eaa" = (
+/obj/structure/disposalpipe/junction{
+	tag = "icon-pipe-j2 (EAST)";
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "eAA" = (
 /obj/machinery/gameboard,
 /obj/machinery/firealarm{
@@ -95995,6 +96008,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -96100,6 +96116,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "jKj" = (
@@ -96161,6 +96178,13 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"lpS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "lqH" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -96367,6 +96391,9 @@
 	name = "Bar Privacy Shutters";
 	opacity = 0
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -96382,6 +96409,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
+/area/crew_quarters/bar)
+"qMB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "qOl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -96463,6 +96497,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "rSv" = (
@@ -96489,6 +96526,14 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"srd" = (
+/obj/structure/chair/wood/wings,
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "sUK" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -96587,6 +96632,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "wiV" = (
@@ -96650,6 +96698,10 @@
 "xiB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "xxW" = (
@@ -130997,11 +131049,11 @@ aGY
 aGY
 aUS
 bfs
-btq
-bja
+qMB
+srd
 bkP
 jwq
-bmq
+lpS
 btg
 wNz
 wNz
@@ -131258,7 +131310,7 @@ aYd
 bnQ
 bkO
 xiB
-bmq
+btq
 brg
 mZb
 brg
@@ -131515,7 +131567,7 @@ aZR
 brT
 brT
 rIY
-bmq
+btq
 brg
 brg
 oGR
@@ -132029,12 +132081,12 @@ aUS
 aUS
 aUS
 iqt
-bmq
-bmq
-bmq
-bmq
-bmq
-btq
+qMB
+aZV
+aZV
+aZV
+aZV
+eaa
 bmq
 bze
 bAk

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -28934,18 +28934,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"baM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "baN" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -131439,7 +131427,7 @@ bcy
 bfj
 aOI
 aGY
-baM
+bkN
 aGY
 aUS
 bfk
@@ -131696,7 +131684,7 @@ aSD
 bfi
 aOI
 aOI
-baM
+bkN
 aGY
 aUS
 dji


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- This change will rework the entire bar area, the first change will be the moving of the bar to the kitchen shutters area.

- Due to the moving of the bar I've moved the bartenders backroom east to allow the bartender to access his backroom from the bar while leaving a maint exit as well. 

- The old location of the backroom has been turned into a maint tunnel area with a new door added to the north to allow passage from the dorms to bar maints. 

- I've moved the slot machines, furniture, alarms, APCs, and intercoms to different locations to fit the new design.

 
I've also made some small edits to the kitchen and freezer, 

- I've added a door to the primary hallway in which the chef can use in order to not have always leave through the bar every time. 

- I've made the freeze smaller by moving the entire wall 1 tile to the right to fit for the new backroom.

## Why It's Good For The Game
The main purpose of this design is to put the bar and kitchen next to each other, why? To encourage a more dynamic and cooperative playstyle between the bartender and chef.

To simply put our current bar could be much better than what we have today. Bartender/Chef cooperations in our current design tend to be rather slim or none. Due to the fact that our current bar is secluded from the kitchen. This changes that and allows the Chef to leave food for the Bartender to serve patrons. Patrons will be able to sit at the bar, order drinks, and foods. Not only will this encourage RP and make you feel like your in a diner. It will also add a new dynamic basis for teamwork between the Chef and Bartender.

 To summarize the idea would be fun, encourage RP, and add new dynamic cooperation between the jobs!
## Images of changes
### Current Bar Design
![dreamseeker_G8O5BRFtF6](https://user-images.githubusercontent.com/62493359/78419126-350bc080-7608-11ea-8235-7809c5f23178.png)
### Updated Bar Design
![dreamseeker_6yjQENhYFs](https://user-images.githubusercontent.com/62493359/78419144-5d93ba80-7608-11ea-91a4-6c186688d3a6.png)
### Current Bar Backroom
![dreamseeker_TUfdaakvhf](https://user-images.githubusercontent.com/62493359/78419170-a481b000-7608-11ea-9c2f-8169c8b14ef3.png)
### Update Bar Backroom
![dreamseeker_aU5GdVeF3y](https://user-images.githubusercontent.com/62493359/78419171-af3c4500-7608-11ea-8a1b-d6b6587ad5a5.png)
### Old Bar Backroom Location
![dreamseeker_pqg5Q9bVrs](https://user-images.githubusercontent.com/62493359/78419176-bb280700-7608-11ea-83d5-622d5ca7ed24.png)
### Current Kitchen
![dreamseeker_NJfLRD8faf](https://user-images.githubusercontent.com/62493359/78419186-e6aaf180-7608-11ea-9f8d-cf9a9fc546ae.png)
### Updated Kitchen
![dreamseeker_kbRfFoNMDZ](https://user-images.githubusercontent.com/62493359/78419187-ec083c00-7608-11ea-96c0-c55f641d1040.png)
### Current Freezer
![dreamseeker_EaRgM3wqIi](https://user-images.githubusercontent.com/62493359/78419191-f9bdc180-7608-11ea-8e01-63b24212f9d8.png)
### Updated Freezer
![dreamseeker_CHJs8YN0UR](https://user-images.githubusercontent.com/62493359/78419198-03dfc000-7609-11ea-9f59-5d0a2a7ca1c2.png)
## Changelog
:cl:Tokorizo
tweak: bar redesigned, new door for kitchen, freezer space decreased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
