### PR TITLE
Allow heads to be put on trophy rack backpack

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -97,6 +97,25 @@
 	name = "trophy rack"
 	desc = "It's useful for both carrying extra gear and proudly declaring your insanity."
 	icon_state = "cultpack"
+	var/image/IM
+
+/obj/item/storage/backpack/cultpack/attackby(obj/item/I, mob/living/user)
+	..()
+	if(istype(I, /obj/item/organ/external/head))
+		if(user.drop_item())
+			to_chat(user, "<span class='notice'>You stick [I] onto the trophy rack.</span>")
+			var/matrix/M = matrix()
+			I.transform = M
+			IM = mutable_appearance(I.icon, I.icon_state)
+			IM.add_overlay(I.overlays)
+			add_overlay(IM)
+
+/obj/item/storage/backpack/cultpack/remove_from_storage(obj/item/W as obj, atom/new_location)
+	..()
+	if(istype(W, /obj/item/organ/external/head))
+		cut_overlay(IM)
+		to_chat(usr, "<span class='notice'>You remove [W] from the trophy rack.</span>")
+
 
 /obj/item/storage/backpack/clown
 	name = "Giggles Von Honkerton"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -103,56 +103,59 @@
 	var/mutable_appearance/LSma
 	var/mutable_appearance/MSma
 	var/mutable_appearance/RSma
-	var/list/placement
+	var/placement
 
 /obj/item/storage/backpack/cultpack/attackby(obj/item/I, mob/living/user)
 	..()
 	if(istype(I, /obj/item/organ/external/head))
 		placement = input(user, "Where would you like to put the head?") in list(!LS ? "Left Spike" : "", !MS ? "Middle Spike" : "", !RS ? "Right Spike" : "", "Bag")
 		switch(placement)
+			if("Bag")
+				return
 			if("Left Spike")
-				LS = I
-				user.visible_message("[user] sticks [I] onto the left spike of the trophy rack","You stick [I] on the left spike of the trophy rack.")
-				LSma = mutable_appearance(I.icon, I.icon_state)
-				var/matrix/M = matrix()
-				M.Turn(335)
-				M.Translate(-4,0)
-				I.transform = M
-				LSma.transform = M
-				add_overlay(LSma)
-				playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
+				if(!LS)
+					LS = I
+					LSma = mutable_appearance(I.icon, I.icon_state)
+					var/matrix/M = matrix()
+					M.Turn(335)
+					M.Translate(-4, 0)
+					I.transform = M
+					LSma.transform = M
+					add_overlay(LSma)
+				else return
 			if("Middle Spike")
-				MS = I
-				user.visible_message("[user] sticks [I] onto the middle spike of the trophy rack","You stick [I] on the middle spike of the trophy rack.")
-				MSma = mutable_appearance(I.icon, I.icon_state)
-				add_overlay(MSma)
-				playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
+				if(!MS)
+					MS = I
+					MSma = mutable_appearance(I.icon, I.icon_state)
+					add_overlay(MSma)
+				else return
 			if("Right Spike")
-				RS = I
-				user.visible_message("[user] sticks [I] onto the right spike of the trophy rack","You stick [I] on the right spike of the the trophy rack.")
-				RSma = mutable_appearance(I.icon, I.icon_state)
-				var/matrix/M = matrix()
-				M.Turn(25)
-				M.Translate(4,0)
-				I.transform = M
-				RSma.transform = M
-				add_overlay(RSma)
-				playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
+				if(!RS)
+					RS = I
+					RSma = mutable_appearance(I.icon, I.icon_state)
+					var/matrix/M = matrix()
+					M.Turn(25)
+					M.Translate(4, 0)
+					I.transform = M
+					RSma.transform = M
+					add_overlay(RSma)
+				else return
+		user.visible_message("<span class='notice'>[user] sticks [I] onto the [placement] of the trophy rack</span>", "<span class='notice'>You stick [I] on the [placement] of the the trophy rack.</span>")
+		playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
 
-/obj/item/storage/backpack/cultpack/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/storage/backpack/cultpack/remove_from_storage(obj/item/W, atom/new_location)
 	..()
 	if(W == LS)
 		LS = FALSE
 		cut_overlay(LSma)
-		usr.visible_message("[usr] removes [W] from the left spike of the trophy rack","You remove [W] from the left spike of the trophy rack.")
-	else if(W == MS)
+	if(W == MS)
 		MS = FALSE
 		cut_overlay(MSma)
-		usr.visible_message("[usr] removes [W] from the middle spike of the trophy rack","You remove [W] from the middle spike of the trophy rack.")
-	else if(W == RS)
+	if(W == RS)
 		RS = FALSE
 		cut_overlay(RSma)
-		usr.visible_message("[usr] removes [W] from the right spike of the trophy rack","You remove [W] from the right spike of the trophy rack.")
+	else return
+	usr.visible_message("<span class='notice'>[usr] unspikes [W] from the trophy rack</span>", "<span class='notice'>You unspike [W] from the trophy rack.</span>")
 
 /obj/item/storage/backpack/cultpack/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -120,11 +120,13 @@
 				I.transform = M
 				LSma.transform = M
 				add_overlay(LSma)
+				playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
 			if("Middle Spike")
 				MS = I
 				user.visible_message("[user] sticks [I] onto the middle spike of the trophy rack","You stick [I] on the middle spike of the trophy rack.")
 				MSma = mutable_appearance(I.icon, I.icon_state)
 				add_overlay(MSma)
+				playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
 			if("Right Spike")
 				RS = I
 				user.visible_message("[user] sticks [I] onto the right spike of the trophy rack","You stick [I] on the right spike of the the trophy rack.")
@@ -135,6 +137,7 @@
 				I.transform = M
 				RSma.transform = M
 				add_overlay(RSma)
+				playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
 
 /obj/item/storage/backpack/cultpack/remove_from_storage(obj/item/W as obj, atom/new_location)
 	..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -98,22 +98,28 @@
 	desc = "It's useful for both carrying extra gear and proudly declaring your insanity."
 	icon_state = "cultpack"
 	var/IM
+	var/obj/item/organ/external/head/mounted_head
 
 /obj/item/storage/backpack/cultpack/attackby(obj/item/I, mob/living/user)
 	..()
 	if(istype(I, /obj/item/organ/external/head))
-		if(user.drop_item())
-			to_chat(user, "<span class='notice'>You stick [I] onto the trophy rack.</span>")
-			var/matrix/M = matrix()
-			I.transform = M
-			IM = mutable_appearance(I.icon, I.icon_state)
-			add_overlay(IM)
+		if(!mounted_head)
+			mounted_head = I
+			if(user.drop_item())
+				user.visible_message("[user] sticks [I] onto the tropy rack","You stick [I] onto the trophy rack.")
+				var/matrix/M = matrix()
+				I.transform = M
+				IM = mutable_appearance(I.icon, I.icon_state)
+				add_overlay(IM)
+		else
+			to_chat(user, "<span class='notice'>You can only mount a single head onto the trophy rack at a time.</span>")
 
 /obj/item/storage/backpack/cultpack/remove_from_storage(obj/item/W as obj, atom/new_location)
 	..()
-	if(istype(W, /obj/item/organ/external/head))
+	if(W == mounted_head)
+		mounted_head = FALSE
 		cut_overlay(IM)
-		to_chat(usr, "<span class='notice'>You remove [W] from the trophy rack.</span>")
+		usr.visible_message("[usr] removes [W] from the tropy rack","You remove [W] from the trophy rack.")
 
 
 /obj/item/storage/backpack/clown

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -122,13 +122,15 @@
 					I.transform = M
 					LSma.transform = M
 					add_overlay(LSma)
-				else return
+				else
+					return
 			if("Middle Spike")
 				if(!MS)
 					MS = I
 					MSma = mutable_appearance(I.icon, I.icon_state)
 					add_overlay(MSma)
-				else return
+				else
+					return
 			if("Right Spike")
 				if(!RS)
 					RS = I
@@ -139,7 +141,8 @@
 					I.transform = M
 					RSma.transform = M
 					add_overlay(RSma)
-				else return
+				else
+					return
 		user.visible_message("<span class='notice'>[user] sticks [I] onto the [placement] of the trophy rack</span>", "<span class='notice'>You stick [I] on the [placement] of the the trophy rack.</span>")
 		playsound(loc, 'sound/effects/bone_break_3.ogg', 25, 1)
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -121,6 +121,10 @@
 		cut_overlay(IM)
 		usr.visible_message("[usr] removes [W] from the tropy rack","You remove [W] from the trophy rack.")
 
+/obj/item/storage/backpack/cultpack/examine(mob/user)
+	. = ..()
+	if(mounted_head)
+		. += "\ [mounted_head] is mounted on it."
 
 /obj/item/storage/backpack/clown
 	name = "Giggles Von Honkerton"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -97,7 +97,7 @@
 	name = "trophy rack"
 	desc = "It's useful for both carrying extra gear and proudly declaring your insanity."
 	icon_state = "cultpack"
-	var/image/IM
+	var/IM
 
 /obj/item/storage/backpack/cultpack/attackby(obj/item/I, mob/living/user)
 	..()
@@ -107,7 +107,6 @@
 			var/matrix/M = matrix()
 			I.transform = M
 			IM = mutable_appearance(I.icon, I.icon_state)
-			IM.add_overlay(I.overlays)
 			add_overlay(IM)
 
 /obj/item/storage/backpack/cultpack/remove_from_storage(obj/item/W as obj, atom/new_location)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -97,34 +97,68 @@
 	name = "trophy rack"
 	desc = "It's useful for both carrying extra gear and proudly declaring your insanity."
 	icon_state = "cultpack"
-	var/IM
-	var/obj/item/organ/external/head/mounted_head
+	var/obj/item/organ/external/head/LS
+	var/obj/item/organ/external/head/MS
+	var/obj/item/organ/external/head/RS
+	var/mutable_appearance/LSma
+	var/mutable_appearance/MSma
+	var/mutable_appearance/RSma
+	var/list/placement
 
 /obj/item/storage/backpack/cultpack/attackby(obj/item/I, mob/living/user)
 	..()
 	if(istype(I, /obj/item/organ/external/head))
-		if(!mounted_head)
-			mounted_head = I
-			if(user.drop_item())
-				user.visible_message("[user] sticks [I] onto the tropy rack","You stick [I] onto the trophy rack.")
+		placement = input(user, "Where would you like to put the head?") in list(!LS ? "Left Spike" : "", !MS ? "Middle Spike" : "", !RS ? "Right Spike" : "", "Bag")
+		switch(placement)
+			if("Left Spike")
+				LS = I
+				user.visible_message("[user] sticks [I] onto the left spike of the trophy rack","You stick [I] on the left spike of the trophy rack.")
+				LSma = mutable_appearance(I.icon, I.icon_state)
 				var/matrix/M = matrix()
+				M.Turn(335)
+				M.Translate(-4,0)
 				I.transform = M
-				IM = mutable_appearance(I.icon, I.icon_state)
-				add_overlay(IM)
-		else
-			to_chat(user, "<span class='notice'>You can only mount a single head onto the trophy rack at a time.</span>")
+				LSma.transform = M
+				add_overlay(LSma)
+			if("Middle Spike")
+				MS = I
+				user.visible_message("[user] sticks [I] onto the middle spike of the trophy rack","You stick [I] on the middle spike of the trophy rack.")
+				MSma = mutable_appearance(I.icon, I.icon_state)
+				add_overlay(MSma)
+			if("Right Spike")
+				RS = I
+				user.visible_message("[user] sticks [I] onto the right spike of the trophy rack","You stick [I] on the right spike of the the trophy rack.")
+				RSma = mutable_appearance(I.icon, I.icon_state)
+				var/matrix/M = matrix()
+				M.Turn(25)
+				M.Translate(4,0)
+				I.transform = M
+				RSma.transform = M
+				add_overlay(RSma)
 
 /obj/item/storage/backpack/cultpack/remove_from_storage(obj/item/W as obj, atom/new_location)
 	..()
-	if(W == mounted_head)
-		mounted_head = FALSE
-		cut_overlay(IM)
-		usr.visible_message("[usr] removes [W] from the tropy rack","You remove [W] from the trophy rack.")
+	if(W == LS)
+		LS = FALSE
+		cut_overlay(LSma)
+		usr.visible_message("[usr] removes [W] from the left spike of the trophy rack","You remove [W] from the left spike of the trophy rack.")
+	else if(W == MS)
+		MS = FALSE
+		cut_overlay(MSma)
+		usr.visible_message("[usr] removes [W] from the middle spike of the trophy rack","You remove [W] from the middle spike of the trophy rack.")
+	else if(W == RS)
+		RS = FALSE
+		cut_overlay(RSma)
+		usr.visible_message("[usr] removes [W] from the right spike of the trophy rack","You remove [W] from the right spike of the trophy rack.")
 
 /obj/item/storage/backpack/cultpack/examine(mob/user)
 	. = ..()
-	if(mounted_head)
-		. += "\ [mounted_head] is mounted on it."
+	if(LS)
+		. += "\ [LS] is mounted on the left spike."
+	if(MS)
+		. += "\ [MS] is mounted on the middle spike."
+	if(RS)
+		. += "\ [RS] is mounted on the right spike."
 
 /obj/item/storage/backpack/clown
 	name = "Giggles Von Honkerton"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows the chaplain to put up to 3 heads on his trophy rack. When you go to put a head (and only that item type) in the backpack, you get a popup with a choice of any currently unused spike, or just straight into the bag.  If there are no spikes available, it goes straight into the bag without the popup.

The head items still take up backpack space and show up in the backpack inventory. Removing a spiked head from backpack removes it from the spike.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because how else are you going to show all of your vampire and cult kills? Deus Vult!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![Capture](https://user-images.githubusercontent.com/4948622/84206072-6c6d7200-aa7c-11ea-96a8-eb3f9dc8cc5a.PNG)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Allows the chaplain to stick up to 3 heads on his trophy rack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
