### PR TITLE
Fix colored lips drawing over masks and random lipstick colouring

### DIFF
--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -55,16 +55,15 @@
 
 /obj/item/lipstick/random/Initialize(mapload)
 	. = ..()
-	var/lscolor = pick(lipstick_colors) // A random color is picked from the var defined initially in a new var.
-	colour = lipstick_colors[lscolor] // The color of the lipstick is pulled from the new variable (right hand side, HTML & Hex RGB)
-	name = "[lscolor] lipstick" // The new variable is also used to match the name to the color of the lipstick. Kudos to Desolate & Lemon
+	colour = pick(lipstick_colors)
+	name = "[colour] lipstick"
 
 /obj/item/lipstick/attack_self(mob/user)
 	cut_overlays()
 	to_chat(user, "<span class='notice'>You twist \the [src] [open ? "closed" : "open"].</span>")
 	open = !open
 	if(open)
-		var/image/colored = mutable_appearance('icons/obj/items.dmi', "lipstick_uncap_color")
+		var/mutable_appearance/colored = mutable_appearance('icons/obj/items.dmi', "lipstick_uncap_color")
 		colored.color = lipstick_colors[colour]
 		icon_state = "lipstick_uncap"
 		add_overlay(colored)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1465,12 +1465,13 @@
 	var/obj/item/organ/internal/eyes/eyes = get_int_organ(/obj/item/organ/internal/eyes)
 	var/obj/item/organ/internal/cyberimp/eyes/eye_implant = get_int_organ(/obj/item/organ/internal/cyberimp/eyes)
 	if(istype(dna.species) && dna.species.eyes)
-		var/icon/eyes_icon = new /icon('icons/mob/human_face.dmi', dna.species.eyes)
+		var/icon/eyes_icon
 		if(eye_implant) //Eye implants override native DNA eye colo(u)r
 			eyes_icon = eye_implant.generate_icon()
 		else if(eyes)
 			eyes_icon = eyes.generate_icon()
 		else //Error 404: Eyes not found!
+			eyes_icon = new('icons/mob/human_face.dmi', dna.species.eyes)
 			eyes_icon.Blend("#800000", ICON_ADD)
 
 		return eyes_icon

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -273,11 +273,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		overlays_standing[UNDERWEAR_LAYER] = mutable_appearance(underwear_standing, layer = -UNDERWEAR_LAYER)
 	apply_overlay(UNDERWEAR_LAYER)
 
-	if(lip_style && (LIPS in dna.species.species_traits))
-		var/mutable_appearance/lips = mutable_appearance('icons/mob/human_face.dmi', "lips_[lip_style]_s")
-		lips.color = lip_color
-		standing += lips
-
 	overlays_standing[BODY_LAYER] = standing
 	apply_overlay(BODY_LAYER)
 	//tail
@@ -1304,6 +1299,11 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	var/obj/item/organ/internal/eyes/eyes = get_int_organ(/obj/item/organ/internal/eyes)
 	if(eyes)
 		. += "[eyes.eye_colour]"
+	else
+		. += "#000000"
+
+	if(lip_color && (LIPS in dna.species.species_traits))
+		. += "[lip_color]"
 	else
 		. += "#000000"
 

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -107,7 +107,10 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 			add_overlay(eyes_icon)
 
 	if(owner.lip_style && (LIPS in dna.species.species_traits))
-		add_overlay(mutable_appearance('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")) //Hefty icon not necessary.
+		var/icon/lips_icon = new('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
+		lips_icon.Blend(owner.lip_color, ICON_MULTIPLY)
+		mob_icon.Blend(lips_icon, ICON_OVERLAY)
+		add_overlay(lips_icon)
 
 	var/head_marking = owner.m_styles["head"]
 	if(head_marking)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Context
PR #13911 fixed lipsticks not having a visual effect. As it turns out, they are being rendered in the wrong place (base body icon rather than the head organ) which resulted in two things:
- Them rendering over masks due to layering
- Them not showing up on detached heads when they should.

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Fixes the above issues by moving the lip rendering code to the same place as where eyes are rendered (in the head organ). _Fixes #13986_
- Opportunistically fixes eyes icon being created redundantly in `/mob/living/carbon/human/proc/get_eyecon()`
- Additionally, this PR integrates PR #14113: it fixes random lipsticks always appearing white because the RGB value (rather than the colour name) was being used in the `colour` variable.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- Lipsticks now render properly on both mob and detached head
- Lipsticks (hopefully) fixed for good
- Very minor performance/memory improvement when rendering human eyes.

## Changelog
:cl:
fix: Fix lipsticks rendering over masks
fix: Fix random lipstick colour always appearing white
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
