### PR TITLE
Borgs can no longer access mounted defibs

### DIFF
--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -15,6 +15,9 @@
 	var/obj/item/defibrillator/defib //this mount's defibrillator
 	var/clamps_locked = FALSE //if true, and a defib is loaded, it can't be removed without unlocking the clamps
 
+/obj/machinery/defibrillator_mount/attack_ai()
+	return
+
 /obj/machinery/defibrillator_mount/get_cell()
 	if(defib)
 		return defib.get_cell()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #13383
Makes it so that borgs can not use mounted defibrillators at all. Previous issue with borgs being able to access them from range and drop the paddles on the floor under them, Borgs will now not be able to use them at all.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents and issue with them being able to drop the paddles under them away from the mount itself, and then being unable to put them back in or use them after.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Images of changes
![8xob3E6ECj](https://user-images.githubusercontent.com/59520813/81409070-b6420000-913e-11ea-9c7f-4200cd86dda7.gif)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:

tweak: Made borgs be unable to access mounted defibrillators 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
