### PR TITLE
Gives flashes and cameras a light flash

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -58,6 +58,8 @@
 
 	playsound(loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("[base_state]_flash", src)
+	set_light(2, 1, COLOR_WHITE)
+	addtimer(CALLBACK(src, /atom./proc/set_light, 0), 2)
 	last_flash = world.time
 	use_power(1000)
 

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -71,18 +71,18 @@
 	flash_recharge(user)
 
 	if(broken)
-		return 0
+		return FALSE
 
-	playsound(src.loc, use_sound, 100, 1)
+	playsound(loc, use_sound, 100, 1)
 	flick("[initial(icon_state)]2", src)
 	set_light(2, 1, COLOR_WHITE)
 	addtimer(CALLBACK(src, /atom./proc/set_light, 0), 2)
 	times_used++
 
 	if(user && !clown_check(user))
-		return 0
+		return FALSE
 
-	return 1
+	return TRUE
 
 
 /obj/item/flash/proc/flash_carbon(var/mob/living/carbon/M, var/mob/user = null, var/power = 5, targeted = 1)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -67,7 +67,7 @@
 	times_used = max(0, times_used) //sanity
 
 
-/obj/item/flash/proc/try_use_flash(var/mob/user = null)
+/obj/item/flash/proc/try_use_flash(mob/user = null)
 	flash_recharge(user)
 
 	if(broken)
@@ -75,6 +75,8 @@
 
 	playsound(src.loc, use_sound, 100, 1)
 	flick("[initial(icon_state)]2", src)
+	set_light(2, 1, COLOR_WHITE)
+	addtimer(CALLBACK(src, /atom./proc/set_light, 0), 2)
 	times_used++
 
 	if(user && !clown_check(user))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -324,24 +324,26 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 				mob_detail += "You can also see [A] on the photo[A:health < 75 ? " - [A] looks hurt":""].[holding ? " [holding]":"."]."
 	return mob_detail
 
-/obj/item/camera/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
-	if(!on || !pictures_left || ismob(target.loc)) return
+/obj/item/camera/afterattack(atom/target, mob/user, flag)
+	if(!on || !pictures_left || ismob(target.loc))
+		return
 	captureimage(target, user, flag)
 
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, 1, -3)
-
+	set_light(3, 2, LIGHT_COLOR_TUNGSTEN)
+	addtimer(CALLBACK(src, /atom./proc/set_light, 0), 2)
 	pictures_left--
 	desc = "A polaroid camera. It has [pictures_left] photos left."
 	to_chat(user, "<span class='notice'>[pictures_left] photos left.</span>")
 	icon_state = icon_off
-	on = 0
+	on = FALSE
 	if(istype(src,/obj/item/camera/spooky))
 		if(user.mind && user.mind.assigned_role == "Chaplain" && see_ghosts)
 			if(prob(24))
 				handle_haunt(user)
 	spawn(64)
 		icon_state = icon_on
-		on = 1
+		on = TRUE
 
 /obj/item/camera/proc/can_capture_turf(turf/T, mob/user)
 	var/viewer = user


### PR DESCRIPTION
## What Does This PR Do
Gives both flashers (the portable one and the brig cell ones), flashes and cameras a flash of light when used. Both taking 2 ticks (0.2 seconds)

## Why It's Good For The Game
Makes way for some interesting uses of cameras and flashes. Spooky station coming to you soon

## Images of changes
![1A72sO0He1](https://user-images.githubusercontent.com/15887760/82838585-f76f3980-9ecc-11ea-8cfc-18f05bb87f39.gif)


## Changelog
:cl:
add: Gives a flasher (portable and brig flashers) a light flash after it is used
add: Gives a flash a light flash after it is used
add: Gives a camera a light flash after it is used
/:cl: