### PR TITLE
Cyborg Cryo equity

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -458,7 +458,7 @@
 			announce.autosay("[occupant.real_name]  ([announce_rank]) [on_store_message]", "[on_store_name]")
 		else
 			announce.autosay("[occupant.real_name] [on_store_message]", "[on_store_name]")
-	visible_message("<span class='notice'>\The [src] hums and hisses as it moves [occupant.real_name] into storage.</span>")
+	visible_message("<span class='notice'>\The [src] hums and hisses as it moves [occupant.real_name] into AI storage and recycles the usable parts of [p_their()] chassis.</span>")
 
 	// Ghost and delete the mob.
 	if(!occupant.get_ghost(1))
@@ -756,7 +756,24 @@
 /obj/machinery/cryopod/robot/despawn_occupant()
 	var/mob/living/silicon/robot/R = occupant
 	if(!istype(R)) return ..()
-
+	var/obj/item/robot_parts/robot_suit/S = new /obj/item/robot_parts/robot_suit(get_turf(R)) //generates a vacant robot chassis with a number of missing body parts proportional to the cryoing borg's health
+	var/obj/item/robot_parts/chest/C = new /obj/item/robot_parts/chest(S)
+	var/prob_missing = R.health+100/2
+	if(prob(prob_missing))
+		S.l_arm = new /obj/item/robot_parts/l_arm
+	if(prob(prob_missing))
+		S.r_arm = new /obj/item/robot_parts/r_arm
+	if(prob(prob_missing))
+		S.l_leg = new /obj/item/robot_parts/l_leg
+	if(prob(prob_missing))
+		S.r_leg = new /obj/item/robot_parts/r_leg
+	if(prob(prob_missing))
+		S.head = new /obj/item/robot_parts/head
+	S.chest = C
+	C.cell = R.cell
+	C.wired = TRUE
+	S.updateicon()
+	playsound(S.loc, 'sound/machines/ding.ogg', 50, TRUE)
 	R.contents -= R.mmi
 	qdel(R.mmi)
 	for(var/obj/item/I in R.module) // the tools the borg has; metal, glass, guns etc
@@ -766,7 +783,6 @@
 	if(R.module)
 		R.module.remove_subsystems_and_actions(R)
 		qdel(R.module)
-
 	return ..()
 
 


### PR DESCRIPTION
## What Does This PR Do
Generates a robot endoskeleton when a cyborg cryos. Each body part other than the chest has a chance to be missing proportional to how much health the cyborg had when they cryoed, with a 98% chance at -99 health and a 0% chance at 100 health.

## Why It's Good For The Game
If a ghost joins as a cyborg, is assembled by robotics, and then immediately cryos for whatever reason, an entire stack of metal is completely deleted from the round. This PR changes it so that when a cyborg cryos, it gets "recycled", giving some of the materials back in the form of a new vacant chassis. There's a chance that body parts will be missing depending on the cyborg's health, though: damaged cyborgs can't cryo then rejoin at little cost to the crew, so repairing them properly is still the cheaper option.

## Changelog
:cl:
tweak: Cyborgs now return their chassis when they cryo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
