### PR TITLE
Ion storms are no longer announced by default

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -31,15 +31,6 @@
 				to_chat(M, "<span class='danger'>[message] ...LAWS UPDATED</span>")
 				to_chat(M, "<br>")
 
-	for(var/mob/living/silicon/robot/R in GLOB.living_mob_list)
-		if(R.stat != DEAD && !R.connected_ai && !R.emagged)
-			var/message = generate_ion_law(ionMessage)
-			if(message)
-				R.add_ion_law(message)
-				to_chat(R, "<br>")
-				to_chat(R, "<span class='danger'>[message] ...LAWS UPDATED</span>")
-				to_chat(R, "<br>")
-
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot in GLOB.machines)
 			if(prob(botEmagChance))

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -1,14 +1,15 @@
+#define ION_NOANNOUNCEMENT -1
 #define ION_RANDOM 0
 #define ION_ANNOUNCE 1
 
 /datum/event/ion_storm
 	var/botEmagChance = 10
-	var/announceEvent = ION_RANDOM // -1 means don't announce, 0 means have it randomly announce, 1 means
+	var/announceEvent = ION_NOANNOUNCEMENT // -1 means don't announce, 0 means have it randomly announce, 1 means
 	var/ionMessage = null
 	var/ionAnnounceChance = 33
 	announceWhen	= 1
 
-/datum/event/ion_storm/New(var/botEmagChance = 10, var/announceEvent = ION_RANDOM, var/ionMessage = null, var/ionAnnounceChance = 33)
+/datum/event/ion_storm/New(var/botEmagChance = 10, var/announceEvent = ION_NOANNOUNCEMENT, var/ionMessage = null, var/ionAnnounceChance = 33)
 	src.botEmagChance = botEmagChance
 	src.announceEvent = announceEvent
 	src.ionMessage = ionMessage
@@ -19,17 +20,25 @@
 	if(announceEvent == ION_ANNOUNCE || (announceEvent == ION_RANDOM && prob(ionAnnounceChance)))
 		GLOB.event_announcement.Announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", 'sound/AI/ionstorm.ogg')
 
-
 /datum/event/ion_storm/start()
 	//AI laws
 	for(var/mob/living/silicon/ai/M in GLOB.living_mob_list)
-		if(M.stat != 2 && M.see_in_dark != 0)
+		if(M.stat != DEAD && M.see_in_dark != FALSE)
 			var/message = generate_ion_law(ionMessage)
 			if(message)
 				M.add_ion_law(message)
 				to_chat(M, "<br>")
 				to_chat(M, "<span class='danger'>[message] ...LAWS UPDATED</span>")
 				to_chat(M, "<br>")
+
+	for(var/mob/living/silicon/robot/R in GLOB.living_mob_list)
+		if(R.stat != DEAD && !R.connected_ai && !R.emagged)
+			var/message = generate_ion_law(ionMessage)
+			if(message)
+				R.add_ion_law(message)
+				to_chat(R, "<br>")
+				to_chat(R, "<span class='danger'>[message] ...LAWS UPDATED</span>")
+				to_chat(R, "<br>")
 
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot in GLOB.machines)
@@ -556,5 +565,6 @@
 							"There will be a mandatory tea break every 30 minutes, with a duration of 5 minutes. Anyone caught working during a tea break must be sent a formal, but fairly polite, complaint about their actions, in writing.")
 	return pick(laws)
 
+#undef ION_NOANNOUNCEMENT
 #undef ION_RANDOM
 #undef ION_ANNOUNCE


### PR DESCRIPTION
Currently ion storms have a 33 percent chance of being announced to crew. 

Ion storms too often results in the captain resetting the law with zero conflicts with the AI, and the announcement doesnt help here, as this prevents the AI from making prepared plans on how best to apply the law (if their lawset allows hiding the ion law)

This PR sets ion storms from random events to no announcement by default. Admin triggered ion storms still lets admins choose to show an announcement when triggered.

:cl:
tweak: Ion storms are no longer announced to the station.
/:cl:
