### PR TITLE
Hierophant Buff--Staff Nerf

### DIFF
--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -93,7 +93,7 @@
 	blast_range = initial(blast_range)
 	if(isliving(user))
 		var/mob/living/L = user
-		var/health_percent = L.health / L.maxHealth
+		var/health_percent = max(L.health / L.maxHealth, 0) // Don't go negative
 		chaser_cooldown += round(health_percent * 20) //two tenths of a second for each missing 10% of health
 		cooldown_time += round(health_percent * 10) //one tenth of a second for each missing 10% of health
 		chaser_speed = max(chaser_speed + health_percent, 0.5) //one tenth of a second faster for each missing 10% of health

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -452,6 +452,7 @@ Difficulty: Hard
 				else
 					burst_range = 3
 					INVOKE_ASYNC(src, .proc/burst, get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
+				OpenFire()
 			else
 				devour(L)
 		else


### PR DESCRIPTION
A buff to Hierophant that makes him considerably more difficult to fight, as he'll do more than just spam his AoE attack when you're in melee range.

This makes tanking Hierophant in melee a lot more difficult--especially in combination with the dramatic nerf to patches a little while ago.

Additionally, this nerfs the Hierophant staff to cap the percentage buff it gives for being damaged; it cuts off once you hit `0` health---instead of potentially apply negative values. This should make it less egregious when utilized in dire situations.

:cl: Fox McCloud
tweak: Hierophant has been made considerably strong when fighting it in melee range
tweak: Hierophant staff damage and range values can't go negative, making them insanely strong
/:cl: