### PR TITLE
Kills off (hopefully) the last hardcoded zlevel ID

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -591,10 +591,6 @@
 	},
 /turf/simulated/floor/light,
 /area/ruin/unpowered)
-"bq" = (
-/obj/machinery/blackbox_recorder,
-/turf/simulated/floor/plasteel,
-/area/ruin/unpowered)
 "br" = (
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -2575,8 +2571,8 @@ ac
 bg
 bj
 ac
-bq
 bx
+ar
 bG
 bO
 bU

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -8419,12 +8419,6 @@
 	icon_state = "gcircuit"
 	},
 /area/centcom/control)
-"ux" = (
-/obj/machinery/blackbox_recorder,
-/turf/unsimulated/floor{
-	icon_state = "gcircuit"
-	},
-/area/centcom/control)
 "uy" = (
 /obj/machinery/computer/card/centcom,
 /turf/unsimulated/floor{
@@ -37334,7 +37328,7 @@ nD
 tR
 ud
 su
-ux
+uv
 tR
 tR
 tR

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -228,7 +228,15 @@ GLOBAL_DATUM(blackbox, /obj/machinery/blackbox_recorder)
 	GLOB.blackbox = src
 
 /obj/machinery/blackbox_recorder/Destroy()
-	var/turf/T = locate(1,1,2)
+	// If the blackbox on station is destroyed, it is moved to the admin level
+	// It is very clear that the person who made this doesnt know what a datum is
+	// and thinks that an object which is vital for backend logging of when rounds end and begin
+	// should not only be destroyable, but also an on-station. Whoever designed this needs to be educated
+	// Thank you for coming to my ted talk, -aa
+
+	// Hardcoded Zlevel numbers are bad, so we use the level name to grab the admin Z level
+	var/admin_zlevel = level_name_to_num(CENTCOMM)
+	var/turf/T = locate(1, 1, admin_zlevel)
 	if(T)
 		GLOB.blackbox = null
 		var/obj/machinery/blackbox_recorder/BR = new/obj/machinery/blackbox_recorder(T)


### PR DESCRIPTION
## What Does This PR Do
This PR kills off the last (that I can find anyway) hardcoded reference of Z2 being the admin zlevel. This code is used for when the blackbox on station is destroyed and moved to CC (Rant included for how stupid this is). It now dynamically looks at the ZLevel list for the correct ZLevel number instead of just assuming Z2

## Why It's Good For The Game
ZLevel traits were added to make hardcoded stuff like this not a thing, incase we ever want to swap ZLevel orders around (which will be a part of map rotation, specifically Admin/CC becoming Z1). Hardcoding stuff like this makes harder to maintain code as well as just being awful.

## Changelog
:cl: AffectedArc07
fix: Blackbox now looks for which ZLevel is the admin ZLevel instead of just assuming Z2
/:cl:
