### PR TITLE
Adds the guardian element

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -726,3 +726,12 @@
 #define COMSIG_XENO_TURF_CLICK_CTRL "xeno_turf_click_alt"
 ///from monkey CtrlClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"
+
+// /datum/element/guardian signals
+
+///from /mob/living/proc/guardian_recall(): ()
+#define COMSIG_GUARDIAN_RECALL "guardian_recall"
+///from /mob/living/proc/guardian_reset(): ()
+#define COMSIG_GUARDIAN_RESET "guardian_reset"
+///from /mob/living/proc/guardian_comm(): ()
+#define COMSIG_GUARDIAN_COMMUNICATION "guardian_communication"

--- a/code/datums/elements/guardian.dm
+++ b/code/datums/elements/guardian.dm
@@ -1,0 +1,134 @@
+/**
+ * # The guardian element
+ *
+ * An element that is designed to be attached to guardian hosts, which gives them control over the communication, recalling, and the re-rolling of their guardians.
+ * The element will only attach to living mobs.
+ */
+/datum/element/guardian
+	element_flags = ELEMENT_BESPOKE
+	id_arg_index = 2
+	/// The mob who owns the guardian.
+	var/mob/living/host
+	/// The guardian.
+	var/mob/living/simple_animal/hostile/guardian/guardian
+
+/datum/element/guardian/Attach(datum/target, mob/living/simple_animal/hostile/guardian/_guardian)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+
+	host = target
+	guardian = _guardian
+
+	RegisterSignal(host, COMSIG_GUARDIAN_RECALL, .proc/GuardianRecall)
+	RegisterSignal(host, COMSIG_GUARDIAN_RESET, .proc/GuardianReroll)
+	RegisterSignal(host, COMSIG_GUARDIAN_COMMUNICATION, .proc/Communicate)
+
+/datum/element/guardian/Detach(datum/source, force)
+	. = ..()
+	UnregisterSignal(host, COMSIG_GUARDIAN_RECALL)
+	UnregisterSignal(host, COMSIG_GUARDIAN_RESET)
+	UnregisterSignal(host, COMSIG_GUARDIAN_COMMUNICATION)
+
+/**
+ * Proc called after the user clicks their "Recall Guardian" verb in the guardian tab. Called via receiving the `COMSIG_GUARDIAN_RECALL` signal.
+ *
+ * Calls the `Recall()` proc on the `guardian`.
+ *
+ * Arguments:
+ * * source - the `host` mob.
+ */
+/datum/element/guardian/proc/GuardianRecall(datum/source)
+	guardian.Recall()
+
+/**
+ * Proc called after the user clicks their "Communicate" verb in the guardian tab. Called via receiving the `COMSIG_GUARDIAN_COMMUNICATION` signal.
+ *
+ * First, prompt the `host` to enter a message to send.
+ * If the message exists and they didn't press cancel, show the message to the `host`, their `guardian`, and any dead players or observers. Also logs the communication.
+ * If they pressed cancel, return.
+ *
+ * Arguemnts:
+ * * source - the `host` mob.
+ */
+/datum/element/guardian/proc/Communicate(datum/source)
+	// Prompt the `host` for their message.
+	var/message = stripped_input(host, "Please enter a message to tell your guardian.", "Message", "")
+	if(!message)
+		return
+
+	// Show the message to our guardian and to host. Log the message.
+	to_chat(guardian, "<span class='changeling'><i>[host]:</i> [message]</span>")
+	to_chat(host, "<span class='changeling'><i>[host]:</i> [message]</span>")
+	log_say("(GUARDIAN to [key_name(guardian)]) [message]", host)
+	host.create_log(SAY_LOG, "HOST to GUARDIAN: [message]", guardian)
+
+	// Show the message to any ghosts/dead players.
+	for(var/observer in GLOB.dead_mob_list)
+		var/mob/dead/M = observer
+		if(M && M.client && M.stat == DEAD && !isnewplayer(M))
+			to_chat(M, "<span class='changeling'><i>Guardian Communication from <b>[host]</b> ([ghost_follow_link(host, ghost=M)]): [message]</i>")
+
+/**
+ * Proc called after the user clicks their "Reset Guardian Player (One Use)" verb in the guardian tab. Called via receiving the `COMSIG_GUARDIAN_RESET` signal.
+ *
+ * Removes the reset verb from the `host`, and attempts to poll ghosts for a replacement.
+ * If a ghost is found, place them in control of the `guardian.`
+ * If no ghost is found, display an error message and return. Create a callback which re-adds the verb in 5 minutes, so the `host` may try again.
+ *
+ * Arguemnts:
+ * * source - the `host` mob.
+ */
+/datum/element/guardian/proc/GuardianReroll(datum/source)
+	host.verbs -= /mob/living/proc/guardian_reset
+
+	// Poll ghosts for a replacement.
+	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [guardian.real_name]?", ROLE_GUARDIAN, 0, 100)
+	var/mob/dead/observer/new_stand = null
+
+	// No one accepted. Let them try again in 5 minutes.
+	if(!length(candidates))
+		to_chat(host, "<span class='userdanger'>There were no ghosts willing to replace your guardian. You can try again in 5 minutes.</span>")
+		addtimer(CALLBACK(src, .proc/guardian_reset_callback), 5 MINUTES)
+		return
+
+	// Found a ghost. Put them into the guardian and ghost the current guardian player.
+	new_stand = pick(candidates)
+	to_chat(guardian, "<span class='userdanger'>Your user reset you, and your body was taken over by a ghost. Looks like they weren't happy with your performance.</span>")
+	to_chat(host, "<span class='boldnotice'>Your guardian has been successfully reset.</span>")
+	message_admins("[key_name_admin(new_stand)] has taken control of ([key_name_admin(guardian)])")
+	guardian.ghostize()
+	guardian.key = new_stand.key
+
+/**
+ * Gives the `host` the `guardian_reset()` verb.
+ */
+/datum/element/guardian/proc/guardian_reset_callback()
+	host.verbs |= /mob/living/proc/guardian_reset
+
+/**
+ * Gives the guardian host a verb to communicate with their guardian. Sends the `COMSIG_GUARDIAN_COMMUNICATION` signal.
+ */
+/mob/living/proc/guardian_comm()
+	set name = "Communicate"
+	set category = "Guardian"
+	set desc = "Communicate telepathically with your guardian."
+	SEND_SIGNAL(src, COMSIG_GUARDIAN_COMMUNICATION)
+
+/**
+ * Gives the guardian host a verb to recall their guardian. Sends the `COMSIG_GUARDIAN_RECALL` signal.
+ */
+/mob/living/proc/guardian_recall()
+	set name = "Recall Guardian"
+	set category = "Guardian"
+	set desc = "Forcibly recall your guardian."
+	SEND_SIGNAL(src, COMSIG_GUARDIAN_RECALL)
+
+/**
+ * Gives the guardian host a verb to re-roll their guardian. Sends the `COMSIG_GUARDIAN_RESET` signal.
+ */
+/mob/living/proc/guardian_reset()
+	set name = "Reset Guardian Player (One Use)"
+	set category = "Guardian"
+	set desc = "Re-rolls which ghost will control your Guardian. One use."
+	SEND_SIGNAL(src, COMSIG_GUARDIAN_RESET)

--- a/paradise.dme
+++ b/paradise.dme
@@ -365,6 +365,7 @@
 #include "code\datums\diseases\advance\symptoms\weight.dm"
 #include "code\datums\diseases\advance\symptoms\youth.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\guardian.dm"
 #include "code\datums\elements\waddling.dm"
 #include "code\datums\helper_datums\construction_datum.dm"
 #include "code\datums\helper_datums\events.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new element: the guardian element, which is designed to handle all the interactions hosts have with their guardians. Those being recalling, communication and re-rolling.

The current way guardians are handled is gross. For example this happens whenever the user tries to recall their guardian:
```js
for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.mob_list)
    if(G.summoner == src)
        G.Recall()
```
This loops through the entirety of all mobs in the list, filters it, and checks if the summoner is the correct one. Its an awful way to handle things and its what sparked me make this PR.

I thought about converting the guardian verbs into action buttons at first, but decided it might clutter up the host's button list, especially if they have other traitor things like chameleon items or implants. That would certainly be the *simpler* alternative. But with this PR, it allows us to keep the verbs. I thought I'd just throw this up and see what people think. It didn't take that long to write, so not a huge deal.

Backend change, so no CL.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
