### PR TITLE
BSA strikes are now logged to disk

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -215,6 +215,7 @@
 	playsound(src, 'sound/machines/bsa_fire.ogg', 100, 1)
 
 	message_admins("[key_name_admin(user)] has launched an artillery strike.")
+	log_admin("[key_name(user)] has launched an artillery strike.") // Line below handles logging the explosion to disk
 	explosion(bullseye,ex_power,ex_power*2,ex_power*4)
 
 	reload()


### PR DESCRIPTION
## What Does This PR Do
This PR now makes it so BSA strikes are logged to disk. Requested by staff.
![image](https://user-images.githubusercontent.com/25063394/82352097-6a704000-99f5-11ea-9fd7-4e168e2a5bcc.png)

## Why It's Good For The Game
Something like this should really be persistently logged after the round

## Changelog
:cl: AffectedArc07
add: BSA strikes are now logged to disk
/:cl: