### PR TITLE
Makes ai_monitored load the cams on LateInitialize

### DIFF
--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -3,16 +3,14 @@
 	var/obj/machinery/camera/motioncamera = null
 
 
-/area/ai_monitored/New()
-	..()
+/area/ai_monitored/LateInitialize()
+	. = ..()
 	// locate and store the motioncamera
-	spawn (20) // spawn on a delay to let turfs/objs load
-		for(var/obj/machinery/camera/M in src)
-			if(M.isMotion())
-				motioncamera = M
-				M.area_motion = src
-				return
-	return
+	for(var/obj/machinery/camera/M in src)
+		if(M.isMotion())
+			motioncamera = M
+			M.area_motion = src
+			break
 
 /area/ai_monitored/Entered(atom/movable/O)
 	..()


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime when creating ai_monitored areas:
![image](https://user-images.githubusercontent.com/15887760/80414738-c7cf1080-88d1-11ea-9089-cb71c70b4253.png)
Was caused because the cameras were used before they were initialised. On local servers the runtime nearly never happened due to the spawn. But on live it would happen due to the heavy server load.

## Why It's Good For The Game
Less runtimes more funtimes

## Changelog
:cl:
fix: ai_monitored areas now won't runtime on round start
/:cl:
