### PR TITLE
Zeroth law is now above ion laws

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -62,14 +62,14 @@
 	if(sorted_laws.len)
 		return
 
-	for(var/ion_law in ion_laws)
-		sorted_laws += ion_law
-		
-	for(var/evil_law in devil_laws)
-		sorted_laws += evil_law
-
 	if(zeroth_law)
 		sorted_laws += zeroth_law
+
+	for(var/ion_law in ion_laws)
+		sorted_laws += ion_law
+
+	for(var/evil_law in devil_laws)
+		sorted_laws += evil_law
 
 	var/index = 1
 	for(var/datum/ai_law/inherent_law in inherent_laws)
@@ -133,12 +133,12 @@
 	for(var/datum/ai_law/AL in devil_laws)
 		if(AL.law == law)
 			return
-			
+
 	var/new_law = new/datum/ai_law/sixsixsix(law)
 	devil_laws += new_law
 	if(state_devil.len < devil_laws.len)
 		state_devil += 1
-		
+
 	sorted_laws.Cut()
 
 /datum/ai_laws/proc/add_ion_law(var/law)
@@ -209,9 +209,9 @@
 
 /datum/ai_law/ion/delete_law(var/datum/ai_laws/laws)
 	laws.internal_delete_law(laws.ion_laws, laws.state_ion, src)
-	
+
 /datum/ai_law/sixsixsix/delete_law(var/datum/ai_laws/laws)
-	laws.internal_delete_law(laws.devil_laws, laws.state_devil, src) 
+	laws.internal_delete_law(laws.devil_laws, laws.state_devil, src)
 
 /datum/ai_law/inherent/delete_law(var/datum/ai_laws/laws)
 	laws.internal_delete_law(laws.inherent_laws, laws.state_inherent, src)

--- a/nano/templates/law_manager.tmpl
+++ b/nano/templates/law_manager.tmpl
@@ -1,41 +1,41 @@
 <style type="text/css">
     table.borders   {
-        width:95%; 
-        margin-left:2.4%; 
+        width:95%;
+        margin-left:2.4%;
         margin-right:2.4%;
     }
 
     table.borders, table.borders tr {
         border: 1px solid White;
     }
-    
+
     td.law_index {
         width: 50px;
     }
-    
+
     td.state {
         width: 63px;
-		text-align:center; 
+		text-align:center;
     }
-    
+
     td.add {
         width: 36px;
     }
-    
+
     td.edit {
         width: 36px;
-		text-align:center; 
+		text-align:center;
     }
-    
+
     td.delete {
         width: 53px;
-		text-align:center; 
+		text-align:center;
     }
-    
+
     td.law_type {
         width: 65px;
     }
-    
+
     td.position {
         width: 37px;
     }
@@ -55,7 +55,33 @@
 {{/if}}
 
 {{if data.view == 0}}
-	{{if data.has_ion_laws}}    
+	{{if data.has_zeroth_laws}}
+		<table class='borders'>
+		<tr><td class='law_index'>Index</td><td>Law</td><td class='state'>State</td>
+			{{if data.isMalf}}
+				<td class='edit'>Edit</td>
+				<td class='delete'>Delete</td>
+			{{/if}}
+		</tr>
+
+		<div class="itemLabelNarrow">
+			ERR_NULL_VALUE Laws:
+		</div>
+		{{for data.zeroth_laws}}
+			<tr>
+				<td valign="top">{{:value.index}}.</td>
+				<td>{{:value.law}}</td>
+				<td>{{:helper.link('Yes', null, {'ref': value.ref, 'state_law' : 1}, value.state == 1 ? 'selected' : null)}}{{:helper.link('No', null, {'ref': value.ref, 'state_law' : 0}, value.state == 0 ? 'selected' : null)}}</td>
+				{{if data.isMalf}}
+					<td class='edit'>{{:helper.link('Edit', null, {'edit_law': value.ref}, data.isAdmin ? null : 'disabled')}}</td>
+					<td class='delete'>{{:helper.link('Delete', null, {'delete_law': value.ref}, data.isAdmin ? null : 'disabled', data.isAdmin ? 'redButton' : null)}}</td>
+				{{/if}}
+			</tr>
+		{{/for}}
+		</table>
+	{{/if}}
+
+	{{if data.has_ion_laws}}
 		<table class='borders'>
 		<tr><td class='law_index'>Index</td><td>Law</td><td class='state'>State</td>
 			{{if data.isMalf}}
@@ -81,7 +107,7 @@
 		</table>
 	{{/if}}
 
-	{{if data.has_inherent_laws || data.has_zeroth_laws}} 
+	{{if data.has_inherent_laws}}
 		<table class='borders'>
 		<tr><td class='law_index'>Index</td><td>Law</td><td class='state'>State</td>
 			{{if data.isMalf}}
@@ -93,19 +119,7 @@
 		<div class="itemLabelNarrow">
 			Inherent Laws:
 		</div>
-		
-		{{for data.zeroth_laws}} 
-			<tr>
-				<td valign="top">{{:value.index}}.</td>
-				<td><span class='bad'>{{:value.law}}</span></td>
-				<td>{{:helper.link('Yes', null, {'ref': value.ref, 'state_law' : 1}, value.state == 1 ? 'selected' : null)}}{{:helper.link('No', null, {'ref': value.ref, 'state_law' : 0}, value.state != 1 ? 'selected' : null)}}</td>
-				{{if data.isMalf}}
-				<td class='edit'>{{:helper.link('Edit', null, {'edit_law': value.ref}, data.isAdmin ? null : 'disabled')}}</td>
-				<td class='delete'>{{:helper.link('Delete', null, {'delete_law': value.ref}, data.isAdmin ? null : 'disabled', data.isAdmin ? 'redButton' : null)}}</td>
-			{{/if}}
-			</tr>
-		{{/for}}
-		
+
 		{{for data.inherent_laws}}
 			<tr>
 				<td valign="top">{{:value.index}}.</td>
@@ -120,7 +134,7 @@
 		</table>
 	{{/if}}
 
-	{{if data.has_supplied_laws}}    
+	{{if data.has_supplied_laws}}
 		<table class='borders'>
 		<tr><td class='law_index'>Index</td><td>Law</td><td class='state'>State</td>
 			{{if data.isMalf}}
@@ -201,7 +215,7 @@
 			<div class="itemLabelWide">
 				<H2>{{:value.name}}</H2>{{:value.header}}
 			</div>
-			
+
 			{{if value.laws.has_ion_laws}}
 				<table class='borders'>
 					<tr><td class='law_index'>Index</td><td>Law</td>
@@ -213,7 +227,7 @@
 					{{/for}}
 				</table>
 			{{/if}}
-			
+
 			{{if value.laws.has_zeroth_laws || value.laws.has_inherent_laws}}
 				<table class='borders'>
 					<tr><td class='law_index'>Index</td><td>Law</td>
@@ -231,7 +245,7 @@
 					{{/for}}
 				</table>
 			{{/if}}
-			
+
 			{{if value.laws.has_supplied_laws}}
 				<table class='borders'>
 					<tr><td class='law_index'>Index</td><td>Law</td>
@@ -243,7 +257,7 @@
 					{{/for}}
 				</table>
 			{{/if}}
-		
+
 			<div class="itemContent">
 				<br>
 				{{:helper.link('Load Laws', null, {'transfer_laws' : value.ref}, data.isSlaved ? 'disabled' : null)}}{{:helper.link('State Laws', null, {'state_law_set' : value.ref})}}


### PR DESCRIPTION
In the last community meeting, admins explained that a Malf AI antag status take precedence over any hacked/ion laws, and is thus free to delete/ignore those laws.

However, this causes confusion, as server rules are written bind you to follow those hacked/ion laws since they are above your law 0 : Accomplish your objectives at all costs.

This solves the issue by putting the law 0 above everything else, obviously for both cyborgs and AIs.

Law notice/Stating laws :

![image](https://user-images.githubusercontent.com/22121511/79119252-2f447680-7d90-11ea-89fc-a98d600baba1.png)

Admin law manager : 

![image](https://user-images.githubusercontent.com/22121511/79119265-3b303880-7d90-11ea-93b9-4903ee02169b.png)

Malf AI law manager : 

![image](https://user-images.githubusercontent.com/22121511/79119291-513df900-7d90-11ea-8c7d-653619fcdaee.png)


:cl:
tweak: Zeroth laws are now above ion and hacked laws in law order.
/:cl: