### PR TITLE
Fixes TGUI aghost interactions + disposals

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -271,7 +271,7 @@
 
 /obj/machinery/disposal/tgui_data(mob/user)
 	var/list/data = list()
-  
+
 	data["isAI"] = isAI(user)
 	data["flushing"] = flush
 	data["mode"] = mode
@@ -290,15 +290,12 @@
 		to_chat(usr, "<span class='warning'>The disposal units power is disabled.</span>")
 		return
 
-	if(..())
-		return
-
 	if(stat & BROKEN)
 		return
 
 	src.add_fingerprint(usr)
 
-	if(usr.stat || usr.restrained() || src.flushing)
+	if(src.flushing)
 		return
 
 	if(istype(src.loc, /turf))

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -56,3 +56,8 @@ GLOBAL_DATUM_INIT(tgui_default_state, /datum/tgui_state/default, new)
 		return STATUS_INTERACTIVE
 	else
 		return ..()
+
+/mob/dead/observer/default_can_use_tgui_topic()
+	if(can_admin_interact())
+		return STATUS_INTERACTIVE				// Admins are more equal
+	return STATUS_UPDATE						// Ghosts can view updates

--- a/code/modules/tgui/states/observer.dm
+++ b/code/modules/tgui/states/observer.dm
@@ -9,5 +9,7 @@ GLOBAL_DATUM_INIT(tgui_observer_state, /datum/tgui_state/observer_state, new)
 /datum/tgui_state/observer_state/can_use_topic(src_object, mob/user)
 	if(isobserver(user))
 		return STATUS_INTERACTIVE
+	if(check_rights(R_ADMIN, 0, src))
+		return STATUS_INTERACTIVE
 	return STATUS_CLOSE
 


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so admins ghosting can interact with any TGUI, and also fixes redundant checks in the disposal bin TGUI.

## Why It's Good For The Game
Admins should have abilities.

## Changelog
:cl: AffectedArc07
fix: Ghosting admins can now interact with TGUIs
/:cl:
