### PR TITLE
Buff the hazard vest's suit storage

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -162,7 +162,7 @@
 	desc = "A slick, authoritative cloak designed for the Chief Engineer."
 	icon_state = "cemantle"
 	item_state = "cemantle"
-	allowed = list(/obj/item/flashlight, /obj/item/tank, /obj/item/t_scanner, /obj/item/rcd)
+	allowed = list(/obj/item/flashlight, /obj/item/tank, /obj/item/t_scanner, /obj/item/rcd, /obj/item/rpd)
 
 //Chief Medical Officer
 /obj/item/clothing/suit/mantle/labcoat/chief_medical_officer
@@ -231,7 +231,7 @@
 	icon_state = "hazard"
 	item_state = "hazard"
 	blood_overlay_type = "armor"
-	allowed = list (/obj/item/flashlight, /obj/item/t_scanner, /obj/item/tank/emergency_oxygen)
+	allowed = list (/obj/item/flashlight, /obj/item/t_scanner, /obj/item/tank/emergency_oxygen, /obj/item/rcd, /obj/item/rpd)
 	resistance_flags = NONE
 
 	sprite_sheets = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
With plenty of hazard vests in engineering, and one in the CE's closet, you would expect them to hold the most basic of engineering equipment, the RPD and RCD.
It also allows the CE's mantle to hold an RPD

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hazard Vests should be more common among engineers the spacesuits, and having a bit more utility will go a long way to accomplish that, with both the RCD and RPD being Normal sized items, engineers and life support specialists will gain an extra bit of backpack space, and be less reliant on their spacesuits.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/21987702/91606853-351faa80-e973-11ea-976e-7a95477f34f3.png)
![image](https://user-images.githubusercontent.com/21987702/91606872-3d77e580-e973-11ea-93ea-8da11d0721d1.png)
![image](https://user-images.githubusercontent.com/21987702/91606947-613b2b80-e973-11ea-864b-6c01c9031cb9.png)

## Changelog
:cl:
add: Allows the hazard vest to carry a RCD or RPD in it's suit storage
add: Allows the chief engineer's mantle to car a RPD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
