### PR TITLE
Makes grown/On_Consume actually work properly. You can't forcefeed people glowcaps anymore to charge your guns

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -147,11 +147,11 @@
 
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/grown/On_Consume()
-	if(iscarbon(usr))
+/obj/item/reagent_containers/food/snacks/grown/On_Consume(mob/M, mob/user)
+	if(iscarbon(M))
 		if(seed)
 			for(var/datum/plant_gene/trait/T in seed.genes)
-				T.on_consume(src, usr)
+				T.on_consume(src, M)
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/after_slip(mob/living/carbon/human/H)


### PR DESCRIPTION
## What Does This PR Do
Makes fruits and such actually use the On_Consume stuff properly. The actual target will be used as target instead of `usr`.
This will fix any plants with Electrical Activity in them.

## Why It's Good For The Game
It's a bug

## Changelog
:cl:
fix: The Electrical Activity botany trait now won't charge your items when you forcefeed somebody else
/:cl: