### PR TITLE
Moves config loading to world/New not Master/New

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -62,17 +62,13 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	var/static/current_ticklimit = TICK_LIMIT_RUNNING
 
 /datum/controller/master/New()
-	//temporary file used to record errors with loading config, moved to log directory once logging is set up
-	GLOB.config_error_log = GLOB.world_game_log = GLOB.world_runtime_log = "data/logs/config_error.log"
-	load_configuration()
-	// Highlander-style: there can only be one! Kill off the old and replace it with the new.
-
 	if(!random_seed)
 		random_seed = rand(1, 1e9)
 		rand_seed(random_seed)
 
 	var/list/_subsystems = list()
 	subsystems = _subsystems
+	// Highlander-style: there can only be one! Kill off the old and replace it with the new.
 	if(Master != src)
 		if(istype(Master))
 			Recover()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -8,6 +8,10 @@ GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 	log_world("World loaded at [time_stamp()]")
 	log_world("[GLOB.vars.len - GLOB.gvars_datum_in_built_vars.len] global variables")
 
+	//temporary file used to record errors with loading config, moved to log directory once logging is set up
+	GLOB.config_error_log = GLOB.world_game_log = GLOB.world_runtime_log = "data/logs/config_error.log"
+	load_configuration()
+
 	if(byond_version < RECOMMENDED_VERSION)
 		log_world("Your server's byond version does not meet the recommended requirements for this code. Please update BYOND")
 


### PR DESCRIPTION
## What Does This PR Do
This moves loading of the game configuration to `world/New` instead of the `Master/New`. This makes it so the config datum is no re-initialised every time the master controller breaks.

## Why It's Good For The Game
This stops the configs half-breaking when the MC destabilises, and moves it to a place that makes more sense imo.

## Changelog
:cl: AffectedArc07
add: The MC recovering no longer obliterates the config datum
/:cl:
