### PR TITLE
Fix runtime in wires.dm when holder is null

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(wireColours, list("red", "blue", "green", "black", "orange", "b
 	if(..())
 		return 1
 	var/mob/L = usr
-	if(holder && CanUse(L) && href_list["action"])
+	if(CanUse(L) && href_list["action"])
 		var/obj/item/I = L.get_active_hand()
 		var/colour = lowertext(href_list["wire"])
 		holder.add_hiddenprint(L)
@@ -194,7 +194,7 @@ GLOBAL_LIST_INIT(wireColours, list("red", "blue", "green", "black", "orange", "b
 	return 1
 
 /datum/wires/CanUseTopic(mob/user, datum/topic_state/state)
-	if(holder && !CanUse(user))
+	if(!holder || !CanUse(user))
 		return STATUS_CLOSE
 	return ..()
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(wireColours, list("red", "blue", "green", "black", "orange", "b
 	if(..())
 		return 1
 	var/mob/L = usr
-	if(CanUse(L) && href_list["action"])
+	if(holder && CanUse(L) && href_list["action"])
 		var/obj/item/I = L.get_active_hand()
 		var/colour = lowertext(href_list["wire"])
 		holder.add_hiddenprint(L)
@@ -194,7 +194,7 @@ GLOBAL_LIST_INIT(wireColours, list("red", "blue", "green", "black", "orange", "b
 	return 1
 
 /datum/wires/CanUseTopic(mob/user, datum/topic_state/state)
-	if(!CanUse(user))
+	if(holder && !CanUse(user))
 		return STATUS_CLOSE
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtime in wires.dm when holder is null because thing is destroyed and user try interact with still open ui panel.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less runtimes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: azizonkg
fix: fixed runtime in wires.dm when holder is null because thing is destroyed and user try interact with still open ui panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
