### PR TITLE
Fixes a dupe with wet leather

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -242,7 +242,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 					HS.amount++
 					src.use(1)
 					wetness = initial(wetness)
-					break
+					return
 			//If it gets to here it means it did not find a suitable stack on the tile.
 			var/obj/item/stack/sheet/leather/HS = new(src.loc)
 			HS.amount = 1


### PR DESCRIPTION
## What Does This PR Do
Fixes a dupe when heating up wet leather and a leather stack is on the same tile as the wet leather

## Why It's Good For The Game
It's a dupe exploit

## Changelog
:cl:
fix: Heating wet leather now won't dupe leather when a leather stack is on the same tile as the wet leather
/:cl: