### PR TITLE
ERT idiotproofing and minor tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1053,7 +1053,7 @@
 /obj/item/storage/box/responseteam/New()
 	..()
 	new /obj/item/clothing/mask/breath(src)
-	new /obj/item/tank/emergency_oxygen/engi(src)
+	new /obj/item/tank/emergency_oxygen/engi/full(src)
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/kitchen/knife/combat(src)
 	new /obj/item/radio/centcom(src)

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -172,7 +172,7 @@
 	air_contents.oxygen = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 
 
-obj/item/tank/emergency_oxygen/engi/empty/New()
+/obj/item/tank/emergency_oxygen/engi/empty/New()
 	..()
 	air_contents.oxygen = null
 

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -167,7 +167,12 @@
 	icon_state = "emergency_engi"
 	volume = 6
 
-/obj/item/tank/emergency_oxygen/engi/empty/New()
+/obj/item/tank/emergency_oxygen/engi/full/New()
+	..()
+	air_contents.oxygen = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+
+
+obj/item/tank/emergency_oxygen/engi/empty/New()
 	..()
 	air_contents.oxygen = null
 

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -16,15 +16,26 @@
 		"Vox" = 'icons/mob/species/vox/helmet.dmi'
 		)
 
+/obj/item/clothing/head/helmet/space/hardsuit/ert/Initialize()
+	var/mob/living/carbon/human/wearer = src.loc.loc	//src.loc is the hardsuit, so its loc is the wearer
+	if(ishuman(wearer))
+		register_camera(wearer)
+	..()
+
 /obj/item/clothing/head/helmet/space/hardsuit/ert/attack_self(mob/user)
 	if(camera || !has_camera)
 		..(user)
 	else
-		camera = new /obj/machinery/camera(src)
-		camera.network = list("ERT")
-		GLOB.cameranet.removeCamera(camera)
-		camera.c_tag = user.name
-		to_chat(user, "<span class='notice'>User scanned as [camera.c_tag]. Camera activated.</span>")
+		register_camera(user)
+
+/obj/item/clothing/head/helmet/space/hardsuit/ert/proc/register_camera(mob/wearer)
+	if(camera || !has_camera)
+		return
+	camera = new /obj/machinery/camera(src)
+	camera.network = list("ERT")
+	GLOB.cameranet.removeCamera(camera)
+	camera.c_tag = wearer.name
+	to_chat(wearer, "<span class='notice'>User scanned as [camera.c_tag]. Camera activated.</span>")
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -17,7 +17,7 @@
 		)
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/Initialize()
-	var/mob/living/carbon/human/wearer = src.loc.loc	//src.loc is the hardsuit, so its loc is the wearer
+	var/mob/living/carbon/human/wearer = loc.loc	//loc is the hardsuit, so its loc is the wearer
 	if(ishuman(wearer))
 		register_camera(wearer)
 	..()

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -128,6 +128,10 @@
 	item_state = "p_suit"
 	item_color = "purple"
 
+/obj/item/clothing/under/color/purple/sensor	//for jani ert
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
+
 /obj/item/clothing/under/color/lightpurple
 	name = "light purple jumpsuit"
 	icon_state = "lightpurple"

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -48,6 +48,10 @@
 	item_state = "bl_suit"
 	item_color = "chapblack"
 
+/obj/item/clothing/under/rank/chaplain/sensor
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
+
 /obj/item/clothing/under/rank/chef
 	desc = "It's an apron which is given only to the most <b>hardcore</b> chefs in space."
 	name = "chef's uniform"

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -39,6 +39,10 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 60, "acid" = 20)
 	resistance_flags = NONE
 
+/obj/item/clothing/under/rank/engineer/sensor
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
+
 
 /obj/item/clothing/under/rank/engineer/skirt
 	desc = "It's an orange high visibility jumpskirt worn by engineers. It has minor radiation shielding."

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -124,6 +124,10 @@
 	permeability_coefficient = 0.50
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0)
 
+/obj/item/clothing/under/rank/medical/sensor
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
+
 /obj/item/clothing/under/rank/medical/skirt
 	name = "medical doctor's jumpskirt"
 	icon_state = "medicalf"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -34,6 +34,10 @@
 	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	strip_delay = 50
 
+/obj/item/clothing/under/rank/security/sensor
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
+
 /obj/item/clothing/under/rank/security/skirt
 	name = "security officer's jumpskirt"
 	desc = "Standard feminine fashion for Security Officers.  It's made of sturdier material than the standard jumpskirts."

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -88,6 +88,10 @@
 	item_state = "g_suit"
 	item_color = "officer"
 
+/obj/item/clothing/under/rank/centcom_officer/sensor
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
+
 /obj/item/clothing/under/rank/centcom_commander
 	desc = "It's a jumpsuit worn by CentComm's highest-tier Commanders."
 	name = "\improper CentComm officer's jumpsuit"

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -107,7 +107,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/arm/flash
 	)
 
@@ -156,7 +156,7 @@
 		/obj/item/organ/internal/cyberimp/arm/flash,
 		/obj/item/organ/internal/cyberimp/chest/nutriment,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
 	backpack_contents = list(
@@ -192,7 +192,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/arm/telebaton,
 		/obj/item/organ/internal/cyberimp/chest/reviver
 	)
@@ -273,7 +273,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/shield,
 		/obj/item/organ/internal/cyberimp/arm/toolset
 	)
@@ -376,7 +376,7 @@
 		/obj/item/organ/internal/cyberimp/arm/medibeam,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
 //////////////////// PARANORMAL ///////////////////
@@ -436,7 +436,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)
 
 //////////////////// JANITORIAL ///////////////////
@@ -502,5 +502,5 @@
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/advmop,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
 	)

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -156,8 +156,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/flash,
 		/obj/item/organ/internal/cyberimp/chest/nutriment,
-		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+		/obj/item/organ/internal/cyberimp/eyes/hud/security
 	)
 
 	backpack_contents = list(

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -479,7 +479,7 @@
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/advmop,
-		/obj/item/organ/internal/cyberimp/chest/nutriment,
+		/obj/item/organ/internal/cyberimp/chest/nutriment
 	)
 
 /datum/outfit/job/centcom/response_team/janitorial/gamma

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -107,7 +107,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops,
 		/obj/item/organ/internal/cyberimp/arm/flash
 	)
 
@@ -155,7 +155,8 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/flash,
 		/obj/item/organ/internal/cyberimp/chest/nutriment,
-		/obj/item/organ/internal/cyberimp/eyes/hud/security
+		/obj/item/organ/internal/cyberimp/eyes/hud/security,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
 	)
 
 	backpack_contents = list(
@@ -191,7 +192,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops,
 		/obj/item/organ/internal/cyberimp/arm/telebaton,
 		/obj/item/organ/internal/cyberimp/chest/reviver
 	)
@@ -272,7 +273,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops,
 		/obj/item/organ/internal/cyberimp/eyes/shield,
 		/obj/item/organ/internal/cyberimp/arm/toolset
 	)
@@ -375,7 +376,7 @@
 		/obj/item/organ/internal/cyberimp/arm/medibeam,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
 	)
 
 //////////////////// PARANORMAL ///////////////////
@@ -435,7 +436,7 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/obj/item/organ/internal/cyberimp/brain/anti_stun
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
 	)
 
 //////////////////// JANITORIAL ///////////////////
@@ -500,5 +501,6 @@
 	)
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/arm/advmop
+		/obj/item/organ/internal/cyberimp/arm/advmop,
+		/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
 	)

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -36,7 +36,7 @@
 	rt_job = "Emergency Response Team Leader"
 	rt_mob_job = "ERT Commander"
 
-	uniform = /obj/item/clothing/under/rank/centcom_officer
+	uniform = /obj/item/clothing/under/rank/centcom_officer/sensor
 	back = /obj/item/storage/backpack/ert/commander
 
 	id = /obj/item/card/id/ert/commander
@@ -56,12 +56,12 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	suit = /obj/item/clothing/suit/armor/vest/ert/command
 	glasses = /obj/item/clothing/glasses/sunglasses
+	mask = /obj/item/clothing/mask/gas/sechailer
 
 	belt = /obj/item/gun/energy/gun
 
 	backpack_contents = list(
 		/obj/item/clothing/head/helmet/ert/command = 1,
-		/obj/item/clothing/mask/gas/sechailer = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
 		/obj/item/flashlight = 1
@@ -73,6 +73,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/commander
 	glasses = /obj/item/clothing/glasses/sunglasses
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/chest/nutriment
@@ -80,7 +81,6 @@
 	belt = /obj/item/gun/energy/gun/blueshield/pdw9
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/gun/energy/ionrifle/carbine = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/clothing/shoes/magboots = 1,
@@ -93,11 +93,11 @@
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/commander/gamma
 	glasses = /obj/item/clothing/glasses/night
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	suit_store = /obj/item/gun/energy/gun/blueshield/pdw9
 	belt = /obj/item/gun/projectile/automatic/pistol/enforcer/lethal
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
 		/obj/item/gun/energy/ionrifle/carbine = 1,
@@ -117,7 +117,7 @@
 	name = "RT Security"
 	rt_job = "Emergency Response Team Officer"
 	rt_mob_job = "ERT Security"
-	uniform = /obj/item/clothing/under/rank/security
+	uniform = /obj/item/clothing/under/rank/security/sensor
 	back = /obj/item/storage/backpack/ert/security
 	belt = /obj/item/storage/belt/security/response_team
 	pda = /obj/item/pda/heads/ert/security
@@ -130,12 +130,12 @@
 	suit = /obj/item/clothing/suit/armor/vest/ert/security
 	suit_store = /obj/item/gun/energy/gun/advtaser
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	mask = /obj/item/clothing/mask/gas/sechailer
 
 	r_hand = /obj/item/gun/energy/laser
 
 	backpack_contents = list(
 		/obj/item/clothing/head/helmet/ert/security = 1,
-		/obj/item/clothing/mask/gas/sechailer = 1,
 		/obj/item/storage/box/zipties = 1,
 		/obj/item/storage/box/teargas = 1,
 		/obj/item/flashlight/seclite = 1
@@ -149,6 +149,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/security
 	suit_store = /obj/item/gun/energy/gun/blueshield/pdw9
 	glasses = /obj/item/clothing/glasses/sunglasses
+	mask = /obj/item/clothing/mask/gas/sechailer
 
 	r_hand = /obj/item/gun/projectile/automatic/lasercarbine
 
@@ -160,11 +161,9 @@
 	)
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas/sechailer = 1,
 		/obj/item/clothing/shoes/magboots = 1,
 		/obj/item/storage/box/handcuffs = 1,
-		/obj/item/storage/box/teargas = 1,
-		/obj/item/grenade/flashbang = 1,
+		/obj/item/grenade/flashbang = 2,
 		/obj/item/ammo_box/magazine/laser = 2
 	)
 
@@ -176,13 +175,13 @@
 	belt = /obj/item/storage/belt/security/response_team_gamma
 	suit_store = /obj/item/gun/energy/gun/nuclear
 	glasses = /obj/item/clothing/glasses/night
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	l_pocket = /obj/item/restraints/legcuffs/bola/energy
 	r_pocket = /obj/item/extinguisher/mini
 
 	r_hand = /obj/item/gun/energy/immolator/multi
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/storage/box/handcuffs = 1,
 		/obj/item/storage/box/flashbangs = 1,
 		/obj/item/whetstone = 1,
@@ -194,7 +193,7 @@
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/arm/telebaton,
-		/obj/item/organ/internal/cyberimp/chest/reviver
+		/obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	)
 
 
@@ -218,12 +217,12 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	suit_store = /obj/item/tank/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson
+	mask = /obj/item/clothing/mask/gas
 
 	l_pocket = /obj/item/gun/energy/gun/mini
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas = 1,
 		/obj/item/t_scanner = 1,
 		/obj/item/stack/sheet/glass/fifty = 1,
 		/obj/item/stack/sheet/metal/fifty = 1,
@@ -238,6 +237,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer/gamma
 	suit_store = /obj/item/tank/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson
+	mask = /obj/item/clothing/mask/gas
 	cybernetic_implants = list(
 	 /obj/item/organ/internal/cyberimp/eyes/shield,
 	 /obj/item/organ/internal/cyberimp/chest/nutriment
@@ -246,7 +246,6 @@
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas = 1,
 		/obj/item/rcd/preloaded = 1,
 		/obj/item/rcd_ammo = 3,
 		/obj/item/gun/energy/gun = 1
@@ -260,12 +259,12 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer/gamma
 	suit_store = /obj/item/gun/energy/gun/blueshield/pdw9
 	glasses = /obj/item/clothing/glasses/meson/night
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
 
 	l_pocket = /obj/item/t_scanner/extended_range
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/rcd/combat = 1,
 		/obj/item/rcd_ammo/large = 3
 	)
@@ -354,6 +353,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/medical/gamma
 	glasses = /obj/item/clothing/glasses/night
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	suit_store = /obj/item/gun/energy/gun/blueshield/pdw9
 
 	belt = /obj/item/defibrillator/compact/loaded
@@ -362,7 +362,6 @@
 	r_pocket = /obj/item/reagent_containers/hypospray/autoinjector
 
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/bodyanalyzer/advanced = 1,
 		/obj/item/extinguisher/mini = 1,
 		/obj/item/roller = 1,
@@ -391,11 +390,11 @@
 	shoes = /obj/item/clothing/shoes/combat
 	l_ear = /obj/item/radio/headset/ert/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	belt = /obj/item/storage/belt/security/response_team
 	id = /obj/item/card/id/centcom
 	pda = /obj/item/pda/centcom
 	backpack_contents = list(
-		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/storage/box/zipties = 1,
 		/obj/item/flashlight/seclite = 1
 		)
@@ -445,7 +444,7 @@
 	name = "RT Janitor"
 	rt_job = "Emergency Response Team Janitor"
 	rt_mob_job = "ERT Janitor"
-	uniform = /obj/item/clothing/under/color/purple
+	uniform = /obj/item/clothing/under/color/purple/sensor
 	back = /obj/item/storage/backpack/ert/janitor
 	belt = /obj/item/storage/belt/janitor/full
 	gloves = /obj/item/clothing/gloves/color/yellow
@@ -480,7 +479,7 @@
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/advmop,
-		/obj/item/organ/internal/cyberimp/chest/nutriment
+		/obj/item/organ/internal/cyberimp/chest/nutriment,
 	)
 
 /datum/outfit/job/centcom/response_team/janitorial/gamma

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -146,12 +146,11 @@
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/reboot()
 	crit_fail = FALSE
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
-	name = "Specops CNS Rebooter implant"
+/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+	name = "Hardened CNS Rebooter implant"
 	desc = "A military-grade version of the standard implant, for NT's more elite forces."
 	origin_tech = "materials=6;programming=5;biotech=5"
 	emp_proof = TRUE
-	stun_max_amount = 1
 
 /obj/item/organ/internal/cyberimp/brain/clown_voice
 	name = "Comical implant"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -1,5 +1,3 @@
-#define STUN_SET_AMOUNT	2
-
 /obj/item/organ/internal/cyberimp
 	name = "cybernetic implant"
 	desc = "a state-of-the-art implant that improves a baseline's functionality"
@@ -128,15 +126,16 @@
 	implant_color = "#FFFF00"
 	slot = "brain_antistun"
 	origin_tech = "materials=5;programming=4;biotech=5"
+	var/stun_max_amount = 2
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/on_life()
 	..()
 	if(crit_fail)
 		return
-	if(owner.stunned > STUN_SET_AMOUNT)
-		owner.SetStunned(STUN_SET_AMOUNT)
-	if(owner.weakened > STUN_SET_AMOUNT)
-		owner.SetWeakened(STUN_SET_AMOUNT)
+	if(owner.stunned > stun_max_amount)
+		owner.SetStunned(stun_max_amount)
+	if(owner.weakened > stun_max_amount)
+		owner.SetWeakened(stun_max_amount)
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/emp_act(severity)
 	if(crit_fail || emp_proof)
@@ -146,6 +145,13 @@
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/reboot()
 	crit_fail = FALSE
+
+/obj/item/organ/internal/cyberimp/brain/anti_stun/specops
+	name = "Specops CNS Rebooter implant"
+	desc = "A military-grade version of the standard implant, for NT's more elite forces."
+	origin_tech = "materials=6;programming=5;biotech=5"
+	emp_proof = TRUE
+	stun_max_amount = 1
 
 /obj/item/organ/internal/cyberimp/brain/clown_voice
 	name = "Comical implant"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
EDIT: This PR has been expanded from just an implant to a series of general improvements for the ERT.

EDIT 2: The buff to red sec erts has been removed. This is now mostly a QOL PR with some buffs for gamma erts.

This PR intends to idiot-proof and improve the ERTs, ~~along with a buff for red sec erts.~~

To sum up:
ERT suit sensors start at max
ERTs that spawned with breath masks/swat masks/etc in their backpack now start with the mask on their face
ERT hardsuit helmet cameras now automatically activate and do not need to be activated manually
ERT oxygen tanks now start off full rather than almost empty. This change also applies to other roles getting the CC boxed survival kit, ie nt officers.
CNS rebooter implants, where they were already present, have been replaced with a hardened CNS rebooter which is emp immune. This impacts all Gamma ERT except janitor
Gamma janitor ERTs have been given a hardened CNS implant to make them consistent with other Gamma ERTs
The box of teargas grenades given to red sec ERTs has been replaced with another flashbang
The reviver implant given to gamma sec ERT has been replaced with a hardened implant, protecting it from emp.


<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ERT quality varies wildly, very inexperienced or unrobust players can become ERT since it pulls from ghosts.
We should do as much idiot-proofing of ERT gear as we can. Sensors are maxed, camera is set up, mask starts in your face, oxygen tank doesn't need to be filled.

EDIT: Note that the big balance change was removed. The only balance change to red erts is sec erts no longer start with useless tear gas grenades, getting an additional flashbang instead.

>CNS rebooter implants, where they were already present, have been replaced with a hardened CNS rebooter which is emp immune. This impacts all Gamma ERT except janitor
>The reviver implant given to gamma sec ERT has been replaced with a hardened implant, protecting it from emp.

A Gamma ERT is the final line before a deathsquad is called in. They should definitely not die to a simple changeling with the emp power. If this doesn't get in, they'd be better off with the implant removed, frankly.

>Gamma janitor ERTs have been given a hardened CNS implant to make them consistent with other Gamma ERTs

Mostly for consistency reasons. Gamma janitor ERTs are a huge meme anyway, why not have the joke janitor be a total badass able to beat the shit out of you?

>The box of teargas grenades given to red sec ERTs has been replaced with another flashbang

When was the last time a tear gas grenade was used for anything useful? Giving them these grenades just takes up space and might lead to them trying to use a useless piece of gear. A flashbang fills the purpose of a teargas grenade much better, of taking down unprotected people.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: ERT implants are now hardened against emps
tweak: Various quality of life changes for ERTs
add: Gamma janitor ERTs gain a CNS rebooter to match other gamma ERTs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
