### PR TITLE
Makes round end more obvious in game logs.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -513,6 +513,11 @@ SUBSYSTEM_DEF(ticker)
 	//Ask the event manager to print round end information
 	SSevents.RoundEnd()
 
+	//make big obvious note in game logs that round ended
+	log_game("///////////////////////////////////////////////////////")
+	log_game("///////////////////// ROUND ENDED /////////////////////")
+	log_game("///////////////////////////////////////////////////////")
+
 	// Add AntagHUD to everyone, see who was really evil the whole time!
 	for(var/datum/atom_hud/antag/H in GLOB.huds)
 		for(var/m in GLOB.player_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a game log entry that is very visually distinct and easy to find, indicating the point where the round ended (ie shuttle docks or score is otherwise displayed)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Often when I go log diving as an admin it's about investigating shuttle grief, going through lots of lines of attack and say logs in hindsight. It would be useful to tell at a glance where the round actually ended. At the moment, there is a single message telling you that but it's very easy to miss in the flood of logs.

I hope the new message stands out a lot and makes it easier to tell if an attack was part of the round end slaughter or shuttle grief.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![Capture](https://user-images.githubusercontent.com/32099540/82118795-bfa01d80-9779-11ea-98ac-1a2a6003b4c4.PNG)
An example of the new log message, you can easily tell at a glance where the round ended rather than looking for/control+f-ing for the 'Antagonsits at Round End were:' line.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: made round end more obvious in game logs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
