### PR TITLE
Fixes #14107 - giant spider faction assignment

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -58,7 +58,7 @@
 	icon_state = "eggs"
 	var/amount_grown = 0
 	var/player_spiders = 0
-	var/list/faction = list()
+	var/list/faction = list("spiders")
 
 /obj/structure/spider/eggcluster/New()
 	..()
@@ -90,7 +90,7 @@
 	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
 	var/travelling_in_vent = 0
 	var/player_spiders = 0
-	var/list/faction = list()
+	var/list/faction = list("spiders")
 	var/selecting_player = 0
 
 /obj/structure/spider/spiderling/New()


### PR DESCRIPTION
## What Does This PR Do
Fixes #14107  - giant spiders being assigned incorrect factions, which results in them attacking each other.

## How it works
Giant spiders have faction = list("spiders") in their mob definition.
Spider eggs also have S.faction = faction.Copy() in their code for hatching into spiderlings.
Spiderlings also have S.faction = faction.Copy() in their code for growing up into giant spiders.
Unfortunately... all this assumes that a spider lays eggs, which hatch into spiderlings, which grow up into spiders.
There are many cases where this assumption is not true, such as changeling sting, spiderling reagent, spiderlings from botany, etc.
In these cases, the grown spiders inherit the default faction of the spiderlings... which is... an empty list.
Obviously, that will result in spiders with no faction at all, which will attack each other.
The fix is to change the faction = () definition for spiderlings and spider eggs so that they always default to having the spiderlings faction.

## Changelog
:cl: Kyep
fix: giant spiders who grow up from sources other than eggs (such as botany, changeling infestation, reagents, etc) will no longer attack each other.
/:cl: