### PR TITLE
Add the paranormal scanner to Inquisitor ERT

### DIFF
--- a/code/datums/components/README.md
+++ b/code/datums/components/README.md
@@ -6,4 +6,4 @@ Loosely adapted from /vg/. This is an entity component system for adding behavio
 
 See [this thread](https://tgstation13.org/phpBB/viewtopic.php?f=5&t=22674) for an introduction to the system as a whole.
 
-### See/Define signals and their arguments in [__DEFINES\components.dm](../../__DEFINES/components.dm)
+### See/Define signals and their arguments in [__DEFINES\dcs\signals.dm](../../__DEFINES/dcs/signals.dm)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1030,7 +1030,7 @@ obj/item/toy/cards/deck/syndicate/black
 /obj/item/toy/plushie/orange_fox/grump/ComponentInitialize()
 	. = ..()
 	var/static/list/grumps = list("Ahh, yes, you're so clever, var editing that.", "Really?", "If you make a runtime with var edits, it's your own damn fault.",
-	"Don't you dare post issues on the git when you don't even know how this works.", "Was that necessary?", "Ohhh, setting admin edited var must be your faovrite pastime!",
+	"Don't you dare post issues on the git when you don't even know how this works.", "Was that necessary?", "Ohhh, setting admin edited var must be your favorite pastime!",
 	"Oh, so you have time to var edit, but you don't have time to ban that greytider?", "Oh boy, is this another one of those 'events'?", "Seriously, just stop.", "You do realize this is incurring proc call overhead.",
 	"Congrats, you just left a reference with your dirty client and now that thing you edited will never garbage collect properly.", "Is it that time of day, again, for unecessary adminbus?")
 	AddComponent(/datum/component/edit_complainer, grumps)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Based on https://github.com/ParadiseSS13/Paradise/pull/12151

This PR adds the paranormal scanner to Red Inquisitors and the advanced paranormal scanner to Gamma Inquisitors.

The paranormal scanner when used on a human will scan them. After 20 (10 for advanced) seconds, it will reveal if the target is a Vampire, Vampire Thrall, Cultist, Devil, or Wizard.

The main purpose and use case of the scanner is as an admin response to an effective mindswap wizard, which currently has no existing counters as there is no possible test for wizards (other than knowing who was swapped or seeing the wiz cast shit, which removes the need for a test).

As it is slow to use and requires both you and the target to be immobile, it is probably still better to use holy water to test for vamps and cultists, which is intentional. This can still be used to test non-mindshielded command and make sure they are trustworthy, for example.

Currently the scanner uses the spectrometer/advanced spectrometer sprites. I will look into getting unique sprites for it if feedback is positive.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Added the paranormal scanner to Red and Gamma Inquisitor ERT.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
