### PR TITLE
Fixes wizard spell availability

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -610,7 +610,7 @@
 	var/entry_types = subtypesof(/datum/spellbook_entry) - /datum/spellbook_entry/item - /datum/spellbook_entry/summon - /datum/spellbook_entry/loadout
 	for(var/T in entry_types)
 		var/datum/spellbook_entry/E = new T
-		if(GAMEMODE_IS_WIZARD && E.is_ragin_restricted)
+		if(GAMEMODE_IS_RAGIN_MAGES && E.is_ragin_restricted)
 			qdel(E)
 			continue
 		entries |= E


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Silly mistake by me. In #13576, while trying to restrict certain buyable spells in ragin mages, I mistakenly wrote:
```js
if(GAMEMODE_IS_WIZARD && E.is_ragin_restricted)
```
Instead of using the proper define (which I made just for the PR *scream):
```js
if(GAMEMODE_IS_RAGIN_MAGES && E.is_ragin_restricted)
```
This was restricting ragin restricted spells on *normal wizard rounds*, which was bad.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Fixes certain wizard spells not being available
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
