### PR TITLE
Terror queens that evolve from princesses will now be able to see their medhud properly

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
@@ -38,9 +38,12 @@
 	evolvequeen_action.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/princess/proc/evolve_to_queen()
-	var/mob/living/simple_animal/hostile/poison/terror_spider/queen/Q = new /mob/living/simple_animal/hostile/poison/terror_spider/queen(loc)
+	var/mob/living/simple_animal/hostile/poison/terror_spider/queen/Q = new(loc)
 	if(mind)
 		mind.transfer_to(Q)
+		// Calling `transfer_to()` removes our new body (the Queen's) ability to see the med hud, so we have to re-add the queen here.
+		var/datum/atom_hud/U = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+		U.add_hud_to(Q)
 	qdel(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/princess/DoWrap()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If you're a terror princess and you use the evolve to queen ability, you lose the ability to see your medhud. This fixes that.

The reason why this was breaking, in steps, because I found this confusing at first:
1. The new queen gets spawned, they get a medhud just fine.
2. `transfer_to()` is called.
3. Inside `transfer_to()`, the line `current = new_character` is executed, which sets our mind's `current` to the new queen we just spawned.
4. Further on down, `transfer_antag_huds()` and subsequently `leave_all_huds()` is called, which removes all huds, including the medhud, from the queen spider.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an unlisted bug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Terror queens that evolve from princesses will now be able to see their medhud properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
