### PR TITLE
Cyborgs can't look inside storage containers with alt-click anymore

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -83,7 +83,7 @@
 	return
 
 /obj/item/storage/AltClick(mob/user)
-	if(Adjacent(user) && !user.incapacitated(FALSE, TRUE, TRUE))
+	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE, TRUE))
 		orient2hud(user)
 		if(user.s_active)
 			user.s_active.close(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -90,6 +90,7 @@
 		show_to(user)
 		playsound(loc, "rustle", 50, 1, -5)
 		add_fingerprint(user)
+	return ..()
 
 /obj/item/storage/proc/return_inv()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Borgs should not be able to look inside storages at all. This was unintended from #12863.

This also makes it so when *anyone* alt-clicks on a container, it will still bring up the old examine tab that lists a turf's contents, in addition to opening the container. I think this is probably the best thing to do to avoid situations such as backpacks being too big, making it annoying to get the contents of the tile.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13239
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cyborgs can't look inside storage containers with alt-click anymore
tweak: Alt-clicking on a storage container while it's on the floor will bring up the examine tab which lists a turf's contents just like alt-clicking normally does, in addition to opening the container.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
