### PR TITLE
Ranged holoparasites no longer obliterate admin attack logs

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/guardian
 	name = "crystal spray"
 	icon_state = "guardian"
-	damage = 5
+	damage = 25
 	damage_type = BRUTE
 	armour_penetration = 100
 
@@ -11,7 +11,7 @@
 	melee_damage_upper = 10
 	damage_transfer = 0.9
 	projectiletype = /obj/item/projectile/guardian
-	ranged_cooldown_time = 1 //fast!
+	ranged_cooldown_time = 5 //fast!
 	projectilesound = 'sound/effects/hit_on_shattered_glass.ogg'
 	ranged = 1
 	range = 13


### PR DESCRIPTION
## What Does This PR Do
Makes the ranged holoparasite's attacks (the green spray) take 5x as long to reload between shots... but also do 5x the damage.

## Why It's Good For The Game
The current attack speed (0.1 seconds!) is absolutely obnoxious for admins watching attack logs. It completely drowns out everything else in chat. This change makes it much more bearable, without changing its damage per second.

## Changelog
:cl: Kyep
tweak: ranged holoparasite now has 5x longer firing cooldown, but also 5x the damage. Damage per second is unchanged.
/:cl: