### PR TITLE
Fixes wizards on ragin mages being able to buy restricted spells

### DIFF
--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -15,6 +15,7 @@
 #define GAMEMODE_IS_NUCLEAR		(SSticker && istype(SSticker.mode, /datum/game_mode/nuclear))
 #define GAMEMODE_IS_REVOLUTION	(SSticker && istype(SSticker.mode, /datum/game_mode/revolution))
 #define GAMEMODE_IS_WIZARD		(SSticker && istype(SSticker.mode, /datum/game_mode/wizard))
+#define GAMEMODE_IS_RAGIN_MAGES (SSticker && istype(SSticker.mode, /datum/game_mode/wizard/raginmages))
 
 //special roles
 // Distinct from the ROLE_X defines because some antags have multiple special roles but only one ban type

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -1,19 +1,15 @@
 /datum/spellbook_entry
 	var/name = "Entry Name"
-
+	var/is_ragin_restricted = FALSE // FALSE if this is buyable on ragin mages, TRUE if it's not.
 	var/spell_type = null
 	var/desc = ""
 	var/category = "Offensive"
 	var/log_name = "XX" //What it shows up as in logs
 	var/cost = 2
 	var/refundable = TRUE
-	var/surplus = -1 // -1 for infinite, not used by anything atm
 	var/obj/effect/proc_holder/spell/S = null //Since spellbooks can be used by only one person anyway we can track the actual spell
 	var/buy_word = "Learn"
 	var/limit //used to prevent a spellbook_entry from being bought more than X times with one wizard spellbook
-
-/datum/spellbook_entry/proc/IsSpellAvailable() // For config prefs / gamemode restrictions - these are round applied
-	return TRUE
 
 /datum/spellbook_entry/proc/CanBuy(mob/living/carbon/human/user, obj/item/spellbook/book) // Specific circumstances
 	if(book.uses < cost || limit == 0)
@@ -218,12 +214,7 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
 	log_name = "LD"
 	category = "Defensive"
-
-/datum/spellbook_entry/lichdom/IsSpellAvailable()
-	if(GAMEMODE_IS_RAGIN_MAGES)
-		return FALSE
-	else
-		return TRUE
+	is_ragin_restricted = TRUE
 
 /datum/spellbook_entry/magicm
 	name = "Magic Missile"
@@ -325,12 +316,7 @@
 	desc = "Spook the crew out by making them see dead people. Be warned, ghosts are capricious and occasionally vindicative, and some will use their incredibly minor abilities to frustrate you."
 	cost = 0
 	log_name = "SGH"
-
-/datum/spellbook_entry/summon/ghosts/IsSpellAvailable()
-	if(GAMEMODE_IS_RAGIN_MAGES)
-		return FALSE
-	else
-		return TRUE
+	is_ragin_restricted = TRUE
 
 /datum/spellbook_entry/summon/ghosts/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	new /datum/event/wizard/ghost()
@@ -343,12 +329,7 @@
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. There is a good chance that they will shoot each other first."
 	log_name = "SG"
-
-/datum/spellbook_entry/summon/guns/IsSpellAvailable()
-	if(GAMEMODE_IS_RAGIN_MAGES)
-		return FALSE
-	else
-		return TRUE
+	is_ragin_restricted = TRUE
 
 /datum/spellbook_entry/summon/guns/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	feedback_add_details("wizard_spell_learned", log_name)
@@ -362,12 +343,7 @@
 	name = "Summon Magic"
 	desc = "Share the wonders of magic with the crew and show them why they aren't to be trusted with it at the same time."
 	log_name = "SU"
-
-/datum/spellbook_entry/summon/magic/IsSpellAvailable()
-	if(GAMEMODE_IS_RAGIN_MAGES)
-		return FALSE
-	else
-		return TRUE
+	is_ragin_restricted = TRUE
 
 /datum/spellbook_entry/summon/magic/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	feedback_add_details("wizard_spell_learned", log_name)
@@ -394,8 +370,6 @@
 	dat += "<b>[name]</b>"
 	dat += " Cost:[cost]<br>"
 	dat += "<i>[desc]</i><br>"
-	if(surplus>=0)
-		dat += "[surplus] left.<br>"
 	return dat
 
 //Artefacts
@@ -636,11 +610,12 @@
 	var/entry_types = subtypesof(/datum/spellbook_entry) - /datum/spellbook_entry/item - /datum/spellbook_entry/summon - /datum/spellbook_entry/loadout
 	for(var/T in entry_types)
 		var/datum/spellbook_entry/E = new T
-		if(E.IsSpellAvailable())
-			entries |= E
-			categories |= E.category
-		else
+		if(GAMEMODE_IS_WIZARD && E.is_ragin_restricted)
 			qdel(E)
+			continue
+		entries |= E
+		categories |= E.category
+
 	main_tab = main_categories[1]
 	tab = categories[1]
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -220,7 +220,7 @@
 	category = "Defensive"
 
 /datum/spellbook_entry/lichdom/IsSpellAvailable()
-	if(SSticker.mode.name == "ragin' mages")
+	if(GAMEMODE_IS_RAGIN_MAGES)
 		return FALSE
 	else
 		return TRUE
@@ -327,9 +327,7 @@
 	log_name = "SGH"
 
 /datum/spellbook_entry/summon/ghosts/IsSpellAvailable()
-	if(!SSticker.mode) // In case spellbook is placed on map
-		return FALSE
-	if(SSticker.mode.name == "ragin' mages")
+	if(GAMEMODE_IS_RAGIN_MAGES)
 		return FALSE
 	else
 		return TRUE
@@ -347,9 +345,7 @@
 	log_name = "SG"
 
 /datum/spellbook_entry/summon/guns/IsSpellAvailable()
-	if(!SSticker.mode) // In case spellbook is placed on map
-		return FALSE
-	if(SSticker.mode.name == "ragin' mages")
+	if(GAMEMODE_IS_RAGIN_MAGES)
 		return FALSE
 	else
 		return TRUE
@@ -368,9 +364,7 @@
 	log_name = "SU"
 
 /datum/spellbook_entry/summon/magic/IsSpellAvailable()
-	if(!SSticker.mode) // In case spellbook is placed on map
-		return FALSE
-	if(SSticker.mode.name == "ragin' mages")
+	if(GAMEMODE_IS_RAGIN_MAGES)
 		return FALSE
 	else
 		return TRUE

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -21,6 +21,12 @@
 	spells_path = list(/obj/effect/proc_holder/spell/targeted/lichdom, /obj/effect/proc_holder/spell/targeted/ethereal_jaunt, /obj/effect/proc_holder/spell/fireball, \
 		/obj/effect/proc_holder/spell/targeted/rod_form, /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech, /obj/effect/proc_holder/spell/targeted/forcewall/greater)
 
+/datum/spellbook_entry/loadout/lich/IsSpellAvailable()
+	if(GAMEMODE_IS_RAGIN_MAGES)
+		return FALSE
+	else
+		return TRUE
+
 /datum/spellbook_entry/loadout/wands
 	name = "Utility Focus : Wands"
 	desc = "This set contain a Belt of Wands, providing offensive, defensive, and utility wands. Wands have limited charges, but can be partially recharged with the Charge spell included. <br> \

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -20,12 +20,7 @@
 	log_name = "DL"
 	spells_path = list(/obj/effect/proc_holder/spell/targeted/lichdom, /obj/effect/proc_holder/spell/targeted/ethereal_jaunt, /obj/effect/proc_holder/spell/fireball, \
 		/obj/effect/proc_holder/spell/targeted/rod_form, /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech, /obj/effect/proc_holder/spell/targeted/forcewall/greater)
-
-/datum/spellbook_entry/loadout/lich/IsSpellAvailable()
-	if(GAMEMODE_IS_RAGIN_MAGES)
-		return FALSE
-	else
-		return TRUE
+	is_ragin_restricted = TRUE
 
 /datum/spellbook_entry/loadout/wands
 	name = "Utility Focus : Wands"
@@ -69,12 +64,7 @@
 		/obj/effect/proc_holder/spell/targeted/summonitem, /obj/effect/proc_holder/spell/noclothes, /obj/effect/proc_holder/spell/targeted/lichdom/gunslinger)
 	category = "Unique"
 	destroy_spellbook = TRUE
-
-/datum/spellbook_entry/loadout/gunreaper/IsSpellAvailable()
-	if(GAMEMODE_IS_RAGIN_MAGES)
-		return FALSE
-	else
-		return TRUE
+	is_ragin_restricted = TRUE
 
 /obj/effect/proc_holder/spell/targeted/lichdom/gunslinger/equip_lich(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/det_suit(H), slot_wear_suit)

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -70,6 +70,12 @@
 	category = "Unique"
 	destroy_spellbook = TRUE
 
+/datum/spellbook_entry/loadout/gunreaper/IsSpellAvailable()
+	if(GAMEMODE_IS_RAGIN_MAGES)
+		return FALSE
+	else
+		return TRUE
+
 /obj/effect/proc_holder/spell/targeted/lichdom/gunslinger/equip_lich(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/det_suit(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(H), slot_shoes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
There are a few items that wizards on ragin' mages aren't allowed to buy but the code wasn't working properly, and this fixes that. 

The spells are:
- The Bind Soul (lich) spell
- The Summon Guns spell
- The Summon Magic spell
- The Summon Ghosts spell
- The Lich loudout (had to add this one in because it contains the lich spell)
- The Gunslinging Reaper loudout (had to add this one in because it contains the lich spell)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #8278
Fixes: #13541

You'll notice in the second bug report that it suggests apprentices should be restricted as well, but I couldn't fine evidence that it ever was. So that is more of a feature request.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes wizards on ragin mages being able to buy restricted spells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
