### PR TITLE
Blobbernauts can now use the Say verb to automatically speak into the blob hivemind

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -226,6 +226,7 @@
 
 #define isAIEye(A)		(istype((A), /mob/camera/aiEye))
 #define isovermind(A)	(istype((A), /mob/camera/blob))
+#define isblobbernaut(A)	(istype((A), /mob/living/simple_animal/hostile/blob/blobbernaut))
 
 #define isSpirit(A)		(istype((A), /mob/spirit))
 #define ismask(A)		(istype((A), /mob/spirit/mask))

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -200,18 +200,26 @@
 		return FALSE
 	flick("blobbernaut_death", src)
 
-/mob/living/simple_animal/hostile/blob/blobbernaut/verb/communicate_overmind()
-	set category = "Blobbernaut"
-	set name = "Blob Telepathy"
-	set desc = "Send a message to the Overmind"
+/mob/living/simple_animal/hostile/blob/blobbernaut/say(message, verb, sanitize, ignore_speech_problems, ignore_atmospherics)
+	if(!message)
+		return
 
-	if(stat != DEAD)
-		blob_talk()
+	if(client)
+		if(client.prefs.muted & MUTE_IC)
+			to_chat(src, "You cannot send IC messages (muted).")
+			return
+		if(client.handle_spam_prevention(message, MUTE_IC))
+			return
 
-/mob/living/simple_animal/hostile/blob/blobbernaut/proc/blob_talk()
-	var/message = input(src, "Announce to the overmind", "Blob Telepathy")
-	var/rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]([overmind])</span> <span class='message'>states, \"[message]\"</span></span></i></font>"
-	if(message)
-		for(var/mob/M in GLOB.mob_list)
-			if(isovermind(M) || isobserver(M) || istype((M), /mob/living/simple_animal/hostile/blob/blobbernaut))
-				M.show_message(rendered, 2)
+	if(stat == DEAD)
+		return
+
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	log_say("(BLOBBERNAUT) [message]", src)
+
+	var/rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]([overmind])</span> \
+					<span class='message'>states, \"[message]\"</span></span></i></font>"
+	for(var/M in GLOB.mob_list)
+		var/mob/listener = M
+		if(isovermind(listener) || isobserver(listener) || isblobbernaut(listener))
+			listener.show_message(rendered, 2)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -85,7 +85,7 @@
 	var/rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]([blob_reagent_datum.name])</span> <span class='message'>[verb] \"[message]\"</span></span></i></font>"
 
 	for(var/mob/M in GLOB.mob_list)
-		if(isovermind(M) || isobserver(M) || istype((M), /mob/living/simple_animal/hostile/blob/blobbernaut))
+		if(isovermind(M) || isobserver(M) || isblobbernaut(M))
 			M.show_message(rendered, 2)
 
 /mob/camera/blob/emote(act, m_type = 1, message = null, force)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces the blobbernaut telepathy verb in favor of simply using "Say" to communicate over the blob hivemind.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I believe this will make it more user-friendly and less annoying because it eliminates the need to click on a verb every time you want to speak in the hivemind. Also this verb was especially bad since it created an entirely new verb tab just for itself.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Blobbernauts can now speak in the blob hivemind by using the Say verb.
del: Blobbernauts can no longer speak out loud.
del: Removed Blobbernaut's "Blob telepathy" verb and the removed the Blobbernaut verb tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
