### PR TITLE
Makes EMPing a handheld defib only disable safety for 2 minutes

### DIFF
--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -24,6 +24,12 @@
 		if(user)
 			to_chat(user, "<span class='warning'>You restore the safeties on [src]</span>")
 
+/obj/item/handheld_defibrillator/proc/un_emp() 		//EMPs only disable safeties for 120 seconds
+	if(emagged) 		//avoids it from giving the "safety protocols are back online" if it was already un-emagged for being EMPd twice
+		emagged = FALSE
+		visible_message("<span class='notice'>[src] beeps: Safety protocols back online.</span>")
+		desc = initial(desc)
+
 /obj/item/handheld_defibrillator/emp_act(severity)
 	if(emagged)
 		emagged = FALSE
@@ -35,10 +41,8 @@
 		desc += " The screen only shows the word KILL flashing over and over."
 		visible_message("<span class='notice'>[src] beeps: Safety protocols disabled!</span>")
 		playsound(get_turf(src), 'sound/machines/defib_saftyoff.ogg', 50, 0)
-		spawn(1200)
-			emagged = FALSE
-			visible_message("<span class='notice'>[src] beeps: Safety protocols back online.</span>")
-			return
+		addtimer(CALLBACK(src, .proc/un_emp), 1200)
+
 
 /obj/item/handheld_defibrillator/attack(mob/living/carbon/human/H, mob/user)
 	if(!istype(H))

--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -35,6 +35,10 @@
 		desc += " The screen only shows the word KILL flashing over and over."
 		visible_message("<span class='notice'>[src] beeps: Safety protocols disabled!</span>")
 		playsound(get_turf(src), 'sound/machines/defib_saftyoff.ogg', 50, 0)
+		spawn(1200)
+			emagged = FALSE
+			visible_message("<span class='notice'>[src] beeps: Safety protocols back online.</span>")
+			return
 
 /obj/item/handheld_defibrillator/attack(mob/living/carbon/human/H, mob/user)
 	if(!istype(H))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the handheld defibrillator only have their safeties disabled for 120 seconds after an EMP. Unlike an emag that permanently disables them 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
An emagged defib is already an insanely strong weapon, sleeping people and having a chance of stopping their hearts with infinite charge. An EMP that is easy to get should not have as strong of an effect as a 6 TC traitor item on this thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: an EMPd handheld defibrillator now only have their safeties disabled for 120 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
