### PR TITLE
Improves botany fruit logging. Makes throws not spam admins when the item does no damage

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -117,6 +117,7 @@
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom)
 	if(!..()) //was it caught by a mob?
 		if(seed)
+			log_action(thrownby, hit_atom, "Thrown [src] at")
 			for(var/datum/plant_gene/trait/T in seed.genes)
 				T.on_throw_impact(src, hit_atom)
 			if(seed.get_gene(/datum/plant_gene/trait/squash))
@@ -189,4 +190,18 @@
 		D.consume(src)
 	else
 		return ..()
+
+/obj/item/reagent_containers/food/snacks/grown/proc/log_action(mob/user, atom/target, what_done)
+	var/reagent_str = reagents.log_list()
+	var/genes_str
+	if(seed && length(seed.genes))
+		var/list/plant_gene_names = list()
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			if(T.dangerous)
+				plant_gene_names += T.name
+		genes_str = english_list(plant_gene_names)
+	else
+		genes_str = "No genes"
+
+	add_attack_logs(user, target, "[what_done] ([reagent_str] | [genes_str])")
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -193,15 +193,14 @@
 
 /obj/item/reagent_containers/food/snacks/grown/proc/log_action(mob/user, atom/target, what_done)
 	var/reagent_str = reagents.log_list()
-	var/genes_str
+	var/genes_str = "No genes"
 	if(seed && length(seed.genes))
 		var/list/plant_gene_names = list()
-		for(var/datum/plant_gene/trait/T in seed.genes)
-			if(T.dangerous)
-				plant_gene_names += T.name
+		for(var/thing in seed.genes)
+			var/datum/plant_gene/G = thing
+			if(G.dangerous)
+				plant_gene_names += G.name
 		genes_str = english_list(plant_gene_names)
-	else
-		genes_str = "No genes"
 
 	add_attack_logs(user, target, "[what_done] ([reagent_str] | [genes_str])")
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -139,6 +139,8 @@
 	var/rate = 0.05
 	var/examine_line = ""
 	var/list/origin_tech = null
+	/// Used to determine if the trait should be logged when the holder is used
+	var/dangerous = FALSE
 	var/trait_id // must be set and equal for any two traits of the same type
 
 /datum/plant_gene/trait/Copy()
@@ -194,6 +196,7 @@
 	name = "Liquid Contents"
 	examine_line = "<span class='info'>It has a lot of liquid contents inside.</span>"
 	origin_tech = list("biotech" = 5)
+	dangerous = TRUE
 
 /datum/plant_gene/trait/slip
 	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
@@ -201,6 +204,7 @@
 	name = "Slippery Skin"
 	rate = 0.1
 	examine_line = "<span class='info'>It has a very slippery skin.</span>"
+	dangerous = TRUE
 
 /datum/plant_gene/trait/slip/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
 	. = ..()
@@ -224,6 +228,7 @@
 	name = "Electrical Activity"
 	rate = 0.2
 	origin_tech = list("powerstorage" = 5)
+	dangerous = TRUE
 
 /datum/plant_gene/trait/cell_charge/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
 	var/power = G.seed.potency*rate
@@ -298,6 +303,7 @@
 	name = "Bluespace Activity"
 	rate = 0.1
 	origin_tech = list("bluespace" = 5)
+	dangerous = TRUE
 
 /datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))
@@ -385,6 +391,7 @@
 
 /datum/plant_gene/trait/stinging
 	name = "Hypodermic Prickles"
+	dangerous = TRUE
 
 /datum/plant_gene/trait/stinging/on_throw_impact(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target) && G.reagents && G.reagents.total_volume)
@@ -398,6 +405,7 @@
 
 /datum/plant_gene/trait/smoke
 	name = "gaseous decomposition"
+	dangerous = TRUE
 
 /datum/plant_gene/trait/smoke/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	var/datum/effect_system/smoke_spread/chem/S = new

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -1,5 +1,7 @@
 /datum/plant_gene
 	var/name
+	/// Used to determine if the trait should be logged when the holder is used
+	var/dangerous = FALSE
 
 /datum/plant_gene/proc/get_name() // Used for manipulator display and gene disk name.
 	return name
@@ -139,8 +141,6 @@
 	var/rate = 0.05
 	var/examine_line = ""
 	var/list/origin_tech = null
-	/// Used to determine if the trait should be logged when the holder is used
-	var/dangerous = FALSE
 	var/trait_id // must be set and equal for any two traits of the same type
 
 /datum/plant_gene/trait/Copy()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -113,7 +113,7 @@
 			var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].", I.armour_penetration)
 			apply_damage(I.throwforce, dtype, zone, armor, is_sharp(I), I)
 			if(I.thrownby)
-				add_attack_logs(I.thrownby, src, "Hit with thrown [I]")
+				add_attack_logs(I.thrownby, src, "Hit with thrown [I]", !I.throwforce ? ATKLOG_ALMOSTALL : null) // Only message if the person gets damages
 		else
 			return 1
 	else


### PR DESCRIPTION
## What Does This PR Do
- Makes fruits and such log what they exactly did when thrown at somebody
- Makes thrown items that do no damage send a message to admins with `ATKLOG_ALMOSTALL` on

## Why It's Good For The Game
- Gives the log more info about what the fruit actually did. What it contained and what it's effects were
- Less spammy for admins who see gloves being thrown at people.


## Images of changes
![image](https://user-images.githubusercontent.com/15887760/89691555-7f2fe600-d909-11ea-91a4-31a6fd5cb613.png)
When the admin is on ATKLOG_MOST
![image](https://user-images.githubusercontent.com/15887760/89691593-9373e300-d909-11ea-8782-560c12e2ed60.png)


## Changelog
:cl:
add: Added extra logging for botany fruits.
tweak: Thrown objects which do no damage now only send a message to admins with `ATKLOG_ALMOSTALL` on.
/:cl: