### PR TITLE
Fixes a kitchen spike runtime

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -69,15 +69,15 @@
 	if(isliving(G.affecting))
 		if(!has_buckled_mobs())
 			if(do_mob(user, src, 120))
-				if(spike(G.affecting))
-					G.affecting.visible_message("<span class='danger'>[user] slams [G.affecting] onto the meat spike!</span>", "<span class='userdanger'>[user] slams you onto the meat spike!</span>", "<span class='italics'>You hear a squishy wet noise.</span>")
-					qdel(G)
+				var/mob/living/affected = G.affecting
+				if(spike(affected))
+					affected.visible_message("<span class='danger'>[user] slams [affected] onto the meat spike!</span>", "<span class='userdanger'>[user] slams you onto the meat spike!</span>", "<span class='italics'>You hear a squishy wet noise.</span>")
 		return
 	return ..()
 
 /obj/structure/kitchenspike/proc/spike(mob/living/victim)
 
-	if(!istype(victim) || QDELETED(victim))
+	if(!istype(victim))
 		return FALSE
 
 	if(has_buckled_mobs()) //to prevent spam/queing up attacks

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -77,7 +77,7 @@
 
 /obj/structure/kitchenspike/proc/spike(mob/living/victim)
 
-	if(!istype(victim))
+	if(!istype(victim) || QDELETED(victim))
 		return FALSE
 
 	if(has_buckled_mobs()) //to prevent spam/queing up attacks


### PR DESCRIPTION
## What Does This PR Do
Fixes:
```
Runtime in kitchen_spike.dm,73: Cannot execute null.visible message().
   proc name: attackby (/obj/structure/kitchenspike/attackby)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (92,126,1) (/turf/simulated/floor/plasteel)
   src: the meat spike (/obj/structure/kitchenspike)
   src.loc: the floor (93,126,1) (/turf/simulated/floor/plasteel)
   call stack:
   the meat spike (/obj/structure/kitchenspike): attackby(the grab (/obj/item/grab), NAME (/mob/living/carbon/human), "icon-x=8;icon-y=20;left=1;scre...")
   the grab (/obj/item/grab): melee attack chain(NAME (/mob/living/carbon/human), the meat spike (/obj/structure/kitchenspike), "icon-x=8;icon-y=20;left=1;scre...")
   NAME (/mob/living/carbon/human): ClickOn(the meat spike (/obj/structure/kitchenspike), "icon-x=8;icon-y=20;left=1;scre...")
   the meat spike (/obj/structure/kitchenspike): Click(the floor (93,126,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=8;icon-y=20;left=1;scre...")
```

## Why It's Good For The Game
Less runtimes more runfines

## Changelog
🆑 
fix: Putting somebody on a kitchen spike now actually shows the message correctly
/🆑