### PR TITLE
Tcomms fixes and tweaks

### DIFF
--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	GLOB.tcomms_machines += src
 	update_icon()
 	if((!mapload) && (usr))
-		// To the person who asks "Hey affected, why are you using this massive operator when you can use AREACOORD? Well, ill tell you"
+		// To the person who asks "Hey affected, why are you using this massive operator when you can use AREACOORD?" Well, ill tell you
 		// get_area_name is fucking broken and uses a for(x in world) search
 		// It doesnt even work, is expensive, and returns 0
 		// Im not refactoring one thing which could risk breaking all admin location logs

--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -52,6 +52,19 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	. = ..()
 	GLOB.tcomms_machines += src
 	update_icon()
+	if((!mapload) && (usr))
+		// To the person who asks "Hey affected, why are you using this massive operator when you can use AREACOORD? Well, ill tell you"
+		// get_area_name is fucking broken and uses a for(x in world) search
+		// It doesnt even work, is expensive, and returns 0
+		// Im not refactoring one thing which could risk breaking all admin location logs
+		// Fight me
+		log_action(usr, "constructed a new [src] at [src ? "[get_location_name(src, TRUE)] [COORD(src)]" : "nonexistent location"] [ADMIN_JMP(src)]", adminmsg = TRUE)
+	// Add in component parts for the sake of deconstruction
+	component_parts = list()
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stack/cable_coil(null, 1)
+	component_parts += new /obj/item/stack/cable_coil(null, 1)
 
 /**
   * Base Destructor
@@ -60,6 +73,8 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
   */
 /obj/machinery/tcomms/Destroy()
 	GLOB.tcomms_machines -= src
+	if(usr)
+		log_action(usr, "destroyed a [src] at [src ? "[get_location_name(src, TRUE)] [COORD(src)]" : "nonexistent location"] [ADMIN_JMP(src)]", adminmsg = TRUE)
 	return ..()
 
 /**
@@ -462,3 +477,20 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 			break
 	return ..()
 
+/**
+  * Screwdriver Act Handler
+  *
+  * Handles the screwdriver action for all tcomms machines, so they can be open and closed to be deconstructed
+  */
+/obj/machinery/tcomms/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE
+	default_deconstruction_screwdriver(user, icon_state, icon_state, I)
+
+/**
+  * Crowbar Act Handler
+  *
+  * Handles the crowbar action for all tcomms machines, so they can be deconstructed
+  */
+/obj/machinery/tcomms/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
+	default_deconstruction_crowbar(user, I)

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -34,6 +34,7 @@
 	. = ..()
 	link_password = GenerateKey()
 	reachable_zlevels |= loc.z
+	component_parts += new /obj/item/circuitboard/tcomms/core(null)
 
 /**
   * Destructor for the core.

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -25,6 +25,7 @@
   */
 /obj/machinery/tcomms/relay/Initialize(mapload)
 	. = ..()
+	component_parts += new /obj/item/circuitboard/tcomms/relay(null)
 	if(mapload && autolink_id)
 		return INITIALIZE_HINT_LATELOAD
 


### PR DESCRIPTION
## What Does This PR Do
This PR adds admin logging for when tcomms machines are created or destroyed. It also allows them to be deconstructed with proper tools (You couldnt before)

Regular deconstruction and creation
![image](https://user-images.githubusercontent.com/25063394/87924129-5ccb4b00-ca76-11ea-9b00-24a550b6eaab.png)

Forceful deconstruction
![image](https://user-images.githubusercontent.com/25063394/87924149-65bc1c80-ca76-11ea-8b48-8eed26c262e7.png)

## Why It's Good For The Game
Logging and actual deconstruction ability outside of object damage is good

## Changelog
:cl: AffectedArc07
add: Tcomms machines now admin log when being taken apart or built
add: Tcomms machines can now be deconstructed without having to object damage them
/:cl:
