### PR TITLE
Fixes Spectral Blade

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -15,7 +15,6 @@
 
 	// Otherwise jump
 	else
-		following = null
 		forceMove(get_turf(A))
 		update_parallax_contents()
 

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -81,7 +81,7 @@
 	var/mob/dead/observer/current_spirits = list()
 
 	for(var/mob/dead/observer/O in GLOB.player_list)
-		if((O.following in contents))
+		if((O.orbiting in contents))
 			ghost_counter++
 			O.invisibility = 0
 			current_spirits |= O

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -23,7 +23,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 							//If you died in the game and are a ghsot - this will remain as null.
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
 	universal_speak = TRUE
-	var/atom/movable/following = null
 	var/image/ghostimage = null //this mobs ghost image, for deleting and stuff
 	var/ghostvision = TRUE //is the ghost able to see things humans can't?
 	var/seedarkness = TRUE
@@ -230,7 +229,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/Move(NewLoc, direct)
 	update_parallax_contents()
-	following = null
 	setDir(direct)
 	ghostimage.setDir(dir)
 
@@ -412,7 +410,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	forceMove(pick(L))
 	update_parallax_contents()
-	following = null
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"
@@ -424,7 +421,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	A.on_close(CALLBACK(src, .proc/ManualFollow))
 
 // This is the ghost's follow verb with an argument
-/mob/dead/observer/proc/ManualFollow(var/atom/movable/target)
+/mob/dead/observer/proc/ManualFollow(atom/movable/target)
 	if(!target || !isobserver(usr))
 		return
 
@@ -432,7 +429,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	if(target != src)
-		if(following && following == target)
+		if(orbiting && orbiting == target)
 			return
 
 		var/icon/I = icon(target.icon,target.icon_state,target.dir)
@@ -458,7 +455,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			else //Circular
 				rot_seg = 36 //360/10 bby, smooth enough aproximation of a circle
 
-		following = target
 		to_chat(src, "<span class='notice'>Now following [target]</span>")
 		orbit(target,orbitsize, FALSE, 20, rot_seg)
 
@@ -485,7 +481,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(T && isturf(T))	//Make sure the turf exists, then move the source to that destination.
 		A.forceMove(T)
 		M.update_parallax_contents()
-		following = null
 		return
 	to_chat(A, "This mob is not located in the game world.")
 
@@ -642,7 +637,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					if(!client)
 						return
 					forceMove(T)
-				following = null
 
 	if(href_list["reenter"])
 		reenter_corpse()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -237,7 +237,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 			if(A.invisibility)
 				if(see_ghosts && istype(A,/mob/dead/observer))
 					var/mob/dead/observer/O = A
-					if(O.following)
+					if(O.orbiting)
 						continue
 					if(user.mind && !(user.mind.assigned_role == "Chaplain"))
 						atoms.Add(image('icons/mob/mob.dmi', O.loc, pick(GLOB.SpookyGhosts), 4, SOUTH))
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 		if(M.invisibility)
 			if(see_ghosts && istype(M,/mob/dead/observer))
 				var/mob/dead/observer/O = M
-				if(O.following)
+				if(O.orbiting)
 					continue
 				if(!mob_detail)
 					mob_detail = "You can see a g-g-g-g-ghooooost! "


### PR DESCRIPTION
The spectral blade currently doesn't become any more powerful when people are orbiting the person with the blade or the blade itself---which makes this otherwise unique weapon completely useless.

Also removes the unused `following` holder on observers, since we 100% use orbiting now.

:cl: Fox McCloud
fix: Fixes spectral blade not growing more powerful with each ghost that orbits it
/:cl: