### PR TITLE
Alternative mech rebalance PR

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -950,29 +950,11 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	cost = 25
 	containername = "\improper \"Odysseus\" circuit crate"
 
-/datum/supply_packs/science/robotics/mecha_gygax
-	name = "Circuit Crate (Gygax)"
-	contains = list(/obj/item/circuitboard/mecha/gygax/main,
-					/obj/item/circuitboard/mecha/gygax/peripherals,
-					/obj/item/circuitboard/mecha/gygax/targeting)
+/datum/supply_packs/science/robotics/mecha_weapons_control
+	name = "Circuit Crate (Exosuit Weapons)"	//the name has to be short so it doesn't glitch the cargo console
+	contains = list(/obj/item/circuitboard/mecha/generic_targetting)
 	cost = 50
-	containername = "\improper \"Gygax\" circuit crate"
-
-/datum/supply_packs/science/robotics/mecha_durand
-	name = "Circuit Crate (Durand)"
-	contains = list(/obj/item/circuitboard/mecha/durand/main,
-					/obj/item/circuitboard/mecha/durand/peripherals,
-					/obj/item/circuitboard/mecha/durand/targeting)
-	cost = 50
-	containername = "\improper \"Durand\" circuit crate"
-
-/datum/supply_packs/science/robotics/mecha_phazon
-	name = "Circuit Crate (Phazon)"
-	contains = list(/obj/item/circuitboard/mecha/phazon/main,
-					/obj/item/circuitboard/mecha/phazon/peripherals,
-					/obj/item/circuitboard/mecha/phazon/targeting)
-	cost = 100
-	containername = "\improper \"Phazon\" circuit crate"
+	containername = "\improper Exosuit Weapons Control circuit crate"
 
 /datum/supply_packs/science/plasma
 	name = "Plasma Assembly Crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -938,17 +938,41 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/science/robotics/mecha_ripley
 	name = "Circuit Crate (Ripley APLU)"
 	contains = list(/obj/item/book/manual/ripley_build_and_repair,
-					/obj/item/circuitboard/mecha/ripley/main, //TEMPORARY due to lack of circuitboard printer
-					/obj/item/circuitboard/mecha/ripley/peripherals) //TEMPORARY due to lack of circuitboard printer
+					/obj/item/circuitboard/mecha/ripley/main,
+					/obj/item/circuitboard/mecha/ripley/peripherals)
 	cost = 30
 	containername = "\improper APLU \"Ripley\" circuit crate"
 
 /datum/supply_packs/science/robotics/mecha_odysseus
 	name = "Circuit Crate (Odysseus)"
-	contains = list(/obj/item/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer
-					/obj/item/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
+	contains = list(/obj/item/circuitboard/mecha/odysseus/peripherals,
+					/obj/item/circuitboard/mecha/odysseus/main)
 	cost = 25
 	containername = "\improper \"Odysseus\" circuit crate"
+
+/datum/supply_packs/science/robotics/mecha_gygax
+	name = "Circuit Crate (Gygax)"
+	contains = list(/obj/item/circuitboard/mecha/gygax/main,
+					/obj/item/circuitboard/mecha/gygax/peripherals,
+					/obj/item/circuitboard/mecha/gygax/targeting)
+	cost = 50
+	containername = "\improper \"Gygax\" circuit crate"
+
+/datum/supply_packs/science/robotics/mecha_durand
+	name = "Circuit Crate (Durand)"
+	contains = list(/obj/item/circuitboard/mecha/durand/main,
+					/obj/item/circuitboard/mecha/durand/peripherals,
+					/obj/item/circuitboard/mecha/durand/targeting)
+	cost = 50
+	containername = "\improper \"Durand\" circuit crate"
+
+/datum/supply_packs/science/robotics/mecha_phazon
+	name = "Circuit Crate (Phazon)"
+	contains = list(/obj/item/circuitboard/mecha/phazon/main,
+					/obj/item/circuitboard/mecha/phazon/peripherals,
+					/obj/item/circuitboard/mecha/phazon/targeting)
+	cost = 100
+	containername = "\improper \"Phazon\" circuit crate"
 
 /datum/supply_packs/science/plasma
 	name = "Plasma Assembly Crate"

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -331,7 +331,7 @@
 					 		"backkey"=TOOL_CROWBAR,
 					 		"desc"="Scanning module is installed."),
 					 //12
-					 list("key"=/obj/item/circuitboard/mecha/gygax/targeting,
+					 list("key"=/obj/item/circuitboard/mecha/generic_targetting,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="Peripherals control module is secured."),
 					 //13
@@ -448,7 +448,7 @@
 				holder.icon_state = "gygax10"
 			else
 				user.visible_message("[user] removes the weapon control module from the [holder].", "You remove the weapon control module from the [holder].")
-				new /obj/item/circuitboard/mecha/gygax/targeting(get_turf(holder))
+				new /obj/item/circuitboard/mecha/generic_targetting(get_turf(holder))
 				holder.icon_state = "gygax8"
 		if(10)
 			if(diff==FORWARD)
@@ -987,7 +987,7 @@
 					 		"backkey"=TOOL_CROWBAR,
 					 		"desc"="Scanning module is installed."),
 					 //12
-					 list("key"=/obj/item/circuitboard/mecha/durand/targeting,
+					 list("key"=/obj/item/circuitboard/mecha/generic_targetting,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="Peripherals control module is secured."),
 					 //13
@@ -1105,7 +1105,7 @@
 				holder.icon_state = "durand10"
 			else
 				user.visible_message("[user] removes the weapon control module from the [holder].", "You remove the weapon control module from the [holder].")
-				new /obj/item/circuitboard/mecha/durand/targeting(get_turf(holder))
+				new /obj/item/circuitboard/mecha/generic_targetting(get_turf(holder))
 				holder.icon_state = "durand8"
 		if(10)
 			if(diff==FORWARD)
@@ -1285,7 +1285,7 @@
 					 		"backkey"=TOOL_CROWBAR,
 					 		"desc"="Scanning module is installed."),
 					 //16
-					 list("key"=/obj/item/circuitboard/mecha/phazon/targeting,
+					 list("key"=/obj/item/circuitboard/mecha/generic_targetting,
 					 		"backkey"=TOOL_SCREWDRIVER,
 					 		"desc"="Peripherals control module is secured."),
 					 //17
@@ -1403,7 +1403,7 @@
 				holder.icon_state = "phazon10"
 			else
 				user.visible_message("[user] removes the weapon control module from the [holder].", "You remove the weapon control module from the [holder].")
-				new /obj/item/circuitboard/mecha/phazon/targeting(get_turf(holder))
+				new /obj/item/circuitboard/mecha/generic_targetting(get_turf(holder))
 				holder.icon_state = "phazon8"
 		if(14)
 			if(diff==FORWARD)

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -364,17 +364,18 @@
 	name = "Circuit board (Ripley Central Control module)"
 	icon_state = "mainboard"
 
+/obj/item/circuitboard/mecha/generic_targetting
+	name = "Circuit Board (Combat Exosuit Weapons Control and Targetting module)"
+	desc = "The sophisticated components required to interface with and control an Exosuit's weaponry. To control the proliferation of such heavy and destructive technology, they are generally only produced in a few select facilities and shipped to where the rest of the weapon is assembled."
+	origin_tech = "Programming=4;combat=3;engineering=3"
+	icon_state = "mcontroller"
+
 /obj/item/circuitboard/mecha/gygax
 	origin_tech = "programming=4;combat=3;engineering=3"
 
 /obj/item/circuitboard/mecha/gygax/peripherals
 	name = "Circuit board (Gygax Peripherals Control module)"
 	icon_state = "mcontroller"
-
-/obj/item/circuitboard/mecha/gygax/targeting
-	name = "Circuit board (Gygax Weapon Control and Targeting module)"
-	icon_state = "mcontroller"
-	origin_tech = "programming=4;combat=4"
 
 /obj/item/circuitboard/mecha/gygax/main
 	name = "Circuit board (Gygax Central Control module)"
@@ -387,11 +388,6 @@
 	name = "Circuit board (Durand Peripherals Control module)"
 	icon_state = "mcontroller"
 
-/obj/item/circuitboard/mecha/durand/targeting
-	name = "Circuit board (Durand Weapon Control and Targeting module)"
-	icon_state = "mcontroller"
-	origin_tech = "programming=4;combat=4;engineering=3"
-
 /obj/item/circuitboard/mecha/durand/main
 	name = "Circuit board (Durand Central Control module)"
 	icon_state = "mainboard"
@@ -401,10 +397,6 @@
 
 /obj/item/circuitboard/mecha/phazon/peripherals
 	name = "Circuit board (Phazon Peripherals Control module)"
-	icon_state = "mcontroller"
-
-/obj/item/circuitboard/mecha/phazon/targeting
-	name = "Circuit board (Phazon Weapon Control and Targeting module)"
 	icon_state = "mcontroller"
 
 /obj/item/circuitboard/mecha/phazon/main

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -78,6 +78,7 @@
 	new /obj/item/reagent_containers/food/drinks/mug/rd(src)
 	new /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic(src)
 	new /obj/item/clothing/accessory/medal/science(src)
+	new /obj/item/circuitboard/mecha/generic_targetting(src)
 
 /obj/structure/closet/secure_closet/research_reagents
 	name = "research chemical storage closet"

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -43,12 +43,22 @@
 	build_path = /obj/item/circuitboard/mecha/odysseus/peripherals
 	category = list("Exosuit Modules")
 
+/datum/design/generic_combat_targetting
+	name = "Exosuit Board (Combat Exosuit Weapons Control and Targetting Module)"
+	desc = "Allows for the construction of an Exosuit Weapons Control and Targetting Module."
+	id = "mecha_weapon_targ"
+	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4, "syndicate" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/mecha/generic_targetting
+	category = list("Exosuit Modules")
+
 // Gygax
 /datum/design/gygax_main
 	name = "Exosuit Board (\"Gygax\" Central Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Central Control module."
 	id = "gygax_main"
-	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4, "syndicate" = 3)
+	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/gygax/main
@@ -58,28 +68,19 @@
 	name = "Exosuit Board (\"Gygax\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Peripheral Control module."
 	id = "gygax_peri"
-	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4, "syndicate" = 3)
+	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/gygax/peripherals
 	category = list("Exosuit Modules")
 
-/datum/design/gygax_targ
-	name = "Exosuit Board (\"Gygax\" Weapons & Targeting Control module)"
-	desc = "Allows for the construction of a \"Gygax\" Weapons & Targeting Control module."
-	id = "gygax_targ"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4, "syndicate" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000)
-	build_path = /obj/item/circuitboard/mecha/gygax/targeting
-	category = list("Exosuit Modules")
 
 // Durand
 /datum/design/durand_main
 	name = "Exosuit Board (\"Durand\" Central Control module)"
 	desc = "Allows for the construction of a \"Durand\" Central Control module."
 	id = "durand_main"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4, "syndicate" = 3)
+	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/durand/main
@@ -89,20 +90,10 @@
 	name = "Exosuit Board (\"Durand\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Durand\" Peripheral Control module."
 	id = "durand_peri"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4, "syndicate" = 3)
+	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/durand/peripherals
-	category = list("Exosuit Modules")
-
-/datum/design/durand_targ
-	name = "Exosuit Board (\"Durand\" Weapons & Targeting Control module)"
-	desc = "Allows for the construction of a \"Durand\" Weapons & Targeting Control module."
-	id = "durand_targ"
-	req_tech = list("programming" = 5, "combat" = 4, "engineering" = 4, "syndicate" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000)
-	build_path = /obj/item/circuitboard/mecha/durand/targeting
 	category = list("Exosuit Modules")
 
 // Phazon
@@ -110,7 +101,7 @@
 	name = "Exosuit Board (\"Phazon\" Central Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Central Control module."
 	id = "phazon_main"
-	req_tech = list("programming" = 6, "materials" = 6, "plasmatech" = 5, "syndicate" = 3)
+	req_tech = list("programming" = 6, "materials" = 6, "plasmatech" = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 100)
 	build_path = /obj/item/circuitboard/mecha/phazon/main
@@ -120,20 +111,10 @@
 	name = "Exosuit Board (\"Phazon\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Peripheral Control module."
 	id = "phazon_peri"
-	req_tech = list("programming" = 6, "bluespace" = 5, "plasmatech" = 5, "syndicate" = 3)
+	req_tech = list("programming" = 6, "bluespace" = 5, "plasmatech" = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 100)
 	build_path = /obj/item/circuitboard/mecha/phazon/peripherals
-	category = list("Exosuit Modules")
-
-/datum/design/phazon_targ
-	name = "Exosuit Design (\"Phazon\" Weapons & Targeting Control module)"
-	desc = "Allows for the construction of a \"Phazon\" Weapons & Targeting Control module."
-	id = "phazon_targ"
-	req_tech = list("programming" = 6, "magnets" = 5, "plasmatech" = 5, "syndicate" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 100)
-	build_path = /obj/item/circuitboard/mecha/phazon/targeting
 	category = list("Exosuit Modules")
 
 // H.O.N.K.

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -48,7 +48,7 @@
 	name = "Exosuit Board (\"Gygax\" Central Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Central Control module."
 	id = "gygax_main"
-	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
+	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/gygax/main
@@ -58,7 +58,7 @@
 	name = "Exosuit Board (\"Gygax\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Peripheral Control module."
 	id = "gygax_peri"
-	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
+	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/gygax/peripherals
@@ -68,7 +68,7 @@
 	name = "Exosuit Board (\"Gygax\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Weapons & Targeting Control module."
 	id = "gygax_targ"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/gygax/targeting
@@ -79,7 +79,7 @@
 	name = "Exosuit Board (\"Durand\" Central Control module)"
 	desc = "Allows for the construction of a \"Durand\" Central Control module."
 	id = "durand_main"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/durand/main
@@ -89,7 +89,7 @@
 	name = "Exosuit Board (\"Durand\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Durand\" Peripheral Control module."
 	id = "durand_peri"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/durand/peripherals
@@ -99,7 +99,7 @@
 	name = "Exosuit Board (\"Durand\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Durand\" Weapons & Targeting Control module."
 	id = "durand_targ"
-	req_tech = list("programming" = 5, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 5, "combat" = 4, "engineering" = 4, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/mecha/durand/targeting
@@ -110,7 +110,7 @@
 	name = "Exosuit Board (\"Phazon\" Central Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Central Control module."
 	id = "phazon_main"
-	req_tech = list("programming" = 6, "materials" = 6, "plasmatech" = 5)
+	req_tech = list("programming" = 6, "materials" = 6, "plasmatech" = 5, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 100)
 	build_path = /obj/item/circuitboard/mecha/phazon/main
@@ -120,7 +120,7 @@
 	name = "Exosuit Board (\"Phazon\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Peripheral Control module."
 	id = "phazon_peri"
-	req_tech = list("programming" = 6, "bluespace" = 5, "plasmatech" = 5)
+	req_tech = list("programming" = 6, "bluespace" = 5, "plasmatech" = 5, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 100)
 	build_path = /obj/item/circuitboard/mecha/phazon/peripherals
@@ -130,7 +130,7 @@
 	name = "Exosuit Design (\"Phazon\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Weapons & Targeting Control module."
 	id = "phazon_targ"
-	req_tech = list("programming" = 6, "magnets" = 5, "plasmatech" = 5)
+	req_tech = list("programming" = 6, "magnets" = 5, "plasmatech" = 5, "syndicate" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_BLUESPACE = 100)
 	build_path = /obj/item/circuitboard/mecha/phazon/targeting


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is an alternative to my other PR, #13715 , based on some comments I got on there and in the coder_chat on discord.

First, this PR makes it so all three combat mechs (durand, gygax, phazon) now share an Exosuit Weapons Targetting circuitboard, which takes the place of their individual circuitboards. Secondly, said circuitboard requires illegals 3 to create on a circuit printer, but can be ordered from cargo for 50 points. Thirdly, a single such circuitboard starts the round in the RD's locker, allowing them to build a single combat mech for free and giving the RD more control over when/if a mech gets built.

The other circuitboards (main and peripherals) are unaffected and are still required, which addresses the concern that cargo could build their own combat mechs.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mechs are way too cheap and accessible, it is not uncommon for crew to build 3+ mechs on code green just in case. A powerful weapon like a Durand should be a significant investment of resources. Requiring cargo points and inter-department cooperation ensures that they are only built when needed or when people go out of their way for it. Cargo is unlikely to just order you 5 boards so you can give every sec member their own personal mech, for example.

This version of the PR leaves the first mech free and ensures you still need circuit printer access to get the other boards. As in the first version, illegals 3 means you get to make your own mech, to aid traitors with an RD that refuses to hand over the board, etc.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: A generic mecha weapons targetting circuitboard, orderable from cargo or buildable with illegal research
add: A mecha targetting circuitboard to the RD locker
tweak: Mechas now need a generic mecha targetting circuitboard, which can be gotten from cargo or the RD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
