### PR TITLE
Removes references to console screens and removes an unnecessary var from circuitboards

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -45,7 +45,6 @@
 	var/list/req_components = null
 	var/powernet = null
 	var/list/records = null
-	var/frame_desc = null
 	var/contain_parts = 1
 	toolspeed = 1
 	usesound = 'sound/items/deconstruct.ogg'
@@ -64,7 +63,7 @@
 			var/atom/A = B
 			if(!ispath(A))
 				continue
-			nice_list += list("[req_components[A]] [initial(A.name)]")
+			nice_list += list("[req_components[A]] [initial(A.name)]\s")
 		. += "<span class='notice'>Required components: [english_list(nice_list)].</span>"
 
 /obj/item/circuitboard/message_monitor

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -226,7 +226,6 @@ to destroy them and players will be able to make replacements.
 	name = "circuit board (Booze-O-Mat Vendor)"
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Resupply Canister."
 	build_path = /obj/machinery/vending/boozeomat
 	req_components = list(/obj/item/vending_refill/boozeomat = 1)
 
@@ -282,7 +281,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/smes
 	board_type = "machine"
 	origin_tech = "programming=3;powerstorage=3;engineering=3"
-	frame_desc = "Requires 5 pieces of cable, 5 Power Cells and 1 Capacitor."
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/stock_parts/cell = 5,
@@ -293,7 +291,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/emitter
 	board_type = "machine"
 	origin_tech = "programming=3;powerstorage=4;engineering=4"
-	frame_desc = "Requires 1 Micro Laser and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -303,7 +300,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/compressor
 	board_type = "machine"
 	origin_tech = "programming=4;powerstorage=4;engineering=4"
-	frame_desc = "Requires 5 pieces of cable and 6 Manipulators."
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/stock_parts/manipulator = 6)
@@ -313,7 +309,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/turbine
 	board_type = "machine"
 	origin_tech = "programming=4;powerstorage=4;engineering=4"
-	frame_desc = "Requires 5 pieces of cable and 6 Manipulators."
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/stock_parts/capacitor = 6)
@@ -324,7 +319,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/atmospherics/unary/cold_sink/freezer
 	board_type = "machine"
 	origin_tech = "programming=3;plasmatech=3"
-	frame_desc = "Requires 2 Matter Bins, 2 Micro Lasers, 1 piece of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/micro_laser = 2,
@@ -349,7 +343,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/recharger
 	board_type = "machine"
 	origin_tech = "powerstorage=3;materials=2"
-	frame_desc = "Requires 1 Capacitor"
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
 
 /obj/item/circuitboard/snow_machine
@@ -357,7 +350,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/snow_machine
 	board_type = "machine"
 	origin_tech = "programming=2;materials=2"
-	frame_desc = "Requires 1 Matter Bin and 1 Micro Laser."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/micro_laser = 1)
@@ -367,7 +359,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/biogenerator
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=3;materials=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -379,7 +370,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/plantgenes
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=3"
-	frame_desc = "Requires 1 Manipulator, 1 Micro Laser, 1 Sheet of glass, and 1 Scanning Module."
 	req_components = list(
 							/obj/item/stock_parts/manipulator = 1,
 							/obj/item/stock_parts/micro_laser = 1,
@@ -393,7 +383,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/seed_extractor
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Matter Bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -403,7 +392,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/hydroponics/constructable
 	board_type = "machine"
 	origin_tech = "programming=1;biotech=2"
-	frame_desc = "Requires 2 Matter Bins, 1 Manipulator, and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -414,7 +402,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/microwave
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 1 Micro Laser, 2 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stack/cable_coil = 2,
@@ -425,7 +412,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/oven
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 2 Micro Lasers, 5 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 2,
 							/obj/item/stack/cable_coil = 5,
@@ -436,7 +422,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/grill
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 2 Micro Lasers, 5 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 2,
 							/obj/item/stack/cable_coil = 5,
@@ -447,7 +432,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/candy_maker
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 1 Manipulator, 5 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/manipulator = 1,
 							/obj/item/stack/cable_coil = 5,
@@ -458,7 +442,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/cooker/deepfryer
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 2 Micro Laser and 5 pieces of cable."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 2,
 							/obj/item/stack/cable_coil = 5)
@@ -468,7 +451,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/gibber
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -478,7 +460,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/tesla_coil
 	board_type = "machine"
 	origin_tech = "programming=3;magnets=3;powerstorage=3"
-	frame_desc = "Requires 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 1)
 
@@ -487,7 +468,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/grounding_rod
 	board_type = "machine"
 	origin_tech = "programming=3;powerstorage=3;magnets=3;plasmatech=2"
-	frame_desc = "Requires 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 1)
 
@@ -496,7 +476,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/processor
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -506,7 +485,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/recycler
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -516,7 +494,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/smartfridge
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Matter bin."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1)
 	var/list/fridge_names_paths = list(
@@ -560,7 +537,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/monkey_recycler
 	board_type = "machine"
 	origin_tech = "programming=1;biotech=2"
-	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -570,7 +546,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/hologram/holopad
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 1)
 
@@ -579,7 +554,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_dispenser
 	board_type = "machine"
 	origin_tech = "materials=4;programming=4;plasmatech=4;biotech=3"
-	frame_desc = "Requires 2 Matter Bins, 1 Capacitor, 1 Manipulator, 1 Sheet of glass, and 1 Power Cell."
 	req_components = list(	/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/capacitor = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -591,7 +565,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_master
 	board_type = "machine"
 	origin_tech = "materials=3;programming=2;biotech=3"
-	frame_desc = "Requires 1 Manipulator, 2 Beakers and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/reagent_containers/glass/beaker = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -621,7 +594,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_heater
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2;biotech=2"
-	frame_desc = "Requires 1 Micro Laser and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stack/sheet/glass = 1)
@@ -631,7 +603,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/reagentgrinder/empty
 	board_type = "machine"
 	origin_tech = "materials=2;engineering=2;biotech=2"
-	frame_desc = "Requires 2 Manipulators and 1 Matter Bin."
 	req_components = list(
 							/obj/item/stock_parts/manipulator = 2,
 							/obj/item/stock_parts/matter_bin = 1)
@@ -642,7 +613,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/r_n_d/experimentor
 	board_type = "machine"
 	origin_tech = "magnets=1;engineering=1;programming=1;biotech=1;bluespace=2"
-	frame_desc = "Requires 2 Micro Lasers, 2 Manipulators and 1 Scanning Module."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stock_parts/manipulator = 2,
@@ -653,7 +623,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/r_n_d/destructive_analyzer
 	board_type = "machine"
 	origin_tech = "magnets=2;engineering=2;programming=2"
-	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, and 1 Micro Laser."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -664,7 +633,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/autolathe
 	board_type = "machine"
 	origin_tech = "engineering=2;programming=2"
-	frame_desc = "Requires 3 Matter Bins, 1 Manipulator, and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 3,
 							/obj/item/stock_parts/manipulator = 1,
@@ -675,7 +643,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/r_n_d/protolathe
 	board_type = "machine"
 	origin_tech = "engineering=2;programming=2"
-	frame_desc = "Requires 2 Matter Bins, 2 Manipulators, and 2 Beakers."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/manipulator = 2,
@@ -694,7 +661,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/r_n_d/circuit_imprinter
 	board_type = "machine"
 	origin_tech = "engineering=2;programming=2"
-	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, and 2 Beakers."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -705,7 +671,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/port_gen/pacman
 	board_type = "machine"
 	origin_tech = "programming=2;powerstorage=3;plasmatech=3;engineering=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Micro Laser, 2 Pieces of Cable, and 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/micro_laser = 1,
@@ -727,7 +692,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/r_n_d/server
 	board_type = "machine"
 	origin_tech = "programming=3"
-	frame_desc = "Requires 2 pieces of cable, and 1 Scanning Module."
 	req_components = list(
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/stock_parts/scanning_module = 1)
@@ -737,7 +701,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mecha_part_fabricator
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 2 Matter Bins, 1 Manipulator, 1 Micro Laser and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -749,7 +712,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mecha_part_fabricator/spacepod
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 2 Matter Bins, 1 Manipulators, 1 Micro Laser, and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -762,7 +724,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/clonepod
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=2"
-	frame_desc = "Requires 2 Manipulator, 2 Scanning Module, 2 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/stock_parts/scanning_module = 2,
@@ -774,7 +735,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/dna_scannernew
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=2"
-	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, 1 Micro Laser, 2 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -787,7 +747,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mech_bay_recharge_port
 	board_type = "machine"
 	origin_tech = "programming=3;powerstorage=3;engineering=3"
-	frame_desc = "Requires 1 piece of cable and 5 Capacitors."
 	req_components = list(
 							/obj/item/stack/cable_coil = 1,
 							/obj/item/stock_parts/capacitor = 5)
@@ -797,7 +756,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/teleport/hub
 	board_type = "machine"
 	origin_tech = "programming=3;engineering=4;bluespace=4;materials=4"
-	frame_desc = "Requires 3 Bluespace Crystals and 1 Matter Bin."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 3,
 							/obj/item/stock_parts/matter_bin = 1)
@@ -807,7 +765,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/teleport/station
 	board_type = "machine"
 	origin_tech = "programming=4;engineering=4;bluespace=4;plasmatech=3"
-	frame_desc = "Requires 2 Bluespace Crystals, 2 Capacitors and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 2,
 							/obj/item/stock_parts/capacitor = 2,
@@ -818,7 +775,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/teleport/perma
 	board_type = "machine"
 	origin_tech = "programming=3;engineering=4;bluespace=4;materials=4"
-	frame_desc = "Requires 3 Bluespace Crystals and 1 Matter Bin."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 3,
 							/obj/item/stock_parts/matter_bin = 1)
@@ -838,7 +794,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/telepad
 	board_type = "machine"
 	origin_tech = "programming=4;engineering=3;plasmatech=4;bluespace=4"
-	frame_desc = "Requires 2 Bluespace Crystals, 1 Capacitor, 1 piece of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 2,
 							/obj/item/stock_parts/capacitor = 1,
@@ -850,7 +805,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/quantumpad
 	board_type = "machine"
 	origin_tech = "programming=3;engineering=3;plasmatech=3;bluespace=4"
-	frame_desc = "Requires 1 Bluespace Crystal, 1 Capacitor, 1 piece of cable and 1 Manipulator."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 1,
 							/obj/item/stock_parts/capacitor = 1,
@@ -862,7 +816,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/sleeper
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=2;engineering=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 2 Sheets of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -883,7 +836,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/bodyscanner
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=2;engineering=3"
-	frame_desc = "Requires 1 Scanning Module, 2 pieces of cable and 2 Sheets of glass."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stack/cable_coil = 2,
@@ -894,7 +846,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/atmospherics/unary/cryo_cell
 	board_type = "machine"
 	origin_tech = "programming=4;biotech=3;engineering=4;plasmatech=3"
-	frame_desc = "Requires 1 Matter Bin, 1 piece of cable and 4 Sheets of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stack/cable_coil = 1,
@@ -905,7 +856,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/recharge_station
 	board_type = "machine"
 	origin_tech = "powerstorage=3;engineering=3"
-	frame_desc = "Requires 2 Capacitors, 1 Power Cell and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 2,
 							/obj/item/stock_parts/cell = 1,
@@ -917,7 +867,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/tcomms/relay
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2;bluespace=2"
-	frame_desc = "Requires 2 Manipulators and 2 Cable Coil."
 	req_components = list(/obj/item/stock_parts/manipulator = 2, /obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/tcomms/core
@@ -925,7 +874,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/tcomms/core
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 2 Manipulators and 2 Cable Coil."
 	req_components = list(/obj/item/stock_parts/manipulator = 2, /obj/item/stack/cable_coil = 2)
 // End telecomms circuit boards
 /obj/item/circuitboard/ore_redemption
@@ -933,7 +881,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mineral/ore_redemption
 	board_type = "machine"
 	origin_tech = "programming=1;engineering=2"
-	frame_desc = "Requires 1 Matter Bin, 1 Micro-manipulator, 1 Micro Laser, 1 Igniter and 1 Sheets of glass."
 	req_components = list(
 							/obj/item/stack/sheet/glass = 1,
 							/obj/item/stock_parts/matter_bin = 1,
@@ -950,7 +897,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mineral/equipment_vendor
 	board_type = "machine"
 	origin_tech = "programming=1;engineering=3"
-	frame_desc = "Requires 3 Matter bins and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/sheet/glass = 1,
 							/obj/item/stock_parts/matter_bin = 3)
@@ -964,7 +910,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/arcade/claw
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Matter bin, 1 Manipulator, 5 pieces of cable coil and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -976,7 +921,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/prize_counter
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Matter bin, 1 Manipulator, 1 piece of cable coil and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -988,7 +932,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/gameboard
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 1 Micro Laser, 3 pieces of cable coil and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stack/cable_coil = 3,
@@ -1000,7 +943,6 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/logic_gate
 	board_type = "machine"
 	origin_tech = "programming=1"		//This stuff is pretty much the absolute basis of programming, so it's mostly useless for research
-	frame_desc = "Requires 1 piece of cable coil."
 	req_components = list(/obj/item/stack/cable_coil = 1)
 	var/list/names_paths = list(
 							"NOT Gate" = /obj/machinery/logic_gate/not,

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -218,7 +218,7 @@
 
 //Machine Frame Circuit Boards
 /*Common Parts: Parts List: Ignitor, Timer, Infra-red laser, Infra-red sensor, t_scanner, Capacitor, Valve, sensor unit,
-micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
+micro-manipulator, glass sheets, beaker, Microlaser, matter bin, power cells.
 Note: Once everything is added to the public areas, will add MAT_METAL and MAT_GLASS to circuit boards since autolathe won't be able
 to destroy them and players will be able to make replacements.
 */
@@ -293,6 +293,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/emitter
 	board_type = "machine"
 	origin_tech = "programming=3;powerstorage=4;engineering=4"
+	frame_desc = "Requires 1 Micro Laser and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -302,6 +303,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/compressor
 	board_type = "machine"
 	origin_tech = "programming=4;powerstorage=4;engineering=4"
+	frame_desc = "Requires 5 pieces of cable and 6 Manipulators."
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/stock_parts/manipulator = 6)
@@ -311,6 +313,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/turbine
 	board_type = "machine"
 	origin_tech = "programming=4;powerstorage=4;engineering=4"
+	frame_desc = "Requires 5 pieces of cable and 6 Manipulators."
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/stock_parts/capacitor = 6)
@@ -321,7 +324,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/atmospherics/unary/cold_sink/freezer
 	board_type = "machine"
 	origin_tech = "programming=3;plasmatech=3"
-	frame_desc = "Requires 2 Matter Bins, 2 Micro Lasers, 1 piece of cable and 1 Console Screen."
+	frame_desc = "Requires 2 Matter Bins, 2 Micro Lasers, 1 piece of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/micro_laser = 2,
@@ -364,7 +367,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/biogenerator
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=3;materials=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 1 Console Screen."
+	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -376,7 +379,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/plantgenes
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=3"
-	frame_desc = "Requires 1 Manipulator, 1 Micro Laser, 1 Console Screen, and 1 Scanning Module."
+	frame_desc = "Requires 1 Manipulator, 1 Micro Laser, 1 Sheet of glass, and 1 Scanning Module."
 	req_components = list(
 							/obj/item/stock_parts/manipulator = 1,
 							/obj/item/stock_parts/micro_laser = 1,
@@ -400,7 +403,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/hydroponics/constructable
 	board_type = "machine"
 	origin_tech = "programming=1;biotech=2"
-	frame_desc = "Requires 2 Matter Bins, 1 Manipulator, and 1 Console Screen."
+	frame_desc = "Requires 2 Matter Bins, 1 Manipulator, and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -411,7 +414,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/microwave
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 1 Micro Laser, 2 pieces of cable and 1 Console Screen."
+	frame_desc = "Requires 1 Micro Laser, 2 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stack/cable_coil = 2,
@@ -422,7 +425,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/oven
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 2 Micro Lasers, 5 pieces of cable and 1 Console Screen."
+	frame_desc = "Requires 2 Micro Lasers, 5 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 2,
 							/obj/item/stack/cable_coil = 5,
@@ -433,7 +436,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/grill
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 2 Micro Lasers, 5 pieces of cable and 1 Console Screen."
+	frame_desc = "Requires 2 Micro Lasers, 5 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 2,
 							/obj/item/stack/cable_coil = 5,
@@ -444,7 +447,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/kitchen_machine/candy_maker
 	board_type = "machine"
 	origin_tech = "programming=2;magnets=2"
-	frame_desc = "Requires 1 Manipulator, 5 pieces of cable and 1 Console Screen."
+	frame_desc = "Requires 1 Manipulator, 5 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/manipulator = 1,
 							/obj/item/stack/cable_coil = 5,
@@ -455,7 +458,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/cooker/deepfryer
 	board_type = "machine"
 	origin_tech = "programming=1"
-	frame_desc = "Requires 2 Micro Lasers and 5 pieces of cable."
+	frame_desc = "Requires 2 Micro Laser and 5 pieces of cable."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 2,
 							/obj/item/stack/cable_coil = 5)
@@ -465,6 +468,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/gibber
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
+	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -474,6 +478,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/tesla_coil
 	board_type = "machine"
 	origin_tech = "programming=3;magnets=3;powerstorage=3"
+	frame_desc = "Requires 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 1)
 
@@ -482,6 +487,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/grounding_rod
 	board_type = "machine"
 	origin_tech = "programming=3;powerstorage=3;magnets=3;plasmatech=2"
+	frame_desc = "Requires 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 1)
 
@@ -490,6 +496,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/processor
 	board_type = "machine"
 	origin_tech = "programming=1"
+	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -499,6 +506,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/recycler
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
+	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -508,6 +516,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/smartfridge
 	board_type = "machine"
 	origin_tech = "programming=1"
+	frame_desc = "Requires 1 Matter bin."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1)
 	var/list/fridge_names_paths = list(
@@ -551,6 +560,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/monkey_recycler
 	board_type = "machine"
 	origin_tech = "programming=1;biotech=2"
+	frame_desc = "Requires 1 Matter bin and 1 Manipulator."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1)
@@ -560,6 +570,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/hologram/holopad
 	board_type = "machine"
 	origin_tech = "programming=1"
+	frame_desc = "Requires 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 1)
 
@@ -568,7 +579,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_dispenser
 	board_type = "machine"
 	origin_tech = "materials=4;programming=4;plasmatech=4;biotech=3"
-	frame_desc = "Requires 2 Matter Bins, 1 Capacitor, 1 Manipulator, 1 Console Screen, and 1 Power Cell."
+	frame_desc = "Requires 2 Matter Bins, 1 Capacitor, 1 Manipulator, 1 Sheet of glass, and 1 Power Cell."
 	req_components = list(	/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/capacitor = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -580,6 +591,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_master
 	board_type = "machine"
 	origin_tech = "materials=3;programming=2;biotech=3"
+	frame_desc = "Requires 1 Manipulator, 2 Beakers and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/reagent_containers/glass/beaker = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -609,7 +621,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_heater
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2;biotech=2"
-	frame_desc = "Requires 1 Micro Laser and 1 Console Screen."
+	frame_desc = "Requires 1 Micro Laser and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stack/sheet/glass = 1)
@@ -630,6 +642,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/r_n_d/experimentor
 	board_type = "machine"
 	origin_tech = "magnets=1;engineering=1;programming=1;biotech=1;bluespace=2"
+	frame_desc = "Requires 2 Micro Lasers, 2 Manipulators and 1 Scanning Module."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stock_parts/manipulator = 2,
@@ -640,7 +653,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/r_n_d/destructive_analyzer
 	board_type = "machine"
 	origin_tech = "magnets=2;engineering=2;programming=2"
-	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, and 1 Micro-Laser."
+	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, and 1 Micro Laser."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -651,7 +664,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/autolathe
 	board_type = "machine"
 	origin_tech = "engineering=2;programming=2"
-	frame_desc = "Requires 3 Matter Bins, 1 Manipulator, and 1 Console Screen."
+	frame_desc = "Requires 3 Matter Bins, 1 Manipulator, and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 3,
 							/obj/item/stock_parts/manipulator = 1,
@@ -692,7 +705,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/power/port_gen/pacman
 	board_type = "machine"
 	origin_tech = "programming=2;powerstorage=3;plasmatech=3;engineering=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Micro-Laser, 2 Pieces of Cable, and 1 Capacitor."
+	frame_desc = "Requires 1 Matter Bin, 1 Micro Laser, 2 Pieces of Cable, and 1 Capacitor."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/micro_laser = 1,
@@ -724,7 +737,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mecha_part_fabricator
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 2 Matter Bins, 1 Manipulator, 1 Micro-Laser and 1 Console Screen."
+	frame_desc = "Requires 2 Matter Bins, 1 Manipulator, 1 Micro Laser and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -736,7 +749,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mecha_part_fabricator/spacepod
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 2 Matter Bins, 1 Manipulators, 1 Micro-Lasers, and 1 Console Screen."
+	frame_desc = "Requires 2 Matter Bins, 1 Manipulators, 1 Micro Laser, and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
 							/obj/item/stock_parts/manipulator = 1,
@@ -749,7 +762,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/clonepod
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=2"
-	frame_desc = "Requires 2 Manipulator, 2 Scanning Module, 2 pieces of cable and 1 Console Screen."
+	frame_desc = "Requires 2 Manipulator, 2 Scanning Module, 2 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/stock_parts/scanning_module = 2,
@@ -761,7 +774,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/dna_scannernew
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=2"
-	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, 1 Micro-Laser, 2 pieces of cable and 1 Console Screen."
+	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, 1 Micro Laser, 2 pieces of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -794,7 +807,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/teleport/station
 	board_type = "machine"
 	origin_tech = "programming=4;engineering=4;bluespace=4;plasmatech=3"
-	frame_desc = "Requires 2 Bluespace Crystals, 2 Capacitors and 1 Console Screen."
+	frame_desc = "Requires 2 Bluespace Crystals, 2 Capacitors and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 2,
 							/obj/item/stock_parts/capacitor = 2,
@@ -825,7 +838,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/telepad
 	board_type = "machine"
 	origin_tech = "programming=4;engineering=3;plasmatech=4;bluespace=4"
-	frame_desc = "Requires 2 Bluespace Crystals, 1 Capacitor, 1 piece of cable and 1 Console Screen."
+	frame_desc = "Requires 2 Bluespace Crystals, 1 Capacitor, 1 piece of cable and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 2,
 							/obj/item/stock_parts/capacitor = 1,
@@ -849,7 +862,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/sleeper
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=2;engineering=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 2 Console Screens."
+	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 2 Sheets of glasss."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -870,7 +883,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/bodyscanner
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=2;engineering=3"
-	frame_desc = "Requires 1 Scanning Module, 2 pieces of cable and 2 Console Screens."
+	frame_desc = "Requires 1 Scanning Module, 2 pieces of cable and 2 Sheets of glasss."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stack/cable_coil = 2,
@@ -881,7 +894,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/atmospherics/unary/cryo_cell
 	board_type = "machine"
 	origin_tech = "programming=4;biotech=3;engineering=4;plasmatech=3"
-	frame_desc = "Requires 1 Matter Bin, 1 piece of cable and 4 Console Screens."
+	frame_desc = "Requires 1 Matter Bin, 1 piece of cable and 4 Sheets of glasss."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stack/cable_coil = 1,
@@ -920,6 +933,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mineral/ore_redemption
 	board_type = "machine"
 	origin_tech = "programming=1;engineering=2"
+	frame_desc = "Requires 1 Matter Bin, 1 Micro-manipulator, 1 Micro Laser, 1 Igniter and 1 Sheets of glasss."
 	req_components = list(
 							/obj/item/stack/sheet/glass = 1,
 							/obj/item/stock_parts/matter_bin = 1,
@@ -936,6 +950,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mineral/equipment_vendor
 	board_type = "machine"
 	origin_tech = "programming=1;engineering=3"
+	frame_desc = "Requires 3 Matter bins and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stack/sheet/glass = 1,
 							/obj/item/stock_parts/matter_bin = 3)
@@ -949,6 +964,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/arcade/claw
 	board_type = "machine"
 	origin_tech = "programming=1"
+	frame_desc = "Requires 1 Matter bin, 1 Manipulator, 5 pieces of cable coil and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -960,6 +976,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/prize_counter
 	board_type = "machine"
 	origin_tech = "programming=1"
+	frame_desc = "Requires 1 Matter bin, 1 Manipulator, 1 piece of cable coil and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -971,6 +988,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/gameboard
 	board_type = "machine"
 	origin_tech = "programming=1"
+	frame_desc = "Requires 1 Micro Laser, 3 pieces of cable coil and 1 Sheet of glass."
 	req_components = list(
 							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stack/cable_coil = 3,
@@ -982,8 +1000,8 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/logic_gate
 	board_type = "machine"
 	origin_tech = "programming=1"		//This stuff is pretty much the absolute basis of programming, so it's mostly useless for research
+	frame_desc = "Requires 1 piece of cable coil."
 	req_components = list(/obj/item/stack/cable_coil = 1)
-
 	var/list/names_paths = list(
 							"NOT Gate" = /obj/machinery/logic_gate/not,
 							"OR Gate" = /obj/machinery/logic_gate/or,

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -862,7 +862,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/sleeper
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=2;engineering=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 2 Sheets of glasss."
+	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, 1 piece of cable and 2 Sheets of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stock_parts/manipulator = 1,
@@ -883,7 +883,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/bodyscanner
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=2;engineering=3"
-	frame_desc = "Requires 1 Scanning Module, 2 pieces of cable and 2 Sheets of glasss."
+	frame_desc = "Requires 1 Scanning Module, 2 pieces of cable and 2 Sheets of glass."
 	req_components = list(
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stack/cable_coil = 2,
@@ -894,7 +894,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/atmospherics/unary/cryo_cell
 	board_type = "machine"
 	origin_tech = "programming=4;biotech=3;engineering=4;plasmatech=3"
-	frame_desc = "Requires 1 Matter Bin, 1 piece of cable and 4 Sheets of glasss."
+	frame_desc = "Requires 1 Matter Bin, 1 piece of cable and 4 Sheets of glass."
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stack/cable_coil = 1,
@@ -933,7 +933,7 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/mineral/ore_redemption
 	board_type = "machine"
 	origin_tech = "programming=1;engineering=2"
-	frame_desc = "Requires 1 Matter Bin, 1 Micro-manipulator, 1 Micro Laser, 1 Igniter and 1 Sheets of glasss."
+	frame_desc = "Requires 1 Matter Bin, 1 Micro-manipulator, 1 Micro Laser, 1 Igniter and 1 Sheets of glass."
 	req_components = list(
 							/obj/item/stack/sheet/glass = 1,
 							/obj/item/stock_parts/matter_bin = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Since console screens do not exist anymore, they shouldn't be referenced anywhere in the game.
This removes the variable `frame_desc` from circuitboards because it's not even used anywhere, *and* it contained reference to the console screens.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
spellcheck: Examine text for circuit boards that require more than 1 of a part will now have an "s" on the end of the name of that part. For example "2 capacitor" becomes "2 capacitors"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
