### PR TITLE
Fixes a filesystem viewing exploit

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -18,6 +18,8 @@
 		src << browse_rsc(file)
 
 /client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm"))
+	// wow why was this ever a parameter
+	root = "data/logs/"
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)


### PR DESCRIPTION
## What Does This PR Do
Stops a viewing proc from being able to access filesystems it shouldnt on the server

## Why It's Good For The Game
Holes should be plugged

## Changelog
:cl: AffectedArc07
fix: You can no-longer proccall the file browser
/:cl:
