### PR TITLE
Fixes admin dress bug that results in incorrect outfits

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -541,7 +541,7 @@
 		P.attack_self(H) // activate them, display musical notes effect
 
 /datum/outfit/admin/soviet
-
+	name = "Soviet Generic"
 	gloves = /obj/item/clothing/gloves/combat
 	uniform = /obj/item/clothing/under/soviet
 	back = /obj/item/storage/backpack/satchel
@@ -771,6 +771,7 @@
 		apply_to_card(I, H, get_all_accesses(), "Space Explorer")
 
 /datum/outfit/admin/hardsuit
+	name = "Hardsuit Generic"
 	back = /obj/item/tank/jetpack/oxygen
 	mask = /obj/item/clothing/mask/breath
 	shoes = /obj/item/clothing/shoes/magboots
@@ -823,6 +824,7 @@
 
 
 /datum/outfit/admin/tournament
+	name = "Tournament Generic"
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/black
 	head = /obj/item/clothing/head/helmet/thunderdome


### PR DESCRIPTION
## What Does This PR Do
Fixes a bug where admins can go to dress someone in an outfit (e.g: via the Gimmick Team option in the secrets panel), and select "Naked", only to get someone dressed in a completely different outfit (tournament parent outfit, which comes equipped with a pulse destroyer!).

The issue is that outfits without any defined name are called the generic name, "Naked" which leads to them being confused with that outfit.

## Why It's Good For The Game
Prevents people being incorrectly spawned with pulse destroyers.

## Changelog
:cl: Kyep
fix: Fixed a bug where admins spawning a Gimmick Team that is naked can result in a team equipped incorrectly with tournament gear and pulse destroyers.
/:cl: