### PR TITLE
Further New Player GC Fixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -89,6 +89,9 @@
 			if(antag_datum.delete_on_mind_deletion)
 				qdel(i)
 		antag_datums = null
+	current = null
+	original = null
+	soulOwner = null
 	return ..()
 
 /datum/mind/proc/transfer_to(mob/living/new_character)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -210,6 +210,7 @@
 			if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
 				observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
 			observer.key = key
+			QDEL_NULL(mind)
 			GLOB.respawnable_list += observer
 			qdel(src)
 			return 1


### PR DESCRIPTION
When you observe, the mind datum still exists on the `new_player` mob, despite not need to be (it's not even transferred to the observer). 

This deletes the mind right after the transfer occurs, which should make GC'ing more likely.

The mind datum itself will prevent GCing because it holds reference to the `new_player` mob as well.....and the mind datum itself wont' GC because it holds a reference to itself.

This is the sole time the mind datum is actively deleted in the entire codebase.

:cl: Fox McCloud
tweak: further tweaks to ensure new players soft delete, enhancing server performance
/:cl: