### PR TITLE
Minor GC Tweaks

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -44,16 +44,17 @@
 
 /atom/movable/Destroy()
 	unbuckle_all_mobs(force = TRUE)
+
+	. = ..()
 	if(loc)
 		loc.handle_atom_del(src)
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
 	loc = null
 	if(pulledby)
-		if(pulledby.pulling == src)
-			pulledby.pulling = null
-		pulledby = null
-	return ..()
+		pulledby.stop_pulling()
+	if(orbiting)
+		stop_orbit()
 
 //Returns an atom's power cell, if it has one. Overload for individual items.
 /atom/movable/proc/get_cell()

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -64,7 +64,7 @@
 	..()
 	can_hold = typecacheof(can_hold)
 
-/obj/item/gripper/verb/drop_item()
+/obj/item/gripper/verb/drop_item_gripped()
 	set name = "Drop Gripped Item"
 	set desc = "Release an item from your magnetic gripper."
 	set category = "Drone"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -26,25 +26,6 @@
 	else
 		to_chat(usr, "<span class='danger'>This mob type cannot throw items.</span>")
 
-
-/client/verb/drop_item()
-	set hidden = 1
-	if(!isrobot(mob))
-		mob.drop_item_v()
-	return
-
-
-/* /client/Center()
-	/* No 3D movement in 2D spessman game. dir 16 is Z Up
-	if(isobj(mob.loc))
-		var/obj/O = mob.loc
-		if(mob.canmove)
-			return O.relaymove(mob, 16)
-	*/
-	return
- */
-
-
 /client/proc/Move_object(direct)
 	if(mob && mob.control_object)
 		if(mob.control_object.density)
@@ -186,7 +167,7 @@
 		if(newdir)
 			direct = newdir
 			n = get_step(mob, direct)
-	
+
 	. = mob.SelfMove(n, direct, delay)
 	mob.setDir(direct)
 


### PR DESCRIPTION
Just some minor tweaks with garbage collection.

Follows TG's lead in calling parent before completing other tasks.

Also ensures things stop orbiting when they're GC, which clears another atoms reference.

:cl: Fox McCloud
fix: Makes objects garbage collect better, enhancing performance
del: removes drop_item verb, for whaever reason that existed; I doubt anyone used it.
/:cl: