### PR TITLE
Fixes MapMerge Requirements

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
-pygit2==0.27.2
+pygit2==1.0.1
 bidict==0.13.1
 Pillow==6.2.0

--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
 pygit2==1.0.1
 bidict==0.13.1
-Pillow==6.2.0
+Pillow==7.1.1


### PR DESCRIPTION
:cl: Kyep
tweak: Fixed an issue where github contributors cannot install the dependencies for the 'mapmerge' tool, by updating the desired version some dependencies.
/:cl:
