### PR TITLE
Updates to lavaland winter biodome

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -167,7 +167,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
 "aL" = (
-/obj/item/reagent_containers/hypospray/autoinjector/nanocalcium,
+/obj/mecha/working/ripley/mining,
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
 "aM" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -392,12 +392,6 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
-"UM" = (
-/obj/machinery/computer/monitor/secret{
-	dir = 1
-	},
-/turf/simulated/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
 "Wg" = (
 /turf/simulated/wall/r_wall,
 /area/ruin/powered/snow_biodome)
@@ -484,7 +478,7 @@ HP
 tl
 PK
 gz
-UM
+HP
 Wg
 ak
 ak

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -166,6 +166,10 @@
 /obj/item/key,
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
+"aL" = (
+/obj/item/gun/energy/laser/retro,
+/turf/simulated/floor/wood,
+/area/ruin/powered/snow_cabin)
 "aM" = (
 /turf/simulated/floor/carpet,
 /area/ruin/powered/snow_cabin)
@@ -759,7 +763,7 @@ bw
 at
 aD
 at
-at
+aL
 aq
 ak
 az

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -166,10 +166,6 @@
 /obj/item/key,
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
-"aL" = (
-/obj/structure/displaycase/captain,
-/turf/simulated/floor/wood,
-/area/ruin/powered/snow_cabin)
 "aM" = (
 /turf/simulated/floor/carpet,
 /area/ruin/powered/snow_cabin)
@@ -763,7 +759,7 @@ bw
 at
 aD
 at
-aL
+at
 aq
 ak
 az

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -167,7 +167,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
 "aL" = (
-/obj/item/gun/energy/laser/retro,
+/obj/item/reagent_containers/hypospray/autoinjector/nanocalcium,
 /turf/simulated/floor/wood,
 /area/ruin/powered/snow_cabin)
 "aM" = (

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -16,7 +16,7 @@
 	name = "Biodome Winter"
 	id = "biodome-winter"
 	description = "For those getaways where you want to get back to nature, but you don't want to leave the fortified military compound where you spend your days. \
-	Includes a unique(*) laser pistol display case, and the recently introduced I.C.E(tm)."
+	Includes the recently introduced I.C.E(tm)."
 	suffix = "lavaland_biodome_winter.dmm"
 
 /datum/map_template/ruin/lavaland/biodome/clown


### PR DESCRIPTION
## What Does This PR Do
1. In the winter biodome ruin on lavaland, there's a captain's laser in an alarmed displaycase. This PR replaces it with a mining ripley. And removes the mention of the laser/case from the description of the ruin.
2. Fixes  #12913 - ai can get burgular alarm from lavaland (the above display case)
3. Fixes #13530 - lavaland snow biodome has computer that gives error on use, by removing the computer (ruin has no powernet, so a power computer is pointless)


## Why It's Good For The Game
Mining already has a ton of overpowered loot, and the last thing they need is having a captain-level lasergun. Especially one that is also a grand theft objective.

## Changelog
:cl: Kyep
balance: The lavaland winter ruin now has a mining ripley, instead of a copy of the captain's unique lasergun. A broken computer on it has also been removed.
/:cl: