### PR TITLE
Prevents the lightning Guardian from being able to spam manifest for more beams

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -17,6 +17,7 @@
 	var/datum/beam/summonerchain
 	var/list/enemychains = list()
 	var/successfulshocks = 0
+	var/acvtivatedbeam = FALSE
 
 /mob/living/simple_animal/hostile/guardian/beam/AttackingTarget()
 	. = ..()
@@ -39,7 +40,9 @@
 /mob/living/simple_animal/hostile/guardian/beam/Manifest()
 	..()
 	if(summoner)
-		summonerchain = Beam(summoner, "lightning[rand(1,12)]", 'icons/effects/effects.dmi', time=INFINITY, maxdistance=INFINITY, beam_type=/obj/effect/ebeam/chain)
+		if(!cantshock)
+			summonerchain = Beam(summoner, "lightning[rand(1,12)]", 'icons/effects/effects.dmi', time=INFINITY, maxdistance=INFINITY, beam_type=/obj/effect/ebeam/chain)
+			acvtivatedbeam = TRUE
 	while(loc != summoner)
 		if(successfulshocks > 5)
 			successfulshocks = 0
@@ -51,6 +54,7 @@
 	. = ..()
 	if(.)
 		removechains()
+		acvtivatedbeam = FALSE
 
 /mob/living/simple_animal/hostile/guardian/beam/proc/cleardeletedchains()
 	if(summonerchain && QDELETED(summonerchain))

--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -40,7 +40,7 @@
 /mob/living/simple_animal/hostile/guardian/beam/Manifest()
 	..()
 	if(summoner)
-		if(!cantshock)
+		if(!acvtivatedbeam)
 			summonerchain = Beam(summoner, "lightning[rand(1,12)]", 'icons/effects/effects.dmi', time=INFINITY, maxdistance=INFINITY, beam_type=/obj/effect/ebeam/chain)
 			acvtivatedbeam = TRUE
 	while(loc != summoner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

fixes#13573

**I did get help to TEST the ISSUE, though not my changes since it requires two players to test holoparasites with a master(which you need to test the beams)**
But this PR should remove some possible cheese where a lightning holoparasite could spam manifest to get as many beams as they would want. this would make it an instakill beam which is no good.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes a "bug" or an issue that makes the lightning holopara very very overpowered
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Lightning guardians can no longer spam manifest for infinite beams
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
