### PR TITLE
Allows Malf AI to spend CPU to destroy it's core camera.

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -781,3 +781,17 @@
 	if(AI.eyeobj)
 		AI.eyeobj.relay_speech = TRUE
 
+/datum/AI_Module/large/cameracrack
+	module_name = "Core Camera Cracker"
+	mod_pick_name = "cameracrack"
+	description = "By shortcirucuting a network chip, it overheats, along with the camera in your AI core, preventing camera consoles from using your core camera, or you."
+	cost = 10
+	one_purchase = TRUE
+	upgrade = TRUE
+	unlock_text = "<span class='notice'>Network chip short circuited. Core camera fried. Minimal damage to other internal components.</span>"
+	unlock_sound = 'sound/items/wirecutter.ogg'
+
+/datum/AI_Module/large/cameracrack/upgrade(mob/living/silicon/ai/AI)
+	if(AI.builtInCamera)
+		QDEL_NULL(AI.builtInCamera)
+

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -784,11 +784,11 @@
 /datum/AI_Module/large/cameracrack
 	module_name = "Core Camera Cracker"
 	mod_pick_name = "cameracrack"
-	description = "By shortcirucuting a network chip, it overheats, along with the camera in your AI core, preventing camera consoles from using your core camera, or you."
+	description = "By shortcirucuting the camera network chip, it overheats, preventing the camera console from using your internal camera."
 	cost = 10
 	one_purchase = TRUE
 	upgrade = TRUE
-	unlock_text = "<span class='notice'>Network chip short circuited. Core camera fried. Minimal damage to other internal components.</span>"
+	unlock_text = "<span class='notice'>Network chip short circuited. Internal camera disconected from network. Minimal damage to other internal components.</span>"
 	unlock_sound = 'sound/items/wirecutter.ogg'
 
 /datum/AI_Module/large/cameracrack/upgrade(mob/living/silicon/ai/AI)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR adds the upgrade Core Camera Cracker to a malfunctioning AI's arsenal. This allows the malfunctioning AI to spend 10 CPU to destroy its internal camera.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Using this ability prevents people from using the camera console to check the AI's location, even when it has moved its core or shunted, which is overall a silly feature, unless you blow every camera console on the station. This does not affect normal AIs, carded AIs, or the pinpointer pointing to a doomsdaying AI. 

## Changelog
:cl:
add: Adds the Core Camera Cracker upgrade to malf AI, which allows it to destroy its internal camera.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
