### PR TITLE
comments out crafting frag-12 shells

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -183,6 +183,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
+/*
 /datum/crafting_recipe/frag12
 	name = "FRAG-12 Shell"
 	result = /obj/item/ammo_casing/shotgun/frag12
@@ -194,6 +195,7 @@
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
+*/
 
 /datum/crafting_recipe/ionslug
 	name = "Ion Scatter Shell"


### PR DESCRIPTION
For those not in the know, frag-12 shells are gyrojet rounds for your shotgun.

When they hit you, they explode, knocking you out, and possibly delimbing you. They are as a result superior to every other shotgun shell you can make and also every other gun in the game, and they're easy enough to create, as they only need tech shells and easily available chemicals. The hardest one to get is from corn, and you can get corn seeds quite easily.

To anyone with even half a mind, they have infinite instant-KO hardstun shells that can quite possibly crit you on the first hit. Aside from shielded hardsuits, nothing will block this.

They shouldn't be _craftable_. If you want to make them cargo orderable, or something, be my guest. 
## Changelog
:cl:
del: Removed craftable frag-12 rounds. 
/:cl:
