### PR TITLE
Depot Perimeter Shields Tweak

### DIFF
--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -193,10 +193,6 @@
 /obj/machinery/computer/syndicate_depot/shieldcontrol/New()
 	. = ..()
 	perimeterarea = locate(/area/syndicate_depot/perimeter)
-	if(istype(perimeterarea) && (GAMEMODE_IS_NUCLEAR || prob(20)))
-		spawn(200)
-			perimeterarea.perimeter_shields_up()
-			depotarea.perimeter_shield_status = TRUE
 
 /obj/machinery/computer/syndicate_depot/shieldcontrol/Destroy()
 	if(istype(perimeterarea) && perimeterarea.shield_list.len)


### PR DESCRIPTION
## What Does This PR Do
Currently, the syndicate depot starts with perimeter shields enabled during 100% of nukeop rounds, and 20% of other rounds. When these shields are enabled, the depot is inaccessible.
This PR simply removes both of these conditions, so the syndie depot never starts with perimeter shields up.


## Why It's Good For The Game
1. The code for shield startup is poor quality. It is in New(). It uses spawn(). And prob().
2. It doesn't even work right now. The computer New()s before SSticker is initialized, which means GAMEMODE_IS_NUCLEAR always returns false. Which means the primary thing it is meant to check for, the nuke ops game mode, is never detected.
3. It isn't necessary. It was originally added primarily to stop nukeops getting free gear from the depot, but (A) nukeops have never been seen to even attempt that, ever, (B) even if they did, admins could intervene, (C) even if admins did not intervene, the chances of one member of the average nuke op team sending the depot into delta by doing something inadvisable are 100% and (D) nukeops can't even find the depot now since its location is random. Also: (E) if nuke ops want a bunch of extra gear, they can simply declare war.
4. This code's secondary reason for being added was to stop people raiding the depot every shift... but the depot is now a space ruin with a random location, which is a much better way of making it hard to raid every shift. So the random chance factor isn't necessary.

So, overall, the code is bad, doesn't work, and isn't necessary.
So, in the name of code cleanup, I'm just deleting it.

## Changelog
:cl: Kyep
del: The syndicate depot will no longer start with its perimeter shields up sometimes, depending on round type and random chance
/:cl:
