### PR TITLE
Revert "Update mob glide_size prior to movement"

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -187,16 +187,8 @@
 			direct = newdir
 			n = get_step(mob, direct)
 
-	delay = TICKS2DS(-round(-(DS2TICKS(delay)))) //Rounded to the next tick in equivalent ds
-	mob.glide_size = world.icon_size/max(DS2TICKS(delay),1) //Down to whatever decimal
-	
 	. = ..()
 	mob.setDir(direct)
-
-	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
-		delay = mob.movement_delay() * 2 //Will prevent mob diagonal moves from smoothing accurately, sadly
-
-	move_delay += delay
 
 	for(var/obj/item/grab/G in mob)
 		if(G.state == GRAB_NECK)
@@ -204,7 +196,9 @@
 		G.adjust_position()
 	for(var/obj/item/grab/G in mob.grabbed_by)
 		G.adjust_position()
-
+	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
+		delay = mob.movement_delay() * 2
+	move_delay += delay
 	moving = 0
 	if(mob && .)
 		if(mob.throwing)


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#13357

After speaking with people ingame (players, admins, mentors), no one has really said that this is a positive improvement. Movement while moving really slow may look smooth, however moving at normal speed just looks jarring. Not to mention that when you pull objects they lag behind you and sort of jitter about, and it just looks really jarring.

Closes #13363

![9JI5ctMfag](https://user-images.githubusercontent.com/25063394/80865706-00306f00-8c83-11ea-85da-dd0ceac428c2.gif)
