### PR TITLE
Re-adds NTTC filtering

### DIFF
--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -171,6 +171,8 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/vname
 	/// List of all channels this can be sent or recieved on
 	var/list/zlevels = list()
+	/// Should this signal be re-broadcasted (Can be modified by NTTC, defaults to TRUE)
+	var/pass = TRUE
 
 /**
   * Destructor for the TCM datum.

--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -153,6 +153,10 @@
 	var/list/job_card_styles = list(
 		JOB_STYLE_1, JOB_STYLE_2, JOB_STYLE_3, JOB_STYLE_4
 	)
+
+	// List of people who will get blocked out of comms
+	var/list/filtering = list()
+
 	// Used to determine what languages are allowable for conversion. Generated during runtime.
 	var/list/valid_languages = list("--DISABLE--")
 
@@ -220,6 +224,9 @@
 
 // Primary signal modification. This is where all of the variables behavior are actually implemented.
 /datum/nttc_configuration/proc/modify_message(datum/tcomms_message/tcm)
+	// Check if they should be blacklisted right off the bat. We can save CPU if the message wont even be processed
+	if(tcm.sender_name in filtering)
+		tcm.pass = FALSE
 	// All job and coloring shit
 	if(toggle_job_color || toggle_name_color)
 		var/job = tcm.sender_job

--- a/nano/templates/tcomms_core.tmpl
+++ b/nano/templates/tcomms_core.tmpl
@@ -1,5 +1,6 @@
 {{:helper.link('Device Configuration', 'wrench', {'tab' : "CONFIG"}, data.tab == "CONFIG" ? 'selected' : '')}}
 {{:helper.link('Device Links', 'link', {'tab' : "LINKS"}, data.tab == "LINKS" ? 'selected' : '')}}
+{{:helper.link('User Filtering', 'user-times', {'tab' : "FILTER"}, data.tab == "FILTER" ? 'selected' : '')}}
 
 {{if data.tab == "CONFIG"}}
 	<h1>Core Configuration</h1>
@@ -132,6 +133,49 @@
 				<td>{{:value.sector}}</td>
 				<td style={{:value.status_color}}>{{:value.status ? 'Active' : 'Offline'}}</td>
 				<td>{{:helper.link('Unlink', 'unlink', {'unlink' : value.addr}, null, 'infoButton')}}</td>
+			</tr>
+			{{/for}}
+		</tbody>
+	</table>
+{{else data.tab == "FILTER"}}
+	<style>
+		table {
+			border-collapse: collapse;
+		}
+
+		table,
+		td,
+		th {
+			border: 1px solid #ffffff;
+		}
+		.infoButton {
+			background: none;
+			border: none;
+		}
+	</style>
+	<h1>Filtering List</h1>
+	<div class="item">
+		<div class="itemLabel">
+			{{:helper.link('Add User', 'plus', {'add_filter': 1})}}
+		</div>
+	</div>
+	<br>
+	<table style='width: 100%; text-align: center; background-color: #272727;'>
+	    <colgroup>
+       		<col span="1" style="width: 90%;">
+       		<col span="1" style="width: 10%;">
+    	</colgroup>
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Remove</th>
+			</tr>
+		</thead>
+		<tbody>
+			{{for data.filtered_users}}
+			<tr>
+				<td>{{:value}}</td>
+				<td>{{:helper.link('Remove', 'times', {'remove_filter' : value}, null, 'infoButton')}}</td>
 			</tr>
 			{{/for}}
 		</tbody>


### PR DESCRIPTION
## What Does This PR Do
This PR re-adds NTTC filtering. I originally removed this due to lack of use, yet I have seen three occasions myself where this would have come in really useful, hence the re-addition. You just add names into the filter list, and they are then blocked from speaking on comms.

![image](https://user-images.githubusercontent.com/25063394/83952365-5d927f80-a830-11ea-9e44-b1dca3a37ff6.png)
![image](https://user-images.githubusercontent.com/25063394/83952366-608d7000-a830-11ea-9ac4-66a3c565c1b0.png)


## Why It's Good For The Game
Removing the feature wasnt even the best idea, and its useful to be able to shut up comms-spamming greytide.

## Changelog
:cl: AffectedArc07
add: Re-added NTTC filtering
/:cl:

