### PR TITLE
Fixes issues with machines/mechs when a person is teleported out of them

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -57,6 +57,9 @@
 			W.plane = initial(W.plane)
 			W.loc = affected_mob.loc
 			W.dropped(affected_mob)
+		if(isobj(affected_mob.loc))
+			var/obj/O = affected_mob.loc
+			O.force_eject_occupant()
 		var/mob/living/new_mob = new new_form(affected_mob.loc)
 		if(istype(new_mob))
 			new_mob.a_intent = "harm"

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -282,6 +282,9 @@
 	occupant = null
 	icon_state = "scanner_open"
 
+/obj/machinery/dna_scannernew/force_eject_occupant()
+	go_out(null, TRUE)
+
 /obj/machinery/dna_scannernew/ex_act(severity)
 	if(occupant)
 		occupant.ex_act(severity)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -411,6 +411,9 @@
 	for(var/atom/movable/A in contents - component_parts - list(beaker))
 		A.forceMove(loc)
 
+/obj/machinery/sleeper/force_eject_occupant()
+	go_out()
+
 /obj/machinery/sleeper/proc/inject_chemical(mob/living/user as mob, chemical, amount)
 	if(!(chemical in possible_chems))
 		to_chat(user, "<span class='notice'>The sleeper does not offer that chemical!</span>")

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -172,6 +172,9 @@
 	for(var/atom/movable/A in contents - component_parts)
 		A.forceMove(loc)
 
+/obj/machinery/bodyscanner/force_eject_occupant()
+	go_out()
+
 /obj/machinery/bodyscanner/ex_act(severity)
 	if(occupant)
 		occupant.ex_act(severity)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -443,6 +443,9 @@
 	for(var/atom/movable/A in contents - component_parts - list(beaker))
 		A.forceMove(get_step(loc, SOUTH))
 
+/obj/machinery/atmospherics/unary/cryo_cell/force_eject_occupant()
+	go_out()
+
 /// Called when either the occupant is dead and the AUTO_EJECT_DEAD flag is present, OR the occupant is alive, has no external damage, and the AUTO_EJECT_HEALTHY flag is present.
 /obj/machinery/atmospherics/unary/cryo_cell/proc/auto_eject(eject_flag)
 	on = FALSE

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -772,12 +772,9 @@
 /proc/cryo_ssd(var/mob/living/carbon/person_to_cryo)
 	if(istype(person_to_cryo.loc, /obj/machinery/cryopod))
 		return 0
-	if(istype(person_to_cryo.loc, /obj/mecha))
-		var/obj/mecha/E = person_to_cryo.loc
-		E.go_out()
-	if(istype(person_to_cryo.loc, /obj/machinery))
-		var/obj/machinery/E = person_to_cryo.loc
-		E.force_eject_occupant()
+	if(istype(person_to_cryo.loc, /obj))
+		var/obj/O = person_to_cryo.loc
+		O.force_eject_occupant()
 	var/list/free_cryopods = list()
 	for(var/obj/machinery/cryopod/P in GLOB.machines)
 		if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -772,7 +772,7 @@
 /proc/cryo_ssd(var/mob/living/carbon/person_to_cryo)
 	if(istype(person_to_cryo.loc, /obj/machinery/cryopod))
 		return 0
-	if(istype(person_to_cryo.loc, /obj))
+	if(isobj(person_to_cryo.loc))
 		var/obj/O = person_to_cryo.loc
 		O.force_eject_occupant()
 	var/list/free_cryopods = list()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -768,9 +768,16 @@
 
 	return ..()
 
+
 /proc/cryo_ssd(var/mob/living/carbon/person_to_cryo)
 	if(istype(person_to_cryo.loc, /obj/machinery/cryopod))
 		return 0
+	if(istype(person_to_cryo.loc, /obj/mecha))
+		var/obj/mecha/E = person_to_cryo.loc
+		E.go_out()
+	if(istype(person_to_cryo.loc, /obj/machinery))
+		var/obj/machinery/E = person_to_cryo.loc
+		E.force_eject_occupant()
 	var/list/free_cryopods = list()
 	for(var/obj/machinery/cryopod/P in GLOB.machines)
 		if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -597,3 +597,8 @@ Class Procs:
 	. = . % 9
 	AM.pixel_x = -8 + ((.%3)*8)
 	AM.pixel_y = -8 + (round( . / 3)*8)
+
+/obj/machinery/proc/force_eject_occupant()
+	// For each subtype of /machinery, this proc handles safely removing occupants from the machine if they must be cryoed due to being SSD/AFK.
+	// In the event that the machinery doesn't have an overriden version of this proc to do it, log a runtime so one can be added.
+	log_runtime(EXCEPTION("Proc force_eject_occupant() is not overriden on a machine containing a mob."), src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -597,8 +597,3 @@ Class Procs:
 	. = . % 9
 	AM.pixel_x = -8 + ((.%3)*8)
 	AM.pixel_y = -8 + (round( . / 3)*8)
-
-/obj/machinery/proc/force_eject_occupant()
-	// For each subtype of /machinery, this proc handles safely removing occupants from the machine if they must be cryoed due to being SSD/AFK.
-	// In the event that the machinery doesn't have an overriden version of this proc to do it, log a runtime so one can be added.
-	log_runtime(EXCEPTION("Proc force_eject_occupant() is not overriden on a machine containing a mob."), src)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -740,10 +740,11 @@
 	if(!occupant)
 		return
 
-	if(user != occupant)
-		to_chat(occupant, "<span class='warning'>The machine kicks you out!</span>")
-	if(user.loc != loc)
-		to_chat(occupant, "<span class='warning'>You leave the not-so-cozy confines of the SSU.</span>")
+	if(user)
+		if(user != occupant)
+			to_chat(occupant, "<span class='warning'>The machine kicks you out!</span>")
+		if(user.loc != loc)
+			to_chat(occupant, "<span class='warning'>You leave the not-so-cozy confines of the SSU.</span>")
 	occupant.forceMove(loc)
 	occupant = null
 	if(!state_open)
@@ -751,6 +752,8 @@
 	update_icon()
 	return
 
+/obj/machinery/suit_storage_unit/force_eject_occupant()
+	eject_occupant()
 
 /obj/machinery/suit_storage_unit/verb/get_out()
 	set name = "Eject Suit Storage Unit"

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -744,7 +744,7 @@
 		if(user != occupant)
 			to_chat(occupant, "<span class='warning'>The machine kicks you out!</span>")
 		if(user.loc != loc)
-			to_chat(occupant, "<span class='warning'>You leave the not-so-cozy confines of the SSU.</span>")
+			to_chat(occupant, "<span class='warning'>You leave the not-so-cozy confines of [src].</span>")
 	occupant.forceMove(loc)
 	occupant = null
 	if(!state_open)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1264,6 +1264,9 @@
 		L.client.RemoveViewMod("mecha")
 		zoom_mode = FALSE
 
+/obj/mecha/force_eject_occupant()
+	go_out()
+
 /////////////////////////
 ////// Access stuff /////
 /////////////////////////

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -353,7 +353,7 @@ a {
 	return TRUE
 
 /obj/proc/force_eject_occupant()
-	// This proc handles safely removing occupants from the object if they must be cryoed due to being SSD/AFK.
+	// This proc handles safely removing occupant mobs from the object if they must be teleported out (due to being SSD/AFK, by admin teleport, etc) or transformed.
 	// In the event that the object doesn't have an overriden version of this proc to do it, log a runtime so one can be added.
 	log_runtime(EXCEPTION("Proc force_eject_occupant() is not overriden on a machine containing a mob."), src)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -356,3 +356,4 @@ a {
 	// This proc handles safely removing occupants from the object if they must be cryoed due to being SSD/AFK.
 	// In the event that the object doesn't have an overriden version of this proc to do it, log a runtime so one can be added.
 	log_runtime(EXCEPTION("Proc force_eject_occupant() is not overriden on a machine containing a mob."), src)
+

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -351,3 +351,8 @@ a {
 
 /obj/proc/check_uplink_validity()
 	return TRUE
+
+/obj/proc/force_eject_occupant()
+	// This proc handles safely removing occupants from the object if they must be cryoed due to being SSD/AFK.
+	// In the event that the object doesn't have an overriden version of this proc to do it, log a runtime so one can be added.
+	log_runtime(EXCEPTION("Proc force_eject_occupant() is not overriden on a machine containing a mob."), src)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -355,5 +355,5 @@ a {
 /obj/proc/force_eject_occupant()
 	// This proc handles safely removing occupant mobs from the object if they must be teleported out (due to being SSD/AFK, by admin teleport, etc) or transformed.
 	// In the event that the object doesn't have an overriden version of this proc to do it, log a runtime so one can be added.
-	log_runtime(EXCEPTION("Proc force_eject_occupant() is not overriden on a machine containing a mob."), src)
+	CRASH("Proc force_eject_occupant() is not overriden on a machine containing a mob.")
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -354,6 +354,11 @@
 /obj/structure/closet/AllowDrop()
 	return TRUE
 
+/obj/structure/closet/force_eject_occupant()
+	// Its okay to silently teleport mobs out of lockers, since the only thing affected is their contents list.
+	return
+
+
 /obj/structure/closet/bluespace
 	name = "bluespace closet"
 	desc = "A storage unit that moves and stores through the fourth dimension."

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -111,6 +111,10 @@
 
 	log_admin("[key_name(usr)] teleported [key_name(M)]")
 	message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
+
+	if(istype(M.loc, /obj))
+		var/obj/O = M.loc
+		O.force_eject_occupant()
 	admin_forcemove(M, get_turf(usr))
 	feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -135,6 +139,9 @@
 	log_admin("[key_name(usr)] teleported [key_name(M)]")
 	message_admins("[key_name_admin(usr)] teleported [key_name(M)]", 1)
 	if(M)
+		if(istype(M.loc, /obj))
+			var/obj/O = M.loc
+			O.force_eject_occupant()
 		admin_forcemove(M, get_turf(usr))
 		admin_forcemove(usr, M.loc)
 		feedback_add_details("admin_verb","GK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -22,6 +22,10 @@
 		to_chat(src, "Nowhere to jump to!")
 		return
 
+	if(isobj(usr.loc))
+		var/obj/O = usr.loc
+		O.force_eject_occupant()
+
 	admin_forcemove(usr, T)
 	log_admin("[key_name(usr)] jumped to [A]")
 	if(!isobserver(usr))
@@ -35,6 +39,9 @@
 	if(!check_rights(R_ADMIN))
 		return
 
+	if(isobj(usr.loc))
+		var/obj/O = usr.loc
+		O.force_eject_occupant()
 	log_admin("[key_name(usr)] jumped to [T.x], [T.y], [T.z] in [T.loc]")
 	if(!isobserver(usr))
 		message_admins("[key_name_admin(usr)] jumped to [T.x], [T.y], [T.z] in [T.loc]", 1)
@@ -52,6 +59,9 @@
 	log_admin("[key_name(usr)] jumped to [key_name(M)]")
 	if(!isobserver(usr))
 		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
+	if(isobj(usr.loc))
+		var/obj/O = usr.loc
+		O.force_eject_occupant()
 	if(src.mob)
 		var/mob/A = src.mob
 		var/turf/T = get_turf(M)
@@ -70,6 +80,9 @@
 
 	var/turf/T = locate(tx, ty, tz)
 	if(T)
+		if(isobj(usr.loc))
+			var/obj/O = usr.loc
+			O.force_eject_occupant()
 		admin_forcemove(usr, T)
 		if(isobserver(usr))
 			var/mob/dead/observer/O = usr
@@ -96,7 +109,9 @@
 	log_admin("[key_name(usr)] jumped to [key_name(M)]")
 	if(!isobserver(usr))
 		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
-
+	if(isobj(usr.loc))
+		var/obj/O = usr.loc
+		O.force_eject_occupant()
 	admin_forcemove(usr, M.loc)
 
 	feedback_add_details("admin_verb","JK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -155,6 +170,9 @@
 
 	var/area/A = input(usr, "Pick an area.", "Pick an area") in return_sorted_areas()
 	if(A)
+		if(isobj(M.loc))
+			var/obj/O = M.loc
+			O.force_eject_occupant()
 		admin_forcemove(M, pick(get_area_turfs(A)))
 		feedback_add_details("admin_verb","SMOB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		log_admin("[key_name(usr)] teleported [key_name(M)] to [A]")

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -112,7 +112,7 @@
 	log_admin("[key_name(usr)] teleported [key_name(M)]")
 	message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
 
-	if(istype(M.loc, /obj))
+	if(isobj(M.loc))
 		var/obj/O = M.loc
 		O.force_eject_occupant()
 	admin_forcemove(M, get_turf(usr))
@@ -139,7 +139,7 @@
 	log_admin("[key_name(usr)] teleported [key_name(M)]")
 	message_admins("[key_name_admin(usr)] teleported [key_name(M)]", 1)
 	if(M)
-		if(istype(M.loc, /obj))
+		if(isobj(M.loc))
 			var/obj/O = M.loc
 			O.force_eject_occupant()
 		admin_forcemove(M, get_turf(usr))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -917,6 +917,9 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 	if(istype(landmark))
 		var/datum/map_template/ruin/template = landmark.ruin_template
+		if(isobj(usr.loc))
+			var/obj/O = usr.loc
+			O.force_eject_occupant()
 		admin_forcemove(usr, get_turf(landmark))
 
 		to_chat(usr, "<span class='name'>[template.name]</span>")


### PR DESCRIPTION
## What Does This PR Do
Fixes issues created when a human is teleported directly out of a machine/object without the object being told.
Fixes #13132 - similar issue created when a human is transformed into a robot/xeno/etc by a disease while inside a machine.

Teleport types addressed in this PR:
- auto-cryo for SSD/AFK players sending someone to cryo
- admin teleport effects (get mob, send to area, jump to key, jump to ruin, etc)

Machines/objects addressed in this PR:
- sleepers
- cryopods
- bodyscanners
- DNA modifiers
- suit storage units
- lockers
- mechs
IE: all the common things humans might be found inside.
There is also a catch-all which will generate an informative exception for the log in case a human is teleported directly out of any other un-handled object by the above methods.

For those objects, it fixes:
- them getting stuck in a 'occupied' state where nobody can use them
- them having hard references to the teleported mob that are never cleared
- them generating runtimes due to thinking they have a mob in them when they don't

Notes:
- this doesn't un-DNA-lock a mech in cases where a pilot is removed from the mech. Mostly because that would mean admins teleporting a mech pilot would let someone else steal the mech.

## Why It's Good For The Game
Fewer bugs.

## Changelog
:cl: Kyep
fix: Fixed issues occurring when a player is teleported out of an object (by SSD/AFK system, or admin teleport) without the object being told.
fix: Fixed issues occurring when a player is transformed into a new type of creature while inside a machine.
/:cl: