### PR TITLE
Clown lavaland ruin loot change and Honkputer

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -961,7 +961,7 @@
 /area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/table/glass,
-/obj/item/gun/magic/staff/slipping,
+/obj/item/circuitboard/HONKputer,
 /turf/simulated/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bB" = (

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -367,7 +367,7 @@
 	icon = 'icons/obj/machines/HONKputer.dmi'
 	icon_state = "bananium_board"
 	board_type = "honkcomputer"
-	desc = "The contacts on this board are made from pure bananium! What could its purpose be?"
+
 
 /obj/item/circuitboard/supplycomp/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(istype(I,/obj/item/multitool))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -367,7 +367,7 @@
 	icon = 'icons/obj/machines/HONKputer.dmi'
 	icon_state = "bananium_board"
 	board_type = "honkcomputer"
-
+	desc = "The contacts on this board are made from pure bananium! What could its purpose be?"
 
 /obj/item/circuitboard/supplycomp/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(istype(I,/obj/item/multitool))

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -11,6 +11,7 @@
 	integrity_failure = 100
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 20)
 	var/obj/item/circuitboard/circuit = null //if circuit==null, computer can't disassembly
+	var/frame_type = /obj/structure/computerframe
 	var/processing = 0
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
@@ -92,7 +93,7 @@
 	on_deconstruction()
 	if(!(flags & NODECONSTRUCT))
 		if(circuit) //no circuit, no computer frame
-			var/obj/structure/computerframe/A = new /obj/structure/computerframe(loc)
+			var/obj/structure/computerframe/A = new frame_type(loc)
 			var/obj/item/circuitboard/M = new circuit(A)
 			A.setDir(dir)
 			A.circuit = M

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -11,7 +11,6 @@
 	integrity_failure = 100
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 20)
 	var/obj/item/circuitboard/circuit = null //if circuit==null, computer can't disassembly
-	var/frame_type = /obj/structure/computerframe
 	var/processing = 0
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
@@ -93,7 +92,7 @@
 	on_deconstruction()
 	if(!(flags & NODECONSTRUCT))
 		if(circuit) //no circuit, no computer frame
-			var/obj/structure/computerframe/A = new frame_type(loc)
+			var/obj/structure/computerframe/A = new /obj/structure/computerframe(loc)
 			var/obj/item/circuitboard/M = new circuit(A)
 			A.setDir(dir)
 			A.circuit = M

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/HONKputer
-	name = "\improper HONKputer"
+	name = "\improper HONKputer Mark I"
 	desc = "A yellow computer used in case of critically low levels of HONK."
 	icon = 'icons/obj/machines/HONKputer.dmi'
 	icon_state = "honkputer"
@@ -8,7 +8,6 @@
 	light_color = LIGHT_COLOR_PINK
 	req_access = list(ACCESS_CLOWN)
 	circuit = /obj/item/circuitboard/HONKputer
-	frame_type = /obj/structure/computerframe/HONKputer
 	var/authenticated = 0
 	var/message_cooldown = 0
 	var/state = STATE_DEFAULT
@@ -32,15 +31,15 @@
 		// main interface
 		if("main")
 			src.state = STATE_DEFAULT
-
 		if("login")
-			var/mob/living/carbon/human/M = usr
-			var/list/access = M.get_access()
-			if (ACCESS_CLOWN in access)
-				authenticated = 1
-			if(src.emagged==1)
-				authenticated = 1
-
+			var/mob/M = usr
+			var/obj/item/card/id/I = M.get_active_hand()
+			if(istype(I, /obj/item/pda))
+				var/obj/item/pda/pda = I
+				I = pda.id
+			if(I && istype(I))
+				if(src.check_access(I) || src.emagged==1)
+					authenticated = 1
 		if("logout")
 			authenticated = 0
 

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -37,9 +37,9 @@
 			var/mob/living/carbon/human/M = usr
 			var/list/access = M.get_access()
 			if (ACCESS_CLOWN in access)
-				authenticated = 1
-			if(src.emagged==1)
-				authenticated = 1
+				authenticated = TRUE
+			if(emagged)
+				authenticated = TRUE
 
 		if("logout")
 			authenticated = FALSE
@@ -47,7 +47,7 @@
 		if("MessageHonkplanet")
 			if(src.authenticated==1)
 				if(message_cooldown)
-					to_chat(usr, "<span_class = 'warning'>Arrays recycling.  Please stand by.</span>")
+					to_chat(usr, "<span class='warning'>Arrays recycling.  Please stand by.</span>")
 					return
 				var/input = stripped_input(usr, "Please choose a message to transmit to your HONKbrothers on the homeworld. Transmission does not guarantee a response.", "To abort, send an empty message.", "")
 				if(!input || !(usr in view(1,src)))

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/HONKputer
-	name = "\improper HONKputer Mark I"
+	name = "\improper HONKputer"
 	desc = "A yellow computer used in case of critically low levels of HONK."
 	icon = 'icons/obj/machines/HONKputer.dmi'
 	icon_state = "honkputer"
@@ -8,6 +8,7 @@
 	light_color = LIGHT_COLOR_PINK
 	req_access = list(ACCESS_CLOWN)
 	circuit = /obj/item/circuitboard/HONKputer
+	frame_type = /obj/structure/computerframe/HONKputer
 	var/authenticated = 0
 	var/message_cooldown = 0
 	var/state = STATE_DEFAULT
@@ -31,22 +32,22 @@
 		// main interface
 		if("main")
 			src.state = STATE_DEFAULT
+
 		if("login")
-			var/mob/M = usr
-			var/obj/item/card/id/I = M.get_active_hand()
-			if(istype(I, /obj/item/pda))
-				var/obj/item/pda/pda = I
-				I = pda.id
-			if(I && istype(I))
-				if(src.check_access(I) || src.emagged==1)
-					authenticated = 1
+			var/mob/living/carbon/human/M = usr
+			var/list/access = M.get_access()
+			if (ACCESS_CLOWN in access)
+				authenticated = 1
+			if(src.emagged==1)
+				authenticated = 1
+
 		if("logout")
 			authenticated = 0
 
 		if("MessageHonkplanet")
 			if(src.authenticated==1)
 				if(message_cooldown)
-					to_chat(usr, "Arrays recycling.  Please stand by.")
+					to_chat(usr, "<span_class = 'warning'>Arrays recycling.  Please stand by.</span>")
 					return
 				var/input = stripped_input(usr, "Please choose a message to transmit to your HONKbrothers on the homeworld. Transmission does not guarantee a response.", "To abort, send an empty message.", "")
 				if(!input || !(usr in view(1,src)))

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -31,7 +31,7 @@
 	switch(href_list["operation"])
 		// main interface
 		if("main")
-			src.state = STATE_DEFAULT
+			state = STATE_DEFAULT
 
 		if("login")
 			var/mob/living/carbon/human/M = usr

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/HONKputer
-	name = "\improper HONKputer Mark I"
+	name = "\improper HONKputer"
 	desc = "A yellow computer used in case of critically low levels of HONK."
 	icon = 'icons/obj/machines/HONKputer.dmi'
 	icon_state = "honkputer"
@@ -8,6 +8,7 @@
 	light_color = LIGHT_COLOR_PINK
 	req_access = list(ACCESS_CLOWN)
 	circuit = /obj/item/circuitboard/HONKputer
+	frame_type = /obj/structure/computerframe/HONKputer
 	var/authenticated = 0
 	var/message_cooldown = 0
 	var/state = STATE_DEFAULT
@@ -31,15 +32,15 @@
 		// main interface
 		if("main")
 			src.state = STATE_DEFAULT
+
 		if("login")
-			var/mob/M = usr
-			var/obj/item/card/id/I = M.get_active_hand()
-			if(istype(I, /obj/item/pda))
-				var/obj/item/pda/pda = I
-				I = pda.id
-			if(I && istype(I))
-				if(src.check_access(I) || src.emagged==1)
-					authenticated = 1
+			var/mob/living/carbon/human/M = usr
+			var/list/access = M.get_access()
+			if (ACCESS_CLOWN in access)
+				authenticated = 1
+			if(src.emagged==1)
+				authenticated = 1
+
 		if("logout")
 			authenticated = 0
 

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -9,7 +9,7 @@
 	req_access = list(ACCESS_CLOWN)
 	circuit = /obj/item/circuitboard/HONKputer
 	frame_type = /obj/structure/computerframe/HONKputer
-	var/authenticated = 0
+	var/authenticated = FALSE
 	var/message_cooldown = 0
 	var/state = STATE_DEFAULT
 	var/const/STATE_DEFAULT = 1

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -42,7 +42,7 @@
 				authenticated = 1
 
 		if("logout")
-			authenticated = 0
+			authenticated = FALSE
 
 		if("MessageHonkplanet")
 			if(src.authenticated==1)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(bananium_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("Clown Statue", /obj/structure/statue/bananium/clown, 5, one_per_turf = 1, on_floor = 1), \
 	null, \
-	new/datum/stack_recipe("bananium computer frame", /obj/structure/computerframe/HONKputer, 50, time = 25, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("bananium computer frame", /obj/structure/computerframe/HONKputer, 5, time = 25, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("bananium grenade casing", /obj/item/grenade/bananade/casing, 4, on_floor = 1), \
 	))
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(bananium_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("Clown Statue", /obj/structure/statue/bananium/clown, 5, one_per_turf = 1, on_floor = 1), \
 	null, \
-	new/datum/stack_recipe("bananium computer frame", /obj/structure/computerframe/HONKputer, 5, time = 25, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("bananium computer frame", /obj/structure/computerframe/HONKputer, 15, time = 25, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("bananium grenade casing", /obj/item/grenade/bananade/casing, 4, on_floor = 1), \
 	))
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -59,7 +59,7 @@
 
 /proc/HONK_announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
-	msg = "<span class='boldnotice'><font color=pink>HONK: </font>[key_name(Sender, 1)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) (<A HREF='?_src_=holder;HONKReply=[Sender.UID()]'>RPLY</A>):</span> [msg]"
+	msg = "<span class='boldnotice'><font color=#ab009d>CLOWN PLANET: </font>[key_name(Sender, 1)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) (<A HREF='?_src_=holder;HONKReply=[Sender.UID()]'>RPLY</A>):</span> [msg]"
 	for(var/client/X in GLOB.admins)
 		if(R_EVENT & X.holder.rights)
 			to_chat(X, msg)

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -59,7 +59,7 @@
 
 /proc/HONK_announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
-	msg = "<span class='boldnotice'><font color=#ab009d>CLOWN PLANET: </font>[key_name(Sender, 1)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) (<A HREF='?_src_=holder;HONKReply=[Sender.UID()]'>RPLY</A>):</span> [msg]"
+	msg = "<span class='boldnotice'><font color=pink>HONK: </font>[key_name(Sender, 1)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) (<A HREF='?_src_=holder;HONKReply=[Sender.UID()]'>RPLY</A>):</span> [msg]"
 	for(var/client/X in GLOB.admins)
 		if(R_EVENT & X.holder.rights)
 			to_chat(X, msg)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
1. Replaces the Staff of Slipping obtainable from the loot room in the clown biodome ruin with a HONKputer computer board.
2. Fixes a few issues with the HONKputer, including deconstruction path, fixing the way the login works, and making it slightly clearer that a bananium frame is required when examining the board.



## Why It's Good For The Game
1. The staff of slipping is supposed to be wizard-exclusive for a good reason: it's an instant, ranged, self-recharging stun weapon. It's _designed_ to be unfair, it's a wizard item. Miners, miner antags and even security when they get their hands on it, shouldn't really have access to the staff on normal rounds.
2. The circuit board for the HONKputer is unobtainable currently, this PR makes it obtainable. As a refresher, the HONKputer is like a communications console, allowing contact with the clown planet. That is, it PMs admins similar to how the communications console can. Keep in mind, this will NOT result in spam to admins, because the board can only be placed in a bananium computer frame, which takes FIFTY bananium sheets to assemble, and that's very unlikely to happen in a normal round. The computer is also locked to clown-id only, and has a lengthy 10 minute cooldown between messages. If someone does decide to abuse the console, which will happen very rarely, there's always easy options to punish IC with admin smiting. Adding the HONKputer back into the game has potential to add variety on the very few rounds where it's able to be assembled.
3. The honkputer is generally more interesting than the staff, and leads to better scenarios. It could be fun for players to discover the board and try figure out what it does, much more so than just getting easy access to an infinite-ammo wizard's stun-gun.

## Changelog
:cl:
add: Made the mysterious HONKputer obtainable.
fix: Made the HONKputer function properly again.
del: Removed the Staff of Slipping from the clown biodome ruin.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
