### PR TITLE
Maintenance Drone Tweaks

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -191,7 +191,7 @@
 		if(CanUse(U))
 			if(!Use(U))
 				return
-			to_chat(U, "<span class='notice'>You replace the Light [target.fitting] with [src].</span>")
+			to_chat(U, "<span class='notice'>You replace the light [target.fitting] with [src].</span>")
 
 			if(target.status != LIGHT_EMPTY)
 				AddShards(1, U)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -191,7 +191,7 @@
 		if(CanUse(U))
 			if(!Use(U))
 				return
-			to_chat(U, "<span class='notice'>You replace [target.fitting] with [src].</span>")
+			to_chat(U, "<span class='notice'>You replace the Light [target.fitting] with [src].</span>")
 
 			if(target.status != LIGHT_EMPTY)
 				AddShards(1, U)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -40,7 +40,7 @@
 		return
 	if(!in_range(src, user))
 		return
-	if(!iscarbon(usr))
+	if(!iscarbon(usr) && !isrobot(usr))
 		return
 	playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 	opened = !opened

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -162,8 +162,7 @@
 			return
 
 		else
-			var/confirm = null
-			confirm = alert("Using your ID on a Maintenance Drone will shut it down, are you sure you want to do this?", "Disable Drone", "Yes", "No")
+			var/confirm = alert("Using your ID on a Maintenance Drone will shut it down, are you sure you want to do this?", "Disable Drone", "Yes", "No")
 			if(confirm == ("Yes"))
 				user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to shut it down.</span>", "<span class='warning'>You swipe your ID card through \the [src], attempting to shut it down.</span>")
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -35,6 +35,14 @@
 	var/reboot_cooldown = 60 // one minute
 	var/last_reboot
 	var/emagged_time
+	var/list/pullable_drone_items = list(
+		/obj/item/pipe,
+		/obj/structure/disposalconstruct,
+		/obj/item/stack/cable_coil,
+		/obj/item/stack/rods,
+		/obj/item/stack/sheet,
+		/obj/item/stack/tile
+	)
 
 	holder_type = /obj/item/holder/drone
 //	var/sprite[0]
@@ -323,15 +331,6 @@
 
 /mob/living/silicon/robot/drone/Bumped(atom/movable/AM)
 	return
-
-var/list/pullable_drone_items = list(
-	/obj/item/pipe,
-	/obj/structure/disposalconstruct,
-	/obj/item/stack/cable_coil,
-	/obj/item/stack/rods,
-	/obj/item/stack/sheet,
-	/obj/item/stack/tile
-)
 
 /mob/living/silicon/robot/drone/start_pulling(var/atom/movable/AM)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -330,7 +330,7 @@ var/list/pullable_drone_items = list(
 	/obj/item/stack/cable_coil,
 	/obj/item/stack/rods,
 	/obj/item/stack/sheet,
-	/obj/item/stack/tile,)
+	/obj/item/stack/tile)
 
 /mob/living/silicon/robot/drone/start_pulling(var/atom/movable/AM)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -77,6 +77,10 @@
 	verbs -= /mob/living/silicon/robot/verb/Namepick
 	module = new /obj/item/robot_module/drone(src)
 
+	//Allows Drones to hear the Engineering channel.
+	module.channels = list("Engineering" = 1)
+	radio.recalculateChannels()
+
 	//Grab stacks.
 	stack_metal = locate(/obj/item/stack/sheet/metal/cyborg) in src.module
 	stack_wood = locate(/obj/item/stack/sheet/wood) in src.module

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -330,7 +330,8 @@ var/list/pullable_drone_items = list(
 	/obj/item/stack/cable_coil,
 	/obj/item/stack/rods,
 	/obj/item/stack/sheet,
-	/obj/item/stack/tile)
+	/obj/item/stack/tile
+)
 
 /mob/living/silicon/robot/drone/start_pulling(var/atom/movable/AM)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -167,7 +167,7 @@
 
 		else
 			var/confirm = alert("Using your ID on a Maintenance Drone will shut it down, are you sure you want to do this?", "Disable Drone", "Yes", "No")
-			if(confirm == ("Yes") && user in range(3, src))
+			if(confirm == ("Yes") && (user in range(3, src)))
 				user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to shut it down.</span>", "<span class='warning'>You swipe your ID card through \the [src], attempting to shut it down.</span>")
 
 				if(emagged)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -167,7 +167,7 @@
 
 		else
 			var/confirm = alert("Using your ID on a Maintenance Drone will shut it down, are you sure you want to do this?", "Disable Drone", "Yes", "No")
-			if(confirm == ("Yes"))
+			if(confirm == ("Yes") && user in range(3, src))
 				user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to shut it down.</span>", "<span class='warning'>You swipe your ID card through \the [src], attempting to shut it down.</span>")
 
 				if(emagged)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -331,7 +331,8 @@
 	|| istype(AM,/obj/structure/disposalconstruct) \
 	|| istype(AM,/obj/item/stack/cable_coil) \
 	|| istype(AM,/obj/item/stack/rods) \
-	|| istype(AM,/obj/item/stack/sheet))
+	|| istype(AM,/obj/item/stack/sheet) \
+	|| istype(AM,/obj/item/stack/tile))
 		..()
 	else if(istype(AM,/obj/item))
 		var/obj/item/O = AM

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -166,7 +166,6 @@
 					shut_down()
 				else
 					to_chat(user, "<span class='warning'>Access denied.</span>")
-			return
 
 		return
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -156,7 +156,7 @@
 		else
 			var/confirm = null
 			confirm = alert("Using your ID on a Maintenance Drone will shut it down, are you sure you want to do this?", "Disable Drone", "Yes", "No")
-			if (confirm == ("Yes"))
+			if(confirm == ("Yes"))
 				user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to shut it down.</span>", "<span class='warning'>You swipe your ID card through \the [src], attempting to shut it down.</span>")
 
 				if(emagged)
@@ -324,15 +324,19 @@
 /mob/living/silicon/robot/drone/Bumped(atom/movable/AM)
 	return
 
+var/list/pullable_drone_items = list(
+	/obj/item/pipe,
+	/obj/structure/disposalconstruct,
+	/obj/item/stack/cable_coil,
+	/obj/item/stack/rods,
+	/obj/item/stack/sheet,
+	/obj/item/stack/tile,)
+
 /mob/living/silicon/robot/drone/start_pulling(var/atom/movable/AM)
 
-	if(istype(AM,/obj/item/pipe) \
-	|| istype(AM,/obj/structure/disposalconstruct) \
-	|| istype(AM,/obj/item/stack/cable_coil) \
-	|| istype(AM,/obj/item/stack/rods) \
-	|| istype(AM,/obj/item/stack/sheet) \
-	|| istype(AM,/obj/item/stack/tile))
+	if(is_type_in_list(AM, pullable_drone_items))
 		..()
+
 	else if(istype(AM,/obj/item))
 		var/obj/item/O = AM
 		if(O.w_class > WEIGHT_CLASS_SMALL)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -154,15 +154,19 @@
 			return
 
 		else
-			user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to shut it down.</span>", "<span class='warning'>You swipe your ID card through \the [src], attempting to shut it down.</span>")
+			var/confirm = null
+			confirm = alert("Using your ID on a Maintenance Drone will shut it down, are you sure you want to do this?", "Disable Drone", "Yes", "No")
+			if (confirm == ("Yes"))
+				user.visible_message("<span class='warning'>\the [user] swipes [user.p_their()] ID card through [src], attempting to shut it down.</span>", "<span class='warning'>You swipe your ID card through \the [src], attempting to shut it down.</span>")
 
-			if(emagged)
-				return
+				if(emagged)
+					return
 
-			if(allowed(W))
-				shut_down()
-			else
-				to_chat(user, "<span class='warning'>Access denied.</span>")
+				if(allowed(W))
+					shut_down()
+				else
+					to_chat(user, "<span class='warning'>Access denied.</span>")
+			return
 
 		return
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -327,7 +327,11 @@
 
 /mob/living/silicon/robot/drone/start_pulling(var/atom/movable/AM)
 
-	if(istype(AM,/obj/item/pipe) || istype(AM,/obj/structure/disposalconstruct))
+	if(istype(AM,/obj/item/pipe) \
+	|| istype(AM,/obj/structure/disposalconstruct) \
+	|| istype(AM,/obj/item/stack/cable_coil) \
+	|| istype(AM,/obj/item/stack/rods) \
+	|| istype(AM,/obj/item/stack/sheet))
 		..()
 	else if(istype(AM,/obj/item))
 		var/obj/item/O = AM

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -8,7 +8,6 @@
 
 	//Has a list of items that it can hold.
 	var/list/can_hold = list(
-		/obj/item/stock_parts/cell,
 		/obj/item/firealarm_electronics,
 		/obj/item/airalarm_electronics,
 		/obj/item/airlock_electronics,
@@ -24,6 +23,8 @@
 		/obj/item/mounted/frame/firealarm,
 		/obj/item/mounted/frame/newscaster_frame,
 		/obj/item/mounted/frame/intercom,
+		/obj/item/mounted/frame/extinguisher,
+		/obj/item/mounted/frame/light_switch,
 		/obj/item/rack_parts,
 		/obj/item/camera_assembly,
 		/obj/item/tank,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
1. Allows Maintenance drones to drag construction materials such as Rods, Metal sheets and Floor tiles.
2. Shows a popup if you try using your ID on a drone.
3. Allows Maintence drones and Engiborgs to pick up Light Switches and Extinguisher Cabinet frames with their grabber.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. Nobody likes seeing metal rods inside windows.
2. No more accidentaly instakilling a drone.
3. Self explanitory.

## Changelog
:cl:
add: Maintenance drones can now drag construction materials.
add: Warns people what will happen when they try to use their ID on a maintenance drone.
tweak: Maintenance drones can now pick up Light Switches and Extinguisher Cabinet frames.
tweak: Maintenance drones and Cyborgs can now open and close Extinguisher Cabinets.
spellcheck: Fixed light replacer grammar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
