### PR TITLE
Fix bug that allows loading an additional syringe to syringe guns

### DIFF
--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -65,7 +65,8 @@
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe))
-		if(length(syringes) < max_syringes)
+		var/in_clip = length(syringes) + (chambered.BB ? 1 : 0)
+		if(in_clip < max_syringes)
 			if(!user.unEquip(A))
 				return
 			to_chat(user, "<span class='notice'>You load [A] into \the [src]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes the fact that players are able to load an additional syringe on top of the "chambered" one, effectively adding +1 capacity

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Oversight from my previous PR (#13797)

## Changelog
:cl:
fix: Fix bug allowing syringe guns to have one more syringe capacity than intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
