### PR TITLE
Adds the option to randomize an objective when changing or adding an objective

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -545,11 +545,20 @@
 				if(objective&&(objective.type in objective_list) && objective:target)
 					def_target = objective.target.current
 				possible_targets = sortAtom(possible_targets)
-				possible_targets += "Free objective"
 
-				var/new_target = input("Select target:", "Objective target", def_target) as null|anything in possible_targets
-				if(!new_target)
-					return
+				var/new_target
+				if(LAZYLEN(possible_targets) > 0)
+					if(alert(usr, "Do you want to pick the objective yourself? No will randomise it", "Pick objective", "Yes", "No") == "Yes")
+						possible_targets += "Free objective"
+						new_target = input("Select target:", "Objective target", def_target) as null|anything in possible_targets
+					else
+						new_target = pick(possible_targets)
+
+					if(!new_target)
+						return
+				else
+					to_chat(usr, "<span class='warning'>No possible target found. Defaulting to a Free objective.</span>")
+					new_target = "Free objective"
 
 				var/objective_path = text2path("/datum/objective/[new_obj_type]")
 				if(new_target == "Free objective")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -547,7 +547,7 @@
 				possible_targets = sortAtom(possible_targets)
 
 				var/new_target
-				if(LAZYLEN(possible_targets) > 0)
+				if(length(possible_targets) > 0)
 					if(alert(usr, "Do you want to pick the objective yourself? No will randomise it", "Pick objective", "Yes", "No") == "Yes")
 						possible_targets += "Free objective"
 						new_target = input("Select target:", "Objective target", def_target) as null|anything in possible_targets


### PR DESCRIPTION
## What Does This PR Do
Makes it possible for admins to select a random objective instead of them having to pick one themselves when they add or change a players objective

## Why It's Good For The Game
Random objectives are prob what they want usually

## Changelog
:cl:
tweak: New or changed objectives using the admin tools now have the option to randomize the target 
/:cl: