### PR TITLE
Janiborgs can no longer clean while dead

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1147,41 +1147,39 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 					updating = 0
 	if(module)
 		if(module.type == /obj/item/robot_module/janitor)
-			if(stat != DEAD)
-				var/turf/tile = loc
-				if(isturf(tile))
-					var/floor_only = TRUE
-					for(var/A in tile)
-						if(istype(A, /obj/effect))
-							if(is_cleanable(A))
-								var/obj/effect/decal/cleanable/blood/B = A
-								if(istype(B) && B.off_floor)
-									floor_only = FALSE
-								else
-									qdel(A)
-						else if(istype(A, /obj/item))
-							var/obj/item/cleaned_item = A
-							cleaned_item.clean_blood()
-						else if(istype(A, /mob/living/carbon/human))
-							var/mob/living/carbon/human/cleaned_human = A
-							if(cleaned_human.lying)
-								if(cleaned_human.head)
-									cleaned_human.head.clean_blood()
-									cleaned_human.update_inv_head()
-								if(cleaned_human.wear_suit)
-									cleaned_human.wear_suit.clean_blood()
-									cleaned_human.update_inv_wear_suit()
-								else if(cleaned_human.w_uniform)
-									cleaned_human.w_uniform.clean_blood()
-									cleaned_human.update_inv_w_uniform()
-								if(cleaned_human.shoes)
-									cleaned_human.shoes.clean_blood()
-									cleaned_human.update_inv_shoes()
-								cleaned_human.clean_blood()
-								to_chat(cleaned_human, "<span class='danger'>[src] cleans your face!</span>")
-					if(floor_only)
-						tile.clean_blood()
-			return
+			var/turf/tile = loc
+			if(stat != DEAD && isturf(tile))
+				var/floor_only = TRUE
+				for(var/A in tile)
+					if(istype(A, /obj/effect))
+						if(is_cleanable(A))
+							var/obj/effect/decal/cleanable/blood/B = A
+							if(istype(B) && B.off_floor)
+								floor_only = FALSE
+							else
+								qdel(A)
+					else if(istype(A, /obj/item))
+						var/obj/item/cleaned_item = A
+						cleaned_item.clean_blood()
+					else if(istype(A, /mob/living/carbon/human))
+						var/mob/living/carbon/human/cleaned_human = A
+						if(cleaned_human.lying)
+							if(cleaned_human.head)
+								cleaned_human.head.clean_blood()
+								cleaned_human.update_inv_head()
+							if(cleaned_human.wear_suit)
+								cleaned_human.wear_suit.clean_blood()
+								cleaned_human.update_inv_wear_suit()
+							else if(cleaned_human.w_uniform)
+								cleaned_human.w_uniform.clean_blood()
+								cleaned_human.update_inv_w_uniform()
+							if(cleaned_human.shoes)
+								cleaned_human.shoes.clean_blood()
+								cleaned_human.update_inv_shoes()
+							cleaned_human.clean_blood()
+							to_chat(cleaned_human, "<span class='danger'>[src] cleans your face!</span>")
+				if(floor_only)
+					tile.clean_blood()
 		return
 #undef BORG_CAMERA_BUFFER
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1147,39 +1147,41 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 					updating = 0
 	if(module)
 		if(module.type == /obj/item/robot_module/janitor)
-			var/turf/tile = loc
-			if(isturf(tile))
-				var/floor_only = TRUE
-				for(var/A in tile)
-					if(istype(A, /obj/effect))
-						if(is_cleanable(A))
-							var/obj/effect/decal/cleanable/blood/B = A
-							if(istype(B) && B.off_floor)
-								floor_only = FALSE
-							else
-								qdel(A)
-					else if(istype(A, /obj/item))
-						var/obj/item/cleaned_item = A
-						cleaned_item.clean_blood()
-					else if(istype(A, /mob/living/carbon/human))
+			if(stat != DEAD)		
+				var/turf/tile = loc
+				if(isturf(tile))
+					var/floor_only = TRUE
+					for(var/A in tile)
+						if(istype(A, /obj/effect))
+							if(is_cleanable(A))
+								var/obj/effect/decal/cleanable/blood/B = A
+								if(istype(B) && B.off_floor)
+									floor_only = FALSE
+								else
+									qdel(A)
+						else if(istype(A, /obj/item))
+							var/obj/item/cleaned_item = A
+							cleaned_item.clean_blood()
+						else if(istype(A, /mob/living/carbon/human))
 						var/mob/living/carbon/human/cleaned_human = A
-						if(cleaned_human.lying)
-							if(cleaned_human.head)
-								cleaned_human.head.clean_blood()
-								cleaned_human.update_inv_head()
-							if(cleaned_human.wear_suit)
-								cleaned_human.wear_suit.clean_blood()
-								cleaned_human.update_inv_wear_suit()
-							else if(cleaned_human.w_uniform)
-								cleaned_human.w_uniform.clean_blood()
-								cleaned_human.update_inv_w_uniform()
-							if(cleaned_human.shoes)
-								cleaned_human.shoes.clean_blood()
-								cleaned_human.update_inv_shoes()
-							cleaned_human.clean_blood()
-							to_chat(cleaned_human, "<span class='danger'>[src] cleans your face!</span>")
-				if(floor_only)
-					tile.clean_blood()
+							if(cleaned_human.lying)
+								if(cleaned_human.head)
+									cleaned_human.head.clean_blood()
+									cleaned_human.update_inv_head()
+								if(cleaned_human.wear_suit)
+									cleaned_human.wear_suit.clean_blood()
+									cleaned_human.update_inv_wear_suit()
+								else if(cleaned_human.w_uniform)
+									cleaned_human.w_uniform.clean_blood()
+									cleaned_human.update_inv_w_uniform()
+								if(cleaned_human.shoes)
+									cleaned_human.shoes.clean_blood()
+									cleaned_human.update_inv_shoes()
+								cleaned_human.clean_blood()
+								to_chat(cleaned_human, "<span class='danger'>[src] cleans your face!</span>")
+					if(floor_only)
+						tile.clean_blood()
+			return
 		return
 #undef BORG_CAMERA_BUFFER
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1147,7 +1147,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 					updating = 0
 	if(module)
 		if(module.type == /obj/item/robot_module/janitor)
-			if(stat != DEAD)		
+			if(stat != DEAD)
 				var/turf/tile = loc
 				if(isturf(tile))
 					var/floor_only = TRUE
@@ -1163,7 +1163,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 							var/obj/item/cleaned_item = A
 							cleaned_item.clean_blood()
 						else if(istype(A, /mob/living/carbon/human))
-						var/mob/living/carbon/human/cleaned_human = A
+							var/mob/living/carbon/human/cleaned_human = A
 							if(cleaned_human.lying)
 								if(cleaned_human.head)
 									cleaned_human.head.clean_blood()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Messed up my fork so this is a redo with Fox's suggestion

Fixes #13802

This PR makes it so that dead janitor borgs will no longer clean the floors under them.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is just bad, an example of this would be trying to sacrifice a dead janitor borg as a cultist, but the borg cleaning the rune very time you put it on top of the rune.
This also doesn't make sense, if the borg is off or non functional, why would it still clean perfectly fine?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Janitor borgs no longer clean while dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
