### PR TITLE
Buffs Lightning Guardian punch damage, makes guardian and host shock proof

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -363,7 +363,7 @@
 		if("Protector")
 			pickedtype = /mob/living/simple_animal/hostile/guardian/protector
 
-	var/mob/living/simple_animal/hostile/guardian/G = new pickedtype(user)
+	var/mob/living/simple_animal/hostile/guardian/G = new pickedtype(user, user)
 	G.summoner = user
 	G.summoned = TRUE
 	G.key = key

--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -18,7 +18,7 @@
 	var/list/enemychains = list()
 	var/successfulshocks = 0
 
-/mob/living/simple_animal/hostile/guardian/beam/New(loc, mob/living/user)
+/mob/living/simple_animal/hostile/guardian/beam/New(loc, mob/living/user, mob/living/user)
     . = ..()
     if(!user)
         return

--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -18,7 +18,7 @@
 	var/list/enemychains = list()
 	var/successfulshocks = 0
 
-/mob/living/simple_animal/hostile/guardian/beam/New(loc, mob/living/user, mob/living/user)
+/mob/living/simple_animal/hostile/guardian/beam/New(loc, mob/living/user)
     . = ..()
     if(!user)
         return

--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -24,8 +24,8 @@
 		if(!(NO_SHOCK in summoner.mutations))
 			summoner.mutations.Add(NO_SHOCK)
 
-/mob/living/simple_animal/hostile/guardian/beam/electrocute_act()
-	return //You are lightning, you should not be hurt by such things.
+/mob/living/simple_animal/hostile/guardian/beam/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
+	return FALSE //You are lightning, you should not be hurt by such things.
 
 /mob/living/simple_animal/hostile/guardian/beam/AttackingTarget()
 	. = ..()

--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -18,11 +18,13 @@
 	var/list/enemychains = list()
 	var/successfulshocks = 0
 
-/mob/living/simple_animal/hostile/guardian/beam/Life(seconds, times_fired) //Dies if the summoner dies
-	..()
-	if(summoner)
-		if(!(NO_SHOCK in summoner.mutations))
-			summoner.mutations.Add(NO_SHOCK)
+/mob/living/simple_animal/hostile/guardian/beam/New(loc, mob/living/user)
+    . = ..()
+    if(!user)
+        return
+    summoner = user
+    if(!(NO_SHOCK in summoner.mutations))
+        summoner.mutations.Add(NO_SHOCK)
 
 /mob/living/simple_animal/hostile/guardian/beam/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = FALSE, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE)
 	return FALSE //You are lightning, you should not be hurt by such things.
@@ -115,3 +117,8 @@
 					)
 				L.adjustFireLoss(1.2) //adds up very rapidly
 				. = 1
+
+/mob/living/simple_animal/hostile/guardian/beam/death(gibbed)
+    if(summoner && (NO_SHOCK in summoner.mutations))
+        summoner.mutations.Remove(NO_SHOCK)
+    return ..()

--- a/code/game/gamemodes/miniantags/guardian/types/lightning.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/lightning.dm
@@ -3,12 +3,12 @@
 	layer = LYING_MOB_LAYER
 
 /mob/living/simple_animal/hostile/guardian/beam
-	melee_damage_lower = 7
-	melee_damage_upper = 7
+	melee_damage_lower = 12
+	melee_damage_upper = 12
 	attacktext = "shocks"
 	melee_damage_type = BURN
 	attack_sound = 'sound/machines/defib_zap.ogg'
-	damage_transfer = 0.7
+	damage_transfer = 0.6
 	range = 7
 	playstyle_string = "As a <b>Lightning</b> type, you will apply lightning chains to targets on attack and have a lightning chain to your summoner. Lightning chains will shock anyone near them."
 	magic_fluff_string = "..And draw the Tesla, a shocking, lethal source of power."
@@ -17,6 +17,15 @@
 	var/datum/beam/summonerchain
 	var/list/enemychains = list()
 	var/successfulshocks = 0
+
+/mob/living/simple_animal/hostile/guardian/beam/Life(seconds, times_fired) //Dies if the summoner dies
+	..()
+	if(summoner)
+		if(!(NO_SHOCK in summoner.mutations))
+			summoner.mutations.Add(NO_SHOCK)
+
+/mob/living/simple_animal/hostile/guardian/beam/electrocute_act()
+	return //You are lightning, you should not be hurt by such things.
 
 /mob/living/simple_animal/hostile/guardian/beam/AttackingTarget()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR buffs the Lightning guardian in 4 ways. Improves its base punch damage from 7-12, improves its armor from 30% to 40%, has the guardian give its host immunity to shocks, and finally prevents the guardian from being hurt by shocks.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The lightning guardian has a few issues. It's entirely burn damage, which compared to brute, is not that good. It does do much more damage when fighting a group of people, but those people really need to be close together to take the most damage, and holoparas are often not built for group fights. Unlike most other heavy attacking guardians, it had lower armor, so its armor was increased slightly to make it better in close combat. The burn buff to its punches will help it for one on one combat.

Shock immunity was more of a stylistic change, based on how the chaos guardian makes you fire immune, its good for the lightning guardian to be immune to shocks, as well as the host. It also makes this guardian the only one that can be safely used with the telsa released, as even if the user had full shock protection, the guardian would be shocked if deployed, and die instantly from the tesla arc. 

Overall, this should make the lightning guardian easier to use, actually chosen, and give it the bonus of working well in a tesla hijack scenario. 
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Buffs the Lightning guardians damage and armor, and makes it and the host immune to shocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
