### PR TITLE
Fixes runtime in cryopod.dm:310

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -302,6 +302,7 @@
 		// Eject dead people
 		if(occupant.stat == DEAD)
 			go_out()
+			return
 
 		// Allow a gap between entering the pod and actually despawning.
 		if(world.time - time_entered < time_till_despawn)


### PR DESCRIPTION
## What Does This PR Do
Fixes this runtime:
[2020-08-01T19:21:50] Runtime in cryopod.dm,310: Cannot read null.client
   proc name: process (/obj/machinery/cryopod/process)
   src: the cryogenic freezer (XXXXXX... (/obj/machinery/cryopod/right)
   src.loc: the floor (118,152,1) (/turf/simulated/floor/plasteel)
   call stack:
   the cryogenic freezer (Sergey ... (/obj/machinery/cryopod/right): process(2)
This runtime happens because cryopod calls process(), detects it has an occupant, but that the occupant is dead. So it calls go_out(). But it doesn't return(). Which of course means later on, when it checks whether !occupant.client.... occupant is null, and a runtime is thrown. This PR changes it so it aborts the process() early if its already ejected a dead occupant.

## Why It's Good For The Game
Less runtimes.

## Changelog
:cl: Kyep
fix: fixed a runtime error in cryopod.dm that can happen if the occupant is dead.
/:cl: