### PR TITLE
Disables dragon transformation because its users can freeze the whole server

### DIFF
--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -120,18 +120,13 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/random = rand(1,3)
+	var/random = rand(1,2)
 
 	switch(random)
 		if(1)
 			to_chat(user, "<span class='danger'>Your flesh begins to melt! Miraculously, you seem fine otherwise.</span>")
 			H.set_species(/datum/species/skeleton)
 		if(2)
-			to_chat(user, "<span class='danger'>Power courses through you! You can now shift your form at will.")
-			if(user.mind)
-				var/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/D = new
-				user.mind.AddSpell(D)
-		if(3)
 			to_chat(user, "<span class='danger'>You feel like you could walk straight through lava now.</span>")
 			H.weather_immunities |= "lava"
 


### PR DESCRIPTION
## What Does This PR Do
Removes the 1/3 chance of getting the "lesser ash drake transformation" spell when drinking dragon's blood.

## Why It's Good For The Game
We've been having repeated issues where people under the effects of this specific transformation, freeze the entire server.
This happened again today, and required me to manually kill/restart DD.

## Changelog
:cl: Kyep
del: The dragon's blood item on lavaland can no longer grant you the ability to transform into a dragon.
/:cl: