### PR TITLE
Makes the water tank backpack nozzle not have antidrop

### DIFF
--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -119,7 +119,7 @@
 	amount_per_transfer_from_this = 50
 	possible_transfer_amounts = list(25,50,100)
 	volume = 500
-	flags = NODROP | NOBLUDGEON
+	flags = NOBLUDGEON
 	container_type = OPENCONTAINER
 
 	var/obj/item/watertank/tank


### PR DESCRIPTION
## What Does This PR Do
As it says. The nozzle now doesn't have antidrop

## Why It's Good For The Game
No more stuck nozzle till they stand back up from the death and remove it themselves....

## Changelog
:cl:
tweak: The Backpack water tank's nozzle now doesn't have nodrop
/:cl: