### PR TITLE
Refactors matter decompiler and adds some missing trash to the list

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -567,3 +567,6 @@
 
 /atom/movable/proc/portal_destroyed(obj/effect/portal/P)
 	return
+
+/atom/movable/proc/decompile_act(obj/item/matter_decompiler/C, mob/user) // For drones to decompile mobs and objs. See drone for an example.
+	return FALSE

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -29,9 +29,8 @@
 	anchored = TRUE
 
 /obj/effect/decal/remains/robot/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["glass"] += 1
-	C.stored_comms["metal"] += 2
-	C.stored_comms["plastic"] += 2
+	C.stored_comms["glass"] += 2
+	C.stored_comms["metal"] += 3
 	qdel(src)
 	return TRUE
 

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -28,6 +28,13 @@
 	icon_state = "remainsrobot"
 	anchored = TRUE
 
+/obj/effect/decal/remains/robot/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["glass"] += 1
+	C.stored_comms["metal"] += 2
+	C.stored_comms["plastic"] += 2
+	qdel(src)
+	return TRUE
+
 /obj/effect/decal/remains/slime
 	name = "You shouldn't see this"
 	desc = "Noooooooooooooooooooooo"

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -192,10 +192,11 @@
 
 /obj/structure/spider/spiderling/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(!istype(user, /mob/living/silicon/robot/drone))
-		C.loc.visible_message("<span class='notice'>[C.loc] sucks [src] into its decompiler. There's a horrible crunching noise.</span>","<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
-		qdel(src)
+		user.visible_message("<span class='notice'>[user] sucks [src] into its decompiler. There's a horrible crunching noise.</span>", \
+		"<span class='warning'>It's a bit of a struggle, but you manage to suck [user] into your decompiler. It makes a series of visceral crunching noises.</span>")
 		C.stored_comms["wood"] += 2
-		C.stored_comms["plastic"] += 2
+		C.stored_comms["glass"] += 2
+		qdel(src)
 		return TRUE
 	return ..()
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -190,6 +190,15 @@
 								to_chat(S, "<span class='biggerdanger'>You are a spider who is loyal to [S.master_commander], obey [S.master_commander]'s every order and assist [S.master_commander.p_them()] in completing [S.master_commander.p_their()] goals at any cost.</span>")
 			qdel(src)
 
+/obj/structure/spider/spiderling/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!istype(user, /mob/living/silicon/robot/drone))
+		C.loc.visible_message("<span class='notice'>[C.loc] sucks [src] into its decompiler. There's a horrible crunching noise.</span>","<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
+		qdel(src)
+		C.stored_comms["wood"] += 2
+		C.stored_comms["plastic"] += 2
+		return TRUE
+	return ..()
+
 /obj/effect/decal/cleanable/spiderling_remains
 	name = "spiderling remains"
 	desc = "Green squishy mess."

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -8,6 +8,12 @@
 	desc = "This is rubbish."
 	resistance_flags = FLAMMABLE
 
+/obj/item/trash/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["metal"] += 1
+	C.stored_comms["plastic"] += 2
+	qdel(src)
+	return TRUE
+
 /obj/item/trash/raisins
 	name = "4no raisins"
 	icon_state= "4no_raisins"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -9,8 +9,9 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/trash/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["metal"] += 1
-	C.stored_comms["plastic"] += 2
+	C.stored_comms["metal"] += 2
+	C.stored_comms["wood"] += 1
+	C.stored_comms["glass"] += 1
 	qdel(src)
 	return TRUE
 

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -312,7 +312,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	transform = turn(transform,rand(0,360))
 
 /obj/item/cigbutt/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["plastic"] += 1
+	C.stored_comms["wood"] += 1
 	qdel(src)
 	return TRUE
 

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -311,6 +311,11 @@ LIGHTERS ARE IN LIGHTERS.DM
 	pixel_y = rand(-10,10)
 	transform = turn(transform,rand(0,360))
 
+/obj/item/cigbutt/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["plastic"] += 1
+	qdel(src)
+	return TRUE
+
 /obj/item/cigbutt/cigarbutt
 	name = "cigar butt"
 	desc = "A manky old cigar butt."

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -244,11 +244,17 @@
 	else
 		..()
 
+/obj/item/match/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(burnt)
+		C.stored_comms["wood"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
+
 /obj/item/proc/help_light_cig(mob/living/M)
 	var/mask_item = M.get_item_by_slot(slot_wear_mask)
 	if(istype(mask_item, /obj/item/clothing/mask/cigarette))
 		return mask_item
-
 
 /obj/item/match/firebrand
 	name = "firebrand"

--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -88,6 +88,11 @@
 		playsound(loc, 'sound/effects/glass_step.ogg', 50, TRUE)
 	return ..()
 
+/obj/item/shard/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["glass"] += 3
+	qdel(src)
+	return TRUE
+
 /obj/item/shard/plasma
 	name = "plasma shard"
 	desc = "A shard of plasma glass. Considerably tougher then normal glass shards. Apparently not tough enough to be a window."

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -215,6 +215,13 @@
 	//if we get this far, handle the insertion checks as normal
 	.=..()
 
+/obj/item/storage/fancy/cigarettes/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!length(contents))
+		C.stored_comms["wood"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
+
 /obj/item/storage/fancy/cigarettes/dromedaryco
 	name = "\improper DromedaryCo packet"
 	desc = "A packet of six imported DromedaryCo cancer sticks. A label on the packaging reads, \"Wouldn't a slow death make a change?\""

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -124,6 +124,13 @@
 		reagents.reaction(M, REAGENT_TOUCH)
 		reagents.clear_reagents()
 
+/obj/item/reagent_containers/food/drinks/bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!reagents.total_volume)
+		C.stored_comms["glass"] += 3
+		qdel(src)
+		return TRUE
+	return ..()
+
 //Keeping this here for now, I'll ask if I should keep it here.
 /obj/item/broken_bottle
 	name = "Broken Bottle"

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -141,6 +141,11 @@
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 	sharp = 1
 
+/obj/item/broken_bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["glass"] += 3
+	qdel(src)
+	return TRUE
+
 /obj/item/reagent_containers/food/drinks/bottle/gin
 	name = "Griffeater Gin"
 	desc = "A bottle of high quality gin, produced in the New London Space Station."

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -168,6 +168,11 @@
 		return
 	return ..()
 
+/obj/item/reagent_containers/food/snacks/grown/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["wood"] += 4
+	qdel(src)
+	return TRUE
+
 // For item-containing growns such as eggy or gatfruit
 /obj/item/reagent_containers/food/snacks/grown/shell/attack_self(mob/user)
 	user.unEquip(src)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -357,24 +357,23 @@
 
 /mob/living/silicon/robot/drone/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(!client && istype(user, /mob/living/silicon/robot/drone))
-		var/mob/living/silicon/robot/drone/D = C.loc
-		to_chat(D, "<span class='warning'>You begin decompiling the other drone.</span>")
+		to_chat(user, "<span class='warning'>You begin decompiling the other drone.</span>")
 
-		if(!do_after(D, 50, target = src.loc))
-			to_chat(D, "<span class='warning'>You need to remain still while decompiling such a large object.</span>")
+		if(!do_after(user, 5 SECONDS, target = loc))
+			to_chat(user, "<span class='warning'>You need to remain still while decompiling such a large object.</span>")
 			return
 
-		if(!src || !D) return ..()
+		if(QDELETED(src) || QDELETED(user))
+			return ..()
 
-		to_chat(D, "<span class='warning'>You carefully and thoroughly decompile your downed fellow, storing as much of its resources as you can within yourself.</span>")
+		to_chat(user, "<span class='warning'>You carefully and thoroughly decompile your downed fellow, storing as much of its resources as you can within yourself.</span>")
 
 		new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
-		qdel(src)
 
 		C.stored_comms["metal"] += 15
 		C.stored_comms["glass"] += 15
 		C.stored_comms["wood"] += 5
-		C.stored_comms["plastic"] += 5
+		qdel(src)
 
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -358,22 +358,16 @@
 /mob/living/silicon/robot/drone/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(!client && istype(user, /mob/living/silicon/robot/drone))
 		to_chat(user, "<span class='warning'>You begin decompiling the other drone.</span>")
-
 		if(!do_after(user, 5 SECONDS, target = loc))
 			to_chat(user, "<span class='warning'>You need to remain still while decompiling such a large object.</span>")
 			return
-
 		if(QDELETED(src) || QDELETED(user))
 			return ..()
-
 		to_chat(user, "<span class='warning'>You carefully and thoroughly decompile your downed fellow, storing as much of its resources as you can within yourself.</span>")
-
 		new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
-
 		C.stored_comms["metal"] += 15
 		C.stored_comms["glass"] += 15
 		C.stored_comms["wood"] += 5
 		qdel(src)
-
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -368,8 +368,8 @@
 
 		to_chat(D, "<span class='warning'>You carefully and thoroughly decompile your downed fellow, storing as much of its resources as you can within yourself.</span>")
 
-		qdel(src)
 		new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
+		qdel(src)
 
 		C.stored_comms["metal"] += 15
 		C.stored_comms["glass"] += 15

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -354,3 +354,27 @@
 /mob/living/simple_animal/drone/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	if(affect_silicon)
 		return ..()
+
+/mob/living/silicon/robot/drone/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!client && istype(user, /mob/living/silicon/robot/drone))
+		var/mob/living/silicon/robot/drone/D = C.loc
+		to_chat(D, "<span class='warning'>You begin decompiling the other drone.</span>")
+
+		if(!do_after(D, 50, target = src.loc))
+			to_chat(D, "<span class='warning'>You need to remain still while decompiling such a large object.</span>")
+			return
+
+		if(!src || !D) return ..()
+
+		to_chat(D, "<span class='warning'>You carefully and thoroughly decompile your downed fellow, storing as much of its resources as you can within yourself.</span>")
+
+		qdel(src)
+		new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
+
+		C.stored_comms["metal"] += 15
+		C.stored_comms["glass"] += 15
+		C.stored_comms["wood"] += 5
+		C.stored_comms["plastic"] += 5
+
+		return TRUE
+	return ..()

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -151,8 +151,7 @@
 	var/list/stored_comms = list(
 		"metal" = 0,
 		"glass" = 0,
-		"wood" = 0,
-		"plastic" = 0
+		"wood" = 0
 		)
 
 /obj/item/matter_decompiler/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
@@ -167,11 +166,11 @@
 		return
 
 	//Used to give the right message.
-	var/grabbed_something = 0
+	var/grabbed_something = FALSE
 
 	for(var/atom/movable/A in T)
-		if(A.decompile_act(src, usr)) // Each decompileable mob or obj needs to have this defined
-			grabbed_something = 1
+		if(A.decompile_act(src, user)) // Each decompileable mob or obj needs to have this defined
+			grabbed_something = TRUE
 
 	if(grabbed_something)
 		to_chat(user, "<span class='notice'>You deploy your decompiler and clear out the contents of \the [T].</span>")
@@ -262,11 +261,5 @@
 						stack_wood = new /obj/item/stack/sheet/wood(src.module)
 						stack_wood.amount = 1
 					stack = stack_wood
-				if("plastic")
-					if(!stack_plastic)
-						stack_plastic = new /obj/item/stack/sheet/plastic(src.module)
-						stack_plastic.amount = 1
-					stack = stack_plastic
-
 			stack.amount++
 			decompiler.stored_comms[type]--

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -158,8 +158,7 @@
 /obj/item/matter_decompiler/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	return
 
-/obj/item/matter_decompiler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)
-
+/obj/item/matter_decompiler/afterattack(atom/target, mob/living/user, proximity, params)
 	if(!proximity) return //Not adjacent.
 
 	//We only want to deal with using this on turfs. Specific items aren't important.
@@ -170,99 +169,9 @@
 	//Used to give the right message.
 	var/grabbed_something = 0
 
-	for(var/mob/M in T)
-		if(istype(M,/mob/living/simple_animal/lizard) || istype(M,/mob/living/simple_animal/mouse))
-			src.loc.visible_message("<span class='notice'>[src.loc] sucks [M] into its decompiler. There's a horrible crunching noise.</span>","<span class='warning'>It's a bit of a struggle, but you manage to suck [M] into your decompiler. It makes a series of visceral crunching noises.</span>")
-			new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
-			qdel(M)
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
-			return
-
-		else if(istype(M,/mob/living/silicon/robot/drone) && !M.client)
-
-			var/mob/living/silicon/robot/drone/D = src.loc
-
-			if(!istype(D))
-				return
-
-			to_chat(D, "<span class='warning'>You begin decompiling the other drone.</span>")
-
-			if(!do_after(D, 50, target = target))
-				to_chat(D, "<span class='warning'>You need to remain still while decompiling such a large object.</span>")
-				return
-
-			if(!M || !D) return
-
-			to_chat(D, "<span class='warning'>You carefully and thoroughly decompile your downed fellow, storing as much of its resources as you can within yourself.</span>")
-
-			qdel(M)
-			new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
-
-			stored_comms["metal"] += 15
-			stored_comms["glass"] += 15
-			stored_comms["wood"] += 5
-			stored_comms["plastic"] += 5
-
-			return
-		else
-			continue
-
-	for(var/obj/W in T)
-		//Different classes of items give different commodities.
-		if(istype(W,/obj/item/cigbutt))
-			stored_comms["plastic"]++
-		else if(istype(W,/obj/structure/spider/spiderling))
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
-		else if(istype(W,/obj/item/light))
-			var/obj/item/light/L = W
-			if(L.status >= 2) //In before someone changes the inexplicably local defines. ~ Z
-				stored_comms["metal"]++
-				stored_comms["glass"]++
-			else
-				continue
-		else if(istype(W,/obj/effect/decal/remains/robot))
-			stored_comms["metal"]++
-			stored_comms["metal"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
-			stored_comms["glass"]++
-		else if(istype(W,/obj/item/trash))
-			stored_comms["metal"]++
-			stored_comms["plastic"]++
-			stored_comms["plastic"]++
-		else if(istype(W,/obj/effect/decal/cleanable/blood/gibs/robot))
-			stored_comms["metal"]++
-			stored_comms["metal"]++
-			stored_comms["glass"]++
-			stored_comms["glass"]++
-		else if(istype(W,/obj/item/ammo_casing))
-			stored_comms["metal"]++
-		else if(istype(W,/obj/item/shard))
-			stored_comms["glass"]++
-			stored_comms["glass"]++
-			stored_comms["glass"]++
-		else if(istype(W,/obj/item/reagent_containers/food/snacks/grown))
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-			stored_comms["wood"]++
-		else if(istype(W,/obj/item/broken_bottle))
-			stored_comms["glass"]++
-			stored_comms["glass"]++
-			stored_comms["glass"]++
-		else if(istype(W,/obj/item/light/tube) || istype(W,/obj/item/light/bulb))
-			stored_comms["glass"]++
-		else
-			continue
-
-		qdel(W)
-		grabbed_something = 1
+	for(var/atom/movable/A in T)
+		if(A.decompile_act(src)) // Each decompileable mob or obj needs to have this defined
+			grabbed_something = 1
 
 	if(grabbed_something)
 		to_chat(user, "<span class='notice'>You deploy your decompiler and clear out the contents of \the [T].</span>")

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -170,7 +170,7 @@
 	var/grabbed_something = 0
 
 	for(var/atom/movable/A in T)
-		if(A.decompile_act(src)) // Each decompileable mob or obj needs to have this defined
+		if(A.decompile_act(src, usr)) // Each decompileable mob or obj needs to have this defined
 			grabbed_something = 1
 
 	if(grabbed_something)

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -23,3 +23,13 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat = 1)
 	can_collar = 1
 	gold_core_spawnable = FRIENDLY_SPAWN
+
+/mob/living/simple_animal/lizard/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!istype(user, /mob/living/silicon/robot/drone))
+		C.loc.visible_message("<span class='notice'>[C.loc] sucks [src] into its decompiler. There's a horrible crunching noise.</span>","<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
+		new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
+		qdel(src)
+		C.stored_comms["wood"] += 2
+		C.stored_comms["plastic"] += 2
+		return TRUE
+	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -26,10 +26,11 @@
 
 /mob/living/simple_animal/lizard/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(!istype(user, /mob/living/silicon/robot/drone))
-		C.loc.visible_message("<span class='notice'>[C.loc] sucks [src] into its decompiler. There's a horrible crunching noise.</span>","<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
+		user.visible_message("<span class='notice'>[user] sucks [src] into its decompiler. There's a horrible crunching noise.</span>", \
+		"<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
 		new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
-		qdel(src)
 		C.stored_comms["wood"] += 2
-		C.stored_comms["plastic"] += 2
+		C.stored_comms["glass"] += 2
+		qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -234,3 +234,13 @@
 	gold_core_spawnable = NO_SPAWN
 	can_collar = 0
 	butcher_results = list(/obj/item/stack/sheet/metal = 1)
+
+/mob/living/simple_animal/mouse/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!(istype(user, /mob/living/silicon/robot/drone)))
+		C.loc.visible_message("<span class='notice'>[C.loc] sucks [src] into its decompiler. There's a horrible crunching noise.</span>","<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
+		new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
+		qdel(src)
+		C.stored_comms["wood"] += 2
+		C.stored_comms["plastic"] += 2
+		return TRUE
+	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -237,10 +237,11 @@
 
 /mob/living/simple_animal/mouse/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(!(istype(user, /mob/living/silicon/robot/drone)))
-		C.loc.visible_message("<span class='notice'>[C.loc] sucks [src] into its decompiler. There's a horrible crunching noise.</span>","<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
+		user.visible_message("<span class='notice'>[user] sucks [src] into its decompiler. There's a horrible crunching noise.</span>", \
+		"<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
 		new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
-		qdel(src)
 		C.stored_comms["wood"] += 2
-		C.stored_comms["plastic"] += 2
+		C.stored_comms["glass"] += 2
+		qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -634,6 +634,12 @@
 			shatter()
 	return ..()
 
+/obj/item/light/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["glass"] += 1
+	C.stored_comms["metal"] += 1
+	qdel(src)
+	return TRUE
+
 /obj/item/light/tube
 	name = "light tube"
 	desc = "A replacement light tube."

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -42,6 +42,13 @@
 		var/image/lid = image(icon, src, "lid_bottle")
 		overlays += lid
 
+/obj/item/reagent_containers/glass/bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!reagents.total_volume)
+		C.stored_comms["glass"] += 3
+		qdel(src)
+		return TRUE
+	return ..()
+
 /obj/item/reagent_containers/glass/bottle/toxin
 	name = "toxin bottle"
 	desc = "A small bottle containing toxic compounds."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Refactors matter decompiler because it was a terrible mile-long else if statement. The new structure is atom based, so each decompilable item has a defined decompile_act that is called by the decompiler. Also adds the ability to decompile some trash I felt it was missing. Empty cig packets. Burnt matches. Empty Bottles. Also removes the ability for drones to consume living beings.

## Why It's Good For The Game
Cleaning up trash on the floor is good. 
Also, the legacy code was really bad and painful to look at.

## Changelog
:cl:
add: Added the ability for the matter decompiler to pick up empty bottles, burnt matches, and empty cig packets.
del: Removed the ability for drones to eat living things.
tweak: Refactored Matter Decompiler
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
