### PR TITLE
Ups the experience requirements for Warden/HoS

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -18,7 +18,7 @@
 			            ACCESS_RESEARCH, ACCESS_ENGINE, ACCESS_MINING, ACCESS_MEDICAL, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING,
 			            ACCESS_HEADS, ACCESS_HOS, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_GATEWAY, ACCESS_PILOT, ACCESS_WEAPONS)
 	minimal_player_age = 21
-	exp_requirements = 300
+	exp_requirements = 1200
 	exp_type = EXP_TYPE_SECURITY
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/hos
@@ -64,7 +64,7 @@
 	minimal_access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_ARMORY, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_WEAPONS)
 	minimal_player_age = 21
 	exp_requirements = 600
-	exp_type = EXP_TYPE_CREW
+	exp_type = EXP_TYPE_SECURITY
 	outfit = /datum/outfit/job/warden
 
 /datum/outfit/job/warden


### PR DESCRIPTION
## What Does This PR Do
This PR ups the time requirement for HoS to twenty hours as security and more appropriately makes Warden take ten hours as security rather than unlocking at the same time as every other security role. I DID intend to raise the security timelock itself up, but I was unaware it was actually ten hours as crew. Though, I would argue that it could be higher...it would lead to security being staffed less often so that's not entirely a good thing. 

Also..correct me if I'm wrong, but I assume the numbers on the experience required are in minutes.

## Why It's Good For The Game
Ten hours as security is far from enough experience for a HoS to come to grips on the security role on a whole, there are MANY Heads of Security that don't actually know space law despite those ten hours as an officer. I'd actually be more inclined to raise the requirement for HoS to 25 hours, however twenty hours should be fine in most instances I believe. 

A player shouldn't be able to have the responsibility nor access that a Warden has without any experience as an officer, he has access to the armory, is generally in charge of sentencing barring the HoS/Captain/Magistrate/etc. opposing the sentencing, and is generally viewed as a de-facto second in command for security. They should be expected to have a moderate grasp of Space Law at the very least, which is what forcing them to require ten hours in a security position will do.

These numbers can be tweaked incredibly easily, but I strongly feel they should remain as is. At the very least Warden should.

## Changelog
:cl:
tweak: Upped the time required as security to unlock HoS to twenty hours. Made the Warden require ten hours as any security position to unlock.
/:cl:
