### PR TITLE
Gives the arrivals airlocks a open and close sound. Also makes them autoclose after some time

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -31,6 +31,8 @@
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
 	//Multi-tile doors
 	var/width = 1
+	var/SdoorClose  //Shuttle doors aren't subtypes of airlcoks and thus need sepparate vars for sound
+	var/SdoorOpen
 
 /obj/machinery/door/New()
 	..()
@@ -269,6 +271,7 @@
 		return
 	operating = TRUE
 	do_animate("opening")
+	playsound(loc, SdoorOpen, 30, 1)
 	set_opacity(0)
 	sleep(5)
 	density = FALSE
@@ -299,6 +302,7 @@
 	operating = TRUE
 
 	do_animate("closing")
+	playsound(loc, SdoorClose, 30, 1)
 	layer = closingLayer
 	sleep(5)
 	density = TRUE

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -18,3 +18,6 @@
 /obj/machinery/door/unpowered/shuttle
 	icon = 'icons/turf/shuttle.dmi'
 	icon_state = "door1"
+	SdoorOpen = 'sound/machines/airlock_open.ogg'
+	SdoorClose = 'sound/machines/airlock_close.ogg'
+	autoclose = TRUE


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Since the arrivals airlcoks are subtypes directly to doors and not airlocks they do not have a open and close sound, and autoclose is FALSE by default.
This PR gives them the normal open and close airlock sounds, as well as sets autoclose to TRUE
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should have been in long time ago, and i am surprised we never noticed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Makes the arrivals airlocks have sounds for opening and closing as well as automatically close.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
