### PR TITLE
Adds chat message when polling for candidates, fixes blob offspring alert and preferences being ignored

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -569,6 +569,13 @@ so as to remain in compliance with the most up-to-date laws."
 			if(NOTIFY_FOLLOW)
 				G.ManualFollow(target)
 
+/obj/screen/alert/notify_action/Topic(href, href_list)
+	if(..())
+		return TRUE
+
+	if(href_list["signup"] && isobserver(usr) && poll?.sign_up(usr))
+		display_signed_up()
+
 /obj/screen/alert/notify_action/proc/display_signed_up()
 	var/image/I = image('icons/mob/screen_gen.dmi', icon_state = "selector")
 	I.layer = FLOAT_LAYER

--- a/code/controllers/subsystem/ghost_spawns.dm
+++ b/code/controllers/subsystem/ghost_spawns.dm
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 	var/category = "[P.hash]_notify_action"
 
 	for(var/mob/dead/observer/M in (ignore_respawnability ? GLOB.player_list : GLOB.respawnable_list))
-		if(!is_eligible(M))
+		if(!is_eligible(M, role, antag_age_check, role, min_hours, check_antaghud))
 			continue
 
 		SEND_SOUND(M, 'sound/misc/notice2.ogg')
@@ -124,6 +124,13 @@ SUBSYSTEM_DEF(ghost_spawns)
 			I.layer = FLOAT_LAYER
 			I.plane = FLOAT_PLANE
 			A.overlays += I
+
+		// Chat message
+		var/act_jump = ""
+		if(isatom(source))
+			act_jump = "<a href='?src=[M.UID()];jump=\ref[source]'>\[Teleport]</a>"
+		var/act_signup = "<a href='?src=[A.UID()];signup=1'>\[Sign Up]</a>"
+		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup]</span></big>")
 
 		// Start processing it so it updates visually the timer
 		START_PROCESSING(SSprocessing, A)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -17,12 +17,12 @@
 	START_PROCESSING(SSobj, src)
 	GLOB.poi_list |= src
 	adjustcolors(color) //so it atleast appears
-	if(!overmind)
-		create_overmind(new_overmind)
-	if(overmind)
-		adjustcolors(overmind.blob_reagent_datum.color)
 	if(offspring)
 		is_offspring = 1
+	if(overmind)
+		adjustcolors(overmind.blob_reagent_datum.color)
+	if(!overmind)
+		create_overmind(new_overmind)
 	point_rate = new_rate
 	..(loc, h)
 
@@ -104,18 +104,11 @@
 	var/mob/C = null
 	var/list/candidates = list()
 	if(!new_overmind)
-		// Create icon
-		var/mutable_appearance/MA = new
-		var/mutable_appearance/MA1 = new(icon, "blob")
-		MA1.color = overmind ? overmind.blob_reagent_datum.color : color
-		MA.overlays += MA1
-		var/mutable_appearance/MA2 = new(icon, "blob_core_overlay")
-		MA.overlays += MA2
 		// sendit
 		if(is_offspring)
-			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob offspring?", ROLE_BLOB, TRUE, source = MA)
+			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob offspring?", ROLE_BLOB, TRUE, source = src)
 		else
-			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob?", ROLE_BLOB, TRUE, source = MA)
+			candidates = SSghost_spawns.poll_candidates("Do you want to play as a blob?", ROLE_BLOB, TRUE, source = src)
 
 		if(length(candidates))
 			C = pick(candidates)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -389,7 +389,7 @@
 		return
 
 	split_used = TRUE
-	new /obj/structure/blob/core/ (get_turf(N), 200, null, blob_core.point_rate, "offspring")
+	new /obj/structure/blob/core/ (get_turf(N), 200, null, blob_core.point_rate, offspring = TRUE)
 	qdel(N)
 
 	if(SSticker && SSticker.mode.name == "blob")

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -312,7 +312,7 @@
 		used = FALSE
 		return
 	to_chat(user, "[use_message]")
-	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the [mob_name] of [user.real_name]?", ROLE_GUARDIAN, FALSE, 10 SECONDS, source = /mob/living/simple_animal/hostile/guardian)
+	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the [mob_name] of [user.real_name]?", ROLE_GUARDIAN, FALSE, 10 SECONDS, source = src)
 	var/mob/dead/observer/theghost = null
 
 	if(candidates.len)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -50,7 +50,7 @@
 				to_chat(H, "You already used this contract!")
 				return
 			used = 1
-			var/mutable_appearance/source = new('icons/obj/cardboard_cutout.dmi', "cutout_wizard")
+			var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_wizard")
 			var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as the wizard apprentice of [H.real_name]?", ROLE_WIZARD, TRUE, source = source)
 			if(candidates.len)
 				var/mob/C = pick(candidates)
@@ -308,7 +308,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 				if(M.assigned == assigned)
 					M.cooldown = cooldown
 
-			var/mutable_appearance/source = new('icons/obj/cardboard_cutout.dmi', "cutout_wizard")
+			var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_wizard")
 			var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as the wizard apprentice of [user.real_name]?", ROLE_WIZARD, TRUE, 10 SECONDS, source = source)
 			if(candidates.len)
 				var/mob/C = pick(candidates)

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -118,7 +118,7 @@
 		return FALSE
 	making_mage = TRUE
 
-	var/mutable_appearance/source = new('icons/obj/cardboard_cutout.dmi', "cutout_wizard")
+	var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_wizard")
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as a raging Space Wizard?", ROLE_WIZARD, TRUE, poll_time = 20 SECONDS, source = source)
 	var/mob/dead/observer/harry = null
 	message_admins("SWF is still pissed, sending another wizard - [max_mages - mages_made] left.")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3573,7 +3573,7 @@
 		return
 	var/datum/outfit/O = hunter_outfits[dresscode]
 	message_admins("[key_name_admin(mob)] is sending a ([dresscode]) to [killthem ? "assassinate" : "protect"] [key_name_admin(H)]...")
-	var/mutable_appearance/source = new('icons/obj/cardboard_cutout.dmi', "cutout_traitor")
+	var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_traitor")
 	var/list/candidates = SSghost_spawns.poll_candidates("Play as a [killthem ? "murderous" : "protective"] [dresscode]?", ROLE_TRAITOR, TRUE, source = source)
 	if(!candidates.len)
 		to_chat(usr, "<span class='warning'>ERROR: Could not create eventmob. No valid candidates.</span>")

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -37,7 +37,7 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 			break
 
 	// Find ghosts willing to be DS
-	var/mutable_appearance/source = new('icons/obj/cardboard_cutout.dmi', "cutout_deathsquad")
+	var/image/source = image('icons/obj/cardboard_cutout.dmi', "cutout_deathsquad")
 	var/list/commando_ghosts = pollCandidatesWithVeto(src, usr, COMMANDOS_POSSIBLE, "Join the DeathSquad?",, 21, 60 SECONDS, TRUE, GLOB.role_playtime_requirements[ROLE_DEATHSQUAD], TRUE, FALSE, source = source)
 	if(!commando_ghosts.len)
 		to_chat(usr, "<span class='userdanger'>Nobody volunteered to join the DeathSquad.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- **Adds a chat message when polling candidates using `SSghost_spawns.poll_candidates` along with a teleport button (if applicable) and a sign up button**
- Changes Guardian Spirit/holoparasite poll icon to the summoning item rather than the same one (generic guardian) to help distinguish the nature of the guardian
- Fixes blob offspring candidate polling not having a proper icon or the proper text (it would say "Do you want to be a blob?" rather than "Do you want to be a blob offspring?")
- Fixes client preferences and other factors being ignored when polling for a special role (e.g. having Giant spiders off would still show the client the alert)
- Fixes some poll icons being missing (DeathSquad, wizard).

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- Makes it more obvious when polling candidates
- More clarity when polling for certain roles
- Blob offspring alert icon was broken
- Players won't be polled for roles they don't want to play any more.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/1496804/90977355-179eab00-e545-11ea-8787-fb66e7acf661.png)

## Changelog
:cl:
add: Add chat message with teleport and sign up buttons when polling for special roles
fix: Fix blob offspring alert not having an icon and the right text
fix: Fix preferences not being considered when polling for special roles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
