### PR TITLE
Fixes Shadowling darksight not giving night vision when toggled

### DIFF
--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -76,11 +76,11 @@
 		var/mob/living/carbon/human/H = owner
 		H.weakeyes = 1
 		if(!H.vision_type)
-			H.vision_type = new /datum/vision_override/nightvision
+			H.set_sight(new /datum/vision_override/nightvision)
 
 /obj/item/organ/internal/cyberimp/eyes/thermals/ling/remove(mob/living/carbon/M, special = 0)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.weakeyes = 0
-		H.vision_type = null
+		H.set_sight(null)
 	..()

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -76,7 +76,7 @@
 		var/mob/living/carbon/human/H = owner
 		H.weakeyes = 1
 		if(!H.vision_type)
-			H.set_sight(new /datum/vision_override/nightvision)
+			H.set_sight(/datum/vision_override/nightvision)
 
 /obj/item/organ/internal/cyberimp/eyes/thermals/ling/remove(mob/living/carbon/M, special = 0)
 	if(ishuman(owner))

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -184,7 +184,7 @@
 		var/mob/living/carbon/human/H = target
 		if(!H.vision_type)
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
-			H.set_sight(new /datum/vision_override/nightvision)
+			H.set_sight(/datum/vision_override/nightvision)
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
 			H.set_sight(null)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -187,7 +187,7 @@
 			H.set_sight(new /datum/vision_override/nightvision)
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
-			H.set_sight()
+			H.set_sight(null)
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/thrall
 	desc = "Thrall Darksight"

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -186,9 +186,12 @@
 		if(!H.vision_type)
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
 			H.vision_type = new vision_path
+			H.update_sight()
+
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
 			H.vision_type = null
+			H.update_sight()
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/thrall
 	desc = "Thrall Darksight"

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -187,7 +187,6 @@
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
 			H.vision_type = new vision_path
 			H.update_sight()
-
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
 			H.vision_type = null

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -175,7 +175,6 @@
 	range = -1
 	include_user = 1
 	clothes_req = 0
-	var/datum/vision_override/vision_path = /datum/vision_override/nightvision
 	action_icon_state = "darksight"
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/cast(list/targets, mob/user = usr)
@@ -185,12 +184,10 @@
 		var/mob/living/carbon/human/H = target
 		if(!H.vision_type)
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
-			H.vision_type = new vision_path
-			H.update_sight()
+			H.set_sight(new /datum/vision_override/nightvision)
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
-			H.vision_type = null
-			H.update_sight()
+			H.set_sight()
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/thrall
 	desc = "Thrall Darksight"

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -42,7 +42,7 @@
 		H.set_sight(new /datum/vision_override/nightvision)
 		to_chat(H, "<span class='notice'>You adjust your vision to pierce the darkness.</span>")
 	else
-		H.set_sight()
+		H.set_sight(null)
 		to_chat(H, "<span class='notice'>You adjust your vision to recognize the shadows.</span>")
 
 /datum/species/shadow/on_species_gain(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -39,10 +39,10 @@
 /datum/action/innate/shadow/darkvision/Activate()
 	var/mob/living/carbon/human/H = owner
 	if(!H.vision_type)
-		H.vision_type = new /datum/vision_override/nightvision
+		H.set_sight(new /datum/vision_override/nightvision)
 		to_chat(H, "<span class='notice'>You adjust your vision to pierce the darkness.</span>")
 	else
-		H.vision_type = null
+		H.set_sight()
 		to_chat(H, "<span class='notice'>You adjust your vision to recognize the shadows.</span>")
 
 /datum/species/shadow/on_species_gain(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -39,7 +39,7 @@
 /datum/action/innate/shadow/darkvision/Activate()
 	var/mob/living/carbon/human/H = owner
 	if(!H.vision_type)
-		H.set_sight(new /datum/vision_override/nightvision)
+		H.set_sight(/datum/vision_override/nightvision)
 		to_chat(H, "<span class='notice'>You adjust your vision to pierce the darkness.</span>")
 	else
 		H.set_sight(null)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1356,6 +1356,10 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
 	sync_lighting_plane_alpha()
 
+/mob/proc/set_sight(datum/vision_override/O)
+	vision_type = O
+	update_sight()
+
 /mob/proc/sync_lighting_plane_alpha()
 	if(hud_used)
 		var/obj/screen/plane_master/lighting/L = hud_used.plane_masters["[LIGHTING_PLANE]"]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1357,9 +1357,9 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	sync_lighting_plane_alpha()
 
 /mob/proc/set_sight(datum/vision_override/O)
-	if(vision_type)
-		qdel(vision_type) //qdel the old vision_type unless it is null.
-	vision_type = O
+	QDEL_NULL(vision_type)
+	if(O) //in case of null
+		vision_type = new O
 	update_sight()
 
 /mob/proc/sync_lighting_plane_alpha()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1357,6 +1357,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	sync_lighting_plane_alpha()
 
 /mob/proc/set_sight(datum/vision_override/O)
+	if(vision_type)
+		qdel(vision_type) //qdel the old vision_type unless it is null.
 	vision_type = O
 	update_sight()
 

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -327,7 +327,7 @@
 	user.visible_message("[user] shines light onto the tumor in [target]'s [E]!", "<span class='notice'>You cleanse the contamination from [target]'s brain!</span>")
 	if(target.vision_type) //Turns off their darksight if it's still active.
 		to_chat(target, "<span class='boldannounce'>Your eyes are suddenly wrought with immense pain as your darksight is forcibly dismissed!</span>")
-		target.vision_type = null
+		target.set_sight(null)
 	SSticker.mode.remove_thrall(target.mind, 0)
 	target.visible_message("<span class='warning'>A strange black mass falls from [target]'s [E]!</span>")
 	var/obj/item/organ/thing = new /obj/item/organ/internal/shadowtumor(get_turf(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #13596

This fixes the darksight ability for shadowlings, and once again gives them night vision when toggling it.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix Fix, prevents users from having to update their visions in other ways just to use their god damn abilities
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed the shadowling darksight not toggling night vision without something else updating your vision.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
