### PR TITLE
Balances the safety override module and Fixes #14172

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -185,7 +185,7 @@
 
 /obj/item/borg/upgrade/syndicate
 	name = "safety override module"
-	desc = "Unlocks the hidden, deadlier functions of a cyborg. Also prevents emag subversion."
+	desc = "Unlocks the hidden, deadlier functions of a cyborg."
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "combat=4;syndicate=1"
 	require_module = TRUE
@@ -193,12 +193,10 @@
 /obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R)
 	if(..())
 		return
-	if(R.emagged)
-		return
 	if(R.weapons_unlock)
-		to_chat(R, "<span class='warning'>Internal diagnostic error: incompatible upgrade module detected.</span>")
+		to_chat(R, "<span class='warning'>Warning: Safety Overide Protocols have be disabled.</span>")
 		return
-	R.emagged = 1
+	R.weapons_unlock = 1
 	return TRUE
 
 /obj/item/borg/upgrade/lavaproof

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -187,7 +187,7 @@
 	name = "safety override module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."
 	icon_state = "cyborg_upgrade3"
-	origin_tech = "combat=4;syndicate=1"
+	origin_tech = "combat=6;materials=6"
 	require_module = TRUE
 
 /obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1094,7 +1094,7 @@
 	name = "Cyborg Upgrade (Safety Override)"
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4, "syndicate" = 2)
+	req_tech = list("combat" = 7, "materials" = 7)
 	build_path = /obj/item/borg/upgrade/syndicate
 	materials = list(MAT_METAL=10000,MAT_GLASS=15000,MAT_DIAMOND = 10000)
 	construction_time = 120

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1094,7 +1094,7 @@
 	name = "Cyborg Upgrade (Safety Override)"
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "materials" = 7)
+	req_tech = list("combat" = 7, "programming" = 7)
 	build_path = /obj/item/borg/upgrade/syndicate
 	materials = list(MAT_METAL=10000,MAT_GLASS=15000,MAT_DIAMOND = 10000)
 	construction_time = 120


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes #14172 
Cyborgs with the Safety Overide Module does not de-sync the borg
Cyborgs with the Safety Overide Module are no longer protected against the emag act
Cyborgs with the Safety Overide Module can no longer change their own laws.
Cyborgs with the Safety Overide Module no longer show the examine text "The interface seems slightly damaged" when open"
Cyborgs with the Safety Overide Module will no longer have their mmi destroyed upon self destruction
Cyborgs with the Safety Overide Module will do a -1,0,2 explosion instead of a 1,2,4 explosion on self destruct
Due to cyborgs no longer being 'emagged' this is not an illegal piece of tech, so tech requirements has been increased to Combat and Materials 7.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As qwerty stated in his issue "It screws up auto traitor malf ai / admin malf ai if a borg has safety override" and there isnt supposed to be methods to 'protect' again emagging either.
With this change both malf ai's and syndicate traitors can emag cyborgs with or without the safety override.
So now admins can malf an ai at their own pleasure without the issue of it messing with the synced borgs.
Any potential law change abuse is prevented, as well as not making them super destructive if you have to destroy them when ai has been subverted.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Self destruct now
![image](https://user-images.githubusercontent.com/21987702/91643503-10d7d280-ea34-11ea-99cc-b5433c94ff1a.png)
Self destruct after this pr
![image](https://user-images.githubusercontent.com/21987702/91643513-1fbe8500-ea34-11ea-8a0d-390c6dbd9a87.png)

## Changelog
:cl: ppi
tweak: Tweaks the safety override module to not be an emag act
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
