### PR TITLE
Fixes ex_act / take_damage Runtime

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -51,6 +51,8 @@
 	take_damage(AM.throwforce, BRUTE, "melee", 1, get_dir(src, AM))
 
 /obj/ex_act(severity)
+	if(QDELETED(src))
+		return
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
 	switch(severity)


### PR DESCRIPTION
## What Does This PR Do
Alters /obj/ex_act so it no longer even attempts to take_damage() on /objs that are already QDELETED.

## Why It's Good For The Game
A normal round often has dozens or more runtimes like this:
```
[2020-08-07T12:58:17] Runtime in unsorted.dm,1988: The metal rod taking damage after deletion
   proc name: stack trace (/datum/proc/stack_trace)
   src: the metal rod (/obj/item/stack/rods)
   src.loc: null
   call stack:
   the metal rod (/obj/item/stack/rods): stack trace("The metal rod taking damage af...")
   the metal rod (/obj/item/stack/rods): take damage(67, "brute", "bomb", 0, null, 0)
   the metal rod (/obj/item/stack/rods): ex act(3)
   explosion(the floor (228,102,1) (/turf/simulated/floor/plasteel/airless/indestructible), 3, 7, 15, 20, 1, 0, 0, 0, 1, null, 1)
```
These runtimes are typically caused by large-scale use of explosives where objects are hit by multiple explosions in quick succession before they get a chance to qdel successfully.

## Changelog
:cl: Kyep
fix: fixed a common runtime error with metal rods and other qdeleted objects taking damage.
/:cl: