### PR TITLE
Refactors and reworks transit tube pods. Maint drones can now also use them

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -283,6 +283,12 @@
 #define SHELTER_DEPLOY_BAD_AREA "bad area"
 #define SHELTER_DEPLOY_ANCHORED_OBJECTS "anchored objects"
 
+// transit_tube stuff
+#define TRANSIT_TUBE_OPENING 0
+#define TRANSIT_TUBE_OPEN 1
+#define TRANSIT_TUBE_CLOSING 2
+#define TRANSIT_TUBE_CLOSED 3
+
 // Maximum donation level
 #define DONATOR_LEVEL_MAX 4
 

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -1,3 +1,6 @@
+#define CLOSE_DURATION 6
+#define OPEN_DURATION 6
+
 
 // A place where tube pods stop, and people can get in or out.
 // Mappers: use "Generate Instances from Directions" for this
@@ -8,13 +11,12 @@
 	icon_state = "closed"
 	exit_delay = 1
 	enter_delay = 2
-	var/pod_moving = 0
+	var/pod_moving = FALSE
 	var/cooldown_delay = 50
 	var/launch_cooldown = 0
-	var/reverse_launch = 0
+	var/reverse_launch = FALSE
+	var/hatch_state = TRANSIT_TUBE_CLOSED
 
-	var/const/OPEN_DURATION = 6
-	var/const/CLOSE_DURATION = 6
 	var/list/disallowed_mobs = list(/mob/living/silicon/ai)
 
 /obj/structure/transit_tube/station/New()
@@ -27,20 +29,22 @@
 
 // Stations which will send the tube in the opposite direction after their stop.
 /obj/structure/transit_tube/station/reverse
-	reverse_launch = 1
+	reverse_launch = TRUE
 
 /obj/structure/transit_tube/station/should_stop_pod(pod, from_dir)
-	return 1
+	return TRUE
 
-/obj/structure/transit_tube/station/Bumped(mob/AM as mob|obj)
-	if(!pod_moving && icon_state == "open" && istype(AM, /mob/living) && !is_type_in_list(AM, disallowed_mobs))
+/obj/structure/transit_tube/station/Bumped(mob/living/L)
+	if(!pod_moving && hatch_state == TRANSIT_TUBE_OPEN && isliving(L) && !is_type_in_list(L, disallowed_mobs))
+		var/failed = FALSE
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(pod.contents.len)
-				to_chat(AM, "<span class=The pod is already occupied.</span>")
-				return
+				failed = TRUE
 			else if(!pod.moving && (pod.dir in directions()))
-				AM.forceMove(pod)
+				L.forceMove(pod)
 				return
+		if(failed)
+			to_chat(L, "<span class='warning'>The pod is already occupied.</span>")
 
 
 
@@ -48,13 +52,13 @@
 	if(!pod_moving)
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(!pod.moving && (pod.dir in directions()))
-				if(icon_state == "closed")
-					open_animation()
+				if(hatch_state == TRANSIT_TUBE_CLOSED)
+					open_hatch()
 
-				else if(icon_state == "open")
+				else if(hatch_state == TRANSIT_TUBE_OPEN)
 					if(pod.contents.len && user.loc != pod)
 						user.visible_message("<span class='warning'>[user] starts emptying [pod]'s contents onto the floor!</span>")
-						if(do_after(user, 40, target = src)) //So it doesn't default to close_animation() on fail
+						if(do_after(user, 40, target = src)) //So it doesn't default to close_hatch() on fail
 							if(pod.loc == loc)
 								for(var/atom/movable/AM in pod)
 									AM.loc = get_turf(user)
@@ -63,12 +67,12 @@
 										M.Weaken(5)
 
 					else
-						close_animation()
+						close_hatch()
 			break
 
 
 /obj/structure/transit_tube/station/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/grab) && icon_state == "open")
+	if(istype(W, /obj/item/grab) && hatch_state == TRANSIT_TUBE_OPEN)
 		var/obj/item/grab/G = W
 		if(ismob(G.affecting) && G.state >= GRAB_AGGRESSIVE)
 			var/mob/GM = G.affecting
@@ -80,63 +84,76 @@
 					qdel(G)
 				break
 
-/obj/structure/transit_tube/station/proc/open_animation()
-	if(icon_state == "closed")
+/obj/structure/transit_tube/station/proc/open_hatch()
+	if(hatch_state == TRANSIT_TUBE_CLOSED)
 		icon_state = "opening"
-		spawn(OPEN_DURATION)
-			if(icon_state == "opening")
-				icon_state = "open"
+		hatch_state = TRANSIT_TUBE_OPENING
+		addtimer(CALLBACK(src, .proc/open_hatch_callback), OPEN_DURATION)
+
+/obj/structure/transit_tube/station/proc/open_hatch_callback()
+	if(hatch_state == TRANSIT_TUBE_OPENING)
+		icon_state = "open"
+		hatch_state = TRANSIT_TUBE_OPEN
 
 
 
-/obj/structure/transit_tube/station/proc/close_animation()
-	if(icon_state == "open")
+/obj/structure/transit_tube/station/proc/close_hatch()
+	if(hatch_state == TRANSIT_TUBE_OPEN)
 		icon_state = "closing"
-		spawn(CLOSE_DURATION)
-			if(icon_state == "closing")
-				icon_state = "closed"
+		hatch_state = TRANSIT_TUBE_CLOSING
+		addtimer(CALLBACK(src, .proc/close_hatch_calllback), CLOSE_DURATION)
 
-
+/obj/structure/transit_tube/station/proc/close_hatch_calllback()
+	if(hatch_state == TRANSIT_TUBE_CLOSING)
+		icon_state = "closed"
+		hatch_state = TRANSIT_TUBE_CLOSED
 
 /obj/structure/transit_tube/station/proc/launch_pod()
 	for(var/obj/structure/transit_tube_pod/pod in loc)
 		if(!pod.moving && (pod.dir in directions()))
-			spawn(5)
-				pod_moving = 1
-				close_animation()
-				sleep(CLOSE_DURATION + 2)
-
-				//reverse directions for automated cycling
-				var/turf/next_loc = get_step(loc, pod.dir)
-				var/obj/structure/transit_tube/nexttube
-				for(var/obj/structure/transit_tube/tube in next_loc)
-					if(tube.has_entrance(pod.dir))
-						nexttube = tube
-						break
-				if(!nexttube)
-					pod.dir = turn(pod.dir, 180)
-
-				if(icon_state == "closed" && pod)
-					pod.follow_tube()
-
-				pod_moving = 0
-
+			addtimer(CALLBACK(src, .proc/launch_pod_callback, pod), 5)
 			return
+
+/obj/structure/transit_tube/station/proc/launch_pod_callback(obj/structure/transit_tube_pod/pod)
+	pod_moving = TRUE
+	close_hatch()
+	sleep(CLOSE_DURATION + 2)
+
+	//reverse directions for automated cycling
+	var/turf/next_loc = get_step(loc, pod.dir)
+	var/obj/structure/transit_tube/nexttube
+	for(var/obj/structure/transit_tube/tube in next_loc)
+		if(tube.has_entrance(pod.dir))
+			nexttube = tube
+			break
+	if(!nexttube)
+		pod.dir = turn(pod.dir, 180)
+
+	if(hatch_state == TRANSIT_TUBE_CLOSED && pod)
+		pod.follow_tube()
+
+	pod_moving = FALSE
 
 /obj/structure/transit_tube/station/process()
 	if(!pod_moving)
 		launch_pod()
 
 /obj/structure/transit_tube/station/pod_stopped(obj/structure/transit_tube_pod/pod, from_dir)
-	pod_moving = 1
-	spawn(5)
-		launch_cooldown = world.time + cooldown_delay
-		open_animation()
-		sleep(OPEN_DURATION + 2)
-		pod_moving = 0
-		pod.mix_air()
+	pod_moving = TRUE
+	addtimer(CALLBACK(src, .proc/pod_stopped_callback, pod), 5)
+
+/obj/structure/transit_tube/station/proc/pod_stopped_callback(obj/structure/transit_tube_pod/pod)
+	launch_cooldown = world.time + cooldown_delay
+	open_hatch(pod)
+	sleep(OPEN_DURATION + 2)
+	pod.eject_all(dir)
+	pod_moving = FALSE
+	pod.mix_air()
 
 // Tube station directions are simply 90 to either side of
 //  the exit.
 /obj/structure/transit_tube/station/init_dirs()
 	tube_dirs = list(turn(dir, 90), turn(dir, -90))
+
+#undef CLOSE_DURATION
+#undef OPEN_DURATION

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -48,7 +48,7 @@
 
 
 
-/obj/structure/transit_tube/station/attack_hand(mob/user as mob)
+/obj/structure/transit_tube/station/attack_hand(mob/user)
 	if(pod_moving)
 		return
 	var/obj/structure/transit_tube_pod/pod = locate() in loc

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -49,22 +49,28 @@
 
 
 /obj/structure/transit_tube/station/attack_hand(mob/user as mob)
-	if(!pod_moving)
-		for(var/obj/structure/transit_tube_pod/pod in loc)
-			if(!pod.moving && (pod.dir in directions()))
-				if(hatch_state == TRANSIT_TUBE_OPEN)
-					if(pod.contents.len && user.loc != pod)
-						user.visible_message("<span class='warning'>[user] starts emptying [pod]'s contents onto the floor!</span>", \
-							"<span class='notice'>You start emptying [pod]'s contents onto the floor.</span>", "<span class='warning'>You hear a loud noise! As if somebody is throwing stuff on the floor!</span>")
-						if(do_after(user, 20, target = pod))
-							if(pod.loc == loc)
-								for(var/atom/movable/AM in pod)
-									pod.eject(AM)
-									if(ismob(AM))
-										var/mob/M = AM
-										M.Weaken(5)
-
-			break
+	if(pod_moving)
+		return
+	var/obj/structure/transit_tube_pod/pod = locate() in loc
+	if(!pod)
+		return
+	// Can't get in moving pods. Or pods that have openings on the other side
+	if(pod.moving || !(pod.dir in directions()))
+		return
+	if(hatch_state != TRANSIT_TUBE_OPEN)
+		return
+	// Can't empty it when inside or when there is nothing inside
+	if(!length(pod.contents) || user.loc == pod)
+		return
+	user.visible_message("<span class='warning'>[user] starts emptying [pod]'s contents onto the floor!</span>", \
+		"<span class='notice'>You start emptying [pod]'s contents onto the floor.</span>", "<span class='warning'>You hear a loud noise! As if somebody is throwing stuff on the floor!</span>")
+	if(!do_after(user, 20, target = pod))
+		return
+	for(var/atom/movable/AM in pod)
+		pod.eject(AM)
+		if(ismob(AM))
+			var/mob/M = AM
+			M.Weaken(5)
 
 
 /obj/structure/transit_tube/station/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -143,7 +143,7 @@
 	if(istype(mob) && mob.client)
 		// If the pod is not in a tube at all, you can get out at any time.
 		if(!(locate(/obj/structure/transit_tube) in loc))
-			eject_mob(mob, direction)
+			eject(mob, direction)
 			return
 
 			//if(moving && istype(loc, /turf/space))
@@ -156,7 +156,7 @@
 					if(!station.pod_moving)
 						if(direction == station.dir)
 							if(station.hatch_state == TRANSIT_TUBE_OPEN)
-								eject_mob(mob, direction)
+								eject(mob, direction)
 
 							else
 								station.open_hatch()
@@ -172,20 +172,24 @@
 						setDir(direction)
 						return
 
-/obj/structure/transit_tube_pod/proc/eject_all(direction)
-	var/ejected = FALSE
+/obj/structure/transit_tube_pod/proc/move_into(atom/movable/A)
+	icon_state = "pod_occupied"
+	A.forceMove(src)
+
+/obj/structure/transit_tube_pod/proc/eject_mindless(direction)
 	for(var/atom/movable/A in contents)
 		if(ismob(A))
-			eject_mob(A, direction)
-		else
-			A.forceMove(loc)
-			A.Move(get_step(loc, direction), direction)
-		ejected = TRUE
-	if(ejected)
-		playsound(loc, 'sound/machines/ping.ogg', 30, 0)
+			var/mob/M = A
+			if(M.mind) // Only eject mindless mobs
+				continue
+		eject(A, direction)
+		A.Move(get_step(loc, direction), direction)
 
 
-/obj/structure/transit_tube_pod/proc/eject_mob(mob/M, direction)
-	M.forceMove(loc)
-	M.client.Move(get_step(loc, direction), direction)
-	M.reset_perspective(null)
+/obj/structure/transit_tube_pod/proc/eject(atom/movable/A, direction)
+	icon_state = "pod"
+	A.forceMove(loc)
+	A.Move(get_step(loc, direction), direction)
+	if(ismob(A))
+		var/mob/M = A
+		M.reset_perspective(null)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -2,11 +2,10 @@
 	icon = 'icons/obj/pipes/transit_tube_pod.dmi'
 	icon_state = "pod"
 	animate_movement = FORWARD_STEPS
-	anchored = 1.0
-	density = 1
-	var/moving = 0
+	anchored = TRUE
+	density = TRUE
+	var/moving = FALSE
 	var/datum/gas_mixture/air_contents = new()
-
 
 /obj/structure/transit_tube_pod/New(loc)
 	..(loc)
@@ -26,14 +25,14 @@
 
 /obj/structure/transit_tube_pod/Process_Spacemove()
 	if(moving) //No drifting while moving in the tubes
-		return 1
+		return TRUE
 	else return ..()
 
 /obj/structure/transit_tube_pod/proc/follow_tube(var/reverse_launch)
 	if(moving)
 		return
 
-	moving = 1
+	moving = TRUE
 
 	spawn()
 		var/obj/structure/transit_tube/current_tube = null
@@ -70,23 +69,23 @@
 					break
 
 			if(current_tube == null)
-				dir = next_dir
+				setDir(next_dir)
 				Move(get_step(loc, dir), dir) // Allow collisions when leaving the tubes.
 				break
 
 			last_delay = current_tube.enter_delay(src, next_dir)
 			sleep(last_delay)
-			dir = next_dir
-			loc = next_loc // When moving from one tube to another, skip collision and such.
+			setDir(next_dir)
+			forceMove(next_loc) // When moving from one tube to another, skip collision and such.
 			density = current_tube.density
 
 			if(current_tube && current_tube.should_stop_pod(src, next_dir))
 				current_tube.pod_stopped(src, dir)
 				break
 
-		density = 1
+		density = TRUE
 
-		moving = 0
+		moving = FALSE
 
 
 // Should I return a copy here? If the caller edits or qdel()s the returned
@@ -141,10 +140,11 @@
 //  the station, try to exit. If the direction matches one of the station's
 //  tube directions, launch the pod in that direction.
 /obj/structure/transit_tube_pod/relaymove(mob/mob, direction)
-	if(istype(mob, /mob) && mob.client)
+	if(istype(mob) && mob.client)
 		// If the pod is not in a tube at all, you can get out at any time.
 		if(!(locate(/obj/structure/transit_tube) in loc))
-			mob.forceMove(loc)
+			eject_mob(mob, direction)
+			return
 
 			//if(moving && istype(loc, /turf/space))
 				// Todo: If you get out of a moving pod in space, you should move as well.
@@ -155,19 +155,37 @@
 				if(dir in station.directions())
 					if(!station.pod_moving)
 						if(direction == station.dir)
-							if(station.icon_state == "open")
-								mob.forceMove(loc)
+							if(station.hatch_state == TRANSIT_TUBE_OPEN)
+								eject_mob(mob, direction)
 
 							else
-								station.open_animation()
+								station.open_hatch()
 
 						else if(direction in station.directions())
-							dir = direction
+							setDir(direction)
 							station.launch_pod()
 					return
 
 			for(var/obj/structure/transit_tube/tube in loc)
 				if(dir in tube.directions())
 					if(tube.has_exit(direction))
-						dir = direction
+						setDir(direction)
 						return
+
+/obj/structure/transit_tube_pod/proc/eject_all(direction)
+	var/ejected = FALSE
+	for(var/atom/movable/A in contents)
+		if(ismob(A))
+			eject_mob(A, direction)
+		else
+			A.forceMove(loc)
+			A.Move(get_step(loc, direction), direction)
+		ejected = TRUE
+	if(ejected)
+		playsound(loc, 'sound/machines/ping.ogg', 30, 0)
+
+
+/obj/structure/transit_tube_pod/proc/eject_mob(mob/M, direction)
+	M.forceMove(loc)
+	M.client.Move(get_step(loc, direction), direction)
+	M.reset_perspective(null)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -28,6 +28,10 @@
 	var/obj/item/stack/sheet/plastic/stack_plastic = null
 	var/obj/item/matter_decompiler/decompiler = null
 
+	// What objects can drones bump into
+	var/static/list/allowed_bumpable_objects = list(/obj/machinery/door, /obj/machinery/recharge_station, /obj/machinery/disposal/deliveryChute,
+													/obj/machinery/teleport/hub, /obj/effect/portal, /obj/structure/transit_tube/station)
+
 	//Used for self-mailing.
 	var/mail_destination = 0
 	var/reboot_cooldown = 60 // one minute
@@ -309,11 +313,7 @@
 
 
 /mob/living/silicon/robot/drone/Bump(atom/movable/AM, yes)
-	if(istype(AM, /obj/machinery/door) \
-	|| istype(AM, /obj/machinery/recharge_station) \
-	|| istype(AM, /obj/machinery/disposal/deliveryChute) \
-	|| istype(AM, /obj/machinery/teleport/hub) \
-	|| istype(AM, /obj/effect/portal))
+	if(is_type_in_list(AM, allowed_bumpable_objects))
 		return ..()
 
 /mob/living/silicon/robot/drone/Bumped(atom/movable/AM)


### PR DESCRIPTION
## What Does This PR Do
1. Refactors the transit tubes. Dear god what a shit code
2. The transit pods will now wait 5 seconds after arriving before they launch again.
3. Removing things from a pod now takes 2 seconds instead of 4.
4. Putting somebody in a pod using a grab now takes 3 seconds instead of 6.
5. You can't open/close pods yourself anymore. This is pure automated
6. Fixes that you can't use a pod when another pod is already at the station and is full
7. Pods will now eject all mindless things when arriving
8. The pod will have an icon_state when it's full
9. Maint drones can now also use them

Fixes #10111

## Why It's Good For The Game
1. Shit code gone is gut.
2. Pods could get stuck with people inside of them. Or objects and they would be virtually unusable.
3. 4 seconds is way to long since the launch delay is 5 seconds. This wasn't even possible before hand.
4. Same here.
5. This will keep the pods in sync. Instead of them clogging up on one side.
6. It was a bug
7. Fixes the bug
8. User friendlyness
9. Just a QOL for drone mains

## Changelog
:cl:
tweak: Transit pods now eject all mindless things when arriving at a station
tweak: You can't open/close transit pods
tweak: Removing things from a transit pod now takes 2 seconds instead of 4.
tweak: Putting somebody in a transit pod now takes 3 seconds instead of 6.
tweak: Transit pods actually wait 5 seconds now after arriving before launching again. Making the above possible
fix: Having multiple pods at a transit station now won't block you from going in the last one if the first one is full
add: Transit pods now have an full icon state
/:cl: