### PR TITLE
More fixes: Custodial Locator, e-swords, upside-down-itis and grabbing

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -144,7 +144,7 @@
 	set category = null
 	set name = "Enter DNA Scanner"
 
-	if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
+	if(usr.incapacitated() || usr.buckled) //are you cuffed, dying, lying, stunned or other
 		return
 	if(!ishuman(usr)) //Make sure they're a mob that has dna
 		to_chat(usr, "<span class='notice'>Try as you might, you can not climb up into the [src].</span>")

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -526,7 +526,7 @@
 	if(panel_open)
 		to_chat(usr, "<span class='boldnotice'>Close the maintenance panel first.</span>")
 		return
-	if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
+	if(usr.incapacitated() || usr.buckled) //are you cuffed, dying, lying, stunned or other
 		return
 	if(usr.has_buckled_mobs()) //mob attached to us
 		to_chat(usr, "<span class='warning'>[usr] will not fit into [src] because [usr.p_they()] [usr.p_have()] a slime latched onto [usr.p_their()] head.</span>")

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -516,7 +516,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
+	if(usr.incapacitated() || usr.buckled) //are you cuffed, dying, lying, stunned or other
 		return
 
 	put_mob(usr)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -671,6 +671,9 @@
 		to_chat(usr, "<span class='warning'>[usr] will not fit into [src] because [usr.p_they()] [usr.p_have()] a slime latched onto [usr.p_their()] head.</span>")
 		return
 
+	if(usr.incapacitated() || usr.buckled) //are you cuffed, dying, lying, stunned or other
+		return
+
 	visible_message("[usr] starts climbing into [src].")
 
 	if(do_after(usr, 20, target = usr))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -772,6 +772,8 @@
 
 	if(usr.stat != 0)
 		return
+	if(usr.incapacitated() || usr.buckled) //are you cuffed, dying, lying, stunned or other
+		return
 	if(!state_open)
 		to_chat(usr, "<span class='warning'>The unit's doors are shut.</span>")
 		return

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -69,7 +69,7 @@
 		if(buckle_prevents_pull)
 			M.pulledby.stop_pulling()
 
-	if (LAZYLEN(M.grabbed_by))
+	if(LAZYLEN(M.grabbed_by))
 		for(var/obj/item/grab/G in M.grabbed_by)
 			qdel(G)
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -11,7 +11,7 @@
 /atom/movable/attack_hand(mob/living/user)
 	. = ..()
 	if(can_buckle && has_buckled_mobs())
-		if(buckled_mobs.len > 1)
+		if(LAZYLEN(buckled_mobs) > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
 				return TRUE
@@ -28,13 +28,13 @@
 /atom/movable/proc/has_buckled_mobs()
 	if(!buckled_mobs)
 		return FALSE
-	if(buckled_mobs.len)
+	if(LAZYLEN(buckled_mobs))
 		return TRUE
 
 /atom/movable/attack_robot(mob/living/user)
 	. = ..()
 	if(can_buckle && has_buckled_mobs() && Adjacent(user)) // attack_robot is called on all ranges, so the Adjacent check is needed
-		if(buckled_mobs.len > 1)
+		if(LAZYLEN(buckled_mobs) > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
 				return TRUE
@@ -54,7 +54,7 @@
 	if(check_loc && M.loc != loc)
 		return FALSE
 
-	if((!can_buckle && !force) || M.buckled || (buckled_mobs.len >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
+	if((!can_buckle && !force) || M.buckled || (LAZYLEN(buckled_mobs) >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
 		return FALSE
 	M.buckling = src
 	if(!M.can_buckle() && !force)
@@ -68,6 +68,10 @@
 	if(M.pulledby)
 		if(buckle_prevents_pull)
 			M.pulledby.stop_pulling()
+
+	if (LAZYLEN(M.grabbed_by))
+		for(var/obj/item/grab/G in M.grabbed_by)
+			qdel(G)
 
 	if(!check_loc && M.loc != loc)
 		M.forceMove(loc)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -66,7 +66,7 @@
 		if(buckle_prevents_pull)
 			M.pulledby.stop_pulling()
 
-	if(length(M.grabbed_by))
+	if(M.grabbed_by)
 		for(var/obj/item/grab/G in M.grabbed_by)
 			qdel(G)
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -11,7 +11,7 @@
 /atom/movable/attack_hand(mob/living/user)
 	. = ..()
 	if(can_buckle && has_buckled_mobs())
-		if(buckled_mobs && length(buckled_mobs) > 1)
+		if(length(buckled_mobs) > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
 				return TRUE
@@ -26,12 +26,12 @@
 			return TRUE
 
 /atom/movable/proc/has_buckled_mobs()
-	return buckled_mobs && length(buckled_mobs)
+	return length(buckled_mobs)
 
 /atom/movable/attack_robot(mob/living/user)
 	. = ..()
 	if(can_buckle && has_buckled_mobs() && Adjacent(user)) // attack_robot is called on all ranges, so the Adjacent check is needed
-		if(buckled_mobs && length(buckled_mobs) > 1)
+		if(length(buckled_mobs) > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
 				return TRUE

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -66,9 +66,8 @@
 		if(buckle_prevents_pull)
 			M.pulledby.stop_pulling()
 
-	if(M.grabbed_by)
-		for(var/obj/item/grab/G in M.grabbed_by)
-			qdel(G)
+	for(var/obj/item/grab/G in M.grabbed_by)
+		qdel(G)
 
 	if(!check_loc && M.loc != loc)
 		M.forceMove(loc)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -11,7 +11,7 @@
 /atom/movable/attack_hand(mob/living/user)
 	. = ..()
 	if(can_buckle && has_buckled_mobs())
-		if(LAZYLEN(buckled_mobs) > 1)
+		if(buckled_mobs && length(buckled_mobs) > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
 				return TRUE
@@ -26,15 +26,12 @@
 			return TRUE
 
 /atom/movable/proc/has_buckled_mobs()
-	if(!buckled_mobs)
-		return FALSE
-	if(LAZYLEN(buckled_mobs))
-		return TRUE
+	return buckled_mobs && length(buckled_mobs)
 
 /atom/movable/attack_robot(mob/living/user)
 	. = ..()
 	if(can_buckle && has_buckled_mobs() && Adjacent(user)) // attack_robot is called on all ranges, so the Adjacent check is needed
-		if(LAZYLEN(buckled_mobs) > 1)
+		if(buckled_mobs && length(buckled_mobs) > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?", "Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))
 				return TRUE
@@ -54,7 +51,7 @@
 	if(check_loc && M.loc != loc)
 		return FALSE
 
-	if((!can_buckle && !force) || M.buckled || (LAZYLEN(buckled_mobs) >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
+	if((!can_buckle && !force) || M.buckled || (length(buckled_mobs) >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
 		return FALSE
 	M.buckling = src
 	if(!M.can_buckle() && !force)
@@ -69,7 +66,7 @@
 		if(buckle_prevents_pull)
 			M.pulledby.stop_pulling()
 
-	if(LAZYLEN(M.grabbed_by))
+	if(length(M.grabbed_by))
 		for(var/obj/item/grab/G in M.grabbed_by)
 			qdel(G)
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -6,7 +6,7 @@
 	var/list/nemesis_factions //Any mob with a faction that exists in this list will take bonus damage/effects
 	w_class = WEIGHT_CLASS_SMALL
 	var/w_class_on = WEIGHT_CLASS_BULKY
-	var/icon_state_on = "axe1"
+	var/icon_state_on
 	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/blade1.ogg' // Probably more appropriate than the previous hitsound. -- Dave
 	usesound = 'sound/weapons/blade1.ogg'
@@ -48,9 +48,9 @@
 		throw_speed = 4
 		if(attack_verb_on.len)
 			attack_verb = attack_verb_on
-		if(!item_color)
+		if(icon_state_on)
 			icon_state = icon_state_on
-			set_light(brightness_on)
+			set_light(brightness_on, l_color = item_color ? colormap[item_color] : null)
 		else
 			icon_state = "sword[item_color]"
 			set_light(brightness_on, l_color=colormap[item_color])
@@ -80,6 +80,7 @@
 	name = "energy axe"
 	desc = "An energised battle axe."
 	icon_state = "axe0"
+	icon_state_on = "axe1"
 	force = 40
 	force_on = 150
 	throwforce = 25
@@ -301,9 +302,9 @@
 		throw_speed = 4
 		if(attack_verb_on.len)
 			attack_verb = attack_verb_on
-		if(!item_color)
+		if(icon_state_on)
 			icon_state = icon_state_on
-			set_light(brightness_on)
+			set_light(brightness_on, l_color = item_color ? colormap[item_color] : null)
 		else
 			icon_state = "sword[item_color]"
 			set_light(brightness_on, l_color=colormap[item_color])

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -130,15 +130,17 @@
 		release_mob(M)
 
 /obj/structure/kitchenspike/proc/release_mob(mob/living/M)
-	var/matrix/m180 = matrix(M.transform)
-	m180.Turn(180)
-	animate(M, transform = m180, time = 3)
-	M.pixel_y = M.get_standard_pixel_y_offset(180)
 	M.adjustBruteLoss(30)
 	src.visible_message(text("<span class='danger'>[M] falls free of [src]!</span>"))
 	unbuckle_mob(M, force = TRUE)
 	M.emote("scream")
 	M.AdjustWeakened(10)
+
+/obj/structure/kitchenspike/post_unbuckle_mob(mob/living/M)
+	M.pixel_y = M.get_standard_pixel_y_offset(0)
+	var/matrix/m180 = matrix(M.transform)
+	m180.Turn(180)
+	animate(M, transform = m180, time = 3)
 
 /obj/structure/kitchenspike/Destroy()
 	if(has_buckled_mobs())

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -260,8 +260,6 @@
 	add_attack_logs(user, src, "Grabbed passively", ATKLOG_ALL)
 
 	var/obj/item/grab/G = new /obj/item/grab(user, src)
-	if(buckled)
-		to_chat(user, "<span class='notice'>You cannot grab [src]; [p_they()] [p_are()] buckled in!</span>")
 	if(!G)	//the grab will delete itself in New if src is anchored
 		return 0
 	user.put_in_active_hand(G)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -432,7 +432,7 @@
 
 /obj/item/grab/Destroy()
 	if(affecting)
-		if (!affecting.buckled)
+		if(!affecting.buckled)
 			affecting.pixel_x = 0
 			affecting.pixel_y = 0 //used to be an animate, not quick enough for del'ing
 			affecting.layer = initial(affecting.layer)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -296,7 +296,9 @@
 		assailant.next_move = world.time + 10
 		if(!affecting.get_organ_slot("breathing_tube"))
 			affecting.AdjustLoseBreath(1)
-		affecting.setDir(WEST)
+
+		if (!affecting.buckled)
+			affecting.setDir(WEST)
 	adjust_position()
 
 //This is used to make sure the victim hasn't managed to yackety sax away before using the grab.
@@ -433,9 +435,10 @@
 
 /obj/item/grab/Destroy()
 	if(affecting)
-		affecting.pixel_x = 0
-		affecting.pixel_y = 0 //used to be an animate, not quick enough for del'ing
-		affecting.layer = initial(affecting.layer)
+		if (!affecting.buckled)
+			affecting.pixel_x = 0
+			affecting.pixel_y = 0 //used to be an animate, not quick enough for del'ing
+			affecting.layer = initial(affecting.layer)
 		affecting.grabbed_by -= src
 		affecting = null
 	if(assailant)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -53,12 +53,11 @@
 	hud.master = src
 
 	//check if assailant is grabbed by victim as well
-	if(assailant.grabbed_by)
-		for(var/obj/item/grab/G in assailant.grabbed_by)
-			if(G.assailant == affecting && G.affecting == assailant)
-				G.dancing = 1
-				G.adjust_position()
-				dancing = 1
+	for(var/obj/item/grab/G in assailant.grabbed_by)
+		if(G.assailant == affecting && G.affecting == assailant)
+			G.dancing = 1
+			G.adjust_position()
+			dancing = 1
 
 	clean_grabbed_by(assailant, affecting)
 	adjust_position()
@@ -276,7 +275,7 @@
 		assailant.visible_message("<span class='warning'>[assailant] has reinforced [assailant.p_their()] grip on [affecting] (now neck)!</span>")
 		state = GRAB_NECK
 		icon_state = "grabbed+1"
-		assailant.setDir(get_dir(assailant, affecting))
+
 		add_attack_logs(assailant, affecting, "Neck grabbed", ATKLOG_ALL)
 		if(!iscarbon(assailant))
 			affecting.LAssailant = null
@@ -297,8 +296,6 @@
 		if(!affecting.get_organ_slot("breathing_tube"))
 			affecting.AdjustLoseBreath(1)
 
-		if (!affecting.buckled)
-			affecting.setDir(WEST)
 	adjust_position()
 
 //This is used to make sure the victim hasn't managed to yackety sax away before using the grab.

--- a/code/modules/pda/cart_apps.dm
+++ b/code/modules/pda/cart_apps.dm
@@ -386,7 +386,7 @@
 			BucketData[++BucketData.len] = list ("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "volume" = B.reagents.total_volume, "max_volume" = B.reagents.maximum_volume)
 
 	var/CbotData[0]
-	for(var/mob/living/simple_animal/bot/cleanbot/B in GLOB.simple_animals[AI_ON])
+	for(var/mob/living/simple_animal/bot/cleanbot/B in GLOB.bots_list)
 		var/turf/bl = get_turf(B)
 		if(bl)
 			if(bl.z != cl.z)

--- a/code/modules/pda/cart_apps.dm
+++ b/code/modules/pda/cart_apps.dm
@@ -366,6 +366,7 @@
 		JaniData["user_loc"] = list("x" = cl.x, "y" = cl.y)
 	else
 		JaniData["user_loc"] = list("x" = 0, "y" = 0)
+
 	var/MopData[0]
 	for(var/obj/item/mop/M in GLOB.janitorial_equipment)
 		var/turf/ml = get_turf(M)
@@ -375,10 +376,6 @@
 			var/direction = get_dir(pda, M)
 			MopData[++MopData.len] = list ("x" = ml.x, "y" = ml.y, "dir" = uppertext(dir2text(direction)), "status" = M.reagents.total_volume ? "Wet" : "Dry")
 
-	if(!MopData.len)
-		MopData[++MopData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
-
-
 	var/BucketData[0]
 	for(var/obj/structure/mopbucket/B in GLOB.janitorial_equipment)
 		var/turf/bl = get_turf(B)
@@ -386,13 +383,10 @@
 			if(bl.z != cl.z)
 				continue
 			var/direction = get_dir(pda,B)
-			BucketData[++BucketData.len] = list ("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.reagents.total_volume/100)
-
-	if(!BucketData.len)
-		BucketData[++BucketData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
+			BucketData[++BucketData.len] = list ("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "volume" = B.reagents.total_volume, "max_volume" = B.reagents.maximum_volume)
 
 	var/CbotData[0]
-	for(var/mob/living/simple_animal/bot/cleanbot/B in GLOB.simple_animals)
+	for(var/mob/living/simple_animal/bot/cleanbot/B in GLOB.simple_animals[AI_ON])
 		var/turf/bl = get_turf(B)
 		if(bl)
 			if(bl.z != cl.z)
@@ -400,9 +394,6 @@
 			var/direction = get_dir(pda,B)
 			CbotData[++CbotData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.on ? "Online" : "Offline")
 
-
-	if(!CbotData.len)
-		CbotData[++CbotData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
 	var/CartData[0]
 	for(var/obj/structure/janitorialcart/B in GLOB.janitorial_equipment)
 		var/turf/bl = get_turf(B)
@@ -410,12 +401,10 @@
 			if(bl.z != cl.z)
 				continue
 			var/direction = get_dir(pda,B)
-			CartData[++CartData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "status" = B.reagents.total_volume/100)
-	if(!CartData.len)
-		CartData[++CartData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
+			CartData[++CartData.len] = list("x" = bl.x, "y" = bl.y, "dir" = uppertext(dir2text(direction)), "volume" = B.reagents.total_volume, "max_volume" = B.reagents.maximum_volume)
 
-	JaniData["mops"] = MopData
-	JaniData["buckets"] = BucketData
-	JaniData["cleanbots"] = CbotData
-	JaniData["carts"] = CartData
+	JaniData["mops"] = MopData.len ? MopData : null
+	JaniData["buckets"] = BucketData.len ? BucketData : null
+	JaniData["cleanbots"] = CbotData.len ? CbotData : null
+	JaniData["carts"] = CartData.len ? CartData : null
 	data["janitor"] = JaniData

--- a/nano/templates/pda_janitor.tmpl
+++ b/nano/templates/pda_janitor.tmpl
@@ -8,43 +8,59 @@
 		{{/if}}
 	</div>
 		<div class="item">
-			{{for data.janitor.mops}}
-				{{if value.x==0}}
-					<span class="bad">Unable to locate Mop</span>
-				{{else}}
-					<span class="good">Mop Location:</span>
-					<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Status: {{:value.status}}</span><br>
-				{{/if}}
-			{{/for}}
+			{{if data.janitor.mops}}
+				<span class="good">Mop Locations:</span>
+				<ul>
+					{{for data.janitor.mops}}
+						<li>
+							<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Status: {{:value.status}}</span>
+						</li>
+					{{/for}}
+				</ul>
+			{{else}}
+				<span class="bad">Unable to locate Mops</span>
+			{{/if}}
 		</div>
 	<div class="item">
-		{{for data.janitor.buckets}}
-			{{if value.x==0}}
-				<span class="bad">Unable to locate Water Buckets</span>
-			{{else}}
-				<span class="good">Water Buckets Location:</span>
-				<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Water Level: {{:value.status}}</span><br>
-			{{/if}}
-		{{/for}}
+		{{if data.janitor.buckets}}
+			<span class="good">Mop Bucket Locations:</span>
+			<ul>
+				{{for data.janitor.buckets}}
+					<li>
+						<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Capacity: {{:value.volume}}/{{:value.max_volume}}</span>
+					</li>
+				{{/for}}
+			</ul>
+		{{else}}
+			<span class="bad">Unable to locate Mop Buckets</span>
+		{{/if}}
 	</div>
 	<div class="item">
-		{{for data.janitor.cleanbots}}
-			{{if value.x==0}}
-				<span class="bad">Unable to locate Clean Bots</span>
-			{{else}}
-				<span class="good">Clean Bots Location:</span>
-				<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Status: {{:value.status}}</span><br>
-			{{/if}}
-		{{/for}}
+		{{if data.janitor.cleanbots}}
+			<span class="good">Cleanbot Locations:</span>
+			<ul>
+				{{for data.janitor.cleanbots}}
+					<li>
+						<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Status: {{:value.status}}</span>
+					</li>
+				{{/for}}
+			</ul>
+		{{else}}
+			<span class="bad">Unable to locate Cleanbots</span>
+		{{/if}}
 	</div>
-		<div class="item">
-		{{for data.janitor.carts}}
-			{{if value.x==0}}
-				<span class="bad">Unable to locate Janitorial Cart</span>
-			{{else}}
-				<span class="good">Janitorial cart Location:</span>
-				<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Status: {{:value.status}}</span><br>
-			{{/if}}
-		{{/for}}
+	<div class="item">
+		{{if data.janitor.carts}}
+			<span class="good">Janitorial Cart Locations:</span>
+			<ul>
+				{{for data.janitor.carts}}
+					<li>
+						<span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Water Level: {{:value.volume}}/{{:value.max_volume}}</span>
+					</li>
+				{{/for}}
+			</ul>
+		{{else}}
+			<span class="bad">Unable to locate Janitorial Carts</span>
+		{{/if}}
 	</div>
 </div>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #13565 (db1bfd1) and improves Custodial Locator UI: The issue came from the fact `simple_animals` no longer is a list of all simple animals, but is a list of lists of simple animals based on their AI state. The UI change is mostly making the listing a bit cleaner
Fixes #13540 (4055d58): An e-sword not having a `item_color` meant it would fall back to the default e-sword icon when lit when there could be an override set
Fixes #13584 (d39d990): Suddenly leaving a meat spike would result in the mob not turning back in place
f8b76f0 removes the message complaining that a player can't grab a buckled mob despite letting them do so. It also fixes visual glitches that come with letting go of a buckled mob
a67d684 prevents buckled mobs from entering pods and stuff to prevent cheesing out of a buckle that would take longer to resist from

## Why It's Good For The Game
Immersion mostly, but also convenience for the Janitors

## Changelog
:cl:
tweak: Custodial Locator UI touch-up
del: Remove message complaining about grabbing buckled people
fix: Fix Custodial Locator not being able to locate Cleanbots
fix: Fix energy sword children (e.g. cutlass) not using right icon when lit
fix: Fix contracting upside-down-itis when leaving a meat spike abruptly
fix: Fix entering pods etc. while buckled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
