### PR TITLE
Bandaids the parallax runtime

### DIFF
--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(parallax)
 		for (A; isloc(A.loc) && !isturf(A.loc); A = A.loc);
 
 		if(A != C.movingmob)
-			if(C.movingmob != null)
+			if(C.movingmob != null && C.movingmob.client_mobs_in_contents)
 				C.movingmob.client_mobs_in_contents -= C.mob
 				UNSETEMPTY(C.movingmob.client_mobs_in_contents)
 			LAZYINITLIST(A.client_mobs_in_contents)


### PR DESCRIPTION
## What Does This PR Do
Puts a bandaid on the following runtime
```
[2020-08-01T10:26:26] Runtime in parallax.dm,38: type mismatch: null -= Mob Name (/mob/dead/observer)
   proc name: fire (/datum/controller/subsystem/parallax/fire)
   src: Parallax (/datum/controller/subsystem/parallax)
   call stack:
   Parallax (/datum/controller/subsystem/parallax): fire(0)
   Parallax (/datum/controller/subsystem/parallax): ignite(0)
```

I did some digging and these are the only references to this list
![image](https://user-images.githubusercontent.com/25063394/89105114-52b23080-d416-11ea-9200-9f5618088a9d.png)

The only recent change here was in `atoms_movable.dm`, and that was adding `LAZYCLEARLIST(client_mobs_in_contents)` to `/atom/movable/Destroy()`. And even then, thats just calling `Cut` on the list, not nulling it, so this makes no sense

## Why It's Good For The Game
Runtimes bad

## Changelog
:cl: AffectedArc07
wip: Bandaids a parallax runtime
/:cl:
