### PR TITLE
Fix sake makiroll recipe, "makiroll" -> "maki roll"

### DIFF
--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -129,7 +129,7 @@
 	tastes = list("shrimp" = 1, "batter" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Ebi_maki
-	name = "ebi makiroll"
+	name = "ebi maki roll"
 	desc = "A large unsliced roll of Ebi Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Ebi_maki"
@@ -149,7 +149,7 @@
 	tastes = list("shrimp" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Ikura_maki
-	name = "ikura makiroll"
+	name = "ikura maki roll"
 	desc = "A large unsliced roll of Ikura Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Ikura_maki"
@@ -169,7 +169,7 @@
 	tastes = list("salmon roe" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Sake_maki
-	name = "sake makiroll"
+	name = "sake maki roll"
 	desc = "A large unsliced roll of Sake Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Sake_maki"
@@ -189,7 +189,7 @@
 	tastes = list("raw salmon" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/SmokedSalmon_maki
-	name = "smoked salmon makiroll"
+	name = "smoked salmon maki roll"
 	desc = "A large unsliced roll of Smoked Salmon Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "SmokedSalmon_maki"
@@ -209,7 +209,7 @@
 	tastes = list("smoked salmon" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Tamago_maki
-	name = "tamago makiroll"
+	name = "tamago maki roll"
 	desc = "A large unsliced roll of Tamago Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tamago_maki"
@@ -229,7 +229,7 @@
 	tastes = list("egg" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Inari_maki
-	name = "inari makiroll"
+	name = "inari maki roll"
 	desc = "A large unsliced roll of Inari Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Inari_maki"
@@ -249,7 +249,7 @@
 	tastes = list("fried tofu" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Masago_maki
-	name = "masago makiroll"
+	name = "masago maki roll"
 	desc = "A large unsliced roll of Masago Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Masago_maki"
@@ -269,7 +269,7 @@
 	tastes = list("goldfish roe" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Tobiko_maki
-	name = "tobiko makiroll"
+	name = "tobiko maki roll"
 	desc = "A large unsliced roll of Tobkio Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tobiko_maki"
@@ -289,7 +289,7 @@
 	tastes = list("shark roe" = 1, "rice" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/TobikoEgg_maki
-	name = "tobiko and egg makiroll"
+	name = "tobiko and egg maki roll"
 	desc = "A large unsliced roll of Tobkio and Egg Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "TobikoEgg_maki"
@@ -309,7 +309,7 @@
 	tastes = list("shark roe" = 1, "rice" = 1, "egg" = 1, "seaweed" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Tai_maki
-	name = "tai makiroll"
+	name = "tai maki roll"
 	desc = "A large unsliced roll of Tai Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tai_maki"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
@@ -90,7 +90,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/Ebi_maki
-	name = "Ebi Makiroll"
+	name = "Ebi Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/boiled_shrimp = 4,
@@ -111,7 +111,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/Ikura_maki
-	name = "Ikura Makiroll"
+	name = "Ikura Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/fish_eggs/salmon = 4,
@@ -132,7 +132,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/Inari_maki
-	name = "Inari Makiroll"
+	name = "Inari Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/fried_tofu = 4,
@@ -153,7 +153,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/Sake_maki
-	name = "Sake Makiroll"
+	name = "Sake Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/salmonmeat = 4,
@@ -174,7 +174,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/SmokedSalmon_maki
-	name = "Smoked Salmon Makiroll"
+	name = "Smoked Salmon Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/salmonsteak = 4,
@@ -195,7 +195,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/Masago_maki
-	name = "Masago Makiroll"
+	name = "Masago Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/fish_eggs/goldfish = 4,
@@ -216,7 +216,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/Tobiko_maki
-	name = "Tobiko Makiroll"
+	name = "Tobiko Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/fish_eggs/shark = 4,
@@ -237,18 +237,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/TobikoEgg_maki
-	name = "Tobiko Makiroll"
-	reqs = list(
-		/obj/item/reagent_containers/food/snacks/sushi_Tobiko = 4,
-		/obj/item/reagent_containers/food/snacks/egg = 4,
-	)
-	pathtools = list(/obj/item/kitchen/sushimat)
-	result = /obj/item/reagent_containers/food/snacks/sliceable/TobikoEgg_maki
-	category = CAT_FOOD
-	subcategory = CAT_SUSHI
-
-/datum/crafting_recipe/Sake_maki
-	name = "Sake Makiroll"
+	name = "Tobiko and Egg Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/sushi_Tobiko = 4,
 		/obj/item/reagent_containers/food/snacks/egg = 4,
@@ -269,7 +258,7 @@
 	subcategory = CAT_SUSHI
 
 /datum/crafting_recipe/Tai_maki
-	name = "Tai Makiroll"
+	name = "Tai Maki Roll"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/boiledrice = 1,
 		/obj/item/reagent_containers/food/snacks/catfishmeat = 4,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes the **Sake Maki Roll** recipe being overriden by an incorrect recipe (Tobiko Maki Roll) and renames "makiroll" to "maki roll"

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Time to make sushi and change lives. (no really, it makes making sake sushi less of a pain because the maki roll recipe was broken)

## Changelog
:cl:
fix: Fix "sake maki roll" recipe requiring the wrong ingredients
fix: Fix recipe for "tobiko and egg maki" roll using the wrong name ("tobiko maki roll")
spellcheck: Rename "makiroll" to "maki roll"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
