### PR TITLE
Programmatic Profiler Access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /config/*
 !config/**/*/
 
+# ignore cfg, an internal BYOND folder
+/cfg/*
+
 #ignore other, specific files and folers
 *.before
 data/

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -267,6 +267,10 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
 	if(reason == 1) //special reboot, do none of the normal stuff
 		if(usr)
+			if(!check_rights(R_SERVER))
+				message_admins("[key_name_admin(usr)] attempted to restart the server via the Profiler, without access.")
+				log_admin("[key_name(usr)] attempted to restart the server via the Profiler, without access.")
+				return
 			message_admins("[key_name_admin(usr)] has requested an immediate world restart via client side debugging tools")
 			log_admin("[key_name(usr)] has requested an immediate world restart via client side debugging tools")
 		spawn(0)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -130,7 +130,6 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 			var/datum/admins/D = new /datum/admins(rank, rights, ckey)
 
 			if(D.rights & R_DEBUG || D.rights & R_VIEWRUNTIMES) // Grants profiler access to anyone with R_DEBUG or R_VIEWRUNTIMES
-				log_world("Marked [ckey] as app Admin")
 				world.SetConfig("APP/admin", ckey, "role=admin")
 
 			//find the client for a ckey if they are connected and associate them with the new admin datum

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -68,6 +68,10 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 		C.holder = null
 	GLOB.admins.Cut()
 
+	// Remove all profiler access
+	for(var/A in world.GetConfig("admin"))
+		world.SetConfig("APP/admin", A, null)
+
 	if(config.admin_legacy_system)
 		load_admin_ranks()
 
@@ -98,6 +102,9 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 			//create the admin datum and store it for later use
 			var/datum/admins/D = new /datum/admins(rank, rights, ckey)
 
+			if(D.rights & R_DEBUG || D.rights & R_VIEWRUNTIMES) // Grants profiler access to anyone with R_DEBUG or R_VIEWRUNTIMES
+				world.SetConfig("APP/admin", ckey, "role=admin")
+
 			//find the client for a ckey if they are connected and associate them with the new admin datum
 			D.associate(GLOB.directory[ckey])
 
@@ -121,6 +128,10 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 			var/rights = query.item[4]
 			if(istext(rights))	rights = text2num(rights)
 			var/datum/admins/D = new /datum/admins(rank, rights, ckey)
+
+			if(D.rights & R_DEBUG || D.rights & R_VIEWRUNTIMES) // Grants profiler access to anyone with R_DEBUG or R_VIEWRUNTIMES
+				log_world("Marked [ckey] as app Admin")
+				world.SetConfig("APP/admin", ckey, "role=admin")
 
 			//find the client for a ckey if they are connected and associate them with the new admin datum
 			D.associate(GLOB.directory[ckey])

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -247,6 +247,8 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 			verbs += GLOB.admin_verbs_server
 		if(holder.rights & R_DEBUG)
 			verbs += GLOB.admin_verbs_debug
+			spawn(1)
+				control_freak = 0 // Setting control_freak to 0 allows you to use the Profiler and other client-side tools
 		if(holder.rights & R_POSSESS)
 			verbs += GLOB.admin_verbs_possess
 		if(holder.rights & R_PERMISSIONS)
@@ -267,6 +269,9 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 			verbs += GLOB.admin_verbs_proccall
 		if(holder.rights & R_VIEWRUNTIMES)
 			verbs += /client/proc/view_runtimes
+			spawn(1) // This setting exposes the profiler for people with R_VIEWRUNTIMES. They must still have it set in cfg/admin.txt
+				control_freak = 0
+
 
 /client/proc/remove_admin_verbs()
 	verbs.Remove(


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so people with the `R_VIEWRUNTIMES` permission or `R_DEBUG` permission can use the server profiler. It also makes it so `world/Reboot()` requires `R_SERVER`, so people cannot reboot the server via the profiler.

## Why It's Good For The Game
The profiler access should be given out based on ingame admin ranks, not based off of an undocumented file which has to be managed by external tooling

## Changelog
:cl: AffectedArc07
add: The ingame profiler is now granted to people with R_DEBUG and R_VIEWRUNTIMES
/:cl:
