### PR TITLE
Meat hook infinite hitting fix

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -131,6 +131,5 @@
 
 /atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=50, maxdistance=10,beam_type=/obj/effect/ebeam,beam_sleep_time=3)
 	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type,beam_sleep_time)
-	spawn(0)
-		newbeam.Start()
+	INVOKE_ASYNC(newbeam, /datum/beam.proc/Start)
 	return newbeam

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -383,7 +383,10 @@
 		var/mob/living/L = target
 		if(!L.anchored)
 			L.visible_message("<span class='danger'>[L] is snagged by [firer]'s hook!</span>")
+			var/old_density = L.density
+			L.density = FALSE // Ensures the hook does not hit the target multiple times
 			L.forceMove(get_turf(firer))
+			L.density = old_density
 
 /obj/item/projectile/hook/Destroy()
 	QDEL_NULL(chain)


### PR DESCRIPTION
## What Does This PR Do
Makes targets of the meathook have no density while they teleport to the firer.
If you fire a meathook while standing next to somebody and you aim behind them it will currently get stuck. You hit them. They move to you. They bump the projectile. They move to you ... etc
Also fixes a bug where a beam tries to create when it's already destroyed. Happens on the situation described above.

Fixes: #13866

fixes:
```
Runtime in beam.dm,67: Cannot read null.x
   proc name: Draw (/datum/beam/proc/Draw)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The plating (169,159,1) (/turf/simulated/floor/plating)
   src: /datum/beam (/datum/beam)
   call stack:
   /datum/beam (/datum/beam): Draw()
   /datum/beam (/datum/beam): Start()
   NAME (/mob/living/carbon/human): Beam(the hook (/obj/item/projectile/hook), "chain", 'icons/effects/beam.dmi', 1e+031, 1e+031, /obj/effect/ebeam (/obj/effect/ebeam), 3)
```

## Why It's Good For The Game
Less bugs

## Changelog
:cl:
fix: Shooting a meathook next to somebody now won't insta kill them because the hook keeps hitting them.
/:cl: