### PR TITLE
Remove crowbarring sound on blast doors and update the proc

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -204,7 +204,7 @@
 	. = TRUE
 	if(operating)
 		return
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.use_tool(src, user, 0, volume = 0))
 		return
 	try_to_crowbar(user, I)
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -59,16 +59,6 @@
 /obj/machinery/door/poddoor/try_to_activate_door(mob/user)
  	return
 
-/obj/machinery/door/poddoor/crowbar_act(mob/user, obj/item/I)
-	if(user.a_intent == INTENT_HARM)
-		return
-	. = TRUE
-	if(operating)
-		return
-	if(!I.use_tool(src, user, 0, volume = 0))
-		return
-	try_to_crowbar(user, I)
-
 /obj/machinery/door/poddoor/try_to_crowbar(mob/user, obj/item/I)
 	if(!density)
 		return

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -59,9 +59,28 @@
 /obj/machinery/door/poddoor/try_to_activate_door(mob/user)
  	return
 
-/obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
+/obj/machinery/door/poddoor/crowbar_act(mob/user, obj/item/I)
+	if(user.a_intent == INTENT_HARM)
+		return
+	. = TRUE
+	if(operating)
+		return
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	try_to_crowbar(user, I)
+
+/obj/machinery/door/poddoor/try_to_crowbar(mob/user, obj/item/I)
+	if(!density)
+		return
 	if(!hasPower())
-		open()
+		to_chat(user, "<span class='notice'>You start forcing [src] open...</span>")
+		if(do_after(user, 50 * I.toolspeed, target = src))
+			if(!hasPower())
+				open()
+			else
+				to_chat(user, "<span class='warning'>[src] resists your efforts to force it!</span>")
+	else
+		to_chat(user, "<span class='warning'>[src] resists your efforts to force it!</span>")
 
  // Whoever wrote the old code for multi-tile spesspod doors needs to burn in hell. - Unknown
  // Wise words. - Bxil

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -179,6 +179,7 @@
 	slot_flags = SLOT_BACK
 	force_unwielded = 5
 	force_wielded = 24
+	toolspeed = 0.25
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	usesound = 'sound/items/crowbar.ogg'


### PR DESCRIPTION
Remove crowbarring sound on blast doors, whether succesful or not.  Succesfully forcing a blast door open already plays the 'shutters opening' sound.

Trying to force open a powered blast doors (or shutters) will now display a message saying that the door resists your effort to force it.

Forcing open an unpowered blast doors or shutters will now take 5 seconds with a crowbar, or 1.25 seconds with a fire axe or jaws of life.

Fire axe toolspeed is now 0.25 to make it open the blast doors/shutters faster, was not used before this PR.

:cl:
tweak: Blast doors no longer make a sound when crowbarred.
tweak: Forcing open an unpowered blast doors now takes 5 seconds, faster with a fireaxe/power tool.
/:cl:
