### PR TITLE
Fixes the explosion distance on proc/explosion()

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -99,12 +99,12 @@
 			var/flame_dist = 0
 //			var/throw_dist = max_range - dist
 
-			if(dist < flame_range)
+			if(dist <= flame_range)
 				flame_dist = 1
 
-			if(dist < devastation_range)		dist = 1
-			else if(dist < heavy_impact_range)	dist = 2
-			else if(dist < light_impact_range)	dist = 3
+			if(dist <= devastation_range)		dist = 1
+			else if(dist <= heavy_impact_range)	dist = 2
+			else if(dist <= light_impact_range)	dist = 3
 			else 								dist = 0
 
 			//------- TURF FIRES -------


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the explosion distance for proc/explosion().
The distance given for explosions was reduced by one and would not cause the proper explosion effects for the given distance specified.

explosion(loc, 1, 2, 4, flame_range = 2)
The values 1, 2, and 4 are suppose to call levels of  ex_act()  on turfs that are a distance of 1, 2, and 4 tiles from the given location, the same goes with flame_range. These ex_act() effects would only reach tiles at range of 0, 1, and 3.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It would make the distances for the explosions work as intended.
However...
**All explosions using proc/explode() would get a range bump of 1 to it's ex_act() calls.**
Making something like the syndie minibomb and pizza bomb more lethal than what's in the game now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: proc/explosion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->