### PR TITLE
Adds missing offline implications

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -35,7 +35,7 @@
 
 	var/static/list/failure_strikes //How many times we suspect a subsystem type has crashed the MC, 3 strikes and you're out!
 
-	var/offline_implications = "None" // What are the implications of this SS being offlined?
+	var/offline_implications = "None. No immediate action is needed." // What are the implications of this SS being offlined?
 
 //Do not override
 ///datum/controller/subsystem/New()

--- a/code/controllers/subsystem/processing/dcs.dm
+++ b/code/controllers/subsystem/processing/dcs.dm
@@ -3,6 +3,8 @@ PROCESSING_SUBSYSTEM_DEF(dcs)
 	flags = SS_NO_INIT
 
 	var/list/elements_by_type = list()
+	// Update this if you add in components which actually use this as a processor
+	offline_implications = "This SS doesnt actually process anything yet. No immediate action is needed."
 
 /datum/controller/subsystem/processing/dcs/Recover()
 	comp_lookup = SSdcs.comp_lookup

--- a/code/controllers/subsystem/processing/fastprocess.dm
+++ b/code/controllers/subsystem/processing/fastprocess.dm
@@ -4,3 +4,4 @@ PROCESSING_SUBSYSTEM_DEF(fastprocess)
 	name = "Fast Processing"
 	wait = 2
 	stat_tag = "FP"
+	offline_implications = "Objects using the 'Fast Processing' processor will no longer process. Shuttle call recommended."

--- a/code/controllers/subsystem/processing/obj.dm
+++ b/code/controllers/subsystem/processing/obj.dm
@@ -3,3 +3,4 @@ PROCESSING_SUBSYSTEM_DEF(obj)
 	priority = FIRE_PRIORITY_OBJ
 	flags = SS_NO_INIT
 	wait = 20
+	offline_implications = "Objects using the 'Objects' processor will no longer process. Shuttle call recommended."

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(processing)
 	var/stat_tag = "P" //Used for logging
 	var/list/processing = list()
 	var/list/currentrun = list()
+	offline_implications = "Objects using the default processor will no longer process. Shuttle call recommended."
 
 /datum/controller/subsystem/processing/stat_entry()
 	..("[stat_tag]:[processing.len]")

--- a/code/controllers/subsystem/tickets/mentor_tickets.dm
+++ b/code/controllers/subsystem/tickets/mentor_tickets.dm
@@ -10,6 +10,7 @@ GLOBAL_REAL(SSmentor_tickets, /datum/controller/subsystem/tickets/mentor_tickets
 	ticket_name = "Mentor Ticket"
 	span_class = "mentorhelp"
 	close_rights = R_MENTOR | R_ADMIN
+	offline_implications = "Mentor tickets will no longer be marked as stale. No immediate action is needed."
 
 /datum/controller/subsystem/tickets/mentor_tickets/message_staff(var/msg)
 	message_mentorTicket(msg)

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -20,6 +20,7 @@ SUBSYSTEM_DEF(tickets)
 	init_order = INIT_ORDER_TICKETS
 	wait = 300
 	priority = FIRE_PRIORITY_TICKETS
+	offline_implications = "Admin tickets will no longer be marked as stale. No immediate action is needed."
 
 	flags = SS_BACKGROUND
 


### PR DESCRIPTION
## What Does This PR Do
Yes I know I should have done this in #13920 but I forgot to ok

This PR adds in more offline implications for subsystems I forgot about (Processing and tickets). It occurred to me that a processing SS going offline would say there are 0 implications. When actually, its very bad.

## Why It's Good For The Game
Information is important

## Changelog
:cl: AffectedArc07
add: Processing and Ticket subsystems will now properly state offline implications
/:cl:
