### PR TITLE
Makes the attack_hand on mechs and borgs less annoying

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -540,7 +540,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 	playsound(loc, 'sound/weapons/tap.ogg', 40, 1, -1)
-	user.visible_message("<span class='danger'>[user] hits [name]. Nothing happens</span>", "<span class='danger'>You hit [name] with no visible effect.</span>")
+	user.visible_message("<span class='notice'>[user] hits [name]. Nothing happens</span>", "<span class='notice'>You hit [name] with no visible effect.</span>")
 	log_message("Attack by hand/paw. Attacker - [user].")
 
 

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -64,6 +64,6 @@
 		else
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			playsound(loc, 'sound/effects/bang.ogg', 10, 1)
-			visible_message("<span class='danger'>[M] punches [src], but doesn't leave a dent.</span>", \
-						"<span class='userdanger'>[M] punches [src], but doesn't leave a dent.!</span>")
+			visible_message("<span class='notice'>[M] punches [src], but doesn't leave a dent.</span>", \
+						"<span class='notice'>[M] punches [src], but doesn't leave a dent.</span>")
 	return FALSE


### PR DESCRIPTION
## What Does This PR Do
Makes attacking a mech and a borg with your hands (which does no damage) give a notice message instead of a **DANGER** message

## Why It's Good For The Game
Less annoying messages that don't need to be the danger class

## Changelog
:cl:
tweak: Attacking a mech with your hands now won't give a BIG RED TEXT.
tweak: Attacking a borg with your hands now won't give a BIG RED TEXT.
/:cl: