### PR TITLE
fixes certain items unable to light plasma sheets

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 
 /obj/item/stack/sheet/mineral/plasma/proc/log_and_set_aflame(mob/user, obj/item/I)
 	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-	log_game("Plasma sheets ignited by [key_name(user)] in coord(SRC)")
+	log_game("Plasma sheets ignited by [key_name(user)] in [coord(SRC)]")
 	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
 	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", src)
 	fire_act()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -232,7 +232,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([COORD(T)] - [ADMIN_JMP(T)]")
 	log_game("Plasma sheets ignited by [key_name(user)] in [COORD(T)]")
 	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
-	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", T)
+	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", src)
 	fire_act()
 
 /obj/item/stack/sheet/mineral/plasma/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -227,9 +227,9 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 		return ..()
 
 /obj/item/stack/sheet/mineral/plasma/proc/log_and_set_aflame(mob/user, obj/item/I)
-	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user,"?")]) ([ADMIN_FLW(user,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("Plasma sheets ignited by [key_name(user)] in ([x],[y],[z])")
-	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
+	log_game("Plasma sheets ignited by [key_name(user)] in coord(SRC)")
+	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
 	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", src)
 	fire_act()
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -218,10 +218,20 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 
 /obj/item/stack/sheet/mineral/plasma/welder_act(mob/user, obj/item/I)
 	if(I.use_tool(src, user, volume = I.tool_volume))
-		message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user,"?")]) ([ADMIN_FLW(user,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-		log_game("Plasma sheets ignited by [key_name(user)] in ([x],[y],[z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
-		fire_act()
+		log_and_set_aflame(user, I)
+
+/obj/item/stack/sheet/mineral/plasma/attackby(obj/item/I, mob/living/user, params)
+	if(is_hot(I))
+		log_and_set_aflame(user, I)
+	else
+		return ..()
+
+/obj/item/stack/sheet/mineral/plasma/proc/log_and_set_aflame(mob/user, obj/item/I)
+	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user,"?")]) ([ADMIN_FLW(user,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+	log_game("Plasma sheets ignited by [key_name(user)] in ([x],[y],[z])")
+	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", src)
+	fire_act()
 
 /obj/item/stack/sheet/mineral/plasma/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	..()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -228,10 +228,11 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 		return ..()
 
 /obj/item/stack/sheet/mineral/plasma/proc/log_and_set_aflame(mob/user, obj/item/I)
-	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-	log_game("Plasma sheets ignited by [key_name(user)] in [COORD(src)]")
+	var/turf/T = get_turf(src)
+	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([x],[y],[z] - [ADMIN_JMP(T)]")
+	log_game("Plasma sheets ignited by [key_name(user)] in [COORD(T)]")
 	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
-	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", src)
+	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", T)
 	fire_act()
 
 /obj/item/stack/sheet/mineral/plasma/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 
 /obj/item/stack/sheet/mineral/plasma/proc/log_and_set_aflame(mob/user, obj/item/I)
 	var/turf/T = get_turf(src)
-	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([x],[y],[z] - [ADMIN_JMP(T)]")
+	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([COORD(T)] - [ADMIN_JMP(T)]")
 	log_game("Plasma sheets ignited by [key_name(user)] in [COORD(T)]")
 	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
 	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", T)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 
 /obj/item/stack/sheet/mineral/plasma/proc/log_and_set_aflame(mob/user, obj/item/I)
 	message_admins("Plasma sheets ignited by [key_name_admin(user)]([ADMIN_QUE(user, "?")]) ([ADMIN_FLW(user, "FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-	log_game("Plasma sheets ignited by [key_name(user)] in [coord(SRC)]")
+	log_game("Plasma sheets ignited by [key_name(user)] in [COORD(src)]")
 	investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]", "atmos")
 	user.create_log(MISC_LOG, "Plasma sheets ignited using [I]", src)
 	fire_act()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -219,6 +219,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 /obj/item/stack/sheet/mineral/plasma/welder_act(mob/user, obj/item/I)
 	if(I.use_tool(src, user, volume = I.tool_volume))
 		log_and_set_aflame(user, I)
+	return TRUE
 
 /obj/item/stack/sheet/mineral/plasma/attackby(obj/item/I, mob/living/user, params)
 	if(is_hot(I))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes matches, lighters, and candles from being unable to light plasma sheets on fire, as well as adding proper logging to it.
fixes https://github.com/ParadiseSS13/Paradise/issues/13092
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Anything on fire should be able to light plasma sheets ablaze

## Changelog
:cl:
fix: fixed certain items from lighting plasma sheets on fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
