### PR TITLE
Reduces automender attack log spam

### DIFF
--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -83,7 +83,11 @@
 
 		var/contained = english_list(injected)
 
-		add_attack_logs(user, M, "Automends with [src] containing ([contained])", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
+		var/log_level = ATKLOG_ALMOSTALL
+		if(emagged && !(reagents.harmless_helper()))
+			log_level = null
+
+		add_attack_logs(user, M, "Automends with [src] containing ([contained])", log_level)
 
 		var/fractional_applied_amount = total_applied_amount  / reagents.total_volume
 

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -82,12 +82,8 @@
 			injected += R.name
 
 		var/contained = english_list(injected)
-
-		var/log_level = ATKLOG_ALMOSTALL
-		if(emagged && !(reagents.harmless_helper()))
-			log_level = null
-
-		add_attack_logs(user, M, "Automends with [src] containing ([contained])", log_level)
+		// allow normal logging only if reagents are not harmless and automender is emagged
+		add_attack_logs(user, M, "Automends with [src] containing ([contained])", (emagged && !(reagents.harmless_helper())) ? null : ATKLOG_ALMOSTALL)
 
 		var/fractional_applied_amount = total_applied_amount  / reagents.total_volume
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR sets the logging level of automender applications to almostall if the automender is not emagged, since it is impossible for it to do any harm while not emagged. If it is emagged, then the usual harmless check is used, so that normal logging only happens with emagged automenders applying potentially harmful chemicals.

As for the specific code, I put emagged first so that if it isn't emagged (which I expect to be the majority of cases), it will not even have to evaluate the harmless helper. Also some of those brackets are probably unneeded but better safe than sorry imo.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less logspam for admins, they are less likely to overlook stuff
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: attack log level of automenders lowered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
