### PR TITLE
[s] Patches a hole

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -2,6 +2,10 @@
 /datum/admins/proc/player_panel_new()//The new one
 	if(!usr.client.holder)
 		return
+	// This stops the panel from being invoked by mentors who press F7.
+	if(!check_rights(R_ADMIN))
+		message_admins("[key_name_admin(usr)] attempted to invoke player panel without admin rights. If this is a mentor, its a chance they accidentally hit F7. If this is NOT a mentor, there is a high chance an exploit is being used")
+		return
 	var/dat = "<html><head><title>Admin Player Panel</title></head>"
 
 	//javascript, the part that does most of the work~


### PR DESCRIPTION
## What Does This PR Do
Stops mentors from being able to access the player panel, via pressing F7 on their keyboard.

This is meant to be an admin only feature, due to the fact it not only reveals antag status, but also player IP addresses. 

## Why It's Good For The Game
Security good exploits bad

## Changelog
:cl: AffectedArc07
tweak: Mentors can no longer invoke player panel via F7
/:cl:

