### PR TITLE
Improved note search

### DIFF
--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -186,9 +186,11 @@
 			var/err = query_list_notes.ErrorMsg()
 			log_game("SQL ERROR obtaining ckey from notes table. Error : \[[err]\]\n")
 			return
+		to_chat(usr, "<span class='notice'>Started regex note search for [search]. Please wait for results...</span>")
 		while(query_list_notes.NextRow())
 			index_ckey = query_list_notes.item[1]
 			output += "<a href='?_src_=holder;shownoteckey=[index_ckey]'>[index_ckey]</a><br>"
+			CHECK_TICK
 	else
 		output += "<center><a href='?_src_=holder;addnoteempty=1'>\[Add Note\]</a></center>"
 		output += ruler

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -187,10 +187,12 @@
 			log_game("SQL ERROR obtaining ckey from notes table. Error : \[[err]\]\n")
 			return
 		to_chat(usr, "<span class='notice'>Started regex note search for [search]. Please wait for results...</span>")
+		message_admins("[usr] has started a note search with regex [search]. CPU usage may be higher.")
 		while(query_list_notes.NextRow())
 			index_ckey = query_list_notes.item[1]
 			output += "<a href='?_src_=holder;shownoteckey=[index_ckey]'>[index_ckey]</a><br>"
 			CHECK_TICK
+		message_admins("The note search started by [usr] has complete. CPU should return to normal.")
 	else
 		output += "<center><a href='?_src_=holder;addnoteempty=1'>\[Add Note\]</a></center>"
 		output += ruler


### PR DESCRIPTION
## What Does This PR Do
This PR adds in a tickcheck into the `while()` loop which searches for users with notes. This means that the server wont be held up for a minute straight while every single player who has ever connected. 

## Why It's Good For The Game
Admin searching shouldnt halt the entire server for a full minute

## Changelog
:cl: AffectedArc07
fix: Pressing ALL on the notes viewer no longer halts the server for a full minute,
/:cl:
