### PR TITLE
Fixes Garbage Collection Timeout

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(garbage)
 	init_order = INIT_ORDER_GARBAGE
 	offline_implications = "Garbage collection is no longer functional, and objects will not be qdel'd. Immediate server restart recommended."
 
-	var/list/collection_timeout = list(0, 2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
+	var/list/collection_timeout = list(2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
 
 	//Stat tracking
 	var/delslasttick = 0			// number of del()'s we've done this tick


### PR DESCRIPTION
After doing some testing with the GC, I noticed that the queue levels were really odd---the first queue had a wait time of literally 0, while the second one was 2 minutes...and the third one---10 seconds, was never reached.

This is the result of removing the pre-queue at a point in the past.

This also means that unelss something garbage collects *instantaneously* upon qdeling, it'll register as a GC Failure---a false positive.

This also means that things queued for hard deletion were waiting a massive 2 minutes before getting hard deleted instead of 10 seconds---who knows how many problems that's created!

Either way, this is addressed now.