### PR TITLE
Allows players to pick body accessories again

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -28,6 +28,9 @@
 	// Different tails
 	__init_body_accessory(/datum/body_accessory/tail)
 
+	// Setup species:accessory relations
+	initialize_body_accessory_by_species()
+
 	for(var/path in (subtypesof(/datum/surgery)))
 		GLOB.surgeries_list += new path()
 


### PR DESCRIPTION
## What Does This PR Do
During the killing of `/hook`, I forgot to re-implement this call, and never noticed it not working due to being localhost admin, and was only bought to my attention from players asking questions.

![image](https://user-images.githubusercontent.com/25063394/87757875-51241e00-c803-11ea-8683-fe1d706e040f.png)

## Why It's Good For The Game
Vulps should be able to pick tails

## Changelog
:cl: AffectedArc07
fix: Vulp can pick tails again (Also applies to other species with body accessories)
/:cl:

