### PR TITLE
Removes the refresher anomalous crystal

### DIFF
--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -389,32 +389,6 @@
 	if(..())
 		death()
 
-/obj/machinery/anomalous_crystal/refresher //Deletes and recreates a copy of the item, "refreshing" it.
-	activation_method = "touch"
-	cooldown_add = 50
-	activation_sound = 'sound/magic/timeparadox2.ogg'
-	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/item/projectile, /obj/item/spellbook)
-
-/obj/machinery/anomalous_crystal/refresher/New()
-	..()
-	banned_items_typecache = typecacheof(banned_items_typecache)
-
-
-/obj/machinery/anomalous_crystal/refresher/ActivationReaction(mob/user, method)
-	if(..())
-		var/list/L = list()
-		var/turf/T = get_step(src, dir)
-		new /obj/effect/temp_visual/emp/pulse(T)
-		for(var/i in T)
-			if(istype(i, /obj/item) && !is_type_in_typecache(i, banned_items_typecache))
-				var/obj/item/W = i
-				if(!W.admin_spawned && !(W.flags_2 & HOLOGRAM_2) && !(W.flags & ABSTRACT))
-					L += W
-		if(L.len)
-			var/obj/item/CHOSEN = pick(L)
-			new CHOSEN.type(T)
-			qdel(CHOSEN)
-
 /obj/machinery/anomalous_crystal/possessor //Allows you to bodyjack small animals, then exit them at your leisure, but you can only do this once per activation. Because they blow up. Also, if the bodyjacked animal dies, SO DO YOU.
 	activation_method = "touch"
 


### PR DESCRIPTION
## What Does This PR Do
Staff want it gone for the following reasons:
1. Revive gateway xenomorph facehuggers (bad)
2. Refresh guardian injectors for infinite guardians (bad)
3. infinite death alarms

Discussions have led to the decision to remove it

## Why It's Good For The Game
Interesting idea but seems the exploits it brings with it are more of an issue than what it actually brings

## Changelog
:cl:
del: Removes the refresher anomalous crystal
/:cl: