### PR TITLE
Hot Chocolate and Chicken Soup nerf

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -226,7 +226,7 @@
 	desc = "Made in Space Switzerland."
 	icon_state = "hot_coco"
 	item_state = "coffee"
-	list_reagents = list("hot_coco" = 30)
+	list_reagents = list("hot_coco" = 15, "chocolate" = 6, "water" = 9)
 	resistance_flags = FREEZE_PROOF
 
 /obj/item/reagent_containers/food/drinks/weightloss

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -226,7 +226,7 @@
 	desc = "Made in Space Switzerland."
 	icon_state = "hot_coco"
 	item_state = "coffee"
-	list_reagents = list("chocolate" = 30)
+	list_reagents = list("hot_coco" = 30)
 	resistance_flags = FREEZE_PROOF
 
 /obj/item/reagent_containers/food/drinks/weightloss

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -628,7 +628,7 @@
 	reagent_state = LIQUID
 	color = "#B4B400"
 	metabolization_rate = 0.2
-	nutriment_factor = 2
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	taste_description = "broth"
 
 /datum/reagent/consumable/cheese


### PR DESCRIPTION
## What Does This PR Do
Nerfs Hot Chocolate to have 15 units of hot chocolate, 6 units of chocolate and 9 units of water instead of 30 units of pure chocolate. (from 108 nutrition total to 36)
Nerfs Chicken Soup by making the chemical have a metabolism rate, but buffs it's nutrition factor to 2.5 (from 60 nutrition total to 30)

## Why It's Good For The Game
You shouldn't be able to buy a couple of drinks for around 100$ and not worry about hunger ever again, which in return ends with the other vendor items not being bought as much, or the chef being ignored (you can still buy items from the vendors and ignore the chef, but now you'll need to buy more than two for the entire round)

## Changelog
:cl:
tweak: Hot Chocolate now is composed of fifteen units of Hot Chocolate, six units of Chocolate and nine units of Water instead of thirty units of Chocolate.
tweak: Chicken Soup now has a metabolism rate, and it's nutriment factor is now 2.5
/:cl: