### PR TITLE
Fixes Cable GC Issues

### DIFF
--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(machines)
 	while(currentrun.len)
 		var/obj/O = currentrun[currentrun.len]
 		currentrun.len--
-		if(O)
+		if(O && !QDELETED(O))
 			var/datum/powernet/newPN = new() // create a new powernet...
 			propagate_network(O, newPN)//... and propagate it to the other side of the cable
 


### PR DESCRIPTION
Fixes cables not garbage collecting some of the time.

In short, when a cable is destroyed it gets added to the machine SS to propogate the network out the next time the machine SS fires; this is done largely to prevent lag when the singularity releases or an explosion happens.

That said, the controller didn't check for if the cable was `qdel`'d, so `propagate_network` would get called with the deleted cable as the argument and it'd end up adding the cable back to the newly created powernet---thus making a reference again (anddd probably causing bugs and issues).

This fixes that; I wouldn't be all surprised if this also means powernets GC more reliably now too (though they were already super reliable).

Another of the most expensive non-mob things that had GC failures---now resolved

:cl: Fox McCloud
fix: Fixes cables not GC'ing properly
/:cl: