### PR TITLE
Fixes unexpected gibbing in TS away mission

### DIFF
--- a/code/modules/surgery/organs/parasites.dm
+++ b/code/modules/surgery/organs/parasites.dm
@@ -74,7 +74,8 @@
 		if(is_away_level(owner.z))
 			awaymission_infection = TRUE
 	if(awaymission_infection)
-		if(!is_away_level(owner.z))
+		var/turf/T = get_turf(owner)
+		if(istype(T) && !is_away_level(T.z))
 			owner.gib()
 			qdel(src)
 			return


### PR DESCRIPTION
## What Does This PR Do
Fixes a bug where being bitten by a white spider in the terror spider gateway would cause you to gib if you entered a sleeper, mech, locker or other container.

## Why It's Good For The Game
Fixes a bug. A bug with bugs. A bug bug, if you will.
The check that can gib you is meant to stop you accidentally or deliberately taking the spider infection back to the main station. It is not meant to stop you using sleepers, lockers, etc.

## Changelog
:cl: Kyep
fix: fixed a bug where gateway explorers bitten by a white spider could be gibbed if they entered a sleeper, mech, locker or other container.
/:cl: