### PR TITLE
Helps Organs GC Better

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -26,11 +26,9 @@
 	mmi_icon = 'icons/mob/alien.dmi'
 	mmi_icon_state = "AlienMMI"
 
-/obj/item/organ/internal/brain/New()
-	..()
-	spawn(5)
-		if(brainmob && brainmob.client)
-			brainmob.client.screen.len = null //clear the hud
+/obj/item/organ/internal/brain/Destroy()
+	QDEL_NULL(brainmob)
+	return ..()
 
 /obj/item/organ/internal/brain/proc/transfer_identity(var/mob/living/carbon/H)
 	brainmob = new(src)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -141,9 +141,11 @@
 /obj/item/organ/internal/cyberimp/brain/anti_stun/emp_act(severity)
 	if(crit_fail || emp_proof)
 		return
-	crit_fail = 1
-	spawn(90 / severity)
-		crit_fail = 0
+	crit_fail = TRUE
+	addtimer(CALLBACK(src, .proc/reboot), 90 / severity)
+
+/obj/item/organ/internal/cyberimp/brain/anti_stun/proc/reboot()
+	crit_fail = FALSE
 
 /obj/item/organ/internal/cyberimp/brain/clown_voice
 	name = "Comical implant"
@@ -230,11 +232,13 @@
 	if(owner.stat == DEAD)
 		return
 	if(owner.nutrition <= hunger_threshold)
-		synthesizing = 1
+		synthesizing = TRUE
 		to_chat(owner, "<span class='notice'>You feel less hungry...</span>")
 		owner.adjust_nutrition(50)
-		spawn(50)
-			synthesizing = 0
+		addtimer(CALLBACK(src, .proc/synth_cool), 50)
+
+/obj/item/organ/internal/cyberimp/chest/nutriment/proc/synth_cool()
+	synthesizing = FALSE
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/emp_act(severity)
 	if(!owner || emp_proof)
@@ -309,10 +313,15 @@
 		var/mob/living/carbon/human/H = owner
 		if(H.stat != DEAD && prob(50 / severity))
 			H.set_heartattack(TRUE)
-			spawn(600 / severity)
-				H.set_heartattack(FALSE)
-				if(H.stat == CONSCIOUS)
-					to_chat(H, "<span class='notice'>You feel your heart beating again!</span>")
+			addtimer(CALLBACK(src, .proc/undo_heart_attack), 600 / severity)
+
+/obj/item/organ/internal/cyberimp/chest/reviver/proc/undo_heart_attack()
+	var/mob/living/carbon/human/H = owner
+	if(!istype(H))
+		return
+	H.set_heartattack(FALSE)
+	if(H.stat == CONSCIOUS)
+		to_chat(H, "<span class='notice'>You feel your heart beating again!</span>")
 
 //BOX O' IMPLANTS
 

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -23,9 +23,8 @@
 			Stop()
 			return
 
-	spawn(120)
-		if(!owner)
-			Stop()
+	if(!special)
+		addtimer(CALLBACK(src, .proc/stop_if_unowned), 120)
 
 /obj/item/organ/internal/heart/emp_act(intensity)
 	if(!is_robotic() || emp_proof)
@@ -43,13 +42,15 @@
 		return
 	if(!beating)
 		Restart()
-		spawn(80)
-			if(!owner)
-				Stop()
+		addtimer(CALLBACK(src, .proc/stop_if_unowned), 80)
 
 /obj/item/organ/internal/heart/safe_replace(mob/living/carbon/human/target)
 	Restart()
 	..()
+
+/obj/item/organ/internal/heart/proc/stop_if_unowned()
+	if(!owner)
+		Stop()
 
 /obj/item/organ/internal/heart/proc/Stop()
 	beating = FALSE


### PR DESCRIPTION
Refactors a number of organ related behaviors to use `addtimer` instead of `spawn`.

Also removes a worthless `New` for brainmobs and ensure that brain items should GC a bit better.