### PR TITLE
Fixes cling eyes runtiming if you lack eyes

### DIFF
--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -49,7 +49,7 @@
 /obj/item/organ/internal/cyberimp/eyes/shield/ling/on_life()
 	..()
 	var/obj/item/organ/internal/eyes/E = owner.get_int_organ(/obj/item/organ/internal/eyes)
-	if(owner.eye_blind || owner.eye_blurry || (BLINDNESS in owner.mutations) || (NEARSIGHTED in owner.mutations) || (E.damage > 0))
+	if(owner.eye_blind || owner.eye_blurry || (BLINDNESS in owner.mutations) || (NEARSIGHTED in owner.mutations) || (E && E.damage > 0))
 		owner.reagents.add_reagent("oculine", 1)
 
 /obj/item/organ/internal/cyberimp/eyes/shield/ling/prepare_eat()


### PR DESCRIPTION
## What Does This PR Do
Fixes cling eyes from runtiming if you have no eyes.

```
Runtime in augmented_eyesight.dm,52: Cannot read null.damage
   proc name: on life (/obj/item/organ/internal/cyberimp/eyes/shield/ling/on_life)
   src: the protective membranes (/obj/item/organ/internal/cyberimp/eyes/shield/ling)
   src.loc: null
   call stack:
   the protective membranes (/obj/item/organ/internal/cyberimp/eyes/shield/ling): on life()
   NAME (/mob/living/carbon/human): handle organs()
   NAME (/mob/living/carbon/human): handle organs()
   NAME (/mob/living/carbon/human): Life(2, 37)
   NAME (/mob/living/carbon/human): Life(2, 37)
   Mobs (/datum/controller/subsystem/mobs): fire(0)
   Mobs (/datum/controller/subsystem/mobs): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game
Less bugs the better

## Changelog
Pure technical fix. Functionally it's the same outcome