### PR TITLE
Reworks Baseball Bat

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -181,7 +181,7 @@
 	item_state = "baseball_bat"
 	var/deflectmode = FALSE // deflect small/medium thrown objects
 	var/lastdeflect
-	force = 10
+	force = 18
 	throwforce = 12
 	attack_verb = list("beat", "smacked")
 	w_class = WEIGHT_CLASS_HUGE
@@ -253,16 +253,14 @@
 		to_chat(user, "<span class='warning'>You cannot attack in deflect mode!</span>")
 		return
 	. = ..()
-	var/atom/throw_target = get_edge_target_turf(target, user.dir)
 	if(homerun_ready)
+		var/atom/throw_target = get_edge_target_turf(target, user.dir)
 		user.visible_message("<span class='userdanger'>It's a home run!</span>")
 		target.throw_at(throw_target, rand(8,10), 14, user)
 		target.ex_act(2)
 		playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, 1)
 		homerun_ready = 0
 		return
-	else if(!target.anchored)
-		target.throw_at(throw_target, rand(1,2), 7, user)
 
 /obj/item/melee/baseball_bat/ablative
 	name = "metal baseball bat"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -267,7 +267,7 @@
 	desc = "This bat is made of highly reflective, highly armored material."
 	icon_state = "baseball_bat_metal"
 	item_state = "baseball_bat_metal"
-	force = 12
+	force = 20
 	throwforce = 15
 
 /obj/item/melee/baseball_bat/ablative/IsReflect()//some day this will reflect thrown items instead of lasers

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -185,7 +185,7 @@
 	throwforce = 12
 	attack_verb = list("beat", "smacked")
 	w_class = WEIGHT_CLASS_HUGE
-	var/nextthrow_time = 0
+	var/next_throw_time = 0
 	var/homerun_ready = 0
 	var/homerun_able = 0
 
@@ -262,7 +262,7 @@
 		playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, 1)
 		homerun_ready = 0
 		return
-	if(world.time < nextthrow_time)
+	if(world.time < next_throw_time)
 		// Limit the rate of throwing, so you can't spam it.
 		return
 	if(!istype(target))
@@ -285,7 +285,7 @@
 		return
 	var/atom/throw_target = get_edge_target_turf(target, user.dir)
 	target.throw_at(throw_target, rand(1, 2), 7, user)
-	nextthrow_time = world.time + 10 SECONDS
+	next_throw_time = world.time + 10 SECONDS
 
 /obj/item/melee/baseball_bat/ablative
 	name = "metal baseball bat"


### PR DESCRIPTION
## What Does This PR Do
Nerfs the knockback ability of baseball bats, so that it:
- doesn't apply to mobs which are bigger than you, flagged as immune to pushing, or flagged as having higher than normal resistance to being moved
- can only trigger at most once per ten seconds

## Why It's Good For The Game
Right now, baseball bats are overpowered. They're so overpowered I still see sec carrying them during red and gamma alert, when much better weapons should be available.
They're overpowered because of their knockback ability. It throws almost any mob, even including things like megafauna, on every hit.
This is abusable in many ways, such as:
- Cheesing NPCs by batting them away every time they get close, so they can never stay next to you for long enough for them to hit you. So you can beat each NPC without taking any hits at all.
- Spamming it on players in order to block them from acting, because they're constantly being thrown and moved.
- Using it to force-move mobs that are not meant to be movable.

## Changelog
:cl: Kyep
tweak: baseball bats can no longer knockback mobs that are meant to be push-resistant, and can now only get knockback effects once per ten seconds.
/:cl: