### PR TITLE
Fixes #14103 - terror egglaying exploit

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
@@ -51,6 +51,10 @@
 		if(!(eggtype in eggtypes))
 			to_chat(src, "<span class='danger'>Unrecognized egg type.</span>")
 			return 0
+	if(fed < feedings_to_lay)
+		// We have to check this again after the popup, to account for people spam-clicking the button, then doing all the popups at once.
+		to_chat(src, "<span class='warning'>You must wrap more humanoid prey before you can do this!</span>")
+		return
 	visible_message("<span class='notice'>[src] lays a cluster of eggs.</span>")
 	if(eggtype == TS_DESC_RED)
 		DoLayTerrorEggs(/mob/living/simple_animal/hostile/poison/terror_spider/red, 1)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -287,6 +287,10 @@
 	if(eggtype == null || numlings == null)
 		to_chat(src, "<span class='danger'>Cancelled.</span>")
 		return
+	if(canlay < numlings)
+		// We have to check this again after the popups, to account for people spam-clicking the button, then doing all the popups at once.
+		to_chat(src, "<span class='warning'>Too soon to do this again!</span>")
+		return
 	canlay -= numlings
 	eggslaid += numlings
 	if(eggtype == TS_DESC_RED)


### PR DESCRIPTION
## What Does This PR Do
Fixes #14103 - green and queen terrors being able to lay more eggs than intended.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl: Kyep
fix: fixed green/queen terrors who spam-click the lay eggs button being able to lay more eggs than was intended.
/:cl: