### PR TITLE
AFK grammar fix

### DIFF
--- a/code/controllers/subsystem/afk.dm
+++ b/code/controllers/subsystem/afk.dm
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(afk)
 				if(mins_afk >= config.auto_cryo_afk && A.can_get_auto_cryod)
 					if(A.fast_despawn)
 						toRemove += H.ckey
-						warn(H, "<span class='danger'>You are have been despawned after being AFK for [mins_afk] minutes. You have been despawned instantly due to you being in a secure area.</span>")
+						warn(H, "<span class='danger'>You have been despawned after being AFK for [mins_afk] minutes. You have been despawned instantly due to you being in a secure area.</span>")
 						log_afk_action(H, mins_afk, T, "despawned", "AFK in a fast despawn area")
 						force_cryo_human(H)
 					else
@@ -67,7 +67,7 @@ SUBSYSTEM_DEF(afk)
 
 			else if(afk_players[H.ckey] != AFK_ADMINS_WARNED && mins_afk >= config.auto_despawn_afk)
 				log_afk_action(H, mins_afk, T, "despawned")
-				warn(H, "<span class='danger'>You are have been despawned after being AFK for [mins_afk] minutes.</span>")
+				warn(H, "<span class='danger'>You have been despawned after being AFK for [mins_afk] minutes.</span>")
 				toRemove += H.ckey
 				force_cryo_human(H)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Fixes #13737

Fixes the grammar of the AFK warning message from "You are have been despawned after being AFK" to "You have been despawned after being AFK"

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Because grammar is good in a RP game

## Changelog
:cl:
spellcheck: fixed a few typos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
