### PR TITLE
Makes more wooden structures deconstructable.

### DIFF
--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -61,8 +61,7 @@
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-		new /obj/item/stack/sheet/wood(loc, 30)
-		qdel(src)
+		deconstruct(disassembled = TRUE)
 
 /obj/structure/dresser/wrench_act(mob/user, obj/item/I)
 	. = TRUE
@@ -78,6 +77,9 @@
 		WRENCH_ANCHOR_MESSAGE
 		anchored = TRUE
 
-/obj/structure/dresser/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/wood(drop_location(), 30)
+obj/structure/dresser/deconstruct(disassembled = FALSE)
+	var/mat_drop = 15
+	if(disassembled)
+		mat_drop = 30
+	new /obj/item/stack/sheet/wood(drop_location(), mat_drop)
 	qdel(src)

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -73,7 +73,7 @@
 		anchored = FALSE
 	else
 		if(!isfloorturf(loc))
-			user.visible_message("<span class='warning'>A floor must be present to secure [src]!</span>")
+			to_chat(user, "<span class='warning'>A floor must be present to secure [src]!</span>")
 			return
 		WRENCH_ANCHOR_MESSAGE
 		anchored = TRUE

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -56,12 +56,13 @@
 
 /obj/structure/dresser/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_start_check(src, user, 0))
+	if(!I.use_tool(src, user, 0))
 		return
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-
+		new /obj/item/stack/sheet/wood(loc, 30)
+		qdel(src)
 
 /obj/structure/dresser/wrench_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -65,17 +65,9 @@
 
 /obj/structure/dresser/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.tool_use_check(user, 0))
 		return
-	if(anchored)
-		WRENCH_UNANCHOR_MESSAGE
-		anchored = FALSE
-	else
-		if(!isfloorturf(loc))
-			to_chat(user, "<span class='warning'>A floor must be present to secure [src]!</span>")
-			return
-		WRENCH_ANCHOR_MESSAGE
-		anchored = TRUE
+	default_unfasten_wrench(user, I, time = 20)
 
 obj/structure/dresser/deconstruct(disassembled = FALSE)
 	var/mat_drop = 15

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -65,8 +65,6 @@
 
 /obj/structure/dresser/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
 	default_unfasten_wrench(user, I, time = 20)
 
 obj/structure/dresser/deconstruct(disassembled = FALSE)
@@ -74,4 +72,4 @@ obj/structure/dresser/deconstruct(disassembled = FALSE)
 	if(disassembled)
 		mat_drop = 30
 	new /obj/item/stack/sheet/wood(drop_location(), mat_drop)
-	qdel(src)
+	..()

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -17,6 +17,17 @@
 		return
 	return ..()
 
+/obj/structure/loom/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	TOOL_ATTEMPT_DISMANTLE_MESSAGE
+	if(I.use_tool(src, user, 50, volume = I.tool_volume))
+		TOOL_DISMANTLE_SUCCESS_MESSAGE
+		new /obj/item/stack/sheet/wood(loc, 40)
+		qdel(src)
+	
+
 ///Handles the weaving.
 /obj/structure/loom/proc/weave(obj/item/stack/sheet/cotton/W, mob/user)
 	if(!istype(W))

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -11,8 +11,6 @@
 	anchored = TRUE
 
 /obj/structure/loom/attackby(obj/item/I, mob/user)
-	if(default_unfasten_wrench(user, I, 5))
-		return
 	if(weave(I, user))
 		return
 	return ..()
@@ -24,8 +22,7 @@
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-		new /obj/item/stack/sheet/wood(loc, 10)
-		qdel(src)
+		deconstruct(disassembled = TRUE)
 
 /obj/structure/loom/wrench_act(mob/user, obj/item/I)
 	. = TRUE
@@ -40,6 +37,13 @@
 			return
 		WRENCH_ANCHOR_MESSAGE
 		anchored = TRUE
+
+/obj/structure/loom/deconstruct(disassembled = FALSE)
+	var/mat_drop = 5
+	if(disassembled)
+		mat_drop = 10
+	new /obj/item/stack/sheet/wood(drop_location(), mat_drop)
+	qdel(src)
 
 ///Handles the weaving.
 /obj/structure/loom/proc/weave(obj/item/stack/sheet/cotton/W, mob/user)

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -24,7 +24,7 @@
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-		new /obj/item/stack/sheet/wood(loc, 40)
+		new /obj/item/stack/sheet/wood(loc, 10)
 		qdel(src)
 	
 

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -26,17 +26,9 @@
 
 /obj/structure/loom/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.tool_use_check(user, 0))
 		return
-	if(anchored)
-		WRENCH_UNANCHOR_MESSAGE
-		anchored = FALSE
-	else
-		if(!isfloorturf(loc))
-			to_chat(user, "<span class='warning'>A floor must be present to secure [src]!</span>")
-			return
-		WRENCH_ANCHOR_MESSAGE
-		anchored = TRUE
+	default_unfasten_wrench(user, I, time = 20)
 
 /obj/structure/loom/deconstruct(disassembled = FALSE)
 	var/mat_drop = 5

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -26,8 +26,6 @@
 
 /obj/structure/loom/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
 	default_unfasten_wrench(user, I, time = 20)
 
 /obj/structure/loom/deconstruct(disassembled = FALSE)
@@ -35,7 +33,7 @@
 	if(disassembled)
 		mat_drop = 10
 	new /obj/item/stack/sheet/wood(drop_location(), mat_drop)
-	qdel(src)
+	..()
 
 ///Handles the weaving.
 /obj/structure/loom/proc/weave(obj/item/stack/sheet/cotton/W, mob/user)

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -26,7 +26,20 @@
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
 		new /obj/item/stack/sheet/wood(loc, 10)
 		qdel(src)
-	
+
+/obj/structure/loom/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(anchored)
+		WRENCH_UNANCHOR_MESSAGE
+		anchored = FALSE
+	else
+		if(!isfloorturf(loc))
+			to_chat(user, "<span class='warning'>A floor must be present to secure [src]!</span>")
+			return
+		WRENCH_ANCHOR_MESSAGE
+		anchored = TRUE
 
 ///Handles the weaving.
 /obj/structure/loom/proc/weave(obj/item/stack/sheet/cotton/W, mob/user)

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -205,8 +205,7 @@
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-		new /obj/item/stack/sheet/wood(loc, 40)
-		qdel(src)
+		deconstruct(disassembled = TRUE)
 
 /obj/structure/beebox/wrench_act(mob/user, obj/item/I)
 	. = TRUE
@@ -271,8 +270,11 @@
 					visible_message("<span class='notice'>[user] removes the queen from the apiary.</span>")
 					queen_bee = null
 
-/obj/structure/beebox/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/wood(loc, 20)
+/obj/structure/beebox/deconstruct(disassembled = FALSE)
+	var/mat_drop = 20
+	if(disassembled)
+		mat_drop = 40
+	new /obj/item/stack/sheet/wood(loc, mat_drop)
 	for(var/mob/living/simple_animal/hostile/poison/bees/B in bees)
 		if(B.loc == src)
 			B.forceMove(drop_location())

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -209,8 +209,6 @@
 
 /obj/structure/beebox/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
 	default_unfasten_wrench(user, I, time = 20)
 
 /obj/structure/beebox/attack_hand(mob/user)
@@ -281,7 +279,7 @@
 	for(var/obj/item/honey_frame/HF in honey_frames)
 		HF.forceMove(drop_location())
 		honey_frames -= HF
-	qdel(src)
+	..()
 
 /obj/structure/beebox/unwrenched
 	anchored = FALSE

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -198,6 +198,16 @@
 		return
 	return ..()
 
+/obj/structure/beebox/crowbar_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	TOOL_ATTEMPT_DISMANTLE_MESSAGE
+	if(I.use_tool(src, user, 50, volume = I.tool_volume))
+		TOOL_DISMANTLE_SUCCESS_MESSAGE
+		new /obj/item/stack/sheet/wood(loc, 40)
+		qdel(src)
+
 /obj/structure/beebox/wrench_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -72,8 +72,7 @@
 	TOOL_ATTEMPT_DISMANTLE_MESSAGE
 	if(I.use_tool(src, user, 50, volume = I.tool_volume))
 		TOOL_DISMANTLE_SUCCESS_MESSAGE
-		new /obj/item/stack/sheet/wood(loc, 30)
-		qdel(src)
+		deconstruct(disassembled = TRUE)
 
 /obj/structure/fermenting_barrel/wrench_act(mob/living/user, obj/item/I)
 	. = TRUE
@@ -88,6 +87,13 @@
 			return
 		WRENCH_ANCHOR_MESSAGE
 		anchored = TRUE
+
+/obj/structure/fermenting_barrel/deconstruct(disassembled = FALSE)
+	var/mat_drop = 15
+	if(disassembled)
+		mat_drop = 30
+	new /obj/item/stack/sheet/wood(drop_location(), mat_drop)
+	qdel(src)
 
 /obj/structure/fermenting_barrel/update_icon()
 	if(open)

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -76,8 +76,6 @@
 
 /obj/structure/fermenting_barrel/wrench_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
 	default_unfasten_wrench(user, I, time = 20)
 
 /obj/structure/fermenting_barrel/deconstruct(disassembled = FALSE)
@@ -85,7 +83,7 @@
 	if(disassembled)
 		mat_drop = 30
 	new /obj/item/stack/sheet/wood(drop_location(), mat_drop)
-	qdel(src)
+	..()
 
 /obj/structure/fermenting_barrel/update_icon()
 	if(open)

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -76,17 +76,9 @@
 
 /obj/structure/fermenting_barrel/wrench_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!I.tool_use_check(user, 0))
 		return
-	if(anchored)
-		WRENCH_UNANCHOR_MESSAGE
-		anchored = FALSE
-	else
-		if(!isfloorturf(loc))
-			to_chat(user, "<span class='warning'>A floor must be present to secure [src]!</span>")
-			return
-		WRENCH_ANCHOR_MESSAGE
-		anchored = TRUE
+	default_unfasten_wrench(user, I, time = 20)
 
 /obj/structure/fermenting_barrel/deconstruct(disassembled = FALSE)
 	var/mat_drop = 15

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "barrel"
 	density = TRUE
-	anchored = FALSE
+	anchored = TRUE
 	container_type = DRAINABLE | AMOUNT_VISIBLE
 	pressure_resistance = 2 * ONE_ATMOSPHERE
 	max_integrity = 300
@@ -64,6 +64,30 @@
 		container_type = DRAINABLE | AMOUNT_VISIBLE
 		to_chat(user, "<span class='notice'>You close [src], letting you draw from its tap.</span>")
 	update_icon()
+
+/obj/structure/fermenting_barrel/crowbar_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0))
+		return
+	TOOL_ATTEMPT_DISMANTLE_MESSAGE
+	if(I.use_tool(src, user, 50, volume = I.tool_volume))
+		TOOL_DISMANTLE_SUCCESS_MESSAGE
+		new /obj/item/stack/sheet/wood(loc, 30)
+		qdel(src)
+
+/obj/structure/fermenting_barrel/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(anchored)
+		WRENCH_UNANCHOR_MESSAGE
+		anchored = FALSE
+	else
+		if(!isfloorturf(loc))
+			user.visible_message("<span class='warning'>A floor must be present to secure [src]!</span>")
+			return
+		WRENCH_ANCHOR_MESSAGE
+		anchored = TRUE
 
 /obj/structure/fermenting_barrel/update_icon()
 	if(open)

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -84,7 +84,7 @@
 		anchored = FALSE
 	else
 		if(!isfloorturf(loc))
-			user.visible_message("<span class='warning'>A floor must be present to secure [src]!</span>")
+			to_chat(user, "<span class='warning'>A floor must be present to secure [src]!</span>")
 			return
 		WRENCH_ANCHOR_MESSAGE
 		anchored = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes the Wooden Dresser, Loom, Apiary and Fermenting Barrel deconstructable with a crowbar.
Fixes #14054 
Fermenting barrels are now also anchorable/unanchorable with a wrench.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Indestructable _(with tools)_ objects are bad.

## Changelog
:cl:
add: Dressers, Looms, Apiaries and Fermenting Barrels can now be deconstructed with a crowbar.
tweak: Fermenting Barrels now start anchored, and can be unanchored with a wrench.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
