### PR TITLE
Fix random lipstick colour always defaulting to white

### DIFF
--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -55,16 +55,15 @@
 
 /obj/item/lipstick/random/Initialize(mapload)
 	. = ..()
-	var/lscolor = pick(lipstick_colors) // A random color is picked from the var defined initially in a new var.
-	colour = lipstick_colors[lscolor] // The color of the lipstick is pulled from the new variable (right hand side, HTML & Hex RGB)
-	name = "[lscolor] lipstick" // The new variable is also used to match the name to the color of the lipstick. Kudos to Desolate & Lemon
+	colour = pick(lipstick_colors)
+	name = "[colour] lipstick"
 
 /obj/item/lipstick/attack_self(mob/user)
 	cut_overlays()
 	to_chat(user, "<span class='notice'>You twist \the [src] [open ? "closed" : "open"].</span>")
 	open = !open
 	if(open)
-		var/image/colored = mutable_appearance('icons/obj/items.dmi', "lipstick_uncap_color")
+		var/mutable_appearance/colored = mutable_appearance('icons/obj/items.dmi', "lipstick_uncap_color")
 		colored.color = lipstick_colors[colour]
 		icon_state = "lipstick_uncap"
 		add_overlay(colored)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes random lipsticks always being white because the RGB value (rather than the colour name) was being used in the `colour` variable.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Lipsticks fixed (hopefully) for good

## Changelog
:cl:
fix: Fix random lipstick colour always defaulting to white
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
