### PR TITLE
Replace traitor martyr objective by survive objective

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -105,7 +105,7 @@
 
 /datum/antagonist/traitor/proc/forge_human_objectives()
 	var/is_hijacker = prob(10)
-	var/martyr_chance = prob(20)
+	var/survive_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
 	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors
 		if(!SSticker.mode.exchange_red)
@@ -129,16 +129,16 @@
 	for(var/i = objective_count, i < objective_amount)
 		i += forge_single_objective()
 
-	var/martyr_compatibility = 1 //You can't succeed in stealing if you're dead.
+	var/survive_compatibility = TRUE //There isnt much point in stealing items if you dont deliver them to your employers.
 	for(var/datum/objective/O in owner.objectives)
 		if(!O.martyr_compatible)
-			martyr_compatibility = 0
+			survive_compatibility = FALSE
 			break
 
-	if(martyr_compatibility && martyr_chance)
-		var/datum/objective/die/martyr_objective = new
-		martyr_objective.owner = owner
-		add_objective(martyr_objective)
+	if(survive_compatibility && survive_chance)
+		var/datum/objective/survive/survive_objective = new
+		survive_objective.owner = owner
+		add_objective(survive_objective)
 		return
 
 	if(!(locate(/datum/objective/escape) in objectives))


### PR DESCRIPTION
This PR replaces the traitor 'Die a glorious death' objective by 'Survive until the end' objective.

Die is a glorious death is a fairly unfullfilling objective on Paradise. You cant 'Kill until killed' like you can on LRP servers, and just killing yourself for greentext is meh. I can only remember a single round where I had fun thanks to it in my many hours of playing.

This PR replaces the objective by 'Survive until the end', which serves the same purpose of being an easier objective than escape that can help a newbie pull off a greentext, and can also lead to more interesting moments in security. (Traitor caught by security after the targets are killed. You may have perma'd me, but the deed is done.)

Having this objective also encourages traitors to take it lighter on security, as they risk execution/field execution if they take it too far. Lord knows the redshirts can use the help.

:cl:
tweak: The 'Die a glorious death' objective for traitors has been replaced by 'Survive until the end.'
/:cl: