### PR TITLE
Click prevention for admin frozen players

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2017,5 +2017,18 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	set waitfor = FALSE
 	return call(source, proctype)(arglist(arguments))
 
+/proc/IsFrozen(var/atom/A)
+	if(istype(A, /mob/living))
+		var/mob/living/L = A
+		if(L.frozen)
+			return TRUE
+
+	if(istype(A, /obj/mecha))
+		var/obj/mecha/M = A
+		if(M.frozen)
+			return TRUE
+
+	return FALSE
+
 /// Waits at a line of code until X is true
 #define UNTIL(X) while(!(X)) stoplag()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2018,16 +2018,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return call(source, proctype)(arglist(arguments))
 
 /proc/IsFrozen(var/atom/A)
-	if(istype(A, /mob/living))
-		var/mob/living/L = A
-		if(L.frozen)
-			return TRUE
-
-	if(istype(A, /obj/mecha))
-		var/obj/mecha/M = A
-		if(M.frozen)
-			return TRUE
-
+	if(A in GLOB.frozen_atom_list)
+		return TRUE
 	return FALSE
 
 /// Waits at a line of code until X is true

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2017,7 +2017,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	set waitfor = FALSE
 	return call(source, proctype)(arglist(arguments))
 
-/proc/IsFrozen(var/atom/A)
+/proc/IsFrozen(atom/A)
 	if(A in GLOB.frozen_atom_list)
 		return TRUE
 	return FALSE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -73,7 +73,9 @@
 	var/dragged = modifiers["drag"]
 	if(dragged && !modifiers[dragged])
 		return
-
+	if(IsFrozen(A) && !is_admin(usr))
+		to_chat(usr, "<span class='warning'>Interacting with admin-frozen players is not permitted.</span>")
+		return
 	if(modifiers["middle"] && modifiers["shift"] && modifiers["ctrl"])
 		MiddleShiftControlClickOn(A)
 		return

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -74,7 +74,7 @@
 	if(dragged && !modifiers[dragged])
 		return
 	if(IsFrozen(A) && !is_admin(usr))
-		to_chat(usr, "<span class='warning'>Interacting with admin-frozen players is not permitted.</span>")
+		to_chat(usr, "<span class='boldannounce'>Interacting with admin-frozen players is not permitted.</span>")
 		return
 	if(modifiers["middle"] && modifiers["shift"] && modifiers["ctrl"])
 		MiddleShiftControlClickOn(A)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -519,9 +519,6 @@
 /datum/species/proc/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style = M.martial_art) //Handles any species-specific attackhand events.
 	if(!istype(M))
 		return
-	if(H.frozen)
-		to_chat(M, "<span class='warning'>Do not touch Admin-Frozen people.</span>")
-		return
 
 	if(istype(M))
 		var/obj/item/organ/external/temp = M.bodyparts_by_name["r_hand"]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -880,7 +880,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		return
 	if(!Adjacent(usr))
 		return
-	if(IsFrozen(src))
+	if(IsFrozen(src) && !is_admin(usr))
 		to_chat(usr, "<span class='boldannounce'>Interacting with admin-frozen players is not permitted.</span>")
 		return
 	if(isLivingSSD(src) && M.client && M.client.send_ssd_warning(src))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -880,6 +880,9 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		return
 	if(!Adjacent(usr))
 		return
+	if(IsFrozen(src))
+		to_chat(usr, "<span class='boldannounce'>Interacting with admin-frozen players is not permitted.</span>")
+		return
 	if(isLivingSSD(src) && M.client && M.client.send_ssd_warning(src))
 		return
 	show_inv(usr)


### PR DESCRIPTION
## What Does This PR Do
Prevents click interactions with adminfrozen players. 

## Why It's Good For The Game
Prevents players from attacking, stripping or dragging admin frozen players.

## Changelog
:cl:
del: Outdated admin frozen attack prevention.
add: Click prevention to admin frozen players.
/:cl: