### PR TITLE
*more* Tcomms Tweaks

### DIFF
--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -106,22 +106,36 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 
 
 /**
-  * Start of Ion Anomalie Event
+  * Start of Ion Anomaly Event
   *
-  * Proc to easily start an Ion Anomalie's effects, and update the icon
+  * Proc to easily start an Ion Anomaly's effects, and update the icon
   */
 /obj/machinery/tcomms/proc/start_ion()
 	ion = TRUE
 	update_icon()
 
 /**
-  * End of Ion Anomalie Event
+  * End of Ion Anomaly Event
   *
-  * Proc to easily stop an Ion Anomalie's effects, and update the icon
+  * Proc to easily stop an Ion Anomaly's effects, and update the icon
   */
 /obj/machinery/tcomms/proc/end_ion()
 	ion = FALSE
 	update_icon()
+
+/**
+  * Z-Level transit change helper
+  *
+  * Proc to make sure you cant have two of these active on a Z-level at once. It also makes sure to update the linkage
+  */
+/obj/machinery/tcomms/onTransitZ(old_z, new_z)
+	. = ..()
+	if(active)
+		active = FALSE
+		// This needs a timer because otherwise its on the shuttle Z and the message is missed
+		addtimer(CALLBACK(src, /atom.proc/visible_message, "<span class='warning'>Radio equipment on [src] has been overloaded by heavy bluespace interference. Please restart the machine.</span>"), 5)
+	update_icon()
+
 
 /**
   * Logging helper

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -41,6 +41,7 @@
 		active = TRUE
 	else
 		visible_message("<span class='warning'>Error: Another core is already active in this sector. Power-up cancelled due to radio interference.</span>")
+	update_icon()
 
 /**
   * Destructor for the core.

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -14,6 +14,8 @@
 	name = "Telecommunications Core"
 	desc = "A large rack full of communications equipment. Looks important."
 	icon_state = "core"
+	// This starts as off so you cant make cores as hot spares
+	active = FALSE
 	/// The NTTC config for this device
 	var/datum/nttc_configuration/nttc = new()
 	/// List of all reachable devices
@@ -35,6 +37,10 @@
 	link_password = GenerateKey()
 	reachable_zlevels |= loc.z
 	component_parts += new /obj/item/circuitboard/tcomms/core(null)
+	if(check_power_on())
+		active = TRUE
+	else
+		visible_message("<span class='warning'>Error: Another core is already active in this sector. Power-up cancelled due to radio interference.</span>")
 
 /**
   * Destructor for the core.
@@ -121,6 +127,38 @@
 			reachable_zlevels |= R.loc.z
 
 
+/**
+  * Z-Level transit change helper
+  *
+  * Handles parent call of disabling the machine if it changes Z-level, but also rebuilds the list of reachable levels
+  */
+/obj/machinery/tcomms/core/onTransitZ(old_z, new_z)
+	. = ..()
+	refresh_zlevels()
+
+/**
+  * Power-on checker
+  *
+  * Checks the z-level to see if an existing core is already powered on, and deny this one turning on if there is one. Returns TRUE if it can power on, or FALSE if it cannot
+  */
+/obj/machinery/tcomms/core/proc/check_power_on()
+	// Cancel if we are already on
+	if(active)
+		return TRUE
+
+	for(var/obj/machinery/tcomms/core/C in GLOB.tcomms_machines)
+		// Make sure we dont check ourselves
+		if(C == src)
+			continue
+		// We dont care about ones on other zlevels
+		if(C.z != z)
+			continue
+		// If another core is active, return FALSE
+		if(C.active)
+			return FALSE
+	// If we got here there isnt an active core on this Z-level. So return true
+	return TRUE
+
 //////////////
 // UI STUFF //
 //////////////
@@ -198,8 +236,11 @@
 	if(ui_tab == UI_TAB_CONFIG)
 		// All the toggle on/offs go here
 		if(href_list["toggle_active"])
-			active = !active
-			update_icon()
+			if(check_power_on())
+				active = !active
+				update_icon()
+			else
+				to_chat(usr, "<span class='warning'>Error: Another core is already active in this sector. Power-up cancelled due to radio interference.</span>")
 		// NTTC Toggles
 		if(href_list["nttc_toggle_jobs"])
 			nttc.toggle_jobs = !nttc.toggle_jobs

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -152,7 +152,7 @@
 		if(C == src)
 			continue
 		// We dont care about ones on other zlevels
-		if(C.z != z)
+		if(!atoms_share_level(C, src))
 			continue
 		// If another core is active, return FALSE
 		if(C.active)

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -52,6 +52,40 @@
 			break
 
 /**
+  * Z-Level transit change helper
+  *
+  * Handles parent call of disabling the machine if it changes Z-level, but also rebuilds the list of reachable levels on the linked core
+  */
+/obj/machinery/tcomms/relay/onTransitZ(old_z, new_z)
+	. = ..()
+	if(linked_core)
+		linked_core.refresh_zlevels()
+
+
+/**
+  * Power-on checker
+  *
+  * Checks the z-level to see if an existing relay is already powered on, and deny this one turning on if there is one. Returns TRUE if it can power on, or FALSE if it cannot
+  */
+/obj/machinery/tcomms/relay/proc/check_power_on()
+	// Cancel if we are already on
+	if(active)
+		return TRUE
+
+	for(var/obj/machinery/tcomms/relay/R in GLOB.tcomms_machines)
+		// Make sure we dont check ourselves
+		if(R == src)
+			continue
+		// We dont care about ones on other zlevels
+		if(R.z != z)
+			continue
+		// If another relay is active, return FALSE
+		if(R.active)
+			return FALSE
+	// If we got here there isnt an active relay on this Z-level. So return TRUE
+	return TRUE
+
+/**
   * Proc to link the relay to the core.
   *
   * Sets the linked core to the target (argument below), before adding it to the list of linked relays, then re-freshing the zlevel list
@@ -83,9 +117,9 @@
   * Proc which ensures the host core has its zlevels updated (icons are updated by parent call)
   */
 /obj/machinery/tcomms/relay/power_change()
-    ..()
-    if(linked_core)
-        linked_core.refresh_zlevels()
+	..()
+	if(linked_core)
+		linked_core.refresh_zlevels()
 
 //////////////
 // UI STUFF //
@@ -127,10 +161,13 @@
 
 	// All the toggle on/offs go here
 	if(href_list["toggle_active"])
-		active = !active
-		update_icon()
-		if(linked_core)
-			linked_core.refresh_zlevels()
+		if(check_power_on())
+			active = !active
+			update_icon()
+			if(linked_core)
+				linked_core.refresh_zlevels()
+		else
+			to_chat(usr, "<span class='warning'>Error: Another core is already active in this sector. Power-up cancelled due to radio interference.</span>")
 
 	// Set network ID
 	if(href_list["network_id"])

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -9,6 +9,8 @@
 	name = "Telecommunications Relay"
 	desc = "A large device with several radio antennas on it."
 	icon_state = "relay"
+	// This starts as off so you cant make cores as hot spares
+	active = FALSE
 	/// The host core for this relay
 	var/obj/machinery/tcomms/core/linked_core
 	/// ID of the hub to auto link to
@@ -26,6 +28,11 @@
 /obj/machinery/tcomms/relay/Initialize(mapload)
 	. = ..()
 	component_parts += new /obj/item/circuitboard/tcomms/relay(null)
+	if(check_power_on())
+		active = TRUE
+	else
+		visible_message("<span class='warning'>Error: Another relay is already active in this sector. Power-up cancelled due to radio interference.</span>")
+	update_icon()
 	if(mapload && autolink_id)
 		return INITIALIZE_HINT_LATELOAD
 
@@ -167,7 +174,7 @@
 			if(linked_core)
 				linked_core.refresh_zlevels()
 		else
-			to_chat(usr, "<span class='warning'>Error: Another core is already active in this sector. Power-up cancelled due to radio interference.</span>")
+			to_chat(usr, "<span class='warning'>Error: Another relay is already active in this sector. Power-up cancelled due to radio interference.</span>")
 
 	// Set network ID
 	if(href_list["network_id"])

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -84,7 +84,7 @@
 		if(R == src)
 			continue
 		// We dont care about ones on other zlevels
-		if(R.z != z)
+		if(!atoms_share_level(R, src))
 			continue
 		// If another relay is active, return FALSE
 		if(R.active)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -325,7 +325,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	// If we were to send to a channel we don't have, drop it.
 	return RADIO_CONNECTION_FAIL
 
-/obj/item/radio/talk_into(mob/living/M as mob, list/message_pieces, channel, var/verb = "says")
+/obj/item/radio/talk_into(mob/living/M as mob, list/message_pieces, channel, verbage = "says")
 	if(!on)
 		return 0 // the device has to be on
 	//  Fix for permacell radios, but kinda eh about actually fixing them.
@@ -423,6 +423,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	tcm.connection = connection
 	tcm.vname = M.voice_name
 	tcm.sender = M
+	tcm.verbage = verbage
 	// Now put that through the stuff
 	var/handled = FALSE
 	if(connection)


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so that tcomms machines update when being moved on shuttles, auto disable when moved on shuttles, and also disallowed having multiple machines active on the same zlevel (hot spares).

Fixes #13968

It also fixes this weird bug with verbage

Before:
*notice the difference says and exclaims*
![image](https://user-images.githubusercontent.com/25063394/88713620-7ffb9780-d113-11ea-9c05-d862821667ad.png)

After:
![image](https://user-images.githubusercontent.com/25063394/88713596-74a86c00-d113-11ea-925b-cb05d376c01b.png)


## Why It's Good For The Game
People have started creating multiple tcomms cores on the station, all of which are active at once. This means that you cannot easily take down tcomms. This will make it so that people cant just have a running hot spare tcomms core. You can still make a new core, but cant enable it until the existing one is disabled or destroyed. 

The reason for the shuttle changes is twofold:
1: Moving a tcomms machine between z-levels didnt update the linkage lists, and that was a bug
2: Moving active machines onto zlevels made it so that you could bypass the one-machine checks, so it was done regardless

## Images of changes
*ignore the name differences, I loaded on the wrong SQL version for one run and screwed character loading*
![image](https://user-images.githubusercontent.com/25063394/88708475-9a317780-d10b-11ea-94fb-02252cef2d80.png)

![image](https://user-images.githubusercontent.com/25063394/88709720-75d69a80-d10d-11ea-8386-20e69232584d.png)

![image](https://user-images.githubusercontent.com/25063394/88708496-9f8ec200-d10b-11ea-8464-06f1b482d697.png)


## Changelog
:cl: AffectedArc07
add: Tcomms machines now disable on Z-level changes (Example: Shuttle moves)
add: Tcomms machines now update properly on Z-level changes (Example: Shuttle moves)
tweak: You can no longer have more than 1 running tcomms core per Z-level
tweak: You can no longer have more than 1 running tcomms relay per Z-level
/:cl:
