### PR TITLE
Envirosuit spelling corrections, part II

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -68,7 +68,7 @@
 	on = !on
 	icon_state = "[initial(icon_state)][on ? "-light":""]"
 	item_state = icon_state
-	
+
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
 		H.update_inv_head()
@@ -185,7 +185,7 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/mining
 	name = "mining plasma envirosuit helmet"
-	desc = "A khaki helmet given to plasmamen miners operating on Lavaland."
+	desc = "A khaki helmet given to plasmaman miners operating on Lavaland."
 	icon_state = "explorer_envirohelm"
 	item_state = "explorer_envirohelm"
 	visor_icon = "explorer_envisor"

--- a/code/modules/clothing/under/jobs/plasmamen/civilian_service.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/civilian_service.dm
@@ -1,13 +1,13 @@
 /obj/item/clothing/under/plasmaman/cargo
 	name = "cargo plasma envirosuit"
-	desc = "A joint envirosuit used by plasmamen quartermasters and cargo techs alike, due to the logistical problems of differenciating the two with the length of their pant legs."
+	desc = "An envirosuit used by plasmaman quartermasters and cargo techs alike, due to the logistical problems of differentiating the two by the length of their pant legs."
 	icon_state = "cargo_envirosuit"
 	item_state = "cargo_envirosuit"
 	item_color = "cargo_envirosuit"
 
 /obj/item/clothing/under/plasmaman/mining
 	name = "mining plasma envirosuit"
-	desc = "An air-tight khaki suit designed for operations on lavaland by plasmamen."
+	desc = "An airtight khaki suit designed for operations on Lavaland by plasmamen."
 	icon_state = "explorer_envirosuit"
 	item_state = "explorer_envirosuit"
 	item_color = "explorer_envirosuit"
@@ -15,14 +15,14 @@
 
 /obj/item/clothing/under/plasmaman/chef
 	name = "chef's plasma envirosuit"
-	desc = "A white plasmaman envirosuit designed for cullinary practices. One might question why a member of a species that doesn't need to eat would become a chef."
+	desc = "A white plasmaman envirosuit designed for culinary practices. One might question why a member of a species that doesn't need to eat would become a chef."
 	icon_state = "chef_envirosuit"
 	item_state = "chef_envirosuit"
 	item_color = "chef_envirosuit"
 
 /obj/item/clothing/under/plasmaman/enviroslacks
 	name = "enviroslacks"
-	desc = "The pet project of a particularly posh plasmaman, this custom suit was quickly appropriated by Nano-Trasen for it's detectives, lawyers, and bar-tenders alike."
+	desc = "The pet project of a particularly posh plasmaman, this custom suit was quickly appropriated by Nanotrasen for its detectives, lawyers, and bartenders alike."
 	icon_state = "enviroslacks"
 	item_state = "enviroslacks"
 	item_color = "enviroslacks"
@@ -36,14 +36,14 @@
 
 /obj/item/clothing/under/plasmaman/librarian
 	name = "librarian's plasma envirosuit"
-	desc = "Made out of a modified voidsuit, this suit was Nano-Trasen's first solution to the *logistical problems* that come with employing plasmamen. Due to the modifications, the suit is no longer space-worthy. Despite their limitations, these suits are still in used by historian and old-styled plasmamen alike."
+	desc = "Made out of a modified voidsuit, this suit was Nanotrasen's first solution to the *logistical problems* that come with employing plasmamen. Due to the modifications, the suit is no longer space-worthy. Despite their limitations, these suits are still in used by historian and old-styled plasmamen alike."
 	icon_state = "prototype_envirosuit"
 	item_state = "prototype_envirosuit"
 	item_color = "prototype_envirosuit"
 
 /obj/item/clothing/under/plasmaman/janitor
 	name = "janitor's plasma envirosuit"
-	desc = "A grey and purple envirosuit designated for plasmamen janitors."
+	desc = "A grey and purple envirosuit designated for plasmaman janitors."
 	icon_state = "janitor_envirosuit"
 	item_state = "janitor_envirosuit"
 	item_color = "janitor_envirosuit"

--- a/code/modules/clothing/under/jobs/plasmamen/engineering.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/engineering.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/under/plasmaman/engineering
 	name = "engineering plasma envirosuit"
-	desc = "An air-tight suit designed to be used by plasmamen exployed as engineers, the usual purple stripes being replaced by engineer's orange. It protects the user from fire and acid damage."
+	desc = "An airtight suit designed to be used by plasmamen employed as engineers, the usual purple stripes being replaced by engineering's orange. It protects the user from fire and acid damage."
 	icon_state = "engineer_envirosuit"
 	item_state = "engineer_envirosuit"
 	item_color = "engineer_envirosuit"
@@ -8,14 +8,14 @@
 
 /obj/item/clothing/under/plasmaman/engineering/ce
 	name = "chief engineer plasma envirosuit"
-	desc = "An air-tight suit designed to be used by plasmamen exployed as the chief engineer"
+	desc = "An airtight suit designed to be used by plasmamen employed as the chief engineer."
 	icon_state = "ce_envirosuit"
 	item_state = "ce_envirosuit"
 	item_color = "ce_envirosuit"
 
 /obj/item/clothing/under/plasmaman/atmospherics
 	name = "atmospherics plasma envirosuit"
-	desc = "An air-tight suit designed to be used by plasmamen exployed as atmos technicians, the usual purple stripes being replaced by atmos's blue."
+	desc = "An airtight suit designed to be used by plasmamen employed as atmos technicians, the usual purple stripes being replaced by atmos' blue."
 	icon_state = "atmos_envirosuit"
 	item_state = "atmos_envirosuit"
 	item_color = "atmos_envirosuit"

--- a/code/modules/clothing/under/jobs/plasmamen/medsci.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/medsci.dm
@@ -20,7 +20,7 @@
 	item_color = "scientist_envirosuit"
 
 /obj/item/clothing/under/plasmaman/rd
-	name = "science plasma envirosuit"
+	name = "rd plasma envirosuit"
 	desc = "A plasmaman envirosuit designed for the research director."
 	icon_state = "rd_envirosuit"
 	item_state = "rd_envirosuit"

--- a/code/modules/clothing/under/jobs/plasmamen/security.dm
+++ b/code/modules/clothing/under/jobs/plasmamen/security.dm
@@ -8,7 +8,7 @@
 
 /obj/item/clothing/under/plasmaman/security/warden
 	name = "warden plasma envirosuit"
-	desc = "A plasmaman containment suit designed for the warden, white stripes being added to differeciate them from other members of security."
+	desc = "A plasmaman containment suit designed for the warden, white stripes being added to differentiate them from other members of security."
 	icon_state = "warden_envirosuit"
 	item_state = "warden_envirosuit"
 	item_color = "warden_envirosuit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR corrects more errors in both the envirosuit and envirohelmet descriptions that were found after #13165 was merged. In a few areas, such as the description for the cargo envirosuit, the wording has also been changed slightly for readability.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Central would probably BSA you if you spelled it "Nano-Trasen", and no one's "exployed" with the company.

## Changelog
:cl: Nl208
spellcheck: fix many spelling and grammar errors across the envirosuit files
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
