### PR TITLE
Adds missing and improves existing mech attack logging

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -289,11 +289,15 @@ This is always put in the attack log.
 
 	var/user_str = key_name_log(user) + COORD(user)
 	var/target_str
+	var/target_info
+	var/user_info
 	if(isatom(target))
 		var/atom/AT = target
 		target_str = key_name_log(AT) + COORD(AT)
+		target_info = key_name_admin(target)
 	else
 		target_str = target
+		target_info = target
 	var/mob/MU = user
 	var/mob/MT = target
 	if(istype(MU))
@@ -320,7 +324,8 @@ This is always put in the attack log.
 	if(isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE. Overrides custom level
 		loglevel = ATKLOG_FEW
 
-	msg_admin_attack("[key_name_admin(user)] vs [key_name_admin(target)]: [what_done]", loglevel)
+
+	msg_admin_attack("[key_name_admin(user)] vs [target_info]: [what_done]", loglevel)
 
 /proc/do_mob(mob/user, mob/target, time = 30, uninterruptible = 0, progress = 1, list/extra_checks = list())
 	if(!user || !target)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -320,6 +320,8 @@ This is always put in the attack log.
 			var/area/A = get_area(MT)
 			if(A && A.hide_attacklogs)
 				loglevel = ATKLOG_ALMOSTALL
+	else
+		loglevel = ATKLOG_ALL // Hitting an object. Not a mob
 	if(isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE. Overrides custom level
 		loglevel = ATKLOG_FEW
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -290,7 +290,6 @@ This is always put in the attack log.
 	var/user_str = key_name_log(user) + COORD(user)
 	var/target_str
 	var/target_info
-	var/user_info
 	if(isatom(target))
 		var/atom/AT = target
 		target_str = key_name_log(AT) + COORD(AT)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1,3 +1,5 @@
+#define OCCUPANT_LOGGING occupant ? occupant : "empty mech"
+
 /obj/mecha
 	name = "Mecha"
 	desc = "Exosuit"
@@ -544,6 +546,7 @@
 
 /obj/mecha/attack_alien(mob/living/user)
 	log_message("Attack by alien. Attacker - [user].", TRUE)
+	add_attack_logs(user, OCCUPANT_LOGGING, "Alien attacked mech [src]")
 	playsound(src.loc, 'sound/weapons/slash.ogg', 100, TRUE)
 	attack_generic(user, 15, BRUTE, "melee", 0)
 
@@ -562,7 +565,7 @@
 			animal_damage = user.obj_damage
 		animal_damage = min(animal_damage, 20*user.environment_smash)
 		user.create_attack_log("<font color='red'>attacked [name]</font>")
-		add_attack_logs(user, src, "Attacked")
+		add_attack_logs(user, OCCUPANT_LOGGING, "Animal attacked mech [src]")
 		attack_generic(user, animal_damage, user.melee_damage_type, "melee", play_soundeffect)
 		return TRUE
 
@@ -573,7 +576,7 @@
 	. = ..()
 	if(.)
 		log_message("Attack by hulk. Attacker - [user].", 1)
-		add_attack_logs(user, src, "Punched with hulk powers")
+		add_attack_logs(user, OCCUPANT_LOGGING, "Hulk punched mech [src]")
 
 /obj/mecha/blob_act(obj/structure/blob/B)
 	log_message("Attack by blob. Attacker - [B].")
@@ -584,10 +587,14 @@
 
 /obj/mecha/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum) //wrapper
 	log_message("Hit by [AM].")
+	if(isitem(AM))
+		var/obj/item/I = AM
+		add_attack_logs(I.thrownby, OCCUPANT_LOGGING, "threw [AM] at mech [src]")
 	. = ..()
 
 /obj/mecha/bullet_act(obj/item/projectile/Proj) //wrapper
 	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).")
+	add_attack_logs(Proj.firer, OCCUPANT_LOGGING, "shot [Proj.name]([Proj.flag]) at mech [src]")
 	..()
 
 /obj/mecha/ex_act(severity, target)
@@ -774,6 +781,7 @@
 			to_chat(user, "<span class='notice'>You stop installing [M].</span>")
 
 	else
+		add_attack_logs(user, OCCUPANT_LOGGING, "attacked mech '[src]' using [W]")
 		return ..()
 
 
@@ -1534,3 +1542,5 @@
 	if(L.incapacitated())
 		return FALSE
 	return TRUE
+
+#undef OCCUPANT_LOGGING

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -564,8 +564,8 @@
 		if(user.obj_damage)
 			animal_damage = user.obj_damage
 		animal_damage = min(animal_damage, 20*user.environment_smash)
-		user.create_attack_log("<font color='red'>attacked [name]</font>")
-		add_attack_logs(user, OCCUPANT_LOGGING, "Animal attacked mech [src]")
+		if(animal_damage)
+			add_attack_logs(user, OCCUPANT_LOGGING, "Animal attacked mech [src]")
 		attack_generic(user, animal_damage, user.melee_damage_type, "melee", play_soundeffect)
 		return TRUE
 
@@ -781,7 +781,8 @@
 			to_chat(user, "<span class='notice'>You stop installing [M].</span>")
 
 	else
-		add_attack_logs(user, OCCUPANT_LOGGING, "attacked mech '[src]' using [W]")
+		if(W.force)
+			add_attack_logs(user, OCCUPANT_LOGGING, "attacked mech '[src]' using [W]")
 		return ..()
 
 


### PR DESCRIPTION
## What Does This PR Do
Adds missing and improves existing attack logs for mechs

- alien attack added
- animal attack improved
- Hulk attack is improved
- Throwing added
- projectiles added
- Attackby (items) added

Also makes it so that attacks against non mobs will only be send to admins with ATKLOG_ALL on

## Why It's Good For The Game
Improves the existing logging and adds missing logging so admins can properly solve mech cases

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/88475469-59313b80-cf30-11ea-9243-c857bbdd7b2a.png)


## Changelog
:cl:
add: Alien attacks on mechs are logged
tweak: Animal attacks on mechs are improved
tweak: Hulk attacks on mechs are improved
add: Throwing attacks on mechs are logged
add: Projectiles hitting mechs are logged
add: Attacking mechs with items is now logged
tweak: Attacks against non mobs will now only be send to admins with ATKLOG_ALL on
/:cl: