### PR TITLE
Removes Security Locker from the Cyberiad Checkpoint

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -26499,7 +26499,6 @@
 	},
 /area/security/checkpoint2)
 "aWd" = (
-/obj/structure/closet/secure_closet/security,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -26507,6 +26506,10 @@
 	dir = 2;
 	pixel_y = 24
 	},
+/obj/structure/closet,
+/obj/item/crowbar,
+/obj/item/radio,
+/obj/item/flash,
 /turf/simulated/floor/plasteel{
 	icon_state = "red";
 	dir = 9
@@ -27265,9 +27268,6 @@
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint2)
 "aXB" = (
-/obj/structure/closet,
-/obj/item/crowbar,
-/obj/item/flash,
 /turf/simulated/floor/plasteel{
 	icon_state = "red";
 	dir = 8
@@ -28117,7 +28117,6 @@
 	},
 /area/security/checkpoint2)
 "aZb" = (
-/obj/item/radio,
 /obj/item/radio/intercom/department/security{
 	pixel_x = 0;
 	pixel_y = -28


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes the Security locker in the Cyberiad Checkpoint, moving the regular locker that was in the checkpoint, it's contents, and a hand held radio that was in the corner onto the spot the security locker was at.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The intent is to both prevent antags from getting nearly free security gear (if they have an emag or have access to security, like the HoP) and to prevent that meta Security Officers has had lately in pulling the Checkpoint locker into Security the moment they get a chance to do so.

I don't think antags, specifically traitors, should easily get Security gear, like the stun baton, hud glasses, and the security bowman headset with a low amount of risk, especially since those can prevent flashes and the effects of flashbangs together, compared to breaking into security or stealing them from a security staff.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/32376559/80831842-5f698300-8ba0-11ea-9249-a19dbbb29f7e.png)

## Changelog
:cl: Quantum-M
del: Removes the Security Locker from the Cyberiad Checkpoint.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
