### PR TITLE
Async Lighting

### DIFF
--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -100,6 +100,7 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 		SSlighting.corners_queue += src
 
 /datum/lighting_corner/proc/update_objects()
+	set waitfor = FALSE
 	// Cache these values ahead of time so 4 individual lighting objects don't all calculate them individually.
 	var/lum_r = src.lum_r
 	var/lum_g = src.lum_g

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -52,6 +52,7 @@
 		return QDEL_HINT_LETMELIVE
 
 /atom/movable/lighting_object/proc/update()
+	set waitfor = FALSE
 	if(loc != myturf)
 		if(loc)
 			var/turf/oldturf = get_turf(myturf)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -151,6 +151,7 @@
 	UNSETEMPTY(effect_str)
 
 /datum/light_source/proc/update_corners()
+	set waitfor = FALSE
 	var/update = FALSE
 	var/atom/source_atom = src.source_atom
 


### PR DESCRIPTION
## What Does This PR Do
Makes lighting operations async.

Without async:
![image](https://user-images.githubusercontent.com/25063394/87298837-cd1c1e80-c502-11ea-8225-5b86f7d12bfb.png)

With async:
![image](https://user-images.githubusercontent.com/25063394/87298843-d0afa580-c502-11ea-8107-6d73c93ded8d.png)

*Ignore the log format change, I redid the code and forgot to type the message properly* 

## Why It's Good For The Game
Makes lighting faster

## Changelog
:cl: AffectedArc07
tweak: Lighting is faster now
/:cl:
