### PR TITLE
Gives the Chef the CQC manual as a traitor item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -247,6 +247,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	job = list("Chef")
 
+/datum/uplink_item/jobspecific/Chef_CQC
+	name = " A chefs manual to CQC"
+	desc = "An old manual teaching you how to bring your home advantage outside the kitchen."
+	reference = "CCQC"
+	item = /obj/item/CQC_manual/chef
+	cost = 12
+	job = list("Chef")
+
 //Chaplain
 
 /datum/uplink_item/jobspecific/voodoo

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -204,8 +204,6 @@
 	to_chat(user, "<span class='boldannounce'>You remember the basics of CQC.</span>")
 
 	var/datum/martial_art/cqc/CQC = new(null)
-	var/datum/martial_art/cqc/under_siege/CCQC = new(null)
-	CCQC.remove(user)
 	CQC.teach(user)
 	user.drop_item()
 	visible_message("<span class='warning'>[src] beeps ominously, and a moment later it bursts up in flames.</span>")

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -195,12 +195,17 @@
 	icon = 'icons/obj/library.dmi'
 	icon_state = "cqcmanual"
 
+/obj/item/CQC_manual/chef
+	desc = "A small, black manual. Written on the back it says: Bringing the home advantage with you."
+
 /obj/item/CQC_manual/attack_self(mob/living/carbon/human/user)
 	if(!istype(user) || !user)
 		return
 	to_chat(user, "<span class='boldannounce'>You remember the basics of CQC.</span>")
 
 	var/datum/martial_art/cqc/CQC = new(null)
+	var/datum/martial_art/cqc/under_siege/CCQC = new(null)
+	CCQC.remove(user)
 	CQC.teach(user)
 	user.drop_item()
 	visible_message("<span class='warning'>[src] beeps ominously, and a moment later it bursts up in flames.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR allows the Chef to buy CQC from his uplink for 12 TC. This will also add the manual to the surplus, which should be fine considering you can already get it from a bundle.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
CQC currently can only be gotten for nukies or from the traitor bundle. This would make it possible for a chef, who can already use CQC in the kitchen to bring it outside the kitchen. As well as traitors having a chance of getting it from surplus.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Chefs can now buy the CQC manual from their traitor uplink. It can also now be gotten from the surplus crate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
