### PR TITLE
The logviewer will now work if you have invalid mobs in your selection

### DIFF
--- a/code/datums/log_viewer.dm
+++ b/code/datums/log_viewer.dm
@@ -112,6 +112,9 @@
 	dat += "<span>Mobs being used:</span>"
 	for(var/i in selected_mobs)
 		var/mob/M = i
+		if(QDELETED(M))
+			selected_mobs -= i
+			continue
 		dat += "<a href='?src=[UID()];remove_mob=\ref[M]'>[M.name]</a>"
 	dat += "<a href='?src=[UID()];add_mob=1'>Add Mob</a>"
 	dat += "<a href='?src=[UID()];clear_mobs=1'>Clear All Mobs</a>"


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime happening when the UI is shown and a selected mob is null

fixes:
```
[2020-05-03T16:24:35] Runtime in log_viewer.dm,115: Cannot read null.name
   proc name: show ui (/datum/log_viewer/proc/show_ui)
   usr: NAME (CKEY) (/mob/dead/observer)
   usr.loc: The plating (197,119,1) (/turf/simulated/floor/plating)
   src: /datum/log_viewer (/datum/log_viewer)
   call stack:
   /datum/log_viewer (/datum/log_viewer): show ui(NAME (/mob/dead/observer))
   CKEY (/client): Open Logging View()
```

## Why It's Good For The Game
Makes admins able to open the logging view without having to varedit the global.

## Changelog
:cl:
fix: The logviewer now works if a mob is deleted and is still in the mobs selection
/:cl: