### PR TITLE
Library computer fix

### DIFF
--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -165,7 +165,7 @@
 			dat += "<table>"
 
 			var/list/forbidden = list(
-				/obj/item/book/manual
+				/obj/item/book/manual/random
 			)
 
 			if(!emagged)
@@ -174,11 +174,12 @@
 			var/manualcount = 1
 			var/obj/item/book/manual/M = null
 
-			for(var/manual_type in (typesof(/obj/item/book/manual) - forbidden))
-				M = new manual_type()
-				dat += "<tr><td><A href='?src=[UID()];manual=[manualcount]'>[M.title]</A></td></tr>"
+			for(var/manual_type in subtypesof(/obj/item/book/manual))
+				if(!(manual_type in forbidden))
+					M = new manual_type()
+					dat += "<tr><td><A href='?src=[UID()];manual=[manualcount]'>[M.title]</A></td></tr>"
+					QDEL_NULL(M)
 				manualcount++
-				QDEL_NULL(M)
 			dat += "</table>"
 			dat += "<BR><A href='?src=[UID()];switchscreen=0'>(Return to main menu)</A><BR>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/10435
Makes the library computer print the correct manuals. Also fixes the bug with an empty button in "Print manual" category. 

The computer was printing the wong manuals because the titles went out of sync with what was actually printed. The button without text in the very end was appearing because /obj/item/book/manual/random was being added, which is not an actual book. However due to the books being out of sync instead of printing the random book it printed command SOPs.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Better to have less bugs.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
OLD / NEW
![2](https://user-images.githubusercontent.com/58699696/82753396-e5f33800-9dcd-11ea-876d-2dad9b386778.png)


## Changelog
:cl:
fix: Fixes library computer printing wrong manuals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
