### PR TITLE
Allows toy E-Swords to reflect Laser Tag lasers

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -214,8 +214,9 @@
 /obj/item/twohanded/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0
 
-/obj/item/twohanded/dualsaber/toy/IsReflect()//Stops Toy Dualsabers from reflecting energy projectiles
-	return 0
+/obj/item/twohanded/dualsaber/toy/IsReflect()
+	if(wielded)
+		return 2
 
 /obj/item/toy/katana
 	name = "replica katana"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -13,13 +13,19 @@ emp_act
 	if(!dna.species.bullet_act(P, src))
 		return FALSE
 	if(P.is_reflectable)
-		if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
-			visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
-							"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
+		var/can_reflect = check_reflect(def_zone)
+		if(!can_reflect)
+			return (..(P , def_zone)) //Bad luck
+		else
+			if(can_reflect == 2) //If target is holding a toy sword
+				if(!istype(P, /obj/item/projectile/beam/lasertag)) //And it's not a lasertag beam
+					return (..(P , def_zone)) //Bad luck
+		visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
+						"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
 
-			P.reflect_back(src)
+		P.reflect_back(src)
 
-			return -1 // complete projectile permutation
+		return -1 // complete projectile permutation
 
 	//Shields
 	if(check_shields(P, P.damage, "the [P.name]", PROJECTILE_ATTACK, P.armour_penetration))
@@ -172,10 +178,14 @@ emp_act
 		var/obj/item/I = l_hand
 		if(I.IsReflect(def_zone) == 1)
 			return 1
+		if(I.IsReflect(def_zone) == 2) //Toy swords
+			return 2
 	if(r_hand && istype(r_hand, /obj/item/))
 		var/obj/item/I = r_hand
 		if(I.IsReflect(def_zone) == 1)
 			return 1
+		if(I.IsReflect(def_zone) == 2) //Toy swords
+			return 2
 	return 0
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -18,7 +18,8 @@ emp_act
 			return (..(P , def_zone)) //Bad luck
 		else
 			if(can_reflect == 2) //If target is holding a toy sword
-				if(!istype(P, /obj/item/projectile/beam/lasertag)) //And it's not a lasertag beam
+				var/list/safe_list = list(/obj/item/projectile/beam/lasertag, /obj/item/projectile/beam/practice)
+				if(!is_type_in_list(P, safe_list)) //And it's not safe
 					return (..(P , def_zone)) //Bad luck
 		visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
 						"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This lets you reflect Laser Tag lasers with a toy sword, in order to get the "Full Jedi Experience!™"
Very fluffy, but I thought it'd be fun.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- Allows people to give those laser taggers a taste of their own medicine.

- Gives the arcade more of a use, I guess.

## Changelog
:cl:
add: Double bladed toy swords can now reflect laser tag beams
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
*(🎉25th PR, woo!🎉)*