### PR TITLE
Minor refactor to wireless eguns

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -278,6 +278,7 @@
 	return 1
 
 /atom/movable/proc/onTransitZ(old_z,new_z)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_Z_CHANGED, old_z, new_z)
 	for(var/item in src) // Notify contents of Z-transition. This can be overridden if we know the items contents do not care.
 		var/atom/movable/AM = item
 		AM.onTransitZ(old_z,new_z)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -278,7 +278,6 @@
 	return 1
 
 /atom/movable/proc/onTransitZ(old_z,new_z)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_Z_CHANGED, old_z, new_z)
 	for(var/item in src) // Notify contents of Z-transition. This can be overridden if we know the items contents do not care.
 		var/atom/movable/AM = item
 		AM.onTransitZ(old_z,new_z)

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -191,25 +191,27 @@
 	origin_tech = null
 	selfcharge = 1
 	can_charge = 0
-	var/inawaymission = 1
+	var/inawaymission = TRUE
 
-/obj/item/gun/energy/laser/awaymission_aeg/process()
+/obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
+	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/updateZ)
+	// Force update it incase it spawns outside an away mission and shouldnt be charged
+	updateZ()
+	return ..()
+
+/obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
 	var/turf/my_loc = get_turf(src)
 	if(is_away_level(my_loc.z))
-		if(inawaymission)
-			return ..()
 		if(ismob(loc))
 			to_chat(loc, "<span class='notice'>Your [src] activates, starting to draw power from a nearby wireless power source.</span>")
-		inawaymission = 1
+		inawaymission = TRUE
 	else
 		if(inawaymission)
 			if(ismob(loc))
 				to_chat(loc, "<span class='danger'>Your [src] deactivates, as it is out of range from its power source.</span>")
 			cell.charge = 0
-			inawaymission = 0
+			inawaymission = FALSE
 			update_icon()
-
-
 
 /obj/item/reagent_containers/glass/beaker/terror_black_toxin
 	name = "beaker 'Black Terror Venom'"

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -191,31 +191,25 @@
 	origin_tech = null
 	selfcharge = 1
 	can_charge = 0
-	var/inawaymission = TRUE
+	// Selfcharge is enabled and disabled, and used as the away mission tracker
+	selfcharge = TRUE
 
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/updateZ)
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
-	updateZ()
+	onTransitZ(new_z=loc.z)
 
-/obj/item/gun/energy/laser/awaymission_aeg/process()
-	// Only call the self-recharge proc if inside an away mission
-	if(inawaymission)
-		..()
-
-/obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
-	var/turf/my_loc = get_turf(src)
-	if(is_away_level(my_loc.z))
+/obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
+	if(is_away_level(new_z))
 		if(ismob(loc))
 			to_chat(loc, "<span class='notice'>Your [src] activates, starting to draw power from a nearby wireless power source.</span>")
-		inawaymission = TRUE
+		selfcharge = TRUE
 	else
-		if(inawaymission)
+		if(selfcharge)
 			if(ismob(loc))
 				to_chat(loc, "<span class='danger'>Your [src] deactivates, as it is out of range from its power source.</span>")
 			cell.charge = 0
-			inawaymission = FALSE
+			selfcharge = FALSE
 			update_icon()
 
 /obj/item/reagent_containers/glass/beaker/terror_black_toxin

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -194,10 +194,10 @@
 	var/inawaymission = TRUE
 
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
+	. = ..()
 	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/updateZ)
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
 	updateZ()
-	return ..()
 
 /obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
 	var/turf/my_loc = get_turf(src)

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -197,7 +197,7 @@
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
-	onTransitZ(new_z=loc.z)
+	onTransitZ(new_z = loc.z)
 
 /obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
 	if(is_away_level(new_z))

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -199,6 +199,11 @@
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
 	updateZ()
 
+/obj/item/gun/energy/laser/awaymission_aeg/process()
+	// Only call the self-recharge proc if inside an away mission
+	if(inawaymission)
+		..()
+
 /obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
 	var/turf/my_loc = get_turf(src)
 	if(is_away_level(my_loc.z))


### PR DESCRIPTION
## What Does This PR Do
Wireless eguns now use the `COMSIG_MOVABLE_Z_CHANGED` signal to decide if they are in an away mission or not, which means they arent checking for a location every time they process. Also cuts down on call overhead for recharging

## Why It's Good For The Game
Code should be good

## Changelog
:cl: AffectedArc07
tweak: Optimised the code of wireless eguns
/:cl:
