### PR TITLE
Adds a world/Topic entry for announcing by server

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -266,6 +266,13 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 			update_status()
 			return "Set listed status to invisible."
 
+
+	else if("hostannounce" in input)
+		if(!key_valid)
+			return keySpamProtect(addr)
+
+		to_chat(world, "<hr><span style='color: #12A5F4'><b>Server Announcement:</b> [input["message"]]</span><hr>")
+
 /proc/keySpamProtect(var/addr)
 	if(GLOB.world_topic_spam_protect_ip == addr && abs(GLOB.world_topic_spam_protect_time - world.time) < 50)
 		spawn(50)

--- a/tools/send2server.py
+++ b/tools/send2server.py
@@ -1,0 +1,14 @@
+# Script to send world/Topic announcements to a server via automated tooling
+# Author: AffectedArc07
+# Takes a message as command line argument
+# Example: python send2server.py "This is a message that will be sent to the server"
+import socket, struct, urllib.parse, sys
+
+message = sys.argv[1]
+commskey = "YOURKEYHERE"
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+cmd = "?hostannounce&key={}&message={}".format(urllib.parse.quote(commskey), urllib.parse.quote(message))
+query = b"\x00\x83" + struct.pack('>H', len(cmd) + 6) + b"\x00\x00\x00\x00\x00" + cmd.encode() + b"\x00"
+sock.connect(("localhost", 6666))
+sock.sendall(query)


### PR DESCRIPTION
## What Does This PR Do
This PR adds a world/Topic entry for automated announcements to be sent to the server via internal tooling.
![image](https://user-images.githubusercontent.com/25063394/87969467-1ef01600-caba-11ea-9714-96838b84a3af.png)
This allows the playerbase to be notified of impending restarts, testmerges or more.

## Why It's Good For The Game
People should be informed

## Changelog
:cl: AffectedArc07
add: Added the ability for announcements to be sent to the server via server tooling
/:cl:
