### PR TITLE
Fixes ticker force-end

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -97,7 +97,7 @@ SUBSYSTEM_DEF(ticker)
 				mode.check_finished() // some modes contain var-changing code in here, so call even if we don't uses result
 			else
 				game_finished |= mode.check_finished()
-			if(game_finished)
+			if(game_finished || force_ending)
 				current_state = GAME_STATE_FINISHED
 		if(GAME_STATE_FINISHED)
 			current_state = GAME_STATE_FINISHED


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the force-end on the ticker, which was stopping the server from auto rebooting after a malf AI had triggered doomsday.

Testing and working
![image](https://user-images.githubusercontent.com/25063394/80754600-32c55500-8b27-11ea-805e-7a8ffe9e5c0b.png)

Normally I would suggest killing the person responsible for this, but uhh.
![image](https://user-images.githubusercontent.com/25063394/80754575-280ac000-8b27-11ea-9eb8-d847d81e0a51.png)
*moving on*

## Why It's Good For The Game
The ticker should function properly

## Changelog
:cl: AffectedArc07
fix: The round will actually end properly now if a malf AI uses doomsday
/:cl:
