### PR TITLE
Gives the recycler a higher damage reflection to avoid it breaking from most trash

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -8,7 +8,7 @@
 	layer = MOB_LAYER+1 // Overhead
 	anchored = 1
 	density = 1
-	damage_deflection = 10
+	damage_deflection = 15
 	var/safety_mode = 0 // Temporarily stops machine if it detects a mob
 	var/icon_name = "grinder-o"
 	var/blood = 0
@@ -91,13 +91,6 @@
 	..()
 	if(AM)
 		Bumped(AM)
-
-/obj/machinery/recycler/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	// Makes the recycler temporarily indestructible so it doesn't take damage but all the other effects do happen
-	var/prev_flags = resistance_flags
-	resistance_flags |= INDESTRUCTIBLE
-	..()
-	resistance_flags = prev_flags
 
 /obj/machinery/recycler/Bumped(atom/movable/AM)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -92,6 +92,12 @@
 	if(AM)
 		Bumped(AM)
 
+/obj/machinery/recycler/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	// Makes the recycler temporarily indestructible so it doesn't take damage but all the other effects do happen
+	var/prev_flags = resistance_flags
+	resistance_flags |= INDESTRUCTIBLE
+	. = ..()
+	resistance_flags = prev_flags
 
 /obj/machinery/recycler/Bumped(atom/movable/AM)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -96,7 +96,7 @@
 	// Makes the recycler temporarily indestructible so it doesn't take damage but all the other effects do happen
 	var/prev_flags = resistance_flags
 	resistance_flags |= INDESTRUCTIBLE
-	. = ..()
+	..()
 	resistance_flags = prev_flags
 
 /obj/machinery/recycler/Bumped(atom/movable/AM)


### PR DESCRIPTION
## What Does This PR Do
Gives the recycler 15 damage reflection instead of 10.
Rods, mobs, toolboxes, tanks, basebal bats and a lot of more common items now don't harm the recycler.

## Why It's Good For The Game
It stops the recycler from breaking by common trash.
Especially rods and other common trash can break it now. Items such as the fire axe or such can still break it

## Changelog
:cl:
fix: The recycler can now withstand most things being thrown at it
/:cl: