### PR TITLE
Makes it so only one theta station can spawn

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -175,6 +175,7 @@
 	description = "The crew of a space station awaken one hundred years after a crisis. Awaking to a derelict space station on the verge of collapse, and a hostile force of invading \
 	hivebots. Can the surviving crew overcome the odds and survive and rebuild, or will the cold embrace of the stars become their new home?"
 	cost = 2
+	allow_duplicates = FALSE
 
 /datum/map_template/ruin/space/wizardcrash
 	id = "wizardcrash"


### PR DESCRIPTION
## What Does This PR Do
Makes it so only one theta station can spawn

Fixes #13845

## Why It's Good For The Game
People shouldnt be spawning across split ruins. Also I think this makes fucky areas.

## Changelog
:cl: AffectedArc07
fix: There will no longer be duplicate theta station spawns
/:cl:
