### PR TITLE
Wormhole Jaunters can no longer teleport megafauna to station, unless emagged

### DIFF
--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -11,6 +11,7 @@
 	throw_range = 5
 	origin_tech = "bluespace=2"
 	slot_flags = SLOT_BELT
+	var/emagged = FALSE
 
 /obj/item/wormhole_jaunter/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user.name] activates the [name]!</span>")
@@ -43,6 +44,7 @@
 		return
 	var/chosen_beacon = pick(L)
 	var/obj/effect/portal/jaunt_tunnel/J = new(get_turf(src), get_turf(chosen_beacon), src, 100)
+	J.emagged = emagged
 	if(adjacent)
 		try_move_adjacent(J)
 	else
@@ -57,12 +59,26 @@
 	else
 		to_chat(user, "[src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>")
 
+/obj/item/wormhole_jaunter/emag_act(mob/user)
+	if(!emagged)
+		emagged = TRUE
+		to_chat(user, "<span class='notice'>You emag [src].</span>")
+		var/turf/T = get_turf(src)
+		do_sparks(5, 0, T)
+		playsound(T, "sparks", 50, 1)
+
 /obj/effect/portal/jaunt_tunnel
 	name = "jaunt tunnel"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "bhole3"
 	desc = "A stable hole in the universe made by a wormhole jaunter. Turbulent doesn't even begin to describe how rough passage through one of these is, but at least it will always get you somewhere near a beacon."
 	failchance = 0
+	var/emagged = FALSE
+
+/obj/effect/portal/jaunt_tunnel/can_teleport(atom/movable/M)
+	if(!emagged && ismegafauna(M))
+		return FALSE
+	return ..()
 
 /obj/effect/portal/jaunt_tunnel/teleport(atom/movable/M)
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Alters the "wormhole jaunter" item that shaft miners use.
By default, the portals it creates will no longer be able to teleport megafauna to the station.
If you emag the jaunter though, its portals will then be able to teleport megafauna.

## Why It's Good For The Game
Right now, hijack traitors can teleport megafauna onto the station, effectively weaponizing megafauna against the station, without having to pay a single TC to do so. This is overpowered. Especially when you consider that the station has no idea which of the miners is doing it, and realistically isn't going to be able to hunt them down in lavaland to stop them. Especially if they do it repeatedly and move half the megafauna of lavaland to the station.
If hijackers want to use megafauna as their own personal army, they should either have to pay some TC to enable this tactic (such as the 6 TC for an emag) or they should have to take some other substantial risk (like stealing the more powerful hand tele which doesn't need to be emagged to be capable of moving megafauna).

Regular non-antag miners shouldn't be able to teleport megafauna to the station at all. If a non-antag does it deliberately, its self-antagging - but its incredibly hard to prove they did it deliberately if they claim it was a mistake. Which they often do.
While dying is part of the game, shaft miners being able to accidentally wipe out half the station by teleporting a colossus, drake or bubblegum to the station with an ill-placed jaunt tunnel is not reasonable.

## Changelog
:cl: Kyep
balance: the wormhole jaunter is no longer able to send megafauna to the station, unless you emag it.
/:cl:
