### PR TITLE
Fixes offstation_role bug

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -53,7 +53,6 @@ proc/issyndicate(mob/living/M as mob)
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_mind.assigned_role = SPECIAL_ROLE_NUKEOPS //So they aren't chosen for other jobs.
 		synd_mind.special_role = SPECIAL_ROLE_NUKEOPS
-		synd_mind.offstation_role = TRUE
 	return 1
 
 
@@ -113,7 +112,7 @@ proc/issyndicate(mob/living/M as mob)
 		if(spawnpos > synd_spawn.len)
 			spawnpos = 2
 		synd_mind.current.loc = synd_spawn[spawnpos]
-
+		synd_mind.offstation_role = TRUE
 		forge_syndicate_objectives(synd_mind)
 		create_syndicate(synd_mind)
 		greet_syndicate(synd_mind)


### PR DESCRIPTION
## What Does This PR Do
Fixes #12764 - random crew members getting mind.offstation_role set to TRUE when they are actually normal crew.
The cause was the nuke ops can_start() proc assigning the flag in a way that persists even if the nuke ops game mode is not actually selected to be run.

## Why It's Good For The Game
Fixes a bug.
Ensures random people with nuke op role enabled don't incorrectly get a flag that makes them, for example, immune to being antag targets.
Allows #12765 to be reversed.

## Changelog
:cl: Kyep
fix: fixed random crew members being treated as offstation roles (non crew) when they weren't.
/:cl: