### PR TITLE
Fixes certain worn items being impossible to strip off of IPCs if they weren't wearing a jumpsuit

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -634,11 +634,9 @@
 		if(slot_belt)
 			if(H.belt)
 				return FALSE
-			var/obj/item/organ/external/O = H.get_organ(BODY_ZONE_CHEST)
-
-			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
+			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach this [name].</span>")
+					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach [I].</span>")
 				return FALSE
 			if(!(I.slot_flags & SLOT_BELT))
 				return
@@ -656,11 +654,9 @@
 		if(slot_wear_id)
 			if(H.wear_id)
 				return FALSE
-			var/obj/item/organ/external/O = H.get_organ(BODY_ZONE_CHEST)
-
-			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
+			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach this [name].</span>")
+					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach [I].</span>")
 				return FALSE
 			if(!(I.slot_flags & SLOT_ID))
 				return FALSE
@@ -668,11 +664,9 @@
 		if(slot_wear_pda)
 			if(H.wear_pda)
 				return FALSE
-			var/obj/item/organ/external/O = H.get_organ(BODY_ZONE_CHEST)
-
-			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
+			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach this [name].</span>")
+					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach [I].</span>")
 				return FALSE
 			if(!(I.slot_flags & SLOT_PDA))
 				return FALSE
@@ -682,11 +676,9 @@
 				return FALSE
 			if(H.l_store)
 				return FALSE
-			var/obj/item/organ/external/O = H.get_organ(BODY_ZONE_L_LEG)
-
-			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
+			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach this [name].</span>")
+					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach [I].</span>")
 				return FALSE
 			if(I.slot_flags & SLOT_DENYPOCKET)
 				return
@@ -697,11 +689,9 @@
 				return FALSE
 			if(H.r_store)
 				return FALSE
-			var/obj/item/organ/external/O = H.get_organ(BODY_ZONE_R_LEG)
-
-			if(!H.w_uniform && !nojumpsuit && (!O || !(O.status & ORGAN_ROBOT)))
+			if(!H.w_uniform && !nojumpsuit)
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach this [name].</span>")
+					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach [I].</span>")
 				return FALSE
 			if(I.slot_flags & SLOT_DENYPOCKET)
 				return FALSE
@@ -715,7 +705,7 @@
 				return FALSE
 			if(!H.wear_suit)
 				if(!disable_warning)
-					to_chat(H, "<span class='alert'>You need a suit before you can attach this [name].</span>")
+					to_chat(H, "<span class='alert'>You need a suit before you can attach [I].</span>")
 				return FALSE
 			if(!H.wear_suit.allowed)
 				if(!disable_warning)
@@ -723,7 +713,7 @@
 				return FALSE
 			if(I.w_class > WEIGHT_CLASS_BULKY)
 				if(!disable_warning)
-					to_chat(H, "The [name] is too big to attach.")
+					to_chat(H, "[I] is too big to attach.")
 				return FALSE
 			if(istype(I, /obj/item/pda) || istype(I, /obj/item/pen) || is_type_in_list(I, H.wear_suit.allowed))
 				return TRUE

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -25,6 +25,7 @@
 	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING) //Computers that don't decay? What a lie!
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS
+	nojumpsuit = TRUE
 	dietflags = 0		//IPCs can't eat, so no diet
 	taste_sensitivity = TASTE_SENSITIVITY_NO_TASTE
 	blood_color = "#1F181F"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
IPC could equip items into their belt, ID, PDA, and pocket slots without having to wear a jumpsuit. But, when people tried to stripped them, the items were hidden due to them not wearing a jumpsuit. This corrects that, and makes the items visible.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13262
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/42044220/79265837-57011080-7e5c-11ea-95b4-b72d57373454.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Fixes certain worn items being impossible to strip off of IPCs if they weren't wearing a jumpsuit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
