### PR TITLE
Refactors Intercomms For Less Processing

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -198,6 +198,8 @@
 
 // /area signals
 
+///from base of area/proc/power_change(): ()
+#define COMSIG_AREA_POWER_CHANGE "area_power_change"
 ///from base of area/Entered(): (atom/movable/M)
 #define COMSIG_AREA_ENTERED "area_entered"
 ///from base of area/Exited(): (atom/movable/M)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -291,8 +291,7 @@
 /**
   * Called when the area power status changes
   *
-  * Updates the area icon and calls power change on all machinees in the area
-  * Updates the area icon, calls power change on all machinees in the area, and sends the `COMSIG_AREA_POWER_CHANGE` signal.
+  * Updates the area icon, calls power change on all machines in the area, and sends the `COMSIG_AREA_POWER_CHANGE` signal.
   */
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -288,11 +288,16 @@
 /area/space/powered(chan) //Nope.avi
 	return 0
 
-// called when power status changes
-
+/**
+  * Called when the area power status changes
+  *
+  * Updates the area icon and calls power change on all machinees in the area
+  * Updates the area icon, calls power change on all machinees in the area, and sends the `COMSIG_AREA_POWER_CHANGE` signal.
+  */
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
+	SEND_SIGNAL(src, COMSIG_AREA_POWER_CHANGE)
 	updateicon()
 
 /area/proc/usage(var/chan)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -6,9 +6,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	canhear_range = 2
 	flags = CONDUCT
-	var/number = 0
 	var/circuitry_installed = 1
-	var/last_tick //used to delay the powercheck
 	var/buildstage = 0
 	dog_fashion = null
 
@@ -50,7 +48,7 @@
 	. = ..()
 	buildstage = building
 	if(buildstage)
-		START_PROCESSING(SSobj, src)
+		update_operating_status()
 	else
 		if(direction)
 			setDir(direction)
@@ -105,20 +103,17 @@
 	)
 
 /obj/item/radio/intercom/Destroy()
-	STOP_PROCESSING(SSobj, src)
 	GLOB.global_intercoms.Remove(src)
 	return ..()
 
-/obj/item/radio/intercom/attack_ai(mob/user as mob)
+/obj/item/radio/intercom/attack_ai(mob/user)
 	add_hiddenprint(user)
 	add_fingerprint(user)
-	spawn(0)
-		attack_self(user)
+	attack_self(user)
 
-/obj/item/radio/intercom/attack_hand(mob/user as mob)
+/obj/item/radio/intercom/attack_hand(mob/user)
 	add_fingerprint(user)
-	spawn(0)
-		attack_self(user)
+	attack_self(user)
 
 /obj/item/radio/intercom/receive_range(freq, level)
 	if(!is_listening())
@@ -134,7 +129,7 @@
 
 	return canhear_range
 
-/obj/item/radio/intercom/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/radio/intercom/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/tape_roll)) //eww
 		return
 	else if(iscoil(W) && buildstage == 1)
@@ -184,7 +179,7 @@
 	buildstage = 3
 	to_chat(user, "<span class='notice'>You secure the electronics!</span>")
 	update_icon()
-	START_PROCESSING(SSobj, src)
+	update_operating_status()
 	for(var/i, i<= 5, i++)
 		wires.UpdateCut(i,1)
 
@@ -200,7 +195,7 @@
 	b_stat = 1
 	buildstage = 1
 	update_icon()
-	STOP_PROCESSING(SSobj, src)
+	update_operating_status(FALSE)
 
 /obj/item/radio/intercom/welder_act(mob/user, obj/item/I)
 	if(buildstage != 0)
@@ -220,20 +215,29 @@
 		return
 	icon_state = "intercom[!on?"-p":""][b_stat ? "-open":""]"
 
-/obj/item/radio/intercom/process()
-	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
-		last_tick = world.timeofday
+/obj/item/radio/intercom/proc/update_operating_status(on = TRUE)
+	var/area/current_area = get_area(src)
+	if(!current_area)
+		return
+	if(on)
+		RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, .proc/AreaPowerCheck)
+	else
+		UnregisterSignal(current_area, COMSIG_AREA_POWER_CHANGE)
 
-
-		if(!src.loc)
-			on = 0
-		else
-			var/area/A = get_area(src)
-			if(!A)
-				on = 0
-			else
-				on = A.powered(EQUIP) // set "on" to the power status
-		update_icon()
+/**
+ * Proc called whenever the intercom's area loses or gains power. Responsible for setting the `on` variable and calling `update_icon()`.
+ *
+ * Normally called after the intercom's area recieves the `COMSIG_AREA_POWER_CHANGE` signal, but it can also be called directly.
+ * Arguments:
+ * * source - the area that just had a power change.
+ */
+/obj/item/radio/intercom/proc/AreaPowerCheck(datum/source)
+	var/area/current_area = get_area(src)
+	if(!current_area)
+		on = FALSE
+	else
+		on = current_area.powered(EQUIP) // set "on" to the equipment power status of our area.
+	update_icon()
 
 /obj/item/intercom_electronics
 	name = "intercom electronics"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -225,12 +225,13 @@
 		UnregisterSignal(current_area, COMSIG_AREA_POWER_CHANGE)
 
 /**
- * Proc called whenever the intercom's area loses or gains power. Responsible for setting the `on` variable and calling `update_icon()`.
- *
- * Normally called after the intercom's area recieves the `COMSIG_AREA_POWER_CHANGE` signal, but it can also be called directly.
- * Arguments:
- * * source - the area that just had a power change.
- */
+  * Proc called whenever the intercom's area loses or gains power. Responsible for setting the `on` variable and calling `update_icon()`.
+  *
+  * Normally called after the intercom's area recieves the `COMSIG_AREA_POWER_CHANGE` signal, but it can also be called directly.
+  * Arguments:
+  *
+  * source - the area that just had a power change.
+  */
 /obj/item/radio/intercom/proc/AreaPowerCheck(datum/source)
 	var/area/current_area = get_area(src)
 	if(!current_area)


### PR DESCRIPTION
Ported from TG. Most credit to @SteelSlayer ; made a number of adjustments to make it work with Paracode.

This reduces the processing list of objects, at round start from to ~670 objects down to ~388.

This has obvious performance impacts:

before:
```
                                                    Profile results (total time)
Proc Name                                                         Self CPU    Total CPU    Real Time     Overtime        Calls
/datum/controller/subsystem/processing/fire      1.588        4.818         4.828            0.000             3233
```
after:
```
                                                    Profile results (total time)
Proc Name                                                              Self CPU    Total CPU    Real Time     Overtime        Calls
/datum/controller/subsystem/processing/fire            0.998        3.887        3.897             0.000            3246
```

:cl: SteelSlayer and Fox McCloud
tweak: reduced the performance impact of radio intercomms, improving server performance
/:cl: