### PR TITLE
Shock Proof Heart

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -238,6 +238,8 @@
 /obj/item/organ/internal/heart/cybernetic/upgraded/shock_organ(intensity)
 	if(!ishuman(owner))
 		return
+	if(emp_proof)
+		return
 	intensity = min(intensity, 100)
 	var/numHigh = round(intensity / 5)
 	var/numMid = round(intensity / 10)


### PR DESCRIPTION
Upgraded hearts that are `emp_proof` no longer suffer ill effects from being shocked, either.

`emp_proof` isn't accessible to players, but is generally useful for admin bus for making stronger organs that don't have the drawbacks to emp---that said, the upgraded heart still had an obvious weakness vector; just shocking the person. This shouldn't really be.

:cl: Fox McCloud
tweak: emp proof upgraded hearts are no longer vulnerable to shocks
/:cl: