### PR TITLE
Fix mob sprite drift when doing anims while floating

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -515,8 +515,8 @@
 	else if(direction & WEST)
 		pixel_x_diff = -8
 
-	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
-	animate(pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, time = 2)
+	animate(src, pixel_x = pixel_x_diff, pixel_y = pixel_y_diff, time = 2, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = -pixel_x_diff, pixel_y = -pixel_y_diff, time = 2, flags = ANIMATION_RELATIVE)
 
 /atom/movable/proc/do_item_attack_animation(atom/A, visual_effect_icon, obj/item/used_item)
 	var/image/I

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -515,8 +515,8 @@
 	else if(direction & WEST)
 		pixel_x_diff = -8
 
-	animate(src, pixel_x = pixel_x_diff, pixel_y = pixel_y_diff, time = 2, flags = ANIMATION_RELATIVE)
-	animate(pixel_x = -pixel_x_diff, pixel_y = -pixel_y_diff, time = 2, flags = ANIMATION_RELATIVE)
+	animate(src, pixel_x = pixel_x_diff, pixel_y = pixel_y_diff, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = -pixel_x_diff, pixel_y = -pixel_y_diff, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
 
 /atom/movable/proc/do_item_attack_animation(atom/A, visual_effect_icon, obj/item/used_item)
 	var/image/I

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -3,8 +3,8 @@
 	set invisibility = 0
 
 	if(flying) //TODO: Even better floating
-		animate(src, pixel_y = 5, time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
-		animate(pixel_y = -5, time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+		animate(src, pixel_y = 5, time = 1 SECONDS, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+		animate(pixel_y = -5, time = 1 SECONDS, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
 
 	if(client || registered_z) // This is a temporary error tracker to make sure we've caught everything
 		var/turf/T = get_turf(src)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -2,9 +2,9 @@
 	set waitfor = FALSE
 	set invisibility = 0
 
-	if(flying) //TODO: Better floating
-		animate(src, pixel_y = pixel_y + 5 , time = 10, loop = 1, easing = SINE_EASING)
-		animate(pixel_y = pixel_y - 5, time = 10, loop = 1, easing = SINE_EASING)
+	if(flying) //TODO: Even better floating
+		animate(src, pixel_y = 5, time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+		animate(pixel_y = -5, time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
 
 	if(client || registered_z) // This is a temporary error tracker to make sure we've caught everything
 		var/turf/T = get_turf(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -756,12 +756,12 @@
 		if(floating)
 			return
 
-		animate(src, pixel_y = 2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
-		animate(pixel_y = -2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
+		animate(src, pixel_y = 2, time = 1 SECONDS, loop = -1, flags = ANIMATION_RELATIVE)
+		animate(pixel_y = -2, time = 1 SECONDS, loop = -1, flags = ANIMATION_RELATIVE)
 		floating = TRUE
 	else if((!should_float || fixed_in_place) && floating)
 		var/final_pixel_y = get_standard_pixel_y_offset(lying)
-		animate(src, pixel_y = final_pixel_y, time = 10)
+		animate(src, pixel_y = final_pixel_y, time = 1 SECONDS)
 		floating = FALSE
 
 /mob/living/proc/can_use_vents()
@@ -843,8 +843,8 @@
 	var/amplitude = min(4, (jitteriness / 100) + 1)
 	var/pixel_x_diff = rand(-amplitude, amplitude)
 	var/pixel_y_diff = rand(-amplitude / 3, amplitude / 3)
-	animate(src, pixel_x = pixel_x_diff, pixel_y = pixel_y_diff, time = 2, loop = loop_amount, flags = ANIMATION_RELATIVE)
-	animate(pixel_x = -pixel_x_diff, pixel_y = -pixel_y_diff, time = 2, flags = ANIMATION_RELATIVE)
+	animate(src, pixel_x = pixel_x_diff, pixel_y = pixel_y_diff, time = 0.2 SECONDS, loop = loop_amount, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = -pixel_x_diff, pixel_y = -pixel_y_diff, time = 0.2 SECONDS, flags = ANIMATION_RELATIVE)
 	floating = FALSE  // If we were without gravity, the bouncing animation got stopped, so we make sure we restart it in next life().
 
 /mob/living/proc/get_temperature(datum/gas_mixture/environment)

--- a/code/modules/mob/update_status.dm
+++ b/code/modules/mob/update_status.dm
@@ -58,8 +58,8 @@
 // Does various animations - Jitter, Flying, Spinning
 /mob/proc/update_animations()
 	if(flying)
-		animate(src, pixel_y = pixel_y + 5 , time = 10, loop = 1, easing = SINE_EASING)
-		animate(pixel_y = pixel_y - 5, time = 10, loop = 1, easing = SINE_EASING)
+		animate(src, pixel_y = 5 , time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+		animate(pixel_y = -5, time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
 
 /mob/proc/update_stat()
 	return

--- a/code/modules/mob/update_status.dm
+++ b/code/modules/mob/update_status.dm
@@ -58,8 +58,8 @@
 // Does various animations - Jitter, Flying, Spinning
 /mob/proc/update_animations()
 	if(flying)
-		animate(src, pixel_y = 5 , time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
-		animate(pixel_y = -5, time = 10, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+		animate(src, pixel_y = 5 , time = 1 SECONDS, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+		animate(pixel_y = -5, time = 1 SECONDS, loop = 1, easing = SINE_EASING, flags = ANIMATION_RELATIVE)
 
 /mob/proc/update_stat()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

- Fixes most (if not all) cases of sprite drifting on floating mobs (no gravity/in space) that perform an animation (attacking, jitter). The fix works by making the floating animation (among others) use the `ANIMATION_RELATIVE` flag so that it doesn't use outdated values (fixes #9119, fixes #13686). We should be using that flag where possible anyway.
- Minor code clean-up, improve `mob/living/proc/float` readability

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Prevents mob sprites from drifting away, providing a clear view on their actual location. That glitch may be used maliciously to harm people without them being able to do anything

## Changelog
:cl:
fix: Fix cases of sprite drifting while floating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
