### PR TITLE
Genetics DNA Modifier Fixes

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -125,7 +125,7 @@
 	eject_occupant(null, TRUE)
 	return ..()
 
-/obj/machinery/dna_scannernew/proc/eject_occupant(user = null, force = FALSE)
+/obj/machinery/dna_scannernew/proc/eject_occupant(user, force)
 	go_out(user, force)
 	for(var/obj/O in src)
 		if(!istype(O,/obj/item/circuitboard/clonescanner) && \
@@ -274,11 +274,10 @@
 		if(user)
 			to_chat(user, "<span class='warning'>The scanner is empty!</span>")
 		return
-	if(locked)
+	if(locked && !force)
 		if(user)
 			to_chat(user, "<span class='warning'>The scanner is locked!</span>")
-		if(!force)
-			return
+		return
 	occupant.forceMove(loc)
 	occupant = null
 	icon_state = "scanner_open"

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -118,17 +118,15 @@
 
 	if(usr.incapacitated())
 		return
-
-	eject_occupant()
-
+	eject_occupant(usr)
 	add_fingerprint(usr)
 
 /obj/machinery/dna_scannernew/Destroy()
-	eject_occupant(TRUE)
+	eject_occupant(null, TRUE)
 	return ..()
 
-/obj/machinery/dna_scannernew/proc/eject_occupant(force)
-	go_out(force)
+/obj/machinery/dna_scannernew/proc/eject_occupant(user = null, force = FALSE)
+	go_out(user, force)
 	for(var/obj/O in src)
 		if(!istype(O,/obj/item/circuitboard/clonescanner) && \
 		   !istype(O,/obj/item/stock_parts) && \
@@ -271,14 +269,14 @@
 
 		occupant.notify_ghost_cloning(source = src)
 
-/obj/machinery/dna_scannernew/proc/go_out(force)
+/obj/machinery/dna_scannernew/proc/go_out(mob/user, force)
 	if(!occupant)
-		if(usr)
-			to_chat(usr, "<span class='warning'>The scanner is empty!</span>")
+		if(user)
+			to_chat(user, "<span class='warning'>The scanner is empty!</span>")
 		return
 	if(locked)
-		if(usr)
-			to_chat(usr, "<span class='warning'>The scanner is locked!</span>")
+		if(user)
+			to_chat(user, "<span class='warning'>The scanner is locked!</span>")
 		if(!force)
 			return
 	occupant.forceMove(loc)
@@ -752,7 +750,7 @@
 		return TRUE
 
 	if(href_list["ejectOccupant"])
-		connected.eject_occupant()
+		connected.eject_occupant(usr)
 		return TRUE
 
 	// Transfer Buffer Management

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -124,11 +124,11 @@
 	add_fingerprint(usr)
 
 /obj/machinery/dna_scannernew/Destroy()
-	eject_occupant()
+	eject_occupant(TRUE)
 	return ..()
 
-/obj/machinery/dna_scannernew/proc/eject_occupant()
-	go_out()
+/obj/machinery/dna_scannernew/proc/eject_occupant(force)
+	go_out(force)
 	for(var/obj/O in src)
 		if(!istype(O,/obj/item/circuitboard/clonescanner) && \
 		   !istype(O,/obj/item/stock_parts) && \
@@ -271,15 +271,16 @@
 
 		occupant.notify_ghost_cloning(source = src)
 
-/obj/machinery/dna_scannernew/proc/go_out()
+/obj/machinery/dna_scannernew/proc/go_out(force)
 	if(!occupant)
-		to_chat(usr, "<span class='warning'>The scanner is empty!</span>")
+		if(usr)
+			to_chat(usr, "<span class='warning'>The scanner is empty!</span>")
 		return
-
 	if(locked)
-		to_chat(usr, "<span class='warning'>The scanner is locked!</span>")
-		return
-
+		if(usr)
+			to_chat(usr, "<span class='warning'>The scanner is locked!</span>")
+		if(!force)
+			return
 	occupant.forceMove(loc)
 	occupant = null
 	icon_state = "scanner_open"


### PR DESCRIPTION
## What Does This PR Do
1) Fixes this runtime:
[2020-06-29T23:37:06] Runtime in ,: DEBUG: to_chat called with invalid message/target.
   Message: '<span class='warning'>The scanner is locked!</span>'
   Target: ''
This runtime is caused by dna_scannernew/proc/go_out() assuming that 'usr' is defined when it often isn't.
To fix it, the code is altered so it only attempts to to_chat(usr, ...) if usr exists.

2) Fixes bodies inside a locked DNA scanner not being ejected by Destroy() on the scanner
This was caused by the fact that go_out returns early if the dna scanner is locked... even when go_out is invoked via Destroy() -> eject_occupant() -> go_out(). 
To fix this one, a force param is added to the procs, so that when they're invoked from Destroy() the person is ejected even if the scanner is locked.

## Why It's Good For The Game
1) fixes a common runtime error
2) fixes an oversight

## Changelog
:cl: Kyep
fix: fixed locked DNA scanners in genetics generating runtimes and some other weird behavior
/:cl: