### PR TITLE
Removes fires from depot

### DIFF
--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -6363,7 +6363,7 @@
 	icon_state = "sink";
 	pixel_x = 12
 	},
-/turf/simulated/floor/mineral/plasma,
+/turf/simulated/floor/mineral/silver,
 /area/syndicate_depot/core)
 "of" = (
 /obj/structure/closet/secure_closet/syndicate/depot,
@@ -6448,25 +6448,8 @@
 	icon_state = "wood"
 	},
 /area/derelict/crew_quarters)
-"oo" = (
-/obj/effect/spawner/random_spawners/syndicate/layout/door/secret,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/syndicate_depot/core)
 "op" = (
 /turf/simulated/floor/mineral/silver,
-/area/syndicate_depot/core)
-"oq" = (
-/obj/machinery/door/airlock/plasma{
-	welded = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/syndicate_depot/core)
-"or" = (
-/turf/simulated/floor/mineral/plasma,
 /area/syndicate_depot/core)
 "os" = (
 /obj/structure/table,
@@ -6543,7 +6526,7 @@
 /area/syndicate_depot/core)
 "oB" = (
 /obj/effect/spawner/random_spawners/syndicate/mob,
-/turf/simulated/floor/mineral/plasma,
+/turf/simulated/floor/mineral/silver,
 /area/syndicate_depot/core)
 "oC" = (
 /obj/effect/landmark{
@@ -6706,27 +6689,14 @@
 	icon_state = "dark"
 	},
 /area/syndicate_depot/core)
-"oZ" = (
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/turf/simulated/floor/mineral/plasma,
-/area/syndicate_depot/core)
 "pa" = (
 /obj/structure/toilet{
 	dir = 8
 	},
 /turf/simulated/floor/mineral/silver,
 /area/syndicate_depot/core)
-"pb" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/syndicate_depot/core)
 "pc" = (
 /obj/machinery/light,
-/obj/effect/spawner/random_spawners/syndicate/loot/level3,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -11582,10 +11552,10 @@
 	},
 /area/space/nearstation)
 "zR" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -57707,7 +57677,7 @@ of
 ot
 mA
 mA
-pb
+nX
 pi
 mA
 py
@@ -59251,7 +59221,7 @@ oE
 oR
 oE
 oz
-pb
+mA
 mA
 mA
 mm
@@ -61558,7 +61528,7 @@ mm
 mB
 mm
 mm
-oo
+mm
 mm
 lV
 mA
@@ -61816,7 +61786,7 @@ mA
 zP
 mm
 zR
-oo
+mm
 oL
 ns
 mA
@@ -62072,7 +62042,7 @@ mA
 mA
 mt
 mm
-oq
+mm
 mm
 mm
 mm
@@ -62332,7 +62302,7 @@ mm
 op
 oB
 oM
-oZ
+oM
 ob
 mA
 pu
@@ -62586,7 +62556,7 @@ zP
 mA
 mA
 ob
-or
+op
 nJ
 oe
 pa

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -289,7 +289,6 @@
 		/obj/item/clothing/glasses/thermal = 1,
 		/obj/item/chameleon = 1,
 		/obj/item/reagent_containers/hypospray/autoinjector/stimulants = 1,
-		/obj/item/storage/box/syndie_kit/atmosn2ogrenades = 1,
 		/obj/item/grenade/plastic/x4 = 1)
 
 
@@ -303,11 +302,6 @@
 	result = list(/obj/machinery/door/airlock/hatch/syndicate = 6,
 		/turf/simulated/wall/mineral/plastitanium/nodiagonal = 2,
 		/obj/structure/falsewall/plastitanium = 2)
-
-/obj/effect/spawner/random_spawners/syndicate/layout/door/secret
-	name = "50pc falsewall 50pc wall"
-	result = list(/turf/simulated/wall/mineral/plastitanium/nodiagonal = 1,
-		/obj/structure/falsewall/plastitanium = 1)
 
 /obj/effect/spawner/random_spawners/syndicate/layout/door/vault
 	name = "80pc vaultdoor 20pc wall"

--- a/code/game/objects/structures/depot.dm
+++ b/code/game/objects/structures/depot.dm
@@ -79,7 +79,6 @@
 	var/beepsound = 'sound/items/timer.ogg'
 	var/deliberate = FALSE
 	var/max_cycles = 10
-	var/max_fire_range = 9
 	var/area/syndicate_depot/core/depotarea
 
 /obj/effect/overload/New()
@@ -101,10 +100,6 @@
 		if(!deliberate)
 			playsound(loc, beepsound, 50, 0)
 		cycles++
-		var/fire_range = min(cycles, max_fire_range)
-
-		for(var/turf/simulated/turf in range(fire_range, T))
-			new /obj/effect/hotspot(turf)
 		return
 
 	if(!istype(depotarea))


### PR DESCRIPTION
## What Does This PR Do
1) The depot reactor self destruct no longer spreads fire.
2) Sources of plasma have been removed from the depot. This includes tanks of plasma, a plasma airlock, and plasma floor tiles on the east side of the depot.
3) N2O gas grenade has been removed from depot armory loot table.

## Why It's Good For The Game
Recently, we have been having some issues where by the MC (master controller, a crucial piece of game code) would crash while atmos stuff was going on in the depot.
This series of changes is intended to prevent atmos stuff in the depot from affecting the stability of the server overall.

## Images of changes
Before:
![depot_tank_changes](https://user-images.githubusercontent.com/16434066/81332365-863d2300-9092-11ea-9f9e-f4167443efab.png)

After:
![depot_new](https://user-images.githubusercontent.com/16434066/81331488-3447cd80-9091-11ea-82a0-5a9a48a19bb7.png)
The two smaller red-boxed areas in this image have had plasma tanks removed from them.
The larger red-boxed area on the right has had a plasma tank, plasma airlock, plasma floor tiles, and falsewall spawners removed.

## Changelog
:cl: Kyep
fix: Removed fire-based hazards from depot, for the sake of server stability.
/:cl: