### PR TITLE
Make the request AI use UID instead of \ref

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -195,7 +195,7 @@ GLOBAL_LIST_EMPTY(holopads)
 			for(var/mob/living/silicon/ai/AI in GLOB.ai_list)
 				if(!AI.client)
 					continue
-				to_chat(AI, "<span class='info'>Your presence is requested at <a href='?src=\ref[AI];jumptoholopad=[UID()]'>\the [area]</a>.</span>")
+				to_chat(AI, "<span class='info'>Your presence is requested at <a href='?src=[AI.UID()];jumptoholopad=[UID()]'>\the [area]</a>.</span>")
 		else
 			temp = "A request for AI presence was already sent recently.<br>"
 			temp += "<a href='?src=[UID()];mainmenu=1'>Main Menu</a>"


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime:
```
[2020-07-11T07:14:47] Runtime in code/modules/client/client procs.dm,41: Got \ref-based src in topic from CKEY for NAME (CKEY) (/mob/living/silicon/ai), should be UID: src=[0x30001b6];jumptoholopad=[0x200579f]_5258
   usr: NAME (CKEY) (/mob/living/silicon/ai)
   usr.loc: The floor (143,23,1) (/turf/simulated/floor/bluegrid)
```

## Why It's Good For The Game
Runtime b gone

## Changelog
No CL since pure backend