### PR TITLE
Fixes & Reworks Rogue Combat Drone Event

### DIFF
--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -4,24 +4,16 @@
 	var/list/drones_list = list()
 
 /datum/event/rogue_drone/start()
-	//spawn them at the same place as carp
 	var/list/possible_spawns = list()
 	for(var/thing in GLOB.landmarks_list)
 		var/obj/effect/landmark/C = thing
-		if(C.name == "carpspawn")
+		if(C.name == "carpspawn") //spawn them at the same place as carp
 			possible_spawns.Add(C)
 
-	//25% chance for this to be a false alarm
-	var/num
-	if(prob(25))
-		num = 0
-	else
-		num = rand(2,6)
-	for(var/i=0, i<num, i++)
-		var/mob/living/simple_animal/hostile/retaliate/malf_drone/D = new(get_turf(pick(possible_spawns)))
+	var/num = rand(2, 12)
+	for(var/i = 0, i < num, i++)
+		var/mob/living/simple_animal/hostile/malf_drone/D = new(get_turf(pick(possible_spawns)))
 		drones_list.Add(D)
-		if(prob(25))
-			D.disabled = rand(15, 60)
 
 /datum/event/rogue_drone/announce()
 	var/msg
@@ -38,11 +30,8 @@
 
 /datum/event/rogue_drone/end()
 	var/num_recovered = 0
-	for(var/mob/living/simple_animal/hostile/retaliate/malf_drone/D in drones_list)
+	for(var/mob/living/simple_animal/hostile/malf_drone/D in drones_list)
 		do_sparks(3, 0, D.loc)
-		D.z = level_name_to_num(CENTCOMM)
-		D.has_loot = 0
-
 		qdel(D)
 		num_recovered++
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -1,6 +1,6 @@
 
 //malfunctioning combat drones
-/mob/living/simple_animal/hostile/retaliate/malf_drone
+/mob/living/simple_animal/hostile/malf_drone
 	name = "combat drone"
 	desc = "An automated combat drone armed with state of the art weaponry and shielding."
 	icon_state = "drone3"
@@ -8,254 +8,175 @@
 	icon_dead = "drone_dead"
 	ranged = 1
 	rapid = 3
+	retreat_distance = 3
+	minimum_distance = 3
 	speak_chance = 5
 	turns_per_move = 3
 	response_help = "pokes the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"
-	speak = list("ALERT.","Hostile-ile-ile entities dee-twhoooo-wected.","Threat parameterszzzz- szzet.","Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a.")
-	emote_see = list("beeps menacingly","whirrs threateningly","scans its immediate vicinity")
+	speak = list("ALERT.", "Hostile-ile-ile entities dee-twhoooo-wected.", "Threat parameterszzzz- szzet.", "Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a.")
+	emote_see = list("beeps menacingly.", "whirrs threateningly.", "scans for targets.")
 	a_intent = INTENT_HARM
-	stop_automated_movement_when_pulled = 0
-	health = 300
-	maxHealth = 300
+	stop_automated_movement_when_pulled = FALSE
+	health = 200
+	maxHealth = 200
 	speed = 8
-	projectiletype = /obj/item/projectile/beam/drone
+	projectiletype = /obj/item/projectile/beam/immolator/weak
 	projectilesound = 'sound/weapons/laser3.ogg'
-	var/datum/effect_system/trail_follow/ion/ion_trail
-
-	//the drone randomly switches between these states because it's malfunctioning
-	var/hostile_drone = 0
-	//0 - retaliate, only attack enemies that attack it
-	//1 - hostile, attack everything that comes near
-
-	var/turf/patrol_target
-	var/explode_chance = 1
-	var/disabled = 0
-	var/exploding = 0
-
-	//Drones aren't affected by atmos.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-
-	var/has_loot = 1
 	faction = list("malf_drone")
 	deathmessage = "suddenly breaks apart."
 	del_on_death = 1
+	var/datum/effect_system/trail_follow/ion/ion_trail
+	var/passive_mode = TRUE // if true, don't target anything.
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/New()
-	..()
-	if(prob(5))
-		projectiletype = /obj/item/projectile/beam/pulse/drone
-		projectilesound = 'sound/weapons/pulse2.ogg'
+/mob/living/simple_animal/hostile/malf_drone/Initialize(mapload)
+	. = ..()
 	ion_trail = new
 	ion_trail.set_up(src)
 	ion_trail.start()
+	update_icons()
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Process_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/malf_drone/Process_Spacemove(check_drift = 0)
 	return 1
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/ListTargets()
-	if(hostile_drone)
-		return view(src, 10)
-	else
-		return ..()
-
-//self repair systems have a chance to bring the drone back to life
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Life(seconds, times_fired)
-
-	//emps and lots of damage can temporarily shut us down
-	if(disabled > 0)
-		stat = UNCONSCIOUS
-		icon_state = "drone_dead"
-		disabled--
-		wander = 0
-		speak_chance = 0
-		if(disabled <= 0)
-			stat = CONSCIOUS
-			icon_state = "drone0"
-			wander = 1
-			speak_chance = 5
-
-	//repair a bit of damage
-	if(prob(1))
-		src.visible_message("<span class='warning'>[bicon(src)] [src] shudders and shakes as some of it's damaged systems come back online.</span>")
-		do_sparks(3, 1, src)
-		health += rand(25,100)
-
-	//spark for no reason
-	if(prob(5))
-		do_sparks(3, 1, src)
-
-	//sometimes our targetting sensors malfunction, and we attack anyone nearby
-	if(prob(disabled ? 0 : 1))
-		if(hostile_drone)
-			src.visible_message("<span class='notice'>[bicon(src)] [src] retracts several targetting vanes, and dulls it's running lights.</span>")
-			hostile_drone = 0
-		else
-			src.visible_message("<span class='warning'>[bicon(src)] [src] suddenly lights up, and additional targetting vanes slide into place.</span>")
-			hostile_drone = 1
-
-	if(health / maxHealth > 0.9)
-		icon_state = "drone3"
-		explode_chance = 0
-	else if(health / maxHealth > 0.7)
-		icon_state = "drone2"
-		explode_chance = 0
-	else if(health / maxHealth > 0.5)
-		icon_state = "drone1"
-		explode_chance = 0.5
-	else if(health / maxHealth > 0.3)
-		icon_state = "drone0"
-		explode_chance = 5
-	else if(health > 0)
-		//if health gets too low, shut down
-		icon_state = "drone_dead"
-		exploding = 0
-		if(!disabled)
-			if(prob(50))
-				src.visible_message("<span class='notice'>[bicon(src)] [src] suddenly shuts down!</span>")
-			else
-				src.visible_message("<span class='notice'>[bicon(src)] [src] suddenly lies still and quiet.</span>")
-			disabled = rand(150, 600)
-			walk(src,0)
-
-	if(exploding && prob(20))
-		if(prob(50))
-			src.visible_message("<span class='warning'>[bicon(src)] [src] begins to spark and shake violenty!</span>")
-		else
-			src.visible_message("<span class='warning'>[bicon(src)] [src] sparks and shakes like it's about to explode!</span>")
-		do_sparks(3, 1, src)
-
-	if(!exploding && !disabled && prob(explode_chance))
-		exploding = 1
-		stat = UNCONSCIOUS
-		wander = 1
-		walk(src,0)
-		spawn(rand(50,150))
-			if(!disabled && exploding)
-				explosion(get_turf(src), 0, 1, 4, 7)
-				//proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1)
-	..()
-
-//ion rifle!
-/mob/living/simple_animal/hostile/retaliate/malf_drone/emp_act(severity)
-	health -= rand(3,15) * (severity + 1)
-	disabled = rand(150, 600)
-	hostile_drone = 0
-	walk(src,0)
-
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Destroy() //Seriously, what the actual hell.
-	//some random debris left behind
-	if(has_loot)
-		do_sparks(3, 1, src)
-		var/obj/O
-
-		//shards
-		O = new /obj/item/shard(loc)
-		step_to(O, get_turf(pick(view(7, src))))
-		if(prob(75))
-			O = new /obj/item/shard(loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(50))
-			O = new /obj/item/shard(loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(25))
-			O = new /obj/item/shard(loc)
-			step_to(O, get_turf(pick(view(7, src))))
-
-		//rods
-		O = new /obj/item/stack/rods(src.loc)
-		step_to(O, get_turf(pick(view(7, src))))
-		if(prob(75))
-			O = new /obj/item/stack/rods(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(50))
-			O = new /obj/item/stack/rods(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(25))
-			O = new /obj/item/stack/rods(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-
-		//plasteel
-		O = new /obj/item/stack/sheet/plasteel(src.loc)
-		step_to(O, get_turf(pick(view(7, src))))
-		if(prob(75))
-			O = new /obj/item/stack/sheet/plasteel(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(50))
-			O = new /obj/item/stack/sheet/plasteel(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-		if(prob(25))
-			O = new /obj/item/stack/sheet/plasteel(src.loc)
-			step_to(O, get_turf(pick(view(7, src))))
-
-		//also drop dummy circuit boards deconstructable for research (loot)
-		var/obj/item/circuitboard/C
-
-		//spawn 1-4 boards of a random type
-		var/spawnees = 0
-		var/num_boards = rand(1,4)
-		var/list/options = list(1,2,4,8,16,32,64,128,256, 512)
-		for(var/i=0, i<num_boards, i++)
-			var/chosen = pick(options)
-			options.Remove(options.Find(chosen))
-			spawnees |= chosen
-
-		if(spawnees & 1)
-			C = new(src.loc)
-			C.name = "Drone CPU motherboard"
-			C.origin_tech = "programming=[rand(3,6)]"
-
-		if(spawnees & 2)
-			C = new(src.loc)
-			C.name = "Drone neural interface"
-			C.origin_tech = "biotech=[rand(3,6)]"
-
-		if(spawnees & 4)
-			C = new(src.loc)
-			C.name = "Drone suspension processor"
-			C.origin_tech = "magnets=[rand(3,6)]"
-
-		if(spawnees & 8)
-			C = new(src.loc)
-			C.name = "Drone shielding controller"
-			C.origin_tech = "bluespace=[rand(3,6)]"
-
-		if(spawnees & 16)
-			C = new(src.loc)
-			C.name = "Drone power capacitor"
-			C.origin_tech = "powerstorage=[rand(3,6)]"
-
-		if(spawnees & 32)
-			C = new(src.loc)
-			C.name = "Drone hull reinforcer"
-			C.origin_tech = "materials=[rand(3,6)]"
-
-		if(spawnees & 64)
-			C = new(src.loc)
-			C.name = "Drone auto-repair system"
-			C.origin_tech = "engineering=[rand(3,6)]"
-
-		if(spawnees & 128)
-			C = new(src.loc)
-			C.name = "Drone plasma overcharge counter"
-			C.origin_tech = "plasmatech=[rand(3,6)]"
-
-		if(spawnees & 256)
-			C = new(src.loc)
-			C.name = "Drone targetting circuitboard"
-			C.origin_tech = "combat=[rand(3,6)]"
-
-		if(spawnees & 512)
-			C = new(src.loc)
-			C.name = "Corrupted drone morality core"
-			C.origin_tech = "syndicate=[rand(3,6)]"
-
+/mob/living/simple_animal/hostile/malf_drone/ListTargets()
+	if(passive_mode)
+		return list()
 	return ..()
 
-/obj/item/projectile/beam/drone
-	damage = 15
+/mob/living/simple_animal/hostile/malf_drone/AttackingTarget()
+	OpenFire(target) // prevents it pointlessly nuzzling its target in melee if its cornered
 
-/obj/item/projectile/beam/pulse/drone
-	damage = 10
+/mob/living/simple_animal/hostile/malf_drone/update_icons()
+	if(passive_mode)
+		icon_state = "drone_dead"
+	else if(health / maxHealth > 0.9)
+		icon_state = "drone3"
+	else if(health / maxHealth > 0.7)
+		icon_state = "drone2"
+	else if(health / maxHealth > 0.5)
+		icon_state = "drone1"
+	else
+		icon_state = "drone0"
+
+/mob/living/simple_animal/hostile/malf_drone/adjustHealth(damage, updating_health)
+	do_sparks(3, 1, src)
+	passive_mode = FALSE
+	update_icons()
+	. = ..() // this will handle finding a target if there is a valid one nearby
+
+/mob/living/simple_animal/hostile/malf_drone/Life(seconds, times_fired)
+	. = ..()
+	if(.) // mob is alive. We check this just in case Life() can fire for qdel'ed mobs.
+		if(times_fired % 30 == 0) // every 30 cycles, aka 1 minute, 50% chance to switch between modes
+			scramble_settings()
+
+/mob/living/simple_animal/hostile/malf_drone/proc/scramble_settings()
+	if(prob(50))
+		do_sparks(3, 1, src)
+		passive_mode = !passive_mode
+		if(passive_mode)
+			visible_message("<span class='notice'>[src] retracts several targetting vanes.</span>")
+			if(target)
+				LoseTarget()
+		else
+			visible_message("<span class='warning'>[src] suddenly lights up, and additional targetting vanes slide into place.</span>")
+		update_icons()
+
+/mob/living/simple_animal/hostile/malf_drone/emp_act(severity)
+	adjustHealth(100 / severity) // takes the same damage as a mining drone from emp
+
+/mob/living/simple_animal/hostile/malf_drone/drop_loot()
+	do_sparks(3, 1, src)
+
+	var/turf/T = get_turf(src)
+
+	//shards
+	var/obj/O = new /obj/item/shard(T)
+	step_to(O, get_turf(pick(view(7, src))))
+	if(prob(75))
+		O = new /obj/item/shard(T)
+		step_to(O, get_turf(pick(view(7, src))))
+	if(prob(50))
+		O = new /obj/item/shard(T)
+		step_to(O, get_turf(pick(view(7, src))))
+	if(prob(25))
+		O = new /obj/item/shard(T)
+		step_to(O, get_turf(pick(view(7, src))))
+
+	//rods
+	var/obj/item/stack/K = new /obj/item/stack/rods(T)
+	step_to(K, get_turf(pick(view(7, src))))
+	K.amount = pick(1, 2, 3, 4)
+	K.update_icon()
+
+	//plasteel
+	K = new /obj/item/stack/sheet/plasteel(T)
+	step_to(K, get_turf(pick(view(7, src))))
+	K.amount = pick(1, 2, 3, 4)
+	K.update_icon()
+
+	//also drop dummy circuit boards deconstructable for research (loot)
+	var/obj/item/circuitboard/C
+
+	//spawn 1-4 boards of a random type
+	var/spawnees = 0
+	var/num_boards = rand(1, 4)
+	var/list/options = list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
+	for(var/i=0, i<num_boards, i++)
+		var/chosen = pick(options)
+		options.Remove(options.Find(chosen))
+		spawnees |= chosen
+
+	if(spawnees & 1)
+		C = new(T)
+		C.name = "Drone CPU motherboard"
+		C.origin_tech = "programming=[rand(3, 6)]"
+
+	if(spawnees & 2)
+		C = new(T)
+		C.name = "Drone neural interface"
+		C.origin_tech = "biotech=[rand(3, 6)]"
+
+	if(spawnees & 4)
+		C = new(T)
+		C.name = "Drone suspension processor"
+		C.origin_tech = "magnets=[rand(3, 6)]"
+
+	if(spawnees & 8)
+		C = new(T)
+		C.name = "Drone shielding controller"
+		C.origin_tech = "bluespace=[rand(3, 6)]"
+
+	if(spawnees & 16)
+		C = new(T)
+		C.name = "Drone power capacitor"
+		C.origin_tech = "powerstorage=[rand(3, 6)]"
+
+	if(spawnees & 32)
+		C = new(T)
+		C.name = "Drone hull reinforcer"
+		C.origin_tech = "materials=[rand(3, 6)]"
+
+	if(spawnees & 64)
+		C = new(T)
+		C.name = "Drone auto-repair system"
+		C.origin_tech = "engineering=[rand(3, 6)]"
+
+	if(spawnees & 128)
+		C = new(T)
+		C.name = "Drone plasma overcharge counter"
+		C.origin_tech = "plasmatech=[rand(3, 6)]"
+
+	if(spawnees & 256)
+		C = new(T)
+		C.name = "Drone targetting circuitboard"
+		C.origin_tech = "combat=[rand(3, 6)]"
+
+	if(spawnees & 512)
+		C = new(T)
+		C.name = "Corrupted drone morality core"
+		C.origin_tech = "syndicate=[rand(3, 6)]"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -71,7 +71,7 @@
 /mob/living/simple_animal/hostile/malf_drone/Life(seconds, times_fired)
 	. = ..()
 	if(.) // mob is alive. We check this just in case Life() can fire for qdel'ed mobs.
-		if(times_fired % 30 == 0) // every 30 cycles, aka 1 minute, 50% chance to switch between modes
+		if(times_fired % 15 == 0) // every 15 cycles, aka 30 seconds, 50% chance to switch between modes
 			scramble_settings()
 
 /mob/living/simple_animal/hostile/malf_drone/proc/scramble_settings()


### PR DESCRIPTION
## What Does This PR Do
Fixes #14038 - combat drones not working
Rewrites combat drone code for more interesting encounters & improved code quality.
Details:

1. Drones are quite dangerous now. They have a burst-fire ranged laser pellet weapon. When active, they attack anything near them except other drones. They also spawn in greater numbers. Hitting them when they're deactivated makes them activate.
2. Drones can be bypassed by waiting for them to enter their deactivated state, then slipping by before they reactivate.
3. You can also fight them for boards useful for R&D.
4. They're removed when the event ends.

## Why It's Good For The Game
Right now, combat drones are utterly broken, never attacking anyone.
Much of their code is also terrible, running in Life(), using src. everywhere, New() instead of Initialize(), etc.
This PR addresses the many issues with them and their code.

## Changelog
:cl: Kyep
add: Rewrote the "rogue combat drone" event code. Combat drones are now dangerous, but options exist to evade or fight them.
/:cl:
