### PR TITLE
Allows clients to reload their UI assets

### DIFF
--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -20,16 +20,16 @@ SUBSYSTEM_DEF(tickets)
 	init_order = INIT_ORDER_TICKETS
 	wait = 300
 	priority = FIRE_PRIORITY_TICKETS
-	
+
 	flags = SS_BACKGROUND
-	
+
 	var/list/allTickets = list()	//make it here because someone might ahelp before the system has initialized
 
 	var/ticketCounter = 1
 
 /datum/controller/subsystem/tickets/Initialize()
 	close_messages = list("<font color='red' size='4'><b>- [ticket_name] Rejected! -</b></font>",
-				"<span class='boldmessage'>Please try to be calm, clear, and descriptive in admin helps, do not assume the staff member has seen any related events, and clearly state the names of anybody you are reporting. If you asked a question, please ensure it was clear what you were asking.</span>", 
+				"<span class='boldmessage'>Please try to be calm, clear, and descriptive in admin helps, do not assume the staff member has seen any related events, and clearly state the names of anybody you are reporting. If you asked a question, please ensure it was clear what you were asking.</span>",
 				"<span class='[span_class]'>Your [ticket_name] has now been closed.</span>")
 	return ..()
 
@@ -112,7 +112,7 @@ SUBSYSTEM_DEF(tickets)
 		message_staff("<span class='[span_class]'>[usr.client] / ([usr]) resolved [ticket_name] number [N]</span>")
 		to_chat_safe(returnClient(N), "<span class='[span_class]'>Your [ticket_name] has now been resolved.</span>")
 		return TRUE
-		
+
 
 /datum/controller/subsystem/tickets/proc/autoRespond(N)
 	if(!check_rights(R_ADMIN|R_MOD))
@@ -124,19 +124,19 @@ SUBSYSTEM_DEF(tickets)
 		if(alert(usr, "[T.ticketState == TICKET_OPEN ? "Another admin appears to already be handling this." : "This ticket is already marked as closed or resolved"] Are you sure you want to continue?", "Confirmation", "Yes", "No") != "Yes")
 			return
 	T.assignStaff(C)
-	
-	var/response_phrases = list("Thanks" = "Thanks, have a Paradise day!", 
+
+	var/response_phrases = list("Thanks" = "Thanks, have a Paradise day!",
 		"Handling It" = "The issue is being looked into, thanks.",
 		"Already Resolved" = "The problem has been resolved already.",
 		"Mentorhelp" = "Please redirect your question to Mentorhelp, as they are better experienced with these types of questions.",
 		"Happens Again" = "Thanks, let us know if it continues to happen.",
-		"Clear Cache" = "To fix a blank screen, please leave the game and clear your Byond Cache. To clear your Byond Cache, there is a Settings icon in the top right of the launcher. After you click that, go into the Games tab and hit the Clear Cache button. If the issue persists a few minutes after rejoining and doing this, please adminhelp again and state you cleared your cache." ,
+		"Clear Cache" = "To fix a blank screen, go to the 'Special Verbs' tab and press 'Reload UI Resources'. If that fails, clear your BYOND cache (instructions provided with 'Reload UI Resources'). If that still fails, please adminhelp again, stating you have already done the following." ,
 		"IC Issue" = "This is an In Character (IC) issue and will not be handled by admins. You could speak to Security, Internal Affairs, a Departmental Head, Nanotrasen Representetive, or any other relevant authority currently on station.",
 		"Reject" = "Reject",
 		"Man Up" = "Man Up",
 		"Appeal on the Forums" = "Appealing a ban must occur on the forums. Privately messaging, or adminhelping about your ban will not resolve it. To appeal your ban, please head to <a href='[config.banappeals]'>[config.banappeals]</a>"
 		)
-		
+
 	var/sorted_responses = list()
 	for(var/key in response_phrases)	//build a new list based on the short descriptive keys of the master list so we can send this as the input instead of the full paragraphs to the admin choosing which autoresponse
 		sorted_responses += key
@@ -351,7 +351,7 @@ UI STUFF
 			dat += "<tr><td>[T.content[i]]</td></tr>"
 
 	dat += "</table><br /><br />"
-	dat += "<a href='?src=[UID()];detailreopen=[T.ticketNum]'>Re-Open</a>[check_rights(R_ADMIN|R_MOD, 0) ? "<a href='?src=[UID()];autorespond=[T.ticketNum]'>Auto</a>": ""]<a href='?src=[UID()];detailresolve=[T.ticketNum]'>Resolve</a><br /><br />" 
+	dat += "<a href='?src=[UID()];detailreopen=[T.ticketNum]'>Re-Open</a>[check_rights(R_ADMIN|R_MOD, 0) ? "<a href='?src=[UID()];autorespond=[T.ticketNum]'>Auto</a>": ""]<a href='?src=[UID()];detailresolve=[T.ticketNum]'>Resolve</a><br /><br />"
 
 	if(!T.staffAssigned)
 		dat += "No staff member assigned to this [ticket_name] - <a href='?src=[UID()];assignstaff=[T.ticketNum]'>Take Ticket</a><br />"
@@ -447,7 +447,7 @@ UI STUFF
 			return
 		if(closeTicket(indexNum))
 			showDetailUI(usr, indexNum)
-			
+
 
 	if(href_list["detailreopen"])
 		var/indexNum = text2num(href_list["detailreopen"])

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1232,22 +1232,6 @@
 		log_admin("[key_name(usr)] has removed the organ [rem_organ] from [key_name(M)]")
 		qdel(rem_organ)
 
-	else if(href_list["fix_nano"])
-		if(!check_rights(R_DEBUG)) return
-
-		var/mob/H = locateUID(href_list["fix_nano"])
-
-		if(!istype(H) || !H.client)
-			to_chat(usr, "This can only be done on mobs with clients")
-			return
-
-		H.client.reload_nanoui_resources()
-
-		to_chat(usr, "Resource files sent")
-		to_chat(H, "Your NanoUI Resource files have been refreshed")
-
-		log_admin("[key_name(usr)] resent the NanoUI resource files to [key_name(H)]")
-
 	else if(href_list["regenerateicons"])
 		if(!check_rights(0))	return
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -816,21 +816,6 @@ GLOBAL_PROTECT(AdminProcCaller)
 	else
 		alert("Invalid mob")
 
-/client/proc/reload_nanoui_resources()
-	set category = "Debug"
-	set name = "Reload NanoUI Resources"
-	set desc = "Force the client to redownload NanoUI Resources"
-
-	// Close open NanoUIs.
-	SSnanoui.close_user_uis(usr)
-
-	// Re-load the assets.
-	var/datum/asset/assets = get_asset_datum(/datum/asset/nanoui)
-	assets.register()
-
-	// Clear the user's cache so they get resent.
-	usr.client.cache = list()
-
 /client/proc/view_runtimes()
 	set category = "Debug"
 	set name = "View Runtimes"

--- a/code/modules/admin/verbs/toggledebugverbs.dm
+++ b/code/modules/admin/verbs/toggledebugverbs.dm
@@ -18,7 +18,6 @@ GLOBAL_LIST_INIT(admin_verbs_show_debug_verbs, list(
 	/client/proc/print_jobban_old_filter,
 	/client/proc/forceEvent,
 	/client/proc/nanomapgen_DumpImage,
-	/client/proc/reload_nanoui_resources,
 	/client/proc/admin_redo_space_transitions,
 	/client/proc/make_turf_space_map,
 	/client/proc/vv_by_ref

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -92,3 +92,6 @@
 	var/next_keysend_reset = 0
 	var/next_keysend_trip_reset = 0
 	var/keysend_tripped = FALSE
+
+	// Last world.time that the player tried to request their resources.
+	var/last_ui_resource_send = 0

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -915,8 +915,8 @@
 	var/choice = alert(usr, "This will reload your NanoUI and TGUI resources. If you have any open UIs this may break them. Are you sure?", "Resource Reloading", "Yes", "No")
 	if(choice == "Yes")
 		// 600 deciseconds = 1 minute
-		if((last_ui_resource_send) < world.time)
-			last_ui_resource_send = world.time + 600
+		if(last_ui_resource_send < world.time)
+			last_ui_resource_send = world.time + 60 SECONDS
 
 			// Close their open UIs
 			SSnanoui.close_user_uis(usr)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -912,27 +912,29 @@
 	set desc = "Reload your UI assets if they are not working"
 	set category = "Special Verbs"
 
+	if(last_ui_resource_send > world.time)
+		to_chat(usr, "<span class='warning'>You requested your UI resource files too quickly. Please try again in [(last_ui_resource_send - world.time)/10] seconds.</span>")
+		return
+
 	var/choice = alert(usr, "This will reload your NanoUI and TGUI resources. If you have any open UIs this may break them. Are you sure?", "Resource Reloading", "Yes", "No")
 	if(choice == "Yes")
 		// 600 deciseconds = 1 minute
-		if(last_ui_resource_send < world.time)
-			last_ui_resource_send = world.time + 60 SECONDS
+		last_ui_resource_send = world.time + 60 SECONDS
 
-			// Close their open UIs
-			SSnanoui.close_user_uis(usr)
-			SStgui.close_user_uis(usr)
+		// Close their open UIs
+		SSnanoui.close_user_uis(usr)
+		SStgui.close_user_uis(usr)
 
-			// Resend the resources
-			var/datum/asset/nano_assets = get_asset_datum(/datum/asset/nanoui)
-			nano_assets.register()
+		// Resend the resources
+		var/datum/asset/nano_assets = get_asset_datum(/datum/asset/nanoui)
+		nano_assets.register()
 
-			var/datum/asset/tgui_assets = get_asset_datum(/datum/asset/simple/tgui)
-			tgui_assets.register()
+		var/datum/asset/tgui_assets = get_asset_datum(/datum/asset/simple/tgui)
+		tgui_assets.register()
 
-			// Clear the user's cache so they get resent.
-			// This is not fully clearing their BYOND cache, just their assets sent from the server this round
-			cache = list()
+		// Clear the user's cache so they get resent.
+		// This is not fully clearing their BYOND cache, just their assets sent from the server this round
+		cache = list()
 
-			to_chat(usr, "<span class='notice'>UI resource files resent successfully</span>")
-		else
-			to_chat(usr, "<span class='warning'>You requested your UI resource files too quickly. Please try again in [(last_ui_resource_send - world.time)/10] seconds.</span>")
+		to_chat(usr, "<span class='notice'>UI resource files resent successfully. If you are still having issues, please try manually clearing your BYOND cache. <b>This can be achieved by opening your BYOND launcher, pressing the cog in the top right, selecting preferences, going to the Games tab, and pressing 'Clear Cache'.</b></span>")
+

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -906,3 +906,33 @@
 	return TRUE
 
 #undef SSD_WARNING_TIMER
+
+/client/verb/resend_ui_resources()
+	set name = "Reload UI Resources"
+	set desc = "Reload your UI assets if they are not working"
+	set category = "Special Verbs"
+
+	var/choice = alert(usr, "This will reload your NanoUI and TGUI resources. If you have any open UIs this may break them. Are you sure?", "Resource Reloading", "Yes", "No")
+	if(choice == "Yes")
+		// 600 deciseconds = 1 minute
+		if((last_ui_resource_send) < world.time)
+			last_ui_resource_send = world.time + 600
+
+			// Close their open UIs
+			SSnanoui.close_user_uis(usr)
+			SStgui.close_user_uis(usr)
+
+			// Resend the resources
+			var/datum/asset/nano_assets = get_asset_datum(/datum/asset/nanoui)
+			nano_assets.register()
+
+			var/datum/asset/tgui_assets = get_asset_datum(/datum/asset/simple/tgui)
+			tgui_assets.register()
+
+			// Clear the user's cache so they get resent.
+			// This is not fully clearing their BYOND cache, just their assets sent from the server this round
+			cache = list()
+
+			to_chat(usr, "<span class='notice'>UI resource files resent successfully</span>")
+		else
+			to_chat(usr, "<span class='warning'>You requested your UI resource files too quickly. Please try again in [(last_ui_resource_send - world.time)/10] seconds.</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1297,8 +1297,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	.["Add Organ"] = "?_src_=vars;addorgan=[UID()]"
 	.["Remove Organ"] = "?_src_=vars;remorgan=[UID()]"
 
-	.["Fix NanoUI"] = "?_src_=vars;fix_nano=[UID()]"
-
 	.["Add Verb"] = "?_src_=vars;addverb=[UID()]"
 	.["Remove Verb"] = "?_src_=vars;remverb=[UID()]"
 


### PR DESCRIPTION
## What Does This PR Do
This PR allows users to reload their own UI assets without the need for a cache clear or admin intervention. This was an admin verb in player panel, but so poorly documented that 99% of the staff team didnt even know it existed. I have moved this to a verb which allows players to do it themselves, as well as resending TGUI assets. The verb is on a 60 second cooldown to make it so rapid-resource requesting does not become a DOS vector.

## Why It's Good For The Game
I have recieved three mentorhelps just today about people having white screens and no UI, and people shouldnt have to be taught how to clear their BYOND cache and then reconnect, it should be easy for them.

## Changelog
:cl: AffectedArc07
add: You can now reload your own UI assets if you are getting white screens
/:cl:
