### PR TITLE
Adds a shield overlay to the Empowered Cultist Robes

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -140,6 +140,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/tome,/obj/item/melee/cultblade)
 	var/current_charges = 3
+	var/shield_state = "shield-cult"
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie
 
 /obj/item/clothing/head/hooded/cult_hoodie
@@ -164,12 +165,17 @@
 	if(current_charges)
 		owner.visible_message("<span class='danger'>\The [attack_text] is deflected in a burst of blood-red sparks!</span>")
 		current_charges--
+		playsound(loc, "sparks", 100, 1)
 		new /obj/effect/temp_visual/cult/sparks(get_turf(owner))
 		if(!current_charges)
 			owner.visible_message("<span class='danger'>The runed shield around [owner] suddenly disappears!</span>")
+			shield_state = "broken"
 			owner.update_inv_wear_suit()
 		return 1
 	return 0
+
+/obj/item/clothing/suit/hooded/cultrobes/cult_shield/special_overlays()
+	return mutable_appearance('icons/effects/cult_effects.dmi', shield_state, MOB_LAYER + 0.01)
 
 /obj/item/clothing/suit/hooded/cultrobes/berserker
 	name = "flagellant's robes"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a shield overlay to the Shielded cult robes, similar to the nukies Shielded Hardsuit.
Also adds a spark sound when the shield is hit, again similar to the Shielded Hardsuit.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The robes already have a shield effect, blocking the first few hits, but there's no visual effects tied to it, so it can be hard to actually know about the feature.

The code already tries to do `owner.update_inv_wear_suit()`, despite there being no overlay, which indicates to me that there _should_ be one.

And finally, it looks cooler.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Before:
![Before](https://user-images.githubusercontent.com/57483089/90407596-9a83b980-e09e-11ea-8b36-6cd624c486c6.png)

After:
![After](https://user-images.githubusercontent.com/57483089/90407630-9f486d80-e09e-11ea-98db-2bc399c9e728.png)

## Changelog
:cl:
add: Added a shield overlay to the Shielded cult robes.
add: Added a sparking sound when the shield is hit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
