### PR TITLE
Deconstructing and mice biting wires is now put in the investigation log

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -49,11 +49,11 @@
 				if(C.avail())
 					visible_message("<span class='warning'>[src] chews through [C]. It's toast!</span>")
 					playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
-					C.deconstruct()
 					toast() // mmmm toasty.
 				else
-					C.deconstruct()
 					visible_message("<span class='warning'>[src] chews through [C].</span>")
+				investigate_log("was chewed through by a mouse in [get_area(F)]([F.x], [F.y], [F.z] - [ADMIN_JMP(F)])","wires")
+				C.deconstruct()
 
 /mob/living/simple_animal/mouse/handle_automated_speech()
 	..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -79,8 +79,10 @@ By design, d1 is the smallest direction and d2 is the highest
 	return ..()									// then go ahead and delete the cable
 
 /obj/structure/cable/deconstruct(disassembled = TRUE)
+	var/turf/T = get_turf(src)
+	if(usr)
+		investigate_log("was deconstructed by [key_name(usr, 1)] in [get_area(usr)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
 	if(!(flags & NODECONSTRUCT))
-		var/turf/T = get_turf(src)
 		if(d1)	// 0-X cables are 1 unit, X-X cables are 2 units long
 			new/obj/item/stack/cable_coil(T, 2, paramcolor = color)
 		else


### PR DESCRIPTION
## What Does This PR Do
Destroying a wire one way or the other now is logged if a player destroyed it.
Bombs will not log this but grenades and the like will due to how they are processed.

Mice biting wires is now also logged

## Why It's Good For The Game
Easier to see who destroyed a while if they did not cut it

## Changelog
:cl:
add: Deconstructing a wire is now logged
add: Mice biting wires is now logged
/:cl: