### PR TITLE
Fixes #13243 - Makes wands no longer work in den

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -8,6 +8,7 @@
 	can_charge = 0
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
 	var/variable_charges = 1
+	no_den_usage = 1
 
 /obj/item/gun/magic/wand/New()
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges
@@ -118,7 +119,6 @@
 	ammo_type = /obj/item/ammo_casing/magic/teleport
 	icon_state = "telewand"
 	max_charges = 10 //10, 5, 5, 4
-	no_den_usage = 1
 	fire_sound = 'sound/magic/wand_teleport.ogg'
 
 /obj/item/gun/magic/wand/teleport/zap_self(mob/living/user)
@@ -140,7 +140,6 @@
 	fire_sound = 'sound/magic/staff_door.ogg'
 	icon_state = "doorwand"
 	max_charges = 20 //20, 10, 10, 7
-	no_den_usage = 1
 
 /obj/item/gun/magic/wand/door/zap_self(mob/living/user)
 	to_chat(user, "<span class='notice'>You feel vaguely more open with your feelings.</span>")

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -140,6 +140,7 @@
 	fire_sound = 'sound/magic/staff_door.ogg'
 	icon_state = "doorwand"
 	max_charges = 20 //20, 10, 10, 7
+	no_den_usage = 1
 
 /obj/item/gun/magic/wand/door/zap_self(mob/living/user)
 	to_chat(user, "<span class='notice'>You feel vaguely more open with your feelings.</span>")

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -8,7 +8,6 @@
 	can_charge = 0
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
 	var/variable_charges = 1
-	no_den_usage = TRUE
 
 /obj/item/gun/magic/wand/New()
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -140,7 +140,6 @@
 	fire_sound = 'sound/magic/staff_door.ogg'
 	icon_state = "doorwand"
 	max_charges = 20 //20, 10, 10, 7
-	no_den_usage = 1
 
 /obj/item/gun/magic/wand/door/zap_self(mob/living/user)
 	to_chat(user, "<span class='notice'>You feel vaguely more open with your feelings.</span>")

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -42,7 +42,7 @@
 				to_chat(user, "<span class='warning'>You know better than to violate the security of The Den, best wait until you leave to use [src].</span>")
 				return
 			else
-				no_den_usage = 0
+				no_den_usage = FALSE
 		zap_self(user)
 	else
 		..()
@@ -119,6 +119,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/teleport
 	icon_state = "telewand"
 	max_charges = 10 //10, 5, 5, 4
+	no_den_usage = TRUE
 	fire_sound = 'sound/magic/wand_teleport.ogg'
 
 /obj/item/gun/magic/wand/teleport/zap_self(mob/living/user)
@@ -140,6 +141,7 @@
 	fire_sound = 'sound/magic/staff_door.ogg'
 	icon_state = "doorwand"
 	max_charges = 20 //20, 10, 10, 7
+	no_den_usage = TRUE
 
 /obj/item/gun/magic/wand/door/zap_self(mob/living/user)
 	to_chat(user, "<span class='notice'>You feel vaguely more open with your feelings.</span>")

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -8,7 +8,7 @@
 	can_charge = 0
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
 	var/variable_charges = 1
-	no_den_usage = 1
+	no_den_usage = TRUE
 
 /obj/item/gun/magic/wand/New()
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #13243
~~Makes wand of door creation not work on wizard den~~
Makes wands not work on the wizard den
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right now, wizards can spacewalk into the SST prep room, Central, Admin room etc.
Also prevents people from wasting their charges on the den
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Wizards can no longer raid admin shuttle
tweak: Wands no longer work on the den
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
