### PR TITLE
Makes airlocks destroyable again using weapons when the panel is open

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -864,7 +864,7 @@ About the new airlock wires panel:
 						update_icon()
 					return
 
-	else if(istype(C, /obj/item/assembly/signaler))
+	if(istype(C, /obj/item/assembly/signaler))
 		return interact_with_panel(user)
 	else if(istype(C, /obj/item/pai_cable))	// -- TLE
 		var/obj/item/pai_cable/cable = C


### PR DESCRIPTION
## What Does This PR Do
Makes you able to destroy airlocks when their panel is open.
Fixes: #13093 

## Why It's Good For The Game
Less bugs more mugs

## Changelog
:cl:
fix: You can destroy airlocks again when the panel is open
/:cl: