### PR TITLE
Makes it so you can no longer synth the Gluttony's Blessing reagent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1237,6 +1237,7 @@
 	description = "An advanced corruptive toxin produced by something terrible."
 	reagent_state = LIQUID
 	color = "#5EFF3B" //RGB: 94, 255, 59
+	can_synth = FALSE
 	taste_description = "decay"
 
 /datum/reagent/gluttonytoxin/reaction_mob(mob/living/L, method=REAGENT_TOUCH, reac_volume)


### PR DESCRIPTION
## What Does This PR Do
fixes #14012 
Sets can_synth to FALSE on the Gluttony's Blessing reagent.

## Why It's Good For The Game
As stated in the issue, the other transforming chemicals have this set to false for balance reasons.

## Changelog
:cl: CornMyCob
tweak: You can no longer synthesise the gluttony's blessing reagent.
/:cl: