### PR TITLE
Make wet overlays render on MID_TURF_LAYER plane

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -53,8 +53,7 @@
 				wet_overlay = image('icons/effects/water.dmi', src, "ice_floor")
 			else
 				wet_overlay = image('icons/effects/water.dmi', src, "wet_static")
-		if(plane == PLANE_SPACE)
-			wet_overlay.plane = PLANE_SPACE_PARALLAX + 0.1
+		wet_overlay.plane = MID_TURF_LAYER
 		overlays += wet_overlay
 	if(time == INFINITY)
 		return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -53,6 +53,8 @@
 				wet_overlay = image('icons/effects/water.dmi', src, "ice_floor")
 			else
 				wet_overlay = image('icons/effects/water.dmi', src, "wet_static")
+		if(plane == PLANE_SPACE)
+			wet_overlay.plane = PLANE_SPACE_PARALLAX + 0.1
 		overlays += wet_overlay
 	if(time == INFINITY)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes #14007 by setting `wet_overlay` plane to `MID_TURF_LAYER`.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes it possible to tell whether astral carpet is slippery while keeping the parallax effect.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![dreamseeker_Vry2DfTlyM](https://user-images.githubusercontent.com/1496804/89641444-f6d22680-d8b1-11ea-8bf5-b5fdff73d8c9.png)

## Changelog
:cl:
fix: Fix space floors not looking slippery despite being so
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
