### PR TITLE
Wizmime Mask fix

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -155,7 +155,8 @@
 /obj/item/clothing/mask/gas/mime/wizard
 	name = "magical mime mask"
 	desc = "A mime mask glowing with power. Its eyes gaze deep into your soul."
-	flags_inv = HIDEEARS | HIDEEYES
+	flags = BLOCK_GAS_SMOKE_EFFECT | AIRTIGHT
+	flags_inv = HIDEFACE | HIDEEARS | HIDEEYES
 	magical = TRUE
 
 /obj/item/clothing/mask/gas/mime/nodrop


### PR DESCRIPTION
## What Does This PR Do
Edits the wizard mime mask, making it hide your identity like the clown version.

## Why It's Good For The Game
Fixes #14076 

## Changelog
:cl:
fix: the wizard mime mask is now functionally identical to its clown counterpart
/:cl: