### PR TITLE
Add ability to VV an object's armor easily

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -819,6 +819,59 @@
 		message_admins("<span class='notice'>[key_name(usr)] has made [A] process normally</span>")
 		return TRUE
 
+	else if(href_list["modifyarmor"])
+		if(!check_rights(R_DEBUG|R_ADMIN))
+			return
+		var/obj/A = locateUID(href_list["modifyarmor"])
+		if(!istype(A))
+			return
+		A.var_edited = TRUE
+		var/list/armorlist = A.armor.getList()
+		var/list/displaylist
+
+		var/result
+		do
+			displaylist = list()
+			for(var/key in armorlist)
+				displaylist += "[key] = [armorlist[key]]"
+			result = input(usr, "Select an armor type to modify..", "Modify armor") as null|anything in displaylist + "(ADD ALL)" + "(SET ALL)" + "(DONE)"
+
+			if(result == "(DONE)")
+				break
+			else if(result == "(ADD ALL)" || result == "(SET ALL)")
+				var/new_amount = input(usr, result == "(ADD ALL)" ? "Enter armor to add to all types:" : "Enter new armor value for all types:", "Modify all types") as num|null
+				if(isnull(new_amount))
+					continue
+				var/proper_amount = text2num(new_amount)
+				if(isnull(proper_amount))
+					continue
+				for(var/key in armorlist)
+					armorlist[key] = (result == "(ADD ALL)" ? armorlist[key] : 0) + proper_amount
+			else if(result)
+				var/list/fields = splittext(result, " = ")
+				if(length(fields) != 2)
+					continue
+				var/type = fields[1]
+				if(isnull(armorlist[type]))
+					continue
+				var/new_amount = input(usr, "Enter new armor value for [type]:", "Modify [type]") as num|null
+				if(isnull(new_amount))
+					continue
+				var/proper_amount = text2num(new_amount)
+				if(isnull(proper_amount))
+					continue
+				armorlist[type] = proper_amount
+		while(result)
+
+		if(!result || !A)
+			return TRUE
+
+		A.armor = A.armor.setRating(armorlist["melee"], armorlist["bullet"], armorlist["laser"], armorlist["energy"], armorlist["bomb"], armorlist["bio"], armorlist["rad"], armorlist["fire"], armorlist["acid"], armorlist["magic"])
+
+		log_admin("[key_name(usr)] modified the armor on [A] to: melee = [armorlist["melee"]], bullet = [armorlist["bullet"]], laser = [armorlist["laser"]], energy = [armorlist["energy"]], bomb = [armorlist["bomb"]], bio = [armorlist["bio"]], rad = [armorlist["rad"]], fire = [armorlist["fire"]], acid = [armorlist["acid"]], magic = [armorlist["magic"]]")
+		message_admins("<span class='notice'>[key_name(usr)] modified the armor on [A] to: melee = [armorlist["melee"]], bullet = [armorlist["bullet"]], laser = [armorlist["laser"]], energy = [armorlist["energy"]], bomb = [armorlist["bomb"]], bio = [armorlist["bio"]], rad = [armorlist["rad"]], fire = [armorlist["fire"]], acid = [armorlist["acid"]], magic = [armorlist["magic"]]")
+		return TRUE
+
 	else if(href_list["addreagent"]) /* Made on /TG/, credit to them. */
 		if(!check_rights(R_DEBUG|R_ADMIN))	return
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -347,6 +347,7 @@ a {
 		.["Make speed process"] = "?_src_=vars;makespeedy=[UID()]"
 	else
 		.["Make normal process"] = "?_src_=vars;makenormalspeed=[UID()]"
+	.["Modify armor values"] = "?_src_=vars;modifyarmor=[UID()]"
 
 /obj/proc/check_uplink_validity()
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a VV option on all objects called **Modify armor values**. As the name suggests, it allows for editing an item's armor values. Either individually or blanket setting all of them

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes it less of a pain for admins to modify an object's armor for events and such

## Changelog
:cl:
add: Add option to easily modify an object's armor through VV for admins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
