### PR TITLE
Fix carbon hitby proc not returning parent result

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -12,7 +12,7 @@
 			visible_message("<span class='warning'>[src] catches [AM]!</span>")
 			throw_mode_off()
 			return TRUE
-	..()
+	return ..()
 
 /mob/living/carbon/water_act(volume, temperature, source, method = REAGENT_TOUCH)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Makes `/mob/living/carbon/hitby` proc return the parent's (`/mob/living/hitby`) result **(fixes #13579)**

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The absence of that return resulted in some thrown items that should've been blocked on impact (e.g. bola) still triggering their impact code - in the case of the bola, ensnaring the mob. **This PR fixes that and now thrown items that can be blocked will no longer trigger if they are indeed blocked**

## Changelog
:cl:
fix: Fix thrown bolas (and other items) ignoring being blocked by a weapons and shields
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
