### PR TITLE
Makes it so you can't repair wooden barricades with a welder

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -30,6 +30,8 @@
 		new stacktype(get_turf(src), drop_amount)
 
 /obj/structure/barricade/welder_act(mob/user, obj/item/I)
+	if(bar_material != METAL)
+		return
 	if(obj_integrity >= max_integrity)
 		to_chat(user, "<span class='notice'>[src] does not need repairs.</span>")
 		return
@@ -71,8 +73,6 @@
 	bar_material = WOOD
 	stacktype = /obj/item/stack/sheet/wood
 
-/obj/structure/barricade/wooden/welder_act(mob/user, obj/item/I)
-  return
 
 /obj/structure/barricade/wooden/attackby(obj/item/I, mob/user)
 	if(istype(I,/obj/item/stack/sheet/wood))

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -71,6 +71,9 @@
 	bar_material = WOOD
 	stacktype = /obj/item/stack/sheet/wood
 
+/obj/structure/barricade/wooden/welder_act(mob/user, obj/item/I)
+  return
+
 /obj/structure/barricade/wooden/attackby(obj/item/I, mob/user)
 	if(istype(I,/obj/item/stack/sheet/wood))
 		var/obj/item/stack/sheet/wood/W = I


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #13259
You will now hit the barricade with a welder, even on help intent. Makes Wooden barricades non repairable.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to repair wooden barricades with a welder makes no sense, and will blind people thinking the same while trying to attack it with a welder on help intent.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![am8dXeocIj](https://user-images.githubusercontent.com/59520813/81396607-019be480-9126-11ea-9246-076a1078a747.gif)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:

fix: Makes the wooden barricades non repairable with a welder.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
