### PR TITLE
Changes the changelings absorb objective description to be more clear

### DIFF
--- a/code/game/gamemodes/changeling/powers/spiders.dm
+++ b/code/game/gamemodes/changeling/powers/spiders.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/spiders
 	name = "Spread Infestation"
 	desc = "Our form divides, creating arachnids which will grow into deadly beasts."
-	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 5 DNA absorptions."
+	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 5 stored DNA."
 	button_icon_state = "spread_infestation"
 	chemical_cost = 45
 	dna_cost = 1

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -475,7 +475,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 					n_p++
 		target_amount = min(target_amount, n_p)
 
-	explanation_text = "Absorb [target_amount] compatible genomes."
+	explanation_text = "Acquire [target_amount] compatible genomes. The 'Extract DNA Sting' can be used to stealthily get genomes without killing somebody."
 	return target_amount
 
 /datum/objective/absorb/check_completion()


### PR DESCRIPTION
## What Does This PR Do
Changes the absorb objective to be more clear that you do not have to absorb people but can also use the Extract DNA sting. Also changes the "spread infestation" sting description

## Why It's Good For The Game
Seems people think that you have to absorb people since the objective says to absorb genomes. Hopefully this will make it more clear

## Changelog
:cl:
tweak: The changelings absorb objective description is made more descriptive.
tweak: The changelings spread infestation power description is made more clear.
/:cl: