### PR TITLE
Makes job gear have no overlap cost in loadout

### DIFF
--- a/code/modules/client/preference/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference/loadout/loadout_accessories.dm
@@ -154,6 +154,9 @@
 	display_name = "corset, blue"
 	path = /obj/item/clothing/accessory/corset/blue
 
+/datum/gear/accessory/armband/job
+	subtype_path = /datum/gear/accessory/armband/job
+	subtype_cost_overlap = FALSE
 
 /datum/gear/accessory/armband_red
 	display_name = "armband"
@@ -163,37 +166,37 @@
 	display_name = "armband, blue-yellow"
 	path = /obj/item/clothing/accessory/armband/yb
 
-/datum/gear/accessory/armband_sec
+/datum/gear/accessory/armband/job/sec
 	display_name = " armband, security"
 	path = /obj/item/clothing/accessory/armband/sec
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer", "Brig Physician", "Security Pod Pilot")
 
-/datum/gear/accessory/armband_cargo
+/datum/gear/accessory/armband/job/cargo
 	display_name = "cargo armband"
 	path = /obj/item/clothing/accessory/armband/cargo
 	allowed_roles = list("Quartermaster","Cargo Technician", "Shaft Miner")
 
-/datum/gear/accessory/armband_medical
+/datum/gear/accessory/armband/job/medical
 	display_name = "armband, medical"
 	path = /obj/item/clothing/accessory/armband/med
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Coroner", "Paramedic", "Brig Physician")
 
-/datum/gear/accessory/armband_emt
+/datum/gear/accessory/armband/job/emt
 	display_name = "armband, EMT"
 	path = /obj/item/clothing/accessory/armband/medgreen
 	allowed_roles = list("Paramedic", "Brig Physician")
 
-/datum/gear/accessory/armband_engineering
+/datum/gear/accessory/armband/job/engineering
 	display_name = "armband, engineering"
 	path = /obj/item/clothing/accessory/armband/engine
 	allowed_roles = list("Chief Engineer","Station Engineer", "Life Support Specialist")
 
-/datum/gear/accessory/armband_hydro
+/datum/gear/accessory/armband/job/hydro
 	display_name = "armband, hydroponics"
 	path = /obj/item/clothing/accessory/armband/hydro
 	allowed_roles = list("Botanist")
 
-/datum/gear/accessory/armband_sci
+/datum/gear/accessory/armband/job/sci
 	display_name = "armband, science"
 	path = /obj/item/clothing/accessory/armband/science
 	allowed_roles = list("Research Director","Scientist", "Roboticist")

--- a/code/modules/client/preference/loadout/loadout_hat.dm
+++ b/code/modules/client/preference/loadout/loadout_hat.dm
@@ -42,11 +42,6 @@
 	display_name = "fedora, brown"
 	path = /obj/item/clothing/head/fedora/brownfedora
 
-/datum/gear/hat/beretsec
-	display_name = "security beret"
-	path = /obj/item/clothing/head/beret/sec
-	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Security Pod Pilot")
-
 /datum/gear/hat/capcsec
 	display_name = "security corporate cap"
 	path = /obj/item/clothing/head/soft/sec/corp
@@ -113,31 +108,53 @@
 	display_name = "cowboy hat, pink"
 	path = /obj/item/clothing/head/cowboyhat/pink
 
-/datum/gear/hat/pr_beret
+//Berets Refactor
+//Defining all Job Berets as no-overlap
+//Somehow this doesn't break the DB.
+/datum/gear/hat/beret/job
+	subtype_path = /datum/gear/hat/beret/job
+	subtype_cost_overlap = FALSE
+
+/datum/gear/hat/beret/purple
 	display_name = "beret, purple"
 	path = /obj/item/clothing/head/beret/purple_normal
 
-/datum/gear/hat/bl_beret
+/datum/gear/hat/beret/black
 	display_name = "beret, black"
 	path = /obj/item/clothing/head/beret/black
 
-/datum/gear/hat/blu_beret
+/datum/gear/hat/beret/blue
 	display_name = "beret, blue"
 	path = /obj/item/clothing/head/beret/blue
 
-/datum/gear/hat/red_beret
+/datum/gear/hat/beret/red
 	display_name = "beret, red"
 	path = /obj/item/clothing/head/beret
 
-/datum/gear/hat/sci_beret
+/datum/gear/hat/beret/job/sec
+	display_name = "security beret"
+	path = /obj/item/clothing/head/beret/sec
+	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Security Pod Pilot")
+
+/datum/gear/hat/beret/job/sci
 	display_name = "science beret"
 	path = /obj/item/clothing/head/beret/sci
 	allowed_roles = list("Research Director", "Scientist")
 
-/datum/gear/hat/med_beret
+/datum/gear/hat/beret/job/med
 	display_name = "medical beret"
 	path = /obj/item/clothing/head/beret/med
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor" , "Virologist", "Brig Physician" , "Coroner")
+
+/datum/gear/hat/beret/job/eng
+	display_name = "engineering beret"
+	path = /obj/item/clothing/head/beret/eng
+	allowed_roles = list("Chief Engineer", "Station Engineer")
+
+/datum/gear/hat/beret/job/atmos
+	display_name = "atmospherics beret"
+	path = /obj/item/clothing/head/beret/atmos
+	allowed_roles = list("Chief Engineer", "Life Support Specialist")
 
 /datum/gear/hat/surgicalcap_purple
 	display_name = "surgical cap, purple"

--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -175,32 +175,36 @@
 	display_name = "regal shawl"
 	path = /obj/item/clothing/suit/mantle/regal
 
-/datum/gear/suit/captain_cloak
+/datum/gear/suit/mantle/job
+	subtype_path = /datum/gear/suit/mantle/job
+	subtype_cost_overlap = FALSE
+
+/datum/gear/suit/mantle/job/captain
 	display_name = "mantle, captain"
 	path = /obj/item/clothing/suit/mantle/armor/captain
 	allowed_roles = list("Captain")
 
-/datum/gear/suit/ce_mantle
+/datum/gear/suit/mantle/job/ce
 	display_name = "mantle, chief engineer"
 	path = /obj/item/clothing/suit/mantle/chief_engineer
 	allowed_roles = list("Chief Engineer")
 
-/datum/gear/suit/cmo_mantle
+/datum/gear/suit/mantle/job/cmo
 	display_name = "mantle, chief medical officer"
 	path = /obj/item/clothing/suit/mantle/labcoat/chief_medical_officer
 	allowed_roles = list("Chief Medical Officer")
 
-/datum/gear/suit/armored_shawl
+/datum/gear/suit/mantle/job/hos
 	display_name = "mantle, head of security"
 	path = /obj/item/clothing/suit/mantle/armor
 	allowed_roles = list("Head of Security")
 
-/datum/gear/suit/hop_shawl
+/datum/gear/suit/mantle/job/hop
 	display_name = "mantle, head of personnel"
 	path = /obj/item/clothing/suit/mantle/armor/head_of_personnel
 	allowed_roles = list("Head of Personnel")
 
-/datum/gear/suit/rd_mantle
+/datum/gear/suit/mantle/job/rd
 	display_name = "mantle, research director"
 	path = /obj/item/clothing/suit/mantle/labcoat
 	allowed_roles = list("Research Director")


### PR DESCRIPTION
## What Does This PR Do
Adds Engineering and Atmospherics berets to loadout.
Makes all Job Berets, Armbands and Mantles concurrently selectable with each other at no extra cost, as Winter Coats, Job Mugs and Jumpskirts already are.

## Why It's Good For The Game
Allows easier customisation of job-differing appearances from Loadout, improves consistency of behavior between the various available items.

## Changelog
:cl: Autumn211
add: Engineering and Atmospherics berets to Loadout.
tweak: Multiple Job-specific Berets, Armbands or Mantles will no longer eat into your Loadout points.
/:cl: