### PR TITLE
Fix faction error in listeningpost.dmm

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -71,6 +71,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/syndicate{
+	desc = "A weary looking syndicate operative.";
+	environment_smash = 0
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered)
 "r" = (
@@ -263,13 +267,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/powered)
-"V" = (
-/mob/living/simple_animal/hostile/syndicate{
-	desc = "A weary looking syndicate operative.";
-	environment_smash = 0
-	},
-/turf/simulated/floor/plasteel,
 /area/ruin/powered)
 "Y" = (
 /obj/item/gps/ruin,
@@ -1008,7 +1005,7 @@ b
 f
 k
 q
-V
+m
 m
 i
 m

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -71,11 +71,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/syndicate{
-	desc = "A weary looking syndicate operative.";
-	environment_smash = 0;
-	faction = "syndicate"
-	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered)
 "r" = (
@@ -268,6 +263,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
+/area/ruin/powered)
+"T" = (
+/mob/living/simple_animal/hostile/syndicate{
+	environment_smash = 0
+	},
+/turf/simulated/floor/plasteel,
 /area/ruin/powered)
 "Y" = (
 /obj/item/gps/ruin,
@@ -1006,7 +1007,7 @@ b
 f
 k
 q
-m
+T
 m
 i
 m

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -264,8 +264,9 @@
 	icon_state = "freezerfloor"
 	},
 /area/ruin/powered)
-"T" = (
+"V" = (
 /mob/living/simple_animal/hostile/syndicate{
+	desc = "A weary looking syndicate operative.";
 	environment_smash = 0
 	},
 /turf/simulated/floor/plasteel,
@@ -1007,7 +1008,7 @@ b
 f
 k
 q
-T
+V
 m
 i
 m


### PR DESCRIPTION
## What Does This PR Do
Fixes a mistake in listeningpost.dmm, whereby the hostile mob in the ruin had its faction manually overriden and set to "syndicate", instead of the proper list("syndicate"). This led to runtimes.

## Why It's Good For The Game
Fewer runtimes.

## Changelog
:cl: Kyep
fix: Fixed a mapping error in the syndicate listeningpost.dmm space ruin that was causing runtime errors.
/:cl:
