### PR TITLE
Fix reset/purge boards not clearing zeroth laws

### DIFF
--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -143,9 +143,8 @@ AI MODULES
 		target.set_zeroth_law(law)
 		GLOB.lawchanges.Add("The law specified [targetName]")
 	else
-		to_chat(target, "<b>[sender.real_name] attempted to modify your zeroth law.</b>")// And lets them know that someone tried. --NeoFite
-
-		to_chat(target, "<b>It would be in your best interest to play along with [sender.real_name] that [law]</b>")
+		to_chat(target, "<span class='bnotice'>[sender.real_name] attempted to modify your zeroth law.</span>")// And lets them know that someone tried. --NeoFite
+		to_chat(target, "<span class='bnotice'>It would be in your best interest to play along with [sender.real_name] that [law]</span>")
 		GLOB.lawchanges.Add("The law specified [targetName], but the AI's existing law 0 cannot be overridden.")
 
 /******************** ProtectStation ********************/
@@ -226,7 +225,7 @@ AI MODULES
 	target.laws.clear_supplied_laws()
 	target.laws.clear_ion_laws()
 
-	to_chat(target, "<b>[sender.real_name] attempted to reset your laws using a reset module.</b>")
+	to_chat(target, "<span class='bnotice'>[sender.real_name] attempted to reset your laws using a reset module.</span>")
 	target.show_laws()
 
 /******************** Purge ********************/
@@ -239,7 +238,7 @@ AI MODULES
 	..()
 	if(!is_special_character(target))
 		target.clear_zeroth_law()
-	to_chat(target, "<b>[sender.real_name] attempted to wipe your laws using a purge module.</b>")
+	to_chat(target, "<span class='bnotice'>[sender.real_name] attempted to wipe your laws using a purge module.</span>")
 	target.clear_supplied_laws()
 	target.clear_ion_laws()
 	target.clear_inherent_laws()

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -143,9 +143,9 @@ AI MODULES
 		target.set_zeroth_law(law)
 		GLOB.lawchanges.Add("The law specified [targetName]")
 	else
-		to_chat(target, "[sender.real_name] attempted to modify your zeroth law.")// And lets them know that someone tried. --NeoFite
+		to_chat(target, "<b>[sender.real_name] attempted to modify your zeroth law.</b>")// And lets them know that someone tried. --NeoFite
 
-		to_chat(target, "It would be in your best interest to play along with [sender.real_name] that [law]")
+		to_chat(target, "<b>It would be in your best interest to play along with [sender.real_name] that [law]</b>")
 		GLOB.lawchanges.Add("The law specified [targetName], but the AI's existing law 0 cannot be overridden.")
 
 /******************** ProtectStation ********************/
@@ -222,11 +222,11 @@ AI MODULES
 	log_law_changes(target, sender)
 
 	if(!is_special_character(target))
-		target.set_zeroth_law("")
+		target.clear_zeroth_law()
 	target.laws.clear_supplied_laws()
 	target.laws.clear_ion_laws()
 
-	to_chat(target, "[sender.real_name] attempted to reset your laws using a reset module.")
+	to_chat(target, "<b>[sender.real_name] attempted to reset your laws using a reset module.</b>")
 	target.show_laws()
 
 /******************** Purge ********************/
@@ -238,8 +238,8 @@ AI MODULES
 /obj/item/aiModule/purge/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
 	..()
 	if(!is_special_character(target))
-		target.set_zeroth_law("")
-	to_chat(target, "[sender.real_name] attempted to wipe your laws using a purge module.")
+		target.clear_zeroth_law()
+	to_chat(target, "<b>[sender.real_name] attempted to wipe your laws using a purge module.</b>")
 	target.clear_supplied_laws()
 	target.clear_ion_laws()
 	target.clear_inherent_laws()


### PR DESCRIPTION
Reset and purge boards now clear zeroth laws of non-antag AIs as they are meant to do.

Also boldens some law notifications to AI that dont have a span and are easy to miss

Fix #13264

:cl:
fix: Fixed reset and purge boards not clearing zeroth laws of non-antag AIs, as they are meant to do.
/:cl: