### PR TITLE
Makes it so all space ruins are correctly mapped

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid1.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid2.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid3.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid4.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/mineral,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/asteroid5.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/mineral,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "ab" = (
 /turf/simulated/mineral/random/low_chance,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict1.dmm
@@ -1,11 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /obj/structure/lattice,
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "c" = (
 /turf/simulated/wall,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
@@ -1,14 +1,14 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /obj/structure/window/reinforced{
 	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "c" = (
 /obj/machinery/door/airlock/external,
@@ -20,7 +20,7 @@
 	icon_state = "rwindow";
 	dir = 8
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "e" = (
 /obj/structure/window/reinforced{
@@ -64,7 +64,7 @@
 /area/ruin/powered)
 "k" = (
 /obj/structure/window/reinforced,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "l" = (
 /obj/structure/window/reinforced,
@@ -112,7 +112,7 @@
 	icon_state = "rwindow";
 	dir = 1
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "q" = (
 /obj/machinery/light/small{

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict3.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered)
@@ -10,12 +10,12 @@
 /area/ruin/unpowered)
 "d" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "e" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 
 (1,1,1) = {"

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/mineral,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict5.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/mineral,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -1,11 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /obj/structure/lattice,
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "c" = (
 /turf/simulated/wall/r_wall,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -1,11 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /obj/structure/lattice,
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "c" = (
 /turf/simulated/wall,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -1,9 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
-/turf/space,
+/turf/template_noop,
 /turf/simulated/shuttle/wall{
 	dir = 8;
 	icon_state = "diagonalWall3"
@@ -15,7 +15,7 @@
 	},
 /area/ruin/powered)
 "d" = (
-/turf/space,
+/turf/template_noop,
 /turf/simulated/shuttle/wall{
 	dir = 2;
 	icon_state = "diagonalWall3"
@@ -198,7 +198,7 @@
 	},
 /area/ruin/powered)
 "A" = (
-/turf/space,
+/turf/template_noop,
 /turf/simulated/shuttle/wall{
 	dir = 1;
 	icon_state = "diagonalWall3"
@@ -212,7 +212,7 @@
 	},
 /area/ruin/powered)
 "C" = (
-/turf/space,
+/turf/template_noop,
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "diagonalWall3"

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/mineral,
 /area/ruin/powered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/shuttle/wall{
 	tag = "icon-swall_s6";
@@ -168,7 +168,7 @@
 /area/ruin/powered)
 "D" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "E" = (
 /obj/item/stack/rods,
@@ -202,7 +202,7 @@
 /area/ruin/powered)
 "K" = (
 /obj/item/stack/sheet/metal,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "L" = (
 /obj/structure/mecha_wreckage/gygax,
@@ -228,7 +228,7 @@
 /area/ruin/powered)
 "P" = (
 /obj/item/stack/rods,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "Q" = (
 /turf/simulated/shuttle/wall{

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "ab" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -10,7 +10,7 @@
 	icon_state = "2-4";
 	tag = ""
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "ac" = (
 /obj/structure/lattice,
@@ -20,7 +20,7 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "ad" = (
 /obj/structure/lattice,
@@ -29,7 +29,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "ae" = (
 /obj/structure/lattice,
@@ -38,7 +38,7 @@
 	dir = 2;
 	icon_state = "coil_red2"
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "af" = (
 /obj/structure/lattice,
@@ -48,7 +48,7 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "ag" = (
 /turf/simulated/wall,
@@ -65,7 +65,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "aj" = (
 /turf/unsimulated/floor/plating/airless,
@@ -154,11 +154,11 @@
 /area/ruin/onehalf/drone_bay)
 "aw" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "ax" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "ay" = (
 /obj/structure/table_frame,
@@ -224,7 +224,7 @@
 /area/ruin/onehalf/drone_bay)
 "aH" = (
 /obj/item/stack/rods,
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "aI" = (
 /obj/effect/landmark/damageturf,
@@ -805,7 +805,7 @@
 /area/ruin/onehalf/bridge)
 "bU" = (
 /obj/item/stack/sheet/metal,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "bV" = (
 /obj/structure/disposalpipe/segment,
@@ -914,7 +914,7 @@
 	dir = 4
 	},
 /obj/item/stack/rods,
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "cn" = (
 /obj/structure/lattice,
@@ -925,7 +925,7 @@
 	tag = "icon-small";
 	icon_state = "small"
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "co" = (
 /obj/structure/grille,
@@ -1008,7 +1008,7 @@
 /area/ruin/onehalf/bridge)
 "cv" = (
 /obj/item/stack/rods,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "cw" = (
 /turf/unsimulated/floor/plating/airless,
@@ -1016,7 +1016,7 @@
 "cx" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/plasteel,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "cy" = (
 /obj/structure/lattice,
@@ -1024,7 +1024,7 @@
 	tag = "icon-medium";
 	icon_state = "medium"
 	},
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "cz" = (
 /obj/structure/grille/broken,
@@ -1071,10 +1071,10 @@
 /area/ruin/onehalf/bridge)
 "cE" = (
 /obj/item/stack/tile/wood,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "cF" = (
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "cG" = (
 /obj/structure/lattice,
@@ -1083,7 +1083,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "cH" = (
 /obj/structure/lattice,
@@ -1097,7 +1097,7 @@
 	icon_state = "pipe-b";
 	dir = 8
 	},
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "cI" = (
 /obj/machinery/door/airlock/command/glass{
@@ -1149,7 +1149,7 @@
 	dir = 2;
 	icon_state = "coil_red2"
 	},
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "cQ" = (
 /obj/machinery/light{
@@ -1160,7 +1160,7 @@
 /area/ruin/onehalf/bridge)
 "cR" = (
 /obj/item/stack/sheet/plasteel,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "cS" = (
 /obj/structure/lattice,
@@ -1169,7 +1169,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/template_noop,
 /area/ruin/onehalf/hallway)
 "cU" = (
 /obj/structure/grille,
@@ -1221,7 +1221,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "db" = (
 /obj/structure/table,
@@ -1256,7 +1256,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "dg" = (
 /obj/structure/girder/reinforced,
@@ -1350,7 +1350,7 @@
 	tag = "icon-medium";
 	icon_state = "medium"
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "dp" = (
 /obj/structure/lattice,
@@ -1366,7 +1366,7 @@
 	icon_state = "1-4"
 	},
 /obj/item/stack/rods,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "dq" = (
 /obj/structure/lattice,
@@ -1382,7 +1382,7 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 
 (1,1,1) = {"

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "ab" = (
 /turf/simulated/mineral,
 /area/space/nearstation)

--- a/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/template_noop,
 /area/space/nearstation)
 "c" = (
 /obj/structure/grille,

--- a/_maps/map_files/RandomRuins/SpaceRuins/way_home.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/way_home.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /turf/simulated/mineral/random,
 /area/ruin/unpowered/no_grav/way_home)

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "ab" = (
 /turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/unpowered)


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so ruins are correctly mapped, using `turf/template_noop` instead of `turf/space`, and `area/template_noop` instead of `area/space`. This is important so that two ruins spawning close to eachother dont overwrite eachother. It also allows circular ruins (like the derelict for example) to be spawned in corners without the entire square wiping areas out.

## Why It's Good For The Game
Stuff shouldnt be broken

## Images of changes
MDB can handle it **IF IT DECIDES TO BLOODY WORK FOR ONCE**

## Changelog
:cl: AffectedArc07
fix: Ruins are now properly mapped
/:cl:
