### PR TITLE
Fix runtime in Hallucination.dm when target.client is null

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -159,6 +159,8 @@ Gunshots/explosions/opening doors/less rare audio (done)
 		next_expand = world.time + FAKE_FLOOD_EXPAND_TIME
 
 /obj/effect/hallucination/fake_flood/proc/Expand()
+	if(!target)
+		qdel(src)
 	for(var/turf/FT in flood_turfs)
 		for(var/dir in GLOB.cardinal)
 			var/turf/T = get_step(FT, dir)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -149,18 +149,18 @@ Gunshots/explosions/opening doors/less rare audio (done)
 /obj/effect/hallucination/fake_flood/process()
 	if(!target)
 		qdel(src)
+		return
 	if(next_expand <= world.time)
 		radius++
 		if(radius > FAKE_FLOOD_MAX_RADIUS)
 			qdel(src)
+			return
 		Expand()
 		if((get_turf(target) in flood_turfs) && !target.internal)
 			target.hallucinate("fake_alert", "too_much_tox")
 		next_expand = world.time + FAKE_FLOOD_EXPAND_TIME
 
 /obj/effect/hallucination/fake_flood/proc/Expand()
-	if(!target)
-		qdel(src)
 	for(var/turf/FT in flood_turfs)
 		for(var/dir in GLOB.cardinal)
 			var/turf/T = get_step(FT, dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtime in Hallucination.dm when target.client is null (left the game) and deletes object. 
```
[2020-08-02T16:25:00] WORLD: [2020-08-02T16:25:00] Runtime in Hallucination.dm,169: Cannot read null.client
[2020-08-02T16:25:00] WORLD:   proc name: Expand (/obj/effect/hallucination/fake_flood/proc/Expand)
[2020-08-02T16:25:00] WORLD:   src: the fake flood (/obj/effect/hallucination/fake_flood)
[2020-08-02T16:25:00] WORLD:   src.loc: null
[2020-08-02T16:25:00] WORLD:   call stack:
[2020-08-02T16:25:00] WORLD:   the fake flood (/obj/effect/hallucination/fake_flood): Expand()
[2020-08-02T16:25:00] WORLD:   the fake flood (/obj/effect/hallucination/fake_flood): process(20)
[2020-08-02T16:25:00] WORLD:   Objects (/datum/controller/subsystem/processing/obj): fire(0)
[2020-08-02T16:25:00] WORLD:   Objects (/datum/controller/subsystem/processing/obj): ignite(0)
[2020-08-02T16:25:00] WORLD:   Master (/datum/controller/master): RunQueue()
[2020-08-02T16:25:00] WORLD:   Master (/datum/controller/master): Loop()
[2020-08-02T16:25:00] WORLD:   Master (/datum/controller/master): StartProcessing(0)
```
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Possibly prevent invalid timer runtime.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: azizonkg
fix: fixed runtime in Hallucination.dm when target.client is left the game. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
