### PR TITLE
Fix HUDs taking parent atom's color

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -42,6 +42,7 @@
 				hud_list[hud] = list()
 			else
 				var/image/I = image('icons/mob/hud.dmi', src, "")
+				I.appearance_flags = RESET_COLOR | RESET_ALPHA
 				hud_list[hud] = I
 
 /mob/proc/generate_name()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -42,7 +42,7 @@
 				hud_list[hud] = list()
 			else
 				var/image/I = image('icons/mob/hud.dmi', src, "")
-				I.appearance_flags = RESET_COLOR
+				I.appearance_flags = RESET_COLOR | RESET_TRANSFORM
 				hud_list[hud] = I
 
 /mob/proc/generate_name()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -42,7 +42,7 @@
 				hud_list[hud] = list()
 			else
 				var/image/I = image('icons/mob/hud.dmi', src, "")
-				I.appearance_flags = RESET_COLOR | RESET_ALPHA
+				I.appearance_flags = RESET_COLOR
 				hud_list[hud] = I
 
 /mob/proc/generate_name()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Apply `RESET_COLOR` to `appearance_flags` of all HUDs so that they don't take their parent's colour

## Why It's Good For The Game
Makes viewing HUDs easier (or not outright impossible depending on the colour)

## Images of changes
Before:
![image](https://user-images.githubusercontent.com/1496804/84601737-c27a5500-ae82-11ea-8054-a5d4a16f8037.png)
After:
![image](https://user-images.githubusercontent.com/1496804/84601748-c8703600-ae82-11ea-81d5-cf21da2660c8.png)

## Changelog
:cl:
fix: Fix HUDs being rendered with colour of the object they belong to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
