### PR TITLE
Adds boxing glove crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1767,6 +1767,16 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	cost = 20
 	containername = "polo supply crate"
 
+/datum/supply_packs/misc/boxing			//For non log spamming cargo brawls!
+	name = "Boxing Supply Crate"
+	// 6 brooms, 6 horse masks for the brooms, and 1 beach ball
+	contains = list(/obj/item/clothing/gloves/boxing/blue,
+					/obj/item/clothing/gloves/boxing/green,
+					/obj/item/clothing/gloves/boxing/yellow,
+					/obj/item/clothing/gloves/boxing)
+	cost = 15
+	containername = "boxing supply crate"
+
 ///////////// Station Goals
 
 /datum/supply_packs/misc/station_goal

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1769,7 +1769,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 
 /datum/supply_packs/misc/boxing			//For non log spamming cargo brawls!
 	name = "Boxing Supply Crate"
-	// 6 brooms, 6 horse masks for the brooms, and 1 beach ball
+	// 4 boxing gloves
 	contains = list(/obj/item/clothing/gloves/boxing/blue,
 					/obj/item/clothing/gloves/boxing/green,
 					/obj/item/clothing/gloves/boxing/yellow,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new crate to Cargo that contains boxing gloves. It is a duplicate of the locker in Dorms for contents, four colors, one pair for each color.

## Why It's Good For The Game
People are going to want to make fight rings and the locker in the dorms get stolen sometimes. Fight rings are rules questionable at best and regardless of that spam the crap out of the admins. This will make it easy to make a fight ring that won't spam the admins.

## Changelog
:cl:
add: Added Boxing Supply Crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
