### PR TITLE
Allows the IPC players to select the bald IPC monitor using the "Change Monitor" button

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories/ipc/ipc_face.dm
+++ b/code/modules/mob/new_player/sprite_accessories/ipc/ipc_face.dm
@@ -4,6 +4,10 @@
 	glasses_over = 1
 	models_allowed = list("Bishop Cybernetics mtr.", "Hesphiastos Industries mtr.", "Morpheus Cyberkinetics", "Ward-Takahashi mtr.", "Xion Manufacturing Group mtr.", "Shellguard Munitions Monitor Series")
 
+/datum/sprite_accessory/hair/ipc/ipc_screen_bald
+	name = "Bald"
+	icon_state = "bald"
+
 /datum/sprite_accessory/hair/ipc/ipc_screen_pink
 	name = "Pink IPC Screen"
 	icon_state = "pink"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR allows IPC players to select the bald IPC monitor, which can be selected in character creation screen or using the mirror, which can be found in the bathrooms

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Removes the inconsistency between different menus and allows the player to select the bald IPC monitor without having to go to a mirror, because previously the Change Monitor action button did not have the Bald monitor as an option.

## Changelog
:cl:
add: Added the ability for IPC players to change to bald IPC monitor using the Change Monitor button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
