### PR TITLE
Fixes and re-activates SSchat

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -62,6 +62,9 @@
 #define PRINTER_FONT "Times New Roman"
 #define SIGNFONT "Times New Roman"
 
+//Misc text define. Does 4 spaces. Used as a makeshift tabulator.
+#define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"
+
 //some arbitrary defines to be used by self-pruning global lists. (see master_controller)
 #define PROCESS_KILL 26	//Used to trigger removal from a processing list
 

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -5,7 +5,7 @@ SUBSYSTEM_DEF(chat)
 	priority = FIRE_PRIORITY_CHAT
 	init_order = INIT_ORDER_CHAT
 	offline_implications = "Chat messages will no longer be cleanly queued. No immediate action is needed."
-	// Associative list (/client => /text) containing messages to be sent to the client next fire
+	/// Associative list (/client => /text) containing messages to be sent to the client next fire
 	var/list/payload
 
 /datum/controller/subsystem/chat/Initialize()

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -72,7 +72,7 @@ var opts = {
 	'enableEmoji': true
 };
 
-var regexHasError = false; //variable to check if regex has excepted 
+var regexHasError = false; //variable to check if regex has excepted
 
 function outerHTML(el) {
     var wrap = document.createElement('div');
@@ -92,15 +92,24 @@ if (typeof String.prototype.trim !== 'function') {
 		return this.replace(/^\s+|\s+$/g, '');
 	};
 }
+// Polyfill for endsWith()
+if (typeof String.prototype.endsWith !== 'function') {
+	String.prototype.endsWith = function(search, this_len) {
+		if (this_len === undefined || this_len > this.length) {
+			this_len = this.length;
+		}
+		return this.substring(this_len - search.length, this_len) === search;
+	};
+}
 
 //Polyfill for string.prototype.includes. Why the fuck. Just why the fuck.
 if (!String.prototype.includes) {
 	String.prototype.includes = function(search, start) {
 	  'use strict';
-  
+
 	  if (search instanceof RegExp) {
 		throw TypeError('first argument must not be a RegExp');
-	  } 
+	  }
 	  if (start === undefined) { start = 0; }
 	  return this.indexOf(search, start) !== -1;
 	};
@@ -124,7 +133,7 @@ function byondDecode(message) {
 	// The replace for + is because FOR SOME REASON, BYOND replaces spaces with a + instead of %20, and a plus with %2b.
 	// Marvelous.
 	message = message.replace(/\+/g, "%20");
-	try { 
+	try {
 		// This is a workaround for the above not always working when BYOND's shitty url encoding breaks.
 		// Basically, sometimes BYOND's double encoding trick just arbitrarily produces something that makes decodeURIComponent
 		// throw an "Invalid Encoding URI" URIError... the simplest way to work around this is to just ignore it and use unescape instead
@@ -217,10 +226,10 @@ function highlightTerms(el) {
 				ind = next_tag;
 			}
 		}
-		
+
 		element.innerHTML = s;
 	}
-	
+
 	for (var i = 0; i < opts.highlightTerms.length; i++) { //Each highlight term
 		if(opts.highlightTerms[i]) {
 			if(!opts.highlightRegexEnable){
@@ -366,9 +375,15 @@ function output(message, flag) {
 	if (opts.hideSpam && entry.innerHTML === opts.previousMessage) {
 		opts.previousMessageCount++;
 		var lastIndex = $messages[0].children.length - 1;
-		var countBadge = '<span class="repeatBadge">x' + opts.previousMessageCount + '</span>';
+		var countBadge = '<span class="repeatBadge">x' + opts.previousMessageCount + '</span><br>';
 		var lastEntry = $messages[0].children[lastIndex];
-		lastEntry.innerHTML = opts.previousMessage + countBadge;
+		// So that the badge doesn't end up next line,
+		// we erase the last <br> and add it back after the badge
+		var displayMessage = opts.previousMessage;
+		if (opts.previousMessage.endsWith('<br>')) {
+			displayMessage = opts.previousMessage.substring(0, opts.previousMessage.length - 4);
+		}
+		lastEntry.innerHTML = displayMessage + countBadge;
 		var insertedBadge = $(lastEntry).find('.repeatBadge');
 		insertedBadge.animate({
 			"font-size": "0.9em"
@@ -652,7 +667,7 @@ $(function() {
 		'shideSpam': getCookie('hidespam'),
 		'darkChat': getCookie('darkChat'),
 	};
-	
+
 	if (savedConfig.sfontSize) {
 		$messages.css('font-size', savedConfig.sfontSize);
 		internalOutput('<span class="internal boldnshit">Loaded font size setting of: '+savedConfig.sfontSize+'</span>', 'internal');
@@ -1010,18 +1025,18 @@ $(function() {
 		} else {
 			xmlHttp = new ActiveXObject("Microsoft.XMLHTTP");
 		}
-		
+
 		// synchronous requests are depricated in modern browsers
-		xmlHttp.open('GET', 'browserOutput.css', true);			
+		xmlHttp.open('GET', 'browserOutput.css', true);
 		xmlHttp.onload = function (e) {
 			if (xmlHttp.status === 200) {	// request successful
-				
+
 				// Generate Log
 				var saved = '<style>'+xmlHttp.responseText+'</style>';
 				saved += $messages.html();
 				saved = saved.replace(/&/g, '&amp;');
 				saved = saved.replace(/</g, '&lt;');
-				
+
 				// Generate final output and open the window
 				var finalText = '<head><title>Chat Log</title></head> \
 					<iframe src="saveInstructions.html" id="instructions" style="border:none;" height="220" width="100%"></iframe>'+
@@ -1031,7 +1046,7 @@ $(function() {
 				openWindow('Style Doc Retrieve Error: '+xmlHttp.statusText);
 			}
 		}
-		
+
 		// timeout and request errors
 		xmlHttp.timeout = 300;
 		xmlHttp.ontimeout = function (e) {

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -236,75 +236,86 @@ var/list/chatResources = list(
 
 	return "<img [class] src='data:image/png;base64,[bicon_cache[key]]'>"
 
-/proc/is_valid_tochat_message(message)
-	return istext(message)
-
-/proc/is_valid_tochat_target(target)
-	return !istype(target, /savefile) && (ismob(target) || islist(target) || isclient(target) || target == world)
-
 var/to_chat_filename
 var/to_chat_line
 var/to_chat_src
-// Call using macro: to_chat(target, message, flag)
-/proc/to_chat_immediate(target, message, flag)
-	if(!is_valid_tochat_message(message) || !is_valid_tochat_target(target))
-		target << message
 
-		// Info about the "message"
-		if(isnull(message))
-			message = "(null)"
-		else if(istype(message, /datum))
-			var/datum/D = message
-			message = "([D.type]): '[D]'"
-		else if(!is_valid_tochat_message(message))
-			message = "(bad message) : '[message]'"
-
-		// Info about the target
-		var/targetstring = "'[target]'"
-		if(istype(target, /datum))
-			var/datum/D = target
-			targetstring += ", [D.type]"
-
-		// The final output
-		log_runtime(new/exception("DEBUG: to_chat called with invalid message/target.", to_chat_filename, to_chat_line), to_chat_src, list("Message: '[message]'", "Target: [targetstring]"))
+/**
+  * Sends a chat message to one or multiple targets IMMEDIATELY.
+  *
+  * Unlike [/proc/to_chat], this proc does not try to buffer the message through SSchat,
+  * instead sending it instantly to the target(s). Use it sparingly!
+  * Arguments:
+  * * target - The target or (list of targets) to send the message to
+  * * message - The message in HTML
+  * * handle_whitespace - Whether \n and \t should be converted into HTML counterparts
+  * * trailing_newline - Whether a line break should be added at the end of the message
+  */
+/proc/to_chat_immediate(target, message, handle_whitespace = TRUE, trailing_newline = TRUE)
+	if(!target || !message)
 		return
 
-	else if(is_valid_tochat_message(message))
-		if(istext(target))
-			log_runtime(EXCEPTION("Somehow, to_chat got a text as a target"))
+	if(target == world)
+		target = GLOB.clients
+
+	var/original_message = message
+	if(handle_whitespace)
+		message = replacetext(message, "\n", "<br>")
+		message = replacetext(message, "\t", "[FOURSPACES][FOURSPACES]") //EIGHT SPACES IN TOTAL!!
+	if(trailing_newline)
+		message += "<br>"
+
+	if(islist(target))
+		// Do the double-encoding outside the loop to save nanoseconds
+		var/twiceEncoded = url_encode(url_encode(message))
+		for(var/I in target)
+			var/client/C = CLIENT_FROM_VAR(I) //Grab us a client if possible
+			if(!C)
+				continue
+
+			//Send it to the old style output window.
+			SEND_TEXT(C, original_message)
+
+			if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
+				continue
+
+			if(!C.chatOutput.loaded)
+				//Client still loading, put their messages in a queue
+				C.chatOutput.messageQueue += message
+				continue
+
+			C << output(twiceEncoded, "browseroutput:output")
+	else
+		var/client/C = CLIENT_FROM_VAR(target) //Grab us a client if possible
+		if(!C)
 			return
 
-		message = replacetext(message, "\n", "<br>")
+		//Send it to the old style output window.
+		SEND_TEXT(C, original_message)
 
-		message = macro2html(message)
-		if(findtext(message, "\improper"))
-			message = replacetext(message, "\improper", "")
-		if(findtext(message, "\proper"))
-			message = replacetext(message, "\proper", "")
+		if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
+			return
 
-		var/client/C
-		if(istype(target, /client))
-			C = target
-		if(ismob(target))
-			C = target:client
+		if(!C.chatOutput.loaded) //Client still loading, put their messages in a queue
+			C.chatOutput.messageQueue += message
+			return
 
-		if(C && C.chatOutput)
-			if(C.chatOutput.broken)
-				C << message
-				return
+		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
+		C << output(url_encode(url_encode(message)), "browseroutput:output")
 
-			if(!C.chatOutput.loaded && C.chatOutput.messageQueue && islist(C.chatOutput.messageQueue))
-				C.chatOutput.messageQueue.Add(message)
-				return
-
-		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the javascript.
-		var/output_message = "[url_encode(url_encode(message))]"
-		if(flag)
-			output_message += "&[url_encode(flag)]"
-
-		target << output(output_message, "browseroutput:output")
-
-/proc/to_chat(target, message, flag)
+/**
+  * Sends a chat message to one or multiple targets.
+  *
+  * Tries to buffer messages through SSchat if initialized,
+  * enabled and if MC is initialized. Buffered messages are sent next SSchat fire (next tick).
+  * If messages can't be buffered, they are instead send immediately through [/proc/to_chat_immediate]
+  * Arguments:
+  * * target - The target or (list of targets) to send the message to
+  * * message - The message in HTML
+  * * handle_whitespace - Whether \n and \t should be converted into HTML counterparts
+  * * trailing_newline - Whether a line break should be added at the end of the message
+  */
+/proc/to_chat(target, message, handle_whitespace = TRUE, trailing_newline = TRUE)
 	/*
 	If any of the following conditions are met, do NOT use SSchat. These conditions include:
 		- Is the MC still initializing?
@@ -313,8 +324,8 @@ var/to_chat_src
 	If any of these are met, use the old chat system, otherwise people wont see messages
 	*/
 	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized || SSchat?.flags & SS_NO_FIRE)
-		to_chat_immediate(target, message, flag)
+		to_chat_immediate(target, message, handle_whitespace, trailing_newline)
 		return
-	SSchat.queue(target, message, flag)
+	SSchat.queue(target, message, handle_whitespace, trailing_newline)
 
 #undef MAX_COOKIE_LENGTH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Takes up the torch from @SteelSlayer's `SSchat` fix (itself ported from TG):
- **Fixes `SSchat` not converting `\n` characters into line breaks (`<br>`), causing some text (e.g. human examine) to not render properly due to being one big `\n`-separated message rather than a succession of lines.**
- Fixes minor bug where condensed chat message badge would show up in a separate line rather than the repeated one's.
- Documents `SSchat` and `to_chat` procs.
- Re-activates `SSchat` which was added in #11921 but disabled in #13088 due to the above bug in bold.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As stated in #13088:
> The chat subsystem queues new chat messages and prevents lag spikes that usually happened when you'd be in a situation where you'd get a lot of messages at once, this means fastmos no longer KILLS your game, at least in my tests with 5 monkeys and 15 glass shards and deleting the floor, the game didn't even hang and this was on my laptop. Big performance improvement in that **regard**

**tl;dr perf improvement**

## Changelog
:cl:
tweak: Re-activate chat message buffering, increasing performance in message-heavy situations
fix: Fix condensed chat message badge appearing in a separate line
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
