### PR TITLE
ChemHeater upgrading and QOL

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -1,7 +1,7 @@
 /obj/machinery/chem_heater
 	name = "chemical heater"
 	density = 1
-	anchored = 1
+	anchored = TRUE
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "mixer0b"
 	use_power = IDLE_POWER_USE
@@ -37,7 +37,7 @@
 				on = FALSE
 				SSnanoui.update_uis(src)
 				return
-			beaker.reagents.temperature_reagents(desired_temp, 35 - speed_increase)
+			beaker.reagents.temperature_reagents(desired_temp, max(1, 35 - speed_increase))
 			if(round(beaker.reagents.chem_temp) == round(desired_temp))
 				playsound(loc, 'sound/machines/ding.ogg', 50, 1)
 				on = FALSE
@@ -122,11 +122,11 @@
 		if(!beaker.reagents.total_volume)
 			return FALSE
 		on = !on
-		. = 1
+		. = TRUE
 
 	if(href_list["toggle_autoeject"])
 		auto_eject = !auto_eject
-		. = 1
+		. = TRUE
 
 	if(href_list["adjust_temperature"])
 		var/val = href_list["adjust_temperature"]
@@ -137,11 +137,11 @@
 			desired_temp = Clamp(target, 0, 1000)
 		else
 			return FALSE
-		. = 1
+		. = TRUE
 
 	if(href_list["eject_beaker"])
 		eject_beaker(usr)
-		. = 0 //updated in eject_beaker() already
+		. = FALSE //updated in eject_beaker() already
 
 /obj/machinery/chem_heater/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null)
 	if(user.stat || user.restrained())
@@ -158,17 +158,17 @@
 	var/cur_temp = beaker ? beaker.reagents.chem_temp : null
 
 	data["targetTemp"] = desired_temp
-	data["targetTempReached"] = ""
+	data["targetTempReached"] = FALSE
 	data["autoEject"] = auto_eject
 	data["isActive"] = on
-	data["isBeakerLoaded"] = beaker ? 1 : 0
+	data["isBeakerLoaded"] = beaker ? TRUE : FALSE
 
 	data["currentTemp"] = cur_temp
 	data["beakerCurrentVolume"] = beaker ? beaker.reagents.total_volume : null
 	data["beakerMaxVolume"] = beaker ? beaker.volume : null
 
 	if (cur_temp)
-		data["targetTempReached"] = round(cur_temp) == round(desired_temp) ? "good" : "average"
+		data["targetTempReached"] = round(cur_temp) == round(desired_temp)
 
 	//copy-pasted from chem dispenser
 	var/beakerContents[0]

--- a/nano/templates/chem_heater.tmpl
+++ b/nano/templates/chem_heater.tmpl
@@ -20,6 +20,14 @@ Used In File(s): \code\modules\reagents\newchem\chem_heater.dm
 </div>
 <div class="item">
 	<div class="itemLabel">
+		Auto-eject:
+	</div>
+	<div class="itemContent">
+		{{:helper.link(data.autoEject ? 'On' : 'Off', 'power-off', {'toggle_autoeject' : 1})}}
+	</div>
+</div>
+<div class="item">
+	<div class="itemLabel">
 		Beaker
 	</div>
 	<div class="itemContent">
@@ -33,7 +41,7 @@ Used In File(s): \code\modules\reagents\newchem\chem_heater.dm
 				<div style="width: 100%;">
 					{{if data.isBeakerLoaded}}
 						<b>Volume:&nbsp;{{:helper.smoothRound(data.beakerCurrentVolume)}}&nbsp;/&nbsp;{{:data.beakerMaxVolume}}</b><br>
-						<b>Temperature:&nbsp;{{:helper.smoothRound(data.currentTemp)}}&nbsp;Kelvin</b><br>
+						<b>Temperature:&nbsp;<span class="{{:data.targetTempReached}}">{{:helper.smoothRound(data.currentTemp)}}</span>&nbsp;Kelvin</b><br>
 						{{for data.beakerContents}}
 							<span class="highlight">{{:value.volume}} units of {{:value.name}}</span><br>
 						{{/for}}

--- a/nano/templates/chem_heater.tmpl
+++ b/nano/templates/chem_heater.tmpl
@@ -40,8 +40,14 @@ Used In File(s): \code\modules\reagents\newchem\chem_heater.dm
 			<div class="itemContent">
 				<div style="width: 100%;">
 					{{if data.isBeakerLoaded}}
-						<b>Volume:&nbsp;{{:helper.smoothRound(data.beakerCurrentVolume)}}&nbsp;/&nbsp;{{:data.beakerMaxVolume}}</b><br>
-						<b>Temperature:&nbsp;<span class="{{:data.targetTempReached}}">{{:helper.smoothRound(data.currentTemp)}}</span>&nbsp;Kelvin</b><br>
+						<b>
+							Volume:&nbsp;
+							{{:helper.smoothRound(data.beakerCurrentVolume)}}&nbsp;/&nbsp;{{:data.beakerMaxVolume}}
+						</b><br>
+						<b>
+							Temperature:&nbsp;
+							<span class="{{:data.targetTempReached ? 'good' : 'average'}}">{{:helper.smoothRound(data.currentTemp)}}</span>&nbsp;Kelvin
+						</b><br>
 						{{for data.beakerContents}}
 							<span class="highlight">{{:value.volume}} units of {{:value.name}}</span><br>
 						{{/for}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- ChemHeater's micro-laser component can now be upgraded for faster temperature change
- Adds auto-eject feature (off by default) to ChemHeater when the target has been reached
- Makes ChemHeater temperature label colored depending on whether the target has been reached
- Adds a "ding" sound to ChemHeater when the target has been reached
- ChemHeater no longer turns off when there's a <3 temperature difference between target and current - it now turns off when the target has been reached

## Why It's Good For The Game
Allows Chemists to spend less time waiting for the machine to heat/cool the beaker
Increases quality of life when using ChemHeater

## Images of changes
![image](https://user-images.githubusercontent.com/1496804/83521434-8557af80-a4df-11ea-821c-57aa0b93a93d.png)

## Changelog
:cl:
add: Ability to upgrade the chemical heater's micro-laser for increased speed
add: Auto-eject feature for the chemical heater
add: Chemical heater UI colors temperature label depending on if it reached the target or not
add: Ding sound when chemical heater is done
tweak: Chemical heater now turns off when the target has been reached, not when there's a <3 temperature difference between target and current
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
