### PR TITLE
change tech requirement for xray implant

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -371,7 +371,7 @@
 	name = "X-Ray implant"
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
 	id = "ci-xray"
-	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 7, "magnets" = 5,"plasmatech" = 6)
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 8, "magnets" = 5,"plasmatech" = 6)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
 	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_URANIUM = 1000, MAT_DIAMOND = 1000, MAT_BLUESPACE = 1000)

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -62,7 +62,7 @@
 	name = "X-ray implant"
 	desc = "These cybernetic eye implants will give you X-ray vision. Blinking is futile."
 	implant_color = "#000000"
-	origin_tech = "materials=4;programming=4;biotech=6;magnets=4"
+	origin_tech = "materials=4;programming=4;biotech=7;magnets=4"
 	vision_flags = SEE_MOBS | SEE_OBJS | SEE_TURFS
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is intended as an alternative to both #13614 and #13463, though it could also be merged alongside the cost change if desired.

The tech requirement for making an x-ray implant is raised to biotech 8. This means it is not obtainable in a normal round without midround helping out. Namely, you need to deconstruct one of the following items to reach biotech 8:

- another xray implant, gotten from sol traders or surgically removing it from a nuke ops or deathsquad member without them blowing up (good luck)
- An abductor baton
- An abductor gland
- A slaughter demon heart
- An abductor recall implant
- A changeling egg (as in, let a headslut implant someone then surgically remove it. Good luck)

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This change effectively locks x-ray implants behind the rewards for mid/lateround events. This means both that there will be many rounds where it isn't gotten at all and that in the rounds that do have it, the implants only come into play in the lategame, once antagonists have had plenty of time to prepare and arm up.

It also effectively rewards the crew for actually going out of their way to reach very high tech levels when possible. Quite often even scientists don't care at all about a sol trader selling fleshy masses or research data.

While I see the argument for removing xray completely, I think leaving it as a very rare reward for when science gets access to special rewards is more exciting.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: x-ray vision implants now need higher research to create.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
