### PR TITLE
Fixes inability to login on records tab of ID card program

### DIFF
--- a/nano/templates/card_prog.tmpl
+++ b/nano/templates/card_prog.tmpl
@@ -62,7 +62,7 @@
 				Authorized Identity:
 		    </div>
 		    <div class='itemContent'>
-				{{:helper.link(data.scan_name, 'eject', {'action' : 'scan'})}}
+				{{:helper.link(data.scan_name, 'eject', {'action' : 'PRG_scan'})}}
 		    </div>
 		</div>
 		<div class='item'>


### PR DESCRIPTION
## What Does This PR Do
Fixes a bug where:

- Use the modular computer on the bridge.
- Select the ID Card program
- Select the records tab
- Click the button with your HoP/Captain ID to log in
- Find out that it won't accept your login, even though it should, and will accept it if you login from a different tab

## Why It's Good For The Game
Fixes a bug which could incorrectly give the Captain the impression that they cannot access something they in fact can access, because trying to login directly from that tab did not work.

:cl: Kyep
fix: Fixed a bug which prevented HoP/Captain from logging into the ID Card program on the modular computer in the bridge, if they had the 'Records' tab selected when trying to log in.
/:cl: