### PR TITLE
Removes Set Background

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -183,9 +183,6 @@
 
 
 /proc/get_mobs_in_radio_ranges(var/list/obj/item/radio/radios)
-
-	set background = 1
-
 	. = list()
 	// Returns a list of mobs who can hear any of the radios given in @radios
 	var/list/speaker_coverage = list()

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -11,8 +11,6 @@
 
 #define IS_MODE_COMPILED(MODE) (ispath(text2path("/datum/game_mode/"+(MODE))))
 
-#define BACKGROUND_ENABLED 0 // The default value for all uses of set background. Set background can cause gradual lag and is recommended you only turn this on if necessary.
-
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN 1024
 #define MAX_PAPER_MESSAGE_LEN 3072

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -74,9 +74,6 @@
 
 
 /obj/structure/blob/proc/Pulse(var/pulse = 0, var/origin_dir = 0, var/a_color)//Todo: Fix spaceblob expand
-
-	set background = BACKGROUND_ENABLED
-
 	RegenHealth()
 
 	if(run_action())//If we can do something here then we dont need to pulse more

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -520,8 +520,6 @@ GLOBAL_LIST_EMPTY(turret_icons)
 /obj/machinery/porta_turret/process()
 	//the main machinery process
 
-	set background = BACKGROUND_ENABLED
-
 	if(stat & (NOPOWER|BROKEN))
 		if(!always_up)
 			//if the turret has no power or is broken, make the turret pop down if it hasn't already

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -141,7 +141,6 @@
 	return ..()
 
 /obj/structure/alien/weeds/proc/Life()
-	set background = BACKGROUND_ENABLED
 	var/turf/U = get_turf(src)
 
 	if(istype(U, /turf/space))

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -1,7 +1,6 @@
 /client/proc/atmosscan()
 	set category = "Mapping"
 	set name = "Check Piping"
-	set background = 1
 	if(!src.holder)
 		to_chat(src, "Only administrators may use this command.")
 		return

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -67,9 +67,6 @@
 // The actual updating. It gathers the visible turfs from cameras and puts them into the appropiate lists.
 
 /datum/camerachunk/proc/update()
-
-	set background = BACKGROUND_ENABLED
-
 	var/list/newVisibleTurfs = list()
 
 	for(var/camera in cameras)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -139,7 +139,6 @@
 	grav_pull = 0
 
 /obj/singularity/narsie/wizard/eat()
-	set background = BACKGROUND_ENABLED
 	for(var/atom/X in orange(consume_range,src))
 		if(isturf(X) || istype(X, /atom/movable))
 			consume(X)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -253,7 +253,6 @@
 
 
 /obj/singularity/proc/eat()
-	set background = BACKGROUND_ENABLED
 	for(var/tile in spiral_range_turfs(grav_pull, src))
 		var/turf/T = tile
 		if(!T || !isturf(loc))

--- a/code/modules/procedural_mapping/mapGenerator.dm
+++ b/code/modules/procedural_mapping/mapGenerator.dm
@@ -102,8 +102,6 @@
 
 //Requests the mapGeneratorModule(s) to (re)generate
 /datum/mapGenerator/proc/generate()
-	set background = 1 //this can get beefy
-
 	syncModules()
 	if(!modules || !modules.len)
 		return


### PR DESCRIPTION
Removes `set background` from the code.

This defaulted to `FALSE` in most cases.

what enabling the background does is insert a `sleep(-1)` between each proc in the loop; this can hypothetically cause race conditions----the actual sleep doesn't seem to kick in until tick_useage is really high....at a high enough point where this won't realistically reduce lag.

It does, however, potentially incur proc call overhead, so....getting rid of this is likely to offer a *tiny* speedup to a few procs.

:cl: Fox McCloud
del: removes antiquated code that was hypothetically slowing the game down
/:cl: