### PR TITLE
Personal closet fix, makes it respect nodrop

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -54,36 +54,33 @@
 	new /obj/item/storage/backpack/satchel/withwallet( src )
 	new /obj/item/radio/headset( src )
 
-/obj/structure/closet/secure_closet/personal/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(src.opened)
-		if(istype(W, /obj/item/grab))
-			src.MouseDrop_T(W:affecting, user)      //act like they were dragged onto the closet
-		user.drop_item()
-		if(W) W.forceMove(loc)
-	else if(istype(W, /obj/item/card/id))
-		if(src.broken)
-			to_chat(user, "<span class='warning'>It appears to be broken.</span>")
-			return
-		var/obj/item/card/id/I = W
-		if(!I || !I.registered_name)	return
-		if(src == user.loc)
-			to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
-		else if(src.allowed(user) || !src.registered_name || (istype(I) && (src.registered_name == I.registered_name)))
-			//they can open all lockers, or nobody owns this, or they own this locker
-			src.locked = !( src.locked )
-			if(src.locked)
-				src.icon_state = src.icon_locked
-			else
-				src.icon_state = src.icon_closed
-				registered_name = null
-				desc = initial(desc)
+/obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
+	if(broken)
+		to_chat(user, "<span class='warning'>It appears to be broken.</span>")
+		return
 
-			if(!src.registered_name && src.locked)
-				src.registered_name = I.registered_name
-				src.desc = "Owned by [I.registered_name]."
-		else
-			to_chat(user, "<span class='warning'>Access Denied</span>")
-	else if((istype(W, /obj/item/card/emag) || istype(W, /obj/item/melee/energy/blade)) && !broken)
-		emag_act(user)
-	else
+	if(!istype(W, /obj/item/card/id))
 		return ..()
+
+	var/obj/item/card/id/I = W
+	if(!I || !I.registered_name)
+		return
+
+	if(src == user.loc)
+		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
+
+	else if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
+		//they can open all lockers, or nobody owns this, or they own this locker
+		locked = !locked
+		if(locked)
+			icon_state = icon_locked
+		else
+			icon_state = icon_closed
+			registered_name = null
+			desc = initial(desc)
+
+		if(!registered_name && locked)
+			registered_name = I.registered_name
+			desc = "Owned by [I.registered_name]."
+	else
+		to_chat(user, "<span class='warning'>Access Denied</span>")

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -55,12 +55,12 @@
 	new /obj/item/radio/headset( src )
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
+	if(!istype(W, /obj/item/card/id))
+		return ..()
+
 	if(broken)
 		to_chat(user, "<span class='warning'>It appears to be broken.</span>")
 		return
-
-	if(!istype(W, /obj/item/card/id))
-		return ..()
 
 	var/obj/item/card/id/I = W
 	if(!I || !I.registered_name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Refactors `/personal` type closets so they respect `NODROP`. Previously you could place nodrop items into them, which is bad.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13553
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Clicking open personal closets with nodrop items will no longer place that item into the locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
