### PR TITLE
Changes the projectile path to not be an item

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1752,7 +1752,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			/obj/item/organ/internal = "INT_ORG",
 			/obj/item/organ = "ORGAN",
 			/obj/item/pda = "PDA",
-			/obj/item/projectile = "PROJ",
+			/obj/projectile = "PROJ",
 			/obj/item/radio/headset = "HEADSET",
 			/obj/item/reagent_containers/glass/beaker = "BEAKER",
 			/obj/item/reagent_containers/glass/bottle = "BOTTLE",

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -389,7 +389,7 @@
 	var/turf/T = get_turf(src)
 	var/turf/U = get_turf(A)
 
-	var/obj/item/projectile/beam/LE = new /obj/item/projectile/beam(loc)
+	var/obj/projectile/beam/LE = new /obj/projectile/beam(loc)
 	LE.icon = 'icons/effects/genetics.dmi'
 	LE.icon_state = "eyelasers"
 	playsound(usr.loc, 'sound/weapons/taser2.ogg', 75, 1)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -63,8 +63,8 @@
 		var/obj/item/I = AM
 		if(I.flags & ABSTRACT)
 			return
-		else if(istype(AM, /obj/item/projectile))
-			var/obj/item/projectile/P = AM
+		else if(istype(AM, /obj/projectile))
+			var/obj/projectile/P = AM
 			if(P.original != parent)
 				return
 	var/atom/current_parent = parent

--- a/code/datums/spells/devil.dm
+++ b/code/datums/spells/devil.dm
@@ -71,7 +71,7 @@
 	clothes_req = FALSE
 	invocation = "Your very soul will catch fire!"
 	invocation_type = "shout"
-	fireball_type = /obj/item/projectile/magic/fireball/infernal
+	fireball_type = /obj/projectile/magic/fireball/infernal
 	action_background_icon_state = "bg_demon"
 
 /obj/effect/proc_holder/spell/fireball/hellish/cast(list/targets, mob/living/user = usr)

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -319,7 +319,7 @@
 	invocation_type = "shout"
 	range = 20
 	cooldown_min = 20 //10 deciseconds reduction per rank
-	var/fireball_type = /obj/item/projectile/magic/fireball
+	var/fireball_type = /obj/projectile/magic/fireball
 	action_icon_state = "fireball0"
 	sound = 'sound/magic/fireball.ogg'
 
@@ -370,7 +370,7 @@
 	if(!isturf(U) || !isturf(T))
 		return 0
 
-	var/obj/item/projectile/magic/fireball/FB = new fireball_type(user.loc)
+	var/obj/projectile/magic/fireball/FB = new fireball_type(user.loc)
 	FB.current = get_turf(user)
 	FB.preparePixelProjectile(target, get_turf(target), user)
 	FB.fire()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -263,7 +263,7 @@
 /atom/proc/emp_act(severity)
 	return
 
-/atom/proc/bullet_act(obj/item/projectile/P, def_zone)
+/atom/proc/bullet_act(obj/projectile/P, def_zone)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, P, def_zone)
 	. = P.on_hit(src, 0, def_zone)
 
@@ -831,7 +831,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 /atom/proc/ratvar_act()
 	return
 
-/atom/proc/handle_ricochet(obj/item/projectile/P)
+/atom/proc/handle_ricochet(obj/projectile/P)
 	return
 
 //This proc is called on the location of an atom when the atom is Destroy()'d

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -40,7 +40,7 @@
 	point_return = 9
 	flags_2 = CHECK_RICOCHET_2
 
-/obj/structure/blob/shield/reflective/handle_ricochet(obj/item/projectile/P)
+/obj/structure/blob/shield/reflective/handle_ricochet(obj/projectile/P)
 	var/turf/p_turf = get_turf(P)
 	var/face_direction = get_dir(src, p_turf)
 	var/face_angle = dir2angle(face_direction)

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -218,7 +218,7 @@
 /obj/item/ammo_casing/magic/tentacle
 	name = "tentacle"
 	desc = "a tentacle."
-	projectile_type = /obj/item/projectile/tentacle
+	projectile_type = /obj/projectile/tentacle
 	caliber = "tentacle"
 	icon_state = "tentacle_end"
 	var/obj/item/gun/magic/tentacle/gun //the item that shot it
@@ -231,7 +231,7 @@
 	gun = null
 	return ..()
 
-/obj/item/projectile/tentacle
+/obj/projectile/tentacle
 	name = "tentacle"
 	icon_state = "tentacle_end"
 	pass_flags = PASSTABLE
@@ -242,16 +242,16 @@
 	var/chain
 	var/obj/item/ammo_casing/magic/tentacle/source //the item that shot it
 
-/obj/item/projectile/tentacle/New(obj/item/ammo_casing/magic/tentacle/tentacle_casing)
+/obj/projectile/tentacle/New(obj/item/ammo_casing/magic/tentacle/tentacle_casing)
 	source = tentacle_casing
 	..()
 
-/obj/item/projectile/tentacle/fire(setAngle)
+/obj/projectile/tentacle/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "tentacle", time = INFINITY, maxdistance = INFINITY, beam_sleep_time = 1)
 	..()
 
-/obj/item/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)
+/obj/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)
 	if(H.in_throw_mode)
 		H.throw_mode_off() //Don't annoy the changeling if he doesn't catch the item
 
@@ -277,7 +277,7 @@
 		playsound(get_turf(src), I.hitsound, 75, 1)
 
 
-/obj/item/projectile/tentacle/on_hit(atom/target, blocked = 0)
+/obj/projectile/tentacle/on_hit(atom/target, blocked = 0)
 	qdel(source.gun) //one tentacle only unless you miss
 	if(blocked >= 100)
 		return 0
@@ -334,7 +334,7 @@
 				L.throw_at(get_step_towards(H,L), 8, 2)
 				. = 1
 
-/obj/item/projectile/tentacle/Destroy()
+/obj/projectile/tentacle/Destroy()
 	qdel(chain)
 	source = null
 	return ..()

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -347,7 +347,7 @@
 		var/turf/T = get_turf(turret)
 		if(is_station_level(T.z))
 			turret.health += 30
-			turret.eprojectile = /obj/item/projectile/beam/laser/heavylaser //Once you see it, you will know what it means to FEAR.
+			turret.eprojectile = /obj/projectile/beam/laser/heavylaser //Once you see it, you will know what it means to FEAR.
 			turret.eshot_sound = 'sound/weapons/lasercannonfire.ogg'
 
 //Hostile Station Lockdown: Locks, bolts, and electrifies every airlock on the station. After 90 seconds, the doors reset.

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -94,7 +94,7 @@
 	mob_size = MOB_SIZE_SMALL
 	ventcrawler = VENTCRAWLER_ALWAYS
 	ranged = 1
-	projectiletype = /obj/item/projectile/beam/disabler
+	projectiletype = /obj/projectile/beam/disabler
 	ranged_cooldown_time = 20
 	projectilesound = 'sound/weapons/taser2.ogg'
 	loot = list(/obj/effect/decal/cleanable/robot_debris, /obj/item/stack/ore/bluespace_crystal)
@@ -152,7 +152,7 @@
 		death()
 
 /mob/living/simple_animal/hostile/swarmer/CanPass(atom/movable/O)
-	if(istype(O, /obj/item/projectile/beam/disabler))//Allows for swarmers to fight as a group without wasting their shots hitting each other
+	if(istype(O, /obj/projectile/beam/disabler))//Allows for swarmers to fight as a group without wasting their shots hitting each other
 		return 1
 	if(isswarmer(O))
 		return 1
@@ -648,7 +648,7 @@
 /obj/structure/swarmer/blockade/CanPass(atom/movable/O)
 	if(isswarmer(O))
 		return 1
-	if(istype(O, /obj/item/projectile/beam/disabler))
+	if(istype(O, /obj/projectile/beam/disabler))
 		return 1
 
 /mob/living/simple_animal/hostile/swarmer/proc/CreateSwarmer()

--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/guardian
+/obj/projectile/guardian
 	name = "crystal spray"
 	icon_state = "guardian"
 	damage = 5
@@ -10,7 +10,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	damage_transfer = 0.9
-	projectiletype = /obj/item/projectile/guardian
+	projectiletype = /obj/projectile/guardian
 	ranged_cooldown_time = 1 //fast!
 	projectilesound = 'sound/effects/hit_on_shattered_glass.ogg'
 	ranged = 1

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -513,7 +513,7 @@
 /obj/structure/holohoop/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover,/obj/item) && mover.throwing)
 		var/obj/item/I = mover
-		if(istype(I, /obj/item/projectile))
+		if(istype(I, /obj/projectile))
 			return
 		if(prob(50))
 			I.loc = src.loc
@@ -525,7 +525,7 @@
 		return ..(mover, target, height)
 
 /obj/structure/holohoop/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if(isitem(AM) && !istype(AM,/obj/item/projectile))
+	if(isitem(AM) && !istype(AM,/obj/projectile))
 		if(prob(50))
 			AM.forceMove(get_turf(src))
 			visible_message("<span class='warning'>Swish! [AM] lands in [src].</span>")

--- a/code/game/machinery/computer/salvage_ship.dm
+++ b/code/game/machinery/computer/salvage_ship.dm
@@ -105,5 +105,5 @@
 	updateUsrDialog()
 	return
 
-/obj/machinery/computer/salvage_ship/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/computer/salvage_ship/bullet_act(var/obj/projectile/Proj)
 	visible_message("[Proj] ricochets off [src]!")

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -49,10 +49,10 @@
 /obj/structure/barricade/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
 	if(locate(/obj/structure/barricade) in get_turf(mover))
 		return TRUE
-	else if(istype(mover, /obj/item/projectile))
+	else if(istype(mover, /obj/projectile))
 		if(!anchored)
 			return TRUE
-		var/obj/item/projectile/proj = mover
+		var/obj/projectile/proj = mover
 		if(proj.firer && Adjacent(proj.firer))
 			return TRUE
 		if(prob(proj_pass_rate))

--- a/code/game/machinery/portable_tag_turret.dm
+++ b/code/game/machinery/portable_tag_turret.dm
@@ -77,16 +77,16 @@
 		else
 			icon_state = "[lasercolor]grey_target_prism"
 
-/obj/machinery/porta_turret/tag/bullet_act(obj/item/projectile/P)
+/obj/machinery/porta_turret/tag/bullet_act(obj/projectile/P)
 	..()
 	if(!disabled)
 		if(lasercolor == "b")
-			if(istype(P, /obj/item/projectile/beam/lasertag/redtag))
+			if(istype(P, /obj/projectile/beam/lasertag/redtag))
 				disabled  = TRUE
 				spawn(100)
 					disabled  = FALSE
 		else if(lasercolor == "r")
-			if(istype(P, /obj/item/projectile/beam/lasertag/bluetag))
+			if(istype(P, /obj/projectile/beam/lasertag/bluetag))
 				disabled  = TRUE
 				spawn(100)
 					disabled  = FALSE

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -127,7 +127,7 @@
 	switch(guntype)
 		if(/obj/item/gun/energy/laser/practice)
 			iconholder = 1
-			eprojectile = /obj/item/projectile/beam
+			eprojectile = /obj/projectile/beam
 
 		if(/obj/item/gun/energy/laser/retro)
 			iconholder = 1
@@ -139,26 +139,26 @@
 			iconholder = 1
 
 		if(/obj/item/gun/energy/taser)
-			eprojectile = /obj/item/projectile/beam
+			eprojectile = /obj/projectile/beam
 			eshot_sound = 'sound/weapons/laser.ogg'
 
 		if(/obj/item/gun/energy/gun)
-			eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode
+			eprojectile = /obj/projectile/beam	//If it has, going to kill mode
 			eshot_sound = 'sound/weapons/laser.ogg'
 			egun = 1
 
 		if(/obj/item/gun/energy/gun/nuclear)
-			eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode
+			eprojectile = /obj/projectile/beam	//If it has, going to kill mode
 			eshot_sound = 'sound/weapons/laser.ogg'
 			egun = 1
 
 		if(/obj/item/gun/energy/gun/turret)
-			eprojectile = /obj/item/projectile/beam	//If it has, going to copypaste mode
+			eprojectile = /obj/projectile/beam	//If it has, going to copypaste mode
 			eshot_sound = 'sound/weapons/laser.ogg'
 			egun = 1
 
 		if(/obj/item/gun/energy/pulse/turret)
-			eprojectile = /obj/item/projectile/beam/pulse
+			eprojectile = /obj/projectile/beam/pulse
 			eshot_sound = 'sound/weapons/pulse.ogg'
 
 GLOBAL_LIST_EMPTY(turret_icons)
@@ -464,7 +464,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	if(health <= 0)
 		die()	//the death process :(
 
-/obj/machinery/porta_turret/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/porta_turret/bullet_act(obj/projectile/Proj)
 	if(Proj.damage_type == STAMINA)
 		return
 
@@ -715,7 +715,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		return
 
 	update_icon()
-	var/obj/item/projectile/A
+	var/obj/projectile/A
 	if(emagged || lethal)
 		if(eprojectile)
 			A = new eprojectile(loc)
@@ -967,8 +967,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 
 // Syndicate turrets
 /obj/machinery/porta_turret/syndicate
-	projectile = /obj/item/projectile/bullet
-	eprojectile = /obj/item/projectile/bullet
+	projectile = /obj/projectile/bullet
+	eprojectile = /obj/projectile/bullet
 	// Syndicate turrets *always* operate in lethal mode.
 	// So, nothing, not even emagging them, makes them switch bullet type.
 	// So, its best to always have their projectile and eprojectile settings be the same. That way, you know what they will shoot.
@@ -1036,30 +1036,30 @@ GLOBAL_LIST_EMPTY(turret_icons)
 
 /obj/machinery/porta_turret/syndicate/pod
 	health = 40
-	projectile = /obj/item/projectile/bullet/weakbullet3
-	eprojectile = /obj/item/projectile/bullet/weakbullet3
+	projectile = /obj/projectile/bullet/weakbullet3
+	eprojectile = /obj/projectile/bullet/weakbullet3
 
 /obj/machinery/porta_turret/syndicate/interior
 	name = "machine gun turret (.45)"
 	desc = "Syndicate interior defense turret chambered for .45 rounds. Designed to down intruders without damaging the hull."
-	projectile = /obj/item/projectile/bullet/midbullet
-	eprojectile = /obj/item/projectile/bullet/midbullet
+	projectile = /obj/projectile/bullet/midbullet
+	eprojectile = /obj/projectile/bullet/midbullet
 
 /obj/machinery/porta_turret/syndicate/exterior
 	name = "machine gun turret (7.62)"
 	desc = "Syndicate exterior defense turret chambered for 7.62 rounds. Designed to down intruders with heavy calliber bullets."
-	projectile = /obj/item/projectile/bullet
-	eprojectile = /obj/item/projectile/bullet
+	projectile = /obj/projectile/bullet
+	eprojectile = /obj/projectile/bullet
 
 /obj/machinery/porta_turret/syndicate/grenade
 	name = "mounted grenade launcher (40mm)"
 	desc = "Syndicate 40mm grenade launcher defense turret. If you've had this much time to look at it, you're probably already dead."
-	projectile = /obj/item/projectile/bullet/a40mm
-	eprojectile = /obj/item/projectile/bullet/a40mm
+	projectile = /obj/projectile/bullet/a40mm
+	eprojectile = /obj/projectile/bullet/a40mm
 
 /obj/machinery/porta_turret/syndicate/assault_pod
 	name = "machine gun turret (4.6x30mm)"
 	desc = "Syndicate exterior defense turret chambered for 4.6x30mm rounds. Designed to be fitted to assault pods, it uses low calliber bullets to save space."
 	health = 100
-	projectile = /obj/item/projectile/bullet/weakbullet3
-	eprojectile = /obj/item/projectile/bullet/weakbullet3
+	projectile = /obj/projectile/bullet/weakbullet3
+	eprojectile = /obj/projectile/bullet/weakbullet3

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -61,7 +61,7 @@
 
 	..()
 
-/obj/machinery/shield/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/shield/bullet_act(obj/projectile/Proj)
 	health -= Proj.damage
 	..()
 	if(health <=0)
@@ -515,7 +515,7 @@
 	cleanup(8)
 	return ..()
 
-/obj/machinery/shieldwallgen/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/shieldwallgen/bullet_act(obj/projectile/Proj)
 	storedpower -= Proj.damage
 	..()
 	return
@@ -568,7 +568,7 @@
 			gen_secondary.storedpower -=10
 
 
-/obj/machinery/shieldwall/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/shieldwall/bullet_act(obj/projectile/Proj)
 	if(needs_power)
 		var/obj/machinery/shieldwallgen/G
 		if(prob(50))
@@ -614,7 +614,7 @@
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return prob(20)
 	else
-		if(istype(mover, /obj/item/projectile))
+		if(istype(mover, /obj/projectile))
 			return prob(10)
 		else
 			return !density
@@ -630,7 +630,7 @@
 		var/mob/living/M = mover
 		if("syndicate" in M.faction)
 			return 1
-	if(istype(mover, /obj/item/projectile))
+	if(istype(mover, /obj/projectile))
 		return 0
 	return ..(mover, target, height)
 
@@ -657,7 +657,7 @@
 	phaseout()
 	return ..()
 
-/obj/machinery/shieldwall/syndicate/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/shieldwall/syndicate/bullet_act(obj/projectile/Proj)
 	phaseout()
 	return ..()
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -38,7 +38,7 @@
 
 	set_ready_state(0)
 	for(var/i=1 to get_shot_amount())
-		var/obj/item/projectile/A = new projectile(curloc)
+		var/obj/projectile/A = new projectile(curloc)
 		A.firer = chassis.occupant
 		A.original = target
 		A.current = curloc
@@ -75,14 +75,14 @@
 	icon_state = "mecha_laser"
 	origin_tech = "magnets=3;combat=3;engineering=3"
 	energy_drain = 30
-	projectile = /obj/item/projectile/beam
+	projectile = /obj/projectile/beam
 	fire_sound = 'sound/weapons/laser.ogg'
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/disabler
 	name = "CH-PD Disabler"
 	origin_tech = "combat=3"
-	projectile = /obj/item/projectile/beam/disabler
+	projectile = /obj/projectile/beam/disabler
 	projectiles_per_shot = 2
 	projectile_delay = 1
 	harmful = FALSE
@@ -93,7 +93,7 @@
 	icon_state = "mecha_laser"
 	origin_tech = "magnets=4;combat=4;engineering=3"
 	energy_drain = 60
-	projectile = /obj/item/projectile/beam/laser/heavylaser
+	projectile = /obj/projectile/beam/laser/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
@@ -102,7 +102,7 @@
 	icon_state = "mecha_ion"
 	origin_tech = "materials=4;combat=5;magnets=4"
 	energy_drain = 120
-	projectile = /obj/item/projectile/ion
+	projectile = /obj/projectile/ion
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla
@@ -112,7 +112,7 @@
 	icon_state = "mecha_laser"
 	origin_tech = "materials=4;engineering=4;combat=6;magnets=6"
 	energy_drain = 500
-	projectile = /obj/item/projectile/energy/shock_revolver
+	projectile = /obj/projectile/energy/shock_revolver
 	fire_sound = 'sound/magic/lightningbolt.ogg'
 	harmful = TRUE
 
@@ -123,7 +123,7 @@
 	icon_state = "mecha_laser"
 	origin_tech = "materials=3;combat=5;magnets=2;syndicate=2"
 	energy_drain = 80
-	projectile = /obj/item/projectile/beam/xray
+	projectile = /obj/projectile/beam/xray
 	fire_sound = 'sound/weapons/laser3.ogg'
 	harmful = TRUE
 
@@ -139,7 +139,7 @@
 	icon_state = "mecha_laser"
 	origin_tech = "materials=4;engineering=4;combat=6;magnets=6"
 	energy_drain = 80
-	projectile = /obj/item/projectile/beam/immolator
+	projectile = /obj/projectile/beam/immolator
 	fire_sound = 'sound/weapons/laser3.ogg'
 	harmful = TRUE
 
@@ -149,17 +149,17 @@
 	icon_state = "mecha_pulse"
 	energy_drain = 120
 	origin_tech = "materials=3;combat=6;powerstorage=4"
-	projectile = /obj/item/projectile/beam/pulse/heavy
+	projectile = /obj/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
 	harmful = TRUE
 
 
-/obj/item/projectile/beam/pulse/heavy
+/obj/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"
 	icon_state = "pulse1_bl"
 	var/life = 20
 
-/obj/item/projectile/beam/pulse/heavy/Bump(atom/A)
+/obj/projectile/beam/pulse/heavy/Bump(atom/A)
 	A.bullet_act(src, def_zone)
 	life -= 10
 	if(ismob(A))
@@ -179,7 +179,7 @@
 	origin_tech = "combat=3"
 	energy_drain = 20
 	equip_cooldown = 8
-	projectile = /obj/item/projectile/energy/electrode
+	projectile = /obj/projectile/energy/electrode
 	fire_sound = 'sound/weapons/taser.ogg'
 	size = 1
 
@@ -278,7 +278,7 @@
 	icon_state = "mecha_carbine"
 	origin_tech = "materials=4;combat=4"
 	equip_cooldown = 5
-	projectile = /obj/item/projectile/bullet/incendiary/shell/dragonsbreath
+	projectile = /obj/projectile/bullet/incendiary/shell/dragonsbreath
 	fire_sound = 'sound/weapons/gunshots/gunshot_rifle.ogg'
 	projectiles = 24
 	projectile_energy_cost = 15
@@ -289,7 +289,7 @@
 	fire_sound = 'sound/weapons/gunshots/gunshot_silenced.ogg'
 	icon_state = "mecha_mime"
 	equip_cooldown = 15
-	projectile = /obj/item/projectile/bullet/mime
+	projectile = /obj/projectile/bullet/mime
 	projectiles = 20
 	projectile_energy_cost = 50
 
@@ -304,7 +304,7 @@
 	icon_state = "mecha_scatter"
 	origin_tech = "combat=4"
 	equip_cooldown = 20
-	projectile = /obj/item/projectile/bullet/midbullet
+	projectile = /obj/projectile/bullet/midbullet
 	fire_sound = 'sound/weapons/gunshots/gunshot_shotgun.ogg'
 	projectiles = 40
 	projectile_energy_cost = 25
@@ -317,7 +317,7 @@
 	icon_state = "mecha_uac2"
 	origin_tech = "combat=4"
 	equip_cooldown = 10
-	projectile = /obj/item/projectile/bullet/weakbullet3
+	projectile = /obj/projectile/bullet/weakbullet3
 	fire_sound = 'sound/weapons/gunshots/gunshot_mg.ogg'
 	projectiles = 300
 	projectile_energy_cost = 20
@@ -527,7 +527,7 @@
 	righthand_file = 'icons/mob/inhands/guns_righthand.dmi'
 	energy_drain = 30
 	origin_tech = "materials=3;plasmatech=4;engineering=3"
-	projectile = /obj/item/projectile/plasma/adv/mech
+	projectile = /obj/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/laser.ogg'
 	harmful = TRUE
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -592,7 +592,7 @@
 		add_attack_logs(I.thrownby, OCCUPANT_LOGGING, "threw [AM] at mech [src]")
 	. = ..()
 
-/obj/mecha/bullet_act(obj/item/projectile/Proj) //wrapper
+/obj/mecha/bullet_act(obj/projectile/Proj) //wrapper
 	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).")
 	add_attack_logs(Proj.firer, OCCUPANT_LOGGING, "shot [Proj.name]([Proj.flag]) at mech [src]")
 	..()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -339,8 +339,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 /obj/effect/effect/bad_smoke/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0) return 1
-	if(istype(mover, /obj/item/projectile/beam))
-		var/obj/item/projectile/beam/B = mover
+	if(istype(mover, /obj/projectile/beam))
+		var/obj/projectile/beam/B = mover
 		B.damage = (B.damage/2)
 	return 1
 

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -127,8 +127,8 @@
 /obj/effect/particle_effect/smoke/bad/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0)
 		return 1
-	if(istype(mover, /obj/item/projectile/beam))
-		var/obj/item/projectile/beam/B = mover
+	if(istype(mover, /obj/projectile/beam))
+		var/obj/projectile/beam/B = mover
 		B.damage = (B.damage/2)
 	return 1
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -48,7 +48,7 @@
 		if(prob(50))
 			to_chat(mover, "<span class='danger'>You get stuck in [src] for a moment.</span>")
 			return FALSE
-	else if(istype(mover, /obj/item/projectile))
+	else if(istype(mover, /obj/projectile))
 		return prob(30)
 	return TRUE
 

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -62,7 +62,7 @@
 		if(prob(I.force))
 			push_over()
 
-/obj/item/cardboard_cutout/bullet_act(obj/item/projectile/P)
+/obj/item/cardboard_cutout/bullet_act(obj/projectile/P)
 	visible_message("<span class='danger'>[src] is hit by [P]!</span>")
 	playsound(src, 'sound/weapons/slice.ogg', 50, 1)
 	if(prob(P.damage))

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -46,7 +46,7 @@
 			if (prob(50))
 				qdel(src)
 
-/obj/item/latexballon/bullet_act(obj/item/projectile/P)
+/obj/item/latexballon/bullet_act(obj/projectile/P)
 	if(!P.nodamage)
 		burst()
 	return ..()

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -79,11 +79,11 @@
 #define DECALTYPE_SCORCH 1
 #define DECALTYPE_BULLET 2
 
-/obj/item/target/bullet_act(obj/item/projectile/P)
+/obj/item/target/bullet_act(obj/projectile/P)
 	var/p_x = P.p_x + pick(0,0,0,0,0,-1,1) // really ugly way of coding "sometimes offset P.p_x!"
 	var/p_y = P.p_y + pick(0,0,0,0,0,-1,1)
 	var/decaltype = DECALTYPE_SCORCH
-	if(istype(P, /obj/item/projectile/bullet))
+	if(istype(P, /obj/projectile/bullet))
 		decaltype = DECALTYPE_BULLET
 
 	var/icon/C = icon(icon, icon_state)
@@ -97,7 +97,7 @@
 		bullet_hole.pixel_x = p_x - 1 //offset correction
 		bullet_hole.pixel_y = p_y - 1
 		if(decaltype == DECALTYPE_SCORCH)
-			if(P.damage >= 20 || istype(P, /obj/item/projectile/beam/practice))
+			if(P.damage >= 20 || istype(P, /obj/projectile/beam/practice))
 				bullet_hole.setDir(pick(NORTH,SOUTH,EAST,WEST))// random scorch design. light_scorch does not have different directions
 			else
 				bullet_hole.icon_state = "light_scorch"

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -118,7 +118,7 @@
 		TED.pass_mind(M)
 
 
-/obj/item/projectile/energy/chrono_beam
+/obj/projectile/energy/chrono_beam
 	name = "eradication beam"
 	icon_state = "chronobolt"
 	range = CHRONO_BEAM_RANGE
@@ -126,21 +126,21 @@
 	nodamage = 1
 	var/obj/item/gun/energy/chrono_gun/gun = null
 
-/obj/item/projectile/energy/chrono_beam/fire()
+/obj/projectile/energy/chrono_beam/fire()
 	gun = firer.get_active_hand()
 	if(istype(gun))
 		return ..()
 	else
 		return 0
 
-/obj/item/projectile/energy/chrono_beam/on_hit(atom/target)
+/obj/projectile/energy/chrono_beam/on_hit(atom/target)
 	if(target && gun && isliving(target))
 		var/obj/structure/chrono_field/F = new(target.loc, target, gun)
 		gun.field_connect(F)
 
 /obj/item/ammo_casing/energy/chrono_beam
 	name = "eradication beam"
-	projectile_type = /obj/item/projectile/energy/chrono_beam
+	projectile_type = /obj/projectile/energy/chrono_beam
 	icon_state = "chronobolt"
 	e_cost = 0
 
@@ -228,9 +228,9 @@
 		qdel(src)
 
 
-/obj/structure/chrono_field/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy/chrono_beam))
-		var/obj/item/projectile/energy/chrono_beam/beam = P
+/obj/structure/chrono_field/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/energy/chrono_beam))
+		var/obj/projectile/energy/chrono_beam/beam = P
 		var/obj/item/gun/energy/chrono_gun/Pgun = beam.gun
 		if(Pgun && istype(Pgun))
 			Pgun.field_connect(src)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -237,7 +237,7 @@
 	create_with_tank = TRUE
 
 /obj/item/flamethrower/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/obj/item/projectile/P = hitby
+	var/obj/projectile/P = hitby
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(15))
 		owner.visible_message("<span class='danger'>[attack_text] hits the fueltank on [owner]'s [src], rupturing it! What a shot!</span>")
 		var/turf/target_turf = get_turf(owner)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -115,7 +115,7 @@
 				prime()
 
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/obj/item/projectile/P = hitby
+	var/obj/projectile/P = hitby
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(15))
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -61,7 +61,7 @@
 		if(3)
 			take_damage(rand(10, 90), BRUTE, "bomb", 0)
 
-/obj/bullet_act(obj/item/projectile/P)
+/obj/bullet_act(obj/projectile/P)
 	. = ..()
 	playsound(src, P.hitsound, 50, TRUE)
 	visible_message("<span class='danger'>[src] is hit by \a [P]!</span>")

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -367,7 +367,7 @@
 	if(istype(mover) && mover.checkpass(PASSGRILLE))
 		return prob(girderpasschance)
 	else
-		if(istype(mover, /obj/item/projectile))
+		if(istype(mover, /obj/projectile))
 			return prob(girderpasschance)
 		else
 			return 0

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -104,7 +104,7 @@
 	if(istype(mover) && mover.checkpass(PASSGRILLE))
 		return 1
 	else
-		if(istype(mover, /obj/item/projectile))
+		if(istype(mover, /obj/projectile))
 			return prob(30)
 		else
 			return !density

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -92,11 +92,11 @@
 	max_integrity = 10
 	allow_walk = FALSE
 
-/obj/structure/holosign/barrier/cyborg/bullet_act(obj/item/projectile/P)
+/obj/structure/holosign/barrier/cyborg/bullet_act(obj/projectile/P)
 	take_damage((P.damage / 5) , BRUTE, "melee", 1)	//Doesn't really matter what damage flag it is.
-	if(istype(P, /obj/item/projectile/energy/electrode))
+	if(istype(P, /obj/projectile/energy/electrode))
 		take_damage(10, BRUTE, "melee", 1)	//Tasers aren't harmful.
-	if(istype(P, /obj/item/projectile/beam/disabler))
+	if(istype(P, /obj/projectile/beam/disabler))
 		take_damage(5, BRUTE, "melee", 1)	//Disablers aren't harmful.
 
 /obj/structure/holosign/barrier/cyborg/hacked
@@ -105,7 +105,7 @@
 	max_integrity = 20
 	var/shockcd = 0
 
-/obj/structure/holosign/barrier/cyborg/hacked/bullet_act(obj/item/projectile/P)
+/obj/structure/holosign/barrier/cyborg/hacked/bullet_act(obj/projectile/P)
 	take_damage(P.damage, BRUTE, "melee", 1)	//Yeah no this doesn't get projectile resistance.
 
 /obj/structure/holosign/barrier/cyborg/hacked/proc/cooldown()

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -9,10 +9,10 @@
 	var/finished = 0
 
 
-/obj/structure/reflector/bullet_act(obj/item/projectile/P)
+/obj/structure/reflector/bullet_act(obj/projectile/P)
 	var/turf/reflector_turf = get_turf(src)
 	var/turf/reflect_turf
-	if(!istype(P, /obj/item/projectile/beam))
+	if(!istype(P, /obj/projectile/beam))
 		return ..()
 	var/new_dir = get_reflection(dir, P.dir)
 	if(new_dir)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -115,7 +115,7 @@
 	if(exposed_temperature > 300)
 		PlasmaBurn(exposed_temperature)
 
-/obj/structure/statue/plasma/bullet_act(obj/item/projectile/P)
+/obj/structure/statue/plasma/bullet_act(obj/projectile/P)
 	if(!QDELETED(src)) //wasn't deleted by the projectile's effects.
 		if(!P.nodamage && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))
 			if(P.firer)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -107,7 +107,7 @@
 /obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height == 0)
 		return 1
-	if(istype(mover,/obj/item/projectile))
+	if(istype(mover,/obj/projectile))
 		return (check_cover(mover,target))
 	if(ismob(mover))
 		var/mob/M = mover
@@ -133,7 +133,7 @@
 		. = . || mover.checkpass(PASSTABLE)
 
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
-/obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
+/obj/structure/table/proc/check_cover(obj/projectile/P, turf/from)
 	var/turf/cover = flipped ? get_turf(src) : get_step(loc, get_dir(from, loc))
 	if(get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return 1

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -13,7 +13,7 @@
 		/obj/docking_port,
 		/obj/structure/lattice,
 		/obj/structure/stone_tile,
-		/obj/item/projectile,
+		/obj/projectile,
 		/obj/effect/portal,
 		/obj/effect/hotspot,
 		/obj/effect/landmark,

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -123,7 +123,7 @@
 	if(radiated_temperature > max_temperature)
 		take_damage(rand(10, 20) * (radiated_temperature / max_temperature))
 
-/turf/simulated/wall/handle_ricochet(obj/item/projectile/P)			//A huge pile of shitcode!
+/turf/simulated/wall/handle_ricochet(obj/projectile/P)			//A huge pile of shitcode!
 	var/turf/p_turf = get_turf(P)
 	var/face_direction = get_dir(src, p_turf)
 	var/face_angle = dir2angle(face_direction)

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -125,12 +125,12 @@
 	if(exposed_temperature > 300)
 		PlasmaBurn(exposed_temperature)
 
-/turf/simulated/wall/mineral/plasma/bullet_act(var/obj/item/projectile/Proj)
+/turf/simulated/wall/mineral/plasma/bullet_act(var/obj/projectile/Proj)
 	if(Proj.damage == 0)//lasertag guns and so on don't set off plasma anymore. can't use nodamage here because lasertag guns actually don't have it.
 		return
-	if(istype(Proj,/obj/item/projectile/beam))
+	if(istype(Proj,/obj/projectile/beam))
 		PlasmaBurn(2500)
-	else if(istype(Proj,/obj/item/projectile/ion))
+	else if(istype(Proj,/obj/projectile/ion))
 		PlasmaBurn(500)
 	..()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -113,14 +113,14 @@
 	else if(our_rpd.mode == RPD_DELETE_MODE)
 		our_rpd.delete_all_pipes(user, src)
 
-/turf/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj, /obj/item/projectile/beam/pulse))
+/turf/bullet_act(obj/projectile/Proj)
+	if(istype(Proj, /obj/projectile/beam/pulse))
 		src.ex_act(2)
 	..()
 	return FALSE
 
-/turf/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj, /obj/item/projectile/bullet/gyro))
+/turf/bullet_act(obj/projectile/Proj)
+	if(istype(Proj, /obj/projectile/bullet/gyro))
 		explosion(src, -1, 0, 2)
 	..()
 	return FALSE

--- a/code/modules/awaymissions/mission_code/ruins/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ruins/oldstation.dm
@@ -84,7 +84,7 @@
 	ammo_x_offset = 3
 
 /obj/item/ammo_casing/energy/lasergun/old
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	e_cost = 200
 	select_name = "kill"
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -128,12 +128,12 @@
 	update_icon()
 
 
-/obj/machinery/hydroponics/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
+/obj/machinery/hydroponics/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(!myseed)
 		return ..()
-	if(istype(Proj ,/obj/item/projectile/energy/floramut))
+	if(istype(Proj ,/obj/projectile/energy/floramut))
 		mutate()
-	else if(istype(Proj ,/obj/item/projectile/energy/florayield))
+	else if(istype(Proj ,/obj/projectile/energy/florayield))
 		return myseed.bullet_act(Proj)
 	else
 		return ..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -111,8 +111,8 @@
 
 
 
-/obj/item/seeds/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
-	if(istype(Proj, /obj/item/projectile/energy/florayield))
+/obj/item/seeds/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
+	if(istype(Proj, /obj/projectile/energy/florayield))
 		var/rating = 1
 		if(istype(loc, /obj/machinery/hydroponics))
 			var/obj/machinery/hydroponics/H = loc

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -84,7 +84,7 @@
 		var/turf/proj_turf = user.loc
 		if(!isturf(proj_turf))
 			return
-		var/obj/item/projectile/destabilizer/D = new /obj/item/projectile/destabilizer(proj_turf)
+		var/obj/projectile/destabilizer/D = new /obj/projectile/destabilizer(proj_turf)
 		for(var/t in trophies)
 			var/obj/item/crusher_trophy/T = t
 			T.on_projectile_fire(D, user)
@@ -157,7 +157,7 @@
 	item_state = "crusher[wielded]"
 
 //destablizing force
-/obj/item/projectile/destabilizer
+/obj/projectile/destabilizer
 	name = "destabilizing force"
 	icon_state = "pulse1"
 	nodamage = TRUE
@@ -168,11 +168,11 @@
 	log_override = TRUE
 	var/obj/item/twohanded/kinetic_crusher/hammer_synced
 
-/obj/item/projectile/destabilizer/Destroy()
+/obj/projectile/destabilizer/Destroy()
 	hammer_synced = null
 	return ..()
 
-/obj/item/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/mob/living/L = target
 		var/had_effect = (L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)) //used as a boolean
@@ -230,7 +230,7 @@
 
 /obj/item/crusher_trophy/proc/on_melee_hit(mob/living/target, mob/living/user) //the target and the user
 
-/obj/item/crusher_trophy/proc/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user) //the projectile fired and the user
+/obj/item/crusher_trophy/proc/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user) //the projectile fired and the user
 
 /obj/item/crusher_trophy/proc/on_mark_application(mob/living/target, datum/status_effect/crusher_mark/mark, had_mark) //the target, the mark applied, and if the target had a mark before
 
@@ -287,7 +287,7 @@
 /obj/item/crusher_trophy/blaster_tubes/magma_wing/effect_desc()
 	return "mark detonation to make the next destabilizer shot deal <b>[bonus_value]</b> damage"
 
-/obj/item/crusher_trophy/blaster_tubes/magma_wing/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user)
+/obj/item/crusher_trophy/blaster_tubes/magma_wing/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user)
 	if(deadly_shot)
 		marker.name = "heated [marker.name]"
 		marker.icon_state = "lava"
@@ -406,7 +406,7 @@
 /obj/item/crusher_trophy/blaster_tubes/effect_desc()
 	return "mark detonation to make the next destabilizer shot deal <b>[bonus_value]</b> damage but move slower"
 
-/obj/item/crusher_trophy/blaster_tubes/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user)
+/obj/item/crusher_trophy/blaster_tubes/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user)
 	if(deadly_shot)
 		marker.name = "deadly [marker.name]"
 		marker.icon_state = "chronobolt"

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -140,9 +140,9 @@
 	ActivationReaction(user,"weapon")
 	return ..()
 
-/obj/machinery/anomalous_crystal/bullet_act(obj/item/projectile/P, def_zone)
+/obj/machinery/anomalous_crystal/bullet_act(obj/projectile/P, def_zone)
 	..()
-	if(istype(P, /obj/item/projectile/magic))
+	if(istype(P, /obj/projectile/magic))
 		ActivationReaction(P.firer, "magic", P.damage_type)
 		return
 	ActivationReaction(P.firer, P.flag, P.damage_type)
@@ -265,16 +265,16 @@
 /obj/machinery/anomalous_crystal/emitter //Generates a projectile when interacted with
 	activation_method = "touch"
 	cooldown_add = 50
-	var/generated_projectile = /obj/item/projectile/beam/emitter
+	var/generated_projectile = /obj/projectile/beam/emitter
 
 /obj/machinery/anomalous_crystal/emitter/New()
 	..()
-	generated_projectile = pick(/obj/item/projectile/magic/fireball/infernal,/obj/item/projectile/magic/spellblade,
-								 /obj/item/projectile/bullet/meteorshot, /obj/item/projectile/beam/xray, /obj/item/projectile/colossus)
+	generated_projectile = pick(/obj/projectile/magic/fireball/infernal,/obj/projectile/magic/spellblade,
+								 /obj/projectile/bullet/meteorshot, /obj/projectile/beam/xray, /obj/projectile/colossus)
 
 /obj/machinery/anomalous_crystal/emitter/ActivationReaction(mob/user, method)
 	if(..())
-		var/obj/item/projectile/P = new generated_projectile(get_turf(src))
+		var/obj/projectile/P = new generated_projectile(get_turf(src))
 		P.dir = dir
 		switch(dir)
 			if(NORTH)
@@ -393,7 +393,7 @@
 	activation_method = "touch"
 	cooldown_add = 50
 	activation_sound = 'sound/magic/timeparadox2.ogg'
-	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/item/projectile, /obj/item/spellbook)
+	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/projectile, /obj/item/spellbook)
 
 /obj/machinery/anomalous_crystal/refresher/New()
 	..()

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -355,11 +355,11 @@
 /obj/item/ammo_casing/magic/hook
 	name = "hook"
 	desc = "a hook."
-	projectile_type = /obj/item/projectile/hook
+	projectile_type = /obj/projectile/hook
 	caliber = "hook"
 	icon_state = "hook"
 
-/obj/item/projectile/hook
+/obj/projectile/hook
 	name = "hook"
 	icon_state = "hook"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
@@ -371,13 +371,13 @@
 	weaken = 3
 	var/chain
 
-/obj/item/projectile/hook/fire(setAngle)
+/obj/projectile/hook/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "chain", time = INFINITY, maxdistance = INFINITY)
 	..()
 	//TODO: root the firer until the chain returns
 
-/obj/item/projectile/hook/on_hit(atom/target)
+/obj/projectile/hook/on_hit(atom/target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -388,7 +388,7 @@
 			L.forceMove(get_turf(firer))
 			L.density = old_density
 
-/obj/item/projectile/hook/Destroy()
+/obj/projectile/hook/Destroy()
 	QDEL_NULL(chain)
 	return ..()
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -143,14 +143,14 @@
 	..()
 
 /mob/living/simple_animal/hostile/mining_drone/CanPass(atom/movable/O)
-	if(istype(O, /obj/item/projectile/kinetic))
-		var/obj/item/projectile/kinetic/K = O
+	if(istype(O, /obj/projectile/kinetic))
+		var/obj/projectile/kinetic/K = O
 		if(K.kinetic_gun)
 			for(var/A in K.kinetic_gun.get_modkits())
 				var/obj/item/borg/upgrade/modkit/M = A
 				if(istype(M, /obj/item/borg/upgrade/modkit/minebot_passthrough))
 					return TRUE
-	if(istype(O, /obj/item/projectile/destabilizer))
+	if(istype(O, /obj/projectile/destabilizer))
 		return TRUE
 	return ..()
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -259,7 +259,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	else
 		..()
 
-/obj/item/twohanded/required/gibtonite/bullet_act(var/obj/item/projectile/P)
+/obj/item/twohanded/required/gibtonite/bullet_act(var/obj/projectile/P)
 	GibtoniteReaction(P.firer)
 	..()
 

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -99,7 +99,7 @@ Doesn't work on other aliens/AI.*/
 		if(!isturf(U) || !isturf(T))
 			return
 
-		var/obj/item/projectile/bullet/neurotoxin/A = new /obj/item/projectile/bullet/neurotoxin(usr.loc)
+		var/obj/projectile/bullet/neurotoxin/A = new /obj/projectile/bullet/neurotoxin(usr.loc)
 		A.current = U
 		A.firer = src
 		A.yo = U.y - T.y

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -30,7 +30,7 @@
 
 	return 0
 
-///mob/living/carbon/alien/humanoid/bullet_act(var/obj/item/projectile/Proj) taken care of in living
+///mob/living/carbon/alien/humanoid/bullet_act(var/obj/projectile/Proj) taken care of in living
 
 /mob/living/carbon/alien/humanoid/emp_act(severity)
 	if(r_store) r_store.emp_act(severity)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -9,7 +9,7 @@ emp_act
 */
 
 
-/mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone)
+/mob/living/carbon/human/bullet_act(obj/projectile/P, def_zone)
 	if(!dna.species.bullet_act(P, src))
 		return FALSE
 	if(P.is_reflectable)
@@ -92,7 +92,7 @@ emp_act
 		log_game("[key_name(user)] set [key_name(src)] on fire with [I]")
 
 
-/mob/living/carbon/human/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
+/mob/living/carbon/human/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	var/obj/item/organ/external/affecting = get_organ(check_zone(def_zone))
 	if(affecting && !affecting.cannot_amputate && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))
 		var/damtype = DROPLIMB_SHARP

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -850,7 +850,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	if(abs(temperature - M.bodytemperature) > 10) // If our water and mob temperature varies by more than 10K, cool or/ heat them appropriately.
 		M.bodytemperature = (temperature + M.bodytemperature) * 0.5 // Approximation for gradual heating or cooling.
 
-/datum/species/proc/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H) //return TRUE if hit, FALSE if stopped/reflected/etc
+/datum/species/proc/bullet_act(obj/projectile/P, mob/living/carbon/human/H) //return TRUE if hit, FALSE if stopped/reflected/etc
 	return TRUE
 
 /datum/species/proc/spec_hitby(atom/movable/AM, mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -432,7 +432,7 @@
 		new /obj/item/stack/ore/glass(get_turf(H))
 	qdel(H)
 
-/datum/species/golem/sand/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/sand/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H))
 		if(P.flag == "bullet" || P.flag == "bomb")
 			playsound(H, 'sound/effects/shovel_dig.ogg', 70, 1)
@@ -469,7 +469,7 @@
 		new /obj/item/shard(get_turf(H))
 	qdel(H)
 
-/datum/species/golem/glass/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/glass/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H)) //self-shots don't reflect
 		if(P.is_reflectable)
 			H.visible_message("<span class='danger'>The [P.name] gets reflected by [H]'s glass skin!</span>", \
@@ -539,7 +539,7 @@
 	if(world.time > last_teleport + teleport_cooldown && user != H)
 		reactive_teleport(H)
 
-/datum/species/golem/bluespace/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bluespace/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(world.time > last_teleport + teleport_cooldown)
 		reactive_teleport(H)
 	return TRUE
@@ -659,7 +659,7 @@
 		new/obj/item/grown/bananapeel/specialpeel(get_turf(H))
 		last_banana = world.time
 
-/datum/species/golem/bananium/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bananium/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(world.time > last_banana + banana_cooldown)
 		new/obj/item/grown/bananapeel/specialpeel(get_turf(H))
 		last_banana = world.time

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -43,7 +43,7 @@
 /mob/living/proc/is_eyes_covered(check_glasses = TRUE, check_head = TRUE, check_mask = TRUE)
 	return FALSE
 
-/mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
+/mob/living/bullet_act(var/obj/projectile/P, var/def_zone)
 	//Armor
 	var/armor = run_armor_check(def_zone, P.flag, armour_penetration = P.armour_penetration)
 	if(!P.nodamage)
@@ -52,7 +52,7 @@
 			check_projectile_dismemberment(P, def_zone)
 	return P.on_hit(src, armor, def_zone)
 
-/mob/living/proc/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
+/mob/living/proc/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	return 0
 
 /mob/living/proc/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -714,7 +714,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		if(target)
 			open_nearest_door(target)
 
-/mob/living/silicon/ai/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/silicon/ai/bullet_act(var/obj/projectile/Proj)
 	..(Proj)
 	return 2
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -548,7 +548,7 @@
 
 	. += msg
 
-/mob/living/silicon/pai/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/silicon/pai/bullet_act(var/obj/projectile/Proj)
 	..(Proj)
 	if(stat != 2)
 		spawn(1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -619,7 +619,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	return
 
 
-/mob/living/silicon/robot/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/silicon/robot/bullet_act(var/obj/projectile/Proj)
 	..(Proj)
 	if(prob(75) && Proj.damage > 0) spark_system.start()
 	return 2
@@ -1358,7 +1358,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	radio.recalculateChannels()
 	playsound(loc, 'sound/mecha/nominalsyndi.ogg', 75, 0)
 
-/mob/living/silicon/robot/deathsquad/bullet_act(var/obj/item/projectile/P)
+/mob/living/silicon/robot/deathsquad/bullet_act(var/obj/projectile/P)
 	if(istype(P) && P.is_reflectable && P.starting)
 		visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", "<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
 		P.reflect_back(src)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -121,7 +121,7 @@
 	user.visible_message("<span class='alert'>[user] patches some dents on [src] with [I].</span>")
 
 
-/mob/living/silicon/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/silicon/bullet_act(var/obj/projectile/Proj)
 
 
 	if(!Proj.nodamage)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -85,7 +85,7 @@
 		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
 		return TRUE
 
-/mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bullet_act(obj/projectile/Proj)
 	if(!Proj)
 		return
 	apply_damage(Proj.damage, Proj.damage_type)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -388,7 +388,7 @@
 	add_fingerprint(user)
 	user.visible_message("[user] repairs [src]!","<span class='notice'>You repair [src].</span>")
 
-/mob/living/simple_animal/bot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/bullet_act(obj/projectile/Proj)
 	if(Proj && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		if(prob(75) && Proj.damage > 0)
 			do_sparks(5, 1, src)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -40,7 +40,7 @@
 	var/weaponscheck = 1 //If true, arrest people for weapons if they don't have access
 	var/check_records = 1 //Does it check security records?
 	var/arrest_type = 0 //If true, don't handcuff
-	var/projectile = /obj/item/projectile/energy/electrode //Holder for projectile type
+	var/projectile = /obj/projectile/energy/electrode //Holder for projectile type
 	var/shoot_sound = 'sound/weapons/taser.ogg'
 
 
@@ -194,8 +194,8 @@
 		icon_state = "[lasercolor]ed209[on]"
 		set_weapon()
 
-/mob/living/simple_animal/bot/ed209/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
+/mob/living/simple_animal/bot/ed209/bullet_act(obj/projectile/Proj)
+	if(istype(Proj ,/obj/projectile/beam)||istype(Proj,/obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < src.health)
 				retaliate(Proj.firer)
@@ -419,17 +419,17 @@
 	shoot_sound = 'sound/weapons/laser.ogg'
 	if(emagged == 2)
 		if(lasercolor)
-			projectile = /obj/item/projectile/beam/disabler
+			projectile = /obj/projectile/beam/disabler
 		else
-			projectile = /obj/item/projectile/beam
+			projectile = /obj/projectile/beam
 	else
 		if(!lasercolor)
 			shoot_sound = 'sound/weapons/taser.ogg'
-			projectile = /obj/item/projectile/energy/electrode
+			projectile = /obj/projectile/energy/electrode
 		else if(lasercolor == "b")
-			projectile = /obj/item/projectile/beam/lasertag/bluetag
+			projectile = /obj/projectile/beam/lasertag/bluetag
 		else if(lasercolor == "r")
-			projectile = /obj/item/projectile/beam/lasertag/redtag
+			projectile = /obj/projectile/beam/lasertag/redtag
 
 /mob/living/simple_animal/bot/ed209/proc/shootAt(mob/target)
 	if(lastfired && world.time - lastfired < shot_delay)
@@ -449,7 +449,7 @@
 
 	if(!(istype(U, /turf)))
 		return
-	var/obj/item/projectile/A = new projectile(loc)
+	var/obj/projectile/A = new projectile(loc)
 	playsound(loc, shoot_sound, 50, 1)
 	A.current = U
 	A.yo = U.y - T.y
@@ -502,14 +502,14 @@
 						mode = BOT_HUNT
 
 
-/mob/living/simple_animal/bot/ed209/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/ed209/bullet_act(obj/projectile/Proj)
 	if(!disabled)
 		var/lasertag_check = 0
 		if((lasercolor == "b"))
-			if(istype(Proj, /obj/item/projectile/beam/lasertag/redtag))
+			if(istype(Proj, /obj/projectile/beam/lasertag/redtag))
 				lasertag_check++
 		else if((lasercolor == "r"))
-			if(istype(Proj, /obj/item/projectile/beam/lasertag/bluetag))
+			if(istype(Proj, /obj/projectile/beam/lasertag/bluetag))
 				lasertag_check++
 		if(lasertag_check)
 			icon_state = "[lasercolor]ed2090"

--- a/code/modules/mob/living/simple_animal/bot/griefsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/griefsky.dm
@@ -17,7 +17,7 @@
 	var/stun_chance = 50
 	var/spam_flag = 0
 	var/frustration_number = 15
-	
+
 /mob/living/simple_animal/bot/secbot/griefsky/toy  //A toy version of general griefsky!
 	name = "Genewul Giftskee"
 	desc = "An adorable looking secbot with four toy swords taped to its arms"
@@ -47,7 +47,7 @@
 /mob/living/simple_animal/bot/secbot/griefsky/emag_act(mob/user)
 	..()
 	light_color = LIGHT_COLOR_PURE_RED //if you see a red one. RUN!!
-	
+
 /mob/living/simple_animal/bot/secbot/griefsky/Crossed(atom/movable/AM, oldloc)
 	..()
 	if(ismob(AM) && AM == target)
@@ -74,7 +74,7 @@
 		var/mob/living/carbon/C = A
 		sword_attack(C)
 
-/mob/living/simple_animal/bot/secbot/griefsky/bullet_act(obj/item/projectile/P) //so uncivilized
+/mob/living/simple_animal/bot/secbot/griefsky/bullet_act(obj/projectile/P) //so uncivilized
 	retaliate(P.firer)
 	if((icon_state == spin_icon) && (prob(block_chance_ranged))) //only when the eswords are on
 		visible_message("[src] deflects [P] with its energy swords!")
@@ -90,7 +90,7 @@
 	var/threat = C.assess_threat(src)
 	if(ishuman(C))
 		C.apply_damage(dmg, BRUTE)
-		if(prob(stun_chance)) 
+		if(prob(stun_chance))
 			C.Weaken(5)
 	add_attack_logs(src, C, "sliced")
 	if(declare_arrests)
@@ -135,9 +135,9 @@
 							frustration++
 						else
 							frustration = 0
-				else 
+				else
 					back_to_idle()
-					speak("You fool")			
+					speak("You fool")
 			else
 				back_to_idle()
 
@@ -204,14 +204,14 @@
 
 //this section is blocking attack
 
-/mob/living/simple_animal/bot/secbot/griefsky/bullet_act(obj/item/projectile/P) //so uncivilized
+/mob/living/simple_animal/bot/secbot/griefsky/bullet_act(obj/projectile/P) //so uncivilized
 	retaliate(P.firer)
 	if((icon_state == spin_icon) && (prob(block_chance_ranged))) //only when the eswords are on
 		visible_message("[src] deflects [P] with its energy swords!")
 		playsound(loc, 'sound/weapons/blade1.ogg', 50, 1, 0)
 	else
 		..()
-	
+
 /mob/living/simple_animal/bot/secbot/griefsky/proc/special_retaliate_after_attack(mob/user) //allows special actions to take place after being attacked.
 	return
 
@@ -220,7 +220,7 @@
 		return
 	if(prob(block_chance_melee))
 		visible_message("[src] deflects [user]'s attack with his energy swords!")
-		playsound(loc, 'sound/weapons/blade1.ogg', 50, TRUE, -1)	
+		playsound(loc, 'sound/weapons/blade1.ogg', 50, TRUE, -1)
 		return TRUE
 
 /mob/living/simple_animal/bot/secbot/griefsky/attack_hand(mob/living/carbon/human/H)

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -113,8 +113,8 @@
 		playsound(src, 'sound/machines/honkbot_evil_laugh.ogg', 75, 1, -1) // evil laughter
 		update_icon()
 
-/mob/living/simple_animal/bot/honkbot/bullet_act(obj/item/projectile/Proj)
-	if((istype(Proj,/obj/item/projectile/beam)) || (istype(Proj,/obj/item/projectile/bullet) && (Proj.damage_type == BURN))||(Proj.damage_type == BRUTE) && (!Proj.nodamage && Proj.damage < health && ishuman(Proj.firer)))
+/mob/living/simple_animal/bot/honkbot/bullet_act(obj/projectile/Proj)
+	if((istype(Proj,/obj/projectile/beam)) || (istype(Proj,/obj/projectile/bullet) && (Proj.damage_type == BURN))||(Proj.damage_type == BRUTE) && (!Proj.nodamage && Proj.damage < health && ishuman(Proj.firer)))
 		retaliate(Proj.firer)
 	..()
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -554,7 +554,7 @@
 		return 1
 	return 0
 
-/mob/living/simple_animal/bot/medbot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/medbot/bullet_act(obj/projectile/Proj)
 	if(Proj.flag == "taser")
 		stunned = min(stunned+10,20)
 	..()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -163,7 +163,7 @@
 			wires.RandomCut()
 	return
 
-/mob/living/simple_animal/bot/mulebot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/mulebot/bullet_act(obj/projectile/Proj)
 	if(..())
 		if(prob(50) && !isnull(load))
 			unload(0)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -196,8 +196,8 @@ Auto Patrol: []"},
 		declare_arrests = 0
 		icon_state = "[base_icon][on]"
 
-/mob/living/simple_animal/bot/secbot/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
+/mob/living/simple_animal/bot/secbot/bullet_act(obj/projectile/Proj)
+	if(istype(Proj ,/obj/projectile/beam)||istype(Proj,/obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < src.health)
 				retaliate(Proj.firer)

--- a/code/modules/mob/living/simple_animal/bot/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/bot/syndicate.dm
@@ -149,7 +149,7 @@
 	if(lastfired && world.time - lastfired < shot_delay)
 		return
 	lastfired = world.time
-	var/obj/item/projectile/P = new projectile(loc)
+	var/obj/projectile/P = new projectile(loc)
 	playsound(loc, shoot_sound, 100, 1)
 	P.current = loc
 	P.starting = loc
@@ -174,7 +174,7 @@
 		qdel(src)
 
 /mob/living/simple_animal/bot/ed209/syndicate/set_weapon()
-	projectile = /obj/item/projectile/bullet/a40mm
+	projectile = /obj/projectile/bullet/a40mm
 
 /mob/living/simple_animal/bot/ed209/syndicate/emp_act(severity)
 	return

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -127,8 +127,8 @@
 	AIStatus = AI_ON
 	environment_smash = 1 //only token destruction, don't smash the cult wall NO STOP
 
-/mob/living/simple_animal/hostile/construct/armoured/bullet_act(var/obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
+/mob/living/simple_animal/hostile/construct/armoured/bullet_act(var/obj/projectile/P)
+	if(istype(P, /obj/projectile/energy) || istype(P, /obj/projectile/beam))
 		var/reflectchance = 80 - round(P.damage/3)
 		if(prob(reflectchance))
 			if((P.damage_type == BRUTE || P.damage_type == BURN))

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -713,7 +713,7 @@
 	var/turf/U = get_turf(target)
 	if(!T || !U)
 		return
-	var/obj/item/projectile/beam/A = new /obj/item/projectile/beam(loc)
+	var/obj/projectile/beam/A = new /obj/projectile/beam(loc)
 	A.icon = 'icons/effects/genetics.dmi'
 	A.icon_state = "eyelasers"
 	playsound(src.loc, 'sound/weapons/taser2.ogg', 75, 1)

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -67,7 +67,7 @@
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 
 
@@ -85,7 +85,7 @@
 	minimum_distance = 5
 	move_to_delay = 4
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat= 4, /obj/item/stack/sheet/animalhide/xeno = 1)
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
 	var/sterile = 1
@@ -136,7 +136,7 @@
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 
-/obj/item/projectile/neurotox
+/obj/projectile/neurotox
 	name = "neurotoxin"
 	damage = 30
 	icon_state = "toxin"

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/hivebotbullet
+/obj/projectile/hivebotbullet
 	damage = 10
 	damage_type = BRUTE
 
@@ -16,7 +16,7 @@
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	projectilesound = 'sound/weapons/gunshots/gunshot.ogg'
-	projectiletype = /obj/item/projectile/hivebotbullet
+	projectiletype = /obj/projectile/hivebotbullet
 	faction = list("hivebot")
 	check_friendly_fire = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -118,7 +118,7 @@
 		FindTarget(list(user), 1)
 	return ..()
 
-/mob/living/simple_animal/hostile/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/bullet_act(obj/projectile/P)
 	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client)
 		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
 			FindTarget(list(P.firer), 1)
@@ -402,7 +402,7 @@
 		playsound(src, projectilesound, 100, 1)
 		casing.fire(targeted_atom, src, zone_override = ran_zone())
 	else if(projectiletype)
-		var/obj/item/projectile/P = new projectiletype(startloc)
+		var/obj/projectile/P = new projectiletype(startloc)
 		playsound(src, projectilesound, 100, 1)
 		P.current = startloc
 		P.starting = startloc

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -33,7 +33,7 @@ Difficulty: Medium
 	speak_emote = list("roars")
 	speed = 3
 	move_to_delay = 3
-	projectiletype = /obj/item/projectile/kinetic/miner
+	projectiletype = /obj/projectile/kinetic/miner
 	projectilesound = 'sound/weapons/kenetic_accel.ogg'
 	ranged = TRUE
 	ranged_cooldown_time = 16
@@ -115,7 +115,7 @@ Difficulty: Medium
 	..()
 	target.stun_absorption -= "miner"
 
-/obj/item/projectile/kinetic/miner
+/obj/projectile/kinetic/miner
 	damage = 20
 	speed = 0.9
 	icon_state = "ka_tracer"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -419,7 +419,7 @@ Difficulty: Hard
 		if(.)
 			recovery_time = world.time + 20 // can only attack melee once every 2 seconds but rapid_melee gives higher priority
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/projectile/P)
 	if(BUBBLEGUM_IS_ENRAGED)
 		visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons while enraged!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 		playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 300, TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -169,7 +169,7 @@ Difficulty: Very Hard
 	if(!isnum(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/P = new /obj/item/projectile/colossus(startloc)
+	var/obj/projectile/P = new /obj/projectile/colossus(startloc)
 	P.preparePixelProjectile(marker, marker, startloc)
 	P.firer = src
 	if(target)
@@ -231,7 +231,7 @@ Difficulty: Very Hard
 	target = new_target
 	INVOKE_ASYNC(src, /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE)
 
-/mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/projectile/P)
 	if(!stat)
 		var/obj/effect/temp_visual/at_shield/AT = new /obj/effect/temp_visual/at_shield(loc, src)
 		var/random_x = rand(-32, 32)
@@ -241,7 +241,7 @@ Difficulty: Very Hard
 		AT.pixel_y += random_y
 	return ..()
 
-/obj/item/projectile/colossus
+/obj/projectile/colossus
 	name ="death bolt"
 	icon_state= "chronobolt"
 	damage = 25
@@ -251,7 +251,7 @@ Difficulty: Very Hard
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
 
-/obj/item/projectile/colossus/on_hit(atom/target, blocked = 0)
+/obj/projectile/colossus/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(isturf(target) || isobj(target))
 		target.ex_act(2)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -531,8 +531,8 @@ Difficulty: Hard
 		return FALSE
 	if(mover == caster.pulledby)
 		return TRUE
-	if(istype(mover, /obj/item/projectile))
-		var/obj/item/projectile/P = mover
+	if(istype(mover, /obj/projectile))
+		var/obj/projectile/P = mover
 		if(P.firer == caster)
 			return TRUE
 	if(mover == caster)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -242,7 +242,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/ranged_combat
 	icon_state = "swarmer_ranged"
 	icon_living = "swarmer_ranged"
-	projectiletype = /obj/item/projectile/beam/laser
+	projectiletype = /obj/projectile/beam/laser
 	projectilesound = 'sound/weapons/laser.ogg'
 	check_friendly_fire = TRUE //you're supposed to protect the resource swarmers, you poop
 	retreat_distance = 3

--- a/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
@@ -9,7 +9,7 @@
 	icon_dead = "Basilisk_dead"
 	icon_gib = "syndicate_gib"
 	move_to_delay = 20
-	projectiletype = /obj/item/projectile/temp/basilisk
+	projectiletype = /obj/projectile/temp/basilisk
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
 	ranged_message = "stares"
@@ -34,7 +34,7 @@
 	loot = list(/obj/item/stack/ore/diamond{layer = ABOVE_MOB_LAYER},
 				/obj/item/stack/ore/diamond{layer = ABOVE_MOB_LAYER})
 
-/obj/item/projectile/temp/basilisk
+/obj/projectile/temp/basilisk
 	name = "freezing blast"
 	icon_state = "ice_2"
 	damage = 0
@@ -102,7 +102,7 @@
 	light_range = 3
 	light_power = 2.5
 	light_color = LIGHT_COLOR_LAVA
-	projectiletype = /obj/item/projectile/temp/basilisk/magmawing
+	projectiletype = /obj/projectile/temp/basilisk/magmawing
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/magma_wing
 	crusher_drop_mod = 60
 
@@ -115,12 +115,12 @@
 	icon_dead = "watcher_icewing_dead"
 	maxHealth = 170
 	health = 170
-	projectiletype = /obj/item/projectile/temp/basilisk/icewing
+	projectiletype = /obj/projectile/temp/basilisk/icewing
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/bone = 1) //No sinew; the wings are too fragile to be usable
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing
 	crusher_drop_mod = 30
 
-/obj/item/projectile/temp/basilisk/magmawing
+/obj/projectile/temp/basilisk/magmawing
 	name = "scorching blast"
 	icon_state = "lava"
 	damage = 5
@@ -128,7 +128,7 @@
 	nodamage = FALSE
 	temperature = 500 //Heats you up!
 
-/obj/item/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(.)
 		var/mob/living/L = target
@@ -136,12 +136,12 @@
 			L.adjust_fire_stacks(0.1)
 			L.IgniteMob()
 
-/obj/item/projectile/temp/basilisk/icewing
+/obj/projectile/temp/basilisk/icewing
 	damage = 5
 	damage_type = BURN
 	nodamage = FALSE
 
-/obj/item/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(.)
 		var/mob/living/L = target

--- a/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
@@ -71,7 +71,7 @@
 		visible_message("<span class='danger'>The [name] buries into the ground, vanishing from sight!</span>")
 		qdel(src)
 
-/mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/projectile/P)
 	visible_message("<span class='danger'>[P.name] was repelled by [name]'s girth!</span>")
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/adjustHealth(amount, updating_health = TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/mining/mining.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/mining.dm
@@ -34,7 +34,7 @@
 		return
 	icon_state = icon_living
 
-/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
+/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
 	if(!stat)
 		Aggro()
 	if(P.damage < 30 && P.damage_type != BRUTE)

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -40,6 +40,6 @@
 	rapid = 2
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/beam
+	projectiletype = /obj/projectile/beam
 	loot = list(/obj/effect/mob_spawn/human/corpse/pirate/ranged,
 				/obj/item/gun/energy/laser)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -20,7 +20,7 @@
 	health = 300
 	maxHealth = 300
 	speed = 8
-	projectiletype = /obj/item/projectile/beam/drone
+	projectiletype = /obj/projectile/beam/drone
 	projectilesound = 'sound/weapons/laser3.ogg'
 	var/datum/effect_system/trail_follow/ion/ion_trail
 
@@ -46,7 +46,7 @@
 /mob/living/simple_animal/hostile/retaliate/malf_drone/New()
 	..()
 	if(prob(5))
-		projectiletype = /obj/item/projectile/beam/pulse/drone
+		projectiletype = /obj/projectile/beam/pulse/drone
 		projectilesound = 'sound/weapons/pulse2.ogg'
 	ion_trail = new
 	ion_trail.set_up(src)
@@ -254,8 +254,8 @@
 
 	return ..()
 
-/obj/item/projectile/beam/drone
+/obj/projectile/beam/drone
 	damage = 15
 
-/obj/item/projectile/beam/pulse/drone
+/obj/projectile/beam/pulse/drone
 	damage = 10

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -64,7 +64,7 @@
 		visible_message("<span class='warning'>[user] gently taps [src] with the [O]. </span>")
 
 
-/mob/living/simple_animal/hostile/syndicate/melee/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/syndicate/melee/bullet_act(var/obj/projectile/Proj)
 	if(!Proj)
 		return
 	if(prob(ranged_block_chance))
@@ -245,7 +245,7 @@
 		ranged_block_chance = 0
 		icon_state = "syndicate_pistol"
 		icon_living = "syndicate_pistol"
-		projectiletype = /obj/item/projectile/beam/laser
+		projectiletype = /obj/projectile/beam/laser
 		projectilesound = 'sound/weapons/laser.ogg'
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory
@@ -274,7 +274,7 @@
 		ranged_block_chance = 0
 		icon_state = "syndicate_stormtrooper_shotgun"
 		icon_living = "syndicate_stormtrooper_shotgun"
-		projectiletype = /obj/item/projectile/bullet/sniper/penetrator // Ignores cover.
+		projectiletype = /obj/projectile/bullet/sniper/penetrator // Ignores cover.
 		projectilesound = 'sound/weapons/gunshots/gunshot_sniper.ogg'
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -151,7 +151,7 @@
 /obj/structure/spider/terrorweb/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /mob/living/simple_animal/hostile/poison/terror_spider))
 		return 1
-	if(istype(mover, /obj/item/projectile/terrorqueenspit))
+	if(istype(mover, /obj/projectile/terrorqueenspit))
 		return 1
 	if(isliving(mover))
 		var/mob/living/M = mover
@@ -170,11 +170,11 @@
 			return 1
 		else
 			return 0
-	if(istype(mover, /obj/item/projectile))
+	if(istype(mover, /obj/projectile))
 		return prob(20)
 	return ..()
 
-/obj/structure/spider/terrorweb/bullet_act(obj/item/projectile/Proj)
+/obj/structure/spider/terrorweb/bullet_act(obj/projectile/Proj)
 	if(Proj.damage_type != BRUTE && Proj.damage_type != BURN)
 		visible_message("<span class='danger'>[src] is undamaged by [Proj]!</span>")
 		// Webs don't care about disablers, tasers, etc. Or toxin damage. They're organic, but not alive.

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -22,7 +22,7 @@
 	rapid = 3
 	canlay = 1000
 	spider_tier = TS_TIER_5
-	projectiletype = /obj/item/projectile/terrorqueenspit/empress
+	projectiletype = /obj/projectile/terrorqueenspit/empress
 	icon = 'icons/mob/terrorspider64.dmi'
 	pixel_x = -16
 	mob_size = MOB_SIZE_LARGE
@@ -107,7 +107,7 @@
 	to_chat(src, "<span class='userdanger'>All Terror Spiders, except yourself, will die off shortly.</span>")
 
 
-/obj/item/projectile/terrorqueenspit/empress
+/obj/projectile/terrorqueenspit/empress
 	damage_type = BURN
 	damage = 30
 	bonus_tox = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -31,7 +31,7 @@
 	retreat_distance = 5
 	minimum_distance = 5
 	projectilesound = 'sound/weapons/pierce.ogg'
-	projectiletype = /obj/item/projectile/terrorqueenspit
+	projectiletype = /obj/projectile/terrorqueenspit
 	spider_tier = TS_TIER_4
 	spider_opens_doors = 2
 	web_type = /obj/structure/spider/terrorweb/queen
@@ -328,14 +328,14 @@
 	else
 		to_chat(src, "<span class='danger'>You have run out of uses of this ability.</span>")
 
-/obj/item/projectile/terrorqueenspit
+/obj/projectile/terrorqueenspit
 	name = "poisonous spit"
 	damage = 0
 	icon_state = "toxin"
 	damage_type = TOX
 	var/bonus_tox = 30
 
-/obj/item/projectile/terrorqueenspit/on_hit(mob/living/carbon/target, blocked = 0, hit_zone)
+/obj/projectile/terrorqueenspit/on_hit(mob/living/carbon/target, blocked = 0, hit_zone)
 	if(ismob(target) && blocked < 100)
 		var/mob/living/L = target
 		if(L.reagents)

--- a/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
@@ -51,7 +51,7 @@
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/snowball
+	projectiletype = /obj/projectile/snowball
 
 /mob/living/simple_animal/hostile/winter/reindeer
 	name = "reindeer"
@@ -106,7 +106,7 @@
 	maxHealth = 200		//DID YOU REALLY BELIEVE IT WOULD BE THIS EASY!??!!
 	health = 200
 	ranged = 1
-	projectiletype = /obj/item/projectile/ornament
+	projectiletype = /obj/projectile/ornament
 	retreat_distance = 5
 	minimum_distance = 5
 
@@ -119,7 +119,7 @@
 	ranged = 1
 	rapid = 3
 	speed = 0	//he's lost some weight from the fighting
-	projectiletype = /obj/item/projectile/ornament
+	projectiletype = /obj/projectile/ornament
 	retreat_distance = 3
 	minimum_distance = 3
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -260,7 +260,7 @@
 	return
 
 //Bullets
-/mob/living/simple_animal/parrot/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/parrot/bullet_act(var/obj/projectile/Proj)
 	..()
 	if(!stat && !client)
 		if(parrot_state == PARROT_PERCH)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -240,7 +240,7 @@
 		amount = -abs(amount)
 	return ..() //Heals them
 
-/mob/living/simple_animal/slime/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/slime/bullet_act(obj/projectile/Proj)
 	if(!Proj)
 		return
 	attacked += 10

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -1,7 +1,7 @@
 /mob/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0)
 		return 1
-	if(istype(mover, /obj/item/projectile))
+	if(istype(mover, /obj/projectile))
 		return (!density || lying)
 	if(mover.throwing)
 		return (!density || lying || (mover.throwing.thrower == src))

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -149,6 +149,6 @@ GLOBAL_LIST_EMPTY(global_modular_computers)
 // "Stun" weapons can cause minor damage to components (short-circuits?)
 // "Burn" damage is equally strong against internal components and exterior casing
 // "Brute" damage mostly damages the casing.
-/obj/machinery/modular_computer/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/modular_computer/bullet_act(obj/projectile/Proj)
 	if(cpu)
 		cpu.bullet_act(Proj)

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/ninjaobjects.dmi'
 	fire_sound = 'sound/weapons/genhit.ogg'
 	cell_type = "/obj/item/stock_parts/cell/infinite"
-	projectile_type = "/obj/item/projectile/energy/shuriken"
+	projectile_type = /obj/projectile/energy/shuriken
 	charge_cost = 0
 	silenced = 1
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -21,7 +21,7 @@
 	var/state = 0
 	var/locked = 0
 
-	var/projectile_type = /obj/item/projectile/beam/emitter
+	var/projectile_type = /obj/projectile/beam/emitter
 	var/projectile_sound = 'sound/weapons/emitter.ogg'
 	var/datum/effect_system/spark_spread/sparks
 
@@ -165,7 +165,7 @@
 	return FALSE
 
 /obj/machinery/power/emitter/proc/fire_beam()
-	var/obj/item/projectile/P = new projectile_type(get_turf(src))
+	var/obj/projectile/P = new projectile_type(get_turf(src))
 	playsound(get_turf(src), projectile_sound, 50, TRUE)
 	if(prob(35))
 		sparks.start()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -143,7 +143,7 @@ field_generator power level display
 	else
 		..()
 
-/obj/machinery/field/generator/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/field/generator/bullet_act(obj/projectile/Proj)
 	if(Proj.flag != "bullet")
 		power = min(power + Proj.damage, field_generator_max_power)
 		check_power_level()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -94,7 +94,7 @@
 	return
 
 
-/obj/singularity/bullet_act(obj/item/projectile/P)
+/obj/singularity/bullet_act(obj/projectile/P)
 	qdel(P)
 	return 0 //Will there be an impact? Who knows.  Will we see it? No.
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -279,7 +279,7 @@
 
 /obj/machinery/power/supermatter_shard
 
-/obj/machinery/power/supermatter_shard/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/power/supermatter_shard/bullet_act(var/obj/projectile/Proj)
 	var/turf/L = loc
 	if(!istype(L))		// We don't run process() when we are in space
 		return 0	// This stops people from being able to really power up the supermatter

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -11,7 +11,7 @@
 	var/drop_sound = "casingdrop"               //What sound should play when this ammo hits the ground
 	var/caliber = null							//Which kind of guns it can be loaded into
 	var/projectile_type = null					//The bullet type to create when New() is called
-	var/obj/item/projectile/BB = null 			//The loaded bullet
+	var/obj/projectile/BB = null 			//The loaded bullet
 	var/pellets = 1								//Pellets for spreadshot
 	var/variance = 0							//Variance for inaccuracy fundamental to the casing
 	var/delay = 0								//Delay for energy weapons

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,119 +1,119 @@
 /obj/item/ammo_casing/a357
 	desc = "A .357 bullet casing."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/projectile/bullet
 
 /obj/item/ammo_casing/rubber9mm
 	desc = "A 9mm rubber bullet casing."
 	caliber = "9mm"
 	icon_state = "r-casing"
-	projectile_type = /obj/item/projectile/bullet/weakbullet4
+	projectile_type = /obj/projectile/bullet/weakbullet4
 
 /obj/item/ammo_casing/a762
 	desc = "A 7.62mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/projectile/bullet
 
 /obj/item/ammo_casing/a762/enchanted
-	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	projectile_type = /obj/projectile/bullet/weakbullet3
 
 /obj/item/ammo_casing/a50
 	desc = "A .50AE bullet casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/projectile/bullet
 
 /obj/item/ammo_casing/c38
 	desc = "A .38 bullet casing."
 	caliber = "38"
 	icon_state = "r-casing"
-	projectile_type = /obj/item/projectile/bullet/weakbullet2
+	projectile_type = /obj/projectile/bullet/weakbullet2
 
 /obj/item/ammo_casing/c38/invisible
-	projectile_type = /obj/item/projectile/bullet/weakbullet2/invisible
+	projectile_type = /obj/projectile/bullet/weakbullet2/invisible
 
 /obj/item/ammo_casing/c38/invisible/fake
-	projectile_type = /obj/item/projectile/bullet/weakbullet2/invisible/fake
+	projectile_type = /obj/projectile/bullet/weakbullet2/invisible/fake
 
 /obj/item/ammo_casing/c10mm
 	desc = "A 10mm bullet casing."
 	caliber = "10mm"
-	projectile_type = /obj/item/projectile/bullet/midbullet3
+	projectile_type = /obj/projectile/bullet/midbullet3
 
 /obj/item/ammo_casing/c10mm/ap
-	projectile_type = /obj/item/projectile/bullet/midbullet3/ap
+	projectile_type = /obj/projectile/bullet/midbullet3/ap
 
 /obj/item/ammo_casing/c10mm/fire
-	projectile_type = /obj/item/projectile/bullet/midbullet3/fire
+	projectile_type = /obj/projectile/bullet/midbullet3/fire
 
 /obj/item/ammo_casing/c10mm/hp
-	projectile_type = /obj/item/projectile/bullet/midbullet3/hp
+	projectile_type = /obj/projectile/bullet/midbullet3/hp
 
 /obj/item/ammo_casing/c9mm
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	projectile_type = /obj/projectile/bullet/weakbullet3
 
 /obj/item/ammo_casing/c9mmap
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/armourpiercing
+	projectile_type = /obj/projectile/bullet/armourpiercing
 
 /obj/item/ammo_casing/c9mmtox
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/toxinbullet
+	projectile_type = /obj/projectile/bullet/toxinbullet
 
 /obj/item/ammo_casing/c9mminc
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
+	projectile_type = /obj/projectile/bullet/incendiary/firebullet
 
 /obj/item/ammo_casing/c46x30mm
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	projectile_type = /obj/projectile/bullet/weakbullet3
 
 /obj/item/ammo_casing/c46x30mmap
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/armourpiercing
+	projectile_type = /obj/projectile/bullet/armourpiercing
 
 /obj/item/ammo_casing/c46x30mmtox
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/toxinbullet
+	projectile_type = /obj/projectile/bullet/toxinbullet
 
 /obj/item/ammo_casing/c46x30mminc
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
+	projectile_type = /obj/projectile/bullet/incendiary/firebullet
 
 /obj/item/ammo_casing/rubber45
 	desc = "A .45 rubber bullet casing."
 	caliber = ".45"
 	icon_state = "r-casing"
-	projectile_type = /obj/item/projectile/bullet/midbullet_r
+	projectile_type = /obj/projectile/bullet/midbullet_r
 
 /obj/item/ammo_casing/c45
 	desc = "A .45 bullet casing."
 	caliber = ".45"
-	projectile_type = /obj/item/projectile/bullet/midbullet
+	projectile_type = /obj/projectile/bullet/midbullet
 
 /obj/item/ammo_casing/c45nostamina
 	desc = "A .45 bullet casing."
 	caliber = ".45"
-	projectile_type = /obj/item/projectile/bullet/midbullet3
+	projectile_type = /obj/projectile/bullet/midbullet3
 
 /obj/item/ammo_casing/n762
 	desc = "A 7.62x38mmR bullet casing."
 	caliber = "n762"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/projectile/bullet
 
 /obj/item/ammo_casing/caseless/magspear
 	name = "magnetic spear"
 	desc = "A reusable spear that is typically loaded into kinetic spearguns."
-	projectile_type = /obj/item/projectile/bullet/reusable/magspear
+	projectile_type = /obj/projectile/bullet/reusable/magspear
 	caliber = "speargun"
 	icon_state = "magspear"
 	throwforce = 15 //still deadly when thrown
@@ -125,7 +125,7 @@
 	icon_state = "blshell"
 	caliber = "shotgun"
 	drop_sound = 'sound/weapons/gun_interactions/shotgun_fall.ogg'
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/projectile/bullet
 	materials = list(MAT_METAL=4000)
 
 
@@ -133,7 +133,7 @@
 	name = "buckshot shell"
 	desc = "A 12 gauge buckshot shell."
 	icon_state = "gshell"
-	projectile_type = /obj/item/projectile/bullet/pellet
+	projectile_type = /obj/projectile/bullet/pellet
 	pellets = 6
 	variance = 25
 
@@ -141,7 +141,7 @@
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "cshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/rubber
+	projectile_type = /obj/projectile/bullet/pellet/rubber
 	pellets = 6
 	variance = 25
 	materials = list(MAT_METAL=4000)
@@ -151,7 +151,7 @@
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/weakbullet
+	projectile_type = /obj/projectile/bullet/weakbullet
 	materials = list(MAT_METAL=250)
 
 
@@ -159,7 +159,7 @@
 	name = "improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/weak
+	projectile_type = /obj/projectile/bullet/pellet/weak
 	materials = list(MAT_METAL=250)
 	pellets = 10
 	variance = 25
@@ -170,7 +170,7 @@
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards. This one has been packed with even more \
 	propellant. It's like playing russian roulette, with a shotgun."
 	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/overload
+	projectile_type = /obj/projectile/bullet/pellet/overload
 	materials = list(MAT_METAL=250)
 	pellets = 4
 	variance = 40
@@ -180,7 +180,7 @@
 	name = "taser slug"
 	desc = "A stunning taser slug."
 	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/stunshot
+	projectile_type = /obj/projectile/bullet/stunshot
 	materials = list(MAT_METAL=250)
 
 
@@ -188,13 +188,13 @@
 	name = "meteorshot shell"
 	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
 	icon_state = "mshell"
-	projectile_type = /obj/item/projectile/bullet/meteorshot
+	projectile_type = /obj/projectile/bullet/meteorshot
 
 /obj/item/ammo_casing/shotgun/breaching
 	name = "breaching shell"
 	desc = "An economic version of the meteorshot, utilizing similar technologies. Great for busting down doors."
 	icon_state = "mshell"
-	projectile_type = /obj/item/projectile/bullet/meteorshot/weak
+	projectile_type = /obj/projectile/bullet/meteorshot/weak
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "pulse slug"
@@ -202,25 +202,25 @@
 	energy blast. While the heat and power drain limit it to one use, it can still allow an operator to engage targets that ballistic ammunition \
 	would have difficulty with."
 	icon_state = "pshell"
-	projectile_type = /obj/item/projectile/beam/pulse/shot
+	projectile_type = /obj/projectile/beam/pulse/shot
 
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."
 	icon_state = "ishell"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shell
+	projectile_type = /obj/projectile/bullet/incendiary/shell
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "FRAG-12 slug"
 	desc = "A high explosive breaching round for a 12 gauge shotgun."
 	icon_state = "heshell"
-	projectile_type = /obj/item/projectile/bullet/frag12
+	projectile_type = /obj/projectile/bullet/frag12
 
 /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath
 	name = "dragonsbreath shell"
 	desc = "A shotgun shell which fires a spread of incendiary pellets."
 	icon_state = "ishell2"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shell/dragonsbreath
+	projectile_type = /obj/projectile/bullet/incendiary/shell/dragonsbreath
 	pellets = 4
 	variance = 35
 
@@ -229,7 +229,7 @@
 	desc = "An advanced shotgun shell which uses a subspace ansible crystal to produce an effect similar to a standard ion rifle. \
 	The unique properties of the crystal splot the pulse into a spread of individually weaker bolts."
 	icon_state = "ionshell"
-	projectile_type = /obj/item/projectile/ion/weak
+	projectile_type = /obj/projectile/ion/weak
 	pellets = 4
 	variance = 35
 
@@ -237,7 +237,7 @@
 	name = "laser slug"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
@@ -250,7 +250,7 @@
 	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."
 	icon_state = "cshell"
 	container_type = OPENCONTAINER
-	projectile_type = /obj/item/projectile/bullet/dart
+	projectile_type = /obj/projectile/bullet/dart
 
 /obj/item/ammo_casing/shotgun/dart/New()
 	..()
@@ -274,19 +274,19 @@
 	name = "tranquilizer darts"
 	desc = "A tranquilizer round used to subdue individuals utilizing stimulants."
 	icon_state = "nshell"
-	projectile_type = /obj/item/projectile/bullet/dart/syringe/tranquilizer
+	projectile_type = /obj/projectile/bullet/dart/syringe/tranquilizer
 	materials = list(MAT_METAL=250)
 
 /obj/item/ammo_casing/a556
 	desc = "A 5.56mm bullet casing."
 	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/heavybullet
+	projectile_type = /obj/projectile/bullet/heavybullet
 
 /obj/item/ammo_casing/shotgun/fakebeanbag
 	name = "beanbag shell"
 	desc = "A weak beanbag shell."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/weakbullet/booze
+	projectile_type = /obj/projectile/bullet/weakbullet/booze
 
 /obj/item/ammo_casing/rocket
 	name = "rocket shell"
@@ -308,19 +308,19 @@
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."
 	caliber = "75"
-	projectile_type = /obj/item/projectile/bullet/gyro
+	projectile_type = /obj/projectile/bullet/gyro
 
 /obj/item/ammo_casing/a40mm
 	name = "40mm HE shell"
 	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
 	caliber = "40mm"
 	icon_state = "40mmHE"
-	projectile_type = /obj/item/projectile/bullet/a40mm
+	projectile_type = /obj/projectile/bullet/a40mm
 
 /obj/item/ammo_casing/caseless/foam_dart
 	name = "foam dart"
 	desc = "It's nerf or nothing! Ages 8 and up."
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart
 	caliber = "foam_force"
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foamdart"
@@ -341,7 +341,7 @@
 
 /obj/item/ammo_casing/caseless/foam_dart/attackby(obj/item/A, mob/user, params)
 	..()
-	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
+	var/obj/projectile/bullet/reusable/foam_dart/FD = BB
 	if(istype(A, /obj/item/screwdriver) && !modified)
 		modified = 1
 		FD.damage_type = BRUTE
@@ -359,7 +359,7 @@
 	return
 
 /obj/item/ammo_casing/caseless/foam_dart/attack_self(mob/living/user)
-	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
+	var/obj/projectile/bullet/reusable/foam_dart/FD = BB
 	if(FD.pen)
 		FD.damage = initial(FD.damage)
 		FD.nodamage = initial(FD.nodamage)
@@ -370,14 +370,14 @@
 /obj/item/ammo_casing/caseless/foam_dart/riot
 	name = "riot foam dart"
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"
 
 /obj/item/ammo_casing/caseless/foam_dart/sniper
 	name = "foam sniper dart"
 	desc = "For the big nerf! Ages 8 and up."
 	caliber = "foam_force_sniper"
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/sniper
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart/sniper
 	icon_state = "foamdartsniper"
 
 /obj/item/ammo_casing/caseless/foam_dart/sniper/update_icon()
@@ -396,13 +396,13 @@
 	name = "riot foam sniper dart"
 	desc = "For the bigger brother of the crowd control toy. Ages 18 and up."
 	caliber = "foam_force_sniper"
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/sniper/riot
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart/sniper/riot
 	icon_state = "foamdartsniper_riot"
 
 /obj/item/ammo_casing/shotgun/assassination
 	name = "assassination shell"
 	desc = "A specialist shrapnel shell that has been laced with a silencing toxin."
-	projectile_type = /obj/item/projectile/bullet/pellet/assassination
+	projectile_type = /obj/projectile/bullet/pellet/assassination
 	icon_state = "gshell"
 	pellets = 6
 	variance = 25
@@ -410,10 +410,10 @@
 /obj/item/ammo_casing/cap
 	desc = "A cap for children toys."
 	caliber = "cap"
-	projectile_type = /obj/item/projectile/bullet/cap
+	projectile_type = /obj/projectile/bullet/cap
 
 /obj/item/ammo_casing/laser
 	desc = "An experimental laser casing."
 	caliber = "laser"
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	icon_state = "lasercasing"

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -2,20 +2,20 @@
 	name = "energy weapon lens"
 	desc = "The part of the gun that makes the laser go pew"
 	caliber = "energy"
-	projectile_type = /obj/item/projectile/energy
+	projectile_type = /obj/projectile/energy
 	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
 	var/select_name = "energy"
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/ammo_casing/energy/laser
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/cyborg //to balance cyborg energy cost seperately
 	e_cost = 250
 
 /obj/item/ammo_casing/energy/lasergun
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	e_cost = 83
 	select_name = "kill"
 
@@ -23,55 +23,55 @@
 	e_cost = 100
 
 /obj/item/ammo_casing/energy/laser/practice
-	projectile_type = /obj/item/projectile/beam/practice
+	projectile_type = /obj/projectile/beam/practice
 	select_name = "practice"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/scatter
-	projectile_type = /obj/item/projectile/beam/scatter
+	projectile_type = /obj/projectile/beam/scatter
 	pellets = 5
 	variance = 25
 	select_name = "scatter"
 
 /obj/item/ammo_casing/energy/laser/heavy
-	projectile_type = /obj/item/projectile/beam/laser/heavylaser
+	projectile_type = /obj/projectile/beam/laser/heavylaser
 	select_name = "anti-vehicle"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pulse
-	projectile_type = /obj/item/projectile/beam/pulse
+	projectile_type = /obj/projectile/beam/pulse
 	e_cost = 200
 	select_name = "DESTROY"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
 /obj/item/ammo_casing/energy/laser/scatter/pulse
-	projectile_type = /obj/item/projectile/beam/pulse
+	projectile_type = /obj/projectile/beam/pulse
 	e_cost = 200
 	select_name = "ANNIHILATE"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
 /obj/item/ammo_casing/energy/laser/bluetag
-	projectile_type = /obj/item/projectile/beam/lasertag/bluetag
+	projectile_type = /obj/projectile/beam/lasertag/bluetag
 	select_name = "bluetag"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/redtag
-	projectile_type = /obj/item/projectile/beam/lasertag/redtag
+	projectile_type = /obj/projectile/beam/lasertag/redtag
 	select_name = "redtag"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/xray
-	projectile_type = /obj/item/projectile/beam/xray
+	projectile_type = /obj/projectile/beam/xray
 	e_cost = 100
 	fire_sound = 'sound/weapons/laser3.ogg'
 
 /obj/item/ammo_casing/energy/immolator
-	projectile_type = /obj/item/projectile/beam/immolator
+	projectile_type = /obj/projectile/beam/immolator
 	fire_sound = 'sound/weapons/laser3.ogg'
 	e_cost = 125
 
 /obj/item/ammo_casing/energy/immolator/strong
-	projectile_type = /obj/item/projectile/beam/immolator/strong
+	projectile_type = /obj/projectile/beam/immolator/strong
 	e_cost = 125
 	select_name = "precise"
 
@@ -80,7 +80,7 @@
 	e_cost = 1000 // 5x that of the standard laser, for 2.25x the damage (if 1/1 shots hit) plus ignite. Not energy-efficient, but can be used for sniping.
 
 /obj/item/ammo_casing/energy/immolator/scatter
-	projectile_type = /obj/item/projectile/beam/immolator/weak
+	projectile_type = /obj/projectile/beam/immolator/weak
 	e_cost = 125
 	pellets = 6
 	variance = 25
@@ -91,7 +91,7 @@
 	e_cost = 1000 // 5x that of the standard laser, for 7.5x the damage (if 6/6 shots hit) plus ignite. Efficient only if you hit with at least 4/6 of the shots.
 
 /obj/item/ammo_casing/energy/electrode
-	projectile_type = /obj/item/projectile/energy/electrode
+	projectile_type = /obj/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
 	e_cost = 200
@@ -106,17 +106,17 @@
 	e_cost = 200
 
 /obj/item/ammo_casing/energy/ion
-	projectile_type = /obj/item/projectile/ion
+	projectile_type = /obj/projectile/ion
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
 /obj/item/ammo_casing/energy/declone
-	projectile_type = /obj/item/projectile/energy/declone
+	projectile_type = /obj/projectile/energy/declone
 	select_name = "declone"
 	fire_sound = 'sound/weapons/pulse3.ogg'
 
 /obj/item/ammo_casing/energy/mindflayer
-	projectile_type = /obj/item/projectile/beam/mindflayer
+	projectile_type = /obj/projectile/beam/mindflayer
 	select_name = "MINDFUCK"
 	fire_sound = 'sound/weapons/laser.ogg'
 
@@ -125,15 +125,15 @@
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/flora/yield
-	projectile_type = /obj/item/projectile/energy/florayield
+	projectile_type = /obj/projectile/energy/florayield
 	select_name = "yield"
 
 /obj/item/ammo_casing/energy/flora/mut
-	projectile_type = /obj/item/projectile/energy/floramut
+	projectile_type = /obj/projectile/energy/floramut
 	select_name = "mutation"
 
 /obj/item/ammo_casing/energy/temp
-	projectile_type = /obj/item/projectile/temp
+	projectile_type = /obj/projectile/temp
 	fire_sound = 'sound/weapons/pulse3.ogg'
 	var/temp = 300
 
@@ -145,11 +145,11 @@
 	..(temp)
 
 /obj/item/ammo_casing/energy/meteor
-	projectile_type = /obj/item/projectile/meteor
+	projectile_type = /obj/projectile/meteor
 	select_name = "goddamn meteor"
 
 /obj/item/ammo_casing/energy/disabler
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	select_name  = "disable"
 	e_cost = 50
 	fire_sound = 'sound/weapons/taser2.ogg'
@@ -159,19 +159,19 @@
 	e_cost = 250
 
 /obj/item/ammo_casing/energy/plasma
-	projectile_type = /obj/item/projectile/plasma
+	projectile_type = /obj/projectile/plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	delay = 15
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/adv
-	projectile_type = /obj/item/projectile/plasma/adv
+	projectile_type = /obj/projectile/plasma/adv
 	delay = 10
 	e_cost = 10
 
 /obj/item/ammo_casing/energy/wormhole
-	projectile_type = /obj/item/projectile/beam/wormhole
+	projectile_type = /obj/projectile/beam/wormhole
 	e_cost = 0
 	fire_sound = 'sound/weapons/pulse3.ogg'
 	var/obj/item/gun/energy/wormhole_projector/gun = null
@@ -182,68 +182,68 @@
 	gun = wh
 
 /obj/item/ammo_casing/energy/wormhole/orange
-	projectile_type = /obj/item/projectile/beam/wormhole/orange
+	projectile_type = /obj/projectile/beam/wormhole/orange
 	select_name = "orange"
 
 /obj/item/ammo_casing/energy/bolt
-	projectile_type = /obj/item/projectile/energy/bolt
+	projectile_type = /obj/projectile/energy/bolt
 	select_name = "bolt"
 	e_cost = 500
 	fire_sound = 'sound/weapons/genhit.ogg'
 
 /obj/item/ammo_casing/energy/bolt/large
-	projectile_type = /obj/item/projectile/energy/bolt/large
+	projectile_type = /obj/projectile/energy/bolt/large
 	select_name = "heavy bolt"
 
 /obj/item/ammo_casing/energy/dart
-	projectile_type = /obj/item/projectile/energy/dart
+	projectile_type = /obj/projectile/energy/dart
 	fire_sound = 'sound/weapons/genhit.ogg'
 	e_cost = 500
 	select_name = "toxic dart"
 
 /obj/item/ammo_casing/energy/instakill
-	projectile_type = /obj/item/projectile/beam/instakill
+	projectile_type = /obj/projectile/beam/instakill
 	e_cost = 0
 	select_name = "DESTROY"
 
 /obj/item/ammo_casing/energy/instakill/blue
-	projectile_type = /obj/item/projectile/beam/instakill/blue
+	projectile_type = /obj/projectile/beam/instakill/blue
 
 /obj/item/ammo_casing/energy/instakill/red
-	projectile_type = /obj/item/projectile/beam/instakill/red
+	projectile_type = /obj/projectile/beam/instakill/red
 
 /obj/item/ammo_casing/energy/plasma
-	projectile_type = /obj/item/projectile/plasma
+	projectile_type = /obj/projectile/plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
 /obj/item/ammo_casing/energy/plasma/adv
-	projectile_type = /obj/item/projectile/plasma/adv
+	projectile_type = /obj/projectile/plasma/adv
 
 /obj/item/ammo_casing/energy/shock_revolver
 	fire_sound = 'sound/magic/lightningbolt.ogg'
 	e_cost = 200
 	select_name = "lightning beam"
-	projectile_type = /obj/item/projectile/energy/shock_revolver
+	projectile_type = /obj/projectile/energy/shock_revolver
 
 /obj/item/ammo_casing/energy/toxplasma
-	projectile_type = /obj/item/projectile/energy/toxplasma
+	projectile_type = /obj/projectile/energy/toxplasma
 	fire_sound = 'sound/weapons/taser2.ogg'
 	select_name = "plasma dart"
 
 /obj/item/ammo_casing/energy/clown
-	projectile_type = /obj/item/projectile/clown
+	projectile_type = /obj/projectile/clown
 	fire_sound = 'sound/weapons/gunshots/gunshot_smg.ogg'
 	select_name = "clown"
 
 /obj/item/ammo_casing/energy/sniper
-	projectile_type = /obj/item/projectile/beam/sniper
+	projectile_type = /obj/projectile/beam/sniper
 	fire_sound = 'sound/weapons/marauder.ogg'
 	delay = 50
 	select_name = "snipe"
 
 /obj/item/ammo_casing/energy/teleport
-	projectile_type = /obj/item/projectile/energy/teleport
+	projectile_type = /obj/projectile/energy/teleport
 	fire_sound = 'sound/weapons/wave.ogg'
 	e_cost = 250
 	select_name = "teleport beam"
@@ -257,7 +257,7 @@
 	..(teleport_target)
 
 /obj/item/ammo_casing/energy/mimic
-	projectile_type = /obj/item/projectile/mimic
+	projectile_type = /obj/projectile/mimic
 	fire_sound = 'sound/weapons/bite.ogg'
 	select_name = "gun mimic"
 	var/mimic_type

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -1,47 +1,47 @@
 /obj/item/ammo_casing/magic
 	name = "magic casing"
 	desc = "I didn't even know magic needed ammo..."
-	projectile_type = /obj/item/projectile/magic
+	projectile_type = /obj/projectile/magic
 
 /obj/item/ammo_casing/magic/change
-	projectile_type = /obj/item/projectile/magic/change
+	projectile_type = /obj/projectile/magic/change
 
 /obj/item/ammo_casing/magic/animate
-	projectile_type = /obj/item/projectile/magic/animate
+	projectile_type = /obj/projectile/magic/animate
 
 /obj/item/ammo_casing/magic/heal
-	projectile_type = /obj/item/projectile/magic/resurrection
+	projectile_type = /obj/projectile/magic/resurrection
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/death
-	projectile_type = /obj/item/projectile/magic/death
+	projectile_type = /obj/projectile/magic/death
 
 /obj/item/ammo_casing/magic/teleport
-	projectile_type = /obj/item/projectile/magic/teleport
+	projectile_type = /obj/projectile/magic/teleport
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/door
-	projectile_type = /obj/item/projectile/magic/door
+	projectile_type = /obj/projectile/magic/door
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/fireball
-	projectile_type = /obj/item/projectile/magic/fireball
+	projectile_type = /obj/projectile/magic/fireball
 
 /obj/item/ammo_casing/magic/chaos
-	projectile_type = /obj/item/projectile/magic
+	projectile_type = /obj/projectile/magic
 
 /obj/item/ammo_casing/magic/spellblade
-	projectile_type = /obj/item/projectile/magic/spellblade
+	projectile_type = /obj/projectile/magic/spellblade
 
 /obj/item/ammo_casing/magic/slipping
-	projectile_type = /obj/item/projectile/magic/slipping
+	projectile_type = /obj/projectile/magic/slipping
 
 /obj/item/ammo_casing/magic/chaos/newshot()
-	projectile_type = pick(typesof(/obj/item/projectile/magic))
+	projectile_type = pick(typesof(/obj/projectile/magic))
 	..()
 
 /obj/item/ammo_casing/forcebolt
-	projectile_type = /obj/item/projectile/forcebolt
+	projectile_type = /obj/projectile/forcebolt
 
 /obj/item/ammo_casing/syringegun
 	name = "syringe gun spring"
@@ -49,7 +49,7 @@
 	projectile_type = null
 
 /obj/item/ammo_casing/energy/c3dbullet
-	projectile_type = /obj/item/projectile/bullet/midbullet3
+	projectile_type = /obj/projectile/bullet/midbullet3
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshots/gunshot_mg.ogg'
 	e_cost = 20

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -65,7 +65,7 @@
 	var/dy = abs(target.y - current.y)
 	return locate(target.x + round(gaussian(0, distro) * (dy+2)/8, 1), target.y + round(gaussian(0, distro) * (dx+2)/8, 1), target.z)
 
-/obj/item/projectile/proc/preparePixelProjectile(atom/target, var/turf/targloc, mob/living/user, params, spread)
+/obj/projectile/proc/preparePixelProjectile(atom/target, var/turf/targloc, mob/living/user, params, spread)
 	var/turf/curloc = get_turf(user)
 	loc = get_turf(user)
 	starting = get_turf(user)

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -48,14 +48,14 @@
 /obj/item/ammo_casing/caseless/spike
 	name = "alloy spike"
 	desc = "A broadhead spike made out of a weird silvery metal."
-	projectile_type = /obj/item/projectile/bullet/spike
+	projectile_type = /obj/projectile/bullet/spike
 	throwforce = 5
 	w_class = WEIGHT_CLASS_NORMAL
 	caliber = "spike"
 	icon_state = "bolt"
 	fire_sound = 'sound/weapons/bladeslice.ogg'
 
-/obj/item/projectile/bullet/spike
+/obj/projectile/bullet/spike
 	name = "alloy spike"
 	desc = "It's about a foot of weird silvery metal with a wicked point."
 	damage = 25
@@ -63,7 +63,7 @@
 	armour_penetration = 30
 	icon_state = "magspear"
 
-/obj/item/projectile/bullet/spike/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/spike/on_hit(atom/target, blocked = 0)
 	if((blocked != 100) && istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target
 		H.bleed(50)
@@ -87,12 +87,12 @@
 
 //Casing
 /obj/item/ammo_casing/energy/sonic
-	projectile_type = /obj/item/projectile/energy/sonic
+	projectile_type = /obj/projectile/energy/sonic
 	fire_sound = 'sound/effects/basscannon.ogg'
 	delay = 40
 
 //Projectile.
-/obj/item/projectile/energy/sonic
+/obj/projectile/energy/sonic
 	name = "distortion"
 	icon_state = "particle"
 	damage = 60

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -66,7 +66,7 @@
 	for(var/A in modkits)
 		. += A
 
-/obj/item/gun/energy/kinetic_accelerator/proc/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/gun/energy/kinetic_accelerator/proc/modify_projectile(obj/projectile/kinetic/K)
 	K.kinetic_gun = src //do something special on-hit, easy!
 	for(var/A in get_modkits())
 		var/obj/item/borg/upgrade/modkit/M = A
@@ -172,7 +172,7 @@
 
 //Casing
 /obj/item/ammo_casing/energy/kinetic
-	projectile_type = /obj/item/projectile/kinetic
+	projectile_type = /obj/projectile/kinetic
 	select_name = "kinetic"
 	e_cost = 500
 	fire_sound = 'sound/weapons/kenetic_accel.ogg' // fine spelling there chap
@@ -185,7 +185,7 @@
 
 
 //Projectiles
-/obj/item/projectile/kinetic
+/obj/projectile/kinetic
 	name = "kinetic force"
 	icon_state = null
 	damage = 40
@@ -197,18 +197,18 @@
 	var/pressure_decrease = 0.25
 	var/obj/item/gun/energy/kinetic_accelerator/kinetic_gun
 
-/obj/item/projectile/kinetic/pod
+/obj/projectile/kinetic/pod
 	range = 4
 
-/obj/item/projectile/kinetic/pod/regular
+/obj/projectile/kinetic/pod/regular
 	damage = 50
 	pressure_decrease = 0.5
 
-/obj/item/projectile/kinetic/Destroy()
+/obj/projectile/kinetic/Destroy()
 	kinetic_gun = null
 	return ..()
 
-/obj/item/projectile/kinetic/prehit(atom/target)
+/obj/projectile/kinetic/prehit(atom/target)
 	. = ..()
 	if(.)
 		if(kinetic_gun)
@@ -221,15 +221,15 @@
 			pressure_decrease_active = TRUE
 
 
-/obj/item/projectile/kinetic/on_range()
+/obj/projectile/kinetic/on_range()
 	strike_thing()
 	..()
 
-/obj/item/projectile/kinetic/on_hit(atom/target)
+/obj/projectile/kinetic/on_hit(atom/target)
 	strike_thing(target)
 	. = ..()
 
-/obj/item/projectile/kinetic/proc/strike_thing(atom/target)
+/obj/projectile/kinetic/proc/strike_thing(atom/target)
 	var/turf/target_turf = get_turf(target)
 	if(!target_turf)
 		target_turf = get_turf(src)
@@ -316,14 +316,14 @@
 	forceMove(get_turf(KA))
 	KA.modkits -= src
 
-/obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/projectile/kinetic/K)
 
 //use this one for effects you want to trigger before any damage is done at all and before damage is decreased by pressure
-/obj/item/borg/upgrade/modkit/proc/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //use this one for effects you want to trigger before mods that do damage
-/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //and this one for things that don't need to trigger before other damage-dealing mods
-/obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 
 //Range
 /obj/item/borg/upgrade/modkit/range
@@ -332,7 +332,7 @@
 	modifier = 1
 	cost = 24 //so you can fit four plus a tracer cosmetic
 
-/obj/item/borg/upgrade/modkit/range/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/range/modify_projectile(obj/projectile/kinetic/K)
 	K.range += modifier
 
 
@@ -342,7 +342,7 @@
 	desc = "Increases the damage of kinetic accelerator when installed."
 	modifier = 10
 
-/obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/projectile/kinetic/K)
 	K.damage += modifier
 
 
@@ -397,7 +397,7 @@
 	turf_aoe = initial(turf_aoe)
 	stats_stolen = FALSE
 
-/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(stats_stolen)
 		return
 	new /obj/effect/temp_visual/explosion/fast(target_turf)
@@ -443,7 +443,7 @@
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
-/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	var/valid_repeat = FALSE
 	if(isliving(target))
 		var/mob/living/L = target
@@ -463,7 +463,7 @@
 	cost = 20
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
 
-/obj/item/borg/upgrade/modkit/lifesteal/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/lifesteal/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target) && isliving(K.firer))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
@@ -478,7 +478,7 @@
 	cost = 30
 	modifier = 0.25 //A bonus 15 damage if you burst the field on a target, 60 if you lure them into it.
 
-/obj/item/borg/upgrade/modkit/resonator_blasts/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/resonator_blasts/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(target_turf && !ismineralturf(target_turf)) //Don't make fields on mineral turfs.
 		var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in target_turf
 		if(R)
@@ -496,7 +496,7 @@
 	var/maximum_bounty = 25
 	var/list/bounties_reaped = list()
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/bounty/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		var/list/existing_marks = L.has_status_effect_list(STATUS_EFFECT_SYPHONMARK)
@@ -507,7 +507,7 @@
 				qdel(SM)
 		L.apply_status_effect(STATUS_EFFECT_SYPHONMARK, src)
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(bounties_reaped[L.type])
@@ -535,7 +535,7 @@
 	maximum_of_type = 2
 	cost = 35
 
-/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/projectile/kinetic/K)
 	K.pressure_decrease *= modifier
 
 
@@ -590,7 +590,7 @@
 	denied_type = /obj/item/borg/upgrade/modkit/tracer
 	var/bolt_color = "#FFFFFF"
 
-/obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/projectile/kinetic/K)
 	K.icon_state = "ka_tracer"
 	K.color = bolt_color
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -81,17 +81,17 @@
 	return 0
 
 /obj/item/ammo_casing/energy/laser/accelerator
-	projectile_type = /obj/item/projectile/beam/laser/accelerator
+	projectile_type = /obj/projectile/beam/laser/accelerator
 	select_name = "accelerator"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
-/obj/item/projectile/beam/laser/accelerator
+/obj/projectile/beam/laser/accelerator
 	name = "accelerator laser"
 	icon_state = "heavylaser"
 	range = 255
 	damage = 6
 
-/obj/item/projectile/beam/laser/accelerator/Range()
+/obj/projectile/beam/laser/accelerator/Range()
 	..()
 	damage = min(damage+7, 100)
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -227,7 +227,7 @@
 		if(blue)
 			blue.target = null
 
-/obj/item/gun/energy/wormhole_projector/proc/create_portal(obj/item/projectile/beam/wormhole/W)
+/obj/item/gun/energy/wormhole_projector/proc/create_portal(obj/projectile/beam/wormhole/W)
 	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(W), null, src)
 	P.precision = 0
 	P.failchance = 0

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -82,11 +82,11 @@
 	var/turf/targturf = get_turf(target)
 	message_admins("Blast wave fired from [ADMIN_COORDJMP(starting)] ([get_area_name(user, TRUE)]) at [ADMIN_COORDJMP(targturf)] ([target.name]) by [key_name_admin(user)] with power [heavy]/[medium]/[light].")
 	log_game("Blast wave fired from ([starting.x], [starting.y], [starting.z]) ([get_area_name(user, TRUE)]) at ([target.x], [target.y], [target.z]) ([target]) by [key_name(user)] with power [heavy]/[medium]/[light].")
-	var/obj/item/projectile/blastwave/BW = new(loc, heavy, medium, light)
+	var/obj/projectile/blastwave/BW = new(loc, heavy, medium, light)
 	BW.preparePixelProjectile(target, get_turf(target), user, params, 0)
 	BW.fire()
 
-/obj/item/projectile/blastwave
+/obj/projectile/blastwave
 	name = "blast wave"
 	icon_state = "blastwave"
 	damage = 0
@@ -97,13 +97,13 @@
 	var/mediumr = 0
 	var/lightr = 0
 
-/obj/item/projectile/blastwave/New(loc, _h, _m, _l)
+/obj/projectile/blastwave/New(loc, _h, _m, _l)
 	..()
 	heavyr = _h
 	mediumr = _m
 	lightr = _l
 
-/obj/item/projectile/blastwave/Range()
+/obj/projectile/blastwave/Range()
 	..()
 	var/amount_destruction = 0
 	if(heavyr)
@@ -126,5 +126,5 @@
 	mediumr = max(mediumr - 1, 0)
 	lightr = max(lightr - 1, 0)
 
-/obj/item/projectile/blastwave/ex_act()
+/obj/projectile/blastwave/ex_act()
 	return

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -64,7 +64,7 @@
 	max_ammo = 1
 
 
-/obj/item/projectile/bullet/reusable/arrow
+/obj/projectile/bullet/reusable/arrow
 	name = "arrow"
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow
@@ -77,7 +77,7 @@
 	desc = "Stab, stab, stab."
 	icon_state = "arrow"
 	force = 10
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow
+	projectile_type = /obj/projectile/bullet/reusable/arrow
 	caliber = "arrow"
 
 //quiver

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -61,40 +61,40 @@
 
 //ammo//
 
-/obj/item/projectile/bullet/saw
+/obj/projectile/bullet/saw
 	damage = 45
 	armour_penetration = 5
 
-/obj/item/projectile/bullet/saw/bleeding
+/obj/projectile/bullet/saw/bleeding
 	damage = 20
 	armour_penetration = 0
 
-/obj/item/projectile/bullet/saw/bleeding/on_hit(atom/target, blocked = 0, hit_zone)
+/obj/projectile/bullet/saw/bleeding/on_hit(atom/target, blocked = 0, hit_zone)
 	. = ..()
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/C = target
 		C.bleed(35)
 
-/obj/item/projectile/bullet/saw/hollow
+/obj/projectile/bullet/saw/hollow
 	damage = 60
 	armour_penetration = -10
 
-/obj/item/projectile/bullet/saw/ap
+/obj/projectile/bullet/saw/ap
 	damage = 40
 	armour_penetration = 75
 
-/obj/item/projectile/bullet/saw/incen
+/obj/projectile/bullet/saw/incen
 	damage = 7
 	armour_penetration = 0
 
-obj/item/projectile/bullet/saw/incen/Move()
+obj/projectile/bullet/saw/incen/Move()
 	..()
 	var/turf/location = get_turf(src)
 	if(location)
 		new /obj/effect/hotspot(location)
 		location.hotspot_expose(700, 50, 1)
 
-/obj/item/projectile/bullet/saw/incen/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/saw/incen/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
@@ -141,21 +141,21 @@ obj/item/projectile/bullet/saw/incen/Move()
 	desc = "A 556x45mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "mm55645"
-	projectile_type = /obj/item/projectile/bullet/saw
+	projectile_type = /obj/projectile/bullet/saw
 
 /obj/item/ammo_casing/mm556x45/bleeding
 	desc = "A 556x45mm bullet casing with specialized inner-casing, that when it makes contact with a target, release tiny shrapnel to induce internal bleeding."
 	icon_state = "762-casing"
-	projectile_type = /obj/item/projectile/bullet/saw/bleeding
+	projectile_type = /obj/projectile/bullet/saw/bleeding
 
 /obj/item/ammo_casing/mm556x45/hollow
 	desc = "A 556x45mm bullet casing designed to cause more damage to unarmored targets."
-	projectile_type = /obj/item/projectile/bullet/saw/hollow
+	projectile_type = /obj/projectile/bullet/saw/hollow
 
 /obj/item/ammo_casing/mm556x45/ap
 	desc = "A 556x45mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
-	projectile_type = /obj/item/projectile/bullet/saw/ap
+	projectile_type = /obj/projectile/bullet/saw/ap
 
 /obj/item/ammo_casing/mm556x45/incen
 	desc = "A 556x45mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames. "
-	projectile_type = /obj/item/projectile/bullet/saw/incen
+	projectile_type = /obj/projectile/bullet/saw/incen

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -77,10 +77,10 @@
 /obj/item/ammo_casing/point50
 	desc = "A .50 bullet casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper
+	projectile_type = /obj/projectile/bullet/sniper
 	icon_state = ".50"
 
-/obj/item/projectile/bullet/sniper
+/obj/projectile/bullet/sniper
 	damage = 70
 	stun = 5
 	weaken = 5
@@ -88,7 +88,7 @@
 	armour_penetration = 50
 	var/breakthings = TRUE
 
-/obj/item/projectile/bullet/sniper/on_hit(atom/target, blocked = 0, hit_zone)
+/obj/projectile/bullet/sniper/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target) && breakthings))
 		target.ex_act(rand(1,2))
 
@@ -107,11 +107,11 @@
 /obj/item/ammo_casing/soporific
 	desc = "A .50 bullet casing, specialised in sending the target to sleep, instead of hell."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/soporific
+	projectile_type = /obj/projectile/bullet/sniper/soporific
 	icon_state = ".50"
 	harmful = FALSE
 
-/obj/item/projectile/bullet/sniper/soporific
+/obj/projectile/bullet/sniper/soporific
 	armour_penetration = 0
 	nodamage = 1
 	stun = 0
@@ -119,7 +119,7 @@
 	weaken = 0
 	breakthings = FALSE
 
-/obj/item/projectile/bullet/sniper/soporific/on_hit(atom/target, blocked = 0, hit_zone)
+/obj/projectile/bullet/sniper/soporific/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && istype(target, /mob/living))
 		var/mob/living/L = target
 		L.SetSleeping(20)
@@ -139,10 +139,10 @@
 /obj/item/ammo_casing/haemorrhage
 	desc = "A .50 bullet casing, specialised in causing massive bloodloss"
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/haemorrhage
+	projectile_type = /obj/projectile/bullet/sniper/haemorrhage
 	icon_state = ".50"
 
-/obj/item/projectile/bullet/sniper/haemorrhage
+/obj/projectile/bullet/sniper/haemorrhage
 	armour_penetration = 15
 	damage = 15
 	stun = 0
@@ -150,7 +150,7 @@
 	weaken = 0
 	breakthings = FALSE
 
-/obj/item/projectile/bullet/sniper/haemorrhage/on_hit(atom/target, blocked = 0, hit_zone)
+/obj/projectile/bullet/sniper/haemorrhage/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/C = target
 		C.bleed(100)
@@ -168,10 +168,10 @@
 /obj/item/ammo_casing/penetrator
 	desc = "A .50 caliber penetrator round casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/penetrator
+	projectile_type = /obj/projectile/bullet/sniper/penetrator
 	icon_state = ".50"
 
-/obj/item/projectile/bullet/sniper/penetrator
+/obj/projectile/bullet/sniper/penetrator
 	icon_state = "gauss"
 	name = "penetrator round"
 	damage = 60
@@ -191,10 +191,10 @@
 /obj/item/ammo_casing/compact
 	desc = "A .50 caliber compact round casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/compact
+	projectile_type = /obj/projectile/bullet/sniper/compact
 	icon_state = ".50"
 
-/obj/item/projectile/bullet/sniper/compact //Can't dismember, and can't break things; just deals massive damage.
+/obj/projectile/bullet/sniper/compact //Can't dismember, and can't break things; just deals massive damage.
 	dismemberment = 0
 	breakthings = FALSE
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/beam
+/obj/projectile/beam
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
@@ -15,25 +15,25 @@
 	ricochets_max = 50	//Honk!
 	ricochet_chance = 80
 
-/obj/item/projectile/beam/laser
+/obj/projectile/beam/laser
 
-/obj/item/projectile/beam/laser/heavylaser
+/obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage = 40
 
-/obj/item/projectile/beam/practice
+/obj/projectile/beam/practice
 	name = "practice laser"
 	damage = 0
 	nodamage = 1
 	log_override = TRUE
 
-/obj/item/projectile/beam/scatter
+/obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
 	damage = 5
 
-/obj/item/projectile/beam/xray
+/obj/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"
 	damage = 15
@@ -44,7 +44,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
-/obj/item/projectile/beam/disabler
+/obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
 	damage = 30
@@ -55,32 +55,32 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_CYAN
 
-/obj/item/projectile/beam/pulse
+/obj/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_DARKBLUE
 
-/obj/item/projectile/beam/pulse/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/beam/pulse/on_hit(var/atom/target, var/blocked = 0)
 	if(istype(target,/turf/)||istype(target,/obj/structure/))
 		target.ex_act(2)
 	..()
 
-/obj/item/projectile/beam/pulse/shot
+/obj/projectile/beam/pulse/shot
 	damage = 40
 
-/obj/item/projectile/beam/emitter
+/obj/projectile/beam/emitter
 	name = "emitter beam"
 	icon_state = "emitter"
 	damage = 30
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
-/obj/item/projectile/beam/emitter/singularity_pull()
+/obj/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss
 
-/obj/item/projectile/beam/lasertag
+/obj/projectile/beam/lasertag
 	name = "laser tag beam"
 	icon_state = "omnilaser"
 	hitsound = 'sound/weapons/tap.ogg'
@@ -92,7 +92,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_DARKBLUE
 
-/obj/item/projectile/beam/lasertag/on_hit(atom/target, blocked = 0)
+/obj/projectile/beam/lasertag/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
@@ -101,21 +101,21 @@
 				M.adjustStaminaLoss(34)
 	return 1
 
-/obj/item/projectile/beam/lasertag/omni
+/obj/projectile/beam/lasertag/omni
 	name = "laser tag beam"
 	icon_state = "omnilaser"
 
-/obj/item/projectile/beam/lasertag/redtag
+/obj/projectile/beam/lasertag/redtag
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
 
-/obj/item/projectile/beam/lasertag/bluetag
+/obj/projectile/beam/lasertag/bluetag
 	icon_state = "bluelaser"
 	suit_types = list(/obj/item/clothing/suit/redtag)
 
-/obj/item/projectile/beam/sniper
+/obj/projectile/beam/sniper
 	name = "sniper beam"
 	icon_state = "sniperlaser"
 	damage = 60
@@ -125,27 +125,27 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	light_color = LIGHT_COLOR_PINK
 
-/obj/item/projectile/beam/immolator
+/obj/projectile/beam/immolator
 	name = "immolation beam"
 
-/obj/item/projectile/beam/immolator/strong
+/obj/projectile/beam/immolator/strong
 	name = "heavy immolation beam"
 	damage = 45
 	icon_state = "heavylaser"
 
-/obj/item/projectile/beam/immolator/weak
+/obj/projectile/beam/immolator/weak
 	name = "light immolation beam"
 	damage = 8
 	icon_state = "scatterlaser"
 
-/obj/item/projectile/beam/immolator/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/beam/immolator/on_hit(var/atom/target, var/blocked = 0)
 	. = ..()
 	if(istype(target, /mob/living/carbon))
 		var/mob/living/carbon/M = target
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
 
-/obj/item/projectile/beam/instakill
+/obj/projectile/beam/instakill
 	name = "instagib laser"
 	icon_state = "purple_laser"
 	damage = 200
@@ -153,17 +153,17 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	light_color = LIGHT_COLOR_PURPLE
 
-/obj/item/projectile/beam/instakill/blue
+/obj/projectile/beam/instakill/blue
 	icon_state = "blue_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_DARKBLUE
 
-/obj/item/projectile/beam/instakill/red
+/obj/projectile/beam/instakill/red
 	icon_state = "red_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
 
-/obj/item/projectile/beam/instakill/on_hit(atom/target)
+/obj/projectile/beam/instakill/on_hit(atom/target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet
+/obj/projectile/bullet
 	name = "bullet"
 	icon_state = "bullet"
 	damage = 60
@@ -7,14 +7,14 @@
 	hitsound_wall = "ricochet"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 
-/obj/item/projectile/bullet/weakbullet //beanbag, heavy stamina damage
+/obj/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	name = "beanbag slug"
 	damage = 5
 	stamina = 80
 
-/obj/item/projectile/bullet/weakbullet/booze
+/obj/projectile/bullet/weakbullet/booze
 
-/obj/item/projectile/bullet/weakbullet/booze/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/weakbullet/booze/on_hit(atom/target, blocked = 0)
 	if(..(target, blocked))
 		var/mob/living/M = target
 		M.AdjustDizzy(20)
@@ -31,135 +31,135 @@
 			M.AdjustDrowsy(10)
 			A.volume += 5 //Because we can
 
-/obj/item/projectile/bullet/weakbullet2  //detective revolver instastuns, but multiple shots are better for keeping punks down
+/obj/projectile/bullet/weakbullet2  //detective revolver instastuns, but multiple shots are better for keeping punks down
 	name = "rubber bullet"
 	damage = 5
 	weaken = 3
 	stamina = 60
 	icon_state = "bullet-r"
 
-/obj/item/projectile/bullet/weakbullet2/invisible //finger gun bullets
+/obj/projectile/bullet/weakbullet2/invisible //finger gun bullets
 	name = "invisible bullet"
 	damage = 0
 	icon_state = null
 	hitsound_wall = null
 
-/obj/item/projectile/bullet/weakbullet2/invisible/fake
+/obj/projectile/bullet/weakbullet2/invisible/fake
 	weaken = 0
 	stamina = 0
 	nodamage = 1
 	log_override = TRUE
 
-/obj/item/projectile/bullet/weakbullet3
+/obj/projectile/bullet/weakbullet3
 	damage = 20
 
-/obj/item/projectile/bullet/weakbullet4
+/obj/projectile/bullet/weakbullet4
 	name = "rubber bullet"
 	damage = 5
 	stamina = 30
 	icon_state = "bullet-r"
 
-/obj/item/projectile/bullet/toxinbullet
+/obj/projectile/bullet/toxinbullet
 	damage = 15
 	damage_type = TOX
 
-/obj/item/projectile/bullet/incendiary
+/obj/projectile/bullet/incendiary
 
-/obj/item/projectile/bullet/incendiary/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/bullet/incendiary/on_hit(var/atom/target, var/blocked = 0)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.adjust_fire_stacks(4)
 		M.IgniteMob()
 
-/obj/item/projectile/bullet/incendiary/firebullet
+/obj/projectile/bullet/incendiary/firebullet
 	damage = 10
 
-/obj/item/projectile/bullet/armourpiercing
+/obj/projectile/bullet/armourpiercing
 	damage = 17
 	armour_penetration = 10
 
-/obj/item/projectile/bullet/pellet
+/obj/projectile/bullet/pellet
 	name = "pellet"
 	damage = 12.5
 	tile_dropoff = 0.75
 	tile_dropoff_s = 1.25
 
-/obj/item/projectile/bullet/pellet/rubber
+/obj/projectile/bullet/pellet/rubber
 	name = "rubber pellet"
 	damage = 3
 	stamina = 25
 	icon_state = "bullet-r"
 
-/obj/item/projectile/bullet/pellet/weak
+/obj/projectile/bullet/pellet/weak
 	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.
 	damage = 6
 
-/obj/item/projectile/bullet/pellet/weak/New()
+/obj/projectile/bullet/pellet/weak/New()
 	range = rand(1, 8)
 	..()
 
-/obj/item/projectile/bullet/pellet/weak/on_range()
+/obj/projectile/bullet/pellet/weak/on_range()
  	do_sparks(1, 1, src)
  	..()
 
-/obj/item/projectile/bullet/pellet/overload
+/obj/projectile/bullet/pellet/overload
 	damage = 3
 
-/obj/item/projectile/bullet/pellet/overload/New()
+/obj/projectile/bullet/pellet/overload/New()
 	range = rand(1, 10)
 	..()
 
-/obj/item/projectile/bullet/pellet/assassination
+/obj/projectile/bullet/pellet/assassination
 	damage = 12
 	tile_dropoff = 1	// slightly less damage and greater damage falloff compared to normal buckshot
 
-/obj/item/projectile/bullet/pellet/assassination/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/pellet/assassination/on_hit(atom/target, blocked = 0)
 	if(..(target, blocked))
 		var/mob/living/M = target
 		M.AdjustSilence(2)	// HELP MIME KILLING ME IN MAINT
 
-/obj/item/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
  	..()
  	explosion(target, 0, 0, 2)
 
-/obj/item/projectile/bullet/pellet/overload/on_range()
+/obj/projectile/bullet/pellet/overload/on_range()
  	explosion(src, 0, 0, 2)
  	do_sparks(3, 3, src)
  	..()
 
-/obj/item/projectile/bullet/midbullet
+/obj/projectile/bullet/midbullet
 	damage = 20
 	stamina = 65 //two rounds from the c20r knocks people down
 
-/obj/item/projectile/bullet/midbullet_r
+/obj/projectile/bullet/midbullet_r
 	damage = 5
 	stamina = 75 //Still two rounds to knock people down
 
-/obj/item/projectile/bullet/midbullet2
+/obj/projectile/bullet/midbullet2
 	damage = 25
 
-/obj/item/projectile/bullet/midbullet3
+/obj/projectile/bullet/midbullet3
 	damage = 30
 
-/obj/item/projectile/bullet/midbullet3/hp
+/obj/projectile/bullet/midbullet3/hp
 	damage = 40
 	armour_penetration = -50
 
-/obj/item/projectile/bullet/midbullet3/ap
+/obj/projectile/bullet/midbullet3/ap
 	damage = 27
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/midbullet3/fire/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/midbullet3/fire/on_hit(atom/target, blocked = 0)
 	if(..(target, blocked))
 		var/mob/living/M = target
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
 
-/obj/item/projectile/bullet/heavybullet
+/obj/projectile/bullet/heavybullet
 	damage = 35
 
-/obj/item/projectile/bullet/stunshot//taser slugs for shotguns, nothing special
+/obj/projectile/bullet/stunshot//taser slugs for shotguns, nothing special
 	name = "stunshot"
 	damage = 5
 	stun = 5
@@ -170,22 +170,22 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 
-/obj/item/projectile/bullet/incendiary/shell
+/obj/projectile/bullet/incendiary/shell
 	name = "incendiary slug"
 	damage = 20
 
-/obj/item/projectile/bullet/incendiary/shell/Move()
+/obj/projectile/bullet/incendiary/shell/Move()
 	..()
 	var/turf/location = get_turf(src)
 	if(location)
 		new /obj/effect/hotspot(location)
 		location.hotspot_expose(700, 50, 1)
 
-/obj/item/projectile/bullet/incendiary/shell/dragonsbreath
+/obj/projectile/bullet/incendiary/shell/dragonsbreath
 	name = "dragonsbreath round"
 	damage = 5
 
-/obj/item/projectile/bullet/meteorshot
+/obj/projectile/bullet/meteorshot
 	name = "meteor"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
@@ -194,30 +194,30 @@
 	stun = 8
 	hitsound = 'sound/effects/meteorimpact.ogg'
 
-/obj/item/projectile/bullet/meteorshot/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/bullet/meteorshot/on_hit(var/atom/target, var/blocked = 0)
 	..()
 	if(istype(target, /atom/movable))
 		var/atom/movable/M = target
 		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 		M.throw_at(throw_target, 3, 2)
 
-/obj/item/projectile/bullet/meteorshot/New()
+/obj/projectile/bullet/meteorshot/New()
 	..()
 	SpinAnimation()
 
-/obj/item/projectile/bullet/meteorshot/weak
+/obj/projectile/bullet/meteorshot/weak
 	damage = 10
 	weaken = 4
 	stun = 4
 
-/obj/item/projectile/bullet/mime
+/obj/projectile/bullet/mime
 	damage = 0
 	stun = 5
 	weaken = 5
 	slur = 20
 	stutter = 20
 
-/obj/item/projectile/bullet/mime/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/bullet/mime/on_hit(var/atom/target, var/blocked = 0)
 	..(target, blocked)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
@@ -229,18 +229,18 @@
 		for(var/obj/item/mecha_parts/mecha_equipment/weapon/honker in chassis.equipment)
 			honker.set_ready_state(0)
 
-/obj/item/projectile/bullet/dart
+/obj/projectile/bullet/dart
 	name = "dart"
 	icon_state = "cbbolt"
 	damage = 6
 	var/piercing = FALSE
 
-/obj/item/projectile/bullet/dart/New()
+/obj/projectile/bullet/dart/New()
 	..()
 	create_reagents(50)
 	reagents.set_reacting(FALSE)
 
-/obj/item/projectile/bullet/dart/on_hit(var/atom/target, var/blocked = 0, var/hit_zone)
+/obj/projectile/bullet/dart/on_hit(var/atom/target, var/blocked = 0, var/hit_zone)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100)
@@ -257,44 +257,44 @@
 	reagents.handle_reactions()
 	return 1
 
-/obj/item/projectile/bullet/dart/metalfoam
+/obj/projectile/bullet/dart/metalfoam
 
-/obj/item/projectile/bullet/dart/metalfoam/New()
+/obj/projectile/bullet/dart/metalfoam/New()
 	..()
 	reagents.add_reagent("aluminum", 15)
 	reagents.add_reagent("fluorosurfactant", 5)
 	reagents.add_reagent("sacid", 5)
 
 //This one is for future syringe guns update
-/obj/item/projectile/bullet/dart/syringe
+/obj/projectile/bullet/dart/syringe
 	name = "syringe"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "syringeproj"
 
-/obj/item/projectile/bullet/dart/syringe/tranquilizer
+/obj/projectile/bullet/dart/syringe/tranquilizer
 
-/obj/item/projectile/bullet/dart/syringe/tranquilizer/New()
+/obj/projectile/bullet/dart/syringe/tranquilizer/New()
 	..()
 	reagents.add_reagent("haloperidol", 15)
 
-/obj/item/projectile/bullet/neurotoxin
+/obj/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
 	weaken = 5
 
-/obj/item/projectile/bullet/neurotoxin/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/bullet/neurotoxin/on_hit(var/atom/target, var/blocked = 0)
 	if(isalien(target))
 		weaken = 0
 		nodamage = 1
 	. = ..() // Execute the rest of the code.
 
-/obj/item/projectile/bullet/cap
+/obj/projectile/bullet/cap
 	name = "cap"
 	damage = 0
 	nodamage = 1
 
-/obj/item/projectile/bullet/cap/fire()
+/obj/projectile/bullet/cap/fire()
 	loc = null
 	qdel(src)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy
+/obj/projectile/energy
 	name = "energy"
 	icon_state = "spark"
 	damage = 0
@@ -6,7 +6,7 @@
 	flag = "energy"
 	is_reflectable = TRUE
 
-/obj/item/projectile/energy/electrode
+/obj/projectile/energy/electrode
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
@@ -19,7 +19,7 @@
 	range = 7
 	//Damage will be handled on the MOB side, to prevent window shattering.
 
-/obj/item/projectile/energy/electrode/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/energy/electrode/on_hit(var/atom/target, var/blocked = 0)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, 1, src)
@@ -31,11 +31,11 @@
 			spawn(5)
 				C.do_jitter_animation(jitter)
 
-/obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
+/obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, 1, src)
 	..()
 
-/obj/item/projectile/energy/declone
+/obj/projectile/energy/declone
 	name = "declone"
 	icon_state = "declone"
 	damage = 20
@@ -43,7 +43,7 @@
 	irradiate = 10
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 
-/obj/item/projectile/energy/dart
+/obj/projectile/energy/dart
 	name = "dart"
 	icon_state = "toxin"
 	damage = 5
@@ -51,7 +51,7 @@
 	weaken = 5
 	range = 7
 
-/obj/item/projectile/energy/shuriken
+/obj/projectile/energy/shuriken
 	name = "shuriken"
 	icon_state = "toxin"
 	damage = 10
@@ -59,7 +59,7 @@
 	weaken = 5
 	stutter = 5
 
-/obj/item/projectile/energy/bolt
+/obj/projectile/energy/bolt
 	name = "bolt"
 	icon_state = "cbbolt"
 	damage = 15
@@ -68,10 +68,10 @@
 	weaken = 5
 	stutter = 5
 
-/obj/item/projectile/energy/bolt/large
+/obj/projectile/energy/bolt/large
 	damage = 20
 
-/obj/item/projectile/energy/shock_revolver
+/obj/projectile/energy/shock_revolver
 	name = "shock bolt"
 	icon_state = "purple_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
@@ -79,17 +79,17 @@
 
 /obj/item/ammo_casing/energy/shock_revolver/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
 	..()
-	var/obj/item/projectile/energy/shock_revolver/P = BB
+	var/obj/projectile/energy/shock_revolver/P = BB
 	spawn(1)
 		P.chain = P.Beam(user,icon_state="purple_lightning",icon = 'icons/effects/effects.dmi',time=1000, maxdistance = 30)
 
-/obj/item/projectile/energy/shock_revolver/on_hit(atom/target)
+/obj/projectile/energy/shock_revolver/on_hit(atom/target)
 	. = ..()
 	if(isliving(target))
 		tesla_zap(src, 3, 10000)
 	qdel(chain)
 
-/obj/item/projectile/energy/toxplasma
+/obj/projectile/energy/toxplasma
 	name = "plasma bolt"
 	icon_state = "energy"
 	damage = 20

--- a/code/modules/projectiles/projectile/force.dm
+++ b/code/modules/projectiles/projectile/force.dm
@@ -1,14 +1,14 @@
-/obj/item/projectile/forcebolt
+/obj/projectile/forcebolt
 	name = "force bolt"
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "ice_1"
 	damage = 20
 	flag = "energy"
 
-/obj/item/projectile/forcebolt/strong
+/obj/projectile/forcebolt/strong
 	name = "force bolt"
 
-/obj/item/projectile/forcebolt/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/forcebolt/on_hit(var/atom/target, var/blocked = 0)
 	. = ..()
 	if(blocked < 100)
 		var/obj/T = target

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/magic
+/obj/projectile/magic
 	name = "bolt of nothing"
 	icon_state = "energy"
 	damage = 0
@@ -7,11 +7,11 @@
 	armour_penetration = 100
 	flag = "magic"
 
-/obj/item/projectile/magic/death
+/obj/projectile/magic/death
 	name = "bolt of death"
 	icon_state = "pulse1_bl"
 
-/obj/item/projectile/magic/fireball
+/obj/projectile/magic/fireball
 	name = "bolt of fireball"
 	icon_state = "fireball"
 	damage = 10
@@ -25,7 +25,7 @@
 	var/exp_flash = 3
 	var/exp_fire = 2
 
-/obj/item/projectile/magic/death/on_hit(mob/living/carbon/C)
+/obj/projectile/magic/death/on_hit(mob/living/carbon/C)
 	. = ..()
 	if(isliving(C))
 		if(ismachineperson(C)) //speshul snowfleks deserv speshul treetment
@@ -35,7 +35,7 @@
 
 		visible_message("<span class='danger'>[C] topples backwards as the death bolt impacts [C.p_them()]!</span>")
 
-/obj/item/projectile/magic/fireball/Range()
+/obj/projectile/magic/fireball/Range()
 	var/turf/T1 = get_step(src,turn(dir, -45))
 	var/turf/T2 = get_step(src,turn(dir, 45))
 	var/turf/T3 = get_step(src,dir)
@@ -53,7 +53,7 @@
 		return
 	..()
 
-/obj/item/projectile/magic/fireball/on_hit(var/target)
+/obj/projectile/magic/fireball/on_hit(var/target)
 	. = ..()
 	var/turf/T = get_turf(target)
 	explosion(T, exp_devastate, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire)
@@ -62,18 +62,18 @@
 		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately
 
 
-/obj/item/projectile/magic/fireball/infernal
+/obj/projectile/magic/fireball/infernal
 	name = "infernal fireball"
 	exp_heavy = -1
 	exp_light = -1
 	exp_flash = 4
 	exp_fire= 5
 
-/obj/item/projectile/magic/resurrection
+/obj/projectile/magic/resurrection
 	name = "bolt of resurrection"
 	icon_state = "ion"
 
-/obj/item/projectile/magic/resurrection/on_hit(var/mob/living/carbon/target)
+/obj/projectile/magic/resurrection/on_hit(var/mob/living/carbon/target)
 	. = ..()
 	if(ismob(target))
 		var/old_stat = target.stat
@@ -89,13 +89,13 @@
 		else
 			to_chat(target, "<span class='notice'>You rise with a start, you're alive!!!</span>")
 
-/obj/item/projectile/magic/teleport
+/obj/projectile/magic/teleport
 	name = "bolt of teleportation"
 	icon_state = "bluespace"
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
-/obj/item/projectile/magic/teleport/on_hit(var/mob/target)
+/obj/projectile/magic/teleport/on_hit(var/mob/target)
 	. = ..()
 	var/teleammount = 0
 	var/teleloc = target
@@ -109,14 +109,14 @@
 			smoke.set_up(max(round(10 - teleammount),1), 0, stuff.loc) //Smoke drops off if a lot of stuff is moved for the sake of sanity
 			smoke.start()
 
-/obj/item/projectile/magic/door
+/obj/projectile/magic/door
 	name = "bolt of door creation"
 	icon_state = "energy"
 	var/list/door_types = list(/obj/structure/mineral_door/wood,/obj/structure/mineral_door/iron,/obj/structure/mineral_door/silver,\
 		/obj/structure/mineral_door/gold,/obj/structure/mineral_door/uranium,/obj/structure/mineral_door/sandstone,/obj/structure/mineral_door/transparent/plasma,\
 		/obj/structure/mineral_door/transparent/diamond)
 
-/obj/item/projectile/magic/door/on_hit(var/atom/target)
+/obj/projectile/magic/door/on_hit(var/atom/target)
 	. = ..()
 	var/atom/T = target.loc
 	if(isturf(target) && target.density)
@@ -128,30 +128,30 @@
 	else if(istype(target, /obj/structure/closet))
 		OpenCloset(target)
 
-/obj/item/projectile/magic/door/proc/CreateDoor(turf/T)
+/obj/projectile/magic/door/proc/CreateDoor(turf/T)
 	var/door_type = pick(door_types)
 	var/obj/structure/mineral_door/D = new door_type(T)
 	T.ChangeTurf(/turf/simulated/floor/plasteel)
 	D.Open()
 
-/obj/item/projectile/magic/door/proc/OpenDoor(var/obj/machinery/door/D)
+/obj/projectile/magic/door/proc/OpenDoor(var/obj/machinery/door/D)
 	if(istype(D,/obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/A = D
 		A.locked = FALSE
 	D.open()
 
-/obj/item/projectile/magic/door/proc/OpenCloset(var/obj/structure/closet/C)
+/obj/projectile/magic/door/proc/OpenCloset(var/obj/structure/closet/C)
 	if(istype(C, /obj/structure/closet/secure_closet))
 		var/obj/structure/closet/secure_closet/SC = C
 		SC.locked = FALSE
 	C.open()
 
-/obj/item/projectile/magic/change
+/obj/projectile/magic/change
 	name = "bolt of change"
 	icon_state = "ice_1"
 	damage_type = BURN
 
-/obj/item/projectile/magic/change/on_hit(var/atom/change)
+/obj/projectile/magic/change/on_hit(var/atom/change)
 	. = ..()
 	wabbajack(change)
 
@@ -278,12 +278,12 @@
 		qdel(M)
 		return new_mob
 
-/obj/item/projectile/magic/animate
+/obj/projectile/magic/animate
 	name = "bolt of animation"
 	icon_state = "red_1"
 	damage_type = BURN
 
-/obj/item/projectile/magic/animate/Bump(var/atom/change)
+/obj/projectile/magic/animate/Bump(var/atom/change)
 	..()
 	if(istype(change, /obj/item) || istype(change, /obj/structure) && !is_type_in_list(change, GLOB.protected_objects))
 		if(istype(change, /obj/structure/closet/statue))
@@ -310,7 +310,7 @@
 		var/mob/living/simple_animal/hostile/mimic/copy/C = change
 		C.ChangeOwner(firer)
 
-/obj/item/projectile/magic/spellblade
+/obj/projectile/magic/spellblade
 	name = "blade energy"
 	icon_state = "lavastaff"
 	damage = 15
@@ -319,7 +319,7 @@
 	dismemberment = 50
 	nodamage = 0
 
-/obj/item/projectile/magic/slipping
+/obj/projectile/magic/slipping
 	name = "magical banana"
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "banana"
@@ -327,11 +327,11 @@
 	var/slip_weaken = 5
 	hitsound = 'sound/items/bikehorn.ogg'
 
-/obj/item/projectile/magic/slipping/New()
+/obj/projectile/magic/slipping/New()
 	..()
 	SpinAnimation()
 
-/obj/item/projectile/magic/slipping/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/magic/slipping/on_hit(var/atom/target, var/blocked = 0)
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.slip(src, slip_stun, slip_weaken, 0, FALSE, TRUE) //Slips even with noslips/magboots on. NO ESCAPE!

--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -1,31 +1,31 @@
-/obj/item/projectile/bullet/reusable
+/obj/projectile/bullet/reusable
 	name = "reusable bullet"
 	desc = "How do you even reuse a bullet?"
 	var/ammo_type = /obj/item/ammo_casing/caseless/
 	var/dropped = 0
 	impact_effect_type = null
 
-/obj/item/projectile/bullet/reusable/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/reusable/on_hit(atom/target, blocked = 0)
 	. = ..()
 	handle_drop()
 
-/obj/item/projectile/bullet/reusable/on_range()
+/obj/projectile/bullet/reusable/on_range()
 	handle_drop()
 	..()
 
-/obj/item/projectile/bullet/reusable/proc/handle_drop()
+/obj/projectile/bullet/reusable/proc/handle_drop()
 	if(!dropped)
 		new ammo_type(loc)
 		dropped = 1
 
-/obj/item/projectile/bullet/reusable/magspear
+/obj/projectile/bullet/reusable/magspear
 	name = "magnetic spear"
 	desc = "WHITE WHALE, HOLY GRAIL"
 	damage = 30 //takes 3 spears to kill a mega carp, one to kill a normal carp
 	icon_state = "magspear"
 	ammo_type = /obj/item/ammo_casing/caseless/magspear
 
-/obj/item/projectile/bullet/reusable/foam_dart
+/obj/projectile/bullet/reusable/foam_dart
 	name = "foam dart"
 	desc = "I hope you're wearing eye protection."
 	damage = 0 // It's a damn toy.
@@ -38,7 +38,7 @@
 	var/obj/item/pen/pen = null
 	log_override = TRUE//it won't log even when there's a pen inside, but since the damage will be so low, I don't think there's any point in making it any more complex
 
-/obj/item/projectile/bullet/reusable/foam_dart/handle_drop()
+/obj/projectile/bullet/reusable/foam_dart/handle_drop()
 	if(dropped)
 		return
 	dropped = 1
@@ -46,7 +46,7 @@
 	var/obj/item/ammo_casing/caseless/foam_dart/old_dart = ammo_casing
 	newdart.modified = old_dart.modified
 	if(pen)
-		var/obj/item/projectile/bullet/reusable/foam_dart/newdart_FD = newdart.BB
+		var/obj/projectile/bullet/reusable/foam_dart/newdart_FD = newdart.BB
 		newdart_FD.pen = pen
 		pen.loc = newdart_FD
 		pen = null
@@ -55,24 +55,24 @@
 	newdart.BB.damage_type = damage_type
 	newdart.update_icon()
 
-/obj/item/projectile/bullet/reusable/foam_dart/Destroy()
+/obj/projectile/bullet/reusable/foam_dart/Destroy()
 	QDEL_NULL(pen)
 	return ..()
 
-/obj/item/projectile/bullet/reusable/foam_dart/riot
+/obj/projectile/bullet/reusable/foam_dart/riot
 	name = "riot foam dart"
 	icon_state = "foamdart_riot"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
 	stamina = 25
 	log_override = FALSE
 
-/obj/item/projectile/bullet/reusable/foam_dart/sniper
+/obj/projectile/bullet/reusable/foam_dart/sniper
 	name = "foam sniper dart"
 	icon_state = "foamdartsniper"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/sniper
 	range = 30
 
-/obj/item/projectile/bullet/reusable/foam_dart/sniper/riot
+/obj/projectile/bullet/reusable/foam_dart/sniper/riot
 	name = "riot sniper foam dart"
 	icon_state = "foamdartsniper_riot"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/sniper/riot

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/ion
+/obj/projectile/ion
 	name = "ion bolt"
 	icon_state = "ion"
 	damage = 0
@@ -8,31 +8,31 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 	flag = "energy"
 
-/obj/item/projectile/ion/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/ion/on_hit(var/atom/target, var/blocked = 0)
 	..()
 	empulse(target, 1, 1, 1, cause = "[type] fired by [key_name(firer)]")
 	return 1
 
-/obj/item/projectile/ion/weak
+/obj/projectile/ion/weak
 
-/obj/item/projectile/ion/weak/on_hit(atom/target, blocked = 0)
+/obj/projectile/ion/weak/on_hit(atom/target, blocked = 0)
 	..()
 	empulse(target, 0, 0, 1, cause = "[type] fired by [key_name(firer)]")
 	return 1
 
-/obj/item/projectile/bullet/gyro
+/obj/projectile/bullet/gyro
 	name ="explosive bolt"
 	icon_state= "bolter"
 	damage = 50
 	alwayslog = TRUE
 	flag = "bullet"
 
-/obj/item/projectile/bullet/gyro/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/bullet/gyro/on_hit(var/atom/target, var/blocked = 0)
 	..()
 	explosion(target, -1, 0, 2, cause = "[type] fired by [key_name(firer)]")
 	return 1
 
-/obj/item/projectile/bullet/a40mm
+/obj/projectile/bullet/a40mm
 	name ="40mm grenade"
 	desc = "USE A WEEL GUN"
 	icon_state= "bolter"
@@ -40,12 +40,12 @@
 	damage = 60
 	flag = "bullet"
 
-/obj/item/projectile/bullet/a40mm/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/a40mm/on_hit(atom/target, blocked = 0)
 	..()
 	explosion(target, -1, 0, 2, 1, 0, flame_range = 3, cause = "[type] fired by [key_name(firer)]")
 	return 1
 
-/obj/item/projectile/temp
+/obj/projectile/temp
 	name = "temperature beam"
 	icon_state = "temp_4"
 	damage = 0
@@ -55,7 +55,7 @@
 	var/temperature = 300
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
-/obj/item/projectile/temp/New(loc, shot_temp)
+/obj/projectile/temp/New(loc, shot_temp)
 	..()
 	if(!isnull(shot_temp))
 		temperature = shot_temp
@@ -92,7 +92,7 @@
 			icon_state = "temp_4"
 
 
-/obj/item/projectile/temp/on_hit(var/atom/target, var/blocked = 0)//These two could likely check temp protection on the mob
+/obj/projectile/temp/on_hit(var/atom/target, var/blocked = 0)//These two could likely check temp protection on the mob
 	..()
 	if(isliving(target))
 		var/mob/living/M = target
@@ -103,7 +103,7 @@
 			playsound(M.loc, 'sound/effects/bamf.ogg', 50, 0)
 	return 1
 
-/obj/item/projectile/meteor
+/obj/projectile/meteor
 	name = "meteor"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "small"
@@ -112,7 +112,7 @@
 	nodamage = 1
 	flag = "bullet"
 
-/obj/item/projectile/meteor/Bump(atom/A, yes)
+/obj/projectile/meteor/Bump(atom/A, yes)
 	if(yes)
 		return
 	if(A == firer)
@@ -124,7 +124,7 @@
 			shake_camera(M, 3, 1)
 	qdel(src)
 
-/obj/item/projectile/energy/floramut
+/obj/projectile/energy/floramut
 	name = "alpha somatoray"
 	icon_state = "energy"
 	damage = 0
@@ -133,7 +133,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	flag = "energy"
 
-/obj/item/projectile/energy/floramut/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/energy/floramut/on_hit(var/atom/target, var/blocked = 0)
 	..()
 	var/mob/living/M = target
 	if(ishuman(target))
@@ -157,7 +157,7 @@
 	else
 		return 1
 
-/obj/item/projectile/energy/florayield
+/obj/projectile/energy/florayield
 	name = "beta somatoray"
 	icon_state = "energy2"
 	damage = 0
@@ -165,7 +165,7 @@
 	nodamage = 1
 	flag = "energy"
 
-/obj/item/projectile/energy/florayield/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/energy/florayield/on_hit(var/atom/target, var/blocked = 0)
 	..()
 	var/mob/M = target
 	if(ishuman(target)) //These rays make plantmen fat.
@@ -178,29 +178,29 @@
 		return 1
 
 
-/obj/item/projectile/beam/mindflayer
+/obj/projectile/beam/mindflayer
 	name = "flayer ray"
 
-/obj/item/projectile/beam/mindflayer/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/beam/mindflayer/on_hit(var/atom/target, var/blocked = 0)
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
 		M.adjustBrainLoss(20)
 		M.AdjustHallucinate(20)
 
-/obj/item/projectile/clown
+/obj/projectile/clown
 	name = "snap-pop"
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "snappop"
 
-/obj/item/projectile/clown/Bump(atom/A as mob|obj|turf|area)
+/obj/projectile/clown/Bump(atom/A as mob|obj|turf|area)
 	do_sparks(3, 1, src)
 	new /obj/effect/decal/cleanable/ash(loc)
 	visible_message("<span class='warning'>The [name] explodes!</span>","<span class='warning'>You hear a snap!</span>")
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)
 	qdel(src)
 
-/obj/item/projectile/beam/wormhole
+/obj/projectile/beam/wormhole
 	name = "bluespace beam"
 	icon_state = "spark"
 	hitsound = "sparks"
@@ -209,15 +209,15 @@
 	color = "#33CCFF"
 	nodamage = TRUE
 
-/obj/item/projectile/beam/wormhole/orange
+/obj/projectile/beam/wormhole/orange
 	name = "orange bluespace beam"
 	color = "#FF6600"
 
-/obj/item/projectile/beam/wormhole/New(var/obj/item/ammo_casing/energy/wormhole/casing)
+/obj/projectile/beam/wormhole/New(var/obj/item/ammo_casing/energy/wormhole/casing)
 	if(casing)
 		gun = casing.gun
 
-/obj/item/projectile/beam/wormhole/on_hit(atom/target)
+/obj/projectile/beam/wormhole/on_hit(atom/target)
 	if(ismob(target))
 		if(is_teleport_allowed(target.z))
 			var/turf/portal_destination = pick(orange(6, src))
@@ -227,18 +227,18 @@
 		qdel(src)
 	gun.create_portal(src)
 
-/obj/item/projectile/bullet/frag12
+/obj/projectile/bullet/frag12
 	name ="explosive slug"
 	damage = 25
 	weaken = 5
 	alwayslog = TRUE
 
-/obj/item/projectile/bullet/frag12/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/frag12/on_hit(atom/target, blocked = 0)
 	..()
 	explosion(target, -1, 0, 1)
 	return 1
 
-/obj/item/projectile/plasma
+/obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
@@ -247,7 +247,7 @@
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 
-/obj/item/projectile/plasma/on_hit(atom/target)
+/obj/projectile/plasma/on_hit(atom/target)
 	. = ..()
 	if(ismineralturf(target))
 		forcedodge = 1
@@ -256,15 +256,15 @@
 	else
 		forcedodge = 0
 
-/obj/item/projectile/plasma/adv
+/obj/projectile/plasma/adv
 	damage = 7
 	range = 5
 
-/obj/item/projectile/plasma/adv/mech
+/obj/projectile/plasma/adv/mech
 	damage = 10
 	range = 9
 
-/obj/item/projectile/energy/teleport
+/obj/projectile/energy/teleport
 	name = "teleportation burst"
 	icon_state = "bluespace"
 	damage = 0
@@ -272,12 +272,12 @@
 	alwayslog = TRUE
 	var/teleport_target = null
 
-/obj/item/projectile/energy/teleport/New(loc, tele_target)
+/obj/projectile/energy/teleport/New(loc, tele_target)
 	..(loc)
 	if(tele_target)
 		teleport_target = tele_target
 
-/obj/item/projectile/energy/teleport/on_hit(var/atom/target, var/blocked = 0)
+/obj/projectile/energy/teleport/on_hit(var/atom/target, var/blocked = 0)
 	if(isliving(target))
 		if(teleport_target)
 			do_teleport(target, teleport_target, 0)//teleport what's in the tile to the beacon
@@ -285,32 +285,32 @@
 			do_teleport(target, target, 15) //Otherwise it just warps you off somewhere.
 	add_attack_logs(firer, target, "Shot with a [type] [teleport_target ? "(Destination: [teleport_target])" : ""]")
 
-/obj/item/projectile/snowball
+/obj/projectile/snowball
 	name = "snowball"
 	icon_state = "snowball"
 	hitsound = 'sound/items/dodgeball.ogg'
 	damage = 4
 	damage_type = BURN
 
-/obj/item/projectile/snowball/on_hit(atom/target)	//chilling
+/obj/projectile/snowball/on_hit(atom/target)	//chilling
 	. = ..()
 	if(istype(target, /mob/living))
 		var/mob/living/M = target
 		M.bodytemperature = max(0, M.bodytemperature - 50)	//each hit will drop your body temp, so don't get surrounded!
 		M.ExtinguishMob()	//bright side, they counter being on fire!
 
-/obj/item/projectile/ornament
+/obj/projectile/ornament
 	name = "ornament"
 	icon_state = "ornament-1"
 	hitsound = 'sound/effects/glasshit.ogg'
 	damage = 7
 	damage_type = BRUTE
 
-/obj/item/projectile/ornament/New()
+/obj/projectile/ornament/New()
 	icon_state = pick("ornament-1", "ornament-2")
 	..()
 
-/obj/item/projectile/ornament/on_hit(atom/target)	//knockback
+/obj/projectile/ornament/on_hit(atom/target)	//knockback
 	..()
 	if(istype(target, /turf))
 		return 0
@@ -319,7 +319,7 @@
 	T.throw_at(get_edge_target_turf(target, throwdir),10,10)
 	return 1
 
-/obj/item/projectile/mimic
+/obj/projectile/mimic
 	name = "googly-eyed gun"
 	hitsound = 'sound/weapons/genhit1.ogg'
 	damage = 0
@@ -328,7 +328,7 @@
 	flag = "melee"
 	var/obj/item/gun/stored_gun
 
-/obj/item/projectile/mimic/New(loc, mimic_type)
+/obj/projectile/mimic/New(loc, mimic_type)
 	..(loc)
 	if(mimic_type)
 		stored_gun = new mimic_type(src)
@@ -337,7 +337,7 @@
 		overlays = stored_gun.overlays
 		SpinAnimation(20, -1)
 
-/obj/item/projectile/mimic/on_hit(atom/target)
+/obj/projectile/mimic/on_hit(atom/target)
 	..()
 	var/turf/T = get_turf(src)
 	var/obj/item/gun/G = stored_gun

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -14,7 +14,7 @@
 	sharp = TRUE
 	var/busy = FALSE
 	var/mode = SYRINGE_DRAW
-	var/projectile_type = /obj/item/projectile/bullet/dart/syringe
+	var/projectile_type = /obj/projectile/bullet/dart/syringe
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
 	container_type = TRANSPARENT
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -80,7 +80,7 @@
 	QDEL_NULL(rig)
 	return ..()
 
-/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/item/projectile/P)
+/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/projectile/P)
 	..()
 	if(!QDELETED(src)) //wasn't deleted by the projectile's effects.
 		if(!P.nodamage && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -479,7 +479,7 @@
 /obj/machinery/disposal/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover,/obj/item) && mover.throwing)
 		var/obj/item/I = mover
-		if(istype(I, /obj/item/projectile))
+		if(istype(I, /obj/projectile))
 			return
 		if(prob(75))
 			I.forceMove(src)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -296,7 +296,7 @@
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
-	if(istype(AM, /obj/item/projectile))  return
+	if(istype(AM, /obj/projectile))  return
 	switch(dir)
 		if(NORTH)
 			if(AM.loc.y != src.loc.y+1) return

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -365,7 +365,7 @@
 			if(MT)
 				visible_message("<span class='danger'>[src] dangerously overheats, launching a flaming fuel orb!</span>")
 				investigate_log("Experimentor has launched a <font color='red'>fireball</font> at [M]!", "experimentor")
-				var/obj/item/projectile/magic/fireball/FB = new /obj/item/projectile/magic/fireball(start)
+				var/obj/projectile/magic/fireball/FB = new /obj/projectile/magic/fireball(start)
 				FB.original = MT
 				FB.current = start
 				FB.yo = MT.y - start.y

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -464,8 +464,8 @@
 					H.AIStatus = AI_OFF
 					H.LoseTarget()
 				stopped_atoms |= M
-			else if(istype(A, /obj/item/projectile))
-				var/obj/item/projectile/P = A
+			else if(istype(A, /obj/projectile))
+				var/obj/projectile/P = A
 				P.paused = TRUE
 				stopped_atoms |= P
 
@@ -479,7 +479,7 @@
 	for(var/mob/living/M in stopped_atoms)
 		unfreeze_mob(M)
 
-	for(var/obj/item/projectile/P in stopped_atoms)
+	for(var/obj/projectile/P in stopped_atoms)
 		P.paused = FALSE
 	qdel(src)
 	return

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -32,8 +32,8 @@
 					firstloc = get_turf(my_atom)
 					secondloc = get_step(firstloc,NORTH)
 		olddir = dir
-		var/obj/item/projectile/projone = new projectile_type(firstloc)
-		var/obj/item/projectile/projtwo = new projectile_type(secondloc)
+		var/obj/projectile/projone = new projectile_type(firstloc)
+		var/obj/projectile/projtwo = new projectile_type(secondloc)
 		projone.starting = get_turf(my_atom)
 		projone.firer = usr
 		projone.def_zone = "chest"
@@ -81,7 +81,7 @@
 	desc = "You shouldn't be seeing this"
 	icon = 'icons/vehicles/spacepod.dmi'
 	icon_state = "blank"
-	var/obj/item/projectile/projectile_type
+	var/obj/projectile/projectile_type
 	var/shot_cost = 0
 	var/shots_per = 1
 	var/fire_sound
@@ -92,7 +92,7 @@
 	name = "disabler system"
 	desc = "A weak taser system for space pods, fires disabler beams."
 	icon_state = "weapon_taser"
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	shot_cost = 400
 	fire_sound = 'sound/weapons/taser.ogg'
 	harmful = FALSE
@@ -101,7 +101,7 @@
 	name = "burst taser system"
 	desc = "A weak taser system for space pods, this one fires 3 at a time."
 	icon_state = "weapon_burst_taser"
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	shot_cost = 1200
 	shots_per = 3
 	fire_sound = 'sound/weapons/taser.ogg'
@@ -112,7 +112,7 @@
 	name = "laser system"
 	desc = "A weak laser system for space pods, fires concentrated bursts of energy."
 	icon_state = "weapon_laser"
-	projectile_type = /obj/item/projectile/beam
+	projectile_type = /obj/projectile/beam
 	shot_cost = 600
 	fire_sound = 'sound/weapons/laser.ogg'
 
@@ -122,7 +122,7 @@
 	desc = "A weak mining laser system for space pods, fires bursts of energy that cut through rock."
 	icon = 'icons/goonstation/pods/ship.dmi'
 	icon_state = "pod_taser"
-	projectile_type = /obj/item/projectile/kinetic/pod
+	projectile_type = /obj/projectile/kinetic/pod
 	shot_cost = 300
 	fire_delay = 14
 	fire_sound = 'sound/weapons/kenetic_accel.ogg'
@@ -132,7 +132,7 @@
 	desc = "A mining laser system for space pods, fires bursts of energy that cut through rock."
 	icon = 'icons/goonstation/pods/ship.dmi'
 	icon_state = "pod_m_laser"
-	projectile_type = /obj/item/projectile/kinetic/pod/regular
+	projectile_type = /obj/projectile/kinetic/pod/regular
 	shot_cost = 250
 	fire_delay = 10
 	fire_sound = 'sound/weapons/kenetic_accel.ogg'

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -192,7 +192,7 @@
 
 	light_color = icon_light_color[src.icon_state]
 
-/obj/spacepod/bullet_act(var/obj/item/projectile/P)
+/obj/spacepod/bullet_act(var/obj/projectile/P)
 	if(P.damage_type == BRUTE || P.damage_type == BURN)
 		deal_damage(P.damage)
 	P.on_hit(src)

--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -137,7 +137,7 @@
 	..()
 	handle_vehicle_offsets()
 
-/obj/vehicle/bullet_act(obj/item/projectile/Proj)
+/obj/vehicle/bullet_act(obj/projectile/Proj)
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m


### PR DESCRIPTION
## What Does This PR Do
Makes it so projectiles are not items.
Projectiles and items only shared 2 variables that mattered. `hitsound` and `armour_penetration`. Other logic and values on item were not required for projectiles.

Ports https://github.com/tgstation/tgstation/pull/46692

## Why It's Good For The Game
Should save a bit of memory for each projectile. Also makes the paths a bit more sane.

I've tested this using multiple guns and magic and didn't see any issues.

I did use a mass replace for this. I'll comment on the code that I changed manually.
Replaced:
`obj/item/projectile`
With:
`obj/projectile`
In all files. (only found in the DM files)

## Changelog
Pure backend