### PR TITLE
Fixes duct tape exploit

### DIFF
--- a/code/datums/components/ducttape.dm
+++ b/code/datums/components/ducttape.dm
@@ -54,7 +54,7 @@
 	if(target_turf != get_turf(I)) //Trying to stick it on a wall, don't move it to the actual wall or you can move the item through it. Instead set the pixels as appropriate
 		var/target_direction = get_dir(source_turf, target_turf)//The direction we clicked
 		// Snowflake diagonal handling
-		if(target_direction == NORTHEAST || target_direction == SOUTHEAST || target_direction == NORTHWEST || target_direction == SOUTHWEST)
+		if(target_direction in GLOB.diagonals)
 			to_chat(user, "<span class='warning'>You cant reach [target_turf].</span>")
 			return
 		if(target_direction & EAST)

--- a/code/datums/components/ducttape.dm
+++ b/code/datums/components/ducttape.dm
@@ -47,23 +47,30 @@
 		return
 	if(!isturf(target))
 		return
-	if(!user.unEquip(I))
-		return
 	var/turf/source_turf = get_turf(I)
 	var/turf/target_turf = target
-	var/list/clickparams = params2list(params)
-	var/x_offset = text2num(clickparams["icon-x"]) - 16
-	var/y_offset = text2num(clickparams["icon-y"]) - 16
+	var/x_offset
+	var/y_offset
 	if(target_turf != get_turf(I)) //Trying to stick it on a wall, don't move it to the actual wall or you can move the item through it. Instead set the pixels as appropriate
 		var/target_direction = get_dir(source_turf, target_turf)//The direction we clicked
+		// Snowflake diagonal handling
+		if(target_direction == NORTHEAST || target_direction == SOUTHEAST || target_direction == NORTHWEST || target_direction == SOUTHWEST)
+			to_chat(user, "<span class='warning'>You cant reach [target_turf].</span>")
+			return
 		if(target_direction & EAST)
-			x_offset += 32
+			x_offset = 16
+			y_offset = rand(-12, 12)
 		else if(target_direction & WEST)
-			x_offset -= 32
-		if(target_direction & NORTH)
-			y_offset += 32
+			x_offset = -16
+			y_offset = rand(-12, 12)
+		else if(target_direction & NORTH)
+			x_offset = rand(-12, 12)
+			y_offset = 16
 		else if(target_direction & SOUTH)
-			y_offset -= 32
+			x_offset = rand(-12, 12)
+			y_offset = -16
+	if(!user.unEquip(I))
+		return
 	to_chat(user, "<span class='notice'>You stick [I] to [target_turf].</span>")
 	I.pixel_x = x_offset
 	I.pixel_y = y_offset


### PR DESCRIPTION
## What Does This PR Do
Stops people being able to alt+click walls with duct tape to break the offset and have items 2 tiles away that cant be seen but still affect things such as slips. The walls now ignore mouse positions and just randomise one axis based on which side of the wall youre on. 
![image](https://user-images.githubusercontent.com/25063394/89124493-40e09400-d4cf-11ea-8895-27bb7001ab9d.png)

You also cant attach things to diagonals anymore since you could break the offsets and have the item on a diagonal to the wall, but be on the wall sprite, causing very weird behaviour thats hard to deal with

## Why It's Good For The Game
Exploits are bad

## Changelog
:cl: AffectedArc07
fix: You can no longer abuse duct tape to visually put items 4 tiles away
/:cl:
