### PR TITLE
Makes the cloning scanner eject upon being destroyed

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -127,7 +127,7 @@
 
 /obj/machinery/dna_scannernew/Destroy()
 	eject_occupant()
-	. = ..()
+	return ..()
 
 /obj/machinery/dna_scannernew/proc/eject_occupant()
 	src.go_out()

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -125,6 +125,10 @@
 	add_fingerprint(usr)
 	return
 
+/obj/machinery/dna_scannernew/Destroy()
+	eject_occupant()
+	. = ..()
+
 /obj/machinery/dna_scannernew/proc/eject_occupant()
 	src.go_out()
 	for(var/obj/O in src)


### PR DESCRIPTION
## What Does This PR Do
Makes the DNA scanning things that cloning and genetics use eject the occupant upon being destroyed

## Why It's Good For The Game
No more people disappearing into null space

## Changelog
:cl:
fix: People won't be deleted anymore if the DNA scanner (used in cloning and genetics) is destroyed
/:cl: