### PR TITLE
Reworks the disease outbreak event. Makes sure it is actually a potential dangerous issue to the crew

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -17,8 +17,10 @@
 	if(HasDisease(D))
 		return FALSE
 
-	if(istype(D, /datum/disease/advance) && count_by_type(viruses, /datum/disease/advance) > 0)
-		return FALSE
+	if(istype(D, /datum/disease/advance))
+		var/datum/disease/advance/A = D
+		if(!A.event_spawned && count_by_type(viruses, /datum/disease/advance) > 0)
+			return FALSE
 
 	if(!(type in D.viable_mobtypes))
 		return -1 //for stupid fucking monkies

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -117,6 +117,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 // Mix the symptoms of two diseases (the src and the argument)
 /datum/disease/advance/proc/Mix(datum/disease/advance/D)
 	if(!(IsSame(D)))
+		event_spawned = FALSE // To avoid cheesing
 		var/list/possible_symptoms = shuffle(D.symptoms)
 		for(var/datum/symptom/S in possible_symptoms)
 			AddSymptom(new S.type)
@@ -262,6 +263,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 /datum/disease/advance/proc/Evolve(min_level, max_level)
 	var/s = safepick(GenerateSymptoms(min_level, max_level, 1))
 	if(s)
+		event_spawned = FALSE // To avoid cheesing
 		AddSymptom(s)
 		Refresh(1)
 	return
@@ -269,6 +271,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 // Randomly remove a symptom.
 /datum/disease/advance/proc/Devolve()
 	if(symptoms.len > 1)
+		event_spawned = FALSE // To avoid cheesing
 		var/s = safepick(symptoms)
 		if(s)
 			RemoveSymptom(s)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -37,6 +37,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 	var/list/symptoms = list() // The symptoms of the disease.
 	var/id = ""
 	var/processing = 0
+	var/event_spawned = FALSE	// If the virus is event spawned. If true this will allow the virus to get through the virus limit of a mob
 
 /*
 
@@ -47,6 +48,8 @@ GLOBAL_LIST_INIT(advance_cures, list(
 /datum/disease/advance/New(var/process = 1, var/datum/disease/advance/D)
 	if(!istype(D))
 		D = null
+	else
+		event_spawned = D.event_spawned
 	// Generate symptoms if we weren't given any.
 
 	if(!symptoms || !symptoms.len)
@@ -152,12 +155,12 @@ GLOBAL_LIST_INIT(advance_cures, list(
 
 	return generated
 
-/datum/disease/advance/proc/Refresh(new_name = 0)
+/datum/disease/advance/proc/Refresh(new_name = FALSE, archive_disease = TRUE)
 	var/list/properties = GenerateProperties()
 	AssignProperties(properties)
 	id = null
 
-	if(!GLOB.archive_diseases[GetDiseaseID()])
+	if(archive_diseases && !GLOB.archive_diseases[GetDiseaseID()])
 		if(new_name)
 			AssignName()
 		GLOB.archive_diseases[GetDiseaseID()] = src // So we don't infinite loop

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 	AssignProperties(properties)
 	id = null
 
-	if(archive_diseases && !GLOB.archive_diseases[GetDiseaseID()])
+	if(archive_disease && !GLOB.archive_diseases[GetDiseaseID()])
 		if(new_name)
 			AssignName()
 		GLOB.archive_diseases[GetDiseaseID()] = src // So we don't infinite loop

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -9,12 +9,25 @@
 		D = new virus_type()
 	else
 		var/datum/disease/advance/A = new /datum/disease/advance
+		// Try generating a random spreading virus. If that fails just use the last generated one
+		for(var/i = 0; i < 100; i++)
+			var/symptom_amount = rand(2, 6)
+			QDEL_LIST(A.symptoms)
+			A.symptoms = A.GenerateSymptoms(1, 6, symptom_amount)
+			A.Refresh(FALSE, FALSE) // Don't actually archive the miscreants
+			if(VirusCanSpread(A))
+				break
 		A.name = capitalize(pick(GLOB.adjectives)) + " " + capitalize(pick(GLOB.nouns + GLOB.verbs)) // random silly name
-		A.GenerateSymptoms(1,9,6)
-		A.AssignProperties(list("resistance" = rand(0,11), "stealth" = rand(0,2), "stage_rate" = rand(0,5), "transmittable" = rand(0,5), "severity" = rand(0,10)))
+		A.event_spawned = TRUE
+		A.Refresh() // Actually archive it with it's name
 		D = A
 
 	D.carrier = TRUE
+
+/datum/event/disease_outbreak/proc/VirusCanSpread(datum/disease/advance/A)
+	if(A.spread_flags == BLOOD)
+		return locate(/datum/symptom/sneeze) in A.symptoms // Should atleast have sneezing then to be considered spreading
+	return TRUE
 
 /datum/event/disease_outbreak/announce()
 	GLOB.event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -18,10 +18,12 @@
 			if(VirusCanSpread(A))
 				break
 		A.name = capitalize(pick(GLOB.adjectives)) + " " + capitalize(pick(GLOB.nouns + GLOB.verbs)) // random silly name
-		A.event_spawned = TRUE
 		A.Refresh() // Actually archive it with it's name
 		D = A
 
+	if(istype(D, /datum/disease/advance))
+		var/datum/disease/advance/A = D
+		A.event_spawned = TRUE // Will make random advanced viruses and default ones like the flu or such also able to spread
 	D.carrier = TRUE
 
 /datum/event/disease_outbreak/proc/VirusCanSpread(datum/disease/advance/A)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -10,7 +10,7 @@
 	else
 		var/datum/disease/advance/A = new /datum/disease/advance
 		// Try generating a random spreading virus. If that fails just use the last generated one
-		for(var/i = 0; i < 100; i++)
+		for(var/i in 1 to 100)
 			var/symptom_amount = rand(2, 6)
 			QDEL_LIST(A.symptoms)
 			A.symptoms = A.GenerateSymptoms(1, 6, symptom_amount)


### PR DESCRIPTION
## What Does This PR Do
Makes the disease outbreak event actually work when it rolls to create a random advanced virus.
1. Will actually give it symptoms instead of the default 1 or 2 it gets. Also removes the weird property setting that just broke the virus when it spread to somebody else. Fixes #13787
2. Makes sure the virus created is actually able to spread. Either by it's stats or by sneezing.
3. Makes the virus able to be contracted even if you already have one advanced virus. This will make curing viruses using ABM actually valid again. fixes #11617

Partial revive of #10955

## Why It's Good For The Game
1. It fixes a bug
2. It will ensure the virus actually spreads and not just infects patient 0.
3. It will ensure the virus actually will be an issue to the crew even if the virologist already made his healing virus

## Changelog
:cl:
tweak: Random event viruses are now guaranteed to spread
tweak: Random event viruses now spread to victims even if a victim already has an advanced virus
fix: Random event advanced viruses now actually get a set of symptoms instead of the default generated ones.
/:cl:
