### PR TITLE
Adds MC VIEWING to the VIEWRUNTIMES permission

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -964,8 +964,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		for(var/obj/effect/proc_holder/spell/S in mind.spell_list)
 			add_spell_to_statpanel(S)
 
-
-	if(is_admin(src))
+	// Allow admins + PR reviewers to VIEW the panel. Doesnt mean they can click things.
+	if(is_admin(src) || check_rights(R_VIEWRUNTIMES))
 		if(statpanel("MC")) //looking at that panel
 			var/turf/T = get_turf(client.eye)
 			stat("Location:", COORD(T))


### PR DESCRIPTION
## What Does This PR Do
This PR allows people with the VIEWRUNTIMES to **VIEW** the MC panel. They __cannot__ open the varedit panel or manipulate anything on the panel itself, its purely a viewer to be able to read what subsystems are processing when, whats holding the CPU up, etc. It also allows them to see if a specific subsystem has catastrophically failed, and gives us a pinpoint of what runtimes to look for.

*Example of useful information that can be attained*
![image](https://user-images.githubusercontent.com/25063394/81052983-4e7c8280-8ebc-11ea-8456-dc69bdd73278.png)

## Why It's Good For The Game
More information is available to those who can help solve problems

## Changelog
:cl: AffectedArc07
tweak: The VIEWRUNTIMES permission now grants view-only access to the MC panel. No modifications can be made.
/:cl:
