### PR TITLE
Fixes borgs being given to the last AI and a runtime

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -329,8 +329,9 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/select_active_ai_with_fewest_borgs()
 	var/mob/living/silicon/ai/selected
 	var/list/active = active_ais()
-	for(var/mob/living/silicon/ai/A in active)
-		if(!selected || (selected.connected_robots > A.connected_robots))
+	for(var/thing in active)
+		var/mob/living/silicon/ai/A = thing
+		if(!selected || (length(selected.connected_robots) > length(A.connected_robots)))
 			selected = A
 
 	return selected

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -243,7 +243,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 /mob/living/silicon/ai/proc/show_borg_info()
 	stat(null, text("Connected cyborgs: [connected_robots.len]"))
-	for(var/mob/living/silicon/robot/R in connected_robots)
+	for(var/thing in connected_robots)
+		var/mob/living/silicon/robot/R = thing
 		var/robot_status = "Nominal"
 		if(R.stat || !R.client)
 			robot_status = "OFFLINE"
@@ -251,8 +252,9 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 			robot_status = "DEPOWERED"
 		// Name, Health, Battery, Module, Area, and Status! Everything an AI wants to know about its borgies!
 		var/area/A = get_area(R)
+		var/area_name = A ? sanitize(A.name) : "Unknown"
 		stat(null, text("[R.name] | S.Integrity: [R.health]% | Cell: [R.cell ? "[R.cell.charge] / [R.cell.maxcharge]" : "Empty"] | \
-		Module: [R.designation] | Loc: [sanitize(A.name)] | Status: [robot_status]"))
+		Module: [R.designation] | Loc: [area_name] | Status: [robot_status]"))
 
 /mob/living/silicon/ai/rename_character(oldname, newname)
 	if(!..(oldname, newname))


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime when borgs are on a turf with no area. Causing potential weirdness for the borg list the AI has.
Fixes the issue where new borgs are always assigned to the newest AI instead of the AI with the least amount of borgs.

fixes:
```
[2020-07-03T18:23:05] Runtime in ai.dm,254: Cannot read null.name
   proc name: show borg info (/mob/living/silicon/ai/proc/show_borg_info)
   usr: NAME (CKEY) (/mob/living/silicon/ai)
   usr.loc: The floor (143,23,1) (/turf/simulated/floor/bluegrid)
   src: NAME (/mob/living/silicon/ai)
   src.loc: the floor (143,23,1) (/turf/simulated/floor/bluegrid)
   call stack:
   NAME (/mob/living/silicon/ai): show borg info()
   NAME (/mob/living/silicon/ai): Stat()
   Hostail (/client): Stat()
```

## Why It's Good For The Game
Bug fixing ho

## Changelog
:cl:
fix: Borgs are now given to the AI with the least amount of borgs.
fix: Borgs on a turf without an area now won't break the AIs borg list.
/:cl: