### PR TITLE
bugfix syndicate bomb not triggering defuse properly

### DIFF
--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -96,7 +96,6 @@
 		if(BOMB_WIRE_ACTIVATE)
 			if(!mended && B.active)
 				holder.visible_message("<span class='notice'>[bicon(B)] The timer stops! The bomb has been defused!</span>")
-				B.active = FALSE
 				B.defused = TRUE
 				B.update_icon()
 	..()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -79,10 +79,8 @@
 	//Counter terrorists win
 	else if(defused)
 		active = FALSE
-		if(defused && (payload in src))
+		if(payload in src)
 			payload.defuse()
-			countdown.stop()
-			STOP_PROCESSING(SSfastprocess, src)
 
 /obj/machinery/syndicatebomb/New()
 	wires 	= new(src)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -77,7 +77,8 @@
 		update_icon()
 		try_detonate(TRUE)
 	//Counter terrorists win
-	else if(!active || defused)
+	else if(defused)
+		active = FALSE
 		if(defused && (payload in src))
 			payload.defuse()
 			countdown.stop()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## What Does This PR Do
This PR makes the syndicate bombs, and more importantly for this fix, the training bombs actually trigger the defuse part of the bomb process() proc. 

It did not trigger since cutting the wire would set b.active to false, and would thus instantly break out of process() before it had a chance to check if the bomb was defused. (see line 49 & 54 in /obj/machinery/syndicatebomb/process() )

In order to make sure that it falls into the defused check in process(), i set active to false when actually processing the defused part, instead of in the wire code.

The removal of !active in the if is due to it being redundant inside process()

Only a few lines changed, but due to the way it flows, i did not see many other options of fixing this while touching as little as possible.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes issue #12153 and makes training bombs actually work as intended, go set a new highscore!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

Alien multitool used in the gifs to make finding the correct wire easier for testing.

Before: 
![57ny6v86qL](https://user-images.githubusercontent.com/63977635/86489864-e3d5af00-bd65-11ea-8c0a-6c3b05b0d087.gif)


After: 

![L4GR04TvPQ](https://user-images.githubusercontent.com/63977635/86489868-e59f7280-bd65-11ea-84dd-e22cc6f391b8.gif)



<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: denghis
fix: syndicate bomb not triggering defuse properly, preventing training bombs from working as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
