### PR TITLE
Fixes the steal objective from runtiming

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -399,6 +399,9 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(!steal_target)
 		return 1 // Free Objective
 
+	if(!owner.current)
+		return FALSE
+
 	var/list/all_items = owner.current.GetAllContents()
 
 	for(var/obj/I in all_items)


### PR DESCRIPTION
## What Does This PR Do
Fixes: 
```
[2020-06-06T02:53:25] Runtime in objective.dm,402: Cannot execute null.GetAllContents().
[2020-06-06T02:53:25]   proc name: check completion (/datum/objective/steal/check_completion)
[2020-06-06T02:53:25]   src: /datum/objective/steal (/datum/objective/steal)
[2020-06-06T02:53:25]   call stack:
[2020-06-06T02:53:25]   /datum/objective/steal (/datum/objective/steal): check completion()
[2020-06-06T02:53:25]   changeling (/datum/game_mode/changeling): auto declare completion changeling()
[2020-06-06T02:53:25]   Ticker (/datum/controller/subsystem/ticker): declare completion()
[2020-06-06T02:53:25]   Ticker (/datum/controller/subsystem/ticker): fire(0)
```

## Why It's Good For The Game
It's a runtime

## Changelog
:cl:
fix: Fixes a runtime where a cryod antag breaks the steal objective. Thus not showing the objective at the end and causing tons of runtimes
/:cl: