### PR TITLE
Make light_constructs use X_acts. Fixes a runtime

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -39,81 +39,86 @@
 			if(3)
 				. += "The casing is closed."
 
-/obj/machinery/light_construct/attackby(obj/item/W as obj, mob/living/user as mob, params)
-	src.add_fingerprint(user)
-	if(istype(W, /obj/item/wrench))
-		if(src.stage == 1)
-			playsound(src.loc, W.usesound, 75, 1)
-			to_chat(usr, "You begin deconstructing [src].")
-			if(!do_after(usr, 30 * W.toolspeed, target = src))
+/obj/machinery/light_construct/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	switch(stage)
+		if(1)
+			to_chat(user, "<span class='notice'>You begin deconstructing [src].</span>")
+			if(!I.use_tool(src, user, 30, volume = I.tool_volume))
 				return
-			new /obj/item/stack/sheet/metal( get_turf(src.loc), sheets_refunded )
-			user.visible_message("[user.name] deconstructs [src].", \
-				"You deconstruct [src].", "You hear a noise.")
-			playsound(src.loc, W.usesound, 75, 1)
+			new /obj/item/stack/sheet/metal(get_turf(loc), sheets_refunded)
+			user.visible_message("<span class='notice'>[user.name] deconstructs [src].</span>", \
+				"<span class='notice'>You deconstruct [src].</span>", "You hear a noise.")
 			qdel(src)
-		if(src.stage == 2)
-			to_chat(usr, "You have to remove the wires first.")
-			return
+		if(2)
+			to_chat(user, "<span class='warning'>You have to remove the wires first.</span>")
+		if(3)
+			to_chat(user, "<span class='warning'>You have to unscrew the case first.</span>")
 
-		if(src.stage == 3)
-			to_chat(usr, "You have to unscrew the case first.")
-			return
-
-	if(istype(W, /obj/item/wirecutters))
-		if(src.stage != 2) return
-		src.stage = 1
-		switch(fixture_type)
-			if("tube")
-				src.icon_state = "tube-construct-stage1"
-			if("bulb")
-				src.icon_state = "bulb-construct-stage1"
-		new /obj/item/stack/cable_coil(get_turf(src.loc), 1, paramcolor = COLOR_RED)
-		user.visible_message("[user.name] removes the wiring from [src].", \
-			"You remove the wiring from [src].", "You hear a noise.")
-		playsound(loc, W.usesound, 100, 1)
+/obj/machinery/light_construct/wirecutter_act(mob/living/user, obj/item/I)
+	if(stage != 2)
 		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	playsound(loc, I.usesound, 100, 1)
+	. = TRUE
+	stage = 1
+	switch(fixture_type)
+		if("tube")
+			icon_state = "tube-construct-stage1"
+		if("bulb")
+			icon_state = "bulb-construct-stage1"
+	new /obj/item/stack/cable_coil(get_turf(loc), 1, paramcolor = COLOR_RED)
+	user.visible_message("<span class='notice'>[user] removes the wiring from [src].</span>", \
+		"<span class='notice'>You remove the wiring from [src].</span>", "You hear a noise.")
+
+/obj/machinery/light_construct/screwdriver_act(mob/living/user, obj/item/I)
+	if(stage != 2)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	switch(fixture_type)
+		if("tube")
+			icon_state = "tube-empty"
+		if("bulb")
+			icon_state = "bulb-empty"
+	stage = 3
+	user.visible_message("<span class='notice'>[user] closes [src]'s casing.</span>", \
+		"<span class='notice'>You close [src]'s casing.</span>", "You hear a noise.")
+	playsound(loc, I.usesound, 75, 1)
+
+	switch(fixture_type)
+		if("tube")
+			newlight = new /obj/machinery/light/built(loc)
+		if("bulb")
+			newlight = new /obj/machinery/light/small/built(loc)
+
+	newlight.dir = dir
+	transfer_fingerprints_to(newlight)
+	qdel(src)
+
+/obj/machinery/light_construct/attackby(obj/item/W, mob/living/user, params)
+	add_fingerprint(user)
 
 	if(istype(W, /obj/item/stack/cable_coil))
-		if(src.stage != 1) return
+		if(stage != 1)
+			return
 		var/obj/item/stack/cable_coil/coil = W
 		coil.use(1)
 		switch(fixture_type)
 			if("tube")
-				src.icon_state = "tube-construct-stage2"
+				icon_state = "tube-construct-stage2"
 			if("bulb")
-				src.icon_state = "bulb-construct-stage2"
-		src.stage = 2
+				icon_state = "bulb-construct-stage2"
+		stage = 2
 		playsound(loc, coil.usesound, 50, 1)
-		user.visible_message("[user.name] adds wires to [src].", \
-			"You add wires to [src].")
+		user.visible_message("<span class='notice'>[user.name] adds wires to [src].</span>", \
+			"<span class='notice'>You add wires to [src].</span>")
 		return
 
-	if(istype(W, /obj/item/screwdriver))
-		if(src.stage == 2)
-			switch(fixture_type)
-				if("tube")
-					src.icon_state = "tube-empty"
-				if("bulb")
-					src.icon_state = "bulb-empty"
-			src.stage = 3
-			user.visible_message("[user.name] closes [src]'s casing.", \
-				"You close [src]'s casing.", "You hear a noise.")
-			playsound(src.loc, W.usesound, 75, 1)
-
-			switch(fixture_type)
-
-				if("tube")
-					newlight = new /obj/machinery/light/built(src.loc)
-				if("bulb")
-					newlight = new /obj/machinery/light/small/built(src.loc)
-
-			newlight.dir = src.dir
-			src.transfer_fingerprints_to(newlight)
-			qdel(src)
-			return
-	else
-		return ..()
+	return ..()
 
 /obj/machinery/light_construct/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -47,7 +47,7 @@
 			if(!I.use_tool(src, user, 30, volume = I.tool_volume))
 				return
 			new /obj/item/stack/sheet/metal(get_turf(loc), sheets_refunded)
-			user.visible_message("<span class='notice'>[user.name] deconstructs [src].</span>", \
+			user.visible_message("<span class='notice'>[user] deconstructs [src].</span>", \
 				"<span class='notice'>You deconstruct [src].</span>", "You hear a noise.")
 			qdel(src)
 		if(2)
@@ -95,7 +95,7 @@
 		if("bulb")
 			newlight = new /obj/machinery/light/small/built(loc)
 
-	newlight.dir = dir
+	newlight.setDir(dir)
 	transfer_fingerprints_to(newlight)
 	qdel(src)
 


### PR DESCRIPTION
## What Does This PR Do
Refactors light_construct to use the X_act types. Also fixes a runtime

Fixes
```
[2020-05-31T15:42:54] Runtime in unsorted.dm,2014: The small light fixture frame taking damage after deletion
[2020-05-31T15:42:54]   proc name: stack trace (/datum/proc/stack_trace)
[2020-05-31T15:42:54]   usr: NAME (CKEY) (/mob/living/carbon/human)
[2020-05-31T15:42:54]   usr.loc: The floor (128,110,1) (/turf/simulated/floor/plasteel)
[2020-05-31T15:42:54]   src: the small light fixture frame (/obj/machinery/light_construct/small)
[2020-05-31T15:42:54]   src.loc: null
[2020-05-31T15:42:54]   call stack:
[2020-05-31T15:42:54]   the small light fixture frame (/obj/machinery/light_construct/small): stack trace("The small light fixture frame ...")
[2020-05-31T15:42:54]   the small light fixture frame (/obj/machinery/light_construct/small): take damage(5, "brute", "melee", 1, null, 0)
[2020-05-31T15:42:54]   the small light fixture frame (/obj/machinery/light_construct/small): attacked by(the wrench (/obj/item/wrench), NAME (/mob/living/carbon/human))
[2020-05-31T15:42:54]   the wrench (/obj/item/wrench): attack obj(the small light fixture frame (/obj/machinery/light_construct/small), NAME (/mob/living/carbon/human))
[2020-05-31T15:42:54]   the small light fixture frame (/obj/machinery/light_construct/small): attackby(the wrench (/obj/item/wrench), NAME (/mob/living/carbon/human), "icon-x=16;icon-y=30;left=1;scr...")
[2020-05-31T15:42:54]   the small light fixture frame (/obj/machinery/light_construct/small): attackby(the wrench (/obj/item/wrench), NAME (/mob/living/carbon/human), "icon-x=16;icon-y=30;left=1;scr...")
[2020-05-31T15:42:54]   the wrench (/obj/item/wrench): melee attack chain(NAME (/mob/living/carbon/human), the small light fixture frame (/obj/machinery/light_construct/small), "icon-x=16;icon-y=30;left=1;scr...")
[2020-05-31T15:42:54]   NAME (/mob/living/carbon/human): ClickOn(the small light fixture frame (/obj/machinery/light_construct/small), "icon-x=16;icon-y=30;left=1;scr...")
[2020-05-31T15:42:54]   the small light fixture frame (/obj/machinery/light_construct/small): Click(the floor (128,109,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=16;icon-y=30;left=1;scr...")
```

## Why It's Good For The Game
Less runtimes the better


## Changelog
:cl:
fix: Using a wrench on a light construct now won't hit it when you're trying to deconstruct it
/:cl: