### PR TITLE
bugfix, prevents every accessory from pretending to be a lawyers badge

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -330,7 +330,7 @@
 	item_color = "lawyerbadge"
 	var/cached_bubble_icon = null
 
-/obj/item/clothing/accessory/attack_self(mob/user)
+/obj/item/clothing/accessory/lawyers_badge/attack_self(mob/user)
 	if(prob(1))
 		user.say("The testimony contradicts the evidence!")
 	user.visible_message("<span class='notice'>[user] shows [user.p_their()] attorney's badge.</span>", "<span class='notice'>You show your attorney's badge.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes a small scoping bug with attack_self on the lawyers_badge, it was scoped to every accessory instead of the lawyers_badge specifically
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents everyone from pretending to be an attorney
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before:
![6whVvA9fvL](https://user-images.githubusercontent.com/63977635/86408015-7d458800-bcb6-11ea-8350-7e22a24e4c86.gif)

After: 
![Ow78CjrcRf](https://user-images.githubusercontent.com/63977635/86408031-859dc300-bcb6-11ea-9b8e-c57f20958e2e.gif)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: denghis
fix: proper scoping of laywers_badge/attack_self
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
