### PR TITLE
Adds book DRM

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/library.dmi'
 	due_date = 0 // Game time in 1/10th seconds
 	unique = 1   // 0 - Normal book, 1 - Should not be treated as normal book, unable to be copied, unable to be modified
+	has_drm = TRUE // No reuploading. Piracy is a crime
 
 
 /obj/item/book/manual/engineering_construction

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -463,4 +463,5 @@
 		B.author = newbook.author
 		B.dat = newbook.content
 		B.icon_state = "book[rand(1,16)]"
+		B.has_drm = TRUE
 	visible_message("[src]'s printer hums as it produces a completely bound book. How did it do that?")

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -151,6 +151,8 @@
 	var/carved = 0	 // Has the book been hollowed out for use as a secret storage item?
 	var/forbidden = 0     // Prevent ordering of this book. (0=no, 1=yes, 2=emag only)
 	var/obj/item/store	// What's in the book?
+	/// Book DRM. If this var is TRUE, it cannot be scanned and re-uploaded
+	var/has_drm = FALSE
 
 /obj/item/book/attack_self(var/mob/user as mob)
 	if(carved)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -151,8 +151,9 @@ GLOBAL_LIST_INIT(library_section_names, list("Any", "Fiction", "Non-Fiction", "A
 		return
 	if(istype(I, /obj/item/book))
 		// NT with those pesky DRM schemes
-		if(istype(I, /obj/item/book/manual))
-			atom_say("NT copyrighted material detected. Scanner is unable to copy book to memory.")
+		var/obj/item/book/B = I
+		if(B.has_drm)
+			atom_say("Copyrighted material detected. Scanner is unable to copy book to memory.")
 			return FALSE
 		user.drop_item()
 		I.forceMove(src)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -150,6 +150,10 @@ GLOBAL_LIST_INIT(library_section_names, list("Any", "Fiction", "Non-Fiction", "A
 		power_change()
 		return
 	if(istype(I, /obj/item/book))
+		// NT with those pesky DRM schemes
+		if(istype(I, /obj/item/book/manual))
+			atom_say("NT copyrighted material detected. Scanner is unable to copy book to memory.")
+			return FALSE
 		user.drop_item()
 		I.forceMove(src)
 		return 1


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so you can no longer upload reference manuals to the book database. Why you might ask? Well its because the database has too many clones of the same bloody book which can be printed en mass from the librarians computer. It also stops you from re-uploading books you have already printed out.

## Why It's Good For The Game
Duplicate uploads of stuff we can easily print is terrible

## Images of changes
Happens when trying to put a book into the scanner
![image](https://user-images.githubusercontent.com/25063394/88277373-85eb1600-ccd8-11ea-9a16-49634b0aa0a7.png)

## Changelog
:cl: AffectedArc07
add: You can no longer upload reference manuals to the book database
add: You can no longer re-upload printed books to the book database
/:cl:
