### PR TITLE
Fixes shadowstep and knock admin attack log spam

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -237,10 +237,10 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	if(action)
 		action.UpdateButtonIcon()
 
-/obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = 1, mob/user = usr) //if recharge is started is important for the trigger spells
+/obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = 1, mob/user = usr, make_attack_logs = TRUE) //if recharge is started is important for the trigger spells
 	before_cast(targets)
 	invocation()
-	if(user && user.ckey)
+	if(user && user.ckey && make_attack_logs)
 		add_attack_logs(user, targets, "cast the spell [name]", ATKLOG_ALL)
 	spawn(0)
 		if(charge_type == "recharge" && recharge)

--- a/code/datums/spells/knock.dm
+++ b/code/datums/spells/knock.dm
@@ -13,6 +13,11 @@
 	action_icon_state = "knock"
 	sound = 'sound/magic/knock.ogg'
 
+// Knock doesn't need to generate an attack log for every turf, set `make_attack_logs` to FALSE and just create a custom one.
+/obj/effect/proc_holder/spell/aoe_turf/knock/perform(list/targets, recharge, mob/user)
+	add_attack_logs(user, user, "cast the spell [name]", ATKLOG_ALL)
+	return ..(targets, recharge, user, make_attack_logs = FALSE)
+
 /obj/effect/proc_holder/spell/aoe_turf/knock/cast(list/targets, mob/user = usr)
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)
@@ -29,8 +34,6 @@
 					var/obj/structure/closet/secure_closet/SC = C
 					SC.locked = 0
 				C.open()
-
-	return
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/greater
 	name = "Greater Knock"

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -507,13 +507,13 @@
 		to_chat(user, "<span class='warning'>You cannot find darkness to step to.</span>")
 		return
 
+	turfs = list(pick(turfs)) // Pick a single turf for the vampire to jump to.
 	perform(turfs, user = user)
 
+// `targets` should only ever contain the 1 valid turf we're jumping to, even though its a list, that's just how the cast() proc works.
 /obj/effect/proc_holder/spell/vampire/shadowstep/cast(list/targets, mob/user = usr)
 	spawn(0)
-		var/turf/picked = pick(targets)
-
-		if(!picked || !isturf(picked))
+		if(!targets.len) // If for some reason the turf got deleted.
 			return
 		var/mob/living/U = user
 		U.ExtinguishMob()
@@ -525,7 +525,7 @@
 		animation.alpha = 127
 		animation.layer = 5
 		//animation.master = src
-		user.forceMove(picked)
+		user.forceMove(targets[1])
 		spawn(10)
 			qdel(animation)
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -513,7 +513,7 @@
 // `targets` should only ever contain the 1 valid turf we're jumping to, even though its a list, that's just how the cast() proc works.
 /obj/effect/proc_holder/spell/vampire/shadowstep/cast(list/targets, mob/user = usr)
 	spawn(0)
-		if(!targets.len) // If for some reason the turf got deleted.
+		if(!LAZYLEN(targets)) // If for some reason the turf got deleted.
 			return
 		var/mob/living/U = user
 		U.ExtinguishMob()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
`shadowstep/choose_targets()` was basically passing an entire screens worth of turfs centered around the caster, into `perform()` which generated attack logs for every turf. Bad.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13434
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes shadowstep and knock admin attack log spam.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
