### PR TITLE
Gives thralls their actual masters name in the objective description

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -354,10 +354,10 @@
 	var/datum/objective/protect/serve_objective = new
 	serve_objective.owner = user.mind
 	serve_objective.target = H.mind
-	serve_objective.explanation_text = "You have been Enthralled by [user]. Follow [user.p_their()] every command."
+	serve_objective.explanation_text = "You have been Enthralled by [user.real_name]. Follow [user.p_their()] every command."
 	H.mind.objectives += serve_objective
 
-	to_chat(H, "<span class='biggerdanger'>You have been Enthralled by [user]. Follow [user.p_their()] every command.</span>")
+	to_chat(H, "<span class='biggerdanger'>You have been Enthralled by [user.real_name]. Follow [user.p_their()] every command.</span>")
 	to_chat(user, "<span class='warning'>You have successfully Enthralled [H]. <i>If [H.p_they()] refuse[H.p_s()] to do as you say just adminhelp.</i></span>")
 	H.Stun(2)
 	add_attack_logs(user, H, "Vampire-thralled")


### PR DESCRIPTION
## What Does This PR Do
As the title says.
Thralls will see the `real_name` var instead of the name the user is currently visible with. Makes it impossible to be thralled by Unknown of Count Gasmaskia

## Why It's Good For The Game
It's a bit odd currently and confusing for people

## Changelog
:cl:
tweak: Vampire thralls will now see their masters actual name in the objective text
/:cl: