### PR TITLE
Prevents slimes from feeding on anyone in a Hardsuit or Biosuit

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -99,6 +99,14 @@
 			return FALSE
 		to_chat(src, "<span class='warning'><i>Another slime is already feeding on this subject...</i></span>")
 		return FALSE
+
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if((C.wear_suit && ((C.wear_suit.flags & THICKMATERIAL)) && ((C.head && ((C.head.flags & THICKMATERIAL))))))
+			if(silent)
+				return FALSE
+			to_chat(src, "<span class='warning'><i>This subject's covering is too thick...</i></span>")
+			return FALSE
 	return TRUE
 
 /mob/living/simple_animal/slime/proc/Feedon(mob/living/M)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -102,7 +102,7 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		if((C.wear_suit && ((C.wear_suit.flags & THICKMATERIAL)) && ((C.head && ((C.head.flags & THICKMATERIAL))))))
+		if(C.wear_suit && (C.wear_suit.flags & THICKMATERIAL) && C.head && (C.head.flags & THICKMATERIAL))
 			if(silent)
 				return FALSE
 			to_chat(src, "<span class='warning'><i>This subject's covering is too thick...</i></span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check to slimes that prevents them from latching onto a Hardsuit, biosuit, or any suit with the flag THICKMATERIAL. 

## Why It's Good For The Game
After watching an ERT get messed up by slimes it felt needed. Unlike most damage types their continual TOX and CLONE damage is really hard to resist and even harder to cure. Additionally, it makes it so biosuits will actually protect Xenobiologists from the slimes. They can still be attacked, but if they take the time to wear the suit they will be protected.

## Changelog
:cl:
tweak: Slimes can no longer feed on mobs wearing biosuits or hardsuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
