### PR TITLE
Fixes subsystem clicking

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -179,9 +179,9 @@
 
 	var/title = name
 	if(can_fire)
-		title = "\[[state_letter()]][title]"
+		title = "[state_colour()]\[[state_letter()]][title]</font>"
 
-	stat(title, "[state_colour()][statclick.update(msg)]</font>")
+	stat(title, statclick.update(msg))
 
 /datum/controller/subsystem/proc/state_letter()
 	switch(state)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the issue where you couldn't click subsystems to debug them. Thanks to @SteelSlayer for noticing this

Fixes #13260

It also changes the statpanel so only the name of the SS is coloured, as this makes readability a bit easier
![image](https://user-images.githubusercontent.com/25063394/78508779-61971800-7781-11ea-9576-fef11b20a202.png)

## Why It's Good For The Game
You should be able to click subsystems to debug them

## Changelog
:cl: AffectedArc07
fix: Clicking subsystems in the MC panel lets you debug them again
/:cl: