### PR TITLE
Fixes Excessive PDA Creation

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -30,15 +30,11 @@
 /obj/machinery/pdapainter/New()
 	..()
 	var/blocked = list(/obj/item/pda/silicon/ai, /obj/item/pda/silicon/robot, /obj/item/pda/silicon/pai, /obj/item/pda/heads,
-						/obj/item/pda/clear, /obj/item/pda/syndicate)
+						/obj/item/pda/clear, /obj/item/pda/syndicate, /obj/item/pda/chameleon, /obj/item/pda/chameleon/broken)
 
-	for(var/P in typesof(/obj/item/pda)-blocked)
-		var/obj/item/pda/D = new P
-
-		//D.name = "PDA Style [colorlist.len+1]" //Gotta set the name, otherwise it all comes up as "PDA"
-		D.name = D.icon_state //PDAs don't have unique names, but using the sprite names works.
-
-		src.colorlist += D
+	for(var/thing in typesof(/obj/item/pda) - blocked)
+		var/obj/item/pda/P = thing
+		colorlist[initial(P.icon_state)] = initial(P.desc)
 
 /obj/machinery/pdapainter/Destroy()
 	QDEL_NULL(storedpda)
@@ -104,8 +100,8 @@
 		if(!in_range(src, user))
 			return
 
-		storedpda.icon_state = P.icon_state
-		storedpda.desc = P.desc
+		storedpda.icon_state = P
+		storedpda.desc = colorlist[P]
 
 	else
 		to_chat(user, "<span class='notice'>The [src] is empty.</span>")

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -9,6 +9,10 @@
 	..()
 	initialize_outfits()
 
+/datum/action/chameleon_outfit/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
+	return ..()
+
 /datum/action/chameleon_outfit/proc/initialize_outfits()
 	var/static/list/standard_outfit_options
 	if(!standard_outfit_options)
@@ -140,29 +144,29 @@
 	UpdateButtonIcon()
 
 /datum/action/item_action/chameleon/change/proc/update_item(obj/item/picked_item)
-	// Species-related variables are lists, which can not be retrieved using initial(). As such, we need to instantiate the picked item.
-	var/obj/item/P = new picked_item(null)
-
-	target.name = P.name
-	target.desc = P.desc
-	target.icon_state = P.icon_state
+	target.name = initial(picked_item.name)
+	target.desc = initial(picked_item.desc)
+	target.icon_state = initial(picked_item.icon_state)
 
 	if(isitem(target))
 		var/obj/item/I = target
 
-		I.item_state = P.item_state
-		I.item_color = P.item_color
+		I.item_state = initial(picked_item.item_state)
+		I.item_color = initial(picked_item.item_color)
 
-		I.icon_override = P.icon_override
-		I.sprite_sheets = P.sprite_sheets
+		I.icon_override = initial(picked_item.icon_override)
+		if(initial(picked_item.sprite_sheets))
+			// Species-related variables are lists, which can not be retrieved using initial(). As such, we need to instantiate the picked item.
+			var/obj/item/P = new picked_item(null)
+			I.sprite_sheets = P.sprite_sheets
+			qdel(P)
 
-		if(istype(I, /obj/item/clothing) && istype(P, /obj/item/clothing))
+		if(istype(I, /obj/item/clothing) && istype(initial(picked_item), /obj/item/clothing))
 			var/obj/item/clothing/CL = I
-			var/obj/item/clothing/PCL = P
-			CL.flags_cover = PCL.flags_cover
+			var/obj/item/clothing/PCL = picked_item
+			CL.flags_cover = initial(PCL.flags_cover)
 
-	target.icon = P.icon
-	qdel(P)
+	target.icon = initial(picked_item.icon)
 
 /datum/action/item_action/chameleon/change/Trigger()
 	if(!IsAvailable())
@@ -198,7 +202,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/under/chameleon/Initialize()
+/obj/item/clothing/under/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/under
@@ -206,11 +210,15 @@
 	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
+/obj/item/clothing/under/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/clothing/under/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/under/chameleon/broken/Initialize()
+/obj/item/clothing/under/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -229,7 +237,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/suit/chameleon/Initialize()
+/obj/item/clothing/suit/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/suit
@@ -237,11 +245,15 @@
 	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/suit/armor/abductor), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
+/obj/item/clothing/suit/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/clothing/suit/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/suit/chameleon/broken/Initialize()
+/obj/item/clothing/suit/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -261,7 +273,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/glasses/chameleon/Initialize()
+/obj/item/clothing/glasses/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/glasses
@@ -269,11 +281,15 @@
 	chameleon_action.chameleon_blacklist = list()
 	chameleon_action.initialize_disguises()
 
+/obj/item/clothing/glasses/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/clothing/glasses/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/glasses/chameleon/broken/Initialize()
+/obj/item/clothing/glasses/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -289,7 +305,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/glasses/hud/security/chameleon/Initialize()
+/obj/item/clothing/glasses/hud/security/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/glasses
@@ -297,11 +313,15 @@
 	chameleon_action.chameleon_blacklist = list()
 	chameleon_action.initialize_disguises()
 
+/obj/item/clothing/glasses/hud/security/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/clothing/glasses/hud/security/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/glasses/hud/security/chameleon/broken/Initialize()
+/obj/item/clothing/glasses/hud/security/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -316,7 +336,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/gloves/chameleon/Initialize()
+/obj/item/clothing/gloves/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/gloves
@@ -324,11 +344,15 @@
 	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/gloves, /obj/item/clothing/gloves/color), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
+/obj/item/clothing/gloves/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/clothing/gloves/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/gloves/chameleon/broken/Initialize()
+/obj/item/clothing/gloves/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -347,7 +371,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/head/chameleon/Initialize()
+/obj/item/clothing/head/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/head
@@ -355,11 +379,15 @@
 	chameleon_action.chameleon_blacklist = list()
 	chameleon_action.initialize_disguises()
 
+/obj/item/clothing/head/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/clothing/head/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/head/chameleon/broken/Initialize()
+/obj/item/clothing/head/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -389,7 +417,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/mask/chameleon/Initialize()
+/obj/item/clothing/mask/chameleon/Initialize(mapload)
 	. = ..()
 
 	chameleon_action = new(src)
@@ -402,13 +430,14 @@
 
 /obj/item/clothing/mask/chameleon/Destroy()
 	QDEL_NULL(voice_changer)
+	QDEL_NULL(chameleon_action)
 	return ..()
 
 /obj/item/clothing/mask/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/mask/chameleon/broken/Initialize()
+/obj/item/clothing/mask/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -423,13 +452,17 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/clothing/shoes/chameleon/Initialize()
+/obj/item/clothing/shoes/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/shoes
 	chameleon_action.chameleon_name = "Shoes"
 	chameleon_action.chameleon_blacklist = list()
 	chameleon_action.initialize_disguises()
+
+/obj/item/clothing/shoes/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
 
 /obj/item/clothing/shoes/chameleon/emp_act(severity)
 	. = ..()
@@ -442,7 +475,7 @@
 	desc = "A pair of black shoes."
 	flags = NOSLIP
 
-/obj/item/clothing/shoes/chameleon/noslip/broken/Initialize()
+/obj/item/clothing/shoes/chameleon/noslip/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -455,18 +488,22 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/storage/backpack/chameleon/Initialize()
+/obj/item/storage/backpack/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/storage/backpack
 	chameleon_action.chameleon_name = "Backpack"
 	chameleon_action.initialize_disguises()
 
+/obj/item/storage/backpack/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/storage/backpack/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/storage/backpack/chameleon/broken/Initialize()
+/obj/item/storage/backpack/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -475,7 +512,7 @@
 	desc = "Holds tools."
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/storage/belt/chameleon/Initialize()
+/obj/item/storage/belt/chameleon/Initialize(mapload)
 	. = ..()
 
 	chameleon_action = new(src)
@@ -483,11 +520,15 @@
 	chameleon_action.chameleon_name = "Belt"
 	chameleon_action.initialize_disguises()
 
+/obj/item/storage/belt/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/storage/belt/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/storage/belt/chameleon/broken/Initialize()
+/obj/item/storage/belt/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -495,18 +536,22 @@
 	name = "radio headset"
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/radio/headset/chameleon/Initialize()
+/obj/item/radio/headset/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/radio/headset
 	chameleon_action.chameleon_name = "Headset"
 	chameleon_action.initialize_disguises()
 
+/obj/item/radio/headset/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/radio/headset/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/radio/headset/chameleon/broken/Initialize()
+/obj/item/radio/headset/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
@@ -514,7 +559,7 @@
 	name = "PDA"
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/pda/chameleon/Initialize()
+/obj/item/pda/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/pda
@@ -522,24 +567,32 @@
 	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/pda/heads), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
+/obj/item/pda/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
 /obj/item/pda/chameleon/emp_act(severity)
 	. = ..()
 	chameleon_action.emp_randomise()
 
-/obj/item/pda/chameleon/broken/Initialize()
+/obj/item/pda/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
 /obj/item/stamp/chameleon
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-/obj/item/stamp/chameleon/Initialize()
+/obj/item/stamp/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/stamp
 	chameleon_action.chameleon_name = "Stamp"
 	chameleon_action.initialize_disguises()
 
-/obj/item/stamp/chameleon/broken/Initialize()
+/obj/item/stamp/chameleon/Destroy()
+	QDEL_NULL(chameleon_action)
+	return ..()
+
+/obj/item/stamp/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)


### PR DESCRIPTION
Good heavens.

First off, chameleon items were not properly GC'ing---their action datum was getting added to the processing SS, but never removed from it, causing it to be hard deleted if it was EMP'd or is a broken chameleon item.

Furthermore, the chameleon action itself wasn't properly deleted when a chameleon item was deleted.

Next up, how chameleon items change their states is just plain awful---it has to create an item just to fetch values from it . This is partially understandable because of Bay's awful species icon system, but it wasn't necessary for every single chameleon item when it was changing.

Thirdly, you could make the broken chameleon and chameleon PDA icon states for the PDA printer...not...needed or great.

And fourthly, PDA printers create every single PDA type, minus a few blacklisted ones, just got get their icon state. 

*AWFUL*.

What's changed:
- Chameleon action should GC
- Chameleon items should GC
- How chameleon item changes has been refactored to utilize `initial`, where possible; if something has a `sprite_sheet` set, then it will create the item and copy the list (sadly `initial` doesn't work with lists)---a lot of items have `sprite_sheet` set, but some don't at all (like PDAs)
- PDA printers no longer create PDAs, but instead have an associative list of the PDA icon states to select from and the description of said PDA---functionality is identical without the nonsense of needing to create PDAs. 

The lack of the broken chameleon PDA being blacklisted meant that a broken chameleon PDA was created at round start, then never deleted----and with how icon changing was added, it'd just create a new PDA every 2 seconds to get its icon state and description. AWFUL.

Fixes: https://github.com/ParadiseSS13/Paradise/issues/13550

Performance PR since it makes chameleon handling perform better and also means PDA's aren't being created like crazy, every 2 seconds.

:cl: Fox Mcloud
fix: Fixes thousands of PDA's being created in a round, decreasing game performance
/:cl: