### PR TITLE
Combines Changeling 'Channel DNA' and 'Absorb DNA' into one button

### DIFF
--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -370,15 +370,10 @@ GLOBAL_LIST_EMPTY(sting_paths)
 					mind.changeling.purchasedpowers += path
 				path.on_purchase(src)
 	else //for respec
-		var/datum/action/changeling/hivemind_upload/S1 = new
+		var/datum/action/changeling/hivemind_pick/S1 = new
 		if(!mind.changeling.has_sting(S1))
 			mind.changeling.purchasedpowers+=S1
 			S1.Grant(src)
-
-		var/datum/action/changeling/hivemind_download/S2 = new
-		if(!mind.changeling.has_sting(S2))
-			mind.changeling.purchasedpowers+=S2
-			S2.Grant(src)
 
 	var/mob/living/carbon/C = src		//only carbons have dna now, so we have to typecaste
 	mind.changeling.absorbed_dna |= C.dna.Clone()

--- a/code/game/gamemodes/changeling/powers/hivemind.dm
+++ b/code/game/gamemodes/changeling/powers/hivemind.dm
@@ -38,9 +38,8 @@ GLOBAL_LIST_EMPTY(hivemind_bank)
 		if(changeling.using_stale_dna(user))//If our current DNA is the stalest, we gotta ditch it.
 			to_chat(user, "<span class='warning'>We have reached our capacity to store genetic information! We must transform before absorbing more.</span>")
 			return
-		dna_absorb(user)
-	else
-		return
+		else
+			dna_absorb(user)
 
 /datum/action/changeling/proc/dna_upload(mob/user)
 	var/datum/changeling/changeling = user.mind.changeling

--- a/code/game/gamemodes/changeling/powers/hivemind.dm
+++ b/code/game/gamemodes/changeling/powers/hivemind.dm
@@ -12,27 +12,37 @@
 	var/datum/changeling/changeling=user.mind.changeling
 	changeling.changeling_speak = 1
 	to_chat(user, "<i><font color=#800080>Use say \":g message\" to communicate with the other changelings.</font></i>")
-	var/datum/action/changeling/hivemind_upload/S1 = new
+	var/datum/action/changeling/hivemind_pick/S1 = new
 	if(!changeling.has_sting(S1))
 		changeling.purchasedpowers+=S1
 		S1.Grant(user)
-	var/datum/action/changeling/hivemind_download/S2 = new
-	if(!changeling.has_sting(S2))
-		S2.Grant(user)
-		changeling.purchasedpowers+=S2
 	return
 
 // HIVE MIND UPLOAD/DOWNLOAD DNA
 GLOBAL_LIST_EMPTY(hivemind_bank)
 
-/datum/action/changeling/hivemind_upload
+/datum/action/changeling/hivemind_pick
 	name = "Hive Channel DNA"
-	desc = "Allows us to channel DNA in the airwaves to allow other changelings to absorb it. Costs 10 chemicals."
-	button_icon_state = "hivemind_channel"
+	desc = "Allows us to upload or absorb DNA in the airwaves. Does not count towards absorb objectives. Costs 10 chemicals."
+	button_icon_state = "hive_absorb"
 	chemical_cost = 10
 	dna_cost = -1
 
-/datum/action/changeling/hivemind_upload/sting_action(var/mob/user)
+/datum/action/changeling/hivemind_pick/sting_action(mob/user)
+	var/datum/changeling/changeling = user.mind.changeling
+	var/channel_pick = alert("Upload or Absorb DNA?", "Channel Select", "Upload", "Absorb")
+
+	if(channel_pick == "Upload")
+		dna_upload(user)
+	if(channel_pick == "Absorb")
+		if(changeling.using_stale_dna(user))//If our current DNA is the stalest, we gotta ditch it.
+			to_chat(user, "<span class='warning'>We have reached our capacity to store genetic information! We must transform before absorbing more.</span>")
+			return
+		dna_absorb(user)
+	else
+		return
+
+/datum/action/changeling/proc/dna_upload(mob/user)
 	var/datum/changeling/changeling = user.mind.changeling
 	var/list/names = list()
 	for(var/datum/dna/DNA in (changeling.absorbed_dna+changeling.protected_dna))
@@ -56,23 +66,7 @@ GLOBAL_LIST_EMPTY(hivemind_bank)
 	feedback_add_details("changeling_powers","HU")
 	return 1
 
-/datum/action/changeling/hivemind_download
-	name = "Hive Absorb DNA"
-	desc = "Allows us to absorb DNA that has been channeled to the airwaves. Does not count towards absorb objectives. Costs 10 chemicals."
-	button_icon_state = "hive_absorb"
-	chemical_cost = 10
-	dna_cost = -1
-
-/datum/action/changeling/hivemind_download/can_sting(var/mob/living/carbon/user)
-	if(!..())
-		return
-	var/datum/changeling/changeling = user.mind.changeling
-	if(changeling.using_stale_dna(user))//If our current DNA is the stalest, we gotta ditch it.
-		to_chat(user, "<span class='warning'>We have reached our capacity to store genetic information! We must transform before absorbing more.</span>")
-		return
-	return 1
-
-/datum/action/changeling/hivemind_download/sting_action(var/mob/user)
+/datum/action/changeling/proc/dna_absorb(mob/user)
 	var/datum/changeling/changeling = user.mind.changeling
 	var/list/names = list()
 	for(var/datum/dna/DNA in GLOB.hivemind_bank)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Combines the buttons for `hivemind_upload` and `hivemind_download` into one, `hivemind_pick`. Using the icon for `Hive Absorb DNA`.

![Selection](https://user-images.githubusercontent.com/57483089/91243322-a24bf980-e741-11ea-895d-395dcf12dddf.png)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Changeling actions can get _very_ cluttered, to the point of taking up almost a quarter of the screen when combined with other items.
While this only removes one button, it's definitely a step in the right direction.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Old:
![Old](https://user-images.githubusercontent.com/57483089/91243230-6b75e380-e741-11ea-9475-48ddb2264d41.png)

New:
![New](https://user-images.githubusercontent.com/57483089/91243236-703a9780-e741-11ea-843e-a0636ac0c88b.png)

## Changelog
:cl:
tweak: Combined the buttons for the Changeling 'Channel DNA' and 'Absorb DNA' abilities into one, to reduce screen clutter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
