### PR TITLE
Bonfire Logs

### DIFF
--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -356,6 +356,8 @@
 		var/fail_msg = construct_item(usr, TR)
 		if(!fail_msg)
 			to_chat(usr, "<span class='notice'>[TR.name] constructed.</span>")
+			if(TR.alert_admins_on_craft)
+				message_admins("[usr.ckey] has created a [TR.name] at [ADMIN_COORDJMP(usr)]")
 		else
 			to_chat(usr, "<span class ='warning'>Construction failed[fail_msg]</span>")
 		busy = FALSE

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -11,6 +11,7 @@
 	var/category = CAT_NONE //where it shows up in the crafting UI
 	var/subcategory = CAT_NONE
 	var/always_availible = TRUE //Set to FALSE if it needs to be learned first.
+	var/alert_admins_on_craft = FALSE
 
 /datum/crafting_recipe/IED
 	name = "IED"
@@ -94,6 +95,7 @@
 	tools = list(TOOL_WELDER)
 	time = 120
 	category = CAT_ROBOT
+	alert_admins_on_craft = TRUE
 
 /datum/crafting_recipe/cleanbot
 	name = "Cleanbot"
@@ -147,6 +149,7 @@
 	time = 10
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+	alert_admins_on_craft = TRUE
 
 /datum/crafting_recipe/meteorshot
 	name = "Meteorshot Shell"
@@ -259,6 +262,7 @@
 	time = 50
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+	alert_admins_on_craft = TRUE
 
 /datum/crafting_recipe/spear
 	name = "Spear"
@@ -378,6 +382,7 @@
 	time = 30
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+	alert_admins_on_craft = TRUE
 
 /datum/crafting_recipe/chemical_payload2
 	name = "Chemical Payload (gibtonite)"
@@ -391,6 +396,7 @@
 	time = 50
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+	alert_admins_on_craft = TRUE
 
 /datum/crafting_recipe/toxins_payload
 	name = "Toxins Payload Casing"
@@ -503,6 +509,7 @@
 	reqs = list(/obj/item/grown/log = 5)
 	result = /obj/structure/bonfire
 	category = CAT_PRIMAL
+	alert_admins_on_craft = TRUE
 
 /datum/crafting_recipe/rake //Category resorting incoming
 	name = "Rake"
@@ -611,8 +618,8 @@
 	name = "Paper Jack o'Lantern"
 	result = /obj/item/decorations/sticky_decorations/flammable/jack_o_lantern
 	tools = list(TOOL_WIRECUTTER)
-	pathtools = list(/obj/item/pen, 
-					/obj/item/toy/crayon/orange, 
+	pathtools = list(/obj/item/pen,
+					/obj/item/toy/crayon/orange,
 					/obj/item/toy/crayon/green)//pen ink is black
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -629,7 +636,7 @@
 	name = "Paper Spider"
 	result = /obj/item/decorations/sticky_decorations/flammable/spider
 	tools = list(TOOL_WIRECUTTER)
-	pathtools = list(/obj/item/pen, 
+	pathtools = list(/obj/item/pen,
 					/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -670,7 +677,7 @@
 	name = "Paper Snowman"
 	result = /obj/item/decorations/sticky_decorations/flammable/snowman
 	tools = list(TOOL_WIRECUTTER)
-	pathtools = list(/obj/item/pen, 
+	pathtools = list(/obj/item/pen,
 					/obj/item/toy/crayon/orange)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -687,9 +694,9 @@
 	name = "Paper Christmas Tree"
 	result = /obj/item/decorations/sticky_decorations/flammable/christmas_tree
 	tools = list(TOOL_WIRECUTTER)
-	pathtools = list(/obj/item/toy/crayon/red, 
-					/obj/item/toy/crayon/yellow, 
-					/obj/item/toy/crayon/blue, 
+	pathtools = list(/obj/item/toy/crayon/red,
+					/obj/item/toy/crayon/yellow,
+					/obj/item/toy/crayon/blue,
 					/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -714,7 +721,7 @@
 	name = "Paper Mistletoe"
 	result = /obj/item/decorations/sticky_decorations/flammable/mistletoe
 	tools = list(TOOL_WIRECUTTER)
-	pathtools = list(/obj/item/toy/crayon/red, 
+	pathtools = list(/obj/item/toy/crayon/red,
 					/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -723,7 +730,7 @@
 	name = "Paper Holly"
 	result = /obj/item/decorations/sticky_decorations/flammable/holly
 	tools = list(TOOL_WIRECUTTER)
-	pathtools = list(/obj/item/toy/crayon/red, 
+	pathtools = list(/obj/item/toy/crayon/red,
 					/obj/item/toy/crayon/green)
 	category = CAT_DECORATIONS
 	subcategory = CAT_HOLIDAY
@@ -1012,7 +1019,7 @@
 				/obj/item/stack/rods = 4,
 				/obj/item/stock_parts/cell = 1,
 				/obj/item/stack/cable_coil = 4)//thing is a wireframe construct with an electro magnetic hover field
-	tools = list(TOOL_WIRECUTTER, 
+	tools = list(TOOL_WIRECUTTER,
 				TOOL_WELDER)
 	pathtools = list(/obj/item/pen,
 				/obj/item/toy/crayon/red)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -165,7 +165,7 @@
 
 /obj/structure/bonfire/Crossed(atom/movable/AM, oldloc)
 	if(burning)
-		add_attack_logs(src, AM, "burned by a bonfire (Lit by [lighter])", ATKLOG_FEW)
+		add_attack_logs(src, AM, "burned by a bonfire (Lit by [lighter])", ATKLOG_ALMOSTALL)
 		Burn()
 
 /obj/structure/bonfire/proc/Burn()

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -110,6 +110,7 @@
 	anchored = TRUE
 	buckle_lying = FALSE
 	var/burning = 0
+	var/lighter // Who lit the fucking thing
 	var/fire_stack_strength = 5
 
 /obj/structure/bonfire/dense
@@ -125,6 +126,8 @@
 		var/image/U = image(icon='icons/obj/hydroponics/equipment.dmi',icon_state="bonfire_rod",pixel_y=16)
 		underlays += U
 	if(is_hot(W))
+		lighter = user.ckey
+		user.create_log(MISC_LOG, "lit a bonfire", src)
 		StartBurning()
 
 
@@ -162,6 +165,7 @@
 
 /obj/structure/bonfire/Crossed(atom/movable/AM, oldloc)
 	if(burning)
+		add_attack_logs(src, AM, "burned by a bonfire (Lit by [lighter])", ATKLOG_FEW)
 		Burn()
 
 /obj/structure/bonfire/proc/Burn()

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -165,8 +165,10 @@
 
 /obj/structure/bonfire/Crossed(atom/movable/AM, oldloc)
 	if(burning)
-		add_attack_logs(src, AM, "burned by a bonfire (Lit by [lighter])", ATKLOG_ALMOSTALL)
 		Burn()
+		if(ishuman(AM))
+			var/mob/living/carbon/human/H = AM
+			add_attack_logs(src, H, "Burned by a bonfire (Lit by [lighter])", ATKLOG_ALMOSTALL)
 
 /obj/structure/bonfire/proc/Burn()
 	var/turf/current_location = get_turf(src)


### PR DESCRIPTION
## What Does This PR Do
Requested by Necaladun. This PR adds in logging for when someone lights a bonfire, as well as when people are burned by it

![image](https://user-images.githubusercontent.com/25063394/78668263-4c7dce80-78d2-11ea-9686-12a31d0221f5.png)
![image](https://user-images.githubusercontent.com/25063394/78668269-4e479200-78d2-11ea-9049-c7d8a90f446e.png)
![image](https://user-images.githubusercontent.com/25063394/78668273-50115580-78d2-11ea-83ba-f176681dbd0c.png)

It also admin logs immediately when its crafted
![image](https://user-images.githubusercontent.com/25063394/78890289-410ade80-7a5d-11ea-8ca8-a49563608178.png)


## Why It's Good For The Game
Admins should know when people light people up

## Changelog
:cl: AffectedArc07
add: Bonfire lighting and burn events are now logged
/:cl:
