### PR TITLE
Airlock painter fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -513,6 +513,10 @@ About the new airlock wires panel:
 		to_chat(user, "<span class='warning'>You need to select a paintjob first.</span>")
 		return
 
+	if(!paintable)
+		to_chat(user, "<span class='warning'>This type of airlock cannot be painted.</span>")
+		return
+
 	var/obj/machinery/door/airlock/airlock = painter.available_paint_jobs["[painter.paint_setting]"] // get the airlock type path associated with the airlock name the user just chose
 	var/obj/structure/door_assembly/assembly = initial(airlock.assemblytype)
 

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -592,6 +592,7 @@
 	overlays_file = 'icons/obj/doors/airlocks/glass_large/overlays.dmi'
 	note_overlay_file = 'icons/obj/doors/airlocks/glass_large/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/multi_tile
+	paintable = FALSE
 
 /obj/machinery/door/airlock/multi_tile/narsie_act()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can no longer paint multi-tile airlocks to give it the appearance of a single tile one. Also includes a check for `paintable` when trying to paint an airlock, which I forgot to include in the original painter PR. This properly blacklists things like uranium, plasma, and other airlocks from being painted.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #13838
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer paint multi-tile airlocks to give it the appearance of a single tile one
fix: The airlock painter now respects blacklisted airlocks like uranium or plasma airlocks 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
