### PR TITLE
Makes image on cult talismans appear again.

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -4,7 +4,7 @@
 	var/cultist_name = "talisman"
 	var/cultist_desc = "A basic talisman. It serves no purpose."
 	var/invocation = "Naise meam!"
-	info = "<center><img src='talisman.png'></center><br/><br/>"
+	info = "<center>&ZeroWidthSpace;<img src='talisman.png'></center><br/><br/>"
 	var/uses = 1
 	var/health_cost = 0 //The amount of health taken from the user when invoking the talisman
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
One day standalone images on papers broke - Why? I don't know. I fixed/patched one case of that bug in #13904, but it seems there's more, this time on cult talismans
If there are any more cases of standalone images on papers, that need \&ZeroWidthSpace\; friend to be able to attach itself to it to appear, let me know in a comment, and I'll try to fix it.

What works: Stamps, [logo]

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Image > no image


## Changelog
:cl:

fix: Cult talismans not displaying blood rune image when you look at it.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
