### PR TITLE
Fixes bad tcomms board naming

### DIFF
--- a/code/modules/research/designs/telecomms_designs.dm
+++ b/code/modules/research/designs/telecomms_designs.dm
@@ -13,7 +13,7 @@
 	category = list("Subspace Telecomms")
 
 /datum/design/telecomms_relay
-	name = "Machine Board (Telecommunications Core)"
+	name = "Machine Board (Telecommunications Relay)"
 	desc = "Allows for the construction of Telecommunications Relays."
 	id = "s-relay"
 	req_tech = list("programming" = 2, "engineering" = 2, "bluespace" = 2)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a typo I put in when I was doing the tcomms rework, specifically both boards being listed as cores, despite one being a relay

## Why It's Good For The Game
Boards should be properly named

## Changelog
:cl: AffectedArc07
spellcheck: Fixes the tcomms relay board being called tcomms core
/:cl:
