### PR TITLE
Lowers max charges and recharge time for Staff of Slipping

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -58,8 +58,6 @@
 	ammo_type = /obj/item/ammo_casing/magic/slipping
 	icon_state = "staffofslipping"
 	item_state = "staffofslipping"
-	max_charges = 10
-	recharge_rate = 2
 	fire_sound = 'sound/items/bikehorn.ogg'
 
 /obj/item/gun/magic/staff/slipping/honkmother


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reduces both the maximum number of charges and the recharge time for the staff of slipping - an item that can be found on the clown biodome in lavaland and bought by Wizards for 1SP.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having witnessed a round where a wizard used this combined with instant summons, as well as having used it myself as a cling, I would argue that it is far too strong in its current state regardless of whether you get this as a wizard or a lucky miner antag. The bananas can be fired very quickly, have a range of 50 unlike tasers and also work on borgs and anyone with slip protection.

The staff itself has the same charging stats as the chaos and door creation staff, where chaos is very unpredictable and thus needs the better charge stats to work around this disadvantage and door creation is purely support based and has no combat use whatsoever. This PR brings it to same level as the other more reliable and powerful staffs such as change and animation (**6 max charges, 8 second recharge time**).

I've left the price at 1SP for wizards, since the staff is powerful regardless of whether you're a wizard or miner and this would be an additional nerf for them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Reduces max charges and recharge time for staff of slipping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
