### PR TITLE
Fixes cult god runtime

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -127,7 +127,8 @@
 /obj/singularity/narsie/proc/acquire(var/mob/food)
 	if(food == target)
 		return
-	to_chat(target, "<span class='cultlarge'>[uppertext(SSticker.cultdat.entity_name)] HAS LOST INTEREST IN YOU</span>")
+	if(target)
+		to_chat(target, "<span class='cultlarge'>[uppertext(SSticker.cultdat.entity_name)] HAS LOST INTEREST IN YOU</span>")
 	target = food
 	if(ishuman(target))
 		to_chat(target, "<span class ='cultlarge'>[uppertext(SSticker.cultdat.entity_name)] HUNGERS FOR YOUR SOUL</span>")

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -127,8 +127,9 @@
 /obj/singularity/narsie/proc/acquire(var/mob/food)
 	if(food == target)
 		return
-	if(target)
-		to_chat(target, "<span class='cultlarge'>[uppertext(SSticker.cultdat.entity_name)] HAS LOST INTEREST IN YOU</span>")
+	if(!target)
+		return
+	to_chat(target, "<span class='cultlarge'>[uppertext(SSticker.cultdat.entity_name)] HAS LOST INTEREST IN YOU</span>")
 	target = food
 	if(ishuman(target))
 		to_chat(target, "<span class ='cultlarge'>[uppertext(SSticker.cultdat.entity_name)] HUNGERS FOR YOUR SOUL</span>")


### PR DESCRIPTION
## What Does This PR Do
Fixes runtimes like this after a cult summons:
```
[2020-08-07T13:20:53] Runtime in ,: DEBUG: to_chat called with invalid message/target.
   Message: '<span class='cultlarge'>THE REAPER HAS LOST INTEREST IN YOU</span>'
   Target: ''
```
The fix is simply checking whether the cult god's target even exists, before attempting to send it messages.

## Why It's Good For The Game
Less runtimes.

## Changelog
:cl: Kyep
fix: Fixed a runtime related to cult gods switching targets.
/:cl: