### PR TITLE
AoE spell attack logging tweak

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -444,6 +444,11 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 
 	return
 
+// Normally, AoE spells will generate an attack log for every turf they loop over, while searching for targets.
+// With this override, all /aoe_turf type spells will only generate 1 log, saying that the user has cast the spell.
+/obj/effect/proc_holder/spell/aoe_turf/perform(list/targets, recharge, mob/user, make_attack_logs)
+	add_attack_logs(user, null, "Cast the AoE spell [name]", ATKLOG_ALL)
+	return ..(targets, recharge, user, FALSE)
 
 /obj/effect/proc_holder/spell/targeted/proc/los_check(mob/A,mob/B)
 	//Checks for obstacles from A to B

--- a/code/datums/spells/knock.dm
+++ b/code/datums/spells/knock.dm
@@ -13,11 +13,6 @@
 	action_icon_state = "knock"
 	sound = 'sound/magic/knock.ogg'
 
-// Knock doesn't need to generate an attack log for every turf, set `make_attack_logs` to FALSE and just create a custom one.
-/obj/effect/proc_holder/spell/aoe_turf/knock/perform(list/targets, recharge, mob/user)
-	add_attack_logs(user, user, "cast the spell [name]", ATKLOG_ALL)
-	return ..(targets, recharge, user, make_attack_logs = FALSE)
-
 /obj/effect/proc_holder/spell/aoe_turf/knock/cast(list/targets, mob/user = usr)
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Limits the attack logs that `/aoe_turf` type spells generate. Some of these can generate an absurd amount of attack logs because they take a screen's worth of turfs and make a log on each of them, which can mean hundreds of logs. They will now only generate 1 attack log, which says that the user has has cast the spell.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less attack log spam for admins. Fixes #14093
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: /aoe_turf type spells, such as Boo!, Knock, and Repulse, will now only generate 1 attack log, instead of a log for every turf they loop through while searching for targets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
