### PR TITLE
Revert "Make wet overlays render on MID_TURF_LAYER plane"

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -53,7 +53,6 @@
 				wet_overlay = image('icons/effects/water.dmi', src, "ice_floor")
 			else
 				wet_overlay = image('icons/effects/water.dmi', src, "wet_static")
-		wet_overlay.plane = MID_TURF_LAYER
 		overlays += wet_overlay
 	if(time == INFINITY)
 		return


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#14023

This is an emergency revert.

Reason: original PR breaks the game. Wet floor overlay blocks you from attacking things you want to attack - like blob tiles. And people.