### PR TITLE
You won't hit an airlock now when using a wirecutter on it while the panel is open

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -949,7 +949,7 @@ About the new airlock wires panel:
 	if(note)
 		remove_airlock_note(user, TRUE)
 	else
-		return interact_with_panel(user)
+		interact_with_panel(user)
 
 /obj/machinery/door/airlock/multitool_act(mob/user, obj/item/I)
 	if(!headbutt_shock_check(user))


### PR DESCRIPTION
## What Does This PR Do
As the title says. Fixes a bug from the tool refactor PR

## Why It's Good For The Game
It's cutting edge technology


## Changelog
:cl:
fix: You won't hit an airlock now when using a wirecutter on it while the panel is open
/:cl: