### PR TITLE
Applicator QoL Tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -205,7 +205,7 @@
 	if(empty)
 		return
 	new /obj/item/reagent_containers/hypospray/combat(src)
-	new /obj/item/reagent_containers/applicator/dual(src) // Because you ain't got no time to look at what damage dey taking yo
+	new /obj/item/reagent_containers/applicator/dual/syndi(src) // Because you ain't got no time to look at what damage dey taking yo
 	new /obj/item/defibrillator/compact/combat/loaded(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -103,7 +103,7 @@
 		return
 	if(alert(usr, "Are you sure you want to empty [src]?", "Empty Applicator:", "Yes", "No") != "Yes")
 		return
-	if(isturf(usr.loc) && loc == usr)
+	if(!usr.incapacitated() && isturf(usr.loc) && loc == usr)
 		to_chat(usr, "<span class='notice'>You empty [src] onto the floor.</span>")
 		reagents.reaction(usr.loc)
 		reagents.clear_reagents()

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -5,6 +5,7 @@
 	icon_state = "mender"
 	item_state = "mender"
 	volume = 200
+	possible_transfer_amounts = null
 	resistance_flags = ACID_PROOF
 	container_type = REFILLABLE | AMOUNT_VISIBLE
 	temperature_min = 270
@@ -93,6 +94,20 @@
 
 		playsound(get_turf(src), pick('sound/goonstation/items/mender.ogg', 'sound/goonstation/items/mender2.ogg'), 50, 1)
 
+/obj/item/reagent_containers/applicator/verb/empty()
+	set name = "Empty Applicator"
+	set category = "Object"
+	set src in usr
+
+	if(usr.incapacitated())
+		return
+	if(alert(usr, "Are you sure you want to empty [src]?", "Empty Applicator:", "Yes", "No") != "Yes")
+		return
+	if(isturf(usr.loc) && loc == usr)
+		to_chat(usr, "<span class='notice'>You empty [src] onto the floor.</span>")
+		reagents.reaction(usr.loc)
+		reagents.clear_reagents()
+
 /obj/item/reagent_containers/applicator/brute
 	name = "brute auto-mender"
 	list_reagents = list("styptic_powder" = 200)
@@ -104,3 +119,6 @@
 /obj/item/reagent_containers/applicator/dual
 	name = "dual auto-mender"
 	list_reagents = list("synthflesh" = 200)
+
+/obj/item/reagent_containers/applicator/dual/syndi // It magically goes through hardsuits. Don't ask how.
+	ignore_flags = TRUE


### PR DESCRIPTION
Just a few applicator tweaks, to make it easier to use.

- Applicators can now be emptied with a "empty applicator" verb. 
- Applicators no longer have the ability to set transfer amounts (which did nothing)
- Synthflesh applicator in the syndi tactical first aid kit can pierce hardsuits (don't ask how)

:cl: Fox McCloud
tweak: Applicators no longer have an erroneous "set transfer amount" menu
tweak: Applicators can now be emptied of all their reagents
tweak: Syndicate dual applicator in the tactical first aid kit can pierce hardsuits (don't ask how)
/:cl:
