### PR TITLE
Dark mode tweaks v1.1

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -1,4 +1,4 @@
-GLOBAL_VAR_INIT(normal_ooc_colour, "#337AFF")
+GLOBAL_VAR_INIT(normal_ooc_colour, "#275FC5")
 GLOBAL_VAR_INIT(member_ooc_colour, "#035417")
 GLOBAL_VAR_INIT(mentor_ooc_colour, "#00B0EB")
 GLOBAL_VAR_INIT(moderator_ooc_colour, "#184880")

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -1,4 +1,4 @@
-GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
+GLOBAL_VAR_INIT(normal_ooc_colour, "#1467FF")
 GLOBAL_VAR_INIT(member_ooc_colour, "#035417")
 GLOBAL_VAR_INIT(mentor_ooc_colour, "#0099cc")
 GLOBAL_VAR_INIT(moderator_ooc_colour, "#184880")

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -1,6 +1,6 @@
-GLOBAL_VAR_INIT(normal_ooc_colour, "#1467FF")
+GLOBAL_VAR_INIT(normal_ooc_colour, "#337AFF")
 GLOBAL_VAR_INIT(member_ooc_colour, "#035417")
-GLOBAL_VAR_INIT(mentor_ooc_colour, "#0099cc")
+GLOBAL_VAR_INIT(mentor_ooc_colour, "#00B0EB")
 GLOBAL_VAR_INIT(moderator_ooc_colour, "#184880")
 GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -287,7 +287,7 @@ em						{font-style: normal;	font-weight: bold;}
 .mentor_channel_admin      {color: #A35CFF;	font-weight: bold;}
 .djradio				{color: #996600;}
 .binaryradio				{color: #1B00FB;	font-family: 'Courier New', Courier, monospace;}
-.mommiradio				{color: #1B00AB;}
+.mommiradio				{color: #6685f5;}
 .alert					{color: #ff0000;}
 h1.alert, h2.alert			{color: #FFF;}
 .ghostalert				{color: #cc00c6;	font-style: italic; font-weight: bold;}

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -275,7 +275,7 @@ em						{font-style: normal;	font-weight: bold;}
 .dsquadradio				{color: #998599;}
 .resteamradio				{color: #18BC46;}
 .airadio				{color: #FF94FF;}
-.centradio				{color: #5C5C7C;}
+.centradio				{color: #78789B;}
 .secradio				{color: #CF0000;}
 .engradio				{color: #A66300;}
 .medradio				{color: #009190;}
@@ -359,7 +359,7 @@ h1.alert, h2.alert			{color: #FFF;}
 .cultlarge				{color: #A60000; font-weight: bold; font-size: 120%;}
 .narsie					{color: #A60000; font-weight: bold; font-size: 300%;}
 .narsiesmall			{color: #A60000; font-weight: bold; font-size: 200%;}
-.interface				{color: #330033;}
+.interface				{color: #9031C4;}
 .big					{font-size: 150%;}
 .reallybig				{font-size: 175%;}
 .greentext				{color: #00FF00;	font-size: 150%;}
@@ -375,14 +375,14 @@ h1.alert, h2.alert			{color: #FFF;}
 .orangeb				{color: #ffa500; font-weight: bold;}
 .resonate				{color: #298F85;}
 
-.revennotice				{color: #1d29C3;}
-.revenboldnotice			{color: #1d29C3;	font-weight: bold;}
-.revenbignotice				{color: #1d29C3;	font-weight: bold; font-size: 120%;}
+.revennotice				{color: #6685F5;}
+.revenboldnotice			{color: #6685F5;	font-weight: bold;}
+.revenbignotice				{color: #6685F5;	font-weight: bold; font-size: 120%;}
 .revenminor				{color: #823abb}
 .revenwarning				{color: #760fbb;	font-style: italic;}
 .revendanger				{color: #760fbb;	font-weight: bold; font-size: 120%;}
 
-.specialnotice				{color: #36525e; 	font-weight: bold; font-size: 120%;}
+.specialnotice				{color: ##4A6F82; 	font-weight: bold; font-size: 120%;}
 
 /* /vg/ */
 .good					{color: green;}

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -382,7 +382,7 @@ h1.alert, h2.alert			{color: #FFF;}
 .revenwarning				{color: #760fbb;	font-style: italic;}
 .revendanger				{color: #760fbb;	font-weight: bold; font-size: 120%;}
 
-.specialnotice				{color: ##4A6F82; 	font-weight: bold; font-size: 120%;}
+.specialnotice				{color: #4A6F82; 	font-weight: bold; font-size: 120%;}
 
 /* /vg/ */
 .good					{color: green;}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Tweaks few colours of things I have missed in #14115 : OOC has a bit brighter colour in both light and dark mode, mentor colour will be slightly brighter to be easier to differentiate from new ooc colour, dark mode ert radio is slightly brighter, fixes few occurences of "blue" colour I have missed and few dark mode colours

![changes](https://user-images.githubusercontent.com/35972878/90966585-344eca80-e4d4-11ea-8441-c07eda121e02.png)


## Changelog
:cl:
tweak: Fixes few missed bad dark mode colours
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
