### PR TITLE
Fixes the sensory restoration symptom message

### DIFF
--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -62,4 +62,4 @@ Bonus
 					M.reagents.add_reagent("oculine", 20)
 			else
 				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-					to_chat(M, "<span class='notice'>[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your ears feel great.","Your healing feels more acute.")]</span>")
+					to_chat(M, "<span class='notice'>[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your eyes feel great.","Your hearing feels more acute.")]</span>")


### PR DESCRIPTION
Fixed the "Your healing feels more acute" to "your hearing feels more acute" and "your ears feel great" to "your eyes feel great"

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #11022

Just a small fix fixing the positive message given from the virus symptom sensory. The messages should now read as "Your hearing feels more acute" instead of "Your healing feels more acute" and "your eyes feel great" instead of "your ears feel great"

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Small change just to improve on some small mistakes/typos.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![eyes feels](https://user-images.githubusercontent.com/59520813/81333597-2308bc00-90a5-11ea-8980-8eec8176e5eb.png)


![hearing feels](https://user-images.githubusercontent.com/59520813/81333605-2734d980-90a5-11ea-8ce1-e6f26e25aa1c.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:

spellcheck: Changed "Your healing feels more acute" to "your hearing feels more acute" and "your ears feel great" to "your eyes feel great"

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
