### PR TITLE
Purges a Bunch of In World Calls

### DIFF
--- a/code/game/area/areas/depot-areas.dm
+++ b/code/game/area/areas/depot-areas.dm
@@ -216,7 +216,8 @@
 	if(!silent)
 		announce_here("Depot Code BLUE", reason)
 		var/list/possible_bot_spawns = list()
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(L.name == "syndi_depot_bot")
 				possible_bot_spawns |= L
 		if(possible_bot_spawns.len)
@@ -248,7 +249,8 @@
 			comms_online = TRUE
 	if(comms_online)
 		spawn(0)
-			for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+			for(var/thing in GLOB.landmarks_list)
+				var/obj/effect/landmark/L = thing
 				if(prob(50))
 					if(L.name == "syndi_depot_backup")
 						var/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space/S = new /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space(get_turf(L))
@@ -344,7 +346,8 @@
 /area/syndicate_depot/core/proc/shields_up()
 	if(shield_list.len)
 		return
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(L.name == "syndi_depot_shield")
 			var/obj/machinery/shieldwall/syndicate/S = new /obj/machinery/shieldwall/syndicate(L.loc)
 			shield_list += S.UID()

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -19,7 +19,7 @@
 			intercepttext += "Message ends."
 		if(2)
 			var/nukecode = rand(10000, 99999)
-			for(var/obj/machinery/nuclearbomb/bomb in world)
+			for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
 				if(bomb && bomb.r_code)
 					if(is_station_level(bomb.z))
 						bomb.r_code = nukecode

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -415,7 +415,7 @@ proc/display_roundstart_logout_report()
 
 /proc/get_nuke_code()
 	var/nukecode = "ERROR"
-	for(var/obj/machinery/nuclearbomb/bomb in world)
+	for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
 		if(bomb && bomb.r_code && is_station_level(bomb.z))
 			nukecode = bomb.r_code
 	return nukecode

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -652,7 +652,8 @@
 	button.desc = desc
 
 /datum/action/innate/ai/blackout/Activate()
-	for(var/obj/machinery/power/apc/apc in GLOB.apcs)
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/apc
 		if(prob(30 * apc.overload))
 			apc.overload_lighting()
 		else

--- a/code/game/gamemodes/miniantags/borer/borer_event.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_event.dm
@@ -16,7 +16,7 @@
 
 /datum/event/borer_infestation/start()
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSair.atmos_machinery)
 		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
 			//Stops cortical borers getting stuck in small networks. See: Security, Virology
 			if(temp_vent.parent.other_atmosmch.len > 50)

--- a/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
@@ -26,13 +26,15 @@
 		var/datum/mind/player_mind = new /datum/mind(key_of_revenant)
 		player_mind.active = 1
 		var/list/spawn_locs = list()
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(isturf(L.loc))
 				switch(L.name)
 					if("revenantspawn")
 						spawn_locs += L.loc
 		if(!spawn_locs) //If we can't find any revenant spawns, try the carp spawns
-			for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+			for(var/thing in GLOB.landmarks_list)
+				var/obj/effect/landmark/L = thing
 				if(isturf(L.loc))
 					switch(L.name)
 						if("carpspawn")

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -95,7 +95,8 @@ proc/issyndicate(mob/living/M as mob)
 
 	var/list/turf/synd_spawn = list()
 
-	for(var/obj/effect/landmark/A in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/A = thing
 		if(A.name == "Syndicate-Spawn")
 			synd_spawn += get_turf(A)
 			qdel(A)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -450,7 +450,7 @@ proc/issyndicate(mob/living/M as mob)
 	if(foecount == GLOB.score_arrested)
 		GLOB.score_allarrested = 1
 
-	for(var/obj/machinery/nuclearbomb/nuke in world)
+	for(var/obj/machinery/nuclearbomb/nuke in GLOB.machines)
 		if(nuke.r_code == "Nope")	continue
 		var/turf/T = get_turf(nuke)
 		var/area/A = T.loc
@@ -491,13 +491,16 @@ proc/issyndicate(mob/living/M as mob)
 	for(var/datum/mind/M in SSticker.mode.syndicates)
 		foecount++
 
-	for(var/mob/living/C in world)
+	for(var/mob in GLOB.mob_living_list)
+		var/mob/living/C = mob
 		if(ishuman(C) || isAI(C) || isrobot(C))
-			if(C.stat == 2) continue
-			if(!C.client) continue
+			if(C.stat == DEAD)
+				continue
+			if(!C.client)
+				continue
 			crewcount++
 
-	var/obj/item/disk/nuclear/N = locate() in world
+	var/obj/item/disk/nuclear/N = locate() in GLOB.poi_list
 	if(istype(N))
 		var/atom/disk_loc = N.loc
 		while(!isturf(disk_loc))

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -425,7 +425,8 @@
 				if(player.mind in SSticker.mode.revolutionaries) continue
 				loycount++
 
-	for(var/mob/living/silicon/X in GLOB.mob_living_list)
+	for(var/beepboop in GLOB.silicon_mob_list)
+		var/mob/living/silicon/X = beepboop
 		if(X.stat != DEAD)
 			loycount++
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -385,7 +385,7 @@
 	if(foecount == GLOB.score_arrested)
 		GLOB.score_allarrested = 1
 
-	for(var/mob/living/carbon/human/player in world)
+	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)
 		if(player.mind)
 			var/role = player.mind.assigned_role
 			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director"))
@@ -415,7 +415,7 @@
 	for(var/datum/mind/M in SSticker.mode:revolutionaries)
 		if(M.current && M.current.stat != DEAD)
 			revcount++
-	for(var/mob/living/carbon/human/player in world)
+	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)
 		if(player.mind)
 			var/role = player.mind.assigned_role
 			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director"))
@@ -425,7 +425,7 @@
 				if(player.mind in SSticker.mode.revolutionaries) continue
 				loycount++
 
-	for(var/mob/living/silicon/X in world)
+	for(var/mob/living/silicon/X in GLOB.mob_living_list)
 		if(X.stat != DEAD)
 			loycount++
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -71,7 +71,8 @@
 
 
 	// Check station's power levels
-	for(var/obj/machinery/power/apc/A in GLOB.apcs)
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/A = thing
 		if(!is_station_level(A.z)) continue
 		for(var/obj/item/stock_parts/cell/C in A.contents)
 			if(C.charge < 2300)

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -161,7 +161,8 @@ GLOBAL_LIST_INIT(possibleShadowlingNames, list("U'ruan", "Y`shej", "Nex", "Hel-u
 				for(var/mob/living/M in orange(7, H))
 					M.Weaken(10)
 					to_chat(M, "<span class='userdanger'>An immense pressure slams you onto the ground!</span>")
-				for(var/obj/machinery/power/apc/A in GLOB.apcs)
+				for(var/thing in GLOB.apcs)
+					var/obj/machinery/power/apc/A = thing
 					A.overload_lighting()
 				var/mob/living/simple_animal/ascendant_shadowling/A = new /mob/living/simple_animal/ascendant_shadowling(H.loc)
 				A.announce("VYSHA NERADA YEKHEZET U'RUU!!", 5, 'sound/hallucinations/veryfar_noise.ogg')

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -164,7 +164,7 @@
 	var/turf/T = get_turf(src)
 	if(!T.loc) return
 	var/area/A = get_area(T)
-	for(var/obj/machinery/portable_atmospherics/scrubber/huge/scrubber in world )
+	for(var/obj/machinery/portable_atmospherics/scrubber/huge/scrubber in SSair.atmos_machinery)
 		var/turf/T2 = get_turf(scrubber)
 		if(T2 && T2.loc)
 			var/area/A2 = T2.loc

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -189,12 +189,12 @@
 	active = 1
 	icon_state = "launcheract"
 
-	for(var/obj/machinery/sparker/M in world)
+	for(var/obj/machinery/sparker/M in GLOB.machines)
 		if(M.id == id)
 			spawn( 0 )
 				M.spark()
 
-	for(var/obj/machinery/igniter/M in world)
+	for(var/obj/machinery/igniter/M in GLOB.machines)
 		if(M.id == id)
 			use_power(50)
 			M.on = !( M.on )

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -41,7 +41,7 @@
 		number = 1
 		var/area/A = get_area(src)
 		if(A)
-			for(var/obj/machinery/camera/autoname/C in world)
+			for(var/obj/machinery/camera/autoname/C in GLOB.machines)
 				if(C == src) continue
 				var/area/CA = get_area(C)
 				if(CA.type == A.type)

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -121,7 +121,7 @@
 					data["virus"] += list(list("name" = DS.name, "D" = D))
 			if(MED_DATA_MEDBOT)
 				data["medbots"] = list()
-				for(var/mob/living/simple_animal/bot/medbot/M in world)
+				for(var/mob/living/simple_animal/bot/medbot/M in GLOB.bots_list)
 					if(M.z != z)
 						continue
 					var/turf/T = get_turf(M)

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -23,7 +23,7 @@
 	timings = list()
 	times = list()
 	synced = list()
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in GLOB.machines)
 		if(M.z != src.z)	continue
 		for(var/ident_tag in id_tags)
 			if((M.id_tag == ident_tag) && !(ident_tag in synced))
@@ -49,7 +49,7 @@
 	return
 
 /obj/machinery/computer/pod/proc/solo_sync(var/ident_tag)
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in GLOB.machines)
 		if(M.z != src.z)	continue
 		if((M.id_tag == ident_tag) && !(ident_tag in synced))
 			synced += ident_tag
@@ -78,7 +78,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	var/anydriver = 0
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in GLOB.machines)
 		if(M.z != src.z)	continue
 		if(M.id_tag == ident_tag)
 			anydriver = 1
@@ -94,7 +94,7 @@
 	sleep(20)
 
 
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in GLOB.machines)
 		if(M.z != src.z)	continue
 		if(M.id_tag == ident_tag)
 			M.drive()
@@ -219,7 +219,7 @@
 			var/ident_tag = href_list["driver"]
 			var/t = text2num(href_list["power"])
 			t = min(max(0.25, t), 16)
-			for(var/obj/machinery/mass_driver/M in world)
+			for(var/obj/machinery/mass_driver/M in GLOB.machines)
 				if(M.id_tag == ident_tag)
 					M.power = t
 			powers[ident_tag] = t
@@ -294,7 +294,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	var/anydriver = 0
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in GLOB.machines)
 		if(M.z != src.z)	continue
 		if(M.id_tag == ident_tag)
 			anydriver = 1
@@ -303,10 +303,10 @@
 		return
 
 	var/spawn_marauder[] = new()
-	for(var/obj/effect/landmark/L in world)
+	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 		if(L.name == "Marauder Entry")
 			spawn_marauder.Add(L)
-	for(var/obj/effect/landmark/L in world)
+	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 		if(L.name == "Marauder Exit")
 			var/obj/effect/portal/P = new(L.loc, pick(spawn_marauder))
 			P.invisibility = 101//So it is not seen by anyone.
@@ -320,7 +320,7 @@
 				M.open()
 	sleep(20)
 
-	for(var/obj/machinery/mass_driver/M in world)
+	for(var/obj/machinery/mass_driver/M in GLOB.machines)
 		if(M.z != src.z)	continue
 		if(M.id_tag == ident_tag)
 			M.drive()

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -303,10 +303,12 @@
 		return
 
 	var/spawn_marauder[] = new()
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(L.name == "Marauder Entry")
 			spawn_marauder.Add(L)
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(L.name == "Marauder Exit")
 			var/obj/effect/portal/P = new(L.loc, pick(spawn_marauder))
 			P.invisibility = 101//So it is not seen by anyone.

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -93,7 +93,7 @@ GLOBAL_VAR_INIT(specops_shuttle_timeleft, 0)
 
 	GLOB.specops_shuttle_at_station = 0
 
-	for(var/obj/machinery/computer/specops_shuttle/S in world)
+	for(var/obj/machinery/computer/specops_shuttle/S in GLOB.machines)
 		S.specops_shuttle_timereset = world.time + SPECOPS_RETURN_DELAY
 
 	qdel(announcer)
@@ -160,10 +160,10 @@ GLOBAL_VAR_INIT(specops_shuttle_timeleft, 0)
 		sleep(10)
 
 		var/spawn_marauder[] = new()
-		for(var/obj/effect/landmark/L in world)
+		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 			if(L.name == "Marauder Entry")
 				spawn_marauder.Add(L.loc)
-		for(var/obj/effect/landmark/L in world)
+		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 			if(L.name == "Marauder Exit")
 				var/obj/effect/portal/P = new(L.loc, pick(spawn_marauder))
 				//P.invisibility = 101//So it is not seen by anyone.
@@ -233,7 +233,7 @@ GLOBAL_VAR_INIT(specops_shuttle_timeleft, 0)
 		var/mob/M = locate(/mob) in T
 		to_chat(M, "<span class='warning'>You have arrived to [station_name()]. Commence operation!</span>")
 
-	for(var/obj/machinery/computer/specops_shuttle/S in world)
+	for(var/obj/machinery/computer/specops_shuttle/S in GLOB.machines)
 		S.specops_shuttle_timereset = world.time + SPECOPS_RETURN_DELAY
 
 	qdel(announcer)
@@ -241,7 +241,7 @@ GLOBAL_VAR_INIT(specops_shuttle_timeleft, 0)
 /proc/specops_can_move()
 	if(GLOB.specops_shuttle_moving_to_station || GLOB.specops_shuttle_moving_to_centcom)
 		return 0
-	for(var/obj/machinery/computer/specops_shuttle/S in world)
+	for(var/obj/machinery/computer/specops_shuttle/S in GLOB.machines)
 		if(world.timeofday <= S.specops_shuttle_timereset)
 			return 0
 	return 1

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -160,10 +160,12 @@ GLOBAL_VAR_INIT(specops_shuttle_timeleft, 0)
 		sleep(10)
 
 		var/spawn_marauder[] = new()
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(L.name == "Marauder Entry")
 				spawn_marauder.Add(L.loc)
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(L.name == "Marauder Exit")
 				var/obj/effect/portal/P = new(L.loc, pick(spawn_marauder))
 				//P.invisibility = 101//So it is not seen by anyone.

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -133,7 +133,8 @@ GLOBAL_VAR_INIT(syndicate_elite_shuttle_timeleft, 0)
 		elite_squad.readyreset()//Reset firealarm after the team launched.
 	//End Marauder launchpad.
 
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(L.name == "Syndicate Breach Area")
 			explosion(L.loc,4,6,8,10,0)
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -144,7 +144,7 @@
 	active = 1
 	icon_state = "launcheract"
 
-	for(var/obj/machinery/flasher/M in world)
+	for(var/obj/machinery/flasher/M in GLOB.machines)
 		if(M.id == id)
 			spawn()
 				M.flash()

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -67,7 +67,7 @@
 	else
 		icon_state = "light0"
 
-	for(var/obj/machinery/holosign/M in world)
+	for(var/obj/machinery/holosign/M in GLOB.machines)
 		if(M.id == src.id)
 			spawn( 0 )
 				M.toggle()

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -202,7 +202,7 @@
 	..()
 
 	if(autolink)
-		for(var/obj/machinery/magnetic_module/M in world)
+		for(var/obj/machinery/magnetic_module/M in GLOB.machines)
 			if(M.freq == frequency && M.code == code)
 				magnets.Add(M)
 
@@ -224,7 +224,7 @@
 
 /obj/machinery/magnetic_controller/process()
 	if(magnets.len == 0 && autolink)
-		for(var/obj/machinery/magnetic_module/M in world)
+		for(var/obj/machinery/magnetic_module/M in GLOB.machines)
 			if(M.freq == frequency && M.code == code)
 				magnets.Add(M)
 

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 		var/log_msg = message
 		var/pass = 0
 		screen = RCS_SENTFAIL
-		for(var/obj/machinery/message_server/MS in world)
+		for(var/obj/machinery/message_server/MS in GLOB.machines)
 			if(!MS.active) continue
 			MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority)
 			pass = 1

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -132,7 +132,7 @@
 
 
 /obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
-	for(var/obj/singularity/singulo in world)
+	for(var/obj/singularity/singulo in GLOB.singularities)
 		if(singulo.target == src)
 			singulo.target = null
 	icon_state = "[icontype]0"

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -121,7 +121,8 @@
 		if(user)
 			to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
 		return
-	for(var/obj/singularity/singulo in GLOB.singularities)
+	for(var/thing in GLOB.singularities)
+		var/obj/singularity/singulo = thing
 		if(singulo.z == z)
 			singulo.target = src
 	icon_state = "[icontype]1"
@@ -132,7 +133,8 @@
 
 
 /obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
-	for(var/obj/singularity/singulo in GLOB.singularities)
+	for(var/thing in GLOB.singularities)
+		var/obj/singularity/singulo = thing
 		if(singulo.target == src)
 			singulo.target = null
 	icon_state = "[icontype]0"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -609,6 +609,8 @@
 		occupant = null
 		icon_state = initial(icon_state)+"-open"
 		setDir(dir_in)
+	if(A in trackers)
+		trackers -= A
 
 /obj/mecha/Destroy()
 	if(occupant)
@@ -639,7 +641,7 @@
 	cabin_air = null
 	QDEL_NULL(spark_system)
 	QDEL_NULL(smoke_system)
-
+	QDEL_LIST(trackers)
 	GLOB.mechas_list -= src //global mech list
 	return ..()
 

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -25,10 +25,14 @@
 
 /obj/machinery/computer/mecha/ui_data(mob/user, ui_key = "main", datum/topic_state/state = GLOB.default_state)
 	var/data[0]
+	var/list/trackerlist = list()
+	for(var/obj/mecha/MC in GLOB.mechas_list)
+		trackerlist += MC.trackers
+
 	data["screen"] = screen
 	if(screen == 0)
 		var/list/mechas[0]
-		for(var/obj/item/mecha_parts/mecha_tracking/TR in world)
+		for(var/obj/item/mecha_parts/mecha_tracking/TR in trackerlist)
 			var/answer = TR.get_mecha_info()
 			if(answer)
 				mechas[++mechas.len] = answer

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -26,7 +26,8 @@
 /obj/machinery/computer/mecha/ui_data(mob/user, ui_key = "main", datum/topic_state/state = GLOB.default_state)
 	var/data[0]
 	var/list/trackerlist = list()
-	for(var/obj/mecha/MC in GLOB.mechas_list)
+	for(var/stompy in GLOB.mechas_list)
+		var/obj/mecha/MC = stompy
 		trackerlist += MC.trackers
 
 	data["screen"] = screen

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -25,14 +25,13 @@
 
 /obj/machinery/computer/mecha/ui_data(mob/user, ui_key = "main", datum/topic_state/state = GLOB.default_state)
 	var/data[0]
-	var/list/trackerlist = list()
-	for(var/stompy in GLOB.mechas_list)
-		var/obj/mecha/MC = stompy
-		trackerlist += MC.trackers
-
 	data["screen"] = screen
 	if(screen == 0)
 		var/list/mechas[0]
+		var/list/trackerlist = list()
+		for(var/stompy in GLOB.mechas_list)
+			var/obj/mecha/MC = stompy
+			trackerlist += MC.trackers
 		for(var/thing in trackerlist)
 			var/obj/item/mecha_parts/mecha_tracking/TR = thing
 			var/answer = TR.get_mecha_info()

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -32,7 +32,8 @@
 	data["screen"] = screen
 	if(screen == 0)
 		var/list/mechas[0]
-		for(var/obj/item/mecha_parts/mecha_tracking/TR in trackerlist)
+		for(var/thing in trackerlist)
+			var/obj/item/mecha_parts/mecha_tracking/TR = thing
 			var/answer = TR.get_mecha_info()
 			if(answer)
 				mechas[++mechas.len] = answer

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -124,8 +124,7 @@
 	//Attach hydraulic clamp
 	var/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/HC = new
 	HC.attach(src)
-	for(var/obj/item/mecha_parts/mecha_tracking/B in trackers)//Deletes the beacon so it can't be found easily
-		qdel(B)
+	QDEL_LIST(trackers) //Deletes the beacon so it can't be found easily
 
 	var/obj/item/mecha_parts/mecha_equipment/mining_scanner/scanner = new
 	scanner.attach(src)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -115,7 +115,7 @@ Frequency:
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
 		return
 	var/list/L = list(  )
-	for(var/obj/machinery/computer/teleporter/com in world)
+	for(var/obj/machinery/computer/teleporter/com in GLOB.machines)
 		if(com.target)
 			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
 				L["[com.id] (Active)"] = com.target

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -154,7 +154,7 @@
 				if(!E.teleporting)
 					var/list/L = list()
 					var/list/areaindex = list()
-					for(var/obj/machinery/telepad_cargo/R in world)
+					for(var/obj/machinery/telepad_cargo/R in GLOB.machines)
 						if(R.stage == 0)
 							var/turf/T = get_turf(R)
 							var/tmpname = T.loc.name

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -89,7 +89,7 @@
 				if(!E.teleporting)
 					var/list/L = list()
 					var/list/areaindex = list()
-					for(var/obj/machinery/telepad_cargo/R in world)
+					for(var/obj/machinery/telepad_cargo/R in GLOB.machines)
 						if(R.stage == 0)
 							var/turf/T = get_turf(R)
 							var/tmpname = T.loc.name

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -12,7 +12,8 @@
 
 	to_chat(usr, "Checking for disconnected pipes...")
 	//all plumbing - yes, some things might get stated twice, doesn't matter.
-	for(var/obj/machinery/atmospherics/plumbing in SSair.atmos_machinery)
+	for(var/thing in SSair.atmos_machinery)
+		var/obj/machinery/atmospherics/plumbing = thing
 		if(plumbing.nodealert)
 			to_chat(usr, "Unconnected [plumbing.name] located at [plumbing.x],[plumbing.y],[plumbing.z] ([get_area(plumbing.loc)])")
 

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -12,17 +12,17 @@
 
 	to_chat(usr, "Checking for disconnected pipes...")
 	//all plumbing - yes, some things might get stated twice, doesn't matter.
-	for(var/obj/machinery/atmospherics/plumbing in world)
+	for(var/obj/machinery/atmospherics/plumbing in SSair.atmos_machinery)
 		if(plumbing.nodealert)
 			to_chat(usr, "Unconnected [plumbing.name] located at [plumbing.x],[plumbing.y],[plumbing.z] ([get_area(plumbing.loc)])")
 
 	//Manifolds
-	for(var/obj/machinery/atmospherics/pipe/manifold/pipe in world)
+	for(var/obj/machinery/atmospherics/pipe/manifold/pipe in SSair.atmos_machinery)
 		if(!pipe.node1 || !pipe.node2 || !pipe.node3)
 			to_chat(usr, "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])")
 
 	//Pipes
-	for(var/obj/machinery/atmospherics/pipe/simple/pipe in world)
+	for(var/obj/machinery/atmospherics/pipe/simple/pipe in SSair.atmos_machinery)
 		if(!pipe.node1 || !pipe.node2)
 			to_chat(usr, "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])")
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -487,7 +487,7 @@ GLOBAL_PROTECT(AdminProcCaller)
 	for(var/area/A in world)
 		areas_all |= A.type
 
-	for(var/obj/machinery/power/apc/APC in world)
+	for(var/obj/machinery/power/apc/APC in GLOB.machines)
 		var/area/A = get_area(APC)
 		if(!A)
 			continue
@@ -496,7 +496,7 @@ GLOBAL_PROTECT(AdminProcCaller)
 		else
 			areas_with_multiple_APCs |= A.type
 
-	for(var/obj/machinery/alarm/alarm in world)
+	for(var/obj/machinery/alarm/alarm in GLOB.machines)
 		var/area/A = get_area(alarm)
 		if(!A)
 			continue
@@ -505,31 +505,31 @@ GLOBAL_PROTECT(AdminProcCaller)
 		else
 			areas_with_multiple_air_alarms |= A.type
 
-	for(var/obj/machinery/requests_console/RC in world)
+	for(var/obj/machinery/requests_console/RC in GLOB.machines)
 		var/area/A = get_area(RC)
 		if(!A)
 			continue
 		areas_with_RC |= A.type
 
-	for(var/obj/machinery/light/L in world)
+	for(var/obj/machinery/light/L in GLOB.machines)
 		var/area/A = get_area(L)
 		if(!A)
 			continue
 		areas_with_light |= A.type
 
-	for(var/obj/machinery/light_switch/LS in world)
+	for(var/obj/machinery/light_switch/LS in GLOB.machines)
 		var/area/A = get_area(LS)
 		if(!A)
 			continue
 		areas_with_LS |= A.type
 
-	for(var/obj/item/radio/intercom/I in world)
+	for(var/obj/item/radio/intercom/I in GLOB.global_radios)
 		var/area/A = get_area(I)
 		if(!A)
 			continue
 		areas_with_intercom |= A.type
 
-	for(var/obj/machinery/camera/C in world)
+	for(var/obj/machinery/camera/C in GLOB.machines)
 		var/area/A = get_area(C)
 		if(!A)
 			continue

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -487,7 +487,8 @@ GLOBAL_PROTECT(AdminProcCaller)
 	for(var/area/A in world)
 		areas_all |= A.type
 
-	for(var/obj/machinery/power/apc/APC in GLOB.machines)
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/APC = thing
 		var/area/A = get_area(APC)
 		if(!A)
 			continue
@@ -496,7 +497,8 @@ GLOBAL_PROTECT(AdminProcCaller)
 		else
 			areas_with_multiple_APCs |= A.type
 
-	for(var/obj/machinery/alarm/alarm in GLOB.machines)
+	for(var/thing in GLOB.air_alarms)
+		var/obj/machinery/alarm/alarm = thing
 		var/area/A = get_area(alarm)
 		if(!A)
 			continue

--- a/code/modules/admin/verbs/honksquad.dm
+++ b/code/modules/admin/verbs/honksquad.dm
@@ -48,7 +48,8 @@ GLOBAL_VAR_INIT(sent_honksquad, 0)
 		commandos += candidate//Add their ghost to commandos.
 
 //Spawns HONKsquad and equips them.
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(honksquad_number<=0)	break
 		if(L.name == "HONKsquad")
 			honk_leader_selected = honksquad_number == 1?1:0

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -66,7 +66,8 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 	var/list/sit_spawns = list()
 	var/list/sit_spawns_leader = list()
 	var/list/sit_spawns_mgmt = list()
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(L.name == "Syndicate-Infiltrator")
 			sit_spawns += L
 		if(L.name == "Syndicate-Infiltrator-Leader")

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -118,7 +118,7 @@ GLOBAL_VAR_INIT(intercom_range_display_status, 0)
 		qdel(M)
 
 	if(GLOB.intercom_range_display_status)
-		for(var/obj/item/radio/intercom/I in world)
+		for(var/obj/item/radio/intercom/I in GLOB.global_radios)
 			for(var/turf/T in orange(7,I))
 				var/obj/effect/debugging/marker/F = new/obj/effect/debugging/marker(T)
 				if(!(F in view(7,I.loc)))

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -455,7 +455,8 @@ client/proc/one_click_antag()
 	if(candidates.len)
 		var/raiders = min(antnum, candidates.len)
 		//Spawns vox raiders and equips them.
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(L.name == "voxstart")
 				if(raiders<=0)
 					break
@@ -583,7 +584,8 @@ client/proc/one_click_antag()
 		var/teamOneMembers = 5
 		var/teamTwoMembers = 5
 		var/datum/preferences/A = new()
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(L.name == "tdome1")
 				if(teamOneMembers<=0)
 					break

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -267,7 +267,7 @@ client/proc/one_click_antag()
 							var/I = image('icons/mob/mob.dmi', loc = synd_mind_1.current, icon_state = "synd")
 							synd_mind.current.client.images += I
 
-		for(var/obj/machinery/nuclearbomb/bomb in world)
+		for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
 			bomb.r_code = nuke_code						// All the nukes are set to this code.
 	return 1
 
@@ -455,7 +455,7 @@ client/proc/one_click_antag()
 	if(candidates.len)
 		var/raiders = min(antnum, candidates.len)
 		//Spawns vox raiders and equips them.
-		for(var/obj/effect/landmark/L in world)
+		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 			if(L.name == "voxstart")
 				if(raiders<=0)
 					break
@@ -583,7 +583,7 @@ client/proc/one_click_antag()
 		var/teamOneMembers = 5
 		var/teamTwoMembers = 5
 		var/datum/preferences/A = new()
-		for(var/obj/effect/landmark/L in world)
+		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 			if(L.name == "tdome1")
 				if(teamOneMembers<=0)
 					break

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -30,7 +30,7 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 	// Find the nuclear auth code
 	var/nuke_code
 	var/temp_code
-	for(var/obj/machinery/nuclearbomb/N in world)
+	for(var/obj/machinery/nuclearbomb/N in GLOB.machines)
 		temp_code = text2num(N.r_code)
 		if(temp_code)//if it's actually a number. It won't convert any non-numericals.
 			nuke_code = N.r_code

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -48,7 +48,8 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 	var/commando_number = COMMANDOS_POSSIBLE //for selecting a leader
 	var/is_leader = TRUE // set to FALSE after leader is spawned
 
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 
 		if(commando_number <= 0)
 			break
@@ -109,7 +110,8 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 			commando_number--
 
 	//Spawns the rest of the commando gear.
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(L.name == "Commando_Manual")
 			//new /obj/item/gun/energy/pulse_rifle(L.loc)
 			var/obj/item/paper/P = new(L.loc)
@@ -120,7 +122,8 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 			P.stamp(stamp)
 			qdel(stamp)
 
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 		if(L.name == "Commando-Bomb")
 			new /obj/effect/spawner/newbomb/timer/syndicate(L.loc)
 			qdel(L)

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -53,7 +53,8 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 	GLOB.sent_syndicate_strike_team = 1
 
 	//Spawns commandos and equips them.
-	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/L = thing
 
 		if(syndicate_commando_number <= 0)
 			break

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -38,7 +38,7 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 	// Find the nuclear auth code
 	var/nuke_code
 	var/temp_code
-	for(var/obj/machinery/nuclearbomb/N in world)
+	for(var/obj/machinery/nuclearbomb/N in GLOB.machines)
 		temp_code = text2num(N.r_code)
 		if(temp_code)//if it's actually a number. It won't convert any non-numericals.
 			nuke_code = N.r_code

--- a/code/modules/atmos_automation/implementation/digital_valves.dm
+++ b/code/modules/atmos_automation/implementation/digital_valves.dm
@@ -33,7 +33,7 @@
 			return 1
 		if(href_list["set_subject"])
 			var/list/valves=list()
-			for(var/obj/machinery/atmospherics/binary/valve/digital/V in world)
+			for(var/obj/machinery/atmospherics/binary/valve/digital/V in SSair.atmos_machinery)
 				if(!isnull(V.id_tag) && V.frequency == parent.frequency)
 					valves|=V.id_tag
 			if(valves.len==0)

--- a/code/modules/atmos_automation/implementation/vent_pump.dm
+++ b/code/modules/atmos_automation/implementation/vent_pump.dm
@@ -41,11 +41,11 @@
 		if(href_list["set_vent_pump"])
 			var/list/injector_names = list()
 			if(!vent_type)
-				for(var/obj/machinery/atmospherics/unary/vent_pump/I in GLOB.machines)
+				for(var/obj/machinery/atmospherics/unary/vent_pump/I in SSair.atmos_machinery)
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names |= I.id_tag
 			else
-				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in world)
+				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in SSair.atmos_machinery)
 //					to_chat(world, "test")
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names |= I.id_tag
@@ -98,11 +98,11 @@
 		if(href_list["set_vent_pump"])
 			var/list/injector_names=list()
 			if(!mode)
-				for(var/obj/machinery/atmospherics/unary/vent_pump/I in GLOB.machines)
+				for(var/obj/machinery/atmospherics/unary/vent_pump/I in SSair.atmos_machinery)
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names|=I.id_tag
 			else
-				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in world)
+				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in SSair.atmos_machinery)
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names|=I.id_tag
 			vent_pump = input("Select a vent:", "Vent Pumps", vent_pump) as null|anything in injector_names
@@ -186,11 +186,11 @@
 		if(href_list["set_vent_pump"])
 			var/list/injector_names=list()
 			if(mode)//DP vent selection
-				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in world)
+				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in SSair.atmos_machinery)
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names|=I.id_tag
 			else
-				for(var/obj/machinery/atmospherics/unary/vent_pump/I in GLOB.machines)
+				for(var/obj/machinery/atmospherics/unary/vent_pump/I in SSair.atmos_machinery)
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names|=I.id_tag
 			vent_pump = input("Select a vent:", "Vent Pumps", vent_pump) as null|anything in injector_names
@@ -278,11 +278,11 @@ checks bitflags
 		if(href_list["set_vent_pump"])
 			var/list/injector_names=list()
 			if(mode)//DP vent selection
-				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in world)
+				for(var/obj/machinery/atmospherics/binary/dp_vent_pump/I in SSair.atmos_machinery)
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names|=I.id_tag
 			else
-				for(var/obj/machinery/atmospherics/unary/vent_pump/I in GLOB.machines)
+				for(var/obj/machinery/atmospherics/unary/vent_pump/I in SSair.atmos_machinery)
 					if(!isnull(I.id_tag) && I.frequency == parent.frequency)
 						injector_names|=I.id_tag
 			vent_pump = input("Select a vent:", "Vent Pumps", vent_pump) as null|anything in injector_names

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -48,7 +48,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 	..()
 	update_icon()
 	wait = world.time + config.gateway_delay	//+ thirty minutes default
-	awaygate = locate(/obj/machinery/gateway/centeraway) in world
+	awaygate = locate(/obj/machinery/gateway/centeraway) in GLOB.machines
 
 /obj/machinery/gateway/centerstation/update_density_from_dir()
 	return
@@ -103,7 +103,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 	if(!powered())
 		return
 	if(!awaygate)
-		awaygate = locate(/obj/machinery/gateway/centeraway) in world
+		awaygate = locate(/obj/machinery/gateway/centeraway) in GLOB.machines
 		if(!awaygate)
 			to_chat(user, "<span class='notice'>Error: No destination found.</span>")
 			return
@@ -180,7 +180,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 /obj/machinery/gateway/centeraway/Initialize()
 	..()
 	update_icon()
-	stationgate = locate(/obj/machinery/gateway/centerstation) in world
+	stationgate = locate(/obj/machinery/gateway/centerstation) in GLOB.machines
 
 
 /obj/machinery/gateway/centeraway/update_density_from_dir()
@@ -219,7 +219,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 	if(linked.len != 8)
 		return
 	if(!stationgate)
-		stationgate = locate(/obj/machinery/gateway/centerstation) in world
+		stationgate = locate(/obj/machinery/gateway/centerstation) in GLOB.machines
 		if(!stationgate)
 			to_chat(user, "<span class='notice'>Error: No destination found.</span>")
 			return

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -218,7 +218,8 @@
 			to_chat(user, "<span class='warning'>The communicator buzzes, and you hear the voice again: 'Really? I think not. Get them!'</span>")
 		if(option_threat)
 			to_chat(user, "<span class='warning'>The communicator buzzes, and you hear the voice again: 'Oh really now?' You hear a clicking sound. 'Team, get back here. We have trouble'. Then the line goes dead.</span>")
-			for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+			for(var/thing in GLOB.landmarks_list)
+				var/obj/effect/landmark/L = thing
 				if(L.name == "wildwest_syndipod")
 					var/obj/spacepod/syndi/P = new /obj/spacepod/syndi(get_turf(L))
 					P.name = "Syndi Recon Pod"

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -117,10 +117,8 @@
 			if("Peace")
 				to_chat(user, "<B>Whatever alien sentience that the Wish Granter possesses is satisfied with your wish. There is a distant wailing as the last of the Faithless begin to die, then silence.</B>")
 				to_chat(user, "You feel as if you just narrowly avoided a terrible fate...")
-				for(var/mob/living/simple_animal/hostile/faithless/F in world)
-					F.health = -10
-					F.stat = 2
-					F.icon_state = "faithless_dead"
+				for(var/mob/living/simple_animal/hostile/faithless/F in GLOB.mob_living_list)
+					F.death()
 
 
 ///////////////Meatgrinder//////////////

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -56,7 +56,8 @@ GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "config/away
 			GLOB.space_manager.remove_dirt(zlev)
 			log_world("  Away mission loaded: [map]")
 
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(L.name != "awaystart")
 				continue
 			GLOB.awaydestinations.Add(L)
@@ -89,7 +90,8 @@ GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "config/away
 
 			//map_transition_config.Add(AWAY_MISSION_LIST)
 
-			for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+			for(var/thing in GLOB.landmarks_list)
+				var/obj/effect/landmark/L = thing
 				if(L.name != "awaystart")
 					continue
 				GLOB.awaydestinations.Add(L)

--- a/code/modules/economy/utils.dm
+++ b/code/modules/economy/utils.dm
@@ -5,7 +5,7 @@
 ////////////////////////
 
 /proc/get_money_account(var/account_number, var/from_z=-1)
-	for(var/obj/machinery/computer/account_database/DB in world)
+	for(var/obj/machinery/computer/account_database/DB in GLOB.machines)
 		if(from_z > -1 && DB.z != from_z) continue
 		if((DB.stat & NOPOWER) || !DB.activated ) continue
 		var/datum/money_account/acct = DB.get_account(account_number)

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -17,7 +17,7 @@
 	playercount = length(GLOB.clients)//grab playercount when event starts not when game starts
 	if(playercount >= highpop_trigger) //spawn with 4 if highpop
 		spawncount = 4
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSair.atmos_machinery)
 		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
 			if(temp_vent.parent.other_atmosmch.len > 50)	//Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -18,7 +18,7 @@
 				// Calculate new position (searches through beacons in world)
 			var/obj/item/radio/beacon/chosen
 			var/list/possible = list()
-			for(var/obj/item/radio/beacon/W in world)
+			for(var/obj/item/radio/beacon/W in GLOB.global_radios)
 				if(!is_station_level(W.z))
 					continue
 				possible += W

--- a/code/modules/events/apc_overload.dm
+++ b/code/modules/events/apc_overload.dm
@@ -36,7 +36,8 @@
 
 	// break APC_BREAK_PROBABILITY% of all of the APCs on the station
 	var/affected_apc_count = 0
-	for(var/obj/machinery/power/apc/C in GLOB.apcs)
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/C = thing
 		// skip any APCs that are too critical to break
 		var/area/current_area = get_area(C)
 		if((current_area.type in skipped_areas_apc) || !is_station_level(C.z))

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -36,7 +36,8 @@
 
 	// break APC_BREAK_PROBABILITY% of all of the APCs on the station
 	var/affected_apc_count = 0
-	for(var/obj/machinery/power/apc/C in GLOB.apcs)
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/C = thing
 		// skip any APCs that are too critical to disable
 		var/area/current_area = get_area(C)
 		if((current_area.type in skipped_areas_apc) || !is_station_level(C.z))

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -30,7 +30,8 @@
 /datum/event/carp_migration/proc/spawn_fish(num_groups, group_size_min = 3, group_size_max = 5)
 	var/list/spawn_locations = list()
 
-	for(var/obj/effect/landmark/C in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/C = thing
 		if(C.name == "carpspawn")
 			spawn_locations.Add(C.loc)
 	spawn_locations = shuffle(spawn_locations)

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -10,7 +10,8 @@
 
 	for(var/i=1, i <= lightsoutAmount, i++)
 		var/list/possibleEpicentres = list()
-		for(var/obj/effect/landmark/newEpicentre in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/newEpicentre = thing
 			if(newEpicentre.name == "lightsout" && !(newEpicentre in epicentreList))
 				possibleEpicentres += newEpicentre
 		if(possibleEpicentres.len)
@@ -21,7 +22,8 @@
 	if(!epicentreList.len)
 		return
 
-	for(var/obj/effect/landmark/epicentre in epicentreList)
-		for(var/obj/machinery/power/apc/apc in range(epicentre,lightsoutRange))
+	for(var/thing in epicentreList)
+		var/obj/effect/landmark/epicentre = thing
+		for(var/obj/machinery/power/apc/apc in range(epicentre, lightsoutRange))
 			apc.overload_lighting()
 

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -23,7 +23,7 @@ GLOBAL_VAR_INIT(account_hack_attempted, 0)
 	Notifications will be sent as updates occur.<br>"
 	var/my_department = "[station_name()] firewall subroutines"
 
-	for(var/obj/machinery/message_server/MS in world)
+	for(var/obj/machinery/message_server/MS in GLOB.machines)
 		if(!MS.active) continue
 		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)
 
@@ -64,7 +64,7 @@ GLOBAL_VAR_INIT(account_hack_attempted, 0)
 
 	var/my_department = "[station_name()] firewall subroutines"
 
-	for(var/obj/machinery/message_server/MS in world)
+	for(var/obj/machinery/message_server/MS in GLOB.machines)
 		if(!MS.active) continue
 		MS.send_rc_message("Head of Personnel's Desk", my_department, message, "", "", 2)
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -47,7 +47,7 @@
 	if(areas && areas.len > 0)
 		var/my_department = "[station_name()] firewall subroutines"
 		var/rc_message = "An unknown malicious program has been detected in the [english_list(areaName)] lighting and airlock control systems at [station_time_timestamp()]. Systems will be fully compromised within approximately three minutes. Direct intervention is required immediately.<br>"
-		for(var/obj/machinery/message_server/MS in world)
+		for(var/obj/machinery/message_server/MS in GLOB.machines)
 			MS.send_rc_message("Engineering", my_department, rc_message, "", "", 2)
 		for(var/mob/living/silicon/ai/A in GLOB.player_list)
 			to_chat(A, "<span class='danger'>Malicious program detected in the [english_list(areaName)] lighting and airlock control systems by [my_department].</span>")

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -6,7 +6,8 @@
 /datum/event/rogue_drone/start()
 	//spawn them at the same place as carp
 	var/list/possible_spawns = list()
-	for(var/obj/effect/landmark/C in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/C = thing
 		if(C.name == "carpspawn")
 			possible_spawns.Add(C)
 

--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -16,13 +16,15 @@
 		var/datum/mind/player_mind = new /datum/mind(key_of_slaughter)
 		player_mind.active = 1
 		var/list/spawn_locs = list()
-		for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+		for(var/thing in GLOB.landmarks_list)
+			var/obj/effect/landmark/L = thing
 			if(isturf(L.loc))
 				switch(L.name)
 					if("revenantspawn")
 						spawn_locs += L.loc
 		if(!spawn_locs) //If we can't find any revenant spawns, try the carp spawns
-			for(var/obj/effect/landmark/L in GLOB.landmarks_list)
+			for(var/thing in GLOB.landmarks_list)
+				var/obj/effect/landmark/L = thing
 				if(isturf(L.loc))
 					switch(L.name)
 						if("carpspawn")

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -15,7 +15,7 @@ GLOBAL_VAR_INIT(sent_spiders_to_station, 0)
 /datum/event/spider_infestation/start()
 
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSair.atmos_machinery)
 		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
 			if(temp_vent.parent.other_atmosmch.len > 50)
 				vents += temp_vent

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -24,7 +24,8 @@ GLOBAL_LIST_INIT(unused_trade_stations, list("sol"))
 		return
 
 	var/list/spawnlocs = list()
-	for(var/obj/effect/landmark/landmark in GLOB.landmarks_list)
+	for(var/thing in GLOB.landmarks_list)
+		var/obj/effect/landmark/landmark = thing
 		if(landmark.name == "traderstart_[station]")
 			spawnlocs += get_turf(landmark)
 	if(!spawnlocs.len)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -26,7 +26,7 @@
 /obj/item/wormhole_jaunter/proc/get_destinations(mob/user)
 	var/list/destinations = list()
 
-	for(var/obj/item/radio/beacon/B in world)
+	for(var/obj/item/radio/beacon/B in GLOB.global_radios)
 		var/turf/T = get_turf(B)
 		if(is_station_level(T.z))
 			destinations += B

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -34,7 +34,7 @@
 		spawn(10)
 			explosion(src.loc, 3, 6, 12, 15)
 
-	for(var/obj/machinery/ai_status_display/O in world) //change status
+	for(var/obj/machinery/ai_status_display/O in GLOB.machines) //change status
 		O.mode = 2
 
 	if(istype(loc, /obj/item/aicard))

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/ai/Logout()
 	..()
-	for(var/obj/machinery/ai_status_display/O in world) //change status
+	for(var/obj/machinery/ai_status_display/O in GLOB.machines) //change status
 		O.mode = 0
 	src.view_core()
 	return

--- a/code/modules/mob/living/silicon/decoy/death.dm
+++ b/code/modules/mob/living/silicon/decoy/death.dm
@@ -4,7 +4,7 @@
 	if(!.)
 		return FALSE
 	icon_state = "ai-crash"
-	for(var/obj/machinery/ai_status_display/O in world) //change status
+	for(var/obj/machinery/ai_status_display/O in GLOB.machines) //change status
 		if(atoms_share_level(O, src))
 			O.mode = 2
 	gib()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -144,7 +144,7 @@
 			user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to reboot it.</span>", "<span class='warning'>You swipe your ID card through [src], attempting to reboot it.</span>")
 			last_reboot = world.time / 10
 			var/drones = 0
-			for(var/mob/living/silicon/robot/drone/D in world)
+			for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
 				if(D.key && D.client)
 					drones++
 			if(drones < config.max_maint_drones)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -144,7 +144,7 @@
 			user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to reboot it.</span>", "<span class='warning'>You swipe your ID card through [src], attempting to reboot it.</span>")
 			last_reboot = world.time / 10
 			var/drones = 0
-			for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
+			for(var/mob/living/silicon/robot/drone/D in GLOB.silicon_mob_list)
 				if(D.key && D.client)
 					drones++
 			if(drones < config.max_maint_drones)

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -34,7 +34,7 @@
 	var/dat
 	dat += "<B>Maintenance Units</B><BR>"
 
-	for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
+	for(var/mob/living/silicon/robot/drone/D in GLOB.silicon_mob_list)
 		dat += "<BR>[D.real_name] ([D.stat == 2 ? "<font color='red'>INACTIVE" : "<font color='green'>ACTIVE"]</FONT>)"
 		dat += "<font dize = 9><BR>Cell charge: [D.cell.charge]/[D.cell.maxcharge]."
 		dat += "<BR>Currently located in: [get_area(D)]."
@@ -74,7 +74,7 @@
 	else if(href_list["ping"])
 
 		to_chat(usr, "<span class='notice'>You issue a maintenance request for all active drones, highlighting [drone_call_area].</span>")
-		for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
+		for(var/mob/living/silicon/robot/drone/D in GLOB.silicon_mob_list)
 			if(D.client && D.stat == 0)
 				to_chat(D, "-- Maintenance drone presence requested in: [drone_call_area].")
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -34,7 +34,7 @@
 	var/dat
 	dat += "<B>Maintenance Units</B><BR>"
 
-	for(var/mob/living/silicon/robot/drone/D in world)
+	for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
 		dat += "<BR>[D.real_name] ([D.stat == 2 ? "<font color='red'>INACTIVE" : "<font color='green'>ACTIVE"]</FONT>)"
 		dat += "<font dize = 9><BR>Cell charge: [D.cell.charge]/[D.cell.maxcharge]."
 		dat += "<BR>Currently located in: [get_area(D)]."
@@ -74,7 +74,7 @@
 	else if(href_list["ping"])
 
 		to_chat(usr, "<span class='notice'>You issue a maintenance request for all active drones, highlighting [drone_call_area].</span>")
-		for(var/mob/living/silicon/robot/drone/D in world)
+		for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
 			if(D.client && D.stat == 0)
 				to_chat(D, "-- Maintenance drone presence requested in: [drone_call_area].")
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -52,7 +52,7 @@
 
 /obj/machinery/drone_fabricator/proc/count_drones()
 	var/drones = 0
-	for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
+	for(var/mob/living/silicon/robot/drone/D in GLOB.silicon_mob_list)
 		if(D.key && D.client)
 			drones++
 	return drones

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -52,7 +52,7 @@
 
 /obj/machinery/drone_fabricator/proc/count_drones()
 	var/drones = 0
-	for(var/mob/living/silicon/robot/drone/D in world)
+	for(var/mob/living/silicon/robot/drone/D in GLOB.mob_living_list)
 		if(D.key && D.client)
 			drones++
 	return drones
@@ -142,7 +142,7 @@
 	if(alert("Are you sure you want to respawn as a drone?", "Are you sure?", "Yes", "No") != "Yes")
 		return
 
-	for(var/obj/machinery/drone_fabricator/DF in world)
+	for(var/obj/machinery/drone_fabricator/DF in GLOB.machines)
 		if(DF.stat & NOPOWER || !DF.produce_drones)
 			continue
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -765,7 +765,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	var/list/namecounts = list()
 	var/list/creatures = list()
 
-	for(var/obj/O in world)				//EWWWWWWWWWWWWWWWWWWWWWWWW ~needs to be optimised
+	for(var/obj/O in GLOB.poi_list)
 		if(!O.loc)
 			continue
 		if(istype(O, /obj/item/disk/nuclear))
@@ -1099,7 +1099,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	var/mob/living/simple_animal/mouse/host
 	var/obj/machinery/atmospherics/unary/vent_pump/vent_found
 	var/list/found_vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/v in world)
+	for(var/obj/machinery/atmospherics/unary/vent_pump/v in SSair.atmos_machinery)
 		if(!v.welded && v.z == src.z)
 			found_vents.Add(v)
 	if(found_vents.len)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -375,6 +375,7 @@
 	return null
 
 /area/proc/get_apc()
-	for(var/obj/machinery/power/apc/APC in GLOB.apcs)
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/APC = thing
 		if(APC.area == src)
 			return APC

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -312,7 +312,8 @@ field_generator power level display
 	//I want to avoid using global variables.
 	spawn(1)
 		var/temp = 1 //stops spam
-		for(var/obj/singularity/O in GLOB.singularities)
+		for(var/thing in GLOB.singularities)
+			var/obj/singularity/O = thing
 			if(O.last_warning && temp)
 				if((world.time - O.last_warning) > 50) //to stop message-spam
 					temp = 0

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -131,7 +131,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 //Have it automatically push research to the centcom server so wild griffins can't fuck up R&D's work --NEO
 /obj/machinery/computer/rdconsole/proc/griefProtection()
-	for(var/obj/machinery/r_n_d/server/centcom/C in world)
+	for(var/obj/machinery/r_n_d/server/centcom/C in GLOB.machines)
 		files.push_data(C.files)
 
 /obj/machinery/computer/rdconsole/proc/Maximize()
@@ -148,7 +148,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	files = new /datum/research(src) //Setup the research data holder.
 	matching_designs = list()
 	if(!id)
-		for(var/obj/machinery/r_n_d/server/centcom/S in world)
+		for(var/obj/machinery/r_n_d/server/centcom/S in GLOB.machines)
 			S.initialize_serv()
 			break
 
@@ -390,7 +390,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			spawn(SYNC_RESEARCH_DELAY)
 				clear_wait_message()
 				if(src)
-					for(var/obj/machinery/r_n_d/server/S in world)
+					for(var/obj/machinery/r_n_d/server/S in GLOB.machines)
 						var/server_processed = 0
 						if(S.disabled)
 							continue

--- a/code/modules/security_levels/keycard authentication.dm
+++ b/code/modules/security_levels/keycard authentication.dm
@@ -117,7 +117,7 @@
 
 /obj/machinery/keycard_auth/proc/broadcast_request()
 	icon_state = "auth_on"
-	for(var/obj/machinery/keycard_auth/KA in world)
+	for(var/obj/machinery/keycard_auth/KA in GLOB.machines)
 		if(KA == src) continue
 		KA.reset()
 		spawn()

--- a/code/modules/store/store.dm
+++ b/code/modules/store/store.dm
@@ -47,7 +47,7 @@ GLOBAL_DATUM_INIT(centcomm_store, /datum/store, new())
 	return 1
 
 /datum/store/proc/reconnect_database()
-	for(var/obj/machinery/computer/account_database/DB in world)
+	for(var/obj/machinery/computer/account_database/DB in GLOB.machines)
 		if(is_station_level(DB.z))
 			linked_db = DB
 			break


### PR DESCRIPTION
purges a bunch of `in world` calls, which are obscenely expensive.

Keeping global lists is the way to handle this, these days.

Also fixes potential runtimes with mech trackers leaving a `null` in the `trackers` list if they got deleted.