### PR TITLE
fixed apples not distilling in fermenting barrels

### DIFF
--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -24,7 +24,7 @@
 	filling_color = "#FF4500"
 	bitesize = 100 // Always eat the apple in one bite
 	tastes = list("apple" = 1)
-	distill_reagent = "hcider"
+	distill_reagent = "cider"
 
 // Posioned Apple
 /obj/item/seeds/apple/poisoned


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
apples previously distilled into "hcider," which is an icon state and not actually a reagent proper. this resulted in apples simply not fermenting into anything when processed in a fermenting barrel. (if the apples contained reagents such as plant_matter or sugar or whatever else botanists put in their genes, then these would of course be transferred to the barrel's reagents list normally.)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
apples felt dejected over their inability to be refined into cider, making them... winey

## Changelog
:cl: fix: apples placed in fermenting barrels were incorrectly trying to produce "hcider" (an icon state, not a reagent) instead of "cider"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
