### PR TITLE
Fixes sec bots from causing a runtime warning that they spawned in null space

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -474,7 +474,7 @@
 			return
 		build_step++
 		to_chat(user, "<span class='notice'>You complete the Securitron! Beep boop.</span>")
-		var/mob/living/simple_animal/bot/secbot/S = new /mob/living/simple_animal/bot/secbot
+		var/mob/living/simple_animal/bot/secbot/S = new /mob/living/simple_animal/bot/secbot(loc)
 		S.forceMove(get_turf(src))
 		S.name = created_name
 		S.robot_arm = robot_arm
@@ -512,7 +512,7 @@
 //General Griefsky
 
 	else if((istype(I, /obj/item/wrench)) && (build_step == 3))
-		var/obj/item/griefsky_assembly/A = new /obj/item/griefsky_assembly
+		var/obj/item/griefsky_assembly/A = new /obj/item/griefsky_assembly(loc)
 		user.put_in_hands(A)
 		to_chat(user, "<span class='notice'>You adjust the arm slots for extra weapons!.</span>")
 		user.unEquip(src, 1)

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -474,8 +474,7 @@
 			return
 		build_step++
 		to_chat(user, "<span class='notice'>You complete the Securitron! Beep boop.</span>")
-		var/mob/living/simple_animal/bot/secbot/S = new /mob/living/simple_animal/bot/secbot(loc)
-		S.forceMove(get_turf(src))
+		var/mob/living/simple_animal/bot/secbot/S = new /mob/living/simple_animal/bot/secbot(get_turf(src))
 		S.name = created_name
 		S.robot_arm = robot_arm
 		qdel(I)
@@ -540,8 +539,7 @@
 		if(!user.unEquip(I))
 			return
 		to_chat(user, "<span class='notice'>You complete General Griefsky!.</span>")
-		var/mob/living/simple_animal/bot/secbot/griefsky/S = new /mob/living/simple_animal/bot/secbot/griefsky
-		S.forceMove(get_turf(src))
+		var/mob/living/simple_animal/bot/secbot/griefsky/S = new /mob/living/simple_animal/bot/secbot/griefsky(get_turf(src))
 		qdel(I)
 		qdel(src)
 
@@ -556,8 +554,7 @@
 		if(!user.unEquip(I))
 			return
 		to_chat(user, "<span class='notice'>You complete Genewul Giftskee!.</span>")
-		var/mob/living/simple_animal/bot/secbot/griefsky/toy/S = new /mob/living/simple_animal/bot/secbot/griefsky/toy
-		S.forceMove(get_turf(src))
+		var/mob/living/simple_animal/bot/secbot/griefsky/toy/S = new /mob/living/simple_animal/bot/secbot/griefsky/toy(get_turf(src))
 		qdel(I)
 		qdel(src)
 

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -511,7 +511,7 @@
 //General Griefsky
 
 	else if((istype(I, /obj/item/wrench)) && (build_step == 3))
-		var/obj/item/griefsky_assembly/A = new /obj/item/griefsky_assembly(loc)
+		var/obj/item/griefsky_assembly/A = new /obj/item/griefsky_assembly(get_turf(src))
 		user.put_in_hands(A)
 		to_chat(user, "<span class='notice'>You adjust the arm slots for extra weapons!.</span>")
 		user.unEquip(src, 1)
@@ -539,7 +539,7 @@
 		if(!user.unEquip(I))
 			return
 		to_chat(user, "<span class='notice'>You complete General Griefsky!.</span>")
-		var/mob/living/simple_animal/bot/secbot/griefsky/S = new /mob/living/simple_animal/bot/secbot/griefsky(get_turf(src))
+		new /mob/living/simple_animal/bot/secbot/griefsky(get_turf(src))
 		qdel(I)
 		qdel(src)
 
@@ -554,7 +554,7 @@
 		if(!user.unEquip(I))
 			return
 		to_chat(user, "<span class='notice'>You complete Genewul Giftskee!.</span>")
-		var/mob/living/simple_animal/bot/secbot/griefsky/toy/S = new /mob/living/simple_animal/bot/secbot/griefsky/toy(get_turf(src))
+		new /mob/living/simple_animal/bot/secbot/griefsky/toy(get_turf(src))
 		qdel(I)
 		qdel(src)
 


### PR DESCRIPTION
## What Does This PR Do
Fixes this runtime:
```
Runtime in unsorted.dm,1988: Simple animal being instantiated in nullspace
   proc name: stack trace (/datum/proc/stack_trace)
   usr: The Securitron () (/mob/living/simple_animal/bot/secbot)
   src: the Securitron (/mob/living/simple_animal/bot/secbot)
   src.loc: null
   call stack:
   the Securitron (/mob/living/simple_animal/bot/secbot): stack trace("Simple animal being instantiat...")
   the Securitron (/mob/living/simple_animal/bot/secbot): Initialize(0)
   Atoms (/datum/controller/subsystem/atoms): InitAtom(the Securitron (/mob/living/simple_animal/bot/secbot), /list (/list))
   the Securitron (/mob/living/simple_animal/bot/secbot): attempt init(0)
   the Securitron (/mob/living/simple_animal/bot/secbot): attempt init(null)
   the Securitron (/mob/living/simple_animal/bot/secbot): New(null)
   the Securitron (/mob/living/simple_animal/bot/secbot): New()
   the Securitron (/mob/living/simple_animal/bot/secbot): New()
   the Securitron (/mob/living/simple_animal/bot/secbot): New()
   the helmet/signaler/prox senso... (/obj/item/secbot_assembly): attackby(the stunbaton (/obj/item/melee/baton/loaded), NAME (/mob/living/carbon/human), "icon-x=24;icon-y=14;left=1;scr...")
   the stunbaton (/obj/item/melee/baton/loaded): melee attack chain(NAME (/mob/living/carbon/human), the helmet/signaler/prox senso... (/obj/item/secbot_assembly), "icon-x=24;icon-y=14;left=1;scr...")
   NAME (/mob/living/carbon/human): ClickOn(the helmet/signaler/prox senso... (/obj/item/secbot_assembly), "icon-x=24;icon-y=14;left=1;scr...")
   the helmet/signaler/prox senso... (/obj/item/secbot_assembly): Click(null, "mapwindow.map", "icon-x=24;icon-y=14;left=1;scr...")
```

## Why It's Good For The Game
Less clogging up the runtimes the better

## Changelog
pure backend