### PR TITLE
Fixes typo in NTTC.dm comments

### DIFF
--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -2,7 +2,7 @@
 	NTTC system
 	This is basically the replacement for NTSL and allows tickbox features such as job titles and colours, without needing a script
 	This also means that there is no user input here, which means the system isnt prone to exploits since its only selecting options, no user input
-	Basically, just imagine pfSense for tcomsm
+	Basically, just imagine pfSense for tcomms
 
 	All this code was written by Tigercat2000. I take no credit -aa07
 */


### PR DESCRIPTION
## What Does This PR Do
Fixes a minor typo in NTTC.dm's comments as a Hello World exercise

## Why It's Good For The Game
Affected's bad spelling is bad for the game; proves I've set this up right for future work.

## Changelog
:cl: Autumn211
spellcheck: Fixed a typo in NTTC.dm comments
/:cl:
