### PR TITLE
Makes trail_holders (blood trails) invisible upon examine. Fixing a client hang/crash

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -112,7 +112,8 @@ GLOBAL_LIST_EMPTY(splatter_cache)
 
 /obj/effect/decal/cleanable/trail_holder //not a child of blood on purpose
 	name = "blood"
-	icon_state = "ltrails_1"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "nothing"
 	desc = "Your instincts say you shouldn't be following these."
 	gender = PLURAL
 	density = FALSE


### PR DESCRIPTION
## What Does This PR Do
Makes blood not lag you to pieces when you examine it.
Made the icon be nothing. Currently it'll load up a random icon dmi which will at best hang the client and at it's worst crash it.
I made it nothing because otherwise the logic behind the blood would break

Fixes #13000
Probably fixes #13242 

## Why It's Good For The Game
Less issues is better.

## Changelog
:cl:
fix: Makes blood trials have an invisible icon. Currently they have a corrupt one breaking the client at worst
/:cl: