### PR TITLE
Tcomms rework tweaks

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -43780,6 +43780,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/transit_tube/station{
+	tag = "icon-closed (EAST)";
+	icon_state = "closed";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 5
@@ -53740,25 +53745,13 @@
 /turf/space,
 /area/space/nearstation)
 "bOa" = (
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "bOb" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "bOd" = (
 /turf/space,
@@ -55452,9 +55445,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "bRs" = (
 /obj/structure/cable/yellow{
@@ -55463,9 +55454,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "bRu" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -96545,13 +96534,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "elK" = (
 /obj/effect/spawner/airlock/w_to_e,
@@ -96595,9 +96578,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "gIG" = (
 /obj/machinery/ntnet_relay,
@@ -96621,13 +96602,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "dark";
-	name = "Mainframe Floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "hLL" = (
 /obj/structure/lattice,

--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -40,6 +40,8 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/network_id = "None"
 	/// Is the machine active
 	var/active = TRUE
+	/// Has the machine been hit by an ionspheric anomalie
+	var/ion = FALSE
 
 /**
   * Base Initializer
@@ -67,7 +69,8 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
   */
 /obj/machinery/tcomms/update_icon()
 	. = ..()
-	if(!active || (stat & NOPOWER))
+	// Show the off sprite if were inactive, ion'd or unpowered
+	if(!active || (stat & NOPOWER) || ion)
 		icon_state = "[initial(icon_state)]_off"
 	else
 		icon_state = initial(icon_state)
@@ -88,21 +91,21 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 
 
 /**
-  * Machine Enabler
+  * Start of Ion Anomalie Event
   *
-  * Quick and dirty proc to allow for the machine to be programatically enabled easily. Used for the anomaly event
+  * Proc to easily start an Ion Anomalie's effects, and update the icon
   */
-/obj/machinery/tcomms/proc/enable_machine()
-	active = TRUE
+/obj/machinery/tcomms/proc/start_ion()
+	ion = TRUE
 	update_icon()
 
 /**
-  * Machine Disabler
+  * End of Ion Anomalie Event
   *
-  * Quick and dirty proc to allow for the machine to be programatically disabled easily. Used for the anomaly event
+  * Proc to easily stop an Ion Anomalie's effects, and update the icon
   */
-/obj/machinery/tcomms/proc/disable_machine()
-	active = FALSE
+/obj/machinery/tcomms/proc/end_ion()
+	ion = FALSE
 	update_icon()
 
 /**

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -71,8 +71,8 @@
   * * tcm - The tcomms message datum
   */
 /obj/machinery/tcomms/core/proc/handle_message(datum/tcomms_message/tcm)
-	// Don't do anything with rejected signals, or if were offline, or if we have no power
-	if(tcm.reject || !active || (stat & NOPOWER))
+	// Don't do anything with rejected signals, if were offline, if we are ion'd, or if we have no power
+	if(tcm.reject || !active || (stat & NOPOWER) || ion)
 		return FALSE
 	// Kill the signal if its on a z-level that isnt reachable
 	if(!zlevel_reachable(tcm.source_level))
@@ -131,6 +131,7 @@
 	var/data[0]
 	// What tab are we on
 	data["tab"] = ui_tab
+	data["ion"] = ion
 
 	// Only send NTTC settings if were on the right tab. This saves on sending overhead.
 	if(ui_tab == UI_TAB_CONFIG)

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -76,27 +76,6 @@
 		linked_core = null
 		linked = FALSE
 
-/**
-  * Relay Enabler
-  *
-  * Modification to the standard one so that the links get updated
-  */
-/obj/machinery/tcomms/relay/enable_machine()
-	..()
-	if(linked_core)
-		linked_core.refresh_zlevels()
-
-/**
-  * Relay Disabler
-  *
-  * Modification to the standard one so that the links get updated
-  */
-/obj/machinery/tcomms/relay/disable_machine()
-	..()
-	if(linked_core)
-		linked_core.refresh_zlevels()
-
-
 //////////////
 // UI STUFF //
 //////////////

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -17,7 +17,7 @@
 /datum/event/communications_blackout/start()
 	// This only affects the cores, relays should be unaffected imo
 	for(var/obj/machinery/tcomms/core/T in GLOB.tcomms_machines)
-		T.disable_machine()
+		T.start_ion()
 		// Bring it back sometime between 3-5 minutes. This uses deciseconds, so 1800 and 3000 respecticely.
-		// Note that because this is a strict enable not a toggle, the crew or AI can re-enable the machine themselves
-		addtimer(CALLBACK(T, /obj/machinery/tcomms.proc/enable_machine), rand(1800, 3000))
+		// The AI cannot disable this, it must be waited for
+		addtimer(CALLBACK(T, /obj/machinery/tcomms.proc/end_ion), rand(1800, 3000))

--- a/nano/templates/tcomms_core.tmpl
+++ b/nano/templates/tcomms_core.tmpl
@@ -1,6 +1,12 @@
 {{:helper.link('Device Configuration', 'wrench', {'tab' : "CONFIG"}, data.tab == "CONFIG" ? 'selected' : '')}}
 {{:helper.link('Device Links', 'link', {'tab' : "LINKS"}, data.tab == "LINKS" ? 'selected' : '')}}
 
+{{if data.ion}}
+<div class='notice'>
+ERROR: An Ionspheric overload has occured. Please wait for the machine to reboot. This cannot be manually done.
+</div>
+{{/if}}
+
 {{if data.tab == "CONFIG"}}
 	<h1>Core Configuration</h1>
 	<h3>Status</h3>


### PR DESCRIPTION
## What Does This PR Do
Fixes turfs in the metastation sat being the wrong kind, as well as a missing transit tube piece. It also makes it so AIs cannot disable the ionspheric anomalie event

![image](https://user-images.githubusercontent.com/25063394/85401896-afd2e080-b552-11ea-80b2-8e5e81c1d9ea.png)

## Why It's Good For The Game
The AI shouldnt able to instantly null out a random event, and broken turfs are bad

## Changelog
:cl:
tweak: You can no longer toggle the tcomms core to null out the ionspheric anomalie event
fix: Fixes some broken turfs on MetaStation
/:cl:
