### PR TITLE
Adds Earmuffs providing immunity to Changeling shriek

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -240,3 +240,9 @@
 #define is_admin(user)	(check_rights(R_ADMIN, 0, (user)) != 0)
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
+
+// Hearing protection
+#define HEARING_PROTECTION_NONE	0
+#define HEARING_PROTECTION_MINOR	1
+#define HEARING_PROTECTION_MAJOR	2
+#define HEARING_PROTECTION_TOTAL	3

--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -13,7 +13,7 @@
 		if(iscarbon(M))
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
-				if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
+				if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 					continue
 			if(!M.mind || !M.mind.changeling)
 				M.MinimumDeafTicks(30)

--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -11,6 +11,10 @@
 /datum/action/changeling/resonant_shriek/sting_action(var/mob/user)
 	for(var/mob/living/M in get_mobs_in_view(4, user))
 		if(iscarbon(M))
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
+					continue
 			if(!M.mind || !M.mind.changeling)
 				M.MinimumDeafTicks(30)
 				M.AdjustConfused(20)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -264,7 +264,7 @@
 			continue
 		if(ishuman(C))
 			var/mob/living/carbon/human/H = C
-			if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
+			if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 				continue
 		if(!affects(C))
 			continue

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -209,7 +209,7 @@
 	for(var/mob/living/carbon/M in ohearers(6, chassis))
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-			if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
+			if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 				continue
 		to_chat(M, "<font color='red' size='7'>HONK</font>")
 		M.SetSleeping(0)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -264,7 +264,7 @@
 					limbs_affected -= 1
 				else valid_limbs -= processing_dismember
 
-			if(!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+			if(src.check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(30, 120)
 			if(prob(70) && !shielded)
 				Paralyse(10)
@@ -288,7 +288,7 @@
 						limbs_affected -= 1
 					else valid_limbs -= processing_dismember
 
-			if(!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+			if(src.check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(15, 60)
 			if(prob(50) && !shielded)
 				Paralyse(10)
@@ -941,12 +941,18 @@
 	return number
 
 /mob/living/carbon/human/check_ear_prot()
+	if(!src.can_hear())
+		return HEARING_PROTECTION_TOTAL
+	if(l_ear && istype(l_ear, /obj/item/clothing/ears/earmuffs))
+		return HEARING_PROTECTION_TOTAL
+	if(r_ear && istype(r_ear, /obj/item/clothing/ears/earmuffs))
+		return HEARING_PROTECTION_TOTAL
 	if(head && (head.flags & HEADBANGPROTECT))
-		return 1
+		return HEARING_PROTECTION_MINOR
 	if(l_ear && (l_ear.flags & EARBANGPROTECT))
-		return 1
+		return HEARING_PROTECTION_MINOR
 	if(r_ear && (r_ear.flags & EARBANGPROTECT))
-		return 1
+		return HEARING_PROTECTION_MINOR
 
 ///tintcheck()
 ///Checks eye covering items for visually impairing tinting, such as welding masks

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -941,11 +941,11 @@
 	return number
 
 /mob/living/carbon/human/check_ear_prot()
-	if(!src.can_hear())
+	if(!can_hear())
 		return HEARING_PROTECTION_TOTAL
-	if(l_ear && istype(l_ear, /obj/item/clothing/ears/earmuffs))
+	if(istype(l_ear, /obj/item/clothing/ears/earmuffs))
 		return HEARING_PROTECTION_TOTAL
-	if(r_ear && istype(r_ear, /obj/item/clothing/ears/earmuffs))
+	if(istype(r_ear, /obj/item/clothing/ears/earmuffs))
 		return HEARING_PROTECTION_TOTAL
 	if(head && (head.flags & HEADBANGPROTECT))
 		return HEARING_PROTECTION_MINOR

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -264,7 +264,7 @@
 					limbs_affected -= 1
 				else valid_limbs -= processing_dismember
 
-			if(src.check_ear_prot() < HEARING_PROTECTION_TOTAL)
+			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(30, 120)
 			if(prob(70) && !shielded)
 				Paralyse(10)
@@ -288,7 +288,7 @@
 						limbs_affected -= 1
 					else valid_limbs -= processing_dismember
 
-			if(src.check_ear_prot() < HEARING_PROTECTION_TOTAL)
+			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(15, 60)
 			if(prob(50) && !shielded)
 				Paralyse(10)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -157,7 +157,7 @@ GLOBAL_DATUM_INIT(multispin_words, /regex, regex("like a record baby"))
 		if(L.can_hear() && !L.null_rod_check() && L != owner && L.stat != DEAD)
 			if(ishuman(L))
 				var/mob/living/carbon/human/H = L
-				if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
+				if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 					continue
 			listeners += L
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
For consistency, this makes it so earmuffs protect against changeling shriek just like they do the vampire shriek.

EDIT: PR refactored sonic protection to be a tiered system where earmuffs and deafness provide immunity to all and bowman headsets provide immunity to only bang.

## Why It's Good For The Game
Earmuffs are supposed to provide immunity to all sonic attacks, it is inconsistent that they don't protect against this one.

EDIT: The refactoring will make it easier to expand on sonic damage and sonic protection.

## Changelog
:cl:
add: Earmuffs now provide immunity to changeling shriek
add: Deafness now provides immunity to all sonic attacks
tweak: Refactored sonic protection into a tiered system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
