### PR TITLE
Fixes airlocks that have panel shielding being un-repairable with a welder

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -965,63 +965,58 @@ About the new airlock wires panel:
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	switch(security_level)
-		if(AIRLOCK_SECURITY_METAL)
-			to_chat(user, "<span class='notice'>You begin cutting the panel's shielding...</span>")
-			if(!I.use_tool(src, user, 40, volume = I.tool_volume))
-				return
-			if(!panel_open)
-				return
-			visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
-				"<span class='notice'>You cut through \the [src]'s shielding.</span>",
-				"<span class='italics'>You hear welding.</span>")
-			security_level = AIRLOCK_SECURITY_NONE
-			spawn_atom_to_turf(/obj/item/stack/sheet/metal, user.loc, 2)
-		if(AIRLOCK_SECURITY_PLASTEEL_O)
-			to_chat(user, "<span class='notice'>You begin cutting the outer layer of shielding...</span>")
-			if(!I.use_tool(src, user, 40, volume = I.tool_volume))
-				return
-			if(!panel_open)
-				return
-			visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
-				"<span class='notice'>You cut through \the [src]'s shielding.</span>",
-				"<span class='italics'>You hear welding.</span>")
-			security_level = AIRLOCK_SECURITY_PLASTEEL_O_S
-		if(AIRLOCK_SECURITY_PLASTEEL_I)
-			to_chat(user, "<span class='notice'>You begin cutting the inner layer of shielding...</span>")
-			if(!I.use_tool(src, user, 40, volume = I.tool_volume))
-				return
-			if(!panel_open)
-				return
-			user.visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
-				"<span class='notice'>You cut through \the [src]'s shielding.</span>",
-				"<span class='italics'>You hear welding.</span>")
-			security_level = AIRLOCK_SECURITY_PLASTEEL_I_S
-		else
-			if(user.a_intent != INTENT_HELP)
-				user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
-					"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
+	if(panel_open) // panel should be open before we try to slice out any shielding.
+		switch(security_level)
+			if(AIRLOCK_SECURITY_METAL)
+				to_chat(user, "<span class='notice'>You begin cutting the panel's shielding...</span>")
+				if(!I.use_tool(src, user, 40, volume = I.tool_volume))
+					return
+				visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
+					"<span class='notice'>You cut through \the [src]'s shielding.</span>",
 					"<span class='italics'>You hear welding.</span>")
+				security_level = AIRLOCK_SECURITY_NONE
+				spawn_atom_to_turf(/obj/item/stack/sheet/metal, user.loc, 2)
+			if(AIRLOCK_SECURITY_PLASTEEL_O)
+				to_chat(user, "<span class='notice'>You begin cutting the outer layer of shielding...</span>")
+				if(!I.use_tool(src, user, 40, volume = I.tool_volume))
+					return
+				visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
+					"<span class='notice'>You cut through \the [src]'s shielding.</span>",
+					"<span class='italics'>You hear welding.</span>")
+				security_level = AIRLOCK_SECURITY_PLASTEEL_O_S
+			if(AIRLOCK_SECURITY_PLASTEEL_I)
+				to_chat(user, "<span class='notice'>You begin cutting the inner layer of shielding...</span>")
+				if(!I.use_tool(src, user, 40, volume = I.tool_volume))
+					return
+				user.visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
+					"<span class='notice'>You cut through \the [src]'s shielding.</span>",
+					"<span class='italics'>You hear welding.</span>")
+				security_level = AIRLOCK_SECURITY_PLASTEEL_I_S
+	else
+		if(user.a_intent != INTENT_HELP)
+			user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
+				"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
+				"<span class='italics'>You hear welding.</span>")
 
-				if(I.use_tool(src, user, 40, volume = I.tool_volume, extra_checks = CALLBACK(src, .proc/weld_checks, I, user)))
-					if(!density && !welded)
-						return
-					welded = !welded
-					user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
-						"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
-					update_icon()
-			else if(obj_integrity < max_integrity)
-				user.visible_message("[user] is welding the airlock.", \
-					"<span class='notice'>You begin repairing the airlock...</span>", \
-					"<span class='italics'>You hear welding.</span>")
-				if(I.use_tool(src, user, 40, volume = I.tool_volume, extra_checks = CALLBACK(src, .proc/weld_checks, I, user)))
-					obj_integrity = max_integrity
-					stat &= ~BROKEN
-					user.visible_message("[user.name] has repaired [src].", \
-						"<span class='notice'>You finish repairing the airlock.</span>")
+			if(I.use_tool(src, user, 40, volume = I.tool_volume, extra_checks = CALLBACK(src, .proc/weld_checks, I, user)))
+				if(!density && !welded)
+					return
+				welded = !welded
+				user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
+					"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
 				update_icon()
-			else
-				to_chat(user, "<span class='notice'>The airlock doesn't need repairing.</span>")
+		else if(obj_integrity < max_integrity)
+			user.visible_message("[user] is welding the airlock.", \
+				"<span class='notice'>You begin repairing the airlock...</span>", \
+				"<span class='italics'>You hear welding.</span>")
+			if(I.use_tool(src, user, 40, volume = I.tool_volume, extra_checks = CALLBACK(src, .proc/weld_checks, I, user)))
+				obj_integrity = max_integrity
+				stat &= ~BROKEN
+				user.visible_message("[user.name] has repaired [src].", \
+					"<span class='notice'>You finish repairing the airlock.</span>")
+			update_icon()
+		else
+			to_chat(user, "<span class='notice'>The airlock doesn't need repairing.</span>")
 	update_icon()
 
 /obj/machinery/door/airlock/proc/weld_checks(obj/item/I, mob/user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -994,7 +994,7 @@ About the new airlock wires panel:
 				security_level = AIRLOCK_SECURITY_PLASTEEL_I_S
 	else
 		if(user.a_intent != INTENT_HELP)
-			user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
+			user.visible_message("<span class='notice'>[user] is [welded ? "unwelding":"welding"] the airlock.</span>", \
 				"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
 				"<span class='italics'>You hear welding.</span>")
 
@@ -1002,17 +1002,17 @@ About the new airlock wires panel:
 				if(!density && !welded)
 					return
 				welded = !welded
-				user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
+				user.visible_message("<span class='notice'>[user.name] has [welded? "welded shut":"unwelded"] [src].</span>", \
 					"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
 				update_icon()
 		else if(obj_integrity < max_integrity)
-			user.visible_message("[user] is welding the airlock.", \
+			user.visible_message("<span class='notice'>[user] is welding the airlock.</span>", \
 				"<span class='notice'>You begin repairing the airlock...</span>", \
 				"<span class='italics'>You hear welding.</span>")
 			if(I.use_tool(src, user, 40, volume = I.tool_volume, extra_checks = CALLBACK(src, .proc/weld_checks, I, user)))
 				obj_integrity = max_integrity
 				stat &= ~BROKEN
-				user.visible_message("[user.name] has repaired [src].", \
+				user.visible_message("<span class='notice'>[user.name] has repaired [src].</span>", \
 					"<span class='notice'>You finish repairing the airlock.</span>")
 			update_icon()
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Panel shielding meaning that is has a metal/plasteel sheet added to the airlock that you need to slice off before you could hack it. Includes stuff like high security airlocks, or vault airlocks, etc.

Issue was we weren't checking if the airlock's panel was open before removing shielding, so you could attempt to remove it even while the airlock's panel was closed, which blocked any repair attempts.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13388
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes airlocks that have panel shielding being un-repairable with a welder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
