### PR TITLE
Vendor fix

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -404,7 +404,8 @@
 	cashmoney.use(currently_vending.price)
 
 	// Vending machines have no idea who paid with cash
-	credit_purchase("(cash)")
+	GLOB.vendor_account.credit(currently_vending.price, "Sale of [currently_vending.name]",
+	name, "(cash)")
 	return 1
 
 /**
@@ -445,25 +446,17 @@
 	else
 		// Okay to move the money at this point
 		var/paid = customer_account.charge(currently_vending.price, GLOB.vendor_account,
+		customer_account.charge(currently_vending.price, GLOB.vendor_account,
 			"Purchase of [currently_vending.name]", name, GLOB.vendor_account.owner_name,
 			"Sale of [currently_vending.name]", customer_account.owner_name)
 
-		if(paid)
-			// Give the vendor the money. We use the account owner name, which means
-			// that purchases made with stolen/borrowed card will look like the card
-			// owner made them
-			credit_purchase(customer_account.owner_name)
-		return paid
+		return 1
 
 /**
  *  Add money for current purchase to the vendor account.
  *
  *  Called after the money has already been taken from the customer.
  */
-/obj/machinery/vending/proc/credit_purchase(var/target as text)
-	GLOB.vendor_account.money += currently_vending.price
-	GLOB.vendor_account.credit(currently_vending.price, "Sale of [currently_vending.name]",
-	name, target)
 
 /obj/machinery/vending/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -404,8 +404,7 @@
 	cashmoney.use(currently_vending.price)
 
 	// Vending machines have no idea who paid with cash
-	GLOB.vendor_account.credit(currently_vending.price, "Sale of [currently_vending.name]",
-	name, "(cash)")
+	GLOB.vendor_account.credit(currently_vending.price, "Sale of [currently_vending.name]",	name, "(cash)")
 	return 1
 
 /**
@@ -449,13 +448,8 @@
 			"Purchase of [currently_vending.name]", name, GLOB.vendor_account.owner_name,
 			"Sale of [currently_vending.name]", customer_account.owner_name)
 
-		return 1
+		return TRUE
 
-/**
- *  Add money for current purchase to the vendor account.
- *
- *  Called after the money has already been taken from the customer.
- */
 
 /obj/machinery/vending/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -445,7 +445,6 @@
 		return 0
 	else
 		// Okay to move the money at this point
-		var/paid = customer_account.charge(currently_vending.price, GLOB.vendor_account,
 		customer_account.charge(currently_vending.price, GLOB.vendor_account,
 			"Purchase of [currently_vending.name]", name, GLOB.vendor_account.owner_name,
 			"Sale of [currently_vending.name]", customer_account.owner_name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #13389 by making sure that purchases from vendors are only credited to the vendor account one time. 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously, each purchase was being credited two or three times to the vendor account, although only charging the user once. This could have been used maliciously to dupe money as the HoP or anyone able to access the vendor account.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl: Tinfoiltophat
fix: Vendors will no longer be credited more money than they received for each purchase.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
