### PR TITLE
Makes blobs not add new_players to the HUD list. Fixing AHUD

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -46,7 +46,6 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		var/datum/mind/blob = pick(possible_blobs)
 		infected_crew += blob
 		blob.special_role = SPECIAL_ROLE_BLOB
-		update_blob_icons_added(blob)
 		blob.restricted_roles = restricted_jobs
 		log_game("[key_name(blob)] has been selected as a Blob")
 		possible_blobs -= blob
@@ -152,6 +151,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 	for(var/datum/mind/blob in infected_crew)
 		greet_blob(blob)
+		update_blob_icons_added(blob)
 
 	if(SSshuttle)
 		SSshuttle.emergencyNoEscape = 1


### PR DESCRIPTION
## What Does This PR Do
The blob game mode will now add the picked players to the HUD list when they are actually spawned. Avoiding quite some runtimes and antag hud from breaking

## Why It's Good For The Game
Bug B gone

## Changelog
:cl:
fix: Roundstart blobs now won't break Antag hud
/:cl: