### PR TITLE
Updates the contribution info. Multiplications are not faster than divisions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -479,7 +479,7 @@ in the SQL/updates folder.
 
 * You are expected to help maintain the code that you add, meaning that if there is a problem then you are likely to be approached in order to fix any issues, runtimes, or bugs.
 
-* Do not divide when you can easily convert it to multiplication. (ie `4/2` should be done as `4*0.5`)
+* Multiplications are not significantly faster than divisions. Use whichever operation makes the code more readable.
 
 * If you used regex to replace code during development of your code, post the regex in your PR for the benefit of future developers and downstream users.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -479,8 +479,6 @@ in the SQL/updates folder.
 
 * You are expected to help maintain the code that you add, meaning that if there is a problem then you are likely to be approached in order to fix any issues, runtimes, or bugs.
 
-* Multiplications are not significantly faster than divisions. Use whichever operation makes the code more readable.
-
 * If you used regex to replace code during development of your code, post the regex in your PR for the benefit of future developers and downstream users.
 
 * All new var/proc names should use the American English spelling of words. This is for consistency with BYOND.


### PR DESCRIPTION
## What Does This PR Do
Updates the contribution info file to explain that divisions are not slower than multiplications. @Fox-McCloud and @Crazylemon64  tested this and in some cases divisions were faster than multiplications. 



No CL since it's a github only change