### PR TITLE
Fixes some runtimes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -58,7 +58,7 @@
 				else
 					return 1
 		var/obj/item/organ/external/O = M.get_organ(user.zone_selected)
-		if((is_sharp(src) || (isscrewdriver(src) && O.is_robotic())) && user.a_intent == INTENT_HELP)
+		if((is_sharp(src) || (isscrewdriver(src) && O?.is_robotic())) && user.a_intent == INTENT_HELP)
 			if(!attempt_initiate_surgery(src, M, user))
 				return FALSE
 			else

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -421,13 +421,13 @@
 	return FALSE
 
 /obj/structure/lattice/catwalk/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
-	. = ..()
 	var/turf/here = get_turf(src)
 	for(var/A in here.contents)
 		var/obj/structure/cable/C = A
 		if(istype(C))
 			to_chat(S, "<span class='warning'>Disrupting the power grid would bring no benefit to us. Aborting.</span>")
 			return FALSE
+	return ..()
 
 /obj/item/deactivated_swarmer/IntegrateAmount()
 	return 50

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -37,6 +37,9 @@
 	cuff(C, user)
 
 /obj/item/restraints/handcuffs/proc/cuff(mob/living/carbon/C, mob/user, remove_src = TRUE)
+	if(!istype(C)) // Shouldn't be able to cuff anything but carbons.
+		return
+
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		if(!(H.has_left_hand() || H.has_right_hand()))

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	if(T.turf_type == type)
 		return
 	var/obj/item/thing = user.get_inactive_hand()
-	if(!prying_tool_list.Find(thing.tool_behaviour))
+	if(!thing || !prying_tool_list.Find(thing.tool_behaviour))
 		return
 	var/turf/simulated/floor/plating/P = pry_tile(thing, user, TRUE)
 	if(!istype(P))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## What Does This PR Do
Fixes some runtimes found in the live server's runtime log

## Why It's Good For The Game
Fixes these runtimes:
```
[2020-05-10T03:23:15] Runtime in swarmer.dm,426: Cannot read null.contents
[2020-05-10T03:23:15]   proc name: swarmer act (/obj/structure/lattice/catwalk/swarmer_act)
[2020-05-10T03:23:15]   usr: Swarmer 606-tau (CKEY) (/mob/living/simple_animal/hostile/swarmer)
[2020-05-10T03:23:15]   usr.loc: �space (212,83,1) (/turf/space)
[2020-05-10T03:23:15]   src: the catwalk (/obj/structure/lattice/catwalk)
[2020-05-10T03:23:15]   src.loc: null
[2020-05-10T03:23:15]   call stack:
[2020-05-10T03:23:15]   the catwalk (/obj/structure/lattice/catwalk): swarmer act(Swarmer 606-tau (/mob/living/simple_animal/hostile/swarmer))
[2020-05-10T03:23:15]   Swarmer 606-tau (/mob/living/simple_animal/hostile/swarmer): AttackingTarget()
[2020-05-10T03:23:15]   Swarmer 606-tau (/mob/living/simple_animal/hostile/swarmer): UnarmedAttack(the catwalk (/obj/structure/lattice/catwalk), 1)
[2020-05-10T03:23:15]   Swarmer 606-tau (/mob/living/simple_animal/hostile/swarmer): ClickOn(the catwalk (/obj/structure/lattice/catwalk), "icon-x=25;icon-y=20;left=1;scr...")
[2020-05-10T03:23:15]   the catwalk (/obj/structure/lattice/catwalk): Click(space (212,82,1) (/turf/space), "mapwindow.map", "icon-x=25;icon-y=20;left=1;scr...")
```

```
[2020-05-10T02:39:28] Runtime in floor.dm,190: Cannot read null.tool_behaviour
[2020-05-10T02:39:28]   proc name: try replace tile (/turf/simulated/floor/proc/try_replace_tile)
[2020-05-10T02:39:28]   usr: NAME (CKEY) (/mob/living/carbon/human)
[2020-05-10T02:39:28]   usr.loc: The bananium floor (150,129,1) (/turf/simulated/floor/mineral/bananium)
[2020-05-10T02:39:28]   src: the floor (149,128,1) (/turf/simulated/floor/plasteel)
[2020-05-10T02:39:28]   call stack:
[2020-05-10T02:39:28]   the floor (149,128,1) (/turf/simulated/floor/plasteel): try replace tile(the bananium tile (/obj/item/stack/tile/mineral/bananium), NAME (/mob/living/carbon/human), "icon-x=15;icon-y=15;left=1;scr...")
[2020-05-10T02:39:28]   the floor (149,128,1) (/turf/simulated/floor/plasteel): attackby(the bananium tile (/obj/item/stack/tile/mineral/bananium), NAME (/mob/living/carbon/human), "icon-x=15;icon-y=15;left=1;scr...")
[2020-05-10T02:39:28]   the bananium tile (/obj/item/stack/tile/mineral/bananium): melee attack chain(NAME (/mob/living/carbon/human), the floor (149,128,1) (/turf/simulated/floor/plasteel), "icon-x=15;icon-y=15;left=1;scr...")
[2020-05-10T02:39:28]   NAME (/mob/living/carbon/human): ClickOn(the floor (149,128,1) (/turf/simulated/floor/plasteel), "icon-x=15;icon-y=15;left=1;scr...")
[2020-05-10T02:39:28]   the floor (149,128,1) (/turf/simulated/floor/plasteel): Click(the floor (149,128,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=15;icon-y=15;left=1;scr...")
```

```
[2020-05-10T04:51:26] Runtime in item_attack.dm,61: Cannot execute null.is robotic().
[2020-05-10T04:51:26]   proc name: attack (/obj/item/proc/attack)
[2020-05-10T04:51:26]   usr: NAME (CKEY) (/mob/living/carbon/human)
[2020-05-10T04:51:26]   usr.loc: The floor (119,95,1) (/turf/simulated/floor/plasteel)
[2020-05-10T04:51:26]   src: the screwdriver (/obj/item/screwdriver)
[2020-05-10T04:51:26]   src.loc: NAME (/mob/living/carbon/human)
[2020-05-10T04:51:26]   call stack:
[2020-05-10T04:51:26]   the screwdriver (/obj/item/screwdriver): attack(the maintenance drone (930) (/mob/living/silicon/robot/drone), NAME (/mob/living/carbon/human), null)
[2020-05-10T04:51:26]   the screwdriver (/obj/item/screwdriver): attack(the maintenance drone (930) (/mob/living/silicon/robot/drone), NAME (/mob/living/carbon/human))
[2020-05-10T04:51:26]   the maintenance drone (930) (/mob/living/silicon/robot/drone): attackby(the screwdriver (/obj/item/screwdriver), NAME (/mob/living/carbon/human), "icon-x=19;icon-y=6;left=1;scre...")
[2020-05-10T04:51:26]   the maintenance drone (930) (/mob/living/silicon/robot/drone): attackby(the screwdriver (/obj/item/screwdriver), NAME (/mob/living/carbon/human), "icon-x=19;icon-y=6;left=1;scre...")
[2020-05-10T04:51:26]   the maintenance drone (930) (/mob/living/silicon/robot/drone): attackby(the screwdriver (/obj/item/screwdriver), NAME (/mob/living/carbon/human), "icon-x=19;icon-y=6;left=1;scre...")
[2020-05-10T04:51:26]   the screwdriver (/obj/item/screwdriver): melee attack chain(NAME (/mob/living/carbon/human), the maintenance drone (930) (/mob/living/silicon/robot/drone), "icon-x=19;icon-y=6;left=1;scre...")
[2020-05-10T04:51:26]   NAME (/mob/living/carbon/human): ClickOn(the maintenance drone (930) (/mob/living/silicon/robot/drone), "icon-x=19;icon-y=6;left=1;scre...")
[2020-05-10T04:51:26]   the maintenance drone (930) (/mob/living/silicon/robot/drone): Click(the floor (119,96,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=19;icon-y=6;left=1;scre...")
```

```
[2020-05-10T05:56:12] Runtime in handcuffs.dm,46: undefined variable /mob/living/silicon/robot/var/handcuffed
[2020-05-10T05:56:12]   proc name: cuff (/obj/item/restraints/handcuffs/proc/cuff)
[2020-05-10T05:56:12]   usr: NAME (CKEY) (/mob/living/silicon/robot)
[2020-05-10T05:56:12]   usr.loc: The floor (18,242,2) (/turf/simulated/shuttle/floor)
[2020-05-10T05:56:12]   src: the zipties (/obj/item/restraints/handcuffs/cable/zipties/cyborg)
[2020-05-10T05:56:12]   src.loc: NAME(/mob/living/silicon/robot)
[2020-05-10T05:56:12]   call stack:
[2020-05-10T05:56:12]   the zipties (/obj/item/restraints/handcuffs/cable/zipties/cyborg): cuff(NAME (/mob/living/silicon/robot), NAME(/mob/living/silicon/robot), 0)
[2020-05-10T05:56:12]   the zipties (/obj/item/restraints/handcuffs/cable/zipties/cyborg): attack(NAME(/mob/living/silicon/robot), NAME(/mob/living/silicon/robot))
[2020-05-10T05:56:12]   NAME(/mob/living/silicon/robot): attackby(the zipties (/obj/item/restraints/handcuffs/cable/zipties/cyborg), NAME(/mob/living/silicon/robot), "icon-x=21;icon-y=19;left=1;scr...")
[2020-05-10T05:56:12]   NAME(/mob/living/silicon/robot): attackby(the zipties (/obj/item/restraints/handcuffs/cable/zipties/cyborg), NAME(/mob/living/silicon/robot), "icon-x=21;icon-y=19;left=1;scr...")
[2020-05-10T05:56:12]   the zipties (/obj/item/restraints/handcuffs/cable/zipties/cyborg): melee attack chain(NAME(/mob/living/silicon/robot), NAME(/mob/living/silicon/robot), "icon-x=21;icon-y=19;left=1;scr...")
[2020-05-10T05:56:12]   NAME(/mob/living/silicon/robot): ClickOn(NAME(/mob/living/silicon/robot), "icon-x=21;icon-y=19;left=1;scr...")
[2020-05-10T05:56:12]   NAME(/mob/living/silicon/robot): Click(the floor (17,242,2) (/turf/simulated/shuttle/floor), "mapwindow.map", "icon-x=21;icon-y=19;left=1;scr...")
```
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
