### PR TITLE
A couple of cling bodyswap bugfixes

### DIFF
--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -18,7 +18,7 @@
 	if((NOCLONE || SKELETON || HUSK) in target.mutations)
 		to_chat(user, "<span class='warning'>DNA of [target] is ruined beyond usability!</span>")
 		return
-	if(!istype(target) || issmall(target) || (NO_DNA in target.dna.species.species_traits))
+	if(!istype(target) || !target.mind || issmall(target) || (NO_DNA in target.dna.species.species_traits))
 		to_chat(user, "<span class='warning'>[target] is not compatible with this ability.</span>")
 		return
 	if(target.mind.changeling)

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -24,6 +24,9 @@
 	if(target.mind.changeling)
 		to_chat(user, "<span class='warning'>We are unable to swap forms with another changeling!</span>")
 		return
+	if(target.has_brain_worms() || user.has_brain_worms())
+		to_chat(user, "<span class='warning'>A foreign presence repels us from this body!</span>")
+		return
 	return 1
 
 /datum/action/changeling/swap_form/sting_action(var/mob/living/carbon/user)

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -63,6 +63,8 @@
 	target.add_language("Changeling")
 	user.remove_language("Changeling")
 	user.regenerate_icons()
+	if(target.stat == DEAD && target.suiciding)  //If Target committed suicide, unset flag for User
+		target.suiciding = 0
 
 	for(var/power in lingpowers)
 		var/datum/action/changeling/S = power


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
 1. Fixes a runtime when trying to use the 'Swap Forms' ability on a mob with no mind, by adding a check for that.

 2. If a Changeling swapped forms with someone who committed suicide, they can now commit suicide themselves.
(Not sure why they'd want to, but whatever. 🤷)

 3. You can no longer use 'Swap Forms' if either participant has a Borer.


## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtime bad, suicide good.

## Changelog
:cl:
tweak: Blocked using 'Swap Forms' as a Changeling if you, or the victim has a Cortical Borer.
fix: Fixed runtime when trying to 'Swap Forms' into a mob with no mind.
fix: If a Changeling bodyswaps into someone who suicided, they can now commit suicide themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
