### PR TITLE
Blood trails now mix properly and examining them won't lag your client [DNM]

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -547,24 +547,6 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		return 0
 	return transfer_blood_dna(new_blood_dna)
 
-/obj/effect/decal/cleanable/blood/splatter/transfer_mob_blood_dna(mob/living/L)
-	..(L)
-	var/list/b_data = L.get_blood_data(L.get_blood_id())
-	if(b_data)
-		basecolor = b_data["blood_color"]
-	else
-		basecolor = "#A10808"
-	update_icon()
-
-/obj/effect/decal/cleanable/blood/footprints/transfer_mob_blood_dna(mob/living/L)
-	..(L)
-	var/list/b_data = L.get_blood_data(L.get_blood_id())
-	if(b_data)
-		basecolor = b_data["blood_color"]
-	else
-		basecolor = "#A10808"
-	update_icon()
-
 //to add blood dna info to the object's blood_DNA list
 /atom/proc/transfer_blood_dna(list/blood_dna)
 	if(!blood_DNA)
@@ -608,11 +590,16 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 
 /turf/add_blood(list/blood_dna, color)
 	var/obj/effect/decal/cleanable/blood/splatter/B = locate() in src
+	var/found = TRUE
 	if(!B)
 		B = new /obj/effect/decal/cleanable/blood/splatter(src)
+		found = FALSE
 	B.transfer_blood_dna(blood_dna) //give blood info to the blood decal.
-	B.basecolor = color
-	return 1 //we bloodied the floor
+	if(!found)
+		B.basecolor = color
+	else
+		B.basecolor = BlendRGB(B.basecolor, color, 0.5)
+	return TRUE //we bloodied the floor
 
 /mob/living/carbon/human/add_blood(list/blood_dna, color)
 	if(wear_suit)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -112,6 +112,7 @@ GLOBAL_LIST_EMPTY(splatter_cache)
 
 /obj/effect/decal/cleanable/trail_holder //not a child of blood on purpose
 	name = "blood"
+	icon = 'icons/effects/blood.dmi'
 	icon_state = "ltrails_1"
 	desc = "Your instincts say you shouldn't be following these."
 	gender = PLURAL

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -26,11 +26,11 @@ GLOBAL_LIST_EMPTY(fluidtrack_cache)
 	basecolor = "#A10808"
 	var/entered_dirs = 0
 	var/exited_dirs = 0
+	var/blood_step_times = 1	// Always starts with one person stepping on it eh
 	blood_state = BLOOD_STATE_HUMAN //the icon state to load images from
 
 
 /obj/effect/decal/cleanable/blood/footprints/Crossed(atom/movable/O, oldloc)
-	..()
 	if(ishuman(O))
 		var/mob/living/carbon/human/H = O
 		var/obj/item/clothing/shoes/S = H.shoes
@@ -39,22 +39,11 @@ GLOBAL_LIST_EMPTY(fluidtrack_cache)
 		var/hasfeet = TRUE
 		if(!l_foot && !r_foot)
 			hasfeet = FALSE
-		if(S && S.bloody_shoes[blood_state] && S.blood_color == basecolor)
-			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
-			if(!S.blood_DNA)
-				S.blood_DNA = list()
-			S.blood_DNA |= blood_DNA.Copy()
+		if((S && S.bloody_shoes[blood_state]) || (hasfeet && H.bloody_feet[blood_state]))//Or feet //This will need to be changed.
 			if(!(entered_dirs & H.dir))
 				entered_dirs |= H.dir
 				update_icon()
-		else if(hasfeet && H.bloody_feet[blood_state] && H.feet_blood_color == basecolor)//Or feet //This will need to be changed.
-			H.bloody_feet[blood_state] = max(H.bloody_feet[blood_state] - BLOOD_LOSS_PER_STEP, 0)
-			if(!H.feet_blood_DNA)
-				H.feet_blood_DNA = list()
-			H.feet_blood_DNA |= blood_DNA.Copy()
-			if(!(entered_dirs & H.dir))
-				entered_dirs |= H.dir
-				update_icon()
+	..()
 
 /obj/effect/decal/cleanable/blood/footprints/Uncrossed(atom/movable/O)
 	..()
@@ -66,7 +55,7 @@ GLOBAL_LIST_EMPTY(fluidtrack_cache)
 		var/hasfeet = TRUE
 		if(!l_foot && !r_foot)
 			hasfeet = FALSE
-		if(S && S.bloody_shoes[blood_state] && S.blood_color == basecolor)
+		if(S && S.bloody_shoes[blood_state])
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
 			if(!S.blood_DNA)
 				S.blood_DNA = list()
@@ -74,7 +63,7 @@ GLOBAL_LIST_EMPTY(fluidtrack_cache)
 			if(!(exited_dirs & H.dir))
 				exited_dirs |= H.dir
 				update_icon()
-		else if(hasfeet && H.bloody_feet[blood_state] && H.feet_blood_color == basecolor)//Or feet
+		else if(hasfeet && H.bloody_feet[blood_state])//Or feet
 			H.bloody_feet[blood_state] = max(H.bloody_feet[blood_state] - BLOOD_LOSS_PER_STEP, 0)
 			if(!H.feet_blood_DNA)
 				H.feet_blood_DNA = list()
@@ -83,6 +72,10 @@ GLOBAL_LIST_EMPTY(fluidtrack_cache)
 				exited_dirs |= H.dir
 				update_icon()
 
+/obj/effect/decal/cleanable/blood/footprints/proc/add_to_footprint(color)
+	blood_step_times++
+	basecolor = BlendRGB(basecolor, color, 1 / blood_step_times)
+	update_icon()
 
 /obj/effect/decal/cleanable/blood/footprints/update_icon()
 	overlays.Cut()

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -27,11 +27,14 @@
 			else
 				add_blood = bloodiness
 			bloodiness -= add_blood
+			if(S.blood_color)
+				S.blood_color = BlendRGB(S.blood_color, basecolor, add_blood/(S.bloody_shoes[blood_state] + add_blood))
+			else
+				S.blood_color = basecolor
 			S.bloody_shoes[blood_state] = min(MAX_SHOE_BLOODINESS, S.bloody_shoes[blood_state] + add_blood)
 			if(blood_DNA && blood_DNA.len)
-				S.add_blood(H.blood_DNA, basecolor)
+				S.add_blood(H.blood_DNA, S.blood_color)
 			S.blood_state = blood_state
-			S.blood_color = basecolor
 			update_icon()
 			H.update_inv_shoes()
 		else if(hasfeet && blood_state && bloodiness)//Or feet
@@ -41,12 +44,15 @@
 			else
 				add_blood = bloodiness
 			bloodiness -= add_blood
+			if(H.feet_blood_color)
+				H.feet_blood_color = BlendRGB(H.feet_blood_color, basecolor, add_blood/(H.bloody_feet[blood_state] + add_blood))
+			else
+				H.feet_blood_color = basecolor
 			H.bloody_feet[blood_state] = min(MAX_SHOE_BLOODINESS, H.bloody_feet[blood_state] + add_blood)
 			if(!H.feet_blood_DNA)
 				H.feet_blood_DNA = list()
 			H.blood_state = blood_state
 			H.feet_blood_DNA |= blood_DNA.Copy()
-			H.feet_blood_color = basecolor
 			update_icon()
 			H.update_inv_shoes()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -56,25 +56,30 @@
 	if(!l_foot && !r_foot)
 		hasfeet = FALSE
 
+	var/found = FALSE
 	if(shoes)
 		if(S.bloody_shoes && S.bloody_shoes[S.blood_state])
 			for(var/obj/effect/decal/cleanable/blood/footprints/oldFP in T)
-				if(oldFP && oldFP.blood_state == S.blood_state && oldFP.basecolor == S.blood_color)
-					return
-			//No oldFP or it's a different kind of blood
-			S.bloody_shoes[S.blood_state] = max(0, S.bloody_shoes[S.blood_state] - BLOOD_LOSS_PER_STEP)
-			if(S.bloody_shoes[S.blood_state] > BLOOD_LOSS_IN_SPREAD)
-				createFootprintsFrom(shoes, dir, T)
-			update_inv_shoes()
+				found = TRUE
+				oldFP.add_to_footprint(S.blood_color)
+				break
+			if(!found)
+				//No oldFP or it's a different kind of blood
+				S.bloody_shoes[S.blood_state] = max(0, S.bloody_shoes[S.blood_state] - BLOOD_LOSS_PER_STEP)
+				if(S.bloody_shoes[S.blood_state] > BLOOD_LOSS_IN_SPREAD)
+					createFootprintsFrom(shoes, dir, T)
+				update_inv_shoes()
 	else if(hasfeet)
 		if(bloody_feet && bloody_feet[blood_state])
 			for(var/obj/effect/decal/cleanable/blood/footprints/oldFP in T)
-				if(oldFP && oldFP.blood_state == blood_state && oldFP.basecolor == feet_blood_color)
-					return
-			bloody_feet[blood_state] = max(0, bloody_feet[blood_state] - BLOOD_LOSS_PER_STEP)
-			if(bloody_feet[blood_state] > BLOOD_LOSS_IN_SPREAD)
-				createFootprintsFrom(src, dir, T)
-			update_inv_shoes()
+				found = TRUE
+				oldFP.add_to_footprint(feet_blood_color)
+				break
+			if(!found)
+				bloody_feet[blood_state] = max(0, bloody_feet[blood_state] - BLOOD_LOSS_PER_STEP)
+				if(bloody_feet[blood_state] > BLOOD_LOSS_IN_SPREAD)
+					createFootprintsFrom(src, dir, T)
+				update_inv_shoes()
 	//End bloody footprints
 	if(S)
 		S.step_action(src)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -259,7 +259,7 @@
 				drop.drips++
 				drop.overlays |= pick(drop.random_icon_states)
 				drop.transfer_mob_blood_dna(src)
-				drop.basecolor = b_data["blood_color"]
+				drop.basecolor = BlendRGB(drop.basecolor, b_data["blood_color"], 1/drop.drips)
 				drop.update_icon()
 			else
 				temp_blood_DNA = list()
@@ -280,8 +280,12 @@
 		B = locate() in bloods
 	if(!B)
 		B = new(T)
+		B.basecolor = b_data["blood_color"]
+
 	if(B.bloodiness < MAX_SHOE_BLOODINESS) //add more blood, up to a limit
 		B.bloodiness += BLOOD_AMOUNT_PER_DECAL
+		B.basecolor = BlendRGB(B.basecolor, b_data["blood_color"], BLOOD_AMOUNT_PER_DECAL / B.bloodiness)
+
 	B.transfer_mob_blood_dna(src) //give blood info to the blood decal.
 	if(temp_blood_DNA)
 		B.blood_DNA |= temp_blood_DNA


### PR DESCRIPTION
DNM due to me wanting to test it more later

## What Does This PR Do
Makes blood not lag you to pieces when you examine it.
Makes blood trails and foot prints mix blood colors and they will now always add the new DNA to the list of DNA's in the blood trails. Currently the DNA is lost if the direction of the blood trail is the same when dragging a body over an already existing blood trail

Fixes #13000
Probably fixes #13242 

## Why It's Good For The Game
Less issues is better.
Makes blood behave better.

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/79800104-eece9500-835b-11ea-84b7-8b7382acf820.png)

![image](https://user-images.githubusercontent.com/15887760/79800119-f68e3980-835b-11ea-8c1a-94f3467563ff.png)

![image](https://user-images.githubusercontent.com/15887760/79800174-0dcd2700-835c-11ea-8ed0-07360f5be633.png)

![image](https://user-images.githubusercontent.com/15887760/79800273-335a3080-835c-11ea-9557-c897a85f1210.png)


## Changelog
:cl:
tweak: Blood trails now mix depending on how much blood they still have and how much blood is added to them
fix: Blood trails now don't lag/crash the client when examining them
fix: Stepping on blood while your shoes are also bloodied now won't mute your footstep sounds
/:cl: