### PR TITLE
Refactor and Fixes EMP's

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_storage.dm
+++ b/code/game/objects/items/weapons/implants/implant_storage.dm
@@ -20,6 +20,10 @@
 	..()
 	storage = new /obj/item/storage/hidden/implant(src)
 
+/obj/item/implant/storage/emp_act(severity)
+	..()
+	storage.emp_act(severity)
+
 /obj/item/implant/storage/activate()
 	storage.MouseDrop(imp_in)
 

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -77,6 +77,10 @@
 	item_state = "gift"
 	w_class = WEIGHT_CLASS_BULKY
 
+/obj/item/gift/emp_act(severity)
+	..()
+	gift.emp_act(severity)
+
 /obj/item/kidanglobe
 	name = "Kidan homeworld globe"
 	icon = 'icons/obj/decorations.dmi'

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -481,10 +481,10 @@
 	return ..()
 
 /obj/item/storage/emp_act(severity)
-	if(!istype(loc, /mob/living))
-		for(var/obj/O in contents)
-			O.emp_act(severity)
 	..()
+	for(var/i in contents)
+		var/atom/A = i
+		A.emp_act(severity)
 
 /obj/item/storage/hear_talk(mob/living/M as mob, list/message_pieces)
 	..()

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -25,8 +25,8 @@
 	return pockets.attackby(W, user, params)
 
 /obj/item/clothing/suit/storage/emp_act(severity)
-	pockets.emp_act(severity)
 	..()
+	pockets.emp_act(severity)
 
 /obj/item/clothing/suit/storage/hear_talk(mob/M, list/message_pieces)
 	pockets.hear_talk(M, message_pieces)

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -37,8 +37,8 @@
 	return hold.attackby(W, user, params)
 
 /obj/item/clothing/accessory/storage/emp_act(severity)
-	hold.emp_act(severity)
 	..()
+	hold.emp_act(severity)
 
 /obj/item/clothing/accessory/storage/hear_talk(mob/M, list/message_pieces, verb)
 	hold.hear_talk(M, message_pieces, verb)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -926,9 +926,10 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		return initial(pixel_y)
 
 /mob/living/carbon/emp_act(severity)
-	for(var/obj/item/organ/internal/O in internal_organs)
-		O.emp_act(severity)
 	..()
+	for(var/X in internal_organs)
+		var/obj/item/organ/internal/O = X
+		O.emp_act(severity)
 
 /mob/living/carbon/Stat()
 	..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -206,12 +206,6 @@ emp_act
 	if(martial_art && prob(martial_art.block_chance) && martial_art.can_use(src) && in_throw_mode && !incapacitated(FALSE, TRUE))
 		return TRUE
 
-/mob/living/carbon/human/emp_act(severity)
-	for(var/obj/O in src)
-		if(!O)	continue
-		O.emp_act(severity)
-	..()
-
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc
 	var/list/damaged = list()
 	var/list/inventory_items_to_kill = list()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -73,10 +73,9 @@
 		return shock_damage
 
 /mob/living/emp_act(severity)
-	var/list/L = src.get_contents()
-	for(var/obj/O in L)
-		O.emp_act(severity)
 	..()
+	for(var/obj/O in contents)
+		O.emp_act(severity)
 
 /obj/item/proc/get_volume_by_throwforce_and_or_w_class()
 	if(throwforce && w_class)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -571,13 +571,13 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	return FALSE
 
 /mob/living/silicon/ai/emp_act(severity)
+	..()
 	if(prob(30))
 		switch(pick(1,2))
 			if(1)
 				view_core()
 			if(2)
 				ai_call_shuttle()
-	..()
 
 /mob/living/silicon/ai/ex_act(severity)
 	..()

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -137,9 +137,9 @@
 	..()
 
 /mob/living/silicon/robot/syndicate/saboteur/emp_act()
+	..()
 	if(cham_proj)
 		cham_proj.disrupt(src)
-	..()
 
 /mob/living/silicon/robot/syndicate/saboteur/bullet_act()
 	if(cham_proj)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -76,17 +76,17 @@
 	return FALSE //So borgs they don't die trying to fix wiring
 
 /mob/living/silicon/emp_act(severity)
+	..()
 	switch(severity)
 		if(1)
-			src.take_organ_damage(20)
+			take_organ_damage(20)
 			Stun(8)
 		if(2)
-			src.take_organ_damage(10)
+			take_organ_damage(10)
 			Stun(3)
 	flash_eyes(affect_silicon = 1)
 	to_chat(src, "<span class='danger'>*BZZZT*</span>")
 	to_chat(src, "<span class='warning'>Warning: Electromagnetic pulse detected.</span>")
-	..()
 
 
 /mob/living/silicon/proc/damage_mob(var/brute = 0, var/fire = 0, var/tox = 0)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -7,6 +7,12 @@
 	pressure_resistance = 2
 	resistance_flags = FLAMMABLE
 
+/obj/item/folder/emp_act(severity)
+	..()
+	for(var/i in contents)
+		var/atom/A = i
+		A.emp_act(severity)
+
 /obj/item/folder/blue
 	desc = "A blue folder."
 	icon_state = "folder_blue"

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -95,6 +95,12 @@
 		CHECK_TICK
 	..()
 
+/obj/item/smallDelivery/emp_act(severity)
+	..()
+	for(var/i in contents)
+		var/atom/A = i
+		A.emp_act(severity)
+
 /obj/item/smallDelivery/attack_self(mob/user as mob)
 	if(wrapped && wrapped.loc) //sometimes items can disappear. For example, bombs. --rastaf0
 		wrapped.loc = user.loc


### PR DESCRIPTION
`emp_act` can get called multiple times in certain situations, resulting in more damage done to external limbs or objects than otherwise intended....additionally, there's a lot of edge cases of EMPs not impacting things on the ground, but impacting things held by/within a mob....not...good or intuitive.

Either case, this alters thing a bit to ensure things only get hit once and ensures a few more things properly get EMP'd even when not on a mob.

Side effect: people with robot limbs get a sizeable buff as they're taking half damage--a single EMP isn't enough to one-shot an IPC anymore--it will put them into hard crit however---at least heavy EMPs. They'll be able to survive a single light EMP.

:cl: Fox McCloud
fix: Fixes EMP's impacting some objects and limbs multiple times
/:cl:

