### PR TITLE
Adds the proximity monitor component. Performance improvement for turf/Entered

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1997,5 +1997,26 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		return TRUE
 	return FALSE
 
+/**
+ * Proc which gets all adjacent turfs to `src`, including the turf that `src` is on.
+ *
+ * This is similar to doing `for(var/turf/T in range(1, src))`. However it is slightly more performant.
+ * Additionally, the above proc becomes more costly the more atoms there are nearby. This proc does not care about that.
+ */
+atom/proc/get_all_adjacent_turfs()
+	var/turf/src_turf = get_turf(src)
+	var/list/_list = list(
+		src_turf,
+		get_step(src_turf, NORTH),
+		get_step(src_turf, NORTHEAST),
+		get_step(src_turf, NORTHWEST),
+		get_step(src_turf, SOUTH),
+		get_step(src_turf, SOUTHEAST),
+		get_step(src_turf, SOUTHWEST),
+		get_step(src_turf, EAST),
+		get_step(src_turf, WEST)
+	)
+	return _list
+
 /// Waits at a line of code until X is true
 #define UNTIL(X) while(!(X)) stoplag()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2003,7 +2003,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
  * This is similar to doing `for(var/turf/T in range(1, src))`. However it is slightly more performant.
  * Additionally, the above proc becomes more costly the more atoms there are nearby. This proc does not care about that.
  */
-atom/proc/get_all_adjacent_turfs()
+/atom/proc/get_all_adjacent_turfs()
 	var/turf/src_turf = get_turf(src)
 	var/list/_list = list(
 		src_turf,

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -1,0 +1,140 @@
+/**
+ * # Proximity monitor component
+ *
+ * Attaching this component to an atom means that the atom will be able to detect mobs/objs moving within a 1 tile of it.
+ *
+ * The component creates several `obj/effect/abstract/proximity_checker` objects, which follow the parent atom around, always making sure it's at the center.
+ * When something crosses one of these `proximiy_checker`s, the parent has the `HasProximity()` proc called on it, with the crossing mob/obj as the argument.
+ */
+/datum/component/proximity_monitor
+	var/atom/owner
+	/// A list of currently created `/obj/effect/abstract/proximity_checker`s in use with this component.
+	var/list/proximity_checkers
+
+/datum/component/proximity_monitor/Initialize()
+	. = ..()
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	owner = parent
+	create_prox_checkers()
+
+/datum/component/proximity_monitor/Destroy(force, silent)
+	QDEL_LIST(proximity_checkers)
+	owner = null
+	return .. ()
+
+/datum/component/proximity_monitor/RegisterWithParent()
+	. = ..()
+	if(ismovable(parent))
+		RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/HandleMove)
+
+/datum/component/proximity_monitor/UnregisterFromParent()
+	. = ..()
+	if(ismovable(parent))
+		UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
+
+/**
+ * Called when the `parent` receives the `COMSIG_MOVABLE_MOVED` signal, which occurs when it `Move()`s
+ *
+ * Code is only ran when there is no `Dir`, which occurs when the parent is teleported, gets placed into a storage item, dropped, or picked up.
+ * Normal movement, for example moving 1 tile to the west, is handled by the `proximity_checker` objects.
+ *
+ * Arguments:
+ * * source - this will be the `parent`
+ * * OldLoc - the location the parent just moved from
+ * * Dir - the direction the parent just moved in
+ * * forced - if we were forced to move
+ */
+/datum/component/proximity_monitor/proc/HandleMove(datum/source, atom/OldLoc, Dir, forced)
+	if(!Dir) // No dir means the parent teleported, or moved in a non-standard way like getting placed into disposals, onto a table, dropped, picked up, etc.
+		recenter_prox_checkers()
+
+/**
+ * Called in Initialize(). Generates a set of `/obj/effect/abstract/proximity_checker` objects around the parent, and registers signals to them.
+ */
+/datum/component/proximity_monitor/proc/create_prox_checkers()
+	proximity_checkers = list()
+	for(var/turf/T in range(1, get_turf(parent)))
+		var/obj/effect/abstract/proximity_checker/P = new(T, parent)
+		proximity_checkers += P
+		// Basic movement for the proximity_checker objects. The objects will move 1 tile in the direction the parent just moved.
+		P.RegisterSignal(parent, COMSIG_MOVABLE_MOVED, /obj/effect/abstract/proximity_checker/.proc/HandleMove)
+
+/**
+ * Re-centers all of the parent's `proximity_checker`s around its current location.
+ */
+/datum/component/proximity_monitor/proc/recenter_prox_checkers()
+	var/list/prox_checkers = owner.get_all_adjacent_turfs()
+	for(var/checker in proximity_checkers)
+		var/obj/effect/abstract/proximity_checker/P = checker
+		P.loc = pick_n_take(prox_checkers)
+
+/**
+ * # Proximity checker abstract object
+ *
+ * Inteded for use with the proximity checker component (/datum/component/proximity_monitor).
+ * Whenever a movable atom crosses this object, it calls `HasProximity()` on the object which is listening for proximity (`hasprox_receiver`).
+ */
+/obj/effect/abstract/proximity_checker
+	name = "Proximity checker"
+	/// Whether or not the proximity checker is listening for things crossing it.
+	var/active
+	/// The linked atom which has the proximity_monitor component, and will recieve the `HasProximity()` calls.
+	var/atom/hasprox_receiver
+
+// If this object is initialized without a `_hasprox_receiver` arg, it is qdel'd.
+/obj/effect/abstract/proximity_checker/Initialize(mapload, atom/_hasprox_receiver)
+	if(_hasprox_receiver)
+		hasprox_receiver = _hasprox_receiver
+		RegisterSignal(hasprox_receiver, COMSIG_PARENT_QDELETING, .proc/OnParentDeletion)
+		if(isturf(hasprox_receiver.loc)) // if the reciever is inside a locker/crate/etc, they don't detect proximity
+			active = TRUE
+	else
+		stack_trace("/obj/effect/abstract/proximity_checker created without a receiver")
+		return INITIALIZE_HINT_QDEL
+	return ..()
+
+/obj/effect/abstract/proximity_checker/Destroy()
+	hasprox_receiver = null
+	return ..()
+
+/**
+ * Called when the `hasprox_receiver` receives the `COMSIG_PARENT_QDELETING` signal. When the receiver is deleted, so is this object.
+ *
+ * Arugments:
+ * * source - this will be the `hasprox_receiver`
+ * * force - the force flag taken from the qdel proc currently running on `hasprox_receiver`
+ */
+/obj/effect/abstract/proximity_checker/proc/OnParentDeletion(datum/source, force = FALSE)
+	qdel(src)
+
+/**
+ * Something crossed over the proximity_checker. Notify the `hasprox_receiver` it has proximity with something. Only fires if the checker is `active`.
+ */
+/obj/effect/abstract/proximity_checker/Crossed(atom/movable/AM, oldloc)
+	set waitfor = FALSE
+	if(active)
+		hasprox_receiver.HasProximity(AM)
+
+/**
+ * Moves the proximity_checker 1 tile in the `Dir` direction. If `Dir` is null, it doesn't change location.
+ *
+ * If the new location of the receiver is NOT a turf, set `active` to FALSE, so that it does not receive proximity calls.
+ * If the new location of the receiver IS a turf, set `active` to TRUE, so that it can receive proximity calls again.
+ *
+ * Arguments:
+ * * source - this will be the `hasprox_receiver`
+ * * OldLoc - the location the `hasprox_receiver` just moved from
+ * * Dir - the direction the `hasprox_receiver` just moved in
+ * * forced - if we were forced to move
+ */
+/obj/effect/abstract/proximity_checker/proc/HandleMove(datum/source, atom/OldLoc, Dir, forced)
+	if(Dir)
+		loc = get_step(src, Dir) // Basic movement 1 tile in some direction.
+		return
+	if(!isturf(hasprox_receiver.loc))
+		active = FALSE // Receiver shouldn't detect proximity while in a backpack, closet, etc.
+		return
+	if(isturf(hasprox_receiver.loc))
+		active = TRUE // Receiver can detect proximity again because it's on a turf.
+		return

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -21,7 +21,7 @@
 /datum/component/proximity_monitor/Destroy(force, silent)
 	QDEL_LIST(proximity_checkers)
 	owner = null
-	return .. ()
+	return ..()
 
 /datum/component/proximity_monitor/RegisterWithParent()
 	. = ..()
@@ -117,8 +117,9 @@
 		hasprox_receiver.HasProximity(AM)
 
 /**
- * Moves the proximity_checker 1 tile in the `Dir` direction. If `Dir` is null, it doesn't change location.
+ * Moves the proximity_checker 1 tile in the `Dir` direction.
  *
+ * If `Dir` is null it will be recentered around the receiver via the `recenter_prox_checkers()` proc.
  * If the new location of the receiver is NOT a turf, set `active` to FALSE, so that it does not receive proximity calls.
  * If the new location of the receiver IS a turf, set `active` to TRUE, so that it can receive proximity calls again.
  *
@@ -131,10 +132,7 @@
 /obj/effect/abstract/proximity_checker/proc/HandleMove(datum/source, atom/OldLoc, Dir, forced)
 	if(Dir)
 		loc = get_step(src, Dir) // Basic movement 1 tile in some direction.
-		return
 	if(!isturf(hasprox_receiver.loc))
-		active = FALSE // Receiver shouldn't detect proximity while in a backpack, closet, etc.
-		return
-	if(isturf(hasprox_receiver.loc))
+		active = FALSE // Receiver shouldn't detect proximity while picked up, in a backpack, closet, etc.
+	else
 		active = TRUE // Receiver can detect proximity again because it's on a turf.
-		return

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -132,6 +132,7 @@
 /obj/effect/abstract/proximity_checker/proc/HandleMove(datum/source, atom/OldLoc, Dir, forced)
 	if(Dir)
 		loc = get_step(src, Dir) // Basic movement 1 tile in some direction.
+		return
 	if(!isturf(hasprox_receiver.loc))
 		active = FALSE // Receiver shouldn't detect proximity while picked up, in a backpack, closet, etc.
 	else

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -9,6 +9,7 @@
 		for(var/obj/machinery/camera/M in src)
 			if(M.isMotion())
 				motioncameras.Add(M)
+				M.AddComponent(/datum/component/proximity_monitor)
 				M.set_area_motion(src)
 
 /area/ai_monitored/Entered(atom/movable/O)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -58,7 +58,7 @@
 	detectTime = -1
 	return TRUE
 
-/obj/machinery/camera/HasProximity(atom/movable/AM as mob|obj)
+/obj/machinery/camera/HasProximity(atom/movable/AM)
 	// Motion cameras outside of an "ai monitored" area will use this to detect stuff.
 	if(!area_motion)
 		if(isliving(AM))

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -25,20 +25,17 @@
 	base_state = "pflash"
 	density = 1
 
-/*
-/obj/machinery/flasher/New()
-	sleep(4)					//<--- What the fuck are you doing? D=
-	sd_set_light(2)
-*/
+/obj/machinery/flasher/portable/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/proximity_monitor)
+
 /obj/machinery/flasher/power_change()
 	if( powered() )
 		stat &= ~NOPOWER
 		icon_state = "[base_state]1"
-//		sd_set_light(2)
 	else
 		stat |= ~NOPOWER
 		icon_state = "[base_state]1-p"
-//		sd_set_light(0)
 
 //Let the AI trigger them directly.
 /obj/machinery/flasher/attack_ai(mob/user)
@@ -81,7 +78,7 @@
 		flash()
 	..(severity)
 
-/obj/machinery/flasher/portable/HasProximity(atom/movable/AM as mob|obj)
+/obj/machinery/flasher/portable/HasProximity(atom/movable/AM)
 	if((disable) || (last_flash && world.time < last_flash + 150))
 		return
 
@@ -109,7 +106,7 @@
 	if(anchored)
 		WRENCH_ANCHOR_MESSAGE
 		overlays.Cut()
-	else if(anchored)
+	else
 		WRENCH_UNANCHOR_MESSAGE
 		overlays += "[base_state]-s"
 

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -45,6 +45,42 @@
 			if(prob(25))
 				qdel(src)
 
+/**
+ * # The abstract object
+ *
+ * This is an object that is intended to able to be placed, but that is completely invisible.
+ * The object should be immune to all forms of damage, or things that can delete it, such as the singularity, or explosions.
+ */
+/obj/effect/abstract
+	name = "Abstract object"
+	invisibility = INVISIBILITY_ABSTRACT
+	layer = TURF_LAYER
+	density = FALSE
+	icon = null
+	icon_state = null
+
+// Most of these overrides procs below are overkill, but better safe than sorry.
+/obj/effect/abstract/swarmer_act()
+	return
+
+/obj/effect/abstract/bullet_act(obj/item/projectile/P)
+	return
+
+/obj/effect/abstract/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	return
+
+/obj/effect/abstract/tesla_act(power)
+	return
+
+/obj/effect/abstract/singularity_act()
+	return
+
+/obj/effect/abstract/narsie_act()
+	return
+
+/obj/effect/abstract/ex_act(severity)
+	return
+
 /obj/effect/decal
 	plane = FLOOR_PLANE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -62,6 +62,8 @@
 		to_chat(user, "<span class='notice'>You attach the [A] to the valve controls and secure it.</span>")
 		A.holder = src
 		A.toggle_secure()	//this calls update_icon(), which calls update_icon() on the holder (i.e. the bomb).
+		if(istype(attached_device, /obj/item/assembly/prox_sensor))
+			AddComponent(/datum/component/proximity_monitor)
 
 		investigate_log("[key_name(user)] attached a [A] to a transfer valve.", INVESTIGATE_BOMB)
 		add_attack_logs(user, src, "attached [A] to a transfer valve", ATKLOG_FEW)
@@ -137,6 +139,7 @@
 				attached_device.forceMove(get_turf(src))
 				attached_device.holder = null
 				attached_device = null
+				qdel(GetComponent(/datum/component/proximity_monitor))
 				update_icon()
 		else
 			. = FALSE

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -15,6 +15,10 @@
 	var/armed = 0
 	var/timepassed = 0
 
+/obj/item/caution/proximity_sign/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/proximity_monitor)
+
 /obj/item/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -40,7 +44,7 @@
 		armed = 1
 		timing = 0
 
-/obj/item/caution/proximity_sign/HasProximity(atom/movable/AM as mob|obj)
+/obj/item/caution/proximity_sign/HasProximity(atom/movable/AM)
 	if(armed)
 		if(istype(AM, /mob/living/carbon) && !istype(AM, /mob/living/carbon/brain))
 			var/mob/living/carbon/C = AM

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -190,6 +190,8 @@
 
 		user.drop_item()
 		nadeassembly = A
+		if(nadeassembly.has_prox_sensors())
+			AddComponent(/datum/component/proximity_monitor)
 		A.master = src
 		A.loc = src
 		assemblyattacher = user.ckey
@@ -219,6 +221,7 @@
 			nadeassembly.loc = get_turf(src)
 			nadeassembly.master = null
 			nadeassembly = null
+			qdel(GetComponent(/datum/component/proximity_monitor))
 		if(beakers.len)
 			for(var/obj/O in beakers)
 				O.loc = get_turf(src)
@@ -304,6 +307,8 @@
 /obj/item/grenade/chem_grenade/proc/CreateDefaultTrigger(var/typekey)
 	if(ispath(typekey,/obj/item/assembly))
 		nadeassembly = new(src)
+		if(nadeassembly.has_prox_sensors())
+			AddComponent(/datum/component/proximity_monitor)
 		nadeassembly.a_left = new /obj/item/assembly/igniter(nadeassembly)
 		nadeassembly.a_left.holder = nadeassembly
 		nadeassembly.a_left.secured = 1

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -280,12 +280,14 @@
 /obj/structure/alien/egg/proc/Grow()
 	icon_state = "egg"
 	status = GROWN
+	AddComponent(/datum/component/proximity_monitor)
 
 /obj/structure/alien/egg/proc/Burst(kill = TRUE)	//drops and kills the hugger if any is remaining
 	if(status == GROWN || status == GROWING)
 		icon_state = "egg_hatched"
 		flick("egg_opening", src)
 		status = BURSTING
+		qdel(GetComponent(/datum/component/proximity_monitor))
 		spawn(15)
 			status = BURST
 			var/obj/item/clothing/mask/facehugger/child = GetFacehugger()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -166,13 +166,6 @@
 		if(!O.lastarea)
 			O.lastarea = get_area(O.loc)
 
-	var/loopsanity = 100
-	for(var/atom/A in range(1))
-		if(loopsanity == 0)
-			break
-		loopsanity--
-		A.HasProximity(M)
-
 	// If an opaque movable atom moves around we need to potentially update visibility.
 	if(M.opacity)
 		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -12,6 +12,10 @@
 	var/obj/item/tank/bombtank = null //the second part of the bomb is a plasma tank
 	origin_tech = "materials=1;engineering=1"
 
+/obj/item/onetankbomb/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/proximity_monitor)
+
 /obj/item/onetankbomb/examine(mob/user)
 	. = ..()
 	. += bombtank.examine(user)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -41,19 +41,25 @@
 	if(!A1.remove_item_from_storage(src))
 		if(user)
 			user.remove_from_mob(A1)
-		A1.loc = src
+		A1.forceMove(src)
 	if(!A2.remove_item_from_storage(src))
 		if(user)
 			user.remove_from_mob(A2)
-		A2.loc = src
+		A2.forceMove(src)
 	A1.holder = src
 	A2.holder = src
 	a_left = A1
 	a_right = A2
+	if(has_prox_sensors())
+		AddComponent(/datum/component/proximity_monitor)
 	name = "[A1.name]-[A2.name] assembly"
 	update_icon()
 	return TRUE
 
+/obj/item/assembly_holder/proc/has_prox_sensors()
+	if(istype(a_left, /obj/item/assembly/prox_sensor) || istype(a_right, /obj/item/assembly/prox_sensor))
+		return TRUE
+	return FALSE
 
 /obj/item/assembly_holder/update_icon()
 	overlays.Cut()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -13,6 +13,10 @@
 	var/timing = 0
 	var/time = 10
 
+/obj/item/assembly/prox_sensor/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/proximity_monitor)
+
 /obj/item/assembly/prox_sensor/describe()
 	if(timing)
 		return "<span class='notice'>The proximity sensor is arming.</span>"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -146,6 +146,7 @@
 		trigger.forceMove(src)
 		trigger.master = src
 		trigger.holder = src
+		AddComponent(/datum/component/proximity_monitor)
 		to_chat(user, "<span class='notice'>You attach the [W] to [src].</span>")
 		return TRUE
 	else if(istype(W, /obj/item/assembly))
@@ -165,6 +166,7 @@
 	trigger.master = null
 	trigger.holder = null
 	trigger = null
+	qdel(GetComponent(/datum/component/proximity_monitor))
 
 /obj/item/clothing/mask/muzzle/safety/shock/proc/can_shock(obj/item/clothing/C)
 	if(istype(C))
@@ -186,7 +188,7 @@
 		M.Jitter(20)
 	return
 
-/obj/item/clothing/mask/muzzle/safety/shock/HasProximity(atom/movable/AM as mob|obj)
+/obj/item/clothing/mask/muzzle/safety/shock/HasProximity(atom/movable/AM)
 	if(trigger)
 		trigger.HasProximity(AM)
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -28,6 +28,10 @@
 
 	var/attached = 0
 
+/obj/item/clothing/mask/facehugger/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/proximity_monitor)
+
 /obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	..()
 	if(obj_integrity < 90)
@@ -78,7 +82,7 @@
 		return HasProximity(finder)
 	return 0
 
-/obj/item/clothing/mask/facehugger/HasProximity(atom/movable/AM as mob|obj)
+/obj/item/clothing/mask/facehugger/HasProximity(atom/movable/AM)
 	if(CanHug(AM) && Adjacent(AM))
 		return Attach(AM)
 	return 0
@@ -210,6 +214,7 @@
 	icon_state = "[initial(icon_state)]_dead"
 	item_state = "facehugger_inactive"
 	stat = DEAD
+	qdel(GetComponent(/datum/component/proximity_monitor))
 
 	visible_message("<span class='danger'>[src] curls up into a ball!</span>")
 

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -179,6 +179,7 @@
 		to_chat(usr, "<span class='notice'>You detach [assembly] from [src]</span>")
 		usr.put_in_hands(assembly)
 		assembly = null
+		qdel(GetComponent(/datum/component/proximity_monitor))
 		update_icon()
 	else
 		to_chat(usr, "<span class='notice'>There is no assembly to remove.</span>")
@@ -194,7 +195,9 @@
 			return ..()
 		assembly = W
 		user.drop_item()
-		W.loc = src
+		W.forceMove(src)
+		if(assembly.has_prox_sensors())
+			AddComponent(/datum/component/proximity_monitor)
 		overlays += "assembly"
 	else
 		..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -126,6 +126,7 @@
 			usr.visible_message("<span class='notice'>[usr] detaches [rig] from [src].</span>", "<span class='notice'>You detach [rig] from [src].</span>")
 			rig.forceMove(get_turf(usr))
 			rig = null
+			qdel(GetComponent(/datum/component/proximity_monitor))
 			lastrigger = null
 			overlays.Cut()
 
@@ -148,7 +149,8 @@
 				rig = H
 				user.drop_item()
 				H.forceMove(src)
-
+				if(rig.has_prox_sensors())
+					AddComponent(/datum/component/proximity_monitor)
 				var/icon/test = getFlatIcon(H)
 				test.Shift(NORTH, 1)
 				test.Shift(EAST, 6)

--- a/paradise.dme
+++ b/paradise.dme
@@ -306,6 +306,7 @@
 #include "code\datums\components\label.dm"
 #include "code\datums\components\material_container.dm"
 #include "code\datums\components\paintable.dm"
+#include "code\datums\components\proximity_monitor.dm"
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\spawner.dm"
 #include "code\datums\components\spooky.dm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the proximity monitior component, which can be used for atoms which need to react to things moving with 1 tile of them. This is inspired by TG's `proximity_monitor` datum and `proximity_checker` objects, so credit to them.

Basically how it works is that, there are 9 objects that get created around the parent object. Whenever `Crossed()` is called on these objects, they call `HasProximity()` on the parent object. I won't go into a lengthy explaination of how the component works here, because I have, hopefully, written enough comments in the code to make it easier to understand. Plus the gif below should also help. 

This is a solution to the fairly expensive way in which we handle proximity right now, which is this code in `turf/Entered()`:
```dm
	var/loopsanity = 100
	for(var/atom/A in range(1))
		if(loopsanity == 0)
			break
		loopsanity--
		A.HasProximity(M)
```
This is very inefficient and runs on *everything* regardless of if an atom cares about other things being in proximity of it, which is not a whole lot of things currently.

Now onto the juicy profiler numbers.
```
Proc Name                                             				     Self CPU    Total CPU    Real Time     Overtime        Calls
----------------------------------------------------------------------------------  ---------    ---------    ---------    ---------    ---------
**Paradise proximity_monitor branch**
/datum/component/proximity_checker/proc/HandleMove                                      0.005        0.006        0.010        0.005        40000
/datum/component/proximity_checker/proc/recenter_prox_checkers                          0.251        0.428        0.435        0.251        40000
/obj/effect/abstract/proximity_checker/proc/HandleMove                                  0.169        0.174        0.206        0.167       360000
/turf/Entered                                                                           0.032        0.044        0.049        0.032        40082

**Paradise master branch**
/turf/Entered                                                                           1.594        1.775        1.778        1.589        40019

**TG master branch**
/datum/proximity_monitor/proc/HandleMove                                                0.070        1.631        1.634        0.070        40000
/datum/proximity_monitor/proc/SetRange                                                  0.166        1.561        1.566        0.164        40000
/turf/open/Entered                                                                      0.094        0.286        0.292        0.090        40282
```

Keep in mind you probably wont see a proximity sensing object move or teleport 40,000 times in a "normal" round. And that these numbers were just for stress testing.

Also as a comparison for how many `turf/Entered()` calls there can be in a typical round:
```
/turf/Entered                                          19.387       21.325       21.399        0.441       708954
```
This was profiled from the live server, by Farie, like a month ago. The round length was about an hour and half I believe.

### Tests
#### Basic movement testing
On my branch, I took an object which has the proximity component on it, and called `Move()` on it 40,000 times. This simulates an an object or mob moving 1 tile in any direction, each time. The cost of that, component-side, is the result of adding the two `HandleMove` proc costs together, which is `0.006 + 0.174` = `0.180`. And adding in the `0.044` cost of `turf/Entered`, you get a total cost `0.224`.

This was also done on both the current master branch of Paradise and on TG for comparison. For both of these instances, an object had `Move()` called on it 40,000 times. In TG's case it was an object which uses the `proximity_monitor` datum. As you can see, the implementation I'm currently using is a lot cheaper than Paradise's or TG's current implementation.

#### Non-standard movement test
The other test I did, was calling `recenter_prox_checkers`, which is a proc that fires when something moves in non standard way. This is separate from the basic `Move()` tests above. This handles things like teleporting, getting picked up or dropped, the beginning of a throw, getting placed onto a table/into a closet and so on. The cost of this proc is the most expensive, but still relatively cheap overall.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
*Drastically* cuts down on the amount of CPU cost of the `turf/Entered()` proc.

Also fixes an unlisted bug: Makes the portable flasher's unwrenching message visible. Previously, it would never display.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Visualization of the proximity checker objects that follow the parent. All the "DJ" area sprites are the proximity checkers (sprite won't be visible in the actual game of course)

![proxchecker-min](https://user-images.githubusercontent.com/42044220/91661365-23d4bc00-eaa1-11ea-9f3c-5f9d3983ab1a.gif)

As you can see, there are 9 objects that need to move every time the main parent object needs to move.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Makes the portable flasher's unwrenching message visible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
