### PR TITLE
Tweak, Added wrench_act to slot machines, so that they can be moved by the crew

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -24,7 +24,7 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	default_unfasten_wrench(user, I, 120)
+	default_unfasten_wrench(user, I)
 
 /obj/machinery/slot_machine/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -20,6 +20,12 @@
 			account = null
 	ui_interact(user)
 
+/obj/machinery/slot_machine/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	default_unfasten_wrench(user, I, 120)
+
 /obj/machinery/slot_machine/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds wrench_act to the slot machine, this is the same section of code that is used on most machines, making slot machines wrenchable. 
~~Timer is set to 120 so as to make it take a bit of time to complete the wrenching.~~
Timer set to default value.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows barkeeps (or others for that matter) to move the slot machines found around the station. 
This also allows the barkeep to redecorate more without having to worry about the static placement of the slot machines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Current change:
![sUworUAJ2I](https://user-images.githubusercontent.com/63977635/86238743-5ac04b80-bb9e-11ea-81f3-9d8144c20596.gif)

Comparison with other wrenchable items:
![sxHoskRfsU](https://user-images.githubusercontent.com/63977635/86238808-762b5680-bb9e-11ea-9053-b558ada6a1a5.gif)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: denghis
tweak: Makes slot machines wrenchable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
