### PR TITLE
Replaces the bloodcrawl variable with a trait

### DIFF
--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -62,7 +62,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 //mob traits
 #define TRAIT_PACIFISM			"pacifism"
-#define TRAIT_WATERBREATH       "waterbreathing"
+#define TRAIT_WATERBREATH		"waterbreathing"
+#define TRAIT_BLOODCRAWL		"bloodcrawl"
+#define TRAIT_BLOODCRAWL_EAT	"bloodcrawl_eat"
 
 // common trait sources
 #define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -5,7 +5,10 @@
 */
 GLOBAL_LIST_INIT(traits_by_type, list(
 	/mob = list(
-		"TRAIT_PACIFISM" = TRAIT_PACIFISM
+		"TRAIT_PACIFISM" = TRAIT_PACIFISM,
+		"TRAIT_WATERBREATH"	= TRAIT_WATERBREATH,
+		"BLOODCRAWL" = TRAIT_BLOODCRAWL,
+		"BLOODCRAWL_EAT" = TRAIT_BLOODCRAWL_EAT
 	)))
 
 /// value -> trait name, generated on use from trait_by_type global

--- a/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
+++ b/code/game/gamemodes/miniantags/slaughter/bloodcrawl.dm
@@ -35,8 +35,8 @@
 		animation.dir = dir
 
 		ExtinguishMob()
-		if(pulling && bloodcrawl == BLOODCRAWL_EAT)
-			if(istype(pulling, /mob/living/))
+		if(pulling && HAS_TRAIT(src, TRAIT_BLOODCRAWL_EAT))
+			if(isliving(pulling))
 				var/mob/living/victim = pulling
 				if(victim.stat == CONSCIOUS)
 					visible_message("<span class='warning'>[victim] kicks free of [B] just before entering it!</span>")

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -35,7 +35,6 @@
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	var/boost = 0
-	bloodcrawl = BLOODCRAWL_EAT
 
 
 	var/devoured = 0
@@ -59,6 +58,7 @@
 /mob/living/simple_animal/slaughter/New()
 	..()
 	remove_from_all_data_huds()
+	ADD_TRAIT(src, TRAIT_BLOODCRAWL_EAT, "bloodcrawl_eat")
 	var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new
 	AddSpell(bloodspell)
 	whisper_action = new()
@@ -247,33 +247,39 @@
 	user.visible_message("<span class='warning'>[user] raises [src] to [user.p_their()] mouth and tears into it with [user.p_their()] teeth!</span>", \
 						 "<span class='danger'>An unnatural hunger consumes you. You raise [src] to your mouth and devour it!</span>")
 	playsound(user, 'sound/misc/demon_consume.ogg', 50, 1)
-	for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
-		if(knownspell.type == /obj/effect/proc_holder/spell/bloodcrawl)
-			qdel(src)
-			return
-
-	if(user.bloodcrawl == 0)
-		user.visible_message("<span class='warning'>[user]'s eyes flare a deep crimson!</span>", \
-						 "<span class='userdanger'>You feel a strange power seep into your body... you have absorbed the demon's blood-travelling powers!</span>")
-		user.bloodcrawl = BLOODCRAWL
-	else if(user.bloodcrawl == BLOODCRAWL)
-		to_chat(user, "You feel diffr-<span class = 'danger'> CONSUME THEM! </span>")
-		user.bloodcrawl = BLOODCRAWL_EAT
-	else
-		to_chat(user, "<span class='warning'>...and you don't feel any different.</span>")
-
 	user.drop_item()
 	insert(user) //Consuming the heart literally replaces your heart with a demon heart. H A R D C O R E
 
 /obj/item/organ/internal/heart/demon/insert(mob/living/carbon/M, special = 0)
-	..()
-	if(M.mind)
+	if(!M.mind)
+		return
+
+	// Eating the heart for the first time. Gives basic bloodcrawling.
+	if(!HAS_TRAIT(M, TRAIT_BLOODCRAWL))
+		M.visible_message("<span class='warning'>[M]'s eyes flare a deep crimson!</span>", \
+						 "<span class='userdanger'>You feel a strange power seep into your body... you have absorbed the demon's blood-travelling powers!</span>")
 		M.mind.AddSpell(new /obj/effect/proc_holder/spell/bloodcrawl(null))
+		ADD_TRAIT(M, TRAIT_BLOODCRAWL, "bloodcrawl")
+		return ..() // The only time we actually need to replace the user's heart with the demon heart.
+
+	// Eating a 2nd heart. Gives the ability to drag people into blood and eat them.
+	if(HAS_TRAIT(M, TRAIT_BLOODCRAWL))
+		to_chat(M, "You feel diffr-<span class = 'danger'> CONSUME THEM! </span>")
+		ADD_TRAIT(M, TRAIT_BLOODCRAWL_EAT, "bloodcrawl_eat")
+		qdel(src) // Replacing their demon heart with another demon heart is pointless, just delete this one and return.
+		return TRUE
+
+	// Eating any more than 2 demon hearts does nothing.
+	else
+		to_chat(M, "<span class='warning'>...and you don't feel any different.</span>")
+		qdel(src)
+		return
 
 /obj/item/organ/internal/heart/demon/remove(mob/living/carbon/M, special = 0)
 	..()
 	if(M.mind)
-		M.bloodcrawl = 0
+		REMOVE_TRAIT(M, TRAIT_BLOODCRAWL, "bloodcrawl")
+		REMOVE_TRAIT(M, TRAIT_BLOODCRAWL_EAT, "bloodcrawl_eat")
 		M.mind.RemoveSpell(/obj/effect/proc_holder/spell/bloodcrawl)
 
 /obj/item/organ/internal/heart/demon/Stop()

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -247,33 +247,30 @@
 	user.visible_message("<span class='warning'>[user] raises [src] to [user.p_their()] mouth and tears into it with [user.p_their()] teeth!</span>", \
 						 "<span class='danger'>An unnatural hunger consumes you. You raise [src] to your mouth and devour it!</span>")
 	playsound(user, 'sound/misc/demon_consume.ogg', 50, 1)
-	user.drop_item()
-	insert(user) //Consuming the heart literally replaces your heart with a demon heart. H A R D C O R E
 
-/obj/item/organ/internal/heart/demon/insert(mob/living/carbon/M, special = 0)
-	if(!M.mind)
-		return
-
-	// Eating the heart for the first time. Gives basic bloodcrawling.
-	if(!HAS_TRAIT(M, TRAIT_BLOODCRAWL))
-		M.visible_message("<span class='warning'>[M]'s eyes flare a deep crimson!</span>", \
+	// Eating the heart for the first time. Gives basic bloodcrawling. This is the only time we need to insert the heart.
+	if(!HAS_TRAIT(user, TRAIT_BLOODCRAWL))
+		user.visible_message("<span class='warning'>[user]'s eyes flare a deep crimson!</span>", \
 						 "<span class='userdanger'>You feel a strange power seep into your body... you have absorbed the demon's blood-travelling powers!</span>")
-		M.mind.AddSpell(new /obj/effect/proc_holder/spell/bloodcrawl(null))
-		ADD_TRAIT(M, TRAIT_BLOODCRAWL, "bloodcrawl")
-		return ..() // The only time we actually need to replace the user's heart with the demon heart.
+		ADD_TRAIT(user, TRAIT_BLOODCRAWL, "bloodcrawl")
+		user.drop_item()
+		insert(user) //Consuming the heart literally replaces your heart with a demon heart. H A R D C O R E.
 
 	// Eating a 2nd heart. Gives the ability to drag people into blood and eat them.
-	if(HAS_TRAIT(M, TRAIT_BLOODCRAWL))
-		to_chat(M, "You feel diffr-<span class = 'danger'> CONSUME THEM! </span>")
-		ADD_TRAIT(M, TRAIT_BLOODCRAWL_EAT, "bloodcrawl_eat")
+	if(HAS_TRAIT(user, TRAIT_BLOODCRAWL))
+		to_chat(user, "You feel diffr-<span class = 'danger'> CONSUME THEM! </span>")
+		ADD_TRAIT(user, TRAIT_BLOODCRAWL_EAT, "bloodcrawl_eat")
 		qdel(src) // Replacing their demon heart with another demon heart is pointless, just delete this one and return.
 		return TRUE
 
 	// Eating any more than 2 demon hearts does nothing.
-	else
-		to_chat(M, "<span class='warning'>...and you don't feel any different.</span>")
-		qdel(src)
-		return
+	to_chat(user, "<span class='warning'>...and you don't feel any different.</span>")
+	qdel(src)
+
+/obj/item/organ/internal/heart/demon/insert(mob/living/carbon/M, special = 0)
+	. = ..()
+	if(M.mind)
+		M.mind.AddSpell(new /obj/effect/proc_holder/spell/bloodcrawl(null))
 
 /obj/item/organ/internal/heart/demon/remove(mob/living/carbon/M, special = 0)
 	..()

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -255,6 +255,7 @@
 		ADD_TRAIT(user, TRAIT_BLOODCRAWL, "bloodcrawl")
 		user.drop_item()
 		insert(user) //Consuming the heart literally replaces your heart with a demon heart. H A R D C O R E.
+		return TRUE
 
 	// Eating a 2nd heart. Gives the ability to drag people into blood and eat them.
 	if(HAS_TRAIT(user, TRAIT_BLOODCRAWL))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -33,7 +33,6 @@
 	var/metabolism_efficiency = 1 //more or less efficiency to metabolize helpful/harmful reagents and regulate body temperature..
 	var/digestion_ratio = 1 //controls how quickly reagents metabolize; largely governered by species attributes.
 
-	var/bloodcrawl = 0 //0 No blood crawling, 1 blood crawling, 2 blood crawling+mob devour
 	var/holder = null //The holder for blood crawling
 
 	var/ventcrawler = 0 //0 No vent crawling, 1 vent crawling in the nude, 2 vent crawling always


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the `bloodcrawl` variable from mobs, and replace it with a trait instead. 

In a majority of rounds, `bloodcrawl` is never even used. Having this variable be attached to ALL living mobs is wasteful.

No CL because this is a back-end change.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
