### PR TITLE
Fixes a cause of "Runtime in ,:"

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1419,9 +1419,10 @@
 			return A
 
 /datum/mind/proc/announce_objectives()
-	to_chat(current, "<span class='notice'>Your current objectives:</span>")
-	for(var/line in splittext(gen_objective_text(), "<br>"))
-		to_chat(current, line)
+	if(current)
+		to_chat(current, "<span class='notice'>Your current objectives:</span>")
+		for(var/line in splittext(gen_objective_text(), "<br>"))
+			to_chat(current, line)
 
 /datum/mind/proc/find_syndicate_uplink()
 	var/list/L = current.get_contents()


### PR DESCRIPTION
## What Does This PR Do
Fixes weird runtimes like this:
[2020-08-01T18:38:00] Runtime in ,: DEBUG: to_chat called with invalid message/target.
   Message: '<span class='notice'>Your current objectives:</span>'
   Target: ''
These runtimes are caused by calls to /datum/mind/proc/announce_objectives() on minds that don't currently have a body.
To fix it, the proc now checks for a current body actually existing before it attempts to send messages to that body.

## Why It's Good For The Game
Less weird runtimes.

## Changelog
:cl: Kyep
fix: fixed a cause of weird runtime errors when objectives were announced to a mind with no body.
/:cl:
