### PR TITLE
bugfix: drones opening or closing lockers while ventcrawling

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -230,7 +230,7 @@
 	add_fingerprint(user)
 
 /obj/structure/closet/attack_ai(mob/user)
-	if(isrobot(user) && Adjacent(user)) //Robots can open/close it, but not the AI
+	if(isrobot(user) && Adjacent(user) && !istype(user.loc, /obj/machinery/atmospherics)) //Robots can open/close it, but not the AI
 		attack_hand(user)
 
 /obj/structure/closet/relaymove(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes an ancient bug #5363 by including a check on closet/attack_ai to see if the usr.loc is type (or subtype)  of /obj/machinery/atmospherics. 
Thus preventing a ventcrawling maintenance drone from opening or closing a locker while adjacent to it and ventcrawling
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixing bugs is good, fixing old bugs is even better. Besides a maintenance drone should not be able to physically open a locker adjacent to the pipe it is currently crawling through. 

Before: 

![5mmjluMTDW](https://user-images.githubusercontent.com/63977635/86454644-d8f82b80-bd1f-11ea-835b-d191f74563e0.gif)

After: 

![M3ZEmiZASP](https://user-images.githubusercontent.com/63977635/86453891-c5989080-bd1e-11ea-9db4-34e43ba5b8d8.gif)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: denghis
fix: drones opening lockers while ventcrawling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
