### PR TITLE
Fixes whiteship spawning above station

### DIFF
--- a/_maps/map_files/generic/tcommsat-blown.dmm
+++ b/_maps/map_files/generic/tcommsat-blown.dmm
@@ -119,10 +119,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"be" = (
-/obj/item/trash/cheesie,
-/turf/space,
-/area/space/nearstation)
 "bj" = (
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
@@ -957,6 +953,17 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/AIsattele)
+"ji" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 10;
+	height = 35;
+	id = "whiteship_away";
+	name = "Deep Space";
+	width = 21
+	},
+/turf/space,
+/area/space)
 "yn" = (
 /turf/space,
 /area/space/nearstation)
@@ -8721,7 +8728,7 @@ aa
 aa
 aa
 aa
-be
+aa
 aa
 aa
 aa
@@ -17223,7 +17230,7 @@ aa
 aa
 aa
 aa
-aa
+ji
 aa
 aa
 aa


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so that the whiteship actually spawns on Z3 now isntead of above the station. I broke this during the tcomms overhaul and never realised the blown out sat didnt have a docking port for the whiteship. I also removed that random packet of empty cheesie honkers in space because I have always seen that as a mapping accident.

## Why It's Good For The Game
The whiteship should spawn away from the station, but at the moment it actually spawns on top

## Images of changes
*Ingame this looks the exact same ingame becaue docking ports are invisible, so an image would not help. If you really need images, MapDiffBot can generate them*

## Changelog
:cl: AffectedArc07
fix: The white ship no longer spawns above the station
/:cl:
