### PR TITLE
This time I dont break logs

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -62,10 +62,6 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	var/static/current_ticklimit = TICK_LIMIT_RUNNING
 
 /datum/controller/master/New()
-	//temporary file used to record errors with loading config, moved to log directory once logging is set up
-	GLOB.config_error_log = GLOB.world_game_log = GLOB.world_runtime_log = "data/logs/config_error.log"
-	load_configuration()
-	// Highlander-style: there can only be one! Kill off the old and replace it with the new.
 
 	if(!random_seed)
 		random_seed = rand(1, 1e9)
@@ -73,6 +69,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 	var/list/_subsystems = list()
 	subsystems = _subsystems
+	// Highlander-style: there can only be one! Kill off the old and replace it with the new.
 	if(Master != src)
 		if(istype(Master))
 			Recover()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -3,6 +3,10 @@
 GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 
 /world/New()
+	//temporary file used to record errors with loading config, moved to log directory once logging is set up
+	GLOB.config_error_log = GLOB.world_game_log = GLOB.world_runtime_log = "data/logs/config_error.log"
+	load_configuration()
+	// Setup all log paths and stamp them with startups
 	SetupLogs()
 	enable_debugger() // Enable the extools debugger
 	log_world("World loaded at [time_stamp()]")


### PR DESCRIPTION
## What Does This PR Do
Remake of #13408, but this time I dont obliterate the logging system

The MC restarting no longer re-creates the config datum, which unset any toggles set in round (such as OOC being disabled)

Config items still exist after an MC crash:
![image](https://user-images.githubusercontent.com/25063394/82665281-5dd52d00-9c2b-11ea-9053-0e6328343758.png)
![image](https://user-images.githubusercontent.com/25063394/82665283-60378700-9c2b-11ea-84c7-a52fd2b434ba.png)

Oh and logs still work this time
![image](https://user-images.githubusercontent.com/25063394/82665302-66c5fe80-9c2b-11ea-97fe-40d2a933f09d.png)

## Why It's Good For The Game
An MC restart should not obliterate the entire `config` global item, nor should it re-read all the config files from disk after an MC reload.

## Changelog
:cl: AffectedArc07
fix: The MC restarting no longer re-enables OOC
/:cl: