### PR TITLE
Prevents the Head of Personnel from rolling round-start shadowling

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -74,7 +74,7 @@ Made by Xhuis
 	required_enemies = 2
 	recommended_enemies = 2
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Brig Physician", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Brig Physician", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer")
 
 /datum/game_mode/shadowling/announce()
 	to_chat(world, "<b>The current game mode is - Shadowling!</b>")


### PR DESCRIPTION
## What Does This PR Do
The Head of Personnel can no longer be selectible to be a round-start shadowling in the shadowling gamemode.

## Why It's Good For The Game
Having it seen in multiple rounds, it is very silly for a job that can give all-access to be part round-start of a team antagonist gamemode. The Head of Personnel already cannot be round-start cult for the same reason, so it's good to keep consistency between all crew team gamemodes.

## Changelog
:cl:
tweak: Head of Personnel can no longer be a round-start shadowling
/:cl: