### PR TITLE
Fixes destroyer borg lawsync, laws, sound

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1437,7 +1437,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	default_cell_type = /obj/item/stock_parts/cell/bluespace
 
 /mob/living/silicon/robot/destroyer/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
-	..()
+	laws = new /datum/ai_laws/deathsquad
 	module = new /obj/item/robot_module/destroyer(src)
 	module.add_languages(src)
 	module.add_subsystems_and_actions(src)
@@ -1446,6 +1446,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		qdel(radio)
 	radio = new /obj/item/radio/borg/ert/specops(src)
 	radio.recalculateChannels()
+	playsound(loc, 'sound/mecha/nominalsyndi.ogg', 75, 0)
 
 /mob/living/silicon/robot/destroyer/borg_icons()
 	if(base_icon == "")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1437,6 +1437,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	default_cell_type = /obj/item/stock_parts/cell/bluespace
 
 /mob/living/silicon/robot/destroyer/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
+	aiCamera = new/obj/item/camera/siliconcam/robot_camera(src)
+	additional_law_channels["Binary"] = ":b "
 	laws = new /datum/ai_laws/deathsquad
 	module = new /obj/item/robot_module/destroyer(src)
 	module.add_languages(src)


### PR DESCRIPTION
## What Does This PR Do
Fixes a few bugs with the admin-only destroyer borgs, such as them:
- syncing to an AI, when they're supposed to be an event borg
- getting a random lawset, instead of the blank or DS-borg lawset they're meant to have
- not playing a sound on creation

## Changelog
:cl: Kyep
fix: fixed a few bugs with admin-only destroyer borgs, such as them linking to an AI (and thus generating a notice to the station AI when spawned in admin test area).
/:cl:
