### PR TITLE
Removes GPS from Lavaland Tendrils

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -15,7 +15,6 @@
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
-	var/gps = null
 	var/obj/effect/light_emitter/tendril/emitted_light
 
 /obj/structure/spawner/lavaland/goliath
@@ -58,7 +57,6 @@ GLOBAL_LIST_INIT(tendrils, list())
 				SSmedals.SetScore(TENDRIL_CLEAR_SCORE, L.client, 1)
 	GLOB.tendrils -= src
 	QDEL_NULL(emitted_light)
-	QDEL_NULL(gps)
 	return ..()
 
 /obj/effect/light_emitter/tendril

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -29,7 +29,6 @@ GLOBAL_LIST_INIT(tendrils, list())
 /obj/structure/spawner/lavaland/Initialize(mapload)
 	. = ..()
 	emitted_light = new(loc)
-	//gps = new /obj/item/gps/internal(src)
 	GLOB.tendrils += src
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 /obj/structure/spawner/lavaland/Initialize(mapload)
 	. = ..()
 	emitted_light = new(loc)
-	gps = new /obj/item/gps/internal(src)
+	//gps = new /obj/item/gps/internal(src)
 	GLOB.tendrils += src
 	return INITIALIZE_HINT_LATELOAD
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This comments out the GPS that all tendrils starts with

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Often you got 2-3 shaft miners getting all the tendril loot, cause they rush for it, removing this from gps will make it an equal opportunity thing, and focusing on getting that and looting the various ruins instead of just finding them naturally.
This change prevents that, and makes powergaming as a miner harder, unless you wanna fight the megafauna.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/21987702/87971015-f4578a80-cac4-11ea-8f5c-b630d507f496.png)


## Changelog
:cl: PPI
add: Removes the Lavaland Tendrils GPS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
