### PR TITLE
Issue #13423 Fix - Headcrab death check

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -25,7 +25,9 @@
 	var/list/human_overlays = list()
 
 /mob/living/simple_animal/hostile/headcrab/Life(seconds, times_fired)
-	if(!is_zombie && isturf(src.loc) && stat != DEAD)
+	if(stat == DEAD)
+		return
+	if(!is_zombie && isturf(src.loc))
 		for(var/mob/living/carbon/human/H in oview(src, 1)) //Only for corpse right next to/on same tile
 			if(H.stat == DEAD || (!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD))
 				Zombify(H)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -25,24 +25,23 @@
 	var/list/human_overlays = list()
 
 /mob/living/simple_animal/hostile/headcrab/Life(seconds, times_fired)
-	if(stat == DEAD)
-		return
-	if(!is_zombie && isturf(src.loc))
-		for(var/mob/living/carbon/human/H in oview(src, 1)) //Only for corpse right next to/on same tile
-			if(H.stat == DEAD || (!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD))
-				Zombify(H)
-				break
-	var/cycles = 4
-	if(cycles >= 4)
-		for(var/mob/living/simple_animal/K in oview(src, 1)) //Only for corpse right next to/on same tile
-			if(K.stat == DEAD || (!K.check_death_method() && K.health <= HEALTH_THRESHOLD_DEAD))
-				visible_message("<span class='danger'>[src] consumes [target] whole!</span>")
-				if(health < maxHealth)
-					health += 10
-				qdel(K)
-				break
-			cycles = 0
-	cycles++
+	if(stat != DEAD)
+		if(!is_zombie && isturf(src.loc))
+			for(var/mob/living/carbon/human/H in oview(src, 1)) //Only for corpse right next to/on same tile
+				if(H.stat == DEAD || (!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD))
+					Zombify(H)
+					break
+		var/cycles = 4
+		if(cycles >= 4)
+			for(var/mob/living/simple_animal/K in oview(src, 1)) //Only for corpse right next to/on same tile
+				if(K.stat == DEAD || (!K.check_death_method() && K.health <= HEALTH_THRESHOLD_DEAD))
+					visible_message("<span class='danger'>[src] consumes [target] whole!</span>")
+					if(health < maxHealth)
+						health += 10
+					qdel(K)
+					break
+				cycles = 0
+		cycles++
 	..()
 
 /mob/living/simple_animal/hostile/headcrab/OpenFire(atom/A)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -25,7 +25,7 @@
 	var/list/human_overlays = list()
 
 /mob/living/simple_animal/hostile/headcrab/Life(seconds, times_fired)
-	if(stat != DEAD)
+	if(..())
 		if(!is_zombie && isturf(src.loc))
 			for(var/mob/living/carbon/human/H in oview(src, 1)) //Only for corpse right next to/on same tile
 				if(H.stat == DEAD || (!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD))
@@ -42,7 +42,6 @@
 					break
 				cycles = 0
 		cycles++
-	..()
 
 /mob/living/simple_animal/hostile/headcrab/OpenFire(atom/A)
 	if(check_friendly_fire)


### PR DESCRIPTION
## What Does This PR Do
Fixes #13423 - dead headcrabs eating adjacent dead animals.

## Why It's Good For The Game
Unintentional behaviour is bad, mkay?

## Changelog
:cl:
fix: dead headcrabs no longer consume adjacent dead animals.
/:cl:
