### PR TITLE
Nanopaste resizeing (w_class)

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -4,6 +4,7 @@
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	icon = 'icons/obj/nanopaste.dmi'
 	icon_state = "tube"
+	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "materials=2;engineering=3"
 	amount = 6
 	max_amount = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Resizes the Nanopaste to tiny size to match the organic equivalent of it, like the trauma and burn kit. 
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Before this resizing, the Nanopaste couldn't be stored in one's pocket or in any medkit box, making it quite inconvenient to carry or to store. This small change is to fix this, may it make this item more commonly used among the crew due to not taking up space as 50 metal sheet would.
## Changelog
:cl:
tweak: Modified the 'size' of the nano paste to tiny
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
