### PR TITLE
Adds a message to lockers and crates if they are emagged 

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -12,6 +12,7 @@
 	var/opened = FALSE
 	var/welded = FALSE
 	var/locked = FALSE
+	var/emagged = FALSE
 	var/wall_mounted = 0 //never solid (You can always pass over it)
 	var/lastbang
 	var/sound = 'sound/machines/click.ogg'
@@ -449,3 +450,8 @@
 /obj/structure/closet/bluespace/close()
 	. = ..()
 	density = 0
+
+/obj/structure/closet/examine(mob/user)
+	. = ..() 					//This does the standard locker examine proc
+	if(emagged)			//show text that its emagged to user
+		. += "<span class='notice'>The ID lock is sparking, looks like it was hacked</span>"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -454,4 +454,4 @@
 /obj/structure/closet/examine(mob/user)
 	. = ..() 					//This does the standard locker examine proc
 	if(emagged)			//show text that its emagged to user
-		. += "<span class='notice'>The ID lock is sparking, looks like it was hacked</span>"
+		. += "<span class='notice'>The ID lock is sparking, looks like it was hacked.</span>"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -454,4 +454,4 @@
 /obj/structure/closet/examine(mob/user)
 	. = ..() 					//This does the standard locker examine proc
 	if(emagged)			//show text that its emagged to user
-		. += "<span class='notice'>The ID lock is sparking, looks like it has been fried.</span>"
+		. += "<span class='warning'>The ID lock is sparking, looks like it has been fried.</span>"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -454,4 +454,4 @@
 /obj/structure/closet/examine(mob/user)
 	. = ..() 					//This does the standard locker examine proc
 	if(emagged)			//show text that its emagged to user
-		. += "<span class='notice'>The ID lock is sparking, looks like it was hacked.</span>"
+		. += "<span class='notice'>The ID lock is sparking, looks like it has been fried.</span>"

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -96,6 +96,7 @@
 	if(!broken)
 		broken = TRUE
 		locked = FALSE
+		emagged = TRUE
 		icon_state = icon_off
 		flick(icon_broken, src)
 		to_chat(user, "<span class='notice'>You break the lock on \the [src].</span>")

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -325,6 +325,7 @@
 		playsound(src.loc, "sparks", 60, 1)
 		src.locked = 0
 		src.broken = 1
+		src.emagged = 1
 		update_icon()
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -325,7 +325,7 @@
 		playsound(src.loc, "sparks", 60, 1)
 		src.locked = 0
 		src.broken = 1
-		src.emagged = 1
+		src.emagged = TRUE
 		update_icon()
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds the text "The ID lock is sparking, looks like it has been fried." to the examine text you get when examining an emagged secure locker or crate.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it possible to see the difference between a locker or crate that has been opened with brute force or just emagged. Like airlocks to a degree.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes


**A picture of both an emagged locker and an emagged crate.**


![Y1yHvfhfD8](https://user-images.githubusercontent.com/59520813/81614349-3a66e280-93e0-11ea-9259-b446a059adc6.png)



<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:

tweak: Added a line of text upon examining an emagged locker or crate

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
