### PR TITLE
Makes the assembly cooldown happen before it triggers. Stopping an infinite loop

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -59,8 +59,7 @@
 	cooldown--
 	if(cooldown <= 0)
 		return FALSE
-	spawn(10)
-		process_cooldown()
+	addtimer(CALLBACK(src, .proc/process_cooldown), 10)
 	return TRUE
 
 /obj/item/assembly/Destroy()
@@ -94,8 +93,7 @@
 	if(!secured || cooldown > 0)
 		return FALSE
 	cooldown = 2
-	spawn(10)
-		process_cooldown()
+	addtimer(CALLBACK(src, .proc/process_cooldown), 10)
 	return TRUE
 
 /obj/item/assembly/toggle_secure()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -127,13 +127,12 @@
 /obj/item/assembly/infra/proc/trigger_beam()
 	if(!secured || !on || cooldown > 0)
 		return FALSE
-	pulse(0)
+	cooldown = 2
+	pulse(FALSE)
 	audible_message("[bicon(src)] *beep* *beep*", null, 3)
 	if(first)
 		qdel(first)
-	cooldown = 2
-	spawn(10)
-		process_cooldown()
+	addtimer(CALLBACK(src, .proc/process_cooldown), 10)
 
 /obj/item/assembly/infra/interact(mob/user)//TODO: change this this to the wire control panel
 	if(!secured)	return

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -47,11 +47,10 @@
 /obj/item/assembly/prox_sensor/proc/sense()
 	if(!secured || !scanning || cooldown > 0)
 		return FALSE
-	pulse(0)
-	visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2
-	spawn(10)
-		process_cooldown()
+	pulse(FALSE)
+	visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
+	addtimer(CALLBACK(src, .proc/process_cooldown), 10)
 
 /obj/item/assembly/prox_sensor/process()
 	if(timing && (time >= 0))

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -41,8 +41,7 @@
 	if(cooldown > 0)
 		return FALSE
 	cooldown = 2
-	spawn(10)
-		process_cooldown()
+	addtimer(CALLBACK(src, .proc/process_cooldown), 10)
 
 	signal()
 	return TRUE

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -39,12 +39,11 @@
 /obj/item/assembly/timer/proc/timer_end()
 	if(!secured || cooldown > 0)
 		return FALSE
-	pulse(0)
+	cooldown = 2
+	pulse(FALSE)
 	if(loc)
 		loc.visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
-	cooldown = 2
-	spawn(10)
-		process_cooldown()
+	addtimer(CALLBACK(src, .proc/process_cooldown), 10)
 
 /obj/item/assembly/timer/process()
 	if(timing && (time > 0))


### PR DESCRIPTION
## What Does This PR Do
Makes assemblies go into cooldown whenever it is triggered before they trigger their holder.
Also refactors the stuff around it a bit to use timers instead of spawns

fixes #12629

## Why It's Good For The Game
Fixes a potential infinite loop

## Changelog
:cl:
fix: Fixes a potential infinite loop in assembly grenades.
/:cl: