### PR TITLE
Adds missed fingerprints logging to papers and adds normal logging

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -876,6 +876,8 @@ About the new airlock wires panel:
 		if(!user.unEquip(C))
 			to_chat(user, "<span class='warning'>For some reason, you can't attach [C]!</span>")
 			return
+		C.add_fingerprint(user)
+		user.create_log(MISC_LOG, "put [C] on", src)
 		C.forceMove(src)
 		user.visible_message("<span class='notice'>[user] pins [C] to [src].</span>", "<span class='notice'>You pin [C] to [src].</span>")
 		note = C
@@ -1347,10 +1349,13 @@ About the new airlock wires panel:
 			if (ishuman(user) && user.a_intent == INTENT_GRAB)//grab that note
 				user.visible_message("<span class='notice'>[user] removes [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
 				playsound(src, 'sound/items/poster_ripped.ogg', 50, 1)
-			else return FALSE
+			else
+				return FALSE
 		else
 			user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
 			playsound(src, 'sound/items/wirecutter.ogg', 50, 1)
+		note.add_fingerprint(user)
+		user.create_log(MISC_LOG, "removed [note] from", src)
 		user.put_in_hands(note)
 		note = null
 		update_icon()

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -11,7 +11,7 @@
 	var/amount = 30					//How much paper is in the bin.
 	var/list/papers = list()	//List of papers put in the bin for reference.
 	var/letterhead_type
-	
+
 /obj/item/paper_bin/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	if(amount)
 		amount = 0
@@ -84,6 +84,7 @@
 
 		P.loc = user.loc
 		user.put_in_hands(P)
+		P.add_fingerprint(user)
 		to_chat(user, "<span class='notice'>You take [P] out of the [src].</span>")
 	else
 		to_chat(user, "<span class='notice'>[src] is empty!</span>")
@@ -143,7 +144,7 @@
 
 	add_fingerprint(user)
 	return
-	
+
 
 /obj/item/paper_bin/nanotrasen
 	name = "nanotrasen paper bin"


### PR DESCRIPTION
## What Does This PR Do
Fixes a few oversights in the fingerprint system regarding papers.
1. The removal of papers from the bin did not add fingerprints to the papers themselves
2. Putting a paper on an airlock did not add a fingerprint to the paper. It is also logged now under misc.
3. Removing a paper from an airlock did not add a fingerprint. It is also logged now under misc.

## Why It's Good For The Game
Better logging for admins and some fixed fingerprints that the detective might like to find

## Changelog
:cl:
add: Adding a paper to an airlock is now logged under misc.
add: Removing a paper from an airlock is now logged under misc.
fix: Removing a paper from a paperbin will generate a fingerprint on the paper
fix: Removing a pinned paper from an airlock will generate a fingerprint on the paper
fix: Adding a paper to an airlock will generate a fingerprint on the paper
/:cl: