### PR TITLE
Terror spider event types now depend on server pop

### DIFF
--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -41,7 +41,7 @@
 			spawncount = 2
 		if(4)
 			// Pretty strong.
-			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess
+			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/princess
 			spawncount = 2
 		if(5)
 			// Strongest, only used during highpop.

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -71,3 +71,4 @@
 			spawncount--
 
 #undef TS_HIGHPOP_TRIGGER
+

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -23,8 +23,10 @@
 				vents += temp_vent
 	var/spider_type
 	var/highpop_trigger = 80
-	var/infestation_type = pick(1, 2, 3, 4)
-	if((length(GLOB.clients)) >= highpop_trigger)
+	var/infestation_type
+	if((length(GLOB.clients)) < highpop_trigger)
+		infestation_type = pick(1, 2, 3, 4)
+	else
 		infestation_type = pick(2, 3, 4, 5)
 	switch(infestation_type)
 		if(1)

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -1,3 +1,4 @@
+#define TS_HIGHPOP_TRIGGER 80
 
 /datum/event/spider_terror
 	announceWhen = 240
@@ -22,9 +23,8 @@
 			if(temp_vent.parent.other_atmosmch.len > 50)
 				vents += temp_vent
 	var/spider_type
-	var/highpop_trigger = 80
 	var/infestation_type
-	if((length(GLOB.clients)) < highpop_trigger)
+	if((length(GLOB.clients)) < TS_HIGHPOP_TRIGGER)
 		infestation_type = pick(1, 2, 3, 4)
 	else
 		infestation_type = pick(2, 3, 4, 5)
@@ -70,3 +70,4 @@
 			new spider_type(vent.loc)
 			spawncount--
 
+#undef TS_HIGHPOP_TRIGGER

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -22,23 +22,31 @@
 			if(temp_vent.parent.other_atmosmch.len > 50)
 				vents += temp_vent
 	var/spider_type
-	var/infestation_type = pick(1, 2, 3, 4, 5)
+	var/highpop_trigger = 80
+	var/infestation_type = pick(1, 2, 3, 4)
+	if((length(GLOB.clients)) >= highpop_trigger)
+		infestation_type = pick(2, 3, 4, 5)
 	switch(infestation_type)
 		if(1)
+			// Weakest, only used during lowpop.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/green
 			spawncount = 5
 		if(2)
-			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/white
-			spawncount = 2
-		if(3)
+			// Fairly weak. Dangerous in single combat but has little staying power. Always gets whittled down.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/prince
 			spawncount = 1
+		if(3)
+			// Variable. Depends how many they infect.
+			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/white
+			spawncount = 2
 		if(4)
+			// Pretty strong.
+			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess
+			spawncount = 2
+		if(5)
+			// Strongest, only used during highpop.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen
 			spawncount = 1
-		if(5)
-			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/princess
-			spawncount = 2
 	while(spawncount >= 1 && vents.len)
 		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(vents)
 

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -70,5 +70,6 @@
 			new spider_type(vent.loc)
 			spawncount--
 
+
 #undef TS_HIGHPOP_TRIGGER
 


### PR DESCRIPTION
## What Does This PR Do
Terror spider events now consider server pop when deciding what type of spiders to spawn.
On lowpop (<80 clients), it picks from: greens/princes/whites/princesses.
On highpop (80+) it picks from: prince/whites/princesses/queen.
This means greens (weakest infestation type) are never seen on highpop, and queen (strongest infestation type) are never seen on lowpop.

## Why It's Good For The Game
Helps ensure that terror events are more scaled to server pop.

## Changelog
:cl: Kyep
balance: Terror spider events now have their severity scaled by server pop.
/:cl: