### PR TITLE
Fixes sparks not checking for deletion

### DIFF
--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -49,6 +49,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	holder = atom
 
 /datum/effect_system/proc/start()
+	if(QDELETED(src))
+		return
 	for(var/i in 1 to number)
 		if(total_effects > 20)
 			return
@@ -68,7 +70,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/j in 1 to steps_amt)
 		sleep(5)
 		step(E,direction)
-	if(!QDELETED(holder))
+	if(!QDELETED(src))
 		addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
 
 /datum/effect_system/proc/decrement_total_effect()

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -68,7 +68,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/j in 1 to steps_amt)
 		sleep(5)
 		step(E,direction)
-	addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
+	if(!QDELETED(holder))
+		addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
 
 /datum/effect_system/proc/decrement_total_effect()
 	total_effects--


### PR DESCRIPTION
## What Does This PR Do
This PR adds a qdel check to the spark effect system to ensure it doesnt try to attach sparks to a qdeleted object, causing a runtime.

The sparks were broken, whats new. 

## Why It's Good For The Game
Runtimes bad,

## Changelog
:cl: AffectedArc07
fix: Fixed a spark runtime
/:cl:

