### PR TITLE
Fixes admin ghost ert shuttle issue

### DIFF
--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -9,10 +9,10 @@
 /obj/machinery/computer/shuttle/ert/Topic(href, href_list)
 	if(href_list["move"])
 		var/authorized_roles = list(SPECIAL_ROLE_ERT, SPECIAL_ROLE_DEATHSQUAD)
-		if(!((usr.mind.assigned_role in authorized_roles) || is_admin(usr)))
+		if(!((usr.mind?.assigned_role in authorized_roles) || is_admin(usr)))
 			message_admins("Potential ERT shuttle hijack, ERT shuttle moved by unauthorized user: [key_name_admin(usr)]")
 	..()
-	
+
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/ert
 	name = "specops navigation computer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #13862
I didn't know a ghost's mind could be null under certain circumstances.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
being able to move the shuttle as a ghost that was never in the round is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: admin ghosts can now properly move the ert shuttle again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
