### PR TITLE
Removes Non-existent docking port from Delta

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -112194,17 +112194,6 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"dTU" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "sit_scimaint";
-	name = "Cyberiad Science Maint";
-	width = 11
-	},
-/turf/space,
-/area/space/nearstation)
 "dTV" = (
 /obj/machinery/power/solar{
 	name = "Aft Starboard Solar Panel"
@@ -170544,7 +170533,7 @@ aaa
 aaa
 aaa
 aaa
-dTU
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
## What Does This PR Do
DeltaStation has a docking port which not only has no reference in the code, but its also named after a Cyberiad port.

## Why It's Good For The Game
This shouldnt be a thing.

## Changelog
:cl: AffectedArc07
fix: DeltaStation no longer has an invalid docking port
/:cl:
