### PR TITLE
Revert #12765 - make offstation roles immune to cult conversion rune again

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -231,6 +231,8 @@ GLOBAL_LIST_EMPTY(all_cults)
 /datum/game_mode/cult/proc/get_unconvertables()
 	var/list/ucs = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
+		if(player.mind && player.mind.offstation_role)
+			continue
 		if(!is_convertable_to_cult(player.mind))
 			ucs += player.mind
 	return ucs

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -20,8 +20,8 @@ GLOBAL_LIST_EMPTY(all_cults)
 		var/mob/living/carbon/human/H = mind.current
 		if(ismindshielded(H)) //mindshield protects against conversions unless removed
 			return FALSE
-//	if(mind.offstation_role) cant convert offstation roles such as ghost spawns
-//		return FALSE Commented out until we can figure out why offstation_role is getting set to TRUE on normal crew
+	if(mind.offstation_role)
+		return FALSE
 	if(issilicon(mind.current))
 		return FALSE //can't convert machines, that's ratvar's thing
 	if(isguardian(mind.current))


### PR DESCRIPTION
## What Does This PR Do
#12765 changed offstation roles (like lavaland golems, ashwalkers, etc) so that they could be converted to cult.
It was done because of bug #12764. 
That bug has now been found, and fixed.
So, this PR reverts #12765, and makes offstation roles like lavaland golems/cult/ashwalkers once again immune to cult conversion using the convert rune.

## Why It's Good For The Game
Admins are really tired of cult basing in lavaland and converting all the free golems/ashwalkers/etc.

## Note
This doesn't block cultists from killing these people, then sharding them, and turning them into constructs.
While I could block that as well, I'd like some feedback before doing so.
It also doesn't block cult from saccing those people.
It simply blocks standard conversion.

## Changelog
:cl: Kyep
balance: offstation roles (e.g: all lavaland ghost roles) can no longer be converted to cult via the conversion rune.
/:cl: