### PR TITLE
Makes borgs (dis)connect properly to the AI. Fixing invisible borgs for the AI and a runtime or more

### DIFF
--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -15,16 +15,16 @@
 	switch(index)
 		if(BORG_WIRE_MAIN_POWER)
 			return "Main Power"
-		
+
 		if(BORG_WIRE_LOCKED_DOWN)
 			return "Lockdown"
-		
+
 		if(BORG_WIRE_CAMERA)
 			return "Camera"
-			
+
 		if(BORG_WIRE_AI_CONTROL)
 			return "AI Control"
-		
+
 		if(BORG_WIRE_LAWCHECK)
 			return "Law Check"
 
@@ -52,7 +52,7 @@
 		if(BORG_WIRE_AI_CONTROL) //Cut the AI wire to reset AI control
 			if(!mended)
 				if(R.connected_ai)
-					R.connected_ai = null
+					R.disconnect_from_ai()
 
 		if(BORG_WIRE_CAMERA)
 			if(!isnull(R.camera) && !R.scrambledcodes)
@@ -74,8 +74,7 @@
 	switch(index)
 		if(BORG_WIRE_AI_CONTROL) //pulse the AI wire to make the borg reselect an AI
 			if(!R.emagged)
-				R.connected_ai = select_active_ai()
-				R.notify_ai(1)
+				R.connect_to_ai(select_active_ai())
 
 		if(BORG_WIRE_CAMERA)
 			if(!isnull(R.camera) && R.camera.can_use() && !R.scrambledcodes)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -253,7 +253,16 @@
 				to_chat(user, "<span class='warning'>This [W] does not seem to fit.</span>")
 				return
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1)
+			var/datum/ai_laws/laws_to_give
+			if(M.syndiemmi)
+				aisync = FALSE
+				lawsync = FALSE
+				laws_to_give = new /datum/ai_laws/syndicate_override
+
+			if(!aisync)
+				lawsync = FALSE
+
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1, ai_to_sync_to = forced_ai)
 			if(!O)
 				return
 
@@ -263,24 +272,15 @@
 			if(istype(task))
 				task.unit_completed()
 
-			if(M.syndiemmi)
-				aisync = 0
-				lawsync = 0
-				O.laws = new /datum/ai_laws/syndicate_override
-
 			O.invisibility = 0
 			//Transfer debug settings to new mob
 			O.custom_name = created_name
 			O.rename_character(O.real_name, O.get_default_name())
 			O.locked = panel_locked
-			if(!aisync)
-				lawsync = 0
-				O.connected_ai = null
-			else
-				O.notify_ai(1)
-				if(forced_ai)
-					O.connected_ai = forced_ai
-			if(!lawsync && !M.syndiemmi)
+
+			if(laws_to_give)
+				O.laws = laws_to_give
+			else if(!lawsync)
 				O.lawupdate = 0
 				O.make_laws()
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -83,7 +83,7 @@
 	scanner.Grant(src)
 	update_icons()
 
-/mob/living/silicon/robot/drone/init()
+/mob/living/silicon/robot/drone/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/drone()
 	connected_ai = null
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 /mob/living/silicon/robot/get_cell()
 	return cell
 
-/mob/living/silicon/robot/New(loc,var/syndie = 0,var/unfinished = 0, var/alien = 0)
+/mob/living/silicon/robot/New(loc, syndie = FALSE, unfinished = FALSE, alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	radio = new /obj/item/radio/borg(src)
 	common_radio = radio
 
-	init()
+	init(ai_to_sync_to = ai_to_sync_to)
 
 	if(has_camera && !camera)
 		camera = new /obj/machinery/camera(src)
@@ -172,14 +172,16 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	scanner = new(src)
 	scanner.Grant(src)
 
-/mob/living/silicon/robot/proc/init(var/alien=0)
+/mob/living/silicon/robot/proc/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
 	make_laws()
 	additional_law_channels["Binary"] = ":b "
-	var/new_ai = select_active_ai_with_fewest_borgs()
-	if(new_ai)
+	var/found_ai = ai_to_sync_to
+	if(!found_ai)
+		found_ai = select_active_ai_with_fewest_borgs()
+	if(found_ai)
 		lawupdate = 1
-		connect_to_ai(new_ai)
+		connect_to_ai(found_ai)
 	else
 		lawupdate = 0
 
@@ -1348,7 +1350,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	is_emaggable = FALSE
 	default_cell_type = /obj/item/stock_parts/cell/bluespace
 
-/mob/living/silicon/robot/deathsquad/init()
+/mob/living/silicon/robot/deathsquad/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/deathsquad
 	module = new /obj/item/robot_module/deathsquad(src)
 	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
@@ -1378,7 +1380,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/eprefix = "Amber"
 
 
-/mob/living/silicon/robot/ert/init()
+/mob/living/silicon/robot/ert/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/ert_override
 	radio = new /obj/item/radio/borg/ert(src)
 	radio.recalculateChannels()
@@ -1434,7 +1436,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	xeno_disarm_chance = 10
 	default_cell_type = /obj/item/stock_parts/cell/bluespace
 
-/mob/living/silicon/robot/destroyer/init()
+/mob/living/silicon/robot/destroyer/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	..()
 	module = new /obj/item/robot_module/destroyer(src)
 	module.add_languages(src)

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -21,7 +21,7 @@
 	..()
 	cell = new /obj/item/stock_parts/cell/hyper(src)
 
-/mob/living/silicon/robot/syndicate/init()
+/mob/living/silicon/robot/syndicate/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/syndicate_override
 	module = new /obj/item/robot_module/syndicate(src)
 
@@ -47,7 +47,7 @@
 						Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
 						<i>Help the operatives secure the disk at all costs!</i></b>"
 
-/mob/living/silicon/robot/syndicate/medical/init()
+/mob/living/silicon/robot/syndicate/medical/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	..()
 	module = new /obj/item/robot_module/syndicate_medical(src)
 
@@ -67,7 +67,7 @@
 						Be aware that physical contact or taking damage will break your disguise. \
 						<i>Help the operatives secure the disk at all costs!</i></b>"
 
-/mob/living/silicon/robot/syndicate/saboteur/init()
+/mob/living/silicon/robot/syndicate/saboteur/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	..()
 	module = new /obj/item/robot_module/syndicate_saboteur(src)
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -196,7 +196,7 @@
 				var/mob/living/silicon/robot/Robot = new_mob
 				Robot.mmi = new /obj/item/mmi(new_mob)
 				Robot.lawupdate = FALSE
-				Robot.connected_ai = null
+				Robot.disconnect_from_ai()
 				Robot.clear_inherent_laws()
 				Robot.clear_zeroth_law()
 				if(ishuman(M))


### PR DESCRIPTION
## What Does This PR Do
Makes it so that borgs are properly disconnected and connected to AIs when they get their AI overlord removed/added.

## Why It's Good For The Game
Less bugs more ... well it's just better

## Changelog
:cl:
fix: Fixes a case where a borg would be synced to the AI but wouldn't be visible to the AI in it's stat screen.
/:cl: