### PR TITLE
Fixes another potential infinite metal exploit

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -76,14 +76,14 @@
 		if(istype(W,/obj/item/stack/rods))
 			var/obj/item/stack/rods/S = W
 			if(state == GIRDER_DISPLACED)
-				if(S.get_amount() < 2)
-					to_chat(user, "<span class='warning'>You need at least two rods to create a false wall!</span>")
+				if(S.get_amount() < 5)
+					to_chat(user, "<span class='warning'>You need at least five rods to create a false wall!</span>")
 					return
 				to_chat(user, "<span class='notice'>You start building a reinforced false wall...</span>")
 				if(do_after(user, 20, target = src))
-					if(!loc || !S || S.get_amount() < 2)
+					if(!loc || !S || S.get_amount() < 5)
 						return
-					S.use(2)
+					S.use(5)
 					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
 					var/obj/structure/falsewall/iron/FW = new (loc)
 					transfer_fingerprints_to(FW)


### PR DESCRIPTION
## What Does This PR Do
Before you could turn a dislodged girder into a fake iron wall for 2 metal rods, use a screwdriver on it and then deconstruct it for 5 rods.

## Why It's Good For The Game
Exploits are bad.

## Changelog
:cl: CornMyCob
fix: Fixed a potential infinite metal exploit involving iron walls
/:cl: