### PR TITLE
Fixes brainless cyborgs, Removes "Android" alt job title for cyborgs

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -32,7 +32,7 @@
 	minimal_player_age = 21
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	alt_titles = list("Android", "Robot")
+	alt_titles = list("Robot")
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H)
 	if(!H)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -82,14 +82,11 @@
 	O.notify_ai(1)
 
 	if(O.mind && O.mind.assigned_role == "Cyborg")
-		if(O.mind.role_alt_title == "Android")
+		if(O.mind.role_alt_title == "Android" || O.mind.role_alt_title == "Robot")
 			O.mmi = new /obj/item/mmi/robotic_brain(O)
-		else if(O.mind.role_alt_title == "Robot")
-			O.mmi = null //Robots do not have removable brains.
 		else
 			O.mmi = new /obj/item/mmi(O)
-
-		if(O.mmi) O.mmi.transfer_identity(src) //Does not transfer key/client.
+		O.mmi.transfer_identity(src) //Does not transfer key/client.
 
 	O.update_pipe_vision()
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -82,7 +82,7 @@
 	O.notify_ai(1)
 
 	if(O.mind && O.mind.assigned_role == "Cyborg")
-		if(O.mind.role_alt_title == "Android" || O.mind.role_alt_title == "Robot")
+		if(O.mind.role_alt_title == "Robot")
 			O.mmi = new /obj/item/mmi/robotic_brain(O)
 		else
 			O.mmi = new /obj/item/mmi(O)


### PR DESCRIPTION
## What Does This PR Do
1. Alters the spawning process for cyborgs such that:
- Players spawning as the cyborg job with their job title set to "robot" get robotic brains.
- In all other cases, the cyborg gets a MMI.
2. Removes the "Android" alt cyborg job title.

## Why It's Good For The Game
1. Fixes a bug where players whose cyborg alt job title is set to "Robot" spawn without any brain at all, which leads to nasty results (they cannot have their brain removed by robotics to be put into a new body, which means if they're very damaged players have to ahelp to get us to manually fix it by respawning them). It is also more consistent - we should be able to count on cyborgs always having some form of brain.
2. Removing the Android job title was requested by Fox, and the title (as far as I could see) was pointless anyway.


## Changelog
:cl: Kyep
fix: Fixed a bug where players joining as a cyborg with the alt job title "Robot" were not given a brain.
del: Removed "Android" alt job title for cyborgs.
/:cl:
