### PR TITLE
Removes an unused proc

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -154,12 +154,6 @@
 				T.on_consume(src, usr)
 	..()
 
-/obj/item/reagent_containers/food/snacks/grown/Crossed(atom/movable/AM, oldloc)
-	if(seed)
-		for(var/datum/plant_gene/trait/T in seed.genes)
-			T.on_cross(src, AM)
-	..()
-
 /obj/item/reagent_containers/food/snacks/grown/after_slip(mob/living/carbon/human/H)
 	if(!seed)
 		return

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -50,13 +50,6 @@
 		return 1
 	return 0
 
-
-/obj/item/grown/Crossed(atom/movable/AM, oldloc)
-	if(seed)
-		for(var/datum/plant_gene/trait/T in seed.genes)
-			T.on_cross(src, AM)
-	..()
-
 /obj/item/grown/after_slip(mob/living/carbon/human/H)
 	if(!seed)
 		return

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -175,9 +175,6 @@
 /datum/plant_gene/trait/proc/on_consume(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
 	return
 
-/datum/plant_gene/trait/proc/on_cross(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
-	return
-
 /datum/plant_gene/trait/proc/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the `/datum/plant_gene/trait/proc/on_cross` proc because currently, 0 plant genes make use of this proc. As you can see from the profile below, it can eat up a hefty amount of CPU.

![image](https://user-images.githubusercontent.com/42044220/85596037-0140a580-b60f-11ea-877a-ba402038e971.png)

I got this profile from someone who pasted it into discord a while back, and it is from a live game. Not sure why there are so many calls to this proc, maybe diona nymphs crawling over botany vegetables or something.

Backend change, no CL.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes a CPU hog proc that was running for no reason.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
