### PR TITLE
Lavaland Atmos Fixes

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -112,7 +112,7 @@
 	dir = 1
 	},
 /obj/item/flashlight/lantern,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "av" = (
 /obj/structure/stone_tile/block,
@@ -122,7 +122,7 @@
 /obj/structure/stone_tile{
 	dir = 4
 	},
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "aw" = (
 /obj/structure/stone_tile/block,
@@ -133,7 +133,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "ax" = (
 /obj/structure/stone_tile/block,
@@ -143,7 +143,7 @@
 /obj/structure/stone_tile{
 	dir = 4
 	},
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "ay" = (
 /obj/structure/stone_tile,
@@ -157,7 +157,7 @@
 	dir = 8
 	},
 /obj/item/flashlight/lantern,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "az" = (
 /obj/structure/stone_tile/block{
@@ -214,7 +214,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "aH" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
@@ -251,7 +251,7 @@
 	},
 /obj/structure/stone_tile,
 /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "aM" = (
 /obj/structure/stone_tile/cracked{
@@ -307,7 +307,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "aT" = (
 /obj/structure/stone_tile/block/cracked{
@@ -333,7 +333,7 @@
 /obj/structure/stone_tile{
 	dir = 1
 	},
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "aY" = (
 /obj/structure/stone_tile,
@@ -381,7 +381,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bd" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -421,7 +421,7 @@
 	dir = 1
 	},
 /obj/structure/stone_tile,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bh" = (
 /obj/structure/stone_tile/block{
@@ -519,7 +519,7 @@
 	dir = 4
 	},
 /obj/item/flashlight/lantern,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bq" = (
 /obj/structure/stone_tile/block{
@@ -529,11 +529,11 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "br" = (
 /obj/structure/stone_tile/slab/cracked,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bs" = (
 /obj/structure/stone_tile/block/cracked{
@@ -544,7 +544,7 @@
 	},
 /obj/structure/stone_tile,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bt" = (
 /obj/structure/stone_tile,
@@ -558,7 +558,7 @@
 	dir = 4
 	},
 /obj/item/flashlight/lantern,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bv" = (
 /obj/structure/stone_tile/cracked{
@@ -632,7 +632,7 @@
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
 	},
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bC" = (
 /obj/structure/stone_tile/block/cracked{
@@ -672,7 +672,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/indestructible/boss/air,
+/turf/simulated/floor/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bI" = (
 /obj/structure/stone_tile/slab/cracked,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -95,6 +95,7 @@
 /area/ruin/unpowered)
 "p" = (
 /obj/machinery/door/airlock/hatch,
+/obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
 "q" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -77,6 +77,7 @@
 /area/ruin/powered/pride)
 "Y" = (
 /obj/machinery/door/airlock/diamond,
+/obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/mineral/silver{
 	blocks_air = 1
 	},

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -20,6 +20,7 @@
 /area/ruin/unpowered)
 "e" = (
 /obj/machinery/door/airlock/wood,
+/obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
@@ -103,6 +103,7 @@
 "t" = (
 /obj/machinery/door/airlock/survival_pod/glass,
 /obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered)
 "v" = (

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -45,6 +45,7 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
+	planetary_atmos = TRUE
 
 /turf/simulated/floor/indestructible/necropolis/Initialize(mapload)
 	. = ..()
@@ -52,8 +53,8 @@
 		icon_state = "necro[rand(2,3)]"
 
 /turf/simulated/floor/indestructible/necropolis/air
-	oxygen = 0
-	nitrogen = 0
+	oxygen = MOLES_O2STANDARD
+	nitrogen = MOLES_N2STANDARD
 	temperature = T20C
 
 /turf/simulated/floor/indestructible/boss //you put stone tiles on this and use it as a base
@@ -64,6 +65,7 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
+	planetary_atmos = TRUE
 
 /turf/simulated/floor/indestructible/boss/air
 	oxygen = MOLES_O2STANDARD
@@ -77,6 +79,7 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
+	planetary_atmos = TRUE
 	smooth = SMOOTH_TRUE
 
 /turf/simulated/floor/indestructible/hierophant/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -111,6 +111,7 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
+	planetary_atmos = TRUE
 
 /turf/simulated/floor/lubed
 	name = "slippery floor"


### PR DESCRIPTION
some of the ruins have issues with simulated turfs that are just straight up exposed to lavaland, at roundstart, which causes active turfs to bloat up and stay bloated up for a while, until they equalize.

This doesn't address some of the major ones (Ratvar, summoning rune, and a few others), but this fixes some of the minor ones that have obvious oversights, while also ensuring that some of the turfs properly have planetary_atmos set to true---which should cause them to enter a more "settled" state, easier.

Also there was some errors on some turfs---the `/turf/simulated/floor/indestructible/boss/air` turf was...airless---also in the ashwalker den for some reason (they don't even breathe).

:cl: Fox McCloud
tweak: Tweaks some atmos settings to make lavaland slightly "quieter" in terms of having active atmos
/:cl: