### PR TITLE
Fixes mass hallucination event affecting other zlevels

### DIFF
--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -6,6 +6,9 @@
 		var/mob/living/carbon/human/H = thing
 		if(H.stat == DEAD)
 			continue
+		var/turf/T = get_turf(H)
+		if(!is_station_level(T.z))
+			continue
 		var/armor = H.getarmor(type = "rad")
 		if((RADIMMUNE in H.dna.species.species_traits) || armor >= 75) // Leave radiation-immune species/rad armored players completely unaffected
 			continue


### PR DESCRIPTION
## What Does This PR Do
Alters the "mass hallucination" event so it only affects humanoids on the station zlevel.
The announcement for the event already suggests its limited to the station ("It seems that stationname is passing through a minor radiation field")... but it isn't. It affects mobs on the centcom level, mining level, etc as well.

## Why It's Good For The Game
Miners fighting mobs on lavaland shouldn't suddenly be stunned mid-fight because of the station passing through a radiation field.... when they're not on the station.
Admins testing things in the admin test room shouldn't have their tests invalidated by an event on the station.
Etc.

## Changelog
:cl: Kyep
fix: fixed mass hallucination event applying to people outside the station level, when its description implies it doesn't.
/:cl:
