### PR TITLE
Fixes drift on projectiles firing west

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -247,8 +247,8 @@
 			M.Turn(Angle)
 			transform = M
 
-			var/Pixel_x = round(sin(Angle) + 16 * sin(Angle) * 2)
-			var/Pixel_y = round(cos(Angle) + 16 * cos(Angle) * 2)
+			var/Pixel_x = round(sin(Angle) + 16 * sin(Angle) * 2, 1)
+			var/Pixel_y = round(cos(Angle) + 16 * cos(Angle) * 2, 1)
 			var/pixel_x_offset = pixel_x + Pixel_x
 			var/pixel_y_offset = pixel_y + Pixel_y
 			var/new_x = x


### PR DESCRIPTION
Added variable to offset rounding so that it actually rounds to the closest number instead of flooring it to the next lowest integer.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the projectile X/Y movement calculations to actually round to the nearest integer instead of flooring it to the next lowest integer. This stops projectiles firing straight west from drifting south and makes aiming in general slightly more accurate.
Fixes #13248 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes aim slightly more accurate.
Fixes noticeable southward drift on projectiles that should be firing straight west.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Fixed error causing projectiles to drift slightly off-target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
