### PR TITLE
Update mob glide_size prior to movement

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -187,8 +187,16 @@
 			direct = newdir
 			n = get_step(mob, direct)
 
+	delay = TICKS2DS(-round(-(DS2TICKS(delay)))) //Rounded to the next tick in equivalent ds
+	mob.glide_size = world.icon_size/max(DS2TICKS(delay),1) //Down to whatever decimal
+	
 	. = ..()
 	mob.setDir(direct)
+
+	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
+		delay = mob.movement_delay() * 2 //Will prevent mob diagonal moves from smoothing accurately, sadly
+
+	move_delay += delay
 
 	for(var/obj/item/grab/G in mob)
 		if(G.state == GRAB_NECK)
@@ -196,9 +204,7 @@
 		G.adjust_position()
 	for(var/obj/item/grab/G in mob.grabbed_by)
 		G.adjust_position()
-	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
-		delay = mob.movement_delay() * 2
-	move_delay += delay
+
 	moving = 0
 	if(mob && .)
 		if(mob.throwing)


### PR DESCRIPTION
## What Does This PR Do
Adjusts mob glide_size prior to movement to smooth movement depending on your mob's next available movement time.

## What Does This PR Do - The Long Version
glide_size is the number of pixels per tick to move the sprite during movement glides to adjacent turfs. /tg/ and Bay seem to have opted to just make this number 8, for whatever reason. Instead, you can do math to figure out how long you have in ticks until the next movement is possible, and allow that much time for gliding by adjusting glide_size appropriately.

This is a port of my PR, https://github.com/VOREStation/VOREStation/pull/7534

You may want some of the other changes there, too, since I see you still have ye olde client/Move() for the most part. Note that this only affects client/Move(), so only player-controlled mobs.

## Why It's Good For The Game
It looks nice, removes the 'jumpies', and a cat that used to work here told me a fox that works here might want it.

## Images of changes
**Running:**
![para_run](https://user-images.githubusercontent.com/15028025/80774280-8dac7b80-8b2a-11ea-93d3-357a13306437.gif)

**Walking:**
![para_walk](https://user-images.githubusercontent.com/15028025/80774287-92712f80-8b2a-11ea-8c7d-c9fed64e9fd8.gif)

## Changelog
:cl:
tweak: Adjust mob.glide_size in client/Move()
/:cl: