### PR TITLE
Remove highlight length limit and fix highlights breaking the DOM

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -1049,7 +1049,7 @@ $(function() {
 		if ($('.popup .highlightTerm').is(':visible')) {return;}
 		var termInputs = '';
 		for (var i = 0; i < opts.highlightLimit; i++) {
-			termInputs += '<div><input type="text" name="highlightTermInput'+i+'" id="highlightTermInput'+i+'" class="highlightTermInput'+i+'" maxlength="255" value="'+(opts.highlightTerms[i] ? opts.highlightTerms[i] : '')+'" /></div>';
+			termInputs += '<div><input type="text" name="highlightTermInput'+i+'" id="highlightTermInput'+i+'" class="highlightTermInput'+i+'" value="" /></div>';
 		}
 		var popupContent = '<div class="head">String Highlighting</div>' +
 			'<div class="highlightPopup" id="highlightPopup">' +
@@ -1064,6 +1064,9 @@ $(function() {
 				'</form>' +
 			'</div>';
 		createPopup(popupContent, 250);
+		for(var i = 0; i < opts.highlightLimit; i++){
+			document.querySelector(".highlightTermInput"+i).setAttribute("value",(opts.highlightTerms[i] ? opts.highlightTerms[i] : ''));
+		}
 		document.querySelector(".popup #highlightRegexEnable").checked = opts.highlightRegexEnable;
 	});
 	$('body').on('keyup', '#highlightColor', function() {


### PR DESCRIPTION
## What Does This PR Do
Removes the limit for highlight length, and stops highlights containing " from breaking the DOM.

## Why It's Good For The Game
The highlight length limit imposes problems to those wishing to create regex highlights to match all their character names (and, to some extent, normal highlights ~~@Spacemanspark~~). As far as I can tell, removing it will not cause any issues.
Aswell, The way the highlight popup was originally written, inserted highlight terms as text into the DOM, instead of setting the value of their input boxes, This caused any highlight containing " to cut off when the highlight panel was opened, and could, in theory, break the dom if other special characters such as > were placed after it. This has now been fixed by manipulating the input box elements in code.

## Changelog
:cl:
del: Removed length limit for highlights
fix: Highlight terms being able to break the dom when the highlight panel opens.
/:cl:

I do not understand the person who originally wrote goonchat, The functions for manipulating the DOM in code had to have existed when it was written, but instead, they opted to do popups by appending html code as text? I may refactor this in the future, or completely rewrite goonchat. But if someone else wants to instead, go right ahead.

(posted as draft awaiting for me to test it properly, which may take a while)
