### PR TITLE
Fix up smooth movement issues

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -302,7 +302,7 @@
 			T = get_step(T, direct)
 		console.jump_on_click(src, T)
 		return
-	return ..(n,direct)
+	return ..()
 
 // Other computer monitors.
 /obj/machinery/computer/security/telescreen

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -400,7 +400,9 @@
 							var/turf/newloc = G.affecting.loc
 							if(isturf(oldloc) && isturf(newloc))
 								SpinAnimation(5,1)
+								glide_for(6) // This and the glide_for below are purely arbitrary. Pick something that looks aesthetically pleasing.
 								forceMove(newloc)
+								G.glide_for(6)
 								G.affecting.forceMove(oldloc)
 								message = "<B>[src]</B> flips over [G.affecting]!"
 						else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -511,7 +511,7 @@
 
 	return
 
-/mob/living/Move(atom/newloc, direct)
+/mob/living/Move(atom/newloc, direct, movetime)
 	if(buckled && buckled.loc != newloc) //not updating position
 		if(!buckled.anchored)
 			return buckled.Move(newloc, direct)
@@ -544,7 +544,7 @@
 					var/mob/living/M = pulling
 					if(M.lying && !M.buckled && (prob(M.getBruteLoss() * 200 / M.maxHealth)))
 						M.makeTrail(T)
-				pulling.Move(T, get_dir(pulling, T)) // the pullee tries to reach our previous position
+				pulling.Move(T, get_dir(pulling, T), movetime) // the pullee tries to reach our previous position
 				if(pulling && get_dist(src, pulling) > 1) // the pullee couldn't keep up
 					stop_pulling()
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -495,7 +495,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	if(!path)
 		return 0
 	if(path.len > 1)
-		step_towards(src, path[1])
+		Move(path[1], get_dir(src, path[1]), BOT_STEP_DELAY)
 		if(get_turf(src) == path[1]) //Successful move
 			increment_path()
 			tries = 0

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -143,8 +143,10 @@
 		move_delay = world.time
 	mob.last_movement = world.time
 
+	delay = TICKS2DS(-round(-(DS2TICKS(delay)))) //Rounded to the next tick in equivalent ds
+
 	if(locate(/obj/item/grab, mob))
-		move_delay = max(move_delay, world.time + 7)
+		delay += 7
 		var/list/L = mob.ret_grab()
 		if(istype(L, /list))
 			if(L.len == 2)
@@ -153,14 +155,14 @@
 				if(M)
 					if((get_dist(mob, M) <= 1 || M.loc == mob.loc))
 						var/turf/prev_loc = mob.loc
-						. = ..()
+						. = mob.SelfMove(n, direct, delay)
 						if(M && isturf(M.loc)) // Mob may get deleted during parent call
 							var/diag = get_dir(mob, M)
 							if((diag - 1) & diag)
 							else
 								diag = null
 							if((get_dist(mob, M) > 1 || diag))
-								step(M, get_dir(M.loc, prev_loc))
+								M.Move(prev_loc, get_dir(M.loc, prev_loc), delay)
 			else
 				for(var/mob/M in L)
 					M.other_mobs = 1
@@ -168,12 +170,10 @@
 						M.animate_movement = 3
 				for(var/mob/M in L)
 					spawn(0)
-						step(M, direct)
-						return
+						M.Move(get_step(M,direct), direct, delay)
 					spawn(1)
 						M.other_mobs = null
 						M.animate_movement = 2
-						return
 
 	else if(mob.confused)
 		var/newdir = 0
@@ -186,11 +186,8 @@
 		if(newdir)
 			direct = newdir
 			n = get_step(mob, direct)
-
-	delay = TICKS2DS(-round(-(DS2TICKS(delay)))) //Rounded to the next tick in equivalent ds
-	mob.glide_size = world.icon_size/max(DS2TICKS(delay),1) //Down to whatever decimal
 	
-	. = ..()
+	. = mob.SelfMove(n, direct, delay)
 	mob.setDir(direct)
 
 	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
@@ -214,8 +211,8 @@
 		O.on_mob_move(direct, mob)
 
 
-
-
+/mob/proc/SelfMove(turf/n, direct, movetime)
+	return Move(n, direct, movetime)
 
 ///Process_Grab()
 ///Called by client/Move()

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -92,7 +92,7 @@
 		bed = null
 	. = ..()
 	if(bed && get_dist(oldloc, loc) <= 2)
-		bed.Move(oldloc)
+		bed.Move(oldloc, get_dir(bed, oldloc), (last_move_diagonal? 2 : 1) * (vehicle_move_delay + config.human_delay))
 		bed.dir = Dir
 		if(bed.has_buckled_mobs())
 			for(var/m in bed.buckled_mobs)

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -44,7 +44,7 @@
 	origin_tech = "materials=3;engineering=4"
 
 /obj/vehicle/janicart/Move(atom/OldLoc, Dir)
-	..()
+	. = ..()
 	if(floorbuffer)
 		var/turf/tile = loc
 		if(isturf(tile))

--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -153,7 +153,8 @@
 		unbuckle_mob(user)
 		return
 
-	if(world.time < last_vehicle_move + ((last_move_diagonal? 2 : 1) * (vehicle_move_delay + config.human_delay)))
+	var/delay = (last_move_diagonal? 2 : 1) * (vehicle_move_delay + config.human_delay)
+	if(world.time < last_vehicle_move + delay)
 		return
 	last_vehicle_move = world.time
 
@@ -161,7 +162,7 @@
 		var/turf/next = get_step(src, direction)
 		if(!Process_Spacemove(direction) || !isturf(loc))
 			return
-		step(src, direction)
+		Move(get_step(src, direction), direction, delay)
 
 		if((direction & (direction - 1)) && (loc == next))		//moved diagonally
 			last_move_diagonal = TRUE
@@ -185,7 +186,7 @@
 		to_chat(user, "<span class='warning'>You'll need the keys in one of your hands to drive [src].</span>")
 
 
-/obj/vehicle/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0)
+/obj/vehicle/Move(NewLoc, Dir = 0, movetime)
 	. = ..()
 	handle_vehicle_layer()
 	handle_vehicle_offsets()


### PR DESCRIPTION
## What Does This PR Do
Fixes up some oversights in the mob smooth movement PR, namely when things that aren't you want to move with you (pulling, grabs, vehicles, flips over people, beepsky, etc)

## Why It's Good For The Game
Looks nicer
Fixes #13363 (?) Though the issues in that issue sound somewhat like a byond version issue. Nobody downstream running 513 has noticed any sort of instajumps, unless it was related to the issues fixed in this one.

## Images of changes
![ezgif-7-3c918878e8f0](https://user-images.githubusercontent.com/15028025/80873251-2d7e1c80-8c85-11ea-87df-5693ed6c40b2.gif)
![2020-05-02_15-01-26](https://user-images.githubusercontent.com/15028025/80873337-d75da900-8c85-11ea-9375-e52efca0f18c.gif)


## Changelog
:cl:
fix: fix a few mob smooth movement issues
/:cl: