### PR TITLE
Fix runtime when server trying to send chat message to bot that trying to ban proxy user.

### DIFF
--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -103,7 +103,8 @@ GLOBAL_PROTECT(banlist_savefile) // Obvious reasons
 
 	GLOB.banlist_savefile.cd = "/base"
 	if( GLOB.banlist_savefile.dir.Find("[ckey][computerid]") )
-		to_chat(usr, "<span class='danger'>Ban already exists.</span>")
+		if(usr)
+			to_chat(usr, "<span class='danger'>Ban already exists.</span>")
 		return 0
 	else
 		GLOB.banlist_savefile.dir.Add("[ckey][computerid]")

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -138,9 +138,9 @@ GLOBAL_PROTECT(banlist_savefile) // Obvious reasons
 		log_admin("Ban Expired: [key]")
 		message_admins("Ban Expired: [key]")
 	else
-		ban_unban_log_save("[key_name_admin(usr)] unbanned [key]")
-		log_admin("[key_name_admin(usr)] unbanned [key]")
-		message_admins("[key_name_admin(usr)] unbanned: [key]")
+		ban_unban_log_save("[usr ? key_name_admin(usr) : "Bot"] unbanned [key]")
+		log_admin("[usr ? key_name_admin(usr) : "Bot"] unbanned [key]")
+		message_admins("[usr ? key_name_admin(usr) : "Bot"] unbanned: [key]")
 		feedback_inc("ban_unban",1)
 		usr.client.holder.DB_ban_unban( ckey(key), BANTYPE_ANY_FULLBAN)
 	for(var/A in GLOB.banlist_savefile.dir)

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -138,9 +138,9 @@ GLOBAL_PROTECT(banlist_savefile) // Obvious reasons
 		log_admin("Ban Expired: [key]")
 		message_admins("Ban Expired: [key]")
 	else
-		ban_unban_log_save("[usr ? key_name_admin(usr) : "Bot"] unbanned [key]")
-		log_admin("[usr ? key_name_admin(usr) : "Bot"] unbanned [key]")
-		message_admins("[usr ? key_name_admin(usr) : "Bot"] unbanned: [key]")
+		ban_unban_log_save("[key_name_admin(usr)] unbanned [key]")
+		log_admin("[key_name_admin(usr)] unbanned [key]")
+		message_admins("[key_name_admin(usr)] unbanned: [key]")
 		feedback_inc("ban_unban",1)
 		usr.client.holder.DB_ban_unban( ckey(key), BANTYPE_ANY_FULLBAN)
 	for(var/A in GLOB.banlist_savefile.dir)

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -85,8 +85,8 @@
 		var/err = query_del_note.ErrorMsg()
 		log_game("SQL ERROR removing note from table. Error : \[[err]\]\n")
 		return
-	log_admin("[usr ? key_name(usr) : adminckey] has removed a note made by [adminckey] from [ckey]: [notetext]")
-	message_admins("[usr ? key_name_admin(usr) : adminckey] has removed a note made by [adminckey] from [ckey]:<br>[notetext]")
+	log_admin("[usr ? key_name(usr) : "Bot"] has removed a note made by [adminckey] from [ckey]: [notetext]")
+	message_admins("[usr ? key_name_admin(usr) : "Bot"] has removed a note made by [adminckey] from [ckey]:<br>[notetext]")
 	show_note(ckey)
 
 /proc/edit_note(note_id)
@@ -121,8 +121,8 @@
 			var/err = query_update_note.ErrorMsg()
 			log_game("SQL ERROR editing note. Error : \[[err]\]\n")
 			return
-		log_admin("[usr ? key_name(usr) : adminckey] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
-		message_admins("[usr ? key_name_admin(usr) : adminckey] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
+		log_admin("[usr ? key_name(usr) : "Bot"] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
+		message_admins("[usr ? key_name_admin(usr) : "Bot"] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
 		show_note(target_ckey)
 
 /proc/show_note(target_ckey, index, linkless = 0)

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -2,7 +2,8 @@
 	if(checkrights && !check_rights(R_ADMIN|R_MOD))
 		return
 	if(!GLOB.dbcon.IsConnected())
-		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
+		if(usr)
+			to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
 		return
 
 	if(!target_ckey)
@@ -19,7 +20,8 @@
 		log_game("SQL ERROR obtaining ckey from player table. Error : \[[err]\]\n")
 		return
 	if(!query_find_ckey.NextRow())
-		to_chat(usr, "<span class='redtext'>[target_ckey] has not been seen before, you can only add notes to known players.</span>")
+		if(usr)
+			to_chat(usr, "<span class='redtext'>[target_ckey] has not been seen before, you can only add notes to known players.</span>")
 		return
 
 	var/exp_data = query_find_ckey.item[2]
@@ -52,8 +54,8 @@
 		log_game("SQL ERROR adding new note to table. Error : \[[err]\]\n")
 		return
 	if(logged)
-		log_admin("[key_name(usr)] has added a note to [target_ckey]: [notetext]")
-		message_admins("[key_name_admin(usr)] has added a note to [target_ckey]:<br>[notetext]")
+		log_admin("[usr ? key_name(usr) : "Bot" ] has added a note to [target_ckey]: [notetext]")
+		message_admins("[usr ? key_name_admin(usr) : "Bot"] has added a note to [target_ckey]:<br>[notetext]")
 		show_note(target_ckey)
 
 /proc/remove_note(note_id)
@@ -63,7 +65,8 @@
 	var/notetext
 	var/adminckey
 	if(!GLOB.dbcon.IsConnected())
-		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
+		if(usr)
+			to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
 		return
 	if(!note_id)
 		return
@@ -82,15 +85,16 @@
 		var/err = query_del_note.ErrorMsg()
 		log_game("SQL ERROR removing note from table. Error : \[[err]\]\n")
 		return
-	log_admin("[key_name(usr)] has removed a note made by [adminckey] from [ckey]: [notetext]")
-	message_admins("[key_name_admin(usr)] has removed a note made by [adminckey] from [ckey]:<br>[notetext]")
+	log_admin("[usr ? key_name(usr) : "Bot" ] has removed a note made by [adminckey] from [ckey]: [notetext]")
+	message_admins("[usr ? key_name_admin(usr) : "Bot"] has removed a note made by [adminckey] from [ckey]:<br>[notetext]")
 	show_note(ckey)
 
 /proc/edit_note(note_id)
 	if(!check_rights(R_ADMIN|R_MOD))
 		return
 	if(!GLOB.dbcon.IsConnected())
-		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
+		if(usr)
+			to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
 		return
 	if(!note_id)
 		return
@@ -117,8 +121,8 @@
 			var/err = query_update_note.ErrorMsg()
 			log_game("SQL ERROR editing note. Error : \[[err]\]\n")
 			return
-		log_admin("[key_name(usr)] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
-		message_admins("[key_name_admin(usr)] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
+		log_admin("[usr ? key_name(usr) : "Bot" ] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
+		message_admins("[usr ? key_name_admin(usr) : "Bot"] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
 		show_note(target_ckey)
 
 /proc/show_note(target_ckey, index, linkless = 0)

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -54,8 +54,8 @@
 		log_game("SQL ERROR adding new note to table. Error : \[[err]\]\n")
 		return
 	if(logged)
-		log_admin("[usr ? key_name(usr) : "Bot" ] has added a note to [target_ckey]: [notetext]")
-		message_admins("[usr ? key_name_admin(usr) : "Bot"] has added a note to [target_ckey]:<br>[notetext]")
+		log_admin("[usr ? key_name(usr) : adminckey] has added a note to [target_ckey]: [notetext]")
+		message_admins("[usr ? key_name_admin(usr) : adminckey] has added a note to [target_ckey]:<br>[notetext]")
 		show_note(target_ckey)
 
 /proc/remove_note(note_id)
@@ -85,8 +85,8 @@
 		var/err = query_del_note.ErrorMsg()
 		log_game("SQL ERROR removing note from table. Error : \[[err]\]\n")
 		return
-	log_admin("[usr ? key_name(usr) : "Bot" ] has removed a note made by [adminckey] from [ckey]: [notetext]")
-	message_admins("[usr ? key_name_admin(usr) : "Bot"] has removed a note made by [adminckey] from [ckey]:<br>[notetext]")
+	log_admin("[usr ? key_name(usr) : adminckey] has removed a note made by [adminckey] from [ckey]: [notetext]")
+	message_admins("[usr ? key_name_admin(usr) : adminckey] has removed a note made by [adminckey] from [ckey]:<br>[notetext]")
 	show_note(ckey)
 
 /proc/edit_note(note_id)
@@ -121,8 +121,8 @@
 			var/err = query_update_note.ErrorMsg()
 			log_game("SQL ERROR editing note. Error : \[[err]\]\n")
 			return
-		log_admin("[usr ? key_name(usr) : "Bot" ] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
-		message_admins("[usr ? key_name_admin(usr) : "Bot"] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
+		log_admin("[usr ? key_name(usr) : adminckey] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
+		message_admins("[usr ? key_name_admin(usr) : adminckey] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[new_note]\"")
 		show_note(target_ckey)
 
 /proc/show_note(target_ckey, index, linkless = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtime in NewBan.dm when server trying to send chat message to bot that trying to ban proxy user.
```
[2020-08-02T15:45:12] ADMIN: zigamus connected from *** using ISP: *** with IP: (***) Proxy: (true)
[2020-08-02T15:45:12] WORLD: [2020-08-02T15:45:12] Runtime in ,: DEBUG: to_chat called with invalid message/target.
[2020-08-02T15:45:12] WORLD:   Message: '<span class='danger'>Ban already exists.</span>'
[2020-08-02T15:45:12] WORLD:   Target: ''
[2020-08-02T15:45:12] DEBUG: Runtime in ,: DEBUG: to_chat called with invalid message/target. <A HREF='?_src_=holder;viewruntime=[0x2100f51c]_485'>[view]</A>
[2020-08-02T15:45:12] ADMIN: SyndiCat has banned zigamus.
[2020-08-02T15:45:12] ADMIN: Reason: Your IP was detected as proxy. No proxy allowed on server.
[2020-08-02T15:45:12] ADMIN: This is a permanent ban.
[2020-08-02T15:45:12] ACCESS OUT: Zigamus/(Zigamus) - IP:*** - CID:*** - BYOND Logged Out
```
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less runtimes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: azizonkg
fix: fixed runtime when server trying to send chat message to bot that trying to ban proxy user.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
