### PR TITLE
Outfits without a name will now be obvious

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -1,5 +1,5 @@
 /datum/outfit
-	var/name = "Naked"
+	var/name = "SOMEBODY FORGOT TO SET A NAME, NOTIFY A CODER"
 	var/collect_not_del = FALSE
 
 	var/uniform = null
@@ -32,6 +32,9 @@
 	var/list/chameleon_extras //extra types for chameleon outfit changes, mostly guns
 
 	var/can_be_admin_equipped = TRUE // Set to FALSE if your outfit requires runtime parameters
+
+/datum/outfit/naked
+	name = "Naked"
 
 /datum/outfit/proc/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	//to be overriden for customization depending on client prefs,species etc

--- a/code/modules/admin/verbs/gimmick_team.dm
+++ b/code/modules/admin/verbs/gimmick_team.dm
@@ -27,7 +27,7 @@
 		if(!themission)
 			alert("No mission specified. Aborting.")
 			return
-	var/admin_outfits = subtypesof(/datum/outfit/admin)
+	var/admin_outfits = subtypesof(/datum/outfit/admin) + list(/datum/outfit/naked)
 	var/outfit_list = list()
 	for(var/type in admin_outfits)
 		var/datum/outfit/admin/O = type


### PR DESCRIPTION
#13280 revealed a flaw in our outfit selection system - so I've changed it so that it won't happen again.
"Naked" is now a separate outfit, and the base outfit is now explicitly named in such a way to avoid this from recurring in the future.