### PR TITLE
Fixes Chainsaw hitsound

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -542,6 +542,7 @@
 	w_class = WEIGHT_CLASS_BULKY // can't fit in backpacks
 	force_unwielded = 15 //still pretty robust
 	force_wielded = 40  //you'll gouge their eye out! Or a limb...maybe even their entire body!
+	hitsound = null // Handled in the snowflaked attack proc
 	wieldsound = 'sound/weapons/chainsawstart.ogg'
 	hitsound = null
 	armour_penetration = 35


### PR DESCRIPTION
Fixes the chainsaw effectively having two hitsounds, the standard swing hit and the chainsaw sound.

:cl: Fox McCloud
fix: Fixes chainsaws having two hitsounds
/:cl: