### PR TITLE
More Tcomms Fixes

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
@@ -411,17 +411,9 @@
 /obj/structure/chair,
 /turf/simulated/floor/plating/airless,
 /area/ruin/tcommsat)
-"bu" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/plating/airless{
-	icon_state = "dark"
-	},
-/area/ruin/tcommsat)
 "bv" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/plating/airless{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating/airless,
 /area/ruin/tcommsat)
 "bw" = (
 /obj/structure/window/reinforced{
@@ -2709,7 +2701,7 @@ aD
 aC
 aC
 ai
-bu
+bC
 ai
 ak
 ak

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -57,6 +57,9 @@
   * * zlevel - The input z level to test
   */
 /obj/machinery/tcomms/core/proc/zlevel_reachable(zlevel)
+	// Nothing is reachable if the core is offline, unpowered, or ion'd
+	if(!active || (stat & NOPOWER) || ion)
+		return FALSE
 	if(zlevel in reachable_zlevels)
 		return TRUE
 	else
@@ -113,7 +116,7 @@
 	// Add all the linked relays in
 	for(var/obj/machinery/tcomms/relay/R in linked_relays)
 		// Only if the relay is active
-		if(R.active)
+		if(R.active && !(R.stat & NOPOWER))
 			reachable_zlevels |= R.loc.z
 
 

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -76,6 +76,16 @@
 		linked_core = null
 		linked = FALSE
 
+/**
+  * Power Change Handler
+  *
+  * Proc which ensures the host core has its zlevels updated (icons are updated by parent call)
+  */
+/obj/machinery/tcomms/relay/power_change()
+    ..()
+    if(linked_core)
+        linked_core.refresh_zlevels()
+
 //////////////
 // UI STUFF //
 //////////////


### PR DESCRIPTION
## What Does This PR Do
Fixes #13775
Fixes #13814
Fixes #13817

![image](https://user-images.githubusercontent.com/25063394/87294537-d35acc80-c4fb-11ea-83d8-68a241e4c860.png)
(Tried PDA messaging twice to double check, hence the x2)

![image](https://user-images.githubusercontent.com/25063394/87294583-deadf800-c4fb-11ea-80b8-5aeaa27b5fc2.png)
(Turfs are fine now)

## Why It's Good For The Game
Things shouldnt be broken

## Changelog
:cl: AffectedArc07
fix: Fixed bad turfs on the tcommsat ruin
fix: PDAs are now unavailable when there is an ion anomalie
fix: TComms relays will now update the host core's zlevel reach on a power change
/:cl:
