### PR TITLE
Energized fire axe rework

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -413,9 +413,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/energizedfireaxe
 	name = "Energized Fire Axe"
-	desc = "A fire axe with a massive electrical charge built into it. It can release this charge on its first victim and will be rather plain after that."
+	desc = "A fire axe with a massive energy charge built into it. It will hit much harder than a regular fireaxe and is capable of penetrating most kinds of armor - however it is much noisier and obvious when wielded."
 	reference = "EFA"
-	item = /obj/item/twohanded/energizedfireaxe
+	item = /obj/item/twohanded/fireaxe/energized
 	cost = 10
 	job = list("Life Support Specialist")
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -413,7 +413,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/energizedfireaxe
 	name = "Energized Fire Axe"
-	desc = "A fire axe with a massive energy charge built into it. It will hit much harder than a regular fireaxe and is capable of penetrating most kinds of armor - however it is much noisier and obvious when wielded."
+	desc = "A fire axe with a massive energy charge built into it. Upon striking someone while charged it will throw them backwards while stunning them briefly, but will take time to charge up again. It is also much sharper than a regular axe and can pierce light armor."
 	reference = "EFA"
 	item = /obj/item/twohanded/fireaxe/energized
 	cost = 10

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -413,7 +413,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/energizedfireaxe
 	name = "Energized Fire Axe"
-	desc = "A fire axe with a massive energy charge built into it. Upon striking someone while charged it will throw them backwards while stunning them briefly, but will take time to charge up again. It is also much sharper than a regular axe and can pierce light armor."
+	desc = "A fire axe with a massive energy charge built into it. Upon striking someone while charged it will throw them backwards while stunning them briefly, but will take some time to charge up again. It is also much sharper than a regular axe and can pierce light armor."
 	reference = "EFA"
 	item = /obj/item/twohanded/fireaxe/energized
 	cost = 10

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -285,7 +285,7 @@
 		/obj/item/clothing/gloves/color/yellow/power = 1,
 		/obj/item/twohanded/chainsaw = 1,
 		/obj/item/bee_briefcase = 1,
-		/obj/item/twohanded/energizedfireaxe = 1,
+		/obj/item/twohanded/fireaxe/energized = 1,
 		/obj/item/clothing/glasses/thermal = 1,
 		/obj/item/chameleon = 1,
 		/obj/item/reagent_containers/hypospray/autoinjector/stimulants = 1,

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -209,6 +209,27 @@
 /obj/item/twohanded/fireaxe/boneaxe/update_icon()
 	icon_state = "bone_axe[wielded]"
 
+/obj/item/twohanded/fireaxe/energized
+	desc = "Someone with a love for fire axes decided to turn one into a high-powered energy weapon. Seems excessive."
+	force_wielded = 36
+	armour_penetration = 30
+	wieldsound = 'sound/weapons/saberon.ogg'
+	unwieldsound = 'sound/weapons/saberoff.ogg'
+
+/obj/item/twohanded/fireaxe/energized/update_icon()
+	if(wielded)
+		icon_state = "fireaxe2"
+	else
+		icon_state = "fireaxe0"
+
+/obj/item/twohanded/fireaxe/energized/unwield()
+	..()
+	hitsound = "sound/weapons/bladeslice.ogg"
+
+/obj/item/twohanded/fireaxe/energized/wield()
+	..()
+	hitsound = 'sound/weapons/blade1.ogg'
+
 /*
  * Double-Bladed Energy Swords - Cheridan
  */
@@ -754,57 +775,6 @@
 				Z.ex_act(2)
 				charged = 3
 				playsound(user, 'sound/weapons/marauder.ogg', 50, 1)
-
-// Energized Fire axe
-/obj/item/twohanded/energizedfireaxe
-	name = "energized fire axe"
-	desc = "Someone with a love for fire axes decided to turn one into a single-charge energy weapon. Seems excessive."
-	icon_state = "fireaxe0"
-	force = 5
-	throwforce = 15
-	sharp = TRUE
-	w_class = WEIGHT_CLASS_HUGE
-	armour_penetration = 20
-	slot_flags = SLOT_BACK
-	force_unwielded  = 5
-	force_wielded = 30
-	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
-	var/charged = 1
-
-/obj/item/twohanded/energizedfireaxe/update_icon()
-	if(wielded)
-		icon_state = "fireaxe2"
-	else
-		icon_state = "fireaxe0"
-	..()
-
-/obj/item/twohanded/energizedfireaxe/afterattack(atom/A, mob/user, proximity)
-	if(!proximity)
-		return
-	if(wielded)
-		if(isliving(A))
-			var/mob/living/Z = A
-			if(charged)
-				charged--
-				Z.take_organ_damage(0, 30)
-				user.visible_message("<span class='danger'>[user] slams the charged axe into [Z.name] with all [user.p_their()] might!</span>")
-				playsound(loc, 'sound/magic/lightningbolt.ogg', 5, 1)
-				do_sparks(1, 1, src)
-
-		if(A && wielded && (istype(A, /obj/structure/window) || istype(A, /obj/structure/grille)))
-			if(istype(A, /obj/structure/window))
-				var/obj/structure/window/W = A
-				W.deconstruct(FALSE)
-				if(prob(4))
-					charged++
-					user.visible_message("<span class='notice'>The axe starts to emit an electric buzz!</span>")
-			else
-				qdel(A)
-				if(prob(4))
-					charged++
-					user.visible_message("<span class='notice'>The axe starts to emit an electric buzz!</span>")
 
 /obj/item/twohanded/pitchfork
 	icon_state = "pitchfork0"

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -210,11 +210,10 @@
 	icon_state = "bone_axe[wielded]"
 
 /obj/item/twohanded/fireaxe/energized
-	desc = "Someone with a love for fire axes decided to turn one into a high-powered energy weapon. Seems excessive."
-	force_wielded = 36
-	armour_penetration = 30
-	wieldsound = 'sound/weapons/saberon.ogg'
-	unwieldsound = 'sound/weapons/saberoff.ogg'
+	desc = "Someone with a love for fire axes decided to turn this one into a high-powered energy weapon. Seems excessive."
+	force_wielded = 30
+	armour_penetration = 20
+	var/charge = 30
 
 /obj/item/twohanded/fireaxe/energized/update_icon()
 	if(wielded)
@@ -222,13 +221,29 @@
 	else
 		icon_state = "fireaxe0"
 
-/obj/item/twohanded/fireaxe/energized/unwield()
+/obj/item/twohanded/fireaxe/energized/New()
 	..()
-	hitsound = "sound/weapons/bladeslice.ogg"
+	START_PROCESSING(SSobj, src)
 
-/obj/item/twohanded/fireaxe/energized/wield()
+/obj/item/twohanded/fireaxe/energized/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/twohanded/fireaxe/energized/process()
+	if(charge < 30)
+		charge++
+
+/obj/item/twohanded/fireaxe/energized/attack(mob/M, mob/user)
 	..()
-	hitsound = 'sound/weapons/blade1.ogg'
+	if(wielded && charge == 30)
+		if(isliving(M))
+			charge = 0
+			playsound(loc, 'sound/magic/lightningbolt.ogg', 5, 1)
+			user.visible_message("<span class='danger'>[user] slams the charged axe into [M.name] with all [user.p_their()] might!</span>")
+			do_sparks(1, 1, src)
+			M.Weaken(4)
+			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
+			M.throw_at(throw_target, 5, 1)
 
 /*
  * Double-Bladed Energy Swords - Cheridan

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -214,6 +214,7 @@
 	force_wielded = 30
 	armour_penetration = 20
 	var/charge = 30
+	var/max_charge = 30
 
 /obj/item/twohanded/fireaxe/energized/update_icon()
 	if(wielded)
@@ -230,12 +231,11 @@
 	return ..()
 
 /obj/item/twohanded/fireaxe/energized/process()
-	if(charge < 30)
-		charge++
+	charge = min(charge + 1, max_charge)
 
 /obj/item/twohanded/fireaxe/energized/attack(mob/M, mob/user)
 	..()
-	if(wielded && charge == 30)
+	if(wielded && charge == max_charge)
 		if(isliving(M))
 			charge = 0
 			playsound(loc, 'sound/magic/lightningbolt.ogg', 5, 1)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -234,7 +234,7 @@
 	charge = min(charge + 1, max_charge)
 
 /obj/item/twohanded/fireaxe/energized/attack(mob/M, mob/user)
-	..()
+	. = ..()
 	if(wielded && charge == max_charge)
 		if(isliving(M))
 			charge = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This reworks the energized fireaxe to be a subtype of the standard axe and have a different and (hopefully) more useful special attack.

Previously, this used a lot of copy-pasted code from the regular axe but wasn't a subtype, meaning you couldn't use it to do things like open airlocks. The charged attack it also carried just did an extra 30 burn damage and was recharged by hitting random windows and grilles until you hit a 4% chance to add a charge to the axe, which is quite situational for general combat. The main changes it brings are:

- No longer has the name "energized fire axe" when examined from a distance, meaning you can hold it one handed or on your back without getting valid'd. Still has a unique sprite when wielded as well as an obvious description.
- Can be used for everything a regular axe is used for, namely forcing open airlocks.
- Retains the same armor penetration and basic wielded damage of the old energized axe.
- Axe now recharges after use, taking 30 ticks to charge up for another use.
- The charge attack now stuns for 4 ticks and flings people backwards about 5 tiles when successfully used. Previously this was 30 extra burn damage.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The energized axe is no longer a completely seperate item from the standard axe and works as a subtype, meaning less copy-pasted code. The somewhat awkward way of recharging the axe has been reworked to be more simple and the axe itself should overall be much more useful since I usually see this thing either used for a laugh or discarded if found in a surplus crate.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Reworked energized axe and made it a subtype of the regular fireaxe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
