### PR TITLE
Removes the X-ray implant from RND

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -367,17 +367,6 @@
 	build_path = /obj/item/organ/internal/cyberimp/eyes/meson
 	category = list("Medical")
 
-/datum/design/cyberimp_xray
-	name = "X-Ray implant"
-	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
-	id = "ci-xray"
-	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 7, "magnets" = 5,"plasmatech" = 6)
-	build_type = PROTOLATHE | MECHFAB
-	construction_time = 60
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_URANIUM = 1000, MAT_DIAMOND = 1000, MAT_BLUESPACE = 1000)
-	build_path = /obj/item/organ/internal/cyberimp/eyes/xray
-	category = list("Medical")
-
 /datum/design/cyberimp_thermals
 	name = "Thermals implant"
 	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes the X-ray implant from RND completely, making it an antag/admin/genetics only thing.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
X-ray is one of the most powerful tools you can have, and not something you should be able to distribute to lots of crew with ease. Considering even antags have a hard time getting this, for example vampires needing full power, and nukies having to pay for it. I don't think the crew should get it basically for free. Especially considering most antags don't have any way to get it at all.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Made it so that you can no longer make the X-ray implant in RND, thus making it an antag/admin/genetics only thing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
