### PR TITLE
Fixes listening outpost by adding relay

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -268,6 +268,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/ruin/powered)
+"U" = (
+/turf/simulated/wall/r_wall,
+/area/ruin/unpowered)
+"W" = (
+/obj/machinery/tcomms/relay/ruskie{
+	network_id = "LISTENINGOUTPOST-RELAY"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/powered)
 "Y" = (
 /obj/item/gps/ruin,
 /turf/simulated/wall/r_wall,
@@ -922,7 +931,7 @@ b
 f
 f
 f
-c
+U
 f
 D
 m
@@ -964,7 +973,7 @@ f
 f
 p
 Y
-f
+W
 f
 j
 i

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -99,6 +99,12 @@
 /obj/item/tank/air,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered)
+"u" = (
+/obj/machinery/tcomms/relay/ruskie{
+	network_id = "LISTENINGOUTPOST-RELAY"
+	},
+/turf/simulated/floor/plasteel,
+/area/ruin/powered)
 "w" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
@@ -267,15 +273,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/powered)
-"U" = (
-/turf/simulated/wall/r_wall,
-/area/ruin/unpowered)
-"W" = (
-/obj/machinery/tcomms/relay/ruskie{
-	network_id = "LISTENINGOUTPOST-RELAY"
-	},
-/turf/simulated/floor/plasteel,
 /area/ruin/powered)
 "Y" = (
 /obj/item/gps/ruin,
@@ -931,7 +928,7 @@ b
 f
 f
 f
-U
+f
 f
 D
 m
@@ -973,7 +970,7 @@ f
 f
 p
 Y
-W
+u
 f
 j
 i


### PR DESCRIPTION
## What Does This PR Do
Adds a hidden telecomms relay to the "listening outpost" space ruin.

## Why It's Good For The Game
Without this, the ruin is useless, as its meant to be a listening outpost... but you can't listen if you have no telecomms.

## Images of changes
![dreammaker_dh4gEswH6I](https://user-images.githubusercontent.com/16434066/91587939-f7a52800-e946-11ea-9e77-36f07d0c91fa.png)

## Changelog
:cl: Kyep
fix: fixed listening outpost space ruin not having telecomms.
/:cl:

