### PR TITLE
Changes dark mode command channel color to the old one

### DIFF
--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -270,7 +270,7 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #B800B1;}
 .radio					{color: #408010;}
 .deptradio				{color: #993399;}
-.comradio				{color: #526aff;}
+.comradio				{color: #2040ff;}
 .syndradio				{color: #993F40;}
 .dsquadradio				{color: #998599;}
 .resteamradio				{color: #18BC46;}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the dark mode color of the command channel back to the old value.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In my opinion the new color the command channel uses was too close to the color logs use, and the old one never actually seemed problematic to me in dark mode.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Current:
![Untitled](https://user-images.githubusercontent.com/46876120/91589830-ae5ed380-e95a-11ea-8e7c-f373d6895e35.png)
With this PR:
![Untitled2](https://user-images.githubusercontent.com/46876120/91589836-b159c400-e95a-11ea-8ba1-3e55336dc4a9.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Changes the command channel color in dark mode to the old one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
