### PR TITLE
Fix runtime when 'item' is null during surgery germs spreading

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -196,7 +196,7 @@
 		if(AStar(E.loc, M.loc, /turf/proc/Distance, 2, simulated_only = 0))
 			germs++
 
-	if(!isnull(tool) && tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
+	if(!tool && tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
 		germs += 30
 
 	if(E.internal_organs.len)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -196,7 +196,7 @@
 		if(AStar(E.loc, M.loc, /turf/proc/Distance, 2, simulated_only = 0))
 			germs++
 
-	if(!tool && tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
+	if(tool && tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
 		germs += 30
 
 	if(E.internal_organs.len)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -196,7 +196,7 @@
 		if(AStar(E.loc, M.loc, /turf/proc/Distance, 2, simulated_only = 0))
 			germs++
 
-	if(tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
+	if(!isnull(tool) && tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
 		germs += 30
 
 	if(E.internal_organs.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtime when 'item' is null during germs spreading because 'tool' is mob's hand. Log from [RU] SS220 Paradise:

```
[2020-08-01T20:58:49] Runtime in surgery.dm,199: Cannot read null.blood_DNA
   proc name: spread germs by incision (/proc/spread_germs_by_incision)
   usr: Mothership Kappa Scientist (garyvary) (/mob/living/carbon/human)
   usr.loc: The alien floor (85,13,2) (/turf/unsimulated/floor/abductor)
   src: null
   call stack:
   spread germs by incision(the upper body (/obj/item/organ/external/chest), null)
   spread germs to organ(the upper body (/obj/item/organ/external/chest), Mothership Kappa Scientist (/mob/living/carbon/human), null)
   remove heart (/datum/surgery_step/internal/extract_organ): begin step(Mothership Kappa Scientist (/mob/living/carbon/human), Дима Няш (/mob/living/carbon/human), "chest", null, Experimental Dissection (/datum/surgery/organ_extraction))
   remove heart (/datum/surgery_step/internal/extract_organ): begin step(Mothership Kappa Scientist (/mob/living/carbon/human), Дима Няш (/mob/living/carbon/human), "chest", null, Experimental Dissection (/datum/surgery/organ_extraction))
   remove heart (/datum/surgery_step/internal/extract_organ): initiate(Mothership Kappa Scientist (/mob/living/carbon/human), Дима Няш (/mob/living/carbon/human), "chest", null, Experimental Dissection (/datum/surgery/organ_extraction))
   remove heart (/datum/surgery_step/internal/extract_organ): try op(Mothership Kappa Scientist (/mob/living/carbon/human), Дима Няш (/mob/living/carbon/human), "chest", null, Experimental Dissection (/datum/surgery/organ_extraction))
   Experimental Dissection (/datum/surgery/organ_extraction): next step(Mothership Kappa Scientist (/mob/living/carbon/human), Дима Няш (/mob/living/carbon/human))
   Дима Няш (/mob/living/carbon/human): attack hand(Mothership Kappa Scientist (/mob/living/carbon/human))
   Дима Няш (/mob/living/carbon/human): attack hand(Mothership Kappa Scientist (/mob/living/carbon/human))
   Mothership Kappa Scientist (/mob/living/carbon/human): UnarmedAttack(Дима Няш (/mob/living/carbon/human), 1)
   Mothership Kappa Scientist (/mob/living/carbon/human): ClickOn(Дима Няш (/mob/living/carbon/human), "icon-x=18;icon-y=18;vis-x=19;v...")
   Дима Няш (/mob/living/carbon/human): Click(the alien floor (86,13,2) (/turf/unsimulated/floor/abductor), "mapwindow.map", "icon-x=18;icon-y=18;vis-x=19;v...")
```

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This runtime probably was affecting on abductors armor's stealth mode causing it to unlink from system.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: azizonkg
fix: Fix runtime when 'item' is null during surgery germs spreading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
