### PR TITLE
Playtime DB update call refactor

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(jobs)
 /datum/controller/subsystem/jobs/fire()
 	if(!config.sql_enabled || !config.use_exp_tracking)
 		return
-	update_exp(5,0)
+	INVOKE_ASYNC(update_exp(5, 0))
 
 /datum/controller/subsystem/jobs/proc/SetupOccupations(var/list/faction = list("Station"))
 	occupations = list()

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(jobs)
 /datum/controller/subsystem/jobs/fire()
 	if(!config.sql_enabled || !config.use_exp_tracking)
 		return
-	INVOKE_ASYNC(update_exp(5, 0))
+	INVOKE_ASYNC(GLOBAL_PROC, /.proc/update_exp, 5, 0)
 
 /datum/controller/subsystem/jobs/proc/SetupOccupations(var/list/faction = list("Station"))
 	occupations = list()

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -224,19 +224,17 @@ GLOBAL_LIST_INIT(role_playtime_requirements, list(
 	else
 		return "none"
 
-/proc/update_exp(var/mins, var/ann = 0)
-	if(!establish_db_connection())
-		return -1
-	spawn(0)
-		for(var/client/L in GLOB.clients)
-			if(L.inactivity >= (10 MINUTES))
-				continue
-			spawn(0)
-				L.update_exp_client(mins, ann)
-			sleep(10)
+/proc/update_exp(mins = 0, ann = 0)
+	if(!GLOB.dbcon.IsConnected())
+		return
+	for(var/client/L in GLOB.clients)
+		if(L.inactivity >= (10 MINUTES))
+			continue
+		L.update_exp_client(mins, ann)
+		CHECK_TICK
 
-/client/proc/update_exp_client(var/minutes, var/announce_changes = 0)
-	if(!src ||!ckey)
+/client/proc/update_exp_client(minutes = 0, announce_changes = 0)
+	if(!src || !ckey || !GLOB.dbcon.IsConnected())
 		return
 	var/DBQuery/exp_read = GLOB.dbcon.NewQuery("SELECT exp FROM [format_table_name("player")] WHERE ckey='[ckey]'")
 	if(!exp_read.Execute())


### PR DESCRIPTION
## What Does This PR Do

- Refactors /proc/update_exp to remove spawn() and sleep(), and instead have a CHECK_TICK. Goal is to ensure it runs as fast as it reasonably can without lagging the server.
- Changes /client/proc/update_exp_client to abort instantly if there's no DB connection. And generally avoid causing issues if it runs past DB connection shutdown time.

## Why It's Good For The Game
- The sleep(10) in /proc/update_exp meant that with 100+ players, it could run for 100+ seconds... which meant it could still be running when DB connection is shut down.... which meant it could runtime/error after that. Fixing that requires that update_exp run quickly.
- ... but doing that might lag the server. So the CHECK_TICK is there to prevent it lagging the server (still requires TM to verify)
- Just in case it still survives to roundend (or we're unlucky) there's also !GLOB.dbcon.IsConnected() to abort it if needed.

## Changelog
:cl:
fix: Fixed playtime tracking system sometimes failing to complete its run before round-end.
/:cl:
