### PR TITLE
Makes 'nodecon' walls on derelict russian station immune to welders

### DIFF
--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -277,6 +277,9 @@
 /turf/simulated/wall/mineral/titanium/nodecon/burn_down()
 	return
 
+/turf/simulated/wall/mineral/titanium/nodecon/welder_act()
+	return
+
 /////////////////////Plastitanium walls/////////////////////
 
 /turf/simulated/wall/mineral/plastitanium


### PR DESCRIPTION
## What Does This PR Do
Fixes #13304 - an oversight whereby the supposedly 'nodecon' titanium walls of the Russian derelict station could be easily deconstructed with a simple welder and wrench.
Does NOT make them absolutely indestructible walls such as https://github.com/ParadiseSS13/Paradise/blob/master/code/game/turfs/simulated/walls_indestructible.dm - you can still break the derelict walls if you have high explosives or similar, but it is no longer as easy as it was.

## Why It's Good For The Game
Stops people cutting through the derelict walls straight into the armory.

## Changelog
:cl: Kyep
fix: The walls of the derelict Russian station now properly resist welding tools.
/:cl:
