### PR TITLE
Monkeys can now gain nutrition from food

### DIFF
--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -18,6 +18,7 @@
 	is_small = 1
 	has_fine_manipulation = 0
 	ventcrawler = VENTCRAWLER_NUDE
+	dietflags = DIET_OMNI
 	show_ssd = 0
 	eyes = "blank_eyes"
 	death_message = "lets out a faint chimper as it collapses and stops moving..."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Monkeys never had their `dietflag` set up properly which means they could never gain nutrition from any foods. 

This gives them the `OMNI` dietflag flag which allows them to eat any food type to gain nutrition, similar to humans.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13296 
To clarify on the above issue, while it says Stok and other lesser mobs were unable to gain nutrition, that turned out to be wrong since Stok's species is actually Unathi, which properly has a diet flag. The same for others, Neara is a Skrell, Wolpin's are Vulp and Farwa's are Tajarran. I tested all of those mobs and they were able to gain nutrition fine.

Fixes #4345
Fixes only half of  #13001 so this wont close that issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes monkeys not being able to gain nutrition
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
