### PR TITLE
Fixes #13348 - howls go trough duct tape. Vulp mimes will also mime howling using the *howl emote.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -139,26 +139,24 @@
 													//WHO THE FUCK THOUGHT THAT WAS A GOOD FUCKING IDEA!?!?
 
 		if("howl", "howls")
-			if(isvulpkanin(src)) 				  //Need this again for some reason, although it's already checked earlier
-				var/M = handle_emote_param(param) //Check to see if the param is valid (mob with the param name is in view).
-				if(miming)
-					message = "<B>[src]</B> acts out a howl[M ? " at [M]" : ""]!"
-					m_type = 1
+			var/M = handle_emote_param(param) //Check to see if the param is valid (mob with the param name is in view).
+			if(miming)
+				message = "<B>[src]</B> acts out a howl[M ? " at [M]" : ""]!"
+				m_type = 1
+			else
+				if(!muzzled)
+					message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
+					playsound(loc, 'sound/goonstation/voice/howl.ogg', 100, 1, 10, frequency = get_age_pitch())
+					m_type = 2
 				else
-					if(!muzzled)
-						message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
-						playsound(loc, 'sound/goonstation/voice/howl.ogg', 100, 1, 10, frequency = get_age_pitch())
-						m_type = 2
-					else
-						message = "<B>[src]</B> makes a very loud noise[M ? " at [M]" : ""]."
-						m_type = 2
+					message = "<B>[src]</B> makes a very loud noise[M ? " at [M]" : ""]."
+					m_type = 2
 
 		if("growl", "growls")
-			if(isvulpkanin(src)) 				  //Need this again for some reason, although it's already checked earlier
-				var/M = handle_emote_param(param)
-				message = "<B>[src]</B> growls[M ? " at [M]" : ""]."
-				playsound(loc, "growls", 80, 1, frequency = get_age_pitch())
-				m_type = 2
+			var/M = handle_emote_param(param)
+			message = "<B>[src]</B> growls[M ? " at [M]" : ""]."
+			playsound(loc, "growls", 80, 1, frequency = get_age_pitch())
+			m_type = 2
 
 		if("ping", "pings")
 			var/M = handle_emote_param(param)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -139,16 +139,26 @@
 													//WHO THE FUCK THOUGHT THAT WAS A GOOD FUCKING IDEA!?!?
 
 		if("howl", "howls")
-			var/M = handle_emote_param(param) //Check to see if the param is valid (mob with the param name is in view).
-			message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
-			playsound(loc, 'sound/goonstation/voice/howl.ogg', 100, 1, 10, frequency = get_age_pitch())
-			m_type = 2
+			if(isvulpkanin(src)) 				  //Need this again for some reason, although it's already checked earlier
+				var/M = handle_emote_param(param) //Check to see if the param is valid (mob with the param name is in view).
+				if(miming)
+					message = "<B>[src]</B> acts out a howl[M ? " at [M]" : ""]!"
+					m_type = 1
+				else
+					if(!muzzled)
+						message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
+						playsound(loc, 'sound/goonstation/voice/howl.ogg', 100, 1, 10, frequency = get_age_pitch())
+						m_type = 2
+					else
+						message = "<B>[src]</B> makes a very loud noise[M ? " at [M]" : ""]."
+						m_type = 2
 
 		if("growl", "growls")
-			var/M = handle_emote_param(param)
-			message = "<B>[src]</B> growls[M ? " at [M]" : ""]."
-			playsound(loc, "growls", 80, 1, frequency = get_age_pitch())
-			m_type = 2
+			if(isvulpkanin(src)) 				  //Need this again for some reason, although it's already checked earlier
+				var/M = handle_emote_param(param)
+				message = "<B>[src]</B> growls[M ? " at [M]" : ""]."
+				playsound(loc, "growls", 80, 1, frequency = get_age_pitch())
+				m_type = 2
 
 		if("ping", "pings")
 			var/M = handle_emote_param(param)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -139,7 +139,7 @@
 													//WHO THE FUCK THOUGHT THAT WAS A GOOD FUCKING IDEA!?!?
 
 		if("howl", "howls")
-			var/M = handle_emote_param(param) //Check to see if the param is valid (mob with the param name is in view).
+			var/M = handle_emote_param(param)
 			if(miming)
 				message = "<B>[src]</B> acts out a howl[M ? " at [M]" : ""]!"
 				m_type = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #13348
Adds miming option to *howl
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Howling trough gags is bad
Crew will lynch mime if he/she howls too loud
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Vulp mimes now act out howling
fix: Can no longer howl trough duct tape
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
