### PR TITLE
Correctly names the SGL-6 and SOB-3 Launchers

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -385,7 +385,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang
-	name = "SGL-6 Grenade Launcher"
+	name = "SGL-6 Flashbang Launcher"
 	icon_state = "mecha_grenadelnchr"
 	origin_tech = "combat=4;engineering=4"
 	projectile = /obj/item/grenade/flashbang
@@ -411,7 +411,7 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang//Because I am a heartless bastard -Sieve
-	name = "SOB-3 Grenade Launcher"
+	name = "SOB-3 Clusterbang Launcher"
 	desc = "A weapon for combat exosuits. Launches primed clusterbangs. You monster."
 	origin_tech = "combat=4;materials=4"
 	projectiles = 3

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -948,8 +948,8 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_grenade_launcher
-	name = "Exosuit Weapon (SGL-6 Grenade Launcher)"
-	desc = "Allows for the construction of SGL-6 Grenade Launcher."
+	name = "Exosuit Weapon (SGL-6 Flashbang Launcher)"
+	desc = "Allows for the construction of SGL-6 Flashbang Launcher."
 	id = "mech_grenade_launcher"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "engineering" = 4)


### PR DESCRIPTION
## What Does This PR Do
Simply changes the SGL-6 Grenade Launcher and SOB-3 Grenade Launchers to their more accurate, and less confusing, names of SGL-6 Flashbang Launcher and SOB-3 Clusterbang Launcher. Ironically under the mechfab file, the SOB-3 was already accurately named Clusterbang Launcher. Under Weapons though, it was named Grenade.

## Why It's Good For The Game
Less confusion overall for players in general. Both those asking for a flashbang launcher, and a syndicate/security officer assuming a grenade launcher would actually fire lethal grenades instead of flashbang. 

## Changelog
:cl:
tweak: Changed the name of the mech SGL-6 Grenade Launcher and SOB-3 Grenade Launcher to Flashbang and Clusterbang launcher respectively.
/:cl: