### PR TITLE
Nerfs Trashbags

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -33,9 +33,11 @@
 	icon_state = "trashbag"
 	item_state = "trashbag"
 
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_BULKY
 	max_w_class = WEIGHT_CLASS_SMALL
+	slot_flags = null
 	storage_slots = 30
+	max_combined_w_class = 30
 	can_hold = list() // any
 	cant_hold = list(/obj/item/disk/nuclear)
 
@@ -45,18 +47,15 @@
 	return TOXLOSS
 
 /obj/item/storage/bag/trash/update_icon()
-	if(contents.len == 0)
-		w_class = WEIGHT_CLASS_TINY
-		icon_state = "[initial(icon_state)]"
-	else if(contents.len < 12)
-		w_class = WEIGHT_CLASS_BULKY
-		icon_state = "[initial(icon_state)]1"
-	else if(contents.len < 21)
-		w_class = WEIGHT_CLASS_BULKY
-		icon_state = "[initial(icon_state)]2"
-	else
-		w_class = WEIGHT_CLASS_BULKY
-		icon_state = "[initial(icon_state)]3"
+	switch(contents.len)
+		if(20 to INFINITY)
+			icon_state = "[initial(icon_state)]3"
+		if(11 to 20)
+			icon_state = "[initial(icon_state)]2"
+		if(1 to 11)
+			icon_state = "[initial(icon_state)]1"
+		else
+			icon_state = "[initial(icon_state)]"
 
 /obj/item/storage/bag/trash/cyborg
 


### PR DESCRIPTION
Trashbags have become problematic, to say the least.

They're basically vastly superior toolbelts; the bluspace trashbag is even worse.

Either case, this nerfs them in two ways:

- Their weight class is always bulky, which makes means you can no longer do the meme of putting a trashbag in a trashbag then one from inside the other. It also means you can't carry it around in your backpack.
- They no longer have a slot flag, meaning you can't wear them on your belt. You'll have to carry it around in your hands.

Trashbag is a janitorial tool that's mean to make life easier for the janitor--and it accomplishes that, but it absolutely should not be the best toolbelt item in the game.

This also fixes regular trashbags only being able to hold 14 items.

:cl: Fox McCloud
tweak: Trashbags no longer fit on belts
tweak: Trashbags are always bulky, even when empty
fix: Fixes regular trashbags only being able to hold 14 items.
/:cl: