### PR TITLE
Floor Tile Memory Useage and Initialization

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -265,8 +265,8 @@
 
 				if(!istype(T, /turf/simulated/floor/plating) && !istype(T, /turf/simulated/floor/engine/cult) && istype(T, /turf/simulated/floor) && prob(15))
 					var/turf/simulated/floor/floor = T
-					if(floor.intact)
-						floor.builtin_tile.loc = floor
+					if(floor.intact && floor.floor_tile)
+						new floor.floor_tile(floor)
 					floor.broken = 0
 					floor.burnt = 0
 					floor.make_plating(1)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -27,7 +27,6 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	var/burnt = 0
 	var/current_overlay = null
 	var/floor_tile = null //tile that this floor drops
-	var/obj/item/stack/tile/builtin_tile = null //needed for performance reasons when the singularity rips off floor tiles
 	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	var/list/burnt_states = list("floorscorched1", "floorscorched2")
 	var/list/prying_tool_list = list(TOOL_CROWBAR) //What tool/s can we use to pry up the tile?
@@ -38,13 +37,6 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 		icon_regular_floor = "floor"
 	else
 		icon_regular_floor = icon_state
-	if(floor_tile)
-		builtin_tile = new floor_tile
-
-/turf/simulated/floor/Destroy()
-	QDEL_NULL(builtin_tile)
-	return ..()
-
 
 //turf/simulated/floor/CanPass(atom/movable/mover, turf/target, height=0)
 //	if((istype(mover, /obj/machinery/vehicle) && !(src.burnt)))
@@ -209,30 +201,29 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	else
 		if(user && !silent)
 			to_chat(user, "<span class='danger'>You remove the floor tile.</span>")
-		if(builtin_tile && make_tile)
-			builtin_tile.forceMove(src)
-			builtin_tile = null
+		if(floor_tile && make_tile)
+			spawn_tile()
 	return make_plating()
+
+/turf/simulated/floor/proc/spawn_tile()
+	new floor_tile(src)
 
 /turf/simulated/floor/singularity_pull(S, current_size)
 	..()
 	if(current_size == STAGE_THREE)
 		if(prob(30))
-			if(builtin_tile)
-				builtin_tile.loc = src
-				builtin_tile = null
+			if(floor_tile)
+				new floor_tile(src)
 				make_plating()
 	else if(current_size == STAGE_FOUR)
 		if(prob(50))
-			if(builtin_tile)
-				builtin_tile.loc = src
-				builtin_tile = null
+			if(floor_tile)
+				new floor_tile(src)
 				make_plating()
 	else if(current_size >= STAGE_FIVE)
-		if(builtin_tile)
+		if(floor_tile)
 			if(prob(70))
-				builtin_tile.loc = src
-				builtin_tile = null
+				new floor_tile(src)
 				make_plating()
 		else if(prob(50))
 			ReplaceWithLattice()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -202,11 +202,8 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 		if(user && !silent)
 			to_chat(user, "<span class='danger'>You remove the floor tile.</span>")
 		if(floor_tile && make_tile)
-			spawn_tile()
+			new floor_tile(src)
 	return make_plating()
-
-/turf/simulated/floor/proc/spawn_tile()
-	new floor_tile(src)
 
 /turf/simulated/floor/singularity_pull(S, current_size)
 	..()

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -31,9 +31,8 @@
 		if(make_tile)
 			if(user && !silent)
 				to_chat(user, "<span class='notice'>You unscrew the planks.</span>")
-			if(builtin_tile)
-				builtin_tile.forceMove(src)
-				builtin_tile = null
+			if(floor_tile)
+				new floor_tile(src)
 		else
 			if(user && !silent)
 				to_chat(user, "<span class='warning'>You forcefully pry off the planks, destroying them in the process.</span>")

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -77,14 +77,13 @@
 
 /turf/simulated/floor/light/attackby(obj/item/C, mob/user, params)
 	if(istype(C,/obj/item/light/bulb)) //only for light tiles
-		if(istype(builtin_tile, /obj/item/stack/tile/light))
-			if(!state)
-				qdel(C)
-				state = LIGHTFLOOR_ON
-				update_icon()
-				to_chat(user, "<span class='notice'>You replace the light bulb.</span>")
-			else
-				to_chat(user, "<span class='notice'>The light bulb seems fine, no need to replace it.</span>")
+		if(!state)
+			qdel(C)
+			state = LIGHTFLOOR_ON
+			update_icon()
+			to_chat(user, "<span class='notice'>You replace the light bulb.</span>")
+		else
+			to_chat(user, "<span class='notice'>The light bulb seems fine, no need to replace it.</span>")
 	else
 		return ..()
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -34,7 +34,6 @@
 	var/sheet_type = /obj/item/stack/sheet/metal
 	var/sheet_amount = 2
 	var/girder_type = /obj/structure/girder
-	var/obj/item/stack/sheet/builtin_sheet = null
 
 	canSmoothWith = list(
 	/turf/simulated/wall,
@@ -45,10 +44,6 @@
 	/turf/simulated/wall/r_wall/rust,
 	/turf/simulated/wall/r_wall/coated)
 	smooth = SMOOTH_TRUE
-
-/turf/simulated/wall/New()
-	..()
-	builtin_sheet = new sheet_type
 
 /turf/simulated/wall/BeforeChange()
 	for(var/obj/effect/overlay/wall_rot/WR in src)

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -3,7 +3,6 @@
 	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound."
 	icon = 'icons/turf/walls/cult_wall.dmi'
 	icon_state = "cult"
-	builtin_sheet = null
 	canSmoothWith = null
 	smooth = SMOOTH_FALSE
 	sheet_type = /obj/item/stack/sheet/runed_metal

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -794,8 +794,8 @@
 		return
 	if(T.intact && istype(T,/turf/simulated/floor)) //intact floor, pop the tile
 		var/turf/simulated/floor/F = T
-		new F.builtin_tile.type(H)
-		F.remove_tile(null,TRUE,FALSE)
+		new F.floor_tile(H)
+		F.remove_tile(null, TRUE, FALSE)
 
 	if(direction)		// direction is specified
 		if(istype(T, /turf/space)) // if ended in space, then range is unlimited


### PR DESCRIPTION
A long time ago, there was an idea that, to cut down on how expensive the singulo was, each floor turf would have its tile built into it---then it'd get `forceMove`'d out when ti got pulled. Likewise, prying up a tile would remove it instead of creating a new one.

Thing is this really doesn't save much on CPU--creation of the tiles is...not expensive at all. Due to the nature of how stacks work, creating a new turf inherently means that the stack you used will not suddenly go into the new turf---and even if it did, you'd be creating a new item anyway.


All of this ends up slowing down initializations (by 1-2 seconds) and bloats up memory useage and instances by some 14,000+ objects.

My testing seems to show that this was using up about ~20 MB of memory--but that seems like an awful lot---still, it'll be a boost.