### PR TITLE
Fixes the virus outbreak event from not being able to generate "normal" viruses. Also the naming is fixed

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -126,11 +126,19 @@
 		AddDisease(D)
 
 
+/**
+ * Forces the mob to contract a virus. If the mob can have viruses. Ignores clothing and other protection
+ * Returns TRUE if it succeeds. False if it doesn't
+ *
+ * Arguments:
+ * * D - the disease the mob will try to contract
+ */
 //Same as ContractDisease, except never overidden clothes checks
 /mob/proc/ForceContractDisease(datum/disease/D)
 	if(!CanContractDisease(D))
-		return 0
+		return FALSE
 	AddDisease(D)
+	return TRUE
 
 
 /mob/living/carbon/human/CanContractDisease(datum/disease/D)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,43 +1,36 @@
 /datum/event/disease_outbreak
 	announceWhen = 15
-
-	var/datum/disease/advance/virus_type
+	var/datum/disease/D
 
 /datum/event/disease_outbreak/setup()
 	announceWhen = rand(15, 30)
+	if(prob(25))
+		var/virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/fluspanish, /datum/disease/pierrot_throat, /datum/disease/lycan)
+		D = new virus_type()
+	else
+		var/datum/disease/advance/A = new /datum/disease/advance
+		A.name = capitalize(pick(GLOB.adjectives)) + " " + capitalize(pick(GLOB.nouns + GLOB.verbs)) // random silly name
+		A.GenerateSymptoms(1,9,6)
+		A.AssignProperties(list("resistance" = rand(0,11), "stealth" = rand(0,2), "stage_rate" = rand(0,5), "transmittable" = rand(0,5), "severity" = rand(0,10)))
+		D = A
+
+	D.carrier = TRUE
 
 /datum/event/disease_outbreak/announce()
 	GLOB.event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 
 /datum/event/disease_outbreak/start()
-	if(prob(25))
-		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/fluspanish, /datum/disease/pierrot_throat, /datum/disease/lycan)
-	else
-		virus_type = new /datum/disease/advance
-		virus_type.name = capitalize(pick(GLOB.adjectives)) + " " + capitalize(pick(GLOB.nouns,GLOB.verbs)) // random silly name
-		virus_type.GenerateSymptoms(1,9,6)
-		virus_type.AssignProperties(list("resistance" = rand(0,11), "stealth" = rand(0,2), "stage_rate" = rand(0,5), "transmittable" = rand(0,5), "severity" = rand(0,10)))
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.living_mob_list))
-		if(issmall(H)) //don't infect monkies; that's a waste
-			continue
 		if(!H.client)
 			continue
-		if(VIRUSIMMUNE in H.dna.species.species_traits) //don't let virus immune things get diseases they're not supposed to get.
+		if(issmall(H)) //don't infect monkies; that's a waste
 			continue
 		var/turf/T = get_turf(H)
 		if(!T)
 			continue
 		if(!is_station_level(T.z))
 			continue
-		var/foundAlready = FALSE	// don't infect someone that already has the virus
-		for(var/thing in H.viruses)
-			foundAlready = TRUE
-			break
-		if(H.stat == DEAD || foundAlready)
-			continue
 
-		var/datum/disease/advance/D
-		D = virus_type
-		D.carrier = TRUE
-		H.AddDisease(D)
+		if(!H.ForceContractDisease(D))
+			continue
 		break


### PR DESCRIPTION
## What Does This PR Do
Fixes the virus event. Normal diseases runtimed due to how the code was made.
Also fixes random diseases being called "fat "
Also refactored the event code a bit.

## Why It's Good For The Game
Two bugs. One virologist

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/83299592-c6f20d00-a1f6-11ea-8f3b-bba6f13ac939.png)


## Changelog
:cl:
fix: Random normal viruses from the virus outbreak event now actually spawn instead of runtime and make everybody sad
fix: Random advanced viruses from the virus outbreak event now have proper working names
/:cl:
