### PR TITLE
Fixes magic missing as armor value and safe codes not having armor

### DIFF
--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -1,9 +1,9 @@
-#define ARMORID "armor-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]"
+#define ARMORID "armor-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]-[magic]"
 
-/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0)
   . = locate(ARMORID)
   if (!.)
-    . = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid)
+    . = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic)
 
 /datum/armor
 	var/melee
@@ -15,8 +15,9 @@
 	var/rad
 	var/fire
 	var/acid
+	var/magic
 
-/datum/armor/New(melee_value = 0, bullet_value = 0, laser_value = 0, energy_value = 0, bomb_value = 0, bio_value = 0, rad_value = 0, fire_value = 0, acid_value = 0)
+/datum/armor/New(melee_value = 0, bullet_value = 0, laser_value = 0, energy_value = 0, bomb_value = 0, bio_value = 0, rad_value = 0, fire_value = 0, acid_value = 0, magic_value = 0)
 	melee = melee_value
 	bullet = bullet_value
 	laser = laser_value
@@ -26,15 +27,16 @@
 	rad = rad_value
 	fire = fire_value
 	acid = acid_value
+	magic = magic_value
 	tag = ARMORID
 
-/datum/armor/proc/modifyRating(melee_value = 0, bullet_value = 0, laser_value = 0, energy_value = 0, bomb_value = 0, bio_value = 0, rad_value = 0, fire_value = 0, acid_value = 0)
-	return getArmor(melee + melee_value, bullet + bullet_value, laser + laser_value, energy + energy_value, bomb + bomb_value, bio + bio_value, rad + rad_value, fire + fire_value, acid + acid_value)
+/datum/armor/proc/modifyRating(melee_value = 0, bullet_value = 0, laser_value = 0, energy_value = 0, bomb_value = 0, bio_value = 0, rad_value = 0, fire_value = 0, acid_value = 0, magic_value = 0)
+	return getArmor(melee + melee_value, bullet + bullet_value, laser + laser_value, energy + energy_value, bomb + bomb_value, bio + bio_value, rad + rad_value, fire + fire_value, acid + acid_value, magic + magic_value)
 
 /datum/armor/proc/modifyAllRatings(modifier = 0)
-	return getArmor(melee + modifier, bullet + modifier, laser + modifier, energy + modifier, bomb + modifier, bio + modifier, rad + modifier, fire + modifier, acid + modifier)
+	return getArmor(melee + modifier, bullet + modifier, laser + modifier, energy + modifier, bomb + modifier, bio + modifier, rad + modifier, fire + modifier, acid + modifier, magic + modifier)
 
-/datum/armor/proc/setRating(melee_value, bullet_value, laser_value, energy_value, bomb_value, bio_value, rad_value, fire_value, acid_value)
+/datum/armor/proc/setRating(melee_value, bullet_value, laser_value, energy_value, bomb_value, bio_value, rad_value, fire_value, acid_value, magic_value)
 	return getArmor((isnull(melee_value) ? melee : melee_value),\
 					(isnull(bullet_value) ? bullet : bullet_value),\
 					(isnull(laser_value) ? laser : laser_value),\
@@ -43,19 +45,20 @@
 					(isnull(bio_value) ? bio : bio_value),\
 					(isnull(rad_value) ? rad : rad_value),\
 					(isnull(fire_value) ? fire : fire_value),\
-					(isnull(acid_value) ? acid : acid_value))
+					(isnull(acid_value) ? acid : acid_value),\
+					(isnull(magic_value) ? magic : magic_value))
 
 /datum/armor/proc/getRating(rating)
 	return vars[rating]
 
 /datum/armor/proc/getList()
-	return list("melee" = melee, "bullet" = bullet, "laser" = laser, "energy" = energy, "bomb" = bomb, "bio" = bio, "rad" = rad, "fire" = fire, "acid" = acid)
+	return list("melee" = melee, "bullet" = bullet, "laser" = laser, "energy" = energy, "bomb" = bomb, "bio" = bio, "rad" = rad, "fire" = fire, "acid" = acid, "magic" = magic)
 
 /datum/armor/proc/attachArmor(datum/armor/AA)
-	return getArmor(melee + AA.melee, bullet + AA.bullet, laser + AA.laser, energy + AA.energy, bomb + AA.bomb, bio + AA.bio, rad + AA.rad, fire + AA.fire, acid + AA.acid)
+	return getArmor(melee + AA.melee, bullet + AA.bullet, laser + AA.laser, energy + AA.energy, bomb + AA.bomb, bio + AA.bio, rad + AA.rad, fire + AA.fire, acid + AA.acid, magic + AA.magic)
 
 /datum/armor/proc/detachArmor(datum/armor/AA)
-	return getArmor(melee - AA.melee, bullet - AA.bullet, laser - AA.laser, energy - AA.energy, bomb - AA.bomb, bio - AA.bio, rad - AA.rad, fire - AA.fire, acid - AA.acid)
+	return getArmor(melee - AA.melee, bullet - AA.bullet, laser - AA.laser, energy - AA.energy, bomb - AA.bomb, bio - AA.bio, rad - AA.rad, fire - AA.fire, acid - AA.acid, magic - AA.magic)
 
 /datum/armor/vv_edit_var(var_name, var_value)
 	if (var_name == NAMEOF(src, tag))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -373,6 +373,7 @@ GLOBAL_LIST_EMPTY(safes)
 	info = "<div style='text-align:center;'><img src='ntlogo.png'><center><h3>Safe Codes</h3></center>"
 
 /obj/item/paper/safe_code/Initialize(mapload)
+	..()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/item/paper/safe_code/LateInitialize(mapload)


### PR DESCRIPTION
## What Does This PR Do
Adds magic to the armor values. Some items use this.
Makes safe codes call their base init properly

I can't be bothered now to add magic to every armor value. It works right now because of the default value of 0.

## Why It's Good For The Game
It is currently causing two runtimes atleast

Fixes:
```
[2020-06-26T21:53:09] Runtime in obj_defense.dm,33: Cannot execute null.getRating().
[2020-06-26T21:53:09]   proc name: run obj armor (/obj/proc/run_obj_armor)
[2020-06-26T21:53:09]   usr: Black Terror spider (405) (CKEY) (/mob/dead/observer)
[2020-06-26T21:53:09]   usr.loc: �space (121,125,1) (/turf/space)
[2020-06-26T21:53:09]   src: the safe codes (/obj/item/paper/safe_code)
[2020-06-26T21:53:09]   src.loc: the floor (123,127,1) (/turf/simulated/floor/wood)
[2020-06-26T21:53:09]   call stack:
[2020-06-26T21:53:09]   the safe codes (/obj/item/paper/safe_code): run obj armor(53, "brute", "bomb", null, 0)
[2020-06-26T21:53:09]   the safe codes (/obj/item/paper/safe_code): take damage(53, "brute", "bomb", 0, null, 0)
[2020-06-26T21:53:09]   the safe codes (/obj/item/paper/safe_code): ex act(3)
[2020-06-26T21:53:09]   explosion(space (121,125,1) (/turf/space), 1, 2, 3, 3, 1, 0, 0, 0, 1, null, 1)
```

```
[2020-06-26T18:40:14] Runtime in armor.dm,49: undefined variable /datum/armor/var/magic
[2020-06-26T18:40:14]   proc name: getRating (/datum/armor/proc/getRating)
[2020-06-26T18:40:14]   src: /datum/armor (/datum/armor)
[2020-06-26T18:40:14]   call stack:
[2020-06-26T18:40:14]   /datum/armor (/datum/armor): getRating("magic")
[2020-06-26T18:40:14]   NAME (/mob/living/carbon/human): getarmor organ(the right foot (/obj/item/organ/external/foot/right), "magic")
[2020-06-26T18:40:14]   NAME (/mob/living/carbon/human): getarmor("r_foot", "magic")
[2020-06-26T18:40:14]   NAME (/mob/living/carbon/human): run armor check("r_foot", "magic", null, null, 100, null)
[2020-06-26T18:40:14]   NAME (/mob/living/carbon/human): bullet act(the bolt of nothing (/obj/item/projectile/magic), "r_foot")
[2020-06-26T18:40:14]   NAME (/mob/living/carbon/human): bullet act(the bolt of nothing (/obj/item/projectile/magic), "r_foot")
[2020-06-26T18:40:14]   NAME (/mob/living/carbon/human): bullet act(the bolt of nothing (/obj/item/projectile/magic), "r_foot")
[2020-06-26T18:40:14]   the bolt of nothing (/obj/item/projectile/magic): Bump(NAME (/mob/living/carbon/human), 1)
[2020-06-26T18:40:14]   the floor (142,129,1) (/turf/simulated/floor/plasteel): Enter(the bolt of nothing (/obj/item/projectile/magic), the floor (143,129,1) (/turf/simulated/floor/plasteel))
[2020-06-26T18:40:14]   the bolt of nothing (/obj/item/projectile/magic): Move(the floor (142,129,1) (/turf/simulated/floor/plasteel), 8, null)
[2020-06-26T18:40:14]   the bolt of nothing (/obj/item/projectile/magic): fire(null)
```

## Changelog
:cl:
fix: Fixes the safe codes not having armor values
fix: Wands of nothing won't cause a runtime now upon hitting somebody
/:cl: