### PR TITLE
Makes special cams not runtime on spawn

### DIFF
--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -2,8 +2,8 @@
 
 // EMP
 
-/obj/machinery/camera/emp_proof/New()
-	..()
+/obj/machinery/camera/emp_proof/Initialize()
+	. = ..()
 	upgradeEmpProof()
 
 // X-RAY
@@ -11,20 +11,20 @@
 /obj/machinery/camera/xray
 	icon_state = "xraycam" // Thanks to Krutchen for the icons.
 
-/obj/machinery/camera/xray/New()
-	..()
+/obj/machinery/camera/xray/Initialize()
+	. = ..()
 	upgradeXRay()
 
 // MOTION
 
-/obj/machinery/camera/motion/New()
-	..()
+/obj/machinery/camera/motion/Initialize()
+	. = ..()
 	upgradeMotion()
 
 // ALL UPGRADES
 
-/obj/machinery/camera/all/New()
-	..()
+/obj/machinery/camera/all/Initialize()
+	. = ..()
 	upgradeEmpProof()
 	upgradeXRay()
 	upgradeMotion()


### PR DESCRIPTION
## What Does This PR Do
Makes preset cams work again. Currently they runtime upon spawning giving them no upgrades.


## Why It's Good For The Game
Less runtimes/bugs the better

fixes:
```
[2020-04-12T05:57:47] Runtime in presets.dm,81: Cannot read null.upgrades
   proc name: upgradeMotion (/obj/machinery/camera/proc/upgradeMotion)
   src: the security camera (/obj/machinery/camera/motion)
   src.loc: the floor (142,20,1) (/turf/simulated/floor/bluegrid)
   call stack:
   the security camera (/obj/machinery/camera/motion): upgradeMotion()
   the security camera (/obj/machinery/camera/motion): New(the floor (142,20,1) (/turf/simulated/floor/bluegrid))
```
```
[2020-04-12T05:57:47] Runtime in presets.dm,70: Cannot read null.upgrades
   proc name: upgradeEmpProof (/obj/machinery/camera/proc/upgradeEmpProof)
   src: the security camera (/obj/machinery/camera/emp_proof)
   src.loc: the plating (104,56,1) (/turf/simulated/floor/plating/airless)
   call stack:
   the security camera (/obj/machinery/camera/emp_proof): upgradeEmpProof()
   the security camera (/obj/machinery/camera/emp_proof): New(the plating (104,56,1) (/turf/simulated/floor/plating/airless))
```
```
[2020-04-12T05:57:49] Runtime in presets.dm,74: Cannot read null.upgrades
   proc name: upgradeXRay (/obj/machinery/camera/proc/upgradeXRay)
   src: the security camera (/obj/machinery/camera/xray)
   src.loc: the plating (116,117,3) (/turf/simulated/floor/plating)
   call stack:
   the security camera (/obj/machinery/camera/xray): upgradeXRay()
   the security camera (/obj/machinery/camera/xray): New(the plating (116,117,3) (/turf/simulated/floor/plating))
```

## Changelog
:cl:
fix: Special cameras spawn with their upgraded modules again
/:cl: