### PR TITLE
Makes guardians not able to call manifest when manifested

### DIFF
--- a/code/_onclick/hud/guardian.dm
+++ b/code/_onclick/hud/guardian.dm
@@ -13,7 +13,7 @@
 	using.icon_state = mymob.a_intent
 	static_inventory += using
 	action_intent = using
-	
+
 	using = new /obj/screen/guardian/Manifest()
 	using.screen_loc = ui_rhand
 	static_inventory += using
@@ -49,8 +49,8 @@
 /obj/screen/guardian/Manifest/Click()
 	if(isguardian(usr))
 		var/mob/living/simple_animal/hostile/guardian/G = usr
-		G.Manifest()
-
+		if(G.loc == G.summoner)
+			G.Manifest()
 
 /obj/screen/guardian/Recall
 	icon_state = "recall"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR prevents guardians calling manifest() while manifested. Fixes #13828 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
There is no need for a guardian to try to manifest when manifested, and with the lightning guardian, it allowed you to make multiple lightning chains and kill anything in seconds, which is not good.

## Changelog
:cl:
fix: Lightning guardians can no longer make multiple lightning chains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
