### PR TITLE
Fixes #9971 - manually spawned paranormal ERT cannot reskin nullrods

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -401,8 +401,9 @@
 
 /datum/outfit/job/centcom/response_team/paranormal/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	if(H.mind)
-		H.mind.isholy = TRUE
+	if(!H.mind)
+		H.mind = new()
+	H.mind.isholy = TRUE
 
 /datum/outfit/job/centcom/response_team/paranormal/amber
 	name = "RT Paranormal (Amber)"


### PR DESCRIPTION
## What Does This PR Do
Fixes #9971
Manually spawning a human mob and dressing them as a paranormal ERT will no longer leave them unable to reskin/usr their nullrod.

## Changelog
:cl: Kyep
fix: fixed humans manually spawned in as paranormal ERT being unable to reskin their nullrods.
/:cl: