### PR TITLE
Fixes #13492 - message monitor key not working

### DIFF
--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -490,7 +490,7 @@
 			for(var/obj/machinery/message_server/server in GLOB.message_servers)
 				if(!isnull(server))
 					if(!isnull(server.decryptkey))
-						info = "<center><h2>Daily Key Reset</h2></center><br>The new message monitor key is '[server.decryptkey]'.<br>Please keep this a secret and away from the clown.<br>If necessary, change the password to a more secure one."
+						info = "<center><h2>Daily Key Reset</h2></center>\n\t<br>The new message monitor key is '[server.decryptkey]'.<br>Please keep this a secret and away from the clown.<br>If necessary, change the password to a more secure one."
 						info_links = info
 						overlays += "paper_words"
 						break


### PR DESCRIPTION
## What Does This PR Do
Fixes #13492 

## Changelog
:cl: Kyep
fix: fixed the message monitor key printout paper so you can once again read the key from it.
/:cl: