### PR TITLE
Removes some non ASCII characters

### DIFF
--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -349,7 +349,7 @@
 		to_chat(user, "<span class='notice'>You modify the appearance of [target].</span>")
 		var/obj/item/clothing/mask/gas/M = target
 		M.name = "Prescription Gas Mask"
-		M.desc = "It looks heavily modified, but otherwise functions as a gas mask. The words “Property of Yon-Dale” can be seen on the inner band."
+		M.desc = "It looks heavily modified, but otherwise functions as a gas mask. The words \"Property of Yon-Dale\" can be seen on the inner band."
 		M.icon = 'icons/obj/custom_items.dmi'
 		M.icon_state = "gas_tariq"
 		M.sprite_sheets = list(


### PR DESCRIPTION
## What Does This PR Do
This removes a non-ascii speech mark from someones fluff description and replaces it with an escaped speech mark.

Yes I know BYOND natively supports unicode now but theres a lot of things which require fuckery to make it work, so this makes life easier inside the game and when doing external tooling.

## Why It's Good For The Game
Bad characters bad

## Changelog
N/A