### PR TITLE
Added security counter to check antags panel

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -624,16 +624,18 @@ GLOBAL_LIST_INIT(do_after_once_tracker, list())
 		return
 	return M.playtime_role ? M.playtime_role : M.assigned_role	//returns current role
 
-//checks the security force on station and returns a list of numbers, of the form:
-// total, active, dead, antag
-// where active is defined as conscious (STAT = 0) and not an antag
+/**	checks the security force on station and returns a list of numbers, of the form:
+ * 	total, active, dead, antag
+ * 	where active is defined as conscious (STAT = 0) and not an antag
+*/
 /proc/check_active_security_force()
 	var/sec_positions = GLOB.security_positions - "Magistrate" - "Brig Physician"
 	var/total = 0
 	var/active = 0
 	var/dead = 0
 	var/antag = 0
-	for(var/mob/living/carbon/human/player in GLOB.human_list)
+	for(var/p in GLOB.human_list)	//contains only human mobs, so no type check needed
+		var/mob/living/carbon/human/player = p	//need to tell it what type it is or we can't access stat without the dreaded :
 		if(determine_role(player) in sec_positions)
 			total++
 			if(player.stat == DEAD)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -616,3 +616,32 @@ GLOBAL_LIST_INIT(do_after_once_tracker, list())
 		chosen = pick(mob_spawn_meancritters)
 	var/mob/living/simple_animal/C = new chosen(spawn_location)
 	return C
+
+//determines the job of a mob, taking into account job transfers
+/proc/determine_role(mob/living/P)
+	var/datum/mind/M = P.mind
+	if(!M)
+		return
+	return M.playtime_role ? M.playtime_role : M.assigned_role	//returns current role
+
+//checks the security force on station and returns a list of numbers, of the form:
+// total, active, dead, antag
+// where active is defined as conscious (STAT = 0) and not an antag
+/proc/check_active_security_force()
+	var/sec_positions = GLOB.security_positions - "Magistrate" - "Brig Physician"
+	var/total = 0
+	var/active = 0
+	var/dead = 0
+	var/antag = 0
+	for(var/mob/living/carbon/human/player in GLOB.human_list)
+		if(determine_role(player) in sec_positions)
+			total++
+			if(player.stat == DEAD)
+				dead++
+				continue
+			if(isAntag(player))
+				antag++
+				continue
+			if(player.stat == CONSCIOUS)
+				active++
+	return list(total, active, dead, antag)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -573,7 +573,12 @@
 
 		//list active security force count, so admins know how bad things are
 		var/list/sec_list = check_active_security_force()
-		dat += "<table cellspacing=5><TR><TD>Security Force Overview(total/active/dead/antag): [sec_list[1]]/[sec_list[2]]/[sec_list[3]]/[sec_list[4]]</TD></TR></TABLE>"
+		dat += "<br><table cellspacing=5><tr><td><b>Security</b></td><td></td></tr>"
+		dat += "<tr><td>Total: </td><td>[sec_list[1]]</td>"
+		dat += "<tr><td>Active: </td><td>[sec_list[2]]</td>"
+		dat += "<tr><td>Dead: </td><td>[sec_list[3]]</td>"
+		dat += "<tr><td>Antag: </td><td>[sec_list[4]]</td>"
+		dat += "</table>"
 
 		dat += "</body></html>"
 		usr << browse(dat, "window=roundstatus;size=400x500")

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -404,7 +404,8 @@
 		<td><A href='?src=[usr.UID()];priv_msg=[M.client ? M.client.UID() : null]'>PM</A> [ADMIN_FLW(M, "FLW")] </td>[close ? "</tr>" : ""]"}
 
 /datum/admins/proc/check_antagonists()
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN))
+		return
 	if(SSticker && SSticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[SSticker.mode.name]</B><BR>"
@@ -569,6 +570,10 @@
 
 		if(SSticker.mode.ert.len)
 			dat += check_role_table("ERT", SSticker.mode.ert)
+
+		//list active security force count, so admins know how bad things are
+		var/list/sec_list = check_active_security_force()
+		dat += "<table cellspacing=5><TR><TD>Security Force Overview(total/active/dead/antag): [sec_list[1]]/[sec_list[2]]/[sec_list[3]]/[sec_list[4]]</TD></TR></TABLE>"
 
 		dat += "</body></html>"
 		usr << browse(dat, "window=roundstatus;size=400x500")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a count to the check antags panel that tells admins the number of security officer on station, as well as how many are active, dead or antagonists.

It takes into account job transfers, so only people currently working as security officer or similar will be counted. Specifically, the roles that count are HoS, Warden, Detective, Security Officer and Pod Pilot

The definition of active is conscious and not an antagonist. Officers currently down for surgery or otherwise unconscious are not counted here. This does mean the three other numbers won't necessarily sum up to the first one, but it seems better than grouping unconscious officers with dead ones, or adding another entry just for unconscious.
Antag can include things like manifest hire traitors, but also shadowling thralls, which i expect to be the most common antagonist where this matters.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It lets admins know how bad things are for the station, letting them gauge if an ert is needed and how many people, if half of sec is sling thralls or not, if the spiders have murdered everyone and are taking over, etc.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![Capture](https://user-images.githubusercontent.com/32099540/87258015-80076080-c4a0-11ea-8c2d-50a45d3d7945.PNG)
A quick picture of the panel addition in action. Not pretty, but most admin tools aren't.
Edit: changed it on kyet's suggestion, slightly less awful I guess.

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Security force counter for admins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
