### PR TITLE
Fixes the exploit where you can put unlimited items in a locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -25,9 +25,13 @@
 	..()
 	spawn(1)
 		if(!opened)		// if closed, any item at the crate's loc is put in the contents
+			var/itemcount = 0
 			for(var/obj/item/I in loc)
 				if(I.density || I.anchored || I == src) continue
 				I.forceMove(src)
+				// Ensure the storage cap is respected
+				if(++itemcount >= storage_capacity)
+					break
 
 // Fix for #383 - C4 deleting fridges with corpses
 /obj/structure/closet/Destroy()


### PR DESCRIPTION
## What Does This PR Do
Fixes an exploit where you can put infinite items in a locker when you create it

## Why It's Good For The Game
It's a bug which causes lag and what not

## Changelog
:cl:
fix: Lockers being spawned now respect the storage capacity they have set when putting items in them
/:cl: