### PR TITLE
Log viewer tweaks. Performance improvements. Record searching limit. And some fixes

### DIFF
--- a/code/datums/log_record.dm
+++ b/code/datums/log_record.dm
@@ -3,8 +3,8 @@
 	var/raw_time		// When did this happen?
 	var/what			// What happened
 	var/who				// Who did it
-	var/target			// Who/what was targeted (can be a string)
-	var/turf/where		// Where did it happen
+	var/target			// Who/what was targeted
+	var/where			// Where did it happen
 
 /datum/log_record/New(_log_type, _who, _what, _target, _where, _raw_time)
 	log_type = _log_type
@@ -12,9 +12,13 @@
 	who = get_subject_text(_who, _log_type)
 	what = _what
 	target = get_subject_text(_target, _log_type)
-	if(!_where)
+	if(!istext(_where) && !isturf(_where))
 		_where = get_turf(_who)
-	where = _where
+	if(isturf(_where))
+		var/turf/T = _where
+		where = ADMIN_COORDJMP(T)
+	else
+		where = _where
 	if(!_raw_time)
 		_raw_time = world.time
 	raw_time = _raw_time


### PR DESCRIPTION
## What Does This PR Do
1. Puts a hard limit on the amount of logs viewed in the viewer. Hardcap is 2500 logs. Warning cap is 1000. The warning will give 3 options. Continue (will check the hardcap still), Limit to 1000 and cancel. The time of the 1000th record is also shown in the message.
2. Fixes a nullpointer when canceling the selecting of a ckey
3. Removes the reference to the turfs in the records. Everything is a soft ref now.
4. Improves the performance of the view

## Why It's Good For The Game
1. After testing I found out that loading up to many logs will hang the client. And also the server a bit. See below
2. It's a bug fix
3. Makes turfs GC better
4. More performance more banning! Oh wait

I've tested the code using these logs:
![image](https://user-images.githubusercontent.com/15887760/90967406-16d32e00-e4df-11ea-8a2e-ea30245d4c16.png)
![image](https://user-images.githubusercontent.com/15887760/90967410-1a66b500-e4df-11ea-9e64-6d62c4dec99c.png)

Outcome:
```
1k logs
start searching 2
end searching 6
start 38
end 182
start sending 183
end sending281

2k logs
start searching 46
end searching 53
start 29
end 333
start sending 335
end sending 759

2.5k logs
start searching 28
end searching 47
start 9
end 236
start sending 239
end sending 928

5k logs
start searching 44
end searching 105
start 27
end 570
start sending 571
end sending 3394
```
The client hung for **way longer** than the sending step displays. This is how long the server was busy with it all displayed in MS. Start* being how many MS the tick was already busy. 

## Changelog
:cl:
tweak: Added a hardcap of 2500to the amount of records being displayed. 
tweak: Added a warning cap of 1000. A choice can be made here to continue. Limit or cancel the search.
fix: Fixed a nullpointer in the logging viewer when cancelling a ckey selection
/:cl: