### PR TITLE
Fixes package wrapper exploit

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -163,11 +163,11 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/stack/packageWrap/afterattack(var/obj/target as obj, mob/user as mob, proximity)
+	var/static/list/no_wrap = list(/obj/item/smallDelivery, /obj/structure/bigDelivery, /obj/item/evidencebag, /obj/structure/closet/body_bag, /obj/item/twohanded/required)
 	if(!proximity) return
 	if(!istype(target))	//this really shouldn't be necessary (but it is).	-Pete
 		return
-	if(istype(target, /obj/item/smallDelivery) || istype(target,/obj/structure/bigDelivery) \
-	|| istype(target, /obj/item/evidencebag) || istype(target, /obj/structure/closet/body_bag))
+	if(is_type_in_list(target, no_wrap))
 		return
 	if(target.anchored)
 		return

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -161,9 +161,9 @@
 	amount = 25
 	max_amount = 25
 	resistance_flags = FLAMMABLE
+	var/static/list/no_wrap = list(/obj/item/smallDelivery, /obj/structure/bigDelivery, /obj/item/evidencebag, /obj/structure/closet/body_bag, /obj/item/twohanded/required)
 
 /obj/item/stack/packageWrap/afterattack(var/obj/target as obj, mob/user as mob, proximity)
-	var/static/list/no_wrap = list(/obj/item/smallDelivery, /obj/structure/bigDelivery, /obj/item/evidencebag, /obj/structure/closet/body_bag, /obj/item/twohanded/required)
 	if(!proximity) return
 	if(!istype(target))	//this really shouldn't be necessary (but it is).	-Pete
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Since nobody has fixed this yet, _(and I got bwoinked for exploiting it)_ I've decided to do it myself.

Currently, it's possible to hold a Potted Plant (or Chainsaw!) one-handed, if you use a package wrapper on it, then unwrap it in your hand.
So to fix that, I've:

 - Moved all unwrappable object to `no_wrap`

 - Added `/obj/item/twohanded/required` to said list.
This stops you from wrapping Potted Plants, Gibtonite and Chainsaws.

1. Fixes #5997
2. Fixes #12732
3. Fixes #14160 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Four years is quite long enough for this to be a problem, I think.

## Changelog
:cl:
fix: You can no longer use a Package Wrapper on a Potted Plant or Chainsaw to hold them one-handed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
