### PR TITLE
Remove Default Donks

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -721,7 +721,6 @@
 /area/shuttle/abandoned)
 "abN" = (
 /obj/structure/table,
-/obj/item/storage/box/syndidonkpockets,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -142,7 +142,6 @@
 /area/shuttle/syndicate)
 "aap" = (
 /obj/structure/table,
-/obj/item/storage/box/syndidonkpockets,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -804,7 +804,6 @@
 /area/security/range)
 "acd" = (
 /obj/structure/table,
-/obj/item/storage/box/syndidonkpockets,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},


### PR DESCRIPTION
Donk pockets were underutilized (and still are, to some degree) for a long time---but as time has progressed there's been more and more tools added for nuke ops for dealing with different situations and movement hindrances. At this stage, the donks are just a bit redundant.

Furthermore, when utilized properly and strategically it borders on the degree of being abusive--especially when stacked with things that limited stuns or cancel them out entirely.

Either case, this removes the donks--not because people are killign themselves or gagging themselves to death in combat situations, but because of the effectiveness they have for players who are skilled at utilizing them.

Not more freebies

:cl: Fox McCloud
del: removes round-start syndie-donks from nukies
/:cl: