### PR TITLE
Fixes Alien Larva Being Unconscious by Default

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -16,7 +16,7 @@
 			death()
 			return
 
-		if(paralysis || sleeping || getOxyLoss() > 50 || (HEALTH_THRESHOLD_CRIT <= health && check_death_method()))
+		if(paralysis || sleeping || getOxyLoss() > 50 || (health <= HEALTH_THRESHOLD_CRIT && check_death_method()))
 			if(stat == CONSCIOUS)
 				KnockOut()
 				create_debug_log("fell unconscious, trigger reason: [reason]")


### PR DESCRIPTION
Fixes alien larva being unconscious by default.

A mistake from the `Life` refactor. Inverted logic. Oops.

fixes: https://github.com/ParadiseSS13/Paradise/issues/13808

:cl: Fox McCloud
fix: Fixes alien larva being unconscious upon spawning in
/:cl: