### PR TITLE
Fixes admin "call shuttle" verb ignoring station alert level

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -826,7 +826,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	else
 		SSshuttle.emergency.canRecall = FALSE
 
-	SSshuttle.emergency.request()
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED)
+		SSshuttle.emergency.request(coefficient = 0.5, redAlert = TRUE)
+	else
+		SSshuttle.emergency.request()
 
 	feedback_add_details("admin_verb","CSHUT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_admin("[key_name(usr)] admin-called the emergency shuttle.")


### PR DESCRIPTION
## What Does This PR Do
Fixes the emergency shuttle ignoring red alert status when called using the admin "call shuttle" verb.
Now, it respects the alert status, displaying a different message, and sending a 5m shuttle instead of a 10m one.
This makes it behave the same way as it already does when the shuttle is called via comms console.

## Changelog
:cl: Kyep
fix: Fixed admin-called shuttles ignoring red alert status.
/:cl: