### PR TITLE
Optimizes Smoking

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -31,6 +31,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	var/smoketime = 150
 	var/chem_volume = 60
 	var/list/list_reagents = list("nicotine" = 40)
+	var/first_puff = TRUE // the first puff is a bit more reagents ingested
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/mask.dmi',
 		"Unathi" = 'icons/mob/species/unathi/mask.dmi',
@@ -194,8 +195,9 @@ LIGHTERS ARE IN LIGHTERS.DM
 	if(reagents && reagents.total_volume)	//	check if it has any reagents at all
 		if(is_being_smoked) // if it's being smoked, transfer reagents to the mob
 			var/mob/living/carbon/C = loc
-			for (var/datum/reagent/R in reagents.reagent_list)
-				reagents.trans_id_to(C, R.id, max(REAGENTS_METABOLISM / reagents.reagent_list.len, 0.1)) //transfer at least .1 of each chem
+			for(var/datum/reagent/R in reagents.reagent_list)
+				reagents.trans_id_to(C, R.id, first_puff ? 1 : max(REAGENTS_METABOLISM / reagents.reagent_list.len, 0.1)) //transfer at least .1 of each chem
+			first_puff = FALSE
 			if(!reagents.total_volume) // There were reagents, but now they're gone
 				to_chat(C, "<span class='notice'>Your [name] loses its flavor.</span>")
 		else // else just remove some of the reagents
@@ -377,6 +379,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 		to_chat(user, "<span class='notice'>You refill the pipe with tobacco.</span>")
 		reagents.add_reagent("nicotine", chem_volume)
 		smoketime = initial(smoketime)
+		first_puff = TRUE
 
 /obj/item/clothing/mask/cigarette/pipe/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers))


### PR DESCRIPTION
I noticed that nicotine was one of the most deleted reagents in the entire game----and I immediately knew why (no, it's not that smoking is super super popular--that plays into it a bit).

Smoking currently injected 0.4 of its current chem into the person---then said person processes said reagent which removes it.

This means two things: every time that person hits 0 on the volume of that particular reagent, it's deleted---it also means that the next time you smoke and ingest more nicotine, it notes that there's no nicotine reagent in the mob, so it creates a new instance.

Reagent creation+destroying is ultra cheap, but this was an obvious optimization that doesn't really increase complexity (and it prevents weirdness with reagent flags getting toggled on and off repeatedly too).

The solution: the first time you take a puff on a cig, it injects 1 reagent instead of 0.4.

What this means is that the reagent is created once, it doesn't instantly deplete, and once the next time you smoke rolls around, it just change a var value instead of creating an entirely new instance of that reagent (let's be honest, ti's going to be nicotine 99% of the time).

If you smoke for 40 minutes straight, this is how many instance of nicotine will be created+destroyed, normally:

```
/datum/reagent/nicotine
	qdel() Count: 1600
	Destroy() Cost: 23ms
```

Here's how much nicotine will be created+destroyed, after this optimization:

```
/datum/reagent/nicotine
	qdel() Count: 5
	Destroy() Cost: 0ms
```

This is a micro optimization; this isn't realistically going to really result in that much of a performance gain (23 ms saved over 40 minutes is practically nothing--there's probably more performance gain to be had by the fact of less `locate` calls and less queue length in the GC), but this was an easy to implement optimization, so why not?

:cl: Fox McCloud
fix: Smoking optimized
/:cl: