### PR TITLE
Subsystems now state implications if offlined.

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -146,7 +146,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				msg = "The [BadBoy.name] subsystem was the last to fire for 2 controller restarts. It will be recovered now and disabled if it happens again."
 				FireHim = TRUE
 			if(3)
-				msg = "The [BadBoy.name] subsystem seems to be destabilizing the MC and will be offlined."
+				msg = "The [BadBoy.name] subsystem seems to be destabilizing the MC and will be offlined. <span class='info'>The following implications are now in effect: [BadBoy.offline_implications]</span>"
 				BadBoy.flags |= SS_NO_FIRE
 		if(msg)
 			to_chat(GLOB.admins, "<span class='boldannounce'>[msg]</span>")

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -35,6 +35,8 @@
 
 	var/static/list/failure_strikes //How many times we suspect a subsystem type has crashed the MC, 3 strikes and you're out!
 
+	var/offline_implications = "None" // What are the implications of this SS being offlined?
+
 //Do not override
 ///datum/controller/subsystem/New()
 

--- a/code/controllers/subsystem/acid.dm
+++ b/code/controllers/subsystem/acid.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(acid)
 	priority = FIRE_PRIORITY_ACID
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	offline_implications = "Objects will no longer react to acid. No immediate action is needed."
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/afk.dm
+++ b/code/controllers/subsystem/afk.dm
@@ -5,6 +5,7 @@ SUBSYSTEM_DEF(afk)
 	name = "AFK Watcher"
 	wait = 300
 	flags = SS_BACKGROUND
+	offline_implications = "Players will no longer be marked as AFK. No immediate action is needed."
 	var/list/afk_players = list() // Associative list. ckey as key and AFK state as value
 
 
@@ -17,27 +18,27 @@ SUBSYSTEM_DEF(afk)
 	for(var/mob/living/carbon/human/H in GLOB.living_mob_list)
 		if(!H.ckey) // Useless non ckey creatures
 			continue
-		
-		var/turf/T 
+
+		var/turf/T
 		// Only players and players with the AFK watch enabled
 		// No dead, unconcious, restrained, people without jobs, people on other Z levels than the station or antags
 		if(!H.client || !H.client.prefs.afk_watch || !H.mind || \
 			H.stat || H.restrained() || !H.job || H.mind.special_role || \
 				!is_station_level((T = get_turf(H)).z)) // Assign the turf as last. Small optimization
-			if(afk_players[H.ckey]) 
+			if(afk_players[H.ckey])
 				toRemove += H.ckey
 			continue
-		
+
 		var/mins_afk = round(H.client.inactivity / 600)
 		if(mins_afk < config.warn_afk_minimum)
 			if(afk_players[H.ckey])
 				toRemove += H.ckey
 			continue
-		
+
 		if(!afk_players[H.ckey])
 			afk_players[H.ckey] = AFK_WARNED
 			warn(H, "<span class='danger'>You are AFK for [mins_afk] minutes. You will be cryod after [config.auto_cryo_afk] total minutes and fully despawned after [config.auto_despawn_afk] total minutes. Please move or click in game if you want to avoid being despawned.</span>")
-		else 
+		else
 			var/area/A = T.loc // Turfs loc is the area
 			if(afk_players[H.ckey] == AFK_WARNED)
 				if(mins_afk >= config.auto_cryo_afk && A.can_get_auto_cryod)
@@ -50,14 +51,14 @@ SUBSYSTEM_DEF(afk)
 						afk_players[H.ckey] = AFK_CRYOD
 						msg_admins(H, mins_afk, T, "put into cryostorage")
 						warn(H, "<span class='danger'>You are AFK for [mins_afk] minutes and have been moved to cryostorage. After being AFK for [config.auto_despawn_afk] total minutes you will be fully despawned. Please eject yourself (right click, eject) out of the cryostorage if you want to avoid being despawned.</span>")
-					
+
 			else if(mins_afk >= config.auto_despawn_afk)
 				var/obj/machinery/cryopod/P = H.loc
 				msg_admins(H, mins_afk, T, "forcefully despawned")
 				warn(H, "<span class='danger'>You are have been despawned after being AFK for [mins_afk] minutes.</span>")
 				toRemove += H.ckey
 				P.despawn_occupant()
-	
+
 	removeFromWatchList(toRemove)
 
 /datum/controller/subsystem/afk/proc/warn(mob/living/carbon/human/H, text)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -14,6 +14,7 @@ SUBSYSTEM_DEF(air)
 	wait = 5
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	offline_implications = "Turfs will no longer process atmos, and all atmospheric machines (including cryotubes) will no longer function. Shuttle call recommended."
 	var/cost_turfs = 0
 	var/cost_groups = 0
 	var/cost_highpressure = 0

--- a/code/controllers/subsystem/alarm.dm
+++ b/code/controllers/subsystem/alarm.dm
@@ -1,6 +1,7 @@
 SUBSYSTEM_DEF(alarms)
 	name = "Alarms"
 	init_order = INIT_ORDER_ALARMS // 2
+	offline_implications = "Alarms (Power, camera, fire, etc) will no longer be checked. No immediate action is needed."
 	var/datum/alarm_handler/atmosphere/atmosphere_alarm = new()
 	var/datum/alarm_handler/burglar/burglar_alarm = new()
 	var/datum/alarm_handler/camera/camera_alarm = new()

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(chat)
 	wait = 1
 	priority = FIRE_PRIORITY_CHAT
 	init_order = INIT_ORDER_CHAT
+	offline_implications = "Chat messages will no longer be cleanly queued. No immediate action is needed."
 
 	var/list/payload = list()
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -2,6 +2,7 @@ SUBSYSTEM_DEF(events)
 	name = "Events"
 	init_order = INIT_ORDER_EVENTS
 	runlevels = RUNLEVEL_GAME
+	offline_implications = "Random events will no longer happen. No immediate action is needed."
 	// Report events at the end of the rouund
 	var/report_at_round_end = 0
 

--- a/code/controllers/subsystem/fires.dm
+++ b/code/controllers/subsystem/fires.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(fires)
 	priority = FIRE_PRIOTITY_BURNING
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	offline_implications = "Objects will no longer react to fires. No immediate action is needed."
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -5,6 +5,7 @@ SUBSYSTEM_DEF(garbage)
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	init_order = INIT_ORDER_GARBAGE
+	offline_implications = "Garbage collection is no longer functional, and objects will not be qdel'd. Immediate server restart recommended."
 
 	var/list/collection_timeout = list(0, 2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
 

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(icon_smooth)
 	wait = 1
 	priority = FIRE_PRIOTITY_SMOOTHING
 	flags = SS_TICKER
+	offline_implications = "Objects will no longer smooth together properly. No immediate action is needed."
 
 	var/list/smooth_queue = list()
 

--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(idlenpcpool)
 	priority = FIRE_PRIORITY_IDLE_NPC
 	wait = 60
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	offline_implications = "Idle simple animals will no longer process. Shuttle call recommended."
 
 	var/list/currentrun = list()
 	var/static/list/idle_mobs_by_zlevel[][]
@@ -39,4 +40,4 @@ SUBSYSTEM_DEF(idlenpcpool)
 			if(SA.stat != DEAD)
 				SA.consider_wakeup()
 		if(MC_TICK_CHECK)
-			return 
+			return

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -5,6 +5,7 @@ SUBSYSTEM_DEF(input)
 	flags = SS_TICKER
 	priority = FIRE_PRIORITY_INPUT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+	offline_implications = "Player input will no longer be recognised. Immediate server restart recommended."
 
 	var/list/macro_sets
 	var/list/movement_keys
@@ -24,7 +25,7 @@ SUBSYSTEM_DEF(input)
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
 	var/list/static/default_macro_sets
-	
+
 	if(default_macro_sets)
 		macro_sets = default_macro_sets
 		return

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(jobs)
 	init_order = INIT_ORDER_JOBS // 12
 	wait = 3000 // 5 minutes (Deciseconds)
 	runlevels = RUNLEVEL_GAME
+	offline_implications = "Job playtime hours will no longer be logged. No immediate action is needed."
 
 	//List of all jobs
 	var/list/occupations = list()

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(lighting)
 	wait = 2
 	init_order = INIT_ORDER_LIGHTING
 	flags = SS_TICKER
+	offline_implications = "Lighting will no longer update. Shuttle call recommended."
 
 /datum/controller/subsystem/lighting/stat_entry()
 	..("L:[GLOB.lighting_update_lights.len]|C:[GLOB.lighting_update_corners.len]|O:[GLOB.lighting_update_objects.len]")

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -6,6 +6,7 @@ SUBSYSTEM_DEF(machines)
 	name = "Machines"
 	init_order = INIT_ORDER_MACHINES
 	flags = SS_KEEP_TIMING
+	offline_implications = "Machinery will no longer process. Shuttle call recommended."
 
 	var/list/processing = list()
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(mobs)
 	priority = FIRE_PRIORITY_MOBS
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	offline_implications = "Mobs will no longer process. Immediate server restart recommended."
 
 	var/list/currentrun = list()
 	var/static/list/clients_by_zlevel[][]

--- a/code/controllers/subsystem/nano_mob_hunter.dm
+++ b/code/controllers/subsystem/nano_mob_hunter.dm
@@ -2,6 +2,7 @@ SUBSYSTEM_DEF(mob_hunt)
 	name = "Nano-Mob Hunter GO Server"
 	init_order = INIT_ORDER_NANOMOB
 	priority = FIRE_PRIORITY_NANOMOB // Low priority, no need for MC_TICK_CHECK due to extremely low performance impact.
+	offline_implications = "Nano-Mob Hunter will no longer spawn mobs. No immediate action is needed."
 	var/max_normal_spawns = 15		//change this to adjust the number of normal spawns that can exist at one time. trapped spawns (from traitors) don't count towards this
 	var/list/normal_spawns = list()
 	var/max_trap_spawns = 15		//change this to adjust the number of trap spawns that can exist at one time. traps spawned beyond this point clear the oldest traps

--- a/code/controllers/subsystem/nanoui.dm
+++ b/code/controllers/subsystem/nanoui.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(nanoui)
 	flags = SS_NO_INIT
 	priority = FIRE_PRIORITY_NANOUI
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
+	offline_implications = "All NanoUIs will no longer process. Shuttle call recommended."
 
 	var/list/currentrun = list()
 	var/list/open_uis = list() // A list of open UIs, grouped by src_object and ui_key.

--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(nightshift)
 	priority = FIRE_PRIORITY_NIGHTSHIFT
 	wait = 600
 	flags = SS_NO_TICK_CHECK
+	offline_implications = "The game will no longer shift between day and night lighting. No immediate action is needed."
 
 	var/nightshift_active = FALSE
 	var/nightshift_start_time = 702000		//7:30 PM, station time

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(npcpool)
     flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_BACKGROUND
     priority = FIRE_PRIORITY_NPC
     runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+    offline_implications = "Simple animals will no longer process. Shuttle call recommended."
 
     var/list/currentrun = list()
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(overlays)
 	wait = 1
 	priority = FIRE_PRIORITY_OVERLAYS
 	init_order = INIT_ORDER_OVERLAY
+	offline_implications = "Overlays may look strange. No immediate action is needed."
 
 	var/list/queue
 	var/list/stats

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(parallax)
 	flags = SS_POST_FIRE_TIMING | SS_BACKGROUND
 	priority = FIRE_PRIORITY_PARALLAX
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
+	offline_implications = "Space parallax will no longer move around. No immediate action is needed."
 	var/list/currentrun
 	var/planet_x_offset = 128
 	var/planet_y_offset = 128

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -6,6 +6,7 @@ SUBSYSTEM_DEF(shuttle)
 	init_order = INIT_ORDER_SHUTTLE
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
 	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
+	offline_implications = "Shuttles will no longer function and cargo will not generate points. Immediate server restart recommended."
 	var/list/mobile = list()
 	var/list/stationary = list()
 	var/list/transit = list()

--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(spacedrift)
 	wait = 5
 	flags = SS_NO_INIT|SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	offline_implications = "Mobs will no longer respect a lack of gravity. No immediate action is needed."
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(sun)
 	wait = 600
 	flags = SS_NO_TICK_CHECK
 	init_order = INIT_ORDER_SUN
+	offline_implications = "Solar panels will no longer rotate. No immediate action is needed."
 	var/angle
 	var/dx
 	var/dy

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(throwing)
 	wait = 1
 	flags = SS_NO_INIT|SS_KEEP_TIMING|SS_TICKER
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	offline_implications = "Thrown objects may not react properly. Shuttle call recommended."
 
 	var/list/currentrun
 	var/list/processing = list()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -5,6 +5,7 @@ SUBSYSTEM_DEF(ticker)
 	priority = FIRE_PRIORITY_TICKER
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME
+	offline_implications = "The game is no longer aware of when the round ends. Immediate server restart recommended."
 
 	var/round_start_time = 0
 	var/const/restart_timeout = 600

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(timer)
 	init_order = INIT_ORDER_TIMER
 
 	flags = SS_TICKER|SS_NO_INIT
+	offline_implications = "The game will no longer process timers. Immediate server restart recommended."
 
 	var/list/second_queue = list() //awe, yes, you've had first queue, but what about second queue?
 	var/list/hashes = list()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(vote)
 	wait = 10
 	flags = SS_KEEP_TIMING|SS_NO_INIT
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
+	offline_implications = "Votes (Endround shuttle) will no longer function. Shuttle call recommended."
 
 	var/initiator = null
 	var/started_time = null

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(weather)
 	flags = SS_BACKGROUND
 	wait = 10
 	runlevels = RUNLEVEL_GAME
+	offline_implications = "Ash storms will no longer trigger.  No immediate action is needed."
 	var/list/processing = list()
 	var/list/eligible_zlevels = list()
 	var/list/next_hit_by_zlevel = list() //Used by barometers to know when the next storm is coming

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -305,7 +305,14 @@ var/to_chat_src
 		target << output(output_message, "browseroutput:output")
 
 /proc/to_chat(target, message, flag)
-	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized)
+	/*
+	If any of the following conditions are met, do NOT use SSchat. These conditions include:
+		- Is the MC still initializing?
+		- Has SSchat initialized?
+		- Has SSchat been offlined due to MC crashes?
+	If any of these are met, use the old chat system, otherwise people wont see messages
+	*/
+	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized || SSchat?.flags & SS_NO_FIRE)
 		to_chat_immediate(target, message, flag)
 		return
 	SSchat.queue(target, message, flag)


### PR DESCRIPTION
## What Does This PR Do
This PR allows subsystems to state their implications if they are offlined by the master controller. 

Implications are stated when the subsystem is offlined, and the implications are split into 3 levels, based on severity

**No immediate action is needed**: Something which doesnt impact the round hugely and the game can live without. Examples include acid and fire processing

**Shuttle call recommended**: Something which impacts the round but doesnt require immediate attention. Examples include air and machine processing

**Immediate server restart recommended**: Something which makes the round completely unplayable and requires immediate attention. Examples include player input and garbage collection.

## Why It's Good For The Game
This can give online admins pointers if something needs to happen to the round, and also answers to questions when people mhelp "Why arent cryotubes working" and such.

## Images of changes
*This screenshot is outdated, as the message has been changed. It still looks the same however*
![image](https://user-images.githubusercontent.com/25063394/81499731-96891400-92c5-11ea-82f1-6e0ca9cbfd2e.png)

## Changelog
:cl: AffectedArc07
tweak: Offlined subsystems will now state their implications when offlined
/:cl:
