### PR TITLE
Removes xray lasers from R&D, replaces it with the L.W.A.P. sniper rifle

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -5193,9 +5193,6 @@
 /area/shuttle/gamma/space)
 "oC" = (
 /obj/structure/closet/secure_closet/guncabinet,
-/obj/item/gun/energy/sniperrifle,
-/obj/item/gun/energy/sniperrifle,
-/obj/item/gun/energy/sniperrifle,
 /obj/machinery/light/spot{
 	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
@@ -5204,6 +5201,9 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
+/obj/item/gun/energy/xray,
+/obj/item/gun/energy/xray,
+/obj/item/gun/energy/xray,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -310,7 +310,7 @@
 	name = "L.W.A.P. Sniper Rifle"
 	desc = "A rifle constructed of lightweight materials, fitted with a SMART aiming-system scope."
 	icon_state = "esniper"
-	origin_tech = "combat=6;materials=5;powerstorage=4"
+	origin_tech = "combat=6;materials=4;magnets=4;syndicate=1"
 	ammo_type = list(/obj/item/ammo_casing/energy/sniper)
 	item_state = null
 	weapon_weight = WEAPON_HEAVY

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -236,15 +236,15 @@
 	build_path = /obj/item/ammo_casing/shotgun/techshell
 	category = list("Weapons")
 
-/datum/design/xray
-	name = "Xray Laser Gun"
-	desc = "Not quite as menacing as it sounds"
-	id = "xray"
+/datum/design/sniperrifle
+	name = "L.W.A.P. Sniper Rifle"
+	desc = "A rifle constructed of lightweight materials, fitted with a SMART aiming-system scope"
+	id = "sniperrifle"
 	req_tech = list("combat" = 7, "magnets" = 5, "biotech" = 5, "powerstorage" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 5000, MAT_URANIUM = 4000, MAT_METAL = 5000, MAT_TITANIUM = 2000, MAT_BLUESPACE = 2000)
-	build_path = /obj/item/gun/energy/xray
-	locked = 1
+	build_path = /obj/item/gun/energy/sniperrifle
+	locked = TRUE
 	category = list("Weapons")
 
 /datum/design/immolator


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is @Qwertyotoforty's code and these are his words, I just copied the changes and made the PR.

This PR removes xray from the protolathe, and replaces it with the LWAP sniper, while putting xray lasers in the gamma armory and removing the LWAPs from the gamma armory. Creating the sniper rifle has the same exact tech requirements as the xray laser.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xray lasers have 10 shots, do 15 damage, decreased by 0.75 damage per tile. They also irradiate anyone hit for 30 points, leading to huge toxin and burn damage after 3-4 hits. They also of course, go through anything really, irradiating whoever they hit, going through walls, and of course, dunking even late game blobs. Crew can naturally mass produce these, and really, compared to normal lasers guns, they don’t have a downside apart from the decreased damage radiation more than makes up for. Based on suggestions of several people who do not think crew should have access to xray type objects normally, this removes xray lasers from the protolathe and puts it in the gamma armory, while moving the LWAP to protolathe instead.

Stat wise, the LWAP has and is:
Bulky, and requires 2 hands to fire.
Has 10 shots
Does 60 damage burn with a 10 second stun with each shot, but has a 4 second cooldown between shots.
Has a zoom function.

This weapon does seem strong at first, but it has a few catches. It is bulky, you are not easily able to carry it around, unless you wear it on armour, in your hand, or in your backpack slot. Since it is a 2 handed weapon, unlike an AEG, you can not have a baton or riot shield in your off hand, you need to have it empty to fire. Yes, the weapon does do a high 60 damage shot with a 10 second stun, but you could also use a taser and a laser gun, for a similar stun, but way more damage in a shorter time. Unlike the LWAP as well, a taser can be fired every second, instead of the 4 second cool down of the LWAP, where if you miss, you are probably screwed. And of course, you could also use a taser and a shotgun as well, for even stronger effects in the more popular brute damage.

LWAP’s tech level value is also increased to xrays value, to not change any R&D pathings.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Xray lasers have been removed from the protolathe design list
add: L.W.A.P Sniper rifles are now buildable from protolathes with the same tech requirements as the now removed xray lasers
tweak: Replaces the L.W.A.P sniper rifles in the gamma armory with xray lasers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
