### PR TITLE
Removes MORE hardcoded zlevel numbers

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -439,7 +439,7 @@
 		var/area/A = get_area(bombturf)
 
 		var/notify_admins = 0
-		if(z != 5)
+		if(!is_mining_level(z))
 			notify_admins = 1
 			if(!triggered_by_explosion)
 				message_admins("[key_name_admin(user)] has triggered a gibtonite deposit reaction at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name] (JMP)</a>.")

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -10,7 +10,7 @@
 
 	for(var/mob/living/simple_animal/L in GLOB.alive_mob_list)
 		var/turf/T = get_turf(L)
-		if (T.z != 1)
+		if (!is_station_level(T.z))
 			continue
 		if(!(L in GLOB.player_list) && !L.mind && (L.sentience_type == sentience_type))
 			potential += L

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -273,7 +273,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		icon_state = "Gibtonite active"
 		var/turf/bombturf = get_turf(src)
 		var/notify_admins = 0
-		if(z != 5)//Only annoy the admins ingame if we're triggered off the mining zlevel
+		if(!is_mining_level(z))//Only annoy the admins ingame if we're triggered off the mining zlevel
 			notify_admins = 1
 
 		if(notify_admins)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -756,7 +756,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 // send a radio signal with multiple data key/values
 /mob/living/simple_animal/bot/proc/post_signal_multiple(var/freq, var/list/keyval)
-	if(z != 1) //Bot control will only work on station.
+	if(!is_station_level(z)) //Bot control will only work on station.
 		return
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(freq)
 	if(!frequency)


### PR DESCRIPTION
## What Does This PR Do
Removes more hardcoded zlevel IDs. This is another stepping stone to map rotation and will also stop admins being spammed with gibtonite logs.

## Why It's Good For The Game
Logspam bad, killing off hardcoded zlevel IDs good.

## Changelog
:cl: AffectedArc07
fix: Fixed some hardcoded zlevel references
/:cl:
