### PR TITLE
Fix command Admin, Secrets, Debug, Make all areas powered

### DIFF
--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -65,7 +65,6 @@
 	// recharge the APCs
 	for(var/thing in GLOB.apcs)
 		var/obj/machinery/power/apc/C = thing
-		var/area/current_area = get_area(C)
 		if(!is_station_level(C.z))
 			continue
 		if(C.cell)

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -59,7 +59,17 @@
 	log_and_message_admins("APC Short event shorted out [affected_apc_count] APCs.")
 
 /proc/power_restore(announce=TRUE)
-	power_restore_quick(announce)
+	if(announce)
+		GLOB.event_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
+
+	// recharge the APCs
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/C = thing
+		var/area/current_area = get_area(C)
+		if(!is_station_level(C.z))
+			continue
+		if(C.cell)
+			C.cell.charge = C.cell.maxcharge
 
 /proc/power_restore_quick(announce=TRUE)
 	if(announce)

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -64,11 +64,12 @@
 
 	// recharge the APCs
 	for(var/thing in GLOB.apcs)
-		var/obj/machinery/power/apc/C = thing
-		if(!is_station_level(C.z))
+		var/obj/machinery/power/apc/A = thing
+		if(!is_station_level(A.z))
 			continue
-		if(C.cell)
-			C.cell.charge = C.cell.maxcharge
+		var/obj/item/stock_parts/cell/C = A.get_cell()
+		if(C)
+			C.give(C.maxcharge)
 
 /proc/power_restore_quick(announce=TRUE)
 	if(announce)


### PR DESCRIPTION
## What Does This PR Do
While working on #13117 , I made `Make all areas powered` an alias to `Power all SMES`. In hindsight, this was a mistake, as there are useful reasons to recharge APCs independently of the SMES.

This PR restores the code necessary to recharge APC cells with the command. Note: It does NOT repair broken APCs or add power cells where they are missing. The command simply recharges APC power cells up to full power.

Originally, the command also restored some charge to the SMES based on the Grid Check event. That part has been removed, as the new APC Short event does not affect the SMES. If you want to recharge the SMES, just use the `Power all SMES` command.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins probably didn't use this command very often in real rounds.
It is a useful command to have for debugging and testing, though.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed Admin command Make all areas powered
/:cl:
