### PR TITLE
Hides the "Set transfer amount" verb on certain items like syringes

### DIFF
--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -33,6 +33,9 @@
 		deltimer(ant_timer)
 	return ..()
 
+/obj/item/reagent_containers/food/set_APTFT()
+	set hidden = TRUE
+
 /obj/item/reagent_containers/food/proc/check_for_ants()
 	if(!antable)
 		return

--- a/code/modules/hydroponics/beekeeping/honeycomb.dm
+++ b/code/modules/hydroponics/beekeeping/honeycomb.dm
@@ -17,6 +17,8 @@
 	pixel_y = rand(8,-8)
 	update_icon()
 
+/obj/item/reagent_containers/honeycomb/set_APTFT()
+	set hidden = TRUE
 
 /obj/item/reagent_containers/honeycomb/update_icon()
 	overlays.Cut()

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -22,6 +22,9 @@
 		ignore_flags = TRUE
 		to_chat(user, "<span class='warning'>You short out the safeties on [src].</span>")
 
+/obj/item/reagent_containers/applicator/set_APTFT()
+	set hidden = TRUE
+
 /obj/item/reagent_containers/applicator/on_reagent_change()
 	if(!emagged)
 		var/found_forbidden_reagent = FALSE

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -24,6 +24,9 @@
 		mode = SYRINGE_INJECT
 		update_icon()
 
+/obj/item/reagent_containers/syringe/set_APTFT()
+	set hidden = TRUE
+
 /obj/item/reagent_containers/syringe/on_reagent_change()
 	update_icon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Some objects, like syringes, have the "Set transfer amount" right click verb, but nothing is meant to happen when you click on it. This PR hides the verb on those objects, so there is no confusion as to why it's not working.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #12888
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Hides the "Set transfer amount" right click verb on syringes, auto-menders, honeycombs, and all food items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
