### PR TITLE
Fixes runtimes caused by trying to force feed non-carbon mobs with beakers

### DIFF
--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -47,8 +47,7 @@
 			reagents.reaction(M, REAGENT_TOUCH)
 			reagents.clear_reagents()
 		else
-			if(!iscarbon(M))
-				// Non-carbons can't process reagents
+			if(!iscarbon(M)) // Non-carbons can't process reagents
 				to_chat(user, "<span class='warning'>You cannot find a way to feed [M].</span>")
 				return
 			if(M != user)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -48,8 +48,7 @@
 			reagents.clear_reagents()
 		else
 			if(!iscarbon(M))
-				// This is a simple mob, or some other kind of mob that cannot process reagents.
-				// It makes no sense to inject reagents into mobs that don't even process them.
+				// Non-carbons can't process reagents
 				to_chat(user, "<span class='warning'>You cannot find a way to feed [M].</span>")
 				return
 			if(M != user)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -47,6 +47,11 @@
 			reagents.reaction(M, REAGENT_TOUCH)
 			reagents.clear_reagents()
 		else
+			if(!iscarbon(M))
+				// This is a simple mob, or some other kind of mob that cannot process reagents.
+				// It makes no sense to inject reagents into mobs that don't even process them.
+				to_chat(user, "<span class='warning'>You cannot find a way to feed [M].</span>")
+				return
 			if(M != user)
 				M.visible_message("<span class='danger'>[user] attempts to feed something to [M].</span>", \
 							"<span class='userdanger'>[user] attempts to feed something to you.</span>")


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime that would happen if you try to force-feed chem reagents to a non-carbon mob using /obj/item/reagent_containers/glass or its subtypes, such as a glass beaker from chemistry.
With this PR, if you, for example, click on ian/renault/etc while holding a beaker containing reagents, it won't runtime error, it will simply give you a message that you can't force-feed them.

## Why It's Good For The Game
Reduces runtime errors like this one:
[2020-07-30T01:39:56] Runtime in reagents.dm,56: Cannot execute null.reaction check().
   proc name: reaction mob (/datum/reagent/proc/reaction_mob)
   usr: XXXX (YYYYYY) (/mob/living/carbon/human)
   usr.loc: The floor (165,18,2) (/turf/simulated/floor/plasteel)
   src: Plasma Dust (/datum/reagent/plasma_dust)
   call stack:
   Plasma Dust (/datum/reagent/plasma_dust): reaction mob(Ian (/mob/living/simple_animal/pet/dog/corgi/Ian), 2, 5, 1)
   Plasma Dust (/datum/reagent/plasma_dust): reaction mob(Ian (/mob/living/simple_animal/pet/dog/corgi/Ian), 2, 5, 1)
   /datum/reagents (/datum/reagents): reaction(Ian (/mob/living/simple_animal/pet/dog/corgi/Ian), 2, 0.166667, 1)
   the plasma dust bottle (/obj/item/reagent_containers/glass/bottle/plasma): attack(Ian (/mob/living/simple_animal/pet/dog/corgi/Ian), Virgam (/mob/living/carbon/human), null)

## Changelog
:cl: Kyep
fix: fixed the fact you could generate runtime errors by attempting to feed animals stuff in beakers.
/:cl:
