### PR TITLE
Allows Saluting and Bowing while buckled.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -308,14 +308,14 @@
 			m_type = 1
 
 		if("bow", "bows")
-			if(!buckled)
+			if(!restrained())
 				var/M = handle_emote_param(param)
 
 				message = "<B>[src]</B> bows[M ? " to [M]" : ""]."
 			m_type = 1
 
 		if("salute", "salutes")
-			if(!buckled)
+			if(!restrained())
 				var/M = handle_emote_param(param)
 
 				message = "<B>[src]</B> salutes[M ? " to [M]" : ""]."


### PR DESCRIPTION
## What Does This PR Do
Fixes #11290. While, that issue report code wise isn't _technically_ a bug. I consider it an inconsistency, personally. Other emotes similar do not check to see if you are buckled into a chair or not, only if you are restrained. I, personally, don't see why it would matter if you were buckled in or not to execute the remote(It might look awkward, but you can still mock bow while sitting, and you can certainly salute just fine while sitting).

## Why It's Good For The Game
Inconsistencies are bad. Though if there is some particular reason it was like this to begin with, either a joke or a reference or something obscure, then that's understandable. Otherwise adds nothing of benefit. 

## Changelog
:cl:
fix: Removes an inconsistency, allowing you to bow and salute while buckled into a chair so long as you are not restrained.
/:cl: