### PR TITLE
Access tweaks to employment consoles

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -59350,6 +59350,7 @@
 "cce" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/skills{
+	req_access_txt = "67";
 	req_one_access = null
 	},
 /turf/simulated/floor/plasteel{
@@ -60291,7 +60292,8 @@
 "cdK" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/skills{
-	req_access_txt = "57"
+	req_access_txt = "73";
+	req_one_access = null
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)

--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -57425,7 +57425,8 @@
 "bVc" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/skills{
-	req_access_txt = "57"
+	req_access_txt = "73";
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
@@ -58256,6 +58257,7 @@
 "bWI" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/skills{
+	req_access_txt = "67";
 	req_one_access = null
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -52687,7 +52687,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/computer/skills{
-	req_access_txt = "57"
+	req_access_txt = "57";
+	req_one_access = null
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
@@ -62593,7 +62594,8 @@
 "cjf" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/skills{
-	req_access_txt = "57"
+	req_access_txt = "73";
+	req_one_access = null
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
@@ -67271,6 +67273,7 @@
 "cqJ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/skills{
+	req_access_txt = "67";
 	req_one_access = null
 	},
 /turf/simulated/floor/plasteel{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks accesses to employment records consoles, so they are actually working as intended.
They all now share the access with the offices they're located in (HoP, NT Representative and Blueshield).
Previously, the ones in HoP and NTR office used combined accesses of HoP office and bridge.
The one in BS office had no restrictions whatsoever. You could log in using a blank ID.

Delta and Meta have no employment records consoles in HoP offices, which is why on those maps only NTR and BS consoles were touched.

## Why It's Good For The Game
It's a relatively minor thing I have found annoying when playing NTR. You have the console in your office, but you cannot access it. Noticed Blueshield one has no restrictions along the way, so changed that, too.
In practice, most of characters lack employment records, so it doesn't affect the game that much.

They also now all use req_access_txt to define their accesses, which seems to be the intended way of handling things.

## Changelog
:cl:
tweak: Employment records consoles now share ID access with the offices they're located in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
