### PR TITLE
Makes emotes that require air gasps when you have 35+ oxygen damage

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -52,12 +52,20 @@
 				return
 		if("howl", "howls")
 			if(isvulpkanin(src))		//Only Vulpkanin can howl
-				on_CD = handle_emote_CD(100)
+				if(getOxyLoss() > 40)
+					emote("gasp")
+					return
+				else
+					on_CD = handle_emote_CD(100)
 			else
 				return
 		if("growl", "growls")
 			if(isvulpkanin(src))		//Only Vulpkanin can growl
-				on_CD = handle_emote_CD()
+				if(getOxyLoss() > 40)
+					emote("gasp")
+					return
+				else
+					on_CD = handle_emote_CD()
 			else
 				return
 		if("squish", "squishes")
@@ -96,7 +104,11 @@
 
 		if("hiss", "hisses")
 			if(isunathi(src)) //Only Unathi can hiss.
-				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
+				if(getOxyLoss() > 40)
+					emote("gasp")
+					return
+				else
+					on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
 			else								//Everyone else fails, skip the emote attempt
 				return
 
@@ -113,7 +125,11 @@
 				return
 
 		if("scream", "screams")
-			on_CD = handle_emote_CD(50) //longer cooldown
+			if(getOxyLoss() > 40)
+				emote("gasp")
+				return
+			else
+				on_CD = handle_emote_CD(50) //longer cooldown
 		if("fart", "farts", "flip", "flips", "snap", "snaps")
 			on_CD = handle_emote_CD()				//proc located in code\modules\mob\emote.dm
 		if("cough", "coughs", "slap", "slaps", "highfive")
@@ -123,6 +139,10 @@
 		if("deathgasp", "deathgasps")
 			on_CD = handle_emote_CD(50)
 		if("sneeze", "sneezes")
+			if(getOxyLoss() > 40)
+				emote("gasp")
+				return
+			else
 			on_CD = handle_emote_CD()
 		if("clap", "claps")
 			on_CD = handle_emote_CD()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -143,7 +143,7 @@
 				emote("gasp")
 				return
 			else
-			on_CD = handle_emote_CD()
+				on_CD = handle_emote_CD()
 		if("clap", "claps")
 			on_CD = handle_emote_CD()
 		//Everything else, including typos of the above emotes

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -30,8 +30,14 @@
 	//handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = FALSE
 	act = lowertext(act)
-	switch(act)
-		//Cooldown-inducing emotes
+
+	switch(act)		//This switch makes sure you have air in your lungs before you scream
+		if("growl", "growls", "howl", "howls", "hiss", "hisses", "scream", "screams", "sneeze", "sneezes")
+			if(getOxyLoss() > 35)		//no screaming if you don't have enough breath to scream
+				on_CD = handle_emote_CD()
+				emote("gasp")
+				return
+	switch(act)		//This switch adds cooldowns to some emotes
 		if("ping", "pings", "buzz", "buzzes", "beep", "beeps", "yes", "no", "buzz2")
 			var/found_machine_head = FALSE
 			if(ismachine(src))		//Only Machines can beep, ping, and buzz, yes, no, and make a silly sad trombone noise.
@@ -44,11 +50,7 @@
 					found_machine_head = TRUE
 
 			if(!found_machine_head)								//Everyone else fails, skip the emote attempt
-				return								//Everyone else fails, skip the emote attempt
-		if("growl", "growls", "howl", "howls", "hiss", "hisses", "scream", "screams", "sneeze", "sneezes")
-			if(getOxyLoss() > 35)		//no screaming if you don't have enough breath to scream
-				emote("gasp")
-				return
+				return											//Everyone else fails, skip the emote attempt
 		if("drone","drones","hum","hums","rumble","rumbles")
 			if(isdrask(src))		//Only Drask can make whale noises
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
@@ -137,7 +139,7 @@
 	if(!force && on_CD == 1)		// Check if we need to suppress the emote attempt.
 		return			// Suppress emote, you're still cooling off.
 
-	switch(act)
+	switch(act)		//This is for actually making the emotes happen
 		if("me")									//OKAY SO RANT TIME, THIS FUCKING HAS TO BE HERE OR A SHITLOAD OF THINGS BREAK
 			return custom_emote(m_type, message)	//DO YOU KNOW WHY SHIT BREAKS? BECAUSE SO MUCH OLDCODE CALLS mob.emote("me",1,"whatever_the_fuck_it_wants_to_emote")
 													//WHO THE FUCK THOUGHT THAT WAS A GOOD FUCKING IDEA!?!?

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -45,6 +45,10 @@
 
 			if(!found_machine_head)								//Everyone else fails, skip the emote attempt
 				return								//Everyone else fails, skip the emote attempt
+		if("growl", "growls", "howl", "howls", "hiss", "hisses", "scream", "screams", "sneeze", "sneezes")
+			if(getOxyLoss() > 35)		//no screaming if you don't have enough breath to scream
+				emote("gasp")
+				return
 		if("drone","drones","hum","hums","rumble","rumbles")
 			if(isdrask(src))		//Only Drask can make whale noises
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
@@ -52,20 +56,12 @@
 				return
 		if("howl", "howls")
 			if(isvulpkanin(src))		//Only Vulpkanin can howl
-				if(getOxyLoss() > 35)
-					emote("gasp")
-					return
-				else
-					on_CD = handle_emote_CD(100)
+				on_CD = handle_emote_CD(100)
 			else
 				return
 		if("growl", "growls")
 			if(isvulpkanin(src))		//Only Vulpkanin can growl
-				if(getOxyLoss() > 35)
-					emote("gasp")
-					return
-				else
-					on_CD = handle_emote_CD()
+				on_CD = handle_emote_CD()
 			else
 				return
 		if("squish", "squishes")
@@ -104,11 +100,7 @@
 
 		if("hiss", "hisses")
 			if(isunathi(src)) //Only Unathi can hiss.
-				if(getOxyLoss() > 35)
-					emote("gasp")
-					return
-				else
-					on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
+				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
 			else								//Everyone else fails, skip the emote attempt
 				return
 
@@ -125,11 +117,7 @@
 				return
 
 		if("scream", "screams")
-			if(getOxyLoss() > 35)
-				emote("gasp")
-				return
-			else
-				on_CD = handle_emote_CD(50) //longer cooldown
+			on_CD = handle_emote_CD(50) //longer cooldown
 		if("fart", "farts", "flip", "flips", "snap", "snaps")
 			on_CD = handle_emote_CD()				//proc located in code\modules\mob\emote.dm
 		if("cough", "coughs", "slap", "slaps", "highfive")
@@ -139,11 +127,7 @@
 		if("deathgasp", "deathgasps")
 			on_CD = handle_emote_CD(50)
 		if("sneeze", "sneezes")
-			if(getOxyLoss() > 35)
-				emote("gasp")
-				return
-			else
-				on_CD = handle_emote_CD()
+			on_CD = handle_emote_CD()
 		if("clap", "claps")
 			on_CD = handle_emote_CD()
 		//Everything else, including typos of the above emotes

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -37,6 +37,7 @@
 				on_CD = handle_emote_CD()
 				emote("gasp")
 				return
+				
 	switch(act)		//This switch adds cooldowns to some emotes
 		if("ping", "pings", "buzz", "buzzes", "beep", "beeps", "yes", "no", "buzz2")
 			var/found_machine_head = FALSE

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -52,7 +52,7 @@
 				return
 		if("howl", "howls")
 			if(isvulpkanin(src))		//Only Vulpkanin can howl
-				if(getOxyLoss() > 40)
+				if(getOxyLoss() > 35)
 					emote("gasp")
 					return
 				else
@@ -61,7 +61,7 @@
 				return
 		if("growl", "growls")
 			if(isvulpkanin(src))		//Only Vulpkanin can growl
-				if(getOxyLoss() > 40)
+				if(getOxyLoss() > 35)
 					emote("gasp")
 					return
 				else
@@ -104,7 +104,7 @@
 
 		if("hiss", "hisses")
 			if(isunathi(src)) //Only Unathi can hiss.
-				if(getOxyLoss() > 40)
+				if(getOxyLoss() > 35)
 					emote("gasp")
 					return
 				else
@@ -125,7 +125,7 @@
 				return
 
 		if("scream", "screams")
-			if(getOxyLoss() > 40)
+			if(getOxyLoss() > 35)
 				emote("gasp")
 				return
 			else
@@ -139,7 +139,7 @@
 		if("deathgasp", "deathgasps")
 			on_CD = handle_emote_CD(50)
 		if("sneeze", "sneezes")
-			if(getOxyLoss() > 40)
+			if(getOxyLoss() > 35)
 				emote("gasp")
 				return
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Turns howls, growls, hisses, screams and sneezes into gasps if you have more than 35 oxygen damage
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It seems a bit ridiculous that people who can't gather enough breath to say a single word (happens at 10+ oxy damage) can scream loud enough to be heard 2 screens away. Also prevents people from endlessly screamspamming when being beaten to death but staying alive due to newcrit.
Note: Getting sucked by a vampire would put you at 35+ oxy damage at 140u drained, and kill you at 180, so it would only kick in in the last few seconds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You can no longer use audible emotes when you have 35+ oxygen damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
