### PR TITLE
NT undercover changes

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -220,12 +220,14 @@
 
 /datum/outfit/admin/nt_undercover
 	name = "NT Undercover Operative"
+	var/access_level = "Emergency Response Team Leader"
 	// Disguised NT special forces, sent to quietly eliminate or keep tabs on people in high positions (e.g: captain)
+	//nerfed ghost version, doesn't get the op centcom combat implant, less access
 
 	uniform = /obj/item/clothing/under/color/black
 	back = /obj/item/storage/backpack
 	belt = /obj/item/storage/belt/utility/full/multitool
-	gloves = /obj/item/clothing/gloves/combat
+	gloves = /obj/item/clothing/gloves/color/yellow
 	shoes = /obj/item/clothing/shoes/chameleon/noslip
 	l_ear = /obj/item/radio/headset/centcom
 	id = /obj/item/card/id
@@ -233,11 +235,25 @@
 	backpack_contents = list(
 		/obj/item/storage/box/engineer = 1,
 		/obj/item/flashlight = 1,
-		/obj/item/pinpointer/crew = 1
+		/obj/item/pinpointer/crew = 1,
+		/obj/item/gun/projectile/automatic/proto = 1,
+		/obj/item/ammo_box/magazine/smgm9mm = 3,
+		/obj/item/suppressor = 1
 	)
 	implants = list(
 		/obj/item/implant/dust
 	)
+	cybernetic_implants = list(
+		/obj/item/organ/internal/cyberimp/eyes/shield,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/obj/item/organ/internal/cyberimp/arm/baton
+	)
+
+/datum/outfit/admin/nt_undercover/officer
+	name = "NT Undercover Officer"
+	access_level = "NT Undercover Officer"
+	//Disguised NT special forces, officer (ie full admeme) version
+
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/shield,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
@@ -254,7 +270,7 @@
 
 	var/obj/item/card/id/I = H.wear_id
 	if(istype(I))
-		apply_to_card(I, H, get_centcom_access("NT Undercover Operative"), "Civilian")
+		apply_to_card(I, H, get_centcom_access(access_level), "Civilian")
 	H.sec_hud_set_ID() // Force it to show as Civ on sec huds
 
 	var/obj/item/radio/R = H.l_ear

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -219,10 +219,10 @@
 	// Will show as ? on sec huds, as this is not a recognized rank.
 
 /datum/outfit/admin/nt_undercover
-	name = "NT Undercover Operative"
+	name = "NT Undercover Agent"
 	var/access_level = "Emergency Response Team Leader"
-	// Disguised NT special forces, sent to quietly eliminate or keep tabs on people in high positions (e.g: captain)
-	//nerfed ghost version, doesn't get the op centcom combat implant, less access
+	// Ghost role for undercover antics on behalf of NT. Much weaker than the "NT Undercover Officer" below.
+	//Lacks CC implant and CC access. Default weapon is silenced saber SMG.
 
 	uniform = /obj/item/clothing/under/color/black
 	back = /obj/item/storage/backpack
@@ -245,6 +245,7 @@
 	)
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/shield,
+		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/arm/baton
 	)
@@ -252,8 +253,7 @@
 /datum/outfit/admin/nt_undercover/officer
 	name = "NT Undercover Officer"
 	access_level = "NT Undercover Officer"
-	//Disguised NT special forces, officer (ie full admeme) version
-
+	// Disguised NT special forces. Admin ("officer") version. Has CC specops implant, and CC access.
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/shield,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -224,7 +224,7 @@
 	// Ghost role for undercover antics on behalf of NT. Much weaker than the "NT Undercover Officer" below.
 	//Lacks CC implant and CC access. Default weapon is silenced saber SMG.
 
-	uniform = /obj/item/clothing/under/color/black
+	uniform = /obj/item/clothing/under/color/random
 	back = /obj/item/storage/backpack
 	belt = /obj/item/storage/belt/utility/full/multitool
 	gloves = /obj/item/clothing/gloves/color/yellow

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -234,7 +234,7 @@
 	pda = /obj/item/pda
 	backpack_contents = list(
 		/obj/item/storage/box/engineer = 1,
-		/obj/item/flashlight = 1,
+		/obj/item/flashlight/emp = 1,
 		/obj/item/pinpointer/crew = 1,
 		/obj/item/gun/projectile/automatic/proto = 1,
 		/obj/item/ammo_box/magazine/smgm9mm = 3,

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -98,7 +98,7 @@
 			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_MEDICAL, ACCESS_CENT_SECURITY, ACCESS_CENT_STORAGE, ACCESS_CENT_SPECOPS, ACCESS_CENT_SPECOPS_COMMANDER, ACCESS_CENT_BLACKOPS) + get_all_accesses()
 		if("Deathsquad Officer")
 			return get_all_centcom_access() + get_all_accesses()
-		if("NT Undercover Operative")
+		if("NT Undercover Officer")
 			return get_all_centcom_access() + get_all_accesses()
 		if("Special Operations Officer")
 			return get_all_centcom_access() + get_all_accesses()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR effectively renames the existing 'NT Undercover Operative' into the newly created 'NT Undercover Officer', then creates a replacement NT Undercover Agent with reduced gear and tools.

The idea is that the Agent is an outfit that can be given to ghosts during events or in response to threats as an alternative to sending an ERT, while the Undercover Officer maintains access to all the OP admin-only tools that would be overkill to give to a player.

Detailed breakdown of changes:
1. Combat gloves of both are replaced with insulated gloves. Combat gloves are not exactly common and draw unwanted attention, an undercover operative should IMO not be using them. The heat resistance is only rarely relevant.
2. An NT Saber SMG was added to both, together with 3 magazines and a suppressor. Since the Agent loses access to the CC combat implant, he needed a replacement weapon. The Saber SMG is deadly, small, suppressed, made by NT and was used by NT Undercover operatives in the past. The Undercover Officer gets this too but can freely ditch it at CC if he doesn't want it, to help his cover.
3. As mentioned, Agents lose the CC combat implant which had a pulse pistol, mindshield implanter, baton, omni-door remote and healing injector. They keep welding shield, nutritien implant, sec hud implant and gain a baton implant for unarmed combat.  They also still have a dust implant
4. Agents no longer have full Centcom access. They now have the same access as an ert team leader, ie basic centcom access. Mostly a flavour thing but it is a role intended to be given to players, so better be safe here.
5. Agents also get an emp flashlight, for disabling coms or borgs or other misc utility.


## Why It's Good For The Game
NT Undercover Operatives have a lot of potential, IMO. Sometimes, CC wants someone eliminated quietly. While an admin could spawn in as the old version of undercover operative, that is in many cases suboptimal since it 1) is pretty damn unfair, raising the barrier for using it quite high. Good luck escaping someone with a centcom combat implant 2) Giving ghosts something to do can't hurt.

So I intend to give us another tool in our event/response toolbox. Maybe rather than an ert a few undercover agents can be sent to help deal with a situation like a mutiny discreetly, giving ghosts something to do and the antagonists still a fair fighting chance. And if full admeme force is required, the Undercover Officer still has all the good stuff.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: NT Undercover Officers
tweak: Changes to NT Undercover Operatives, renamed to NT Undercover Agent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
