### PR TITLE
Newcrit Death Threshold Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -810,7 +810,9 @@
 
 		handle_organs()
 
-		if(getBrainLoss() >= 120 || (health + (getOxyLoss() / 2)) <= -500)
+		var/guaranteed_death_threshold = health + (getOxyLoss() * 0.5) - (getFireLoss() * 0.67) - (getBruteLoss() * 0.67)
+
+		if(getBrainLoss() >= 120 || (guaranteed_death_threshold) <= -500)
 			death()
 			return
 


### PR DESCRIPTION
Credit to Goon for this one.

Tweaks newcrit just a bit to make brute and burn damage more effective towards killing someone.

This does not increase the probability of them dying from brute/burn---that remains unchanged---changing that is likely to have negative consequences that'll make treating deeply critical patients far more frustrating than it should be.

This alters the absolute threshold for dying from these damage types, by making brute and burn both count for 67% more towards that threshold.

What this means: you'll die, absolutely, if you've taken 360 brute (or burn, or combination there-of) damage, instead of 500. Toxin's weighting is the same (500 total), as is Oxy total (1000).

This should make engagements that are clearly one-sided less time consuming to finish while ultimately not impacting, much, the overall medical treatment system.

:cl: Fox McCloud
tweak: Brute and burn damage thresholds for death lowered from 500 to 360
/:cl: