### PR TITLE
Removes isSynthetic() helper, replaces its instances with ismachineperson()

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -196,7 +196,7 @@
 #define isslimeperson(A) (is_species(A, /datum/species/slime))
 #define isgrey(A) (is_species(A, /datum/species/grey))
 #define isdiona(A) (is_species(A, /datum/species/diona))
-#define ismachine(A) (is_species(A, /datum/species/machine))
+#define ismachineperson(A) (is_species(A, /datum/species/machine))
 #define isdrask(A) (is_species(A, /datum/species/drask))
 
 #define isanimal(A)		(istype((A), /mob/living/simple_animal))

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -63,7 +63,7 @@
 	if(!istype(user)) // Make sure user is actually an observer. Revenents also use attack_ghost, but do not have the health_scan var.
 		return
 	if(user.client && user.health_scan)
-		if(issilicon(src) || ismachine(src))
+		if(issilicon(src) || ismachineperson(src))
 			robot_healthscan(user, src)
 		else if(ishuman(src))
 			healthscan(user, src, 1, TRUE)

--- a/code/datums/diseases/critical.dm
+++ b/code/datums/diseases/critical.dm
@@ -159,7 +159,7 @@
 		var/mob/living/carbon/human/H = affected_mob
 		if(NO_HUNGER in H.dna.species.species_traits)
 			return TRUE
-		if(ismachine(H))
+		if(ismachineperson(H))
 			return TRUE
 	return ..()
 

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -36,7 +36,7 @@
 		to_chat(user, "We haven't prepared our sting yet!")
 	if(!iscarbon(target))
 		return
-	if(ismachine(target))
+	if(ismachineperson(target))
 		to_chat(user, "<span class='warning'>This won't work on synthetics.</span>")
 		return
 	if(!isturf(user.loc))

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -36,11 +36,9 @@
 		to_chat(user, "We haven't prepared our sting yet!")
 	if(!iscarbon(target))
 		return
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(H.isSynthetic())
-			to_chat(user, "<span class='warning'>This won't work on synthetics.</span>")
-			return
+	if(ismachine(target))
+		to_chat(user, "<span class='warning'>This won't work on synthetics.</span>")
+		return
 	if(!isturf(user.loc))
 		return
 	if(!AStar(user, target.loc, /turf/proc/Distance, user.mind.changeling.sting_range, simulated_only = 0))

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -604,7 +604,7 @@
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
 			L.electrocute_act(0, src, 1, TRUE, TRUE)
-			if(isrobot(L) || ismachine(L))
+			if(isrobot(L) || ismachineperson(L))
 				L.Weaken(5)
 			qdel(src)
 	..()

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -604,7 +604,7 @@
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
 			L.electrocute_act(0, src, 1, TRUE, TRUE)
-			if(isrobot(L) || L.isSynthetic())
+			if(isrobot(L) || ismachine(L))
 				L.Weaken(5)
 			qdel(src)
 	..()

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -470,7 +470,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 				M.equip_to_slot_or_del(sword, slot_r_hand)
 
 			if("cyborg")
-				if(!ismachine(M))
+				if(!ismachineperson(M))
 					for(var/obj/item/organ/O in M.bodyparts)
 						O.robotize(make_tough = 1)
 				M.equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/eyepatch(M), slot_glasses)

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -282,14 +282,14 @@
 	if(visualsOnly)
 		return
 
-	if(ismachine(H))
+	if(ismachineperson(H))
 		var/obj/item/organ/internal/cyberimp/brain/clown_voice/implant = new
 		implant.insert(H)
 
 	H.dna.SetSEState(GLOB.clumsyblock, TRUE)
 	genemutcheck(H, GLOB.clumsyblock, null, MUTCHK_FORCED)
 	H.dna.default_blocks.Add(GLOB.clumsyblock)
-	if(!ismachine(H))
+	if(!ismachineperson(H))
 		H.dna.SetSEState(GLOB.comicblock, TRUE)
 		genemutcheck(H, GLOB.comicblock, null, MUTCHK_FORCED)
 		H.dna.default_blocks.Add(GLOB.comicblock)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -141,7 +141,7 @@ REAGENT SCANNER
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/M, mode = 1, advanced = FALSE)
-	if(!ishuman(M) || ismachine(M))
+	if(!ishuman(M) || ismachineperson(M))
 		//these sensors are designed for organic life
 		to_chat(user, "<span class='notice'>Analyzing Results for ERROR:\n\t Overall Status: ERROR</span>")
 		to_chat(user, "\t Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -141,7 +141,7 @@ REAGENT SCANNER
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/M, mode = 1, advanced = FALSE)
-	if(!ishuman(M) || M.isSynthetic())
+	if(!ishuman(M) || ismachine(M))
 		//these sensors are designed for organic life
 		to_chat(user, "<span class='notice'>Analyzing Results for ERROR:\n\t Overall Status: ERROR</span>")
 		to_chat(user, "\t Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>")

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -57,7 +57,7 @@
 					E.heal_damage(0, remheal, 0, 1) //Healing Burn
 					remheal = nremheal
 					user.visible_message("<span class='notice'>\The [user] applies some nanite paste at \the [M]'s [E.name] with \the [src].</span>")
-				if(H.bleed_rate && ismachine(H))
+				if(H.bleed_rate && ismachineperson(H))
 					H.bleed_rate = 0
 			else
 				to_chat(user, "<span class='notice'>Nothing to fix here.</span>")

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -57,7 +57,7 @@
 					E.heal_damage(0, remheal, 0, 1) //Healing Burn
 					remheal = nremheal
 					user.visible_message("<span class='notice'>\The [user] applies some nanite paste at \the [M]'s [E.name] with \the [src].</span>")
-				if(H.bleed_rate && H.isSynthetic())
+				if(H.bleed_rate && ismachine(H))
 					H.bleed_rate = 0
 			else
 				to_chat(user, "<span class='notice'>Nothing to fix here.</span>")

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -48,7 +48,7 @@
 
 	var/mob/living/carbon/human/target = M
 
-	if(ismachine(target))
+	if(ismachineperson(target))
 		to_chat(user, "<span class= 'notice'>[target] has no skin, how do you expect to tattoo [target.p_them()]?</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -6,7 +6,7 @@
 	canmove = 0
 	icon = null
 	invisibility = 101
-	if(!isSynthetic())
+	if(!ismachine(src))
 		animation = new(loc)
 		animation.icon_state = "blank"
 		animation.icon = 'icons/mob/mob.dmi'
@@ -37,7 +37,7 @@
 		M.forceMove(get_turf(src))
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
 
-	if(!isSynthetic())
+	if(!ismachine(src))
 		flick("gibbed-h", animation)
 		hgibs(loc, dna)
 	else

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -6,7 +6,7 @@
 	canmove = 0
 	icon = null
 	invisibility = 101
-	if(!ismachine(src))
+	if(!ismachineperson(src))
 		animation = new(loc)
 		animation.icon_state = "blank"
 		animation.icon = 'icons/mob/mob.dmi'
@@ -37,7 +37,7 @@
 		M.forceMove(get_turf(src))
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
 
-	if(!ismachine(src))
+	if(!ismachineperson(src))
 		flick("gibbed-h", animation)
 		hgibs(loc, dna)
 	else

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -34,7 +34,7 @@
 		//Cooldown-inducing emotes
 		if("ping", "pings", "buzz", "buzzes", "beep", "beeps", "yes", "no", "buzz2")
 			var/found_machine_head = FALSE
-			if(ismachine(src))		//Only Machines can beep, ping, and buzz, yes, no, and make a silly sad trombone noise.
+			if(ismachineperson(src))		//Only Machines can beep, ping, and buzz, yes, no, and make a silly sad trombone noise.
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
 				found_machine_head = TRUE
 			else
@@ -947,7 +947,7 @@
 				if("Skrell")
 					emotelist += "\nSkrell specific emotes :- warble(s)"
 
-			if(ismachine(src))
+			if(ismachineperson(src))
 				emotelist += "\nMachine specific emotes :- beep(s)-(none)/mob, buzz(es)-none/mob, no-(none)/mob, ping(s)-(none)/mob, yes-(none)/mob, buzz2-(none)/mob"
 			else
 				var/obj/item/organ/external/head/H = get_organ("head") // If you have a robotic head, you can make beep-boop noises

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -208,7 +208,7 @@
 		if(!E)
 			wound_flavor_text["[organ_tag]"] = "<B>[p_they(TRUE)] [p_are()] missing [p_their()] [organ_descriptor].</B>\n"
 		else
-			if(!ismachine(src))
+			if(!ismachineperson(src))
 				if(E.is_robotic())
 					wound_flavor_text["[E.limb_name]"] = "[p_they(TRUE)] [p_have()] a robotic [E.name]!\n"
 
@@ -252,7 +252,7 @@
 	var/temp = getBruteLoss() //no need to calculate each of these twice
 
 	if(temp)
-		var/brute_message = !ismachine(src) ? "bruising" : "denting"
+		var/brute_message = !ismachineperson(src) ? "bruising" : "denting"
 		if(temp < 30)
 			msg += "[p_they(TRUE)] [p_have()] minor [brute_message ].\n"
 		else
@@ -301,13 +301,13 @@
 	else if(nutrition >= NUTRITION_LEVEL_FAT)
 		msg += "[p_they(TRUE)] [p_are()] quite chubby.\n"
 
-	if(!ismachine(src) && blood_volume < BLOOD_VOLUME_SAFE)
+	if(!ismachineperson(src) && blood_volume < BLOOD_VOLUME_SAFE)
 		msg += "[p_they(TRUE)] [p_have()] pale skin.\n"
 
 	if(bleedsuppress)
 		msg += "[p_they(TRUE)] [p_are()] bandaged with something.\n"
 	else if(bleed_rate)
-		var/bleed_message = !ismachine(src) ? "bleeding" : "leaking"
+		var/bleed_message = !ismachineperson(src) ? "bleeding" : "leaking"
 		msg += "<B>[p_they(TRUE)] [p_are()] [bleed_message]!</B>\n"
 
 	if(reagents.has_reagent("teslium"))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -208,7 +208,7 @@
 		if(!E)
 			wound_flavor_text["[organ_tag]"] = "<B>[p_they(TRUE)] [p_are()] missing [p_their()] [organ_descriptor].</B>\n"
 		else
-			if(!isSynthetic())
+			if(!ismachine(src))
 				if(E.is_robotic())
 					wound_flavor_text["[E.limb_name]"] = "[p_they(TRUE)] [p_have()] a robotic [E.name]!\n"
 
@@ -252,7 +252,7 @@
 	var/temp = getBruteLoss() //no need to calculate each of these twice
 
 	if(temp)
-		var/brute_message = !isSynthetic() ? "bruising" : "denting"
+		var/brute_message = !ismachine(src) ? "bruising" : "denting"
 		if(temp < 30)
 			msg += "[p_they(TRUE)] [p_have()] minor [brute_message ].\n"
 		else
@@ -301,13 +301,13 @@
 	else if(nutrition >= NUTRITION_LEVEL_FAT)
 		msg += "[p_they(TRUE)] [p_are()] quite chubby.\n"
 
-	if(!isSynthetic() && blood_volume < BLOOD_VOLUME_SAFE)
+	if(!ismachine(src) && blood_volume < BLOOD_VOLUME_SAFE)
 		msg += "[p_they(TRUE)] [p_have()] pale skin.\n"
 
 	if(bleedsuppress)
 		msg += "[p_they(TRUE)] [p_are()] bandaged with something.\n"
 	else if(bleed_rate)
-		var/bleed_message = !isSynthetic() ? "bleeding" : "leaking"
+		var/bleed_message = !ismachine(src) ? "bleeding" : "leaking"
 		msg += "<B>[p_they(TRUE)] [p_are()] [bleed_message]!</B>\n"
 
 	if(reagents.has_reagent("teslium"))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1701,14 +1701,14 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 /mob/living/carbon/human/forceFed(var/obj/item/reagent_containers/food/toEat, mob/user, fullness)
 	if(!check_has_mouth())
-		if(!((istype(toEat, /obj/item/reagent_containers/food/drinks) && (ismachine(src)))))
+		if(!((istype(toEat, /obj/item/reagent_containers/food/drinks) && (ismachineperson(src)))))
 			to_chat(user, "Where do you intend to put \the [toEat]? \The [src] doesn't have a mouth!")
 			return 0
 	return ..()
 
 /mob/living/carbon/human/selfDrink(var/obj/item/reagent_containers/food/drinks/toDrink)
 	if(!check_has_mouth())
-		if(!ismachine(src))
+		if(!ismachineperson(src))
 			to_chat(src, "Where do you intend to put \the [src]? You don't have a mouth!")
 			return 0
 		else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -84,7 +84,7 @@ emp_act
 		E.heal_damage(rembrute,0,0,1)
 		rembrute = nrembrute
 		user.visible_message("<span class='alert'>[user] patches some dents on [src]'s [E.name] with [I].</span>")
-	if(bleed_rate && isSynthetic())
+	if(bleed_rate && ismachine(src))
 		bleed_rate = 0
 		user.visible_message("<span class='alert'>[user] patches some leaks on [src] with [I].</span>")
 	if(IgniteMob())

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -84,7 +84,7 @@ emp_act
 		E.heal_damage(rembrute,0,0,1)
 		rembrute = nrembrute
 		user.visible_message("<span class='alert'>[user] patches some dents on [src]'s [E.name] with [I].</span>")
-	if(bleed_rate && ismachine(src))
+	if(bleed_rate && ismachineperson(src))
 		bleed_rate = 0
 		user.visible_message("<span class='alert'>[user] patches some leaks on [src] with [I].</span>")
 	if(IgniteMob())

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -635,7 +635,7 @@
 				else
 					overeatduration -= 2
 
-		if(!ismachine(src) && nutrition < NUTRITION_LEVEL_HYPOGLYCEMIA) //Gosh damn snowflakey IPCs
+		if(!ismachineperson(src) && nutrition < NUTRITION_LEVEL_HYPOGLYCEMIA) //Gosh damn snowflakey IPCs
 			var/datum/disease/D = new /datum/disease/critical/hypoglycemia
 			ForceContractDisease(D)
 
@@ -697,7 +697,7 @@
 	alcohol_strength /= sober_str
 
 	var/obj/item/organ/internal/liver/L
-	if(!ismachine(src))
+	if(!ismachineperson(src))
 		L = get_int_organ(/obj/item/organ/internal/liver)
 		if(L)
 			alcohol_strength *= L.alcohol_intensity
@@ -719,7 +719,7 @@
 		AdjustConfused(3 / sober_str)
 	if(alcohol_strength >= blur_start) //blurry eyes
 		EyeBlurry(10 / sober_str)
-	if(!ismachine(src)) //stuff only for non-synthetics
+	if(!ismachineperson(src)) //stuff only for non-synthetics
 		if(alcohol_strength >= vomit_start) //vomiting
 			if(prob(8))
 				fakevomit()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -697,7 +697,7 @@
 	alcohol_strength /= sober_str
 
 	var/obj/item/organ/internal/liver/L
-	if(!isSynthetic())
+	if(!ismachine(src))
 		L = get_int_organ(/obj/item/organ/internal/liver)
 		if(L)
 			alcohol_strength *= L.alcohol_intensity
@@ -719,7 +719,7 @@
 		AdjustConfused(3 / sober_str)
 	if(alcohol_strength >= blur_start) //blurry eyes
 		EyeBlurry(10 / sober_str)
-	if(!isSynthetic()) //stuff only for non-synthetics
+	if(!ismachine(src)) //stuff only for non-synthetics
 		if(alcohol_strength >= vomit_start) //vomiting
 			if(prob(8))
 				fakevomit()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -376,7 +376,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	//base icons
 	var/icon/hair_standing	= new /icon('icons/mob/human_face.dmi',"bald_s")
-	if(head_organ.h_style && !(head && (head.flags & BLOCKHEADHAIR) && !(ismachine(src))))
+	if(head_organ.h_style && !(head && (head.flags & BLOCKHEADHAIR) && !(ismachineperson(src))))
 		var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_full_list[head_organ.h_style]
 		if(hair_style && hair_style.species_allowed)
 			if((head_organ.dna.species.name in hair_style.species_allowed) || (head_organ.dna.species.bodyflags & ALL_RPARTS)) //If the head's species is in the list of allowed species for the hairstyle, or the head's species is one flagged to have bodies comprised wholly of cybernetics...

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -376,7 +376,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	//base icons
 	var/icon/hair_standing	= new /icon('icons/mob/human_face.dmi',"bald_s")
-	if(head_organ.h_style && !(head && (head.flags & BLOCKHEADHAIR) && !(isSynthetic())))
+	if(head_organ.h_style && !(head && (head.flags & BLOCKHEADHAIR) && !(ismachine(src))))
 		var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_full_list[head_organ.h_style]
 		if(hair_style && hair_style.species_allowed)
 			if((head_organ.dna.species.name in hair_style.species_allowed) || (head_organ.dna.species.bodyflags & ALL_RPARTS)) //If the head's species is in the list of allowed species for the hairstyle, or the head's species is one flagged to have bodies comprised wholly of cybernetics...

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -61,7 +61,7 @@ proc/get_radio_key_from_channel(var/channel)
 	return default_language
 
 /mob/living/proc/handle_speech_problems(list/message_pieces, var/verb)
-	var/robot = ismachine(src)
+	var/robot = ismachineperson(src)
 	for(var/datum/multilingual_say_piece/S in message_pieces)
 		if(S.speaking && S.speaking.flags & NO_STUTTER)
 			continue

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -61,7 +61,7 @@ proc/get_radio_key_from_channel(var/channel)
 	return default_language
 
 /mob/living/proc/handle_speech_problems(list/message_pieces, var/verb)
-	var/robot = isSynthetic()
+	var/robot = ismachine(src)
 	for(var/datum/multilingual_say_piece/S in message_pieces)
 		if(S.speaking && S.speaking.flags & NO_STUTTER)
 			continue

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -313,7 +313,7 @@ proc/robot_healthscan(mob/user, mob/living/M)
 			if(!organ_found)
 				to_chat(user, "<span class='warning'>No prosthetics located.</span>")
 
-			if(ismachine(H))
+			if(ismachineperson(H))
 				to_chat(user, "<span class='notice'>Internal Fluid Level:[H.blood_volume]/[H.max_blood]</span>")
 				if(H.bleed_rate)
 					to_chat(user, "<span class='warning'>Warning:External component leak detected!</span>")

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -253,7 +253,7 @@ proc/robot_healthscan(mob/user, mob/living/M)
 		to_chat(user, "<span class='warning'>You can't analyze non-robotic things!</span>")
 		return
 
-	
+
 	switch(scan_type)
 		if("robot")
 			var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
@@ -269,7 +269,7 @@ proc/robot_healthscan(mob/user, mob/living/M)
 			to_chat(user, "<span class='notice'>Localized Damage:</span>")
 			if(!LAZYLEN(damaged) && !LAZYLEN(missing))
 				to_chat(user, "<span class='notice'>\t Components are OK.</span>")
-			else 
+			else
 				if(LAZYLEN(damaged))
 					for(var/datum/robot_component/org in damaged)
 						user.show_message(text("<span class='notice'>\t []: [][] - [] - [] - []</span>",	\
@@ -282,7 +282,7 @@ proc/robot_healthscan(mob/user, mob/living/M)
 				if(LAZYLEN(missing))
 					for(var/datum/robot_component/org in missing)
 						user.show_message("<span class='warning'>\t [capitalize(org.name)]: MISSING</span>")
-				
+
 			if(H.emagged && prob(5))
 				to_chat(user, "<span class='warning'>\t ERROR: INTERNAL SYSTEMS COMPROMISED</span>")
 
@@ -313,7 +313,7 @@ proc/robot_healthscan(mob/user, mob/living/M)
 			if(!organ_found)
 				to_chat(user, "<span class='warning'>No prosthetics located.</span>")
 
-			if(H.isSynthetic())
+			if(ismachine(H))
 				to_chat(user, "<span class='notice'>Internal Fluid Level:[H.blood_volume]/[H.max_blood]</span>")
 				if(H.bleed_rate)
 					to_chat(user, "<span class='warning'>Warning:External component leak detected!</span>")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -12,14 +12,6 @@
 			return 1
 	return 0
 
-/mob/proc/isSynthetic()
-	return 0
-
-/mob/living/carbon/human/isSynthetic()
-	if(ismachine(src))
-		return TRUE
-	return FALSE
-
 /mob/proc/get_screen_colour()
 
 /mob/proc/update_client_colour(var/time = 10) //Update the mob's client.color with an animation the specified time in length.

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -28,7 +28,7 @@
 /obj/item/projectile/magic/death/on_hit(mob/living/carbon/C)
 	. = ..()
 	if(isliving(C))
-		if(ismachine(C)) //speshul snowfleks deserv speshul treetment
+		if(ismachineperson(C)) //speshul snowfleks deserv speshul treetment
 			C.adjustFireLoss(6969)  //remember - slimes love fire
 		else
 			C.death()

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -32,7 +32,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_selected)
-		if(ismachine(target))
+		if(ismachineperson(target))
 			// RIP bi-centennial man
 			return 0
 		if(!affected)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -54,7 +54,7 @@
 			var/obj/item/organ/external/BP = X
 			var/brutedamage = BP.brute_dam
 
-			if(BP.is_robotic() && !ismachine(src))
+			if(BP.is_robotic() && !ismachineperson(src))
 				continue
 
 			//We want an accurate reading of .len

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -54,7 +54,7 @@
 			var/obj/item/organ/external/BP = X
 			var/brutedamage = BP.brute_dam
 
-			if(BP.is_robotic() && !isSynthetic())
+			if(BP.is_robotic() && !ismachine(src))
 				continue
 
 			//We want an accurate reading of .len

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 				add_overlay(facial_s)
 
 		if(h_style)
-			if(!owner.isSynthetic() || (owner.isSynthetic() && ((owner.head && (owner.head.flags & BLOCKHEADHAIR)) || (owner.wear_mask && (owner.wear_mask.flags & BLOCKHEADHAIR)))))
+			if(!ismachine(owner) || (ismachine(owner) && ((owner.head && (owner.head.flags & BLOCKHEADHAIR)) || (owner.wear_mask && (owner.wear_mask.flags & BLOCKHEADHAIR)))))
 				var/datum/sprite_accessory/hair_style = GLOB.hair_styles_full_list[h_style]
 				if(hair_style && ((dna.species.name in hair_style.species_allowed) || (dna.species.bodyflags & ALL_RPARTS)))
 					var/icon/hair_s = new /icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 				add_overlay(facial_s)
 
 		if(h_style)
-			if(!ismachine(owner) || (ismachine(owner) && ((owner.head && (owner.head.flags & BLOCKHEADHAIR)) || (owner.wear_mask && (owner.wear_mask.flags & BLOCKHEADHAIR)))))
+			if(!ismachineperson(owner) || (ismachineperson(owner) && ((owner.head && (owner.head.flags & BLOCKHEADHAIR)) || (owner.wear_mask && (owner.wear_mask.flags & BLOCKHEADHAIR)))))
 				var/datum/sprite_accessory/hair_style = GLOB.hair_styles_full_list[h_style]
 				if(hair_style && ((dna.species.name in hair_style.species_allowed) || (dna.species.bodyflags & ALL_RPARTS)))
 					var/icon/hair_s = new /icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes `isSynthetic()` helper and replaces all instances of it with `ismachine()`.
Why? Because `isSynthetic()` is literally just calling for `ismachine()` and returns the same value.
This interchangeability leads to inconsistent usage of the two across the code.

I have considered making `isSynthetic()` a helper that would return true value for IPCs and silicon mobs, but the only benefit I could find in that was allowing cyborgs to slur via variable editing.

Additionally, as Fox correctly pointed out, `ismachine()` and `ismachinery()` are extremely similar and possibly confusing. Following their request, I changed the former to `ismachineperson()`.

## Why It's Good For The Game
More consistent code is good, right?

## Changelog
:cl:
del: isSynthetic() helper
tweak: ismachineperson() is now used instead of isSynthetic()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
