### PR TITLE
Finishes out Reagent Container Refactor

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -124,10 +124,10 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	return ..()
 
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
-	if(((src in target) && !target_self) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)))
-		return 0
+	if(((src in target) && !target_self) || (!isturf(target.loc) && !isturf(target) && not_inside))
+		return FALSE
 	else
-		return 1
+		return TRUE
 
 /obj/item/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)

--- a/code/modules/detective_work/footprints_and_rag.dm
+++ b/code/modules/detective_work/footprints_and_rag.dm
@@ -18,7 +18,6 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(5)
 	volume = 5
-	can_be_placed_into = null
 	flags = NOBLUDGEON
 	container_type = OPENCONTAINER
 	has_lid = FALSE

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -61,8 +61,9 @@ obj/item/reagent_containers/proc/add_initial_reagents()
 		update_icon()
 	return
 
-/obj/item/reagent_containers/afterattack(obj/target, mob/user , flag)
-	return
+/obj/item/reagent_containers/attack(mob/M, mob/user, def_zone)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
 
 /obj/item/reagent_containers/wash(mob/user, atom/source)
 	if(is_open_container())

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -14,38 +14,7 @@
 	container_type = OPENCONTAINER
 	has_lid = TRUE
 	resistance_flags = ACID_PROOF
-
 	var/label_text = ""
-	// the fucking asshole who designed this can go die in a fire - Iamgoofball
-	var/list/can_be_placed_into = list(
-		/obj/machinery/chem_master/,
-		/obj/machinery/chem_heater/,
-		/obj/machinery/chem_dispenser/,
-		/obj/machinery/reagentgrinder,
-		/obj/structure/table,
-		/obj/structure/closet,
-		/obj/structure/sink,
-		/obj/structure/toilet,
-		/obj/item/storage,
-		/obj/machinery/atmospherics/unary/cryo_cell,
-		/obj/machinery/dna_scannernew,
-		/obj/item/grenade/chem_grenade,
-		/mob/living/simple_animal/bot/medbot,
-		/obj/item/storage/secure/safe,
-		/obj/machinery/iv_drip,
-		/obj/machinery/computer/pandemic,
-		/obj/machinery/disposal,
-		/mob/living/simple_animal/cow,
-		/mob/living/simple_animal/hostile/retaliate/goat,
-		/obj/machinery/sleeper,
-		/obj/machinery/smartfridge/,
-		/obj/machinery/biogenerator,
-		/obj/machinery/hydroponics,
-		/obj/machinery/constructable_frame,
-		/obj/machinery/icemachine,
-		/obj/item/bombcore/chemical,
-		/obj/machinery/vending,
-		/obj/machinery/fishtank)
 
 /obj/item/reagent_containers/glass/New()
 	..()
@@ -98,56 +67,44 @@
 			reagents.reaction(M, REAGENT_INGEST, fraction)
 			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, M, 5), 5)
 			playsound(M.loc,'sound/items/drink.ogg', rand(10,50), 1)
-	else
-		return ..()
 
 /obj/item/reagent_containers/glass/afterattack(obj/target, mob/user, proximity)
-	if(!proximity)
+	if((!proximity) ||  !check_allowed_items(target,target_self = TRUE))
 		return
 
 	if(!is_open_container())
 		return
 
-	for(var/type in can_be_placed_into)
-		if(istype(target, type))
+	if(target.is_refillable()) //Something like a glass. Player probably wants to transfer TO it.
+		if(!reagents.total_volume)
+			to_chat(user, "<span class='warning'>[src] is empty!</span>")
 			return
 
-	if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
-		if(target.reagents && !target.reagents.total_volume)
+		if(target.reagents.holder_full())
+			to_chat(user, "<span class='warning'>[target] is full.</span>")
+			return
+
+		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
+		to_chat(user, "<span class='notice'>You transfer [trans] unit\s of the solution to [target].</span>")
+
+	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
+		if(!target.reagents.total_volume)
 			to_chat(user, "<span class='warning'>[target] is empty and can't be refilled!</span>")
 			return
 
-		if(reagents.total_volume >= reagents.maximum_volume)
-			to_chat(user, "<span class='notice'>[src] is full.</span>")
+		if(reagents.holder_full())
+			to_chat(user, "<span class='warning'>[src] is full.</span>")
 			return
 
 		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] unit\s of the contents of [target].</span>")
 
-	else if(target.is_refillable() && is_drainable()) //Something like a glass. Player probably wants to transfer TO it.
-		if(!reagents.total_volume)
-			to_chat(user, "<span class='warning'>[src] is empty.</span>")
-			return
-
-		if(target.reagents.total_volume >= target.reagents.maximum_volume)
-			to_chat(user, "<span class='warning'>[target] is full.</span>")
-			return
-
-		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
-		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution to [target].</span>")
-
-	else if(istype(target, /obj/item/reagent_containers/glass) && !target.is_open_container())
-		to_chat(user, "<span class='warning'>You cannot fill [target] while it is sealed.</span>")
-		return
-
-	else if(istype(target, /obj/effect/decal)) //stops splashing while scooping up fluids
-		return
-
-	else if(reagents.total_volume && user.a_intent == INTENT_HARM)
-		user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
-							"<span class='notice'>You splash the contents of [src] onto [target].</span>")
-		reagents.reaction(target, REAGENT_TOUCH)
-		reagents.clear_reagents()
+	else if(reagents.total_volume)
+		if(user.a_intent == INTENT_HARM)
+			user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
+								"<span class='notice'>You splash the contents of [src] onto [target].</span>")
+			reagents.reaction(target, REAGENT_TOUCH)
+			reagents.clear_reagents()
 
 /obj/item/reagent_containers/glass/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/pen) || istype(I, /obj/item/flashlight/pen))


### PR DESCRIPTION
@Anasari ported the refactor to reagent containers for if they're drainable or not--and that caught most of the problems---but glass containers were never refactored.

As such, there was some oddities about them--you couldn't use them in a lot of circumstances where you had to use a drinking glass or something similar.

This meant that you couldn't use a beaker or other container on a fermenting barrel, for instance (I'm sure there's other things too).

Either case, this finishes out the refactor for those containers so anything that is a glass subtype should behave more consistently.

:cl: Fox McCloud
fix: Fixes glass containers behaving inconsistently. Can now use beakers and other glass containers to get liquid from a fermenting barrel
/:cl: