### PR TITLE
Removes Tech Storage access from the Roboticist

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -49036,6 +49036,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/flash/synthetic,
+/obj/item/flash/synthetic,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "bNj" = (

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -96,8 +96,8 @@
 	supervisors = "the research director"
 	department_head = list("Research Director")
 	selection_color = "#ffeeff"
-	access = list(ACCESS_ROBOTICS, ACCESS_TOX, ACCESS_TOX_STORAGE, ACCESS_TECH_STORAGE, ACCESS_MORGUE, ACCESS_RESEARCH, ACCESS_MINERAL_STOREROOM) //As a job that handles so many corpses, it makes sense for them to have morgue access.
-	minimal_access = list(ACCESS_ROBOTICS, ACCESS_TECH_STORAGE, ACCESS_MORGUE, ACCESS_RESEARCH, ACCESS_MAINT_TUNNELS, ACCESS_MINERAL_STOREROOM) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	access = list(ACCESS_ROBOTICS, ACCESS_TOX, ACCESS_TOX_STORAGE, ACCESS_MORGUE, ACCESS_RESEARCH, ACCESS_MINERAL_STOREROOM) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	minimal_access = list(ACCESS_ROBOTICS, ACCESS_MORGUE, ACCESS_RESEARCH, ACCESS_MAINT_TUNNELS, ACCESS_MINERAL_STOREROOM) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 	minimal_player_age = 3
 	exp_requirements = 180


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes Tech Storage access from the Roboticist, adds two flashes to their labs to compensate the two they can no longer access in tech storage.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
From what I have heard, the current access Roboticist has to the Tech Storage is a old carry over from when they used to be part of Engineering, and also adds two more flashes to their lab to compensate for the two they can no longer access in tech storage.

As of the moment, Roboticists has no real reason to have anything to do with tech storage, considering the following:

- All boards in Tech Storage are meant to be replacement/emergency parts
- Roboticists has no real, _direct_ use of the storage and it's items, especially since the AI and Robotics related boards are behind another door they have no access to.
- Most Roboticists always ends up taking insulated gloves and the autolathe board/other boards, which are either not part of their job (insulated gloves), or can be easily created by science (autolathe/other boards).

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/32376559/80752141-e0147a80-8adf-11ea-9dc9-14ed7e945386.png)
Flashes added at the green markings, on top of two previously existing flashes.
## Changelog
:cl: Quantum-M
del: Removes tech storage access from the Roboticists.
add: Two flashes added to robotics lab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
