### PR TITLE
Nerfs butterfly crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1173,11 +1173,10 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	containername = "fox crate"
 
 /datum/supply_packs/organic/butterfly
-	name = "Butterflies Crate"
+	name = "Butterfly Crate"
 	cost = 50
 	containertype = /obj/structure/closet/critter/butterfly
-	containername = "butterflies crate"
-	contraband = 1
+	containername = "butterfly crate"
 
 /datum/supply_packs/organic/deer
 	name = "Deer Crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1172,13 +1172,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	contains = list(/obj/item/clothing/accessory/petcollar)
 	containername = "fox crate"
 
-/datum/supply_packs/organic/butterfly
-	name = "Butterflies Crate"
-	cost = 50
-	containertype = /obj/structure/closet/critter/butterfly
-	containername = "butterflies crate"
-	contraband = 1
-
 /datum/supply_packs/organic/deer
 	name = "Deer Crate"
 	cost = 56 //Deer are best.

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1172,6 +1172,13 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	contains = list(/obj/item/clothing/accessory/petcollar)
 	containername = "fox crate"
 
+/datum/supply_packs/organic/butterfly
+	name = "Butterflies Crate"
+	cost = 50
+	containertype = /obj/structure/closet/critter/butterfly
+	containername = "butterflies crate"
+	contraband = 1
+
 /datum/supply_packs/organic/deer
 	name = "Deer Crate"
 	cost = 56 //Deer are best.

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -82,9 +82,8 @@
 	content_mob = /mob/living/simple_animal/pet/dog/fox
 
 /obj/structure/closet/critter/butterfly
-	name = "butterflies crate"
+	name = "butterfly crate"
 	content_mob = /mob/living/simple_animal/butterfly
-	amount = 50
 
 /obj/structure/closet/critter/deer
 	name = "deer crate"

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -81,11 +81,6 @@
 	name = "fox crate"
 	content_mob = /mob/living/simple_animal/pet/dog/fox
 
-/obj/structure/closet/critter/butterfly
-	name = "butterflies crate"
-	content_mob = /mob/living/simple_animal/butterfly
-	amount = 50
-
 /obj/structure/closet/critter/deer
 	name = "deer crate"
 	content_mob = /mob/living/simple_animal/deer

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -81,6 +81,11 @@
 	name = "fox crate"
 	content_mob = /mob/living/simple_animal/pet/dog/fox
 
+/obj/structure/closet/critter/butterfly
+	name = "butterflies crate"
+	content_mob = /mob/living/simple_animal/butterfly
+	amount = 50
+
 /obj/structure/closet/critter/deer
 	name = "deer crate"
 	content_mob = /mob/living/simple_animal/deer


### PR DESCRIPTION
## What Does This PR Do
Reduces the amount of butterflies in the butterfly crate to 1. Why? Because being able to order packs of 50 butterflies en mass (which obliterates the NPC subsystem) is quite frankly bad design, and shouldn't be a thing.

## Why It's Good For The Game
See above

## Changelog
:cl: AffectedArc07
tweak: Butterfly crate is now non-contraband
tweak: Butterfly crate contains 1 butterfly, instead of 50
/:cl:
