### PR TITLE
Various Life Refactor Fixes

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -51,7 +51,8 @@
 	speak_emote = list("pulses")
 	var/obj/structure/blob/factory/factory = null
 	var/list/human_overlays = list()
-	var/is_zombie = 0
+	var/mob/living/carbon/human/oldguy
+	var/is_zombie = FALSE
 
 /mob/living/simple_animal/hostile/blob/blobspore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	..()
@@ -102,6 +103,7 @@
 	human_overlays = H.overlays
 	update_icons()
 	H.forceMove(src)
+	oldguy = H
 	visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
@@ -130,9 +132,9 @@
 	if(factory)
 		factory.spores -= src
 	factory = null
-	if(contents)
-		for(var/mob/M in contents)
-			M.loc = get_turf(src)
+	if(oldguy)
+		oldguy.forceMove(get_turf(src))
+		oldguy = null
 	return ..()
 
 

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -162,7 +162,7 @@
 	if(loc == summoner)
 		forceMove(get_turf(summoner))
 		new /obj/effect/temp_visual/guardian/phase(loc)
-		src.client.eye = loc
+		reset_perspective()
 		cooldown = world.time + 30
 
 /mob/living/simple_animal/hostile/guardian/proc/Recall(forced = FALSE)

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -100,7 +100,7 @@
 			break
 
 	if(!success)
-		user.loc = pick(L)
+		user.forceMove(pick(L))
 
 	smoke.start()
 	src.uses -= 1

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -336,6 +336,10 @@
 
 		AdjustHallucinate(-2)
 
+	// Keep SSD people asleep
+	if(player_logged)
+		Sleeping(2)
+
 /mob/living/carbon/handle_sleeping()
 	if(..())
 		if(mind?.vampire)
@@ -363,9 +367,6 @@
 		if(prob(10) && health && hal_screwyhud != SCREWYHUD_CRIT)
 			emote("snore")
 
-	// Keep SSD people asleep
-	if(player_logged)
-		Sleeping(2)
 	return sleeping
 
 /mob/living/carbon/update_health_hud(shown_health_amount)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -582,7 +582,7 @@
 		D.expel(src)	// no trunk connected, so expel immediately
 		return
 
-	loc = D.trunk
+	forceMove(D.trunk)
 	active = 1
 	dir = DOWN
 	spawn(1)
@@ -746,9 +746,9 @@
 		if(H2 && !H2.active)
 			H.merge(H2)
 
-		H.loc = P
+		H.forceMove(P)
 	else			// if wasn't a pipe, then set loc to turf
-		H.loc = T
+		H.forceMove(T)
 		return null
 
 	return P
@@ -790,7 +790,7 @@
 
 	if(T.density)		// dense ouput turf, so stop holder
 		H.active = 0
-		H.loc = src
+		H.forceMove(src)
 		return
 	if(T.intact && istype(T,/turf/simulated/floor)) //intact floor, pop the tile
 		var/turf/simulated/floor/F = T
@@ -1069,9 +1069,9 @@
 		var/obj/structure/disposalholder/H2 = locate() in P
 		if(H2 && !H2.active)
 			H.merge(H2)
-		H.loc = P
+		H.forceMove(P)
 	else			// if wasn't a pipe, then set loc to turf
-		H.loc = T
+		H.forceMove(T)
 		return null
 
 	return P
@@ -1128,9 +1128,9 @@
 		if(H2 && !H2.active)
 			H.merge(H2)
 
-		H.loc = P
+		H.forceMove(P)
 	else			// if wasn't a pipe, then set loc to turf
-		H.loc = T
+		H.forceMove(T)
 		return null
 
 	return P


### PR DESCRIPTION
PR to fix some of the issues brought about by the `Life` refactor

- Should hopefully fix mobs ending up in null location unassigned to any z-level by going in disposals
- Should fix guardians having their view messed up/locked
- Should fix SSD players being woken up and staying awake

fixes: https://github.com/ParadiseSS13/Paradise/issues/13537
fixes: https://github.com/ParadiseSS13/Paradise/issues/13538

:cl: Fox McCloud
fix: Fixes guardians view being locked to the player
fix: Fixes SSD players being woken up and not going back to sleep
/:cl: