### PR TITLE
"Reject All" button for cargo console and PDA notifications

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -690,6 +690,9 @@
 			if(i == 1)
 				O.generateRequisition(loc)
 
+	else if (href_list["rejectall"])
+		SSshuttle.requestlist.Cut()
+
 	else if(href_list["confirmorder"])
 		if(SSshuttle.supply.getDockedId() != "supply_away" || SSshuttle.supply.mode != SHUTTLE_IDLE)
 			return 1

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -700,7 +700,7 @@
 			var/datum/supply_order/SO = A
 			if(!orders_by_users["[SO.orderedby][SO.object.name]"])         //orders_by_users is an associative list where index is "[requester name][object name]"
 				orders_by_users["[SO.orderedby][SO.object.name]"] = list() //and the value is another list, which contains order datums from same person of same object
-			orders_by_users["[SO.orderedby][SO.object.name]"] += SO        //they are used later to fill the messages with miltiple orders
+			orders_by_users["[SO.orderedby][SO.object.name]"] += SO        //they are used later to fill the messages with multiple orders
 
 		for(var/A in orders_by_users)                   //take a list from orders_by_users
 			var/list = A
@@ -712,7 +712,7 @@
 					object_name = SO.object.name        //what crate was requested
 				else
 					ordernumbers += ", #[SO.ordernum]"  //when more then one crate was requested add a coma and the next order number
-					multiple = TRUE                     //different verbs are used in the messege when there are multiple orders in it
+					multiple = TRUE                     //different verbs are used in the message when there are multiple orders in it
 			notify_pda(recipient, ordernumbers, object_name, multiple)
 			ordernumbers = null
 			multiple = FALSE
@@ -815,7 +815,7 @@
 			break
 
 	if(!sendable || !receivable)
-		return	
+		return
 
 	var/havehas = "has"
 	var/s
@@ -826,8 +826,8 @@
 		havehas = "have"
 		s = "s"
 
-	useMS.send_pda_message("[recipient]","Supply Ordering Console","Your order[s] #[order_number] ([ordered_object]) [havehas] been [confirmverb]")
-	PM.notify("<b>Automatic message from Supply Ordering Console, </b>\"Your order[s] #[order_number] ([ordered_object]) [havehas] been [confirmverb]\" (No reply)", 0)
+	useMS.send_pda_message("[recipient]", "Supply Ordering Console", "Your order[s] #[order_number] ([ordered_object]) [havehas] been [confirmverb]")
+	PM.notify("<b>Automatic message from Supply Ordering Console, </b>\"Your order[s] #[order_number] ([ordered_object]) [havehas] been [confirmverb]\" (No reply)", FALSE)
 
 #undef ORDER_SCREEN_WIDTH
 #undef ORDER_SCREEN_HEIGHT

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -698,21 +698,21 @@
 		var/multiple = FALSE
 		for(var/A in SSshuttle.requestlist)
 			var/datum/supply_order/SO = A
-			if(!orders_by_users["[SO.orderedby][SO.object.name]"])
-				orders_by_users["[SO.orderedby][SO.object.name]"] = list()
-			orders_by_users["[SO.orderedby][SO.object.name]"] += SO
+			if(!orders_by_users["[SO.orderedby][SO.object.name]"])         //orders_by_users is an associative list where index is "[requester name][object name]"
+				orders_by_users["[SO.orderedby][SO.object.name]"] = list() //and the value is another list, which contains order datums from same person of same object
+			orders_by_users["[SO.orderedby][SO.object.name]"] += SO        //they are used later to fill the messages with miltiple orders
 
-		for(var/A in orders_by_users)
+		for(var/A in orders_by_users)                   //take a list from orders_by_users
 			var/list = A
-			for(var/B in orders_by_users[list])
+			for(var/B in orders_by_users[list])         //loop through the order datums in each list
 				var/datum/supply_order/SO = B
-				if(!ordernumbers)
+				if(!ordernumbers)                       //if its the first item in the list
 					ordernumbers = "[SO.ordernum]"
-					recipient = SO.orderedby
-					object_name = SO.object.name
+					recipient = SO.orderedby            //who will get the message
+					object_name = SO.object.name        //what crate was requested
 				else
-					ordernumbers += ", #[SO.ordernum]"
-					multiple = TRUE
+					ordernumbers += ", #[SO.ordernum]"  //when more then one crate was requested add a coma and the next order number
+					multiple = TRUE                     //different verbs are used in the messege when there are multiple orders in it
 			notify_pda(recipient, ordernumbers, object_name, multiple)
 			ordernumbers = null
 			multiple = FALSE

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -691,7 +691,7 @@
 				O.generateRequisition(loc)
 
 	else if (href_list["rejectall"])
-		sort_and_send_messages()
+		notify_all_requesters()
 		SSshuttle.requestlist.Cut()
 
 	else if(href_list["confirmorder"])
@@ -706,7 +706,7 @@
 				O = SO
 				P = O.object
 				if(SSshuttle.points >= P.cost)
-					notify_pda(SO.orderedby, SO.ordernum, SO.object.name, confirmed = TRUE)
+					notify_pda(SO.orderedby, SO.ordernum, SO.object.name, approved = TRUE)
 					SSshuttle.requestlist.Cut(i,i+1)
 					SSshuttle.points -= P.cost
 					SSshuttle.shoppinglist += O
@@ -720,7 +720,7 @@
 		for(var/i=1, i<=SSshuttle.requestlist.len, i++)
 			var/datum/supply_order/SO = SSshuttle.requestlist[i]
 			if(SO.ordernum == ordernum)
-				notify_pda(SO.orderedby, SO.ordernum, SO.object.name)
+				notify_pda(SO.orderedby, SO.ordernum, SO.object.name, approved = FALSE)
 				SSshuttle.requestlist.Cut(i,i+1)
 				break
 
@@ -752,7 +752,7 @@
 
 	frequency.post_signal(src, status_signal)
 
-/obj/machinery/computer/supplycomp/proc/sort_and_send_messages()
+/obj/machinery/computer/supplycomp/proc/notify_all_requesters()
 	var/list/orders_by_users = list()
 	var/ordernumbers
 	var/recipient
@@ -765,8 +765,8 @@
 		orders_by_users["[SO.orderedby][SO.object.name]"] += SO        //they are used later to fill the messages with multiple orders
 
 	for(var/A in orders_by_users)                   //take a list from orders_by_users
-		var/list = A
-		for(var/B in orders_by_users[list])         //loop through the order datums in each list
+		var/key = A
+		for(var/B in orders_by_users[key])         //loop through the order datums in each list
 			var/datum/supply_order/SO = B
 			if(!ordernumbers)                       //if its the first item in the list
 				ordernumbers = "[SO.ordernum]"
@@ -775,11 +775,11 @@
 			else
 				ordernumbers += ", #[SO.ordernum]"  //when more then one crate was requested add a coma and the next order number
 				multiple = TRUE                     //different verbs are used in the message when there are multiple orders in it
-		notify_pda(recipient, ordernumbers, object_name, multiple)
+		notify_pda(recipient, ordernumbers, object_name, multiple, approved = FALSE)
 		ordernumbers = null
 		multiple = FALSE
 
-/obj/machinery/computer/supplycomp/proc/notify_pda(recipient, order_number, ordered_object, multiple = FALSE, confirmed = FALSE)
+/obj/machinery/computer/supplycomp/proc/notify_pda(recipient, order_number, ordered_object, multiple = FALSE, approved = FALSE)
 
 	var/obj/machinery/message_server/useMS = null
 	if(GLOB.message_servers)
@@ -823,7 +823,7 @@
 	var/havehas = "has"
 	var/s
 	var/confirmverb = "rejected"
-	if(confirmed)
+	if(approved)
 		confirmverb = "approved"
 	if(multiple)
 		havehas = "have"

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -691,31 +691,7 @@
 				O.generateRequisition(loc)
 
 	else if (href_list["rejectall"])
-		var/list/orders_by_users = list()
-		var/ordernumbers
-		var/recipient
-		var/object_name
-		var/multiple = FALSE
-		for(var/A in SSshuttle.requestlist)
-			var/datum/supply_order/SO = A
-			if(!orders_by_users["[SO.orderedby][SO.object.name]"])         //orders_by_users is an associative list where index is "[requester name][object name]"
-				orders_by_users["[SO.orderedby][SO.object.name]"] = list() //and the value is another list, which contains order datums from same person of same object
-			orders_by_users["[SO.orderedby][SO.object.name]"] += SO        //they are used later to fill the messages with multiple orders
-
-		for(var/A in orders_by_users)                   //take a list from orders_by_users
-			var/list = A
-			for(var/B in orders_by_users[list])         //loop through the order datums in each list
-				var/datum/supply_order/SO = B
-				if(!ordernumbers)                       //if its the first item in the list
-					ordernumbers = "[SO.ordernum]"
-					recipient = SO.orderedby            //who will get the message
-					object_name = SO.object.name        //what crate was requested
-				else
-					ordernumbers += ", #[SO.ordernum]"  //when more then one crate was requested add a coma and the next order number
-					multiple = TRUE                     //different verbs are used in the message when there are multiple orders in it
-			notify_pda(recipient, ordernumbers, object_name, multiple)
-			ordernumbers = null
-			multiple = FALSE
+		sort_and_send_messages()
 		SSshuttle.requestlist.Cut()
 
 	else if(href_list["confirmorder"])
@@ -775,6 +751,33 @@
 	status_signal.data["command"] = command
 
 	frequency.post_signal(src, status_signal)
+
+/obj/machinery/computer/supplycomp/proc/sort_and_send_messages()
+	var/list/orders_by_users = list()
+	var/ordernumbers
+	var/recipient
+	var/object_name
+	var/multiple = FALSE
+	for(var/A in SSshuttle.requestlist)
+		var/datum/supply_order/SO = A
+		if(!orders_by_users["[SO.orderedby][SO.object.name]"])         //orders_by_users is an associative list where index is "[requester name][object name]"
+			orders_by_users["[SO.orderedby][SO.object.name]"] = list() //and the value is another list, which contains order datums from same person of same object
+		orders_by_users["[SO.orderedby][SO.object.name]"] += SO        //they are used later to fill the messages with multiple orders
+
+	for(var/A in orders_by_users)                   //take a list from orders_by_users
+		var/list = A
+		for(var/B in orders_by_users[list])         //loop through the order datums in each list
+			var/datum/supply_order/SO = B
+			if(!ordernumbers)                       //if its the first item in the list
+				ordernumbers = "[SO.ordernum]"
+				recipient = SO.orderedby            //who will get the message
+				object_name = SO.object.name        //what crate was requested
+			else
+				ordernumbers += ", #[SO.ordernum]"  //when more then one crate was requested add a coma and the next order number
+				multiple = TRUE                     //different verbs are used in the message when there are multiple orders in it
+		notify_pda(recipient, ordernumbers, object_name, multiple)
+		ordernumbers = null
+		multiple = FALSE
 
 /obj/machinery/computer/supplycomp/proc/notify_pda(recipient, order_number, ordered_object, multiple = FALSE, confirmed = FALSE)
 

--- a/nano/templates/supply_console.tmpl
+++ b/nano/templates/supply_console.tmpl
@@ -126,5 +126,8 @@ Used In File(s): \code\game\supplyshuttle.dm
 				{{/for}}
 			</div>
 		</div>
+		<div class="allOrders">
+			{{:helper.link('Reject All', null, {'rejectall': 1}, null)}}
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a "Reject All" for supply shuttle console that allows to reject all of the pending requests.

Whenever a supply request gets accepted or rejected the requester gets a PDA notification. The message has order number, the name of the requested crate and whether it was accepted or rejected.
However when "Reject All" button is used the requests get grouped. When the recipient has several requests of the same item he will get them in one message.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
PDA notification is a convenient way for crewmembers to get updated on their cargo request status. 
Reject all button is going to allow cargotech/QM to easily clear pending requests instead of manually rejecting all of them whenever someone spams the console with 20 of the same crate.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![2](https://user-images.githubusercontent.com/58699696/83427375-5129b380-a439-11ea-8196-843d2a41ebe3.png)

![2](https://user-images.githubusercontent.com/58699696/83427257-1cb5f780-a439-11ea-8b6c-f790f73dec4e.png)

## Changelog
:cl:
add: Added a "Reject All" button for Supply Shuttle Console
add: A PDA notification is being sent to the requester by cargo console whenever an order gets accepted/rejected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
