### PR TITLE
Fixes Random Drugs failing Travis and Maint Loot

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -6,7 +6,7 @@
 	var/lootdoubles = 1		//if the same item can be spawned twice
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
 
-/obj/effect/spawner/lootdrop/Initialize(mapload)
+/obj/effect/spawner/lootdrop/New()
 	..()
 	if(loot && loot.len)
 		for(var/i = lootcount, i > 0, i--)
@@ -17,7 +17,7 @@
 
 			if(lootspawn)
 				new lootspawn(loc)
-	return INITIALIZE_HINT_QDEL
+	qdel(src)
 
 /obj/effect/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -56,7 +56,7 @@
 	desc = "Huh."
 	allow_wrap = FALSE
 
-/obj/item/storage/pill_bottle/random_drug_bottle/New()
-	..()
+/obj/item/storage/pill_bottle/random_drug_bottle/Initialize(mapload)
+	. = ..()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/food/pill/random_drugs(src)


### PR DESCRIPTION
If the random drugs happen to contain two chems that can react together, they throw a runtime in travis.

This is the issue with relying on `New` right now, over `Initialize`.

Ideally all storage would be converted to `Initialize`, but this is a bandaid fix for the problem.

Also loot properly spawns inside things, once again

:cl: Fox McCloud
fix: Fixes maintenance loot spawning outside of things
/:cl: