### PR TITLE
Fixes Issue #13186 - Unscrewing Lava

### DIFF
--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -113,6 +113,9 @@
 /turf/simulated/floor/plating/lava/attackby(obj/item/C, mob/user, params) //Lava isn't a good foundation to build on
 	return
 
+/turf/simulated/floor/plating/lava/screwdriver_act()
+	return
+
 /turf/simulated/floor/plating/lava/welder_act()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Stops you from unscrewing lava

## Why It's Good For The Game
Unsecured lava is a workplace hazard

## Changelog
:cl:
fix: Added screw protectors to lava to prevent unauthorized unscrewing.
/:cl:
