### PR TITLE
Fixes timings

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -11,25 +11,6 @@
 
 #define TICKS2DS(T) ((T) TICKS)
 
-#define TimeOfGame (get_game_time())
-#define TimeOfTick (world.tick_usage*0.01*world.tick_lag)
-
-/proc/get_game_time()
-	var/global/time_offset = 0
-	var/global/last_time = 0
-	var/global/last_usage = 0
-
-	var/wtime = world.time
-	var/wusage = world.tick_usage * 0.01
-
-	if(last_time < wtime && last_usage > 1)
-		time_offset += last_usage - 1
-
-	last_time = wtime
-	last_usage = wusage
-
-	return wtime + (time_offset + wusage) * world.tick_lag
-
 /* This proc should only be used for world/Topic.
  * If you want to display the time for which dream daemon has been running ("round time") use worldtime2text.
  * If you want to display the canonical station "time" (aka the in-character time of the station) use station_time_timestamp
@@ -98,14 +79,14 @@ proc/isDay(var/month, var/day)
  * Returns "watch handle" (really just a timestamp :V)
  */
 /proc/start_watch()
-	return TimeOfGame
+	return REALTIMEOFDAY
 
 /**
  * Returns number of seconds elapsed.
  * @param wh number The "Watch Handle" from start_watch(). (timestamp)
  */
 /proc/stop_watch(wh)
-	return round(0.1 * (TimeOfGame - wh), 0.1)
+	return round(0.1 * (REALTIMEOFDAY - wh), 0.1)
 
 /proc/numberToMonthName(number)
 	return GLOB.month_names.Find(number)


### PR DESCRIPTION
## What Does This PR Do
Basically, I noticed that when the server inits, timing is all skewed for what actually takes time and what doesnt. 
![image](https://user-images.githubusercontent.com/25063394/86628824-5b077f00-bfc2-11ea-9daf-85db32e1387e.png)

Turns out, all this is from `start_watch()`. A proc which starts a timer, and then `stop_watch()` allows you to calculate the time difference between. Except, ***IT ONLY COUNTS TIME THAT THE GAME IS ACTUALLY RUNNING FOR, MEANING THAT WHILE THE SERVER IS HELD UP INITIALIZING, IT WONT EVEN TIME PROPERLY, MAKING AN INITIALIZATION TIMER BLOODY POINTLESS***. 

This PR makes it so that `start_watch()` uses real time, instead of game time. This means we actually get accurate startup timers now
![image](https://user-images.githubusercontent.com/25063394/86628948-8be7b400-bfc2-11ea-8207-9842874785fd.png)

I looked for each use of `start_watch()`, and its only used for initialization time logging. So this is fine.

## Why It's Good For The Game
A timer that checks how long the server has been doing a length operation for, **should not be affected by the server lagging for the love of god**

## Changelog
:cl: AffectedArc07
fix: Initializations are now accurately timed
/:cl:
