### PR TITLE
Notify admins when AI core is created

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -154,8 +154,8 @@
 			state = SCREWED_CORE
 		if(GLASS_CORE)
 			var/area/R = get_area(src)
-			message_admins("[key_name_admin(usr)] has completed an AI core in [R] on z[z].")
-			log_game("[key_name(usr)] has completed an AI core in [R] on z[z].")
+			message_admins("[key_name_admin(usr)] has completed an AI core in [R]: [ADMIN_COORDJMP(loc)].")
+			log_game("[key_name(usr)] has completed an AI core in [R]: [COORD(loc)].")
 			to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 			if(!brain)
 				var/open_for_latejoin = alert(user, "Would you like this core to be open for latejoining AIs?", "Latejoin", "Yes", "Yes", "No") == "Yes"

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -153,6 +153,9 @@
 			to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
 			state = SCREWED_CORE
 		if(GLASS_CORE)
+			var/area/R = get_area(src)
+			message_admins("[key_name_admin(usr)] has completed an AI core in [R] on z[z].")
+			log_game("[key_name(usr)] has completed an AI core in [R] on z[z].")
 			to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 			if(!brain)
 				var/open_for_latejoin = alert(user, "Would you like this core to be open for latejoining AIs?", "Latejoin", "Yes", "Yes", "No") == "Yes"


### PR DESCRIPTION
## What Does This PR Do
Notifies admins, and writes a message to game.log, whenever an AI core is completed.
The notification includes the name of the person who did it, where they are, and the zlevel.

## Why It's Good For The Game
Lately, we've been having issues with free golems in lavaland creating AIs every shift, even though the rules prohibit this.
This notification to admins will make it easier for admins to catch this, and stop it, before it gets out of control.

## Images
![ai_core_finish_log](https://user-images.githubusercontent.com/16434066/87200843-f7948e80-c2ec-11ea-9b48-9993d3b98c72.png)


## Changelog
:cl: Kyep
add: Completing an AI core now notifies admins.
/:cl:
