### PR TITLE
Organ processing performance

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -173,6 +173,29 @@
 	metabolization_rate = 0.2
 	taste_description = "antibiotics"
 
+/datum/reagent/medicine/spaceacillin/on_mob_life(mob/living/M)
+	var/list/organs_list = list()
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		organs_list += C.internal_organs
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		organs_list += H.bodyparts
+
+	for(var/X in organs_list)
+		var/obj/item/organ/O = X
+		if(O.germ_level < INFECTION_LEVEL_ONE)
+			O.germ_level = 0	//cure instantly
+		else if(O.germ_level < INFECTION_LEVEL_TWO)
+			O.germ_level = max(M.germ_level - 24, 0)	//at germ_level == 500, this should cure the infection in 15 seconds
+		else
+			O.germ_level = max(M.germ_level - 8, 0)	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
+
+	organs_list.Cut()
+	M.germ_level = max(M.germ_level - 20, 0) // Reduces the mobs germ level, too
+	return ..()
+
 /datum/reagent/medicine/silver_sulfadiazine
 	name = "Silver Sulfadiazine"
 	id = "silver_sulfadiazine"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -188,9 +188,9 @@
 		if(O.germ_level < INFECTION_LEVEL_ONE)
 			O.germ_level = 0	//cure instantly
 		else if(O.germ_level < INFECTION_LEVEL_TWO)
-			O.germ_level = max(M.germ_level - 24, 0)	//at germ_level == 500, this should cure the infection in 15 seconds
+			O.germ_level = max(M.germ_level - 25, 0)	//at germ_level == 500, this should cure the infection in 34 seconds
 		else
-			O.germ_level = max(M.germ_level - 8, 0)	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
+			O.germ_level = max(M.germ_level - 10, 0)	// at germ_level == 1000, this will cure the infection in 1 minutes, 14 seconds
 
 	organs_list.Cut()
 	M.germ_level = max(M.germ_level - 20, 0) // Reduces the mobs germ level, too

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -116,18 +116,19 @@
 			necrotize()
 
 	else if(owner.bodytemperature >= 170)	//cryo stops germs from moving and doing their bad stuffs
-		//** Handle antibiotics and curing infections
-		handle_antibiotics()
-		handle_germ_effects()
+		// Handle antibiotics and curing infections
+		if(germ_level)
+			handle_germs()
+		return TRUE
 
 /obj/item/organ/proc/is_preserved()
 	if(istype(loc,/obj/item/mmi))
 		germ_level = max(0, germ_level - 1) // So a brain can slowly recover from being left out of an MMI
-		return 1
+		return TRUE
 	if(is_found_within(/obj/structure/closet/crate/freezer))
-		return 1
+		return TRUE
 	if(is_found_within(/obj/machinery/clonepod))
-		return 1
+		return TRUE
 	if(isturf(loc))
 		if(world.time - last_freezer_update_time > freezer_update_period)
 			// I don't want to loop through everything in the tile constantly, especially since it'll be a pile of organs
@@ -142,7 +143,7 @@
 		return is_in_freezer // I'd like static varibles, please
 
 	// You can do your cool location temperature organ preserving effects here!
-	return 0
+	return FALSE
 
 /obj/item/organ/examine(mob/user)
 	. = ..()
@@ -152,29 +153,38 @@
 		else
 			. += "<span class='notice'>It looks in need of repairs.</span>"
 
-/obj/item/organ/proc/handle_germ_effects()
+/obj/item/organ/proc/handle_germs()
 	//** Handle the effects of infections
 	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
 
-	if(germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
-		germ_level--
+	if(antibiotics >= 0.4)
+		if(germ_level < INFECTION_LEVEL_ONE)
+			germ_level = 0	//cure instantly
+		else if(germ_level < INFECTION_LEVEL_TWO)
+			germ_level -= 24	//at germ_level == 500, this should cure the infection in 15 seconds
+		else
+			germ_level -= 8	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
+							// Let's not drag this on, medbay has only so much antibiotics
 
-	if(germ_level >= INFECTION_LEVEL_ONE/2)
+		if(germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
+			germ_level--
+
+	if(germ_level >= INFECTION_LEVEL_ONE / 2)
 		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 15 minutes
-		if(antibiotics < 5 && prob(round(germ_level/6)))
+		if(antibiotics < 5 && prob(round(germ_level / 6)))
 			germ_level++
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
-		var/fever_temperature = (owner.dna.species.heat_level_1 - owner.dna.species.body_temperature - 5)* min(germ_level/INFECTION_LEVEL_TWO, 1) + owner.dna.species.body_temperature
-		owner.bodytemperature += between(0, (fever_temperature - T20C)/BODYTEMP_COLD_DIVISOR + 1, fever_temperature - owner.bodytemperature)
+		var/fever_temperature = (owner.dna.species.heat_level_1 - owner.dna.species.body_temperature - 5) * min(germ_level / INFECTION_LEVEL_TWO, 1) + owner.dna.species.body_temperature
+		owner.bodytemperature += between(0, (fever_temperature - T20C) / BODYTEMP_COLD_DIVISOR + 1, fever_temperature - owner.bodytemperature)
 
 	if(germ_level >= INFECTION_LEVEL_TWO)
 		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 		//spread germs
-		if(antibiotics < 5 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30) ))
+		if(antibiotics < 5 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE * 2 || prob(30)))
 			parent.germ_level++
 
-/obj/item/organ/internal/handle_germ_effects()
+/obj/item/organ/internal/handle_germs()
 	..()
 	if(germ_level >= INFECTION_LEVEL_TWO)
 		if(prob(3))	//about once every 30 seconds
@@ -199,21 +209,6 @@
 
 /obj/item/organ/proc/is_broken()
 	return (damage >= min_broken_damage || ((status & ORGAN_BROKEN) && !(status & ORGAN_SPLINTED)))
-
-//Germs
-/obj/item/organ/proc/handle_antibiotics()
-	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
-
-	if(!germ_level || antibiotics <= 0.4)
-		return
-
-	if(germ_level < INFECTION_LEVEL_ONE)
-		germ_level = 0	//cure instantly
-	else if(germ_level < INFECTION_LEVEL_TWO)
-		germ_level -= 24	//at germ_level == 500, this should cure the infection in 15 seconds
-	else
-		germ_level -= 8	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
-						// Let's not drag this on, medbay has only so much antibiotics
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon = "Unknown", var/damage)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -166,8 +166,8 @@
 			germ_level -= 8	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
 							// Let's not drag this on, medbay has only so much antibiotics
 
-		if(germ_level > 0 && germ_level < INFECTION_LEVEL_ONE / 2 && prob(30))
-			germ_level--
+	if(germ_level > 0 && germ_level < INFECTION_LEVEL_ONE / 2 && prob(30))
+		germ_level--
 
 	if(germ_level >= INFECTION_LEVEL_ONE / 2)
 		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 15 minutes

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -154,7 +154,7 @@
 			. += "<span class='notice'>It looks in need of repairs.</span>"
 
 /obj/item/organ/proc/handle_germs()
-	//** Handle the effects of infections
+	//** Handle the effects of infections and antibiotics
 	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
 
 	if(antibiotics >= 0.4)
@@ -166,7 +166,7 @@
 			germ_level -= 8	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
 							// Let's not drag this on, medbay has only so much antibiotics
 
-		if(germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
+		if(germ_level > 0 && germ_level < INFECTION_LEVEL_ONE / 2 && prob(30))
 			germ_level--
 
 	if(germ_level >= INFECTION_LEVEL_ONE / 2)
@@ -188,7 +188,7 @@
 	..()
 	if(germ_level >= INFECTION_LEVEL_TWO)
 		if(prob(3))	//about once every 30 seconds
-			receive_damage(1,silent=prob(30))
+			receive_damage(1, silent = prob(30))
 
 /obj/item/organ/proc/rejuvenate()
 	damage = 0

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -154,24 +154,12 @@
 			. += "<span class='notice'>It looks in need of repairs.</span>"
 
 /obj/item/organ/proc/handle_germs()
-	//** Handle the effects of infections and antibiotics
-	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
-
-	if(antibiotics >= 0.4)
-		if(germ_level < INFECTION_LEVEL_ONE)
-			germ_level = 0	//cure instantly
-		else if(germ_level < INFECTION_LEVEL_TWO)
-			germ_level -= 24	//at germ_level == 500, this should cure the infection in 15 seconds
-		else
-			germ_level -= 8	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
-							// Let's not drag this on, medbay has only so much antibiotics
-
 	if(germ_level > 0 && germ_level < INFECTION_LEVEL_ONE / 2 && prob(30))
 		germ_level--
 
 	if(germ_level >= INFECTION_LEVEL_ONE / 2)
 		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 15 minutes
-		if(antibiotics < 5 && prob(round(germ_level / 6)))
+		if(prob(round(germ_level / 6)))
 			germ_level++
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
@@ -181,7 +169,7 @@
 	if(germ_level >= INFECTION_LEVEL_TWO)
 		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 		//spread germs
-		if(antibiotics < 5 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE * 2 || prob(30)))
+		if(parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE * 2 || prob(30)))
 			parent.germ_level++
 
 /obj/item/organ/internal/handle_germs()

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -305,10 +305,9 @@ This function completely restores a damaged organ to perfect condition.
 		if(!(status & ORGAN_BROKEN))
 			perma_injury = 0
 
-		//Infections
-		update_germs()
-	else
-		..()
+	if(..())
+		if(owner.germ_level > germ_level)
+			handle_germ_sync()
 
 //Updating germ levels. Handles organ germ levels and necrosis.
 /*
@@ -329,35 +328,18 @@ INFECTION_LEVEL_THREE	above this germ level the player will take additional toxi
 
 Note that amputating the affected organ does in fact remove the infection from the player's body.
 */
-/obj/item/organ/external/proc/update_germs()
-
-	if(is_robotic() || (NO_GERMS in owner.dna.species.species_traits)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
-		germ_level = 0
-		return
-
-	if(owner.bodytemperature >= 170)	//cryo stops germs from moving and doing their bad stuffs
-		//** Syncing germ levels with external wounds
-		handle_germ_sync()
-
-		//** Handle antibiotics and curing infections
-		handle_antibiotics()
-
-		//** Handle the effects of infections
-		handle_germ_effects()
 
 /obj/item/organ/external/proc/handle_germ_sync()
 	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
 	if(antibiotics < 5)
 		//Open wounds can become infected
-		if(owner.germ_level > germ_level && infection_check())
+		if(infection_check())
 			germ_level++
 
-/obj/item/organ/external/handle_germ_effects()
+/obj/item/organ/external/handle_germs()
 
 	if(germ_level < INFECTION_LEVEL_TWO)
 		return ..()
-
-	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
 
 	if(germ_level >= INFECTION_LEVEL_TWO)
 		//spread the infection to internal organs
@@ -383,17 +365,16 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(children)
 			for(var/obj/item/organ/external/child in children)
 				if(child.germ_level < germ_level && !child.is_robotic())
-					if(child.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
+					if(child.germ_level < INFECTION_LEVEL_ONE * 2 || prob(30))
 						child.germ_level++
 
 		if(parent)
 			if(parent.germ_level < germ_level && !parent.is_robotic())
-				if(parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
+				if(parent.germ_level < INFECTION_LEVEL_ONE * 2 || prob(30))
 					parent.germ_level++
 
-	if(germ_level >= INFECTION_LEVEL_THREE && antibiotics < 30)	//overdosing is necessary to stop severe infections
+	if(germ_level >= INFECTION_LEVEL_THREE && owner.reagents.get_reagent_amount("spaceacillin") < 30)	//overdosing is necessary to stop severe infections
 		necrotize()
-
 		germ_level++
 		owner.adjustToxLoss(1)
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -330,11 +330,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 */
 
 /obj/item/organ/external/proc/handle_germ_sync()
-	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
-	if(antibiotics < 5)
+	if(infection_check() && owner.reagents.get_reagent_amount("spaceacillin") < 5)
 		//Open wounds can become infected
-		if(infection_check())
-			germ_level++
+		germ_level++
 
 /obj/item/organ/external/handle_germs()
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -306,8 +306,9 @@ This function completely restores a damaged organ to perfect condition.
 			perma_injury = 0
 
 	if(..())
-		if(owner.germ_level > germ_level)
-			handle_germ_sync()
+		if(owner.germ_level > germ_level && infection_check())
+			//Open wounds can become infected
+			germ_level++
 
 //Updating germ levels. Handles organ germ levels and necrosis.
 /*
@@ -324,15 +325,10 @@ the actual time is dependent on RNG.
 INFECTION_LEVEL_ONE		below this germ level nothing happens, and the infection doesn't grow
 INFECTION_LEVEL_TWO		above this germ level the infection will start to spread to internal and adjacent organs
 INFECTION_LEVEL_THREE	above this germ level the player will take additional toxin damage per second, and will die in minutes without
-						antitox. also, above this germ level you will need to overdose on spaceacillin to reduce the germ_level.
+						antitox..
 
 Note that amputating the affected organ does in fact remove the infection from the player's body.
 */
-
-/obj/item/organ/external/proc/handle_germ_sync()
-	if(infection_check() && owner.reagents.get_reagent_amount("spaceacillin") < 5)
-		//Open wounds can become infected
-		germ_level++
 
 /obj/item/organ/external/handle_germs()
 
@@ -371,7 +367,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				if(parent.germ_level < INFECTION_LEVEL_ONE * 2 || prob(30))
 					parent.germ_level++
 
-	if(germ_level >= INFECTION_LEVEL_THREE && owner.reagents.get_reagent_amount("spaceacillin") < 30)	//overdosing is necessary to stop severe infections
+	if(germ_level >= INFECTION_LEVEL_THREE)
 		necrotize()
 		germ_level++
 		owner.adjustToxLoss(1)


### PR DESCRIPTION
This is a minor optimization, it's nothing special:

It mostly just reduced proc calls, puts cheaper proc calls first so more expensive ones don't run, and makes it a bit more OOP.

Testing revealed it made organ `process`ing about ~16% cheaper.

:cl: Fox McCloud
tweak: Massive doses of spaceacillin no longer prevents organ necrosis from ever happening.
tweak: Buffs spaceacillin just a hair by making it kill a couple more germs per cycle
tweak: Improves processing of organs so it improves game performance
/:cl: