### PR TITLE
Fixes note search log + Minor TGUI fix

### DIFF
--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -187,12 +187,12 @@
 			log_game("SQL ERROR obtaining ckey from notes table. Error : \[[err]\]\n")
 			return
 		to_chat(usr, "<span class='notice'>Started regex note search for [search]. Please wait for results...</span>")
-		message_admins("[usr] has started a note search with regex [search]. CPU usage may be higher.")
+		message_admins("[usr.ckey] has started a note search with the following regex: [search] | CPU usage may be higher.")
 		while(query_list_notes.NextRow())
 			index_ckey = query_list_notes.item[1]
 			output += "<a href='?_src_=holder;shownoteckey=[index_ckey]'>[index_ckey]</a><br>"
 			CHECK_TICK
-		message_admins("The note search started by [usr] has complete. CPU should return to normal.")
+		message_admins("The note search started by [usr.ckey] has complete. CPU should return to normal.")
 	else
 		output += "<center><a href='?_src_=holder;addnoteempty=1'>\[Add Note\]</a></center>"
 		output += ruler

--- a/code/modules/tgui/modules/crew_monitor.dm
+++ b/code/modules/tgui/modules/crew_monitor.dm
@@ -29,7 +29,7 @@
 		ui.open()
 
 
-/datum/tgui_module/crew_monitor/tgui_data(mob/user, ui_key = "main", datum/topic_state/state = GLOB.default_state)
+/datum/tgui_module/crew_monitor/tgui_data(mob/user)
 	var/data[0]
 	var/turf/T = get_turf(tgui_host())
 


### PR DESCRIPTION
## What Does This PR Do
![image](https://user-images.githubusercontent.com/25063394/86212132-67797b00-bb6f-11ea-8c0d-62a77a68ed06.png)
Fixes admin logs for note searching using character names instead of ckey names. Also fixed the arguments for the `tgui_data` function for the crew monitoring module, to remove the extra arguments which are a remain from nano.

## Why It's Good For The Game
Bugs bad

## Changelog
:cl: AffectedArc07
fix: Admin logs for note searches now use ckeys instead of charcter names
fix: Crew monitor TGUI no longer has remains of nano code inside it
/:cl:
