### PR TITLE
Reorganise AI upload

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -42103,7 +42103,7 @@
 /area/bridge/meeting_room)
 "bzT" = (
 /obj/structure/table,
-/obj/item/aiModule/quarantine,
+/obj/item/aiModule/crewsimov,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43351,8 +43351,8 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Core Modules";
-	req_access_txt = "20"
+	name = "Medium Risk";
+	req_access_txt = "30"
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -43361,11 +43361,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/aiModule/crewsimov,
-/obj/item/aiModule/freeformcore,
-/obj/item/aiModule/corp,
 /obj/item/aiModule/paladin,
 /obj/item/aiModule/robocop,
+/obj/item/aiModule/quarantine,
+/obj/item/aiModule/purge,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bCI" = (
@@ -44055,7 +44054,6 @@
 /area/turret_protected/ai_upload)
 "bEb" = (
 /obj/structure/table,
-/obj/item/aiModule/protectStation,
 /obj/item/aiModule/nanotrasen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44500,7 +44498,7 @@
 /area/maintenance/port)
 "bFe" = (
 /obj/structure/table,
-/obj/item/aiModule/freeform,
+/obj/item/aiModule/corp,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46497,7 +46495,7 @@
 	base_state = "left";
 	dir = 8;
 	icon_state = "left";
-	name = "High-Risk Modules";
+	name = "High-Risk";
 	req_access_txt = "20"
 	},
 /obj/structure/window/reinforced,
@@ -46509,8 +46507,10 @@
 	},
 /obj/item/aiModule/oxygen,
 /obj/item/aiModule/oneCrewMember,
-/obj/item/aiModule/purge,
 /obj/item/aiModule/antimov,
+/obj/item/aiModule/freeform,
+/obj/item/aiModule/freeformcore,
+/obj/item/aiModule/protectStation,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bIN" = (


### PR DESCRIPTION
This PR reorganises the AI upload into three categories that make more sense than the current setup (Freeform board just sitting openly on a table when it should be high-risk, among other issues...)


The new categories and their laws are : 

----- Low-risk laws : Available to anyone in the AI upload, sitting on the tables.

- Crewsimov, Corporate, NT Default - Standard lawsets

- Reset - Very little risk of anything going wrong as this leaves core laws intact

----- Medium-risk laws : The left glass safe of the AI upload, now restricted to RD access

- Purge - Risky board but ultimately a competent RD should have no issue uploading a new lawset immediately after purging, and this is needed to remove some nefarious core laws that reset cant touch.

- Robocop, Paladin, Quarantine - Lawsets useful in emergency/particular situations

----- High-Risk laws : The right glass safe. Still captain only. You probably shouldn't ever touch these unless shit absolutely hit the fan or you really want to get BSA'd by CC.

- Protect Station : A surprisingly dangerous law considering anyone that damages the station isnt crew and needs to be neutralised.

- Freeform core and freeform module : Obviously being able to set ANY law is very dangerous in the wrong hands.

- One crew : Dangerous and not useful for most situations.

- Oxygen Is Toxic To Crew, Antimov : duh

:cl:
tweak: The left glass safe in AI upload is now locked to RD access and contains Medium-Risk boards.
tweak: Moved Corporate and Crewsimov boards to AI upload tables.
tweak: Moved Quarantine and Purge boards to Medium-Risk
tweak: Moved Freeform Core, Freeform and Protect Station boards to High-Risk
/:cl: