### PR TITLE
Bone Reinforcement rename to Hardened Skin

### DIFF
--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -7,7 +7,7 @@
 #define VAULT_NOBREATH "Lung Enhancement"
 #define VAULT_FIREPROOF "Thermal Regulation"
 #define VAULT_STUNTIME "Neural Repathing"
-#define VAULT_ARMOUR "Bone Reinforcement"
+#define VAULT_ARMOUR "Hardened Skin"
 #define VAULT_SPEED "Leg Muscle Stimulus"
 #define VAULT_QUICK "Arm Muscle Stimulus"
 


### PR DESCRIPTION
## What Does This PR Do
Renames the Bone Reinforcement upgrade from the DNA vault to Hardened Skin
Fixes #13794

## Why It's Good For The Game
The upgrade doesn't actually reinforce your bones, but make you take 30% less damage from ALL sources and give you the PIERCEIMMUNE flag, which has caused some confusion in the past (#13778 and #13794, for example)

## Changelog
:cl:
tweak: Renamed the Bone Reinforcement upgrade from the DNA vault to Hardened Skin
/:cl: