### PR TITLE
Fix cardinal direction for treadmills in brig

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -7998,7 +7998,7 @@
 /area/security/prisonlockers)
 "aoW" = (
 /obj/machinery/power/treadmill{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/treadmill_monitor{
 	id = "Cell 3";
@@ -15343,7 +15343,7 @@
 /area/security/lobby)
 "aAA" = (
 /obj/machinery/power/treadmill{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -16315,7 +16315,7 @@
 /area/security/prison/cell_block/A)
 "aCr" = (
 /obj/machinery/power/treadmill{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/treadmill_monitor{
 	id = "Cell 4";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes cardinal direction for treadmills in brig.
Fixes #13603.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Treadmills are no more useless.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: RV666
fix: fixed cardinal direction for treadmills in brig. Treadmills are no more useless.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
