### PR TITLE
Ghosts can now hear guardian communication again

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -189,6 +189,7 @@
 	to_chat(summoner, "<span class='changeling'><i>[src]:</i> [input]</span>")
 	to_chat(src, "<span class='changeling'><i>[src]:</i> [input]</span>")
 	log_say("(GUARDIAN to [key_name(summoner)]) [input]", src)
+	create_log(SAY_LOG, "GUARDIAN to HOST: [input]", summoner)
 
 	// Show the message to any ghosts/dead players.
 	for(var/mob/M in GLOB.dead_mob_list)
@@ -223,6 +224,7 @@
 	to_chat(G, "<span class='changeling'><i>[src]:</i> [input]</span>")
 	to_chat(src, "<span class='changeling'><i>[src]:</i> [input]</span>")
 	log_say("(GUARDIAN to [key_name(G)]) [input]", src)
+	create_log(SAY_LOG, "HOST to GUARDIAN: [input]", G)
 
 	// Show the message to any ghosts/dead players.
 	for(var/mob/M in GLOB.dead_mob_list)

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -182,15 +182,18 @@
 		input = stripped_input(src, "Please enter a message to tell your summoner.", "Guardian", "")
 	else
 		input = message
-	if(!input) return
+	if(!input)
+		return
 
-	for(var/mob/M in GLOB.mob_list)
-		if(M == summoner)
-			to_chat(M, "<span class='changeling'><i>[src]:</i> [input]</span>")
-			log_say("(GUARDIAN to [key_name(M)]) [input]", src)
-		else if(M in GLOB.dead_mob_list && M.client && M.stat == DEAD && !isnewplayer(M))
-			to_chat(M, "<span class='changeling'><i>Guardian Communication from <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>")
+	// Show the message to the host and to the guardian.
+	to_chat(summoner, "<span class='changeling'><i>[src]:</i> [input]</span>")
 	to_chat(src, "<span class='changeling'><i>[src]:</i> [input]</span>")
+	log_say("(GUARDIAN to [key_name(summoner)]) [input]", src)
+
+	// Show the message to any ghosts/dead players.
+	for(var/mob/M in GLOB.dead_mob_list)
+		if(M && M.client && M.stat == DEAD && !isnewplayer(M))
+			to_chat(M, "<span class='changeling'><i>Guardian Communication from <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>")
 
 //override set to true if message should be passed through instead of going to host communication
 /mob/living/simple_animal/hostile/guardian/say(message, override = FALSE)
@@ -208,18 +211,23 @@
 	set category = "Guardian"
 	set desc = "Communicate telepathically with your guardian."
 	var/input = stripped_input(src, "Please enter a message to tell your guardian.", "Message", "")
-	if(!input) return
+	if(!input)
+		return
 
-	for(var/mob/M in GLOB.mob_list)
-		if(istype(M, /mob/living/simple_animal/hostile/guardian))
-			var/mob/living/simple_animal/hostile/guardian/G = M
-			if(G.summoner == src)
-				to_chat(G, "<span class='changeling'><i>[src]:</i> [input]</span>")
-				log_say("(GUARDIAN to [key_name(G)]) [input]", src)
+	// Find the guardian in our host's contents.
+	var/mob/living/simple_animal/hostile/guardian/G = locate() in contents
+	if(!G)
+		return
 
-		else if(M in GLOB.dead_mob_list && M.client && M.stat == DEAD && !isnewplayer(M))
-			to_chat(M, "<span class='changeling'><i>Guardian Communication from <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>")
+	// Show the message to our guardian and to host.
+	to_chat(G, "<span class='changeling'><i>[src]:</i> [input]</span>")
 	to_chat(src, "<span class='changeling'><i>[src]:</i> [input]</span>")
+	log_say("(GUARDIAN to [key_name(G)]) [input]", src)
+
+	// Show the message to any ghosts/dead players.
+	for(var/mob/M in GLOB.dead_mob_list)
+		if(M && M.client && M.stat == DEAD && !isnewplayer(M))
+			to_chat(M, "<span class='changeling'><i>Guardian Communication from <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>")
 
 /mob/living/proc/guardian_recall()
 	set name = "Recall Guardian"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ghosts can now hear guardian (holoparasite) communication again.

Also improves some of the code, removes stupid crap like *looping through the entirety of the global mobs list just to find the guardian's host*, when there is literally a var called `summoner` which is their host. Who though that was a good idea?
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #12929
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ghosts can now hear guardian communication again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
