### PR TITLE
Restores ability to set transfer amount on glasses

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -13,6 +13,10 @@
 	max_integrity = 20
 	resistance_flags = ACID_PROOF
 
+/obj/item/reagent_containers/food/drinks/set_APTFT()
+	set hidden = FALSE
+	..()
+
 /obj/item/reagent_containers/food/drinks/drinkingglass/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/egg)) //breaking eggs
 		var/obj/item/reagent_containers/food/snacks/egg/E = I

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -35,6 +35,7 @@
 
 /obj/item/reagent_containers/food/set_APTFT()
 	set hidden = TRUE
+	..()
 
 /obj/item/reagent_containers/food/proc/check_for_ants()
 	if(!antable)

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -29,6 +29,10 @@
 /obj/item/reagent_containers/food/condiment/attack_self(mob/user)
 	return
 
+/obj/item/reagent_containers/food/condiment/set_APTFT()
+	set hidden = FALSE
+	..()
+
 /obj/item/reagent_containers/food/condiment/attack(mob/M, mob/user, def_zone)
 
 	if(!reagents || !reagents.total_volume)


### PR DESCRIPTION
## What Does This PR Do
This got removed during #14014 and is apparently important to play chef properly, which I can understand.

## Why It's Good For The Game
Should be able to set transfers on condiments and glasses

## Changelog
:cl: AffectedArc07
fix: You can set transfer amount on glasses and condiment bottles again
/:cl:
