### PR TITLE
Adds the ability for the chaplain to change their null rod mid round

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -41,8 +41,18 @@
 
 
 /obj/item/nullrod/attack_self(mob/user)
-	if(user.mind && (user.mind.isholy) && !reskinned)
-		reskin_holy_weapon(user)
+	if(user.mind && (user.mind.isholy))
+		var/area/A = get_area(src)
+		if(!reskinned)
+			reskin_holy_weapon(user)
+		else if(!istype(A, /area/chapel))
+			to_chat(user, "<span class='notice'>You must be in the chapel to gather the power to change [src] now!</span>")
+		else if(istype(A, /area/chapel))
+			user.visible_message("<span class='notice'>[user] gathers divine power from this holy place to reshape their [src]!</span>")
+			if(do_after(user, 2 MINUTES, target = user))
+				reskin_holy_weapon(user)
+			else
+				to_chat(user, "<span class='warning'>You lost your concentration! Try again.</span>")
 
 /obj/item/nullrod/examine(mob/living/user)
 	. = ..()

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -45,14 +45,15 @@
 		var/area/A = get_area(src)
 		if(!reskinned)
 			reskin_holy_weapon(user)
-		else if(!istype(A, /area/chapel))
-			to_chat(user, "<span class='notice'>You must be in the chapel to gather the power to change [src] now!</span>")
-		else if(istype(A, /area/chapel))
-			user.visible_message("<span class='notice'>[user] gathers divine power from this holy place to reshape their [src]!</span>")
-			if(do_after(user, 2 MINUTES, target = user))
-				reskin_holy_weapon(user)
+		else
+			if(istype(A, /area/chapel))
+				user.visible_message("<span class='notice'>[user] gathers divine power from this holy place to reshape their [src]!</span>")
+				if(do_after(user, 2 MINUTES, target = user))
+					reskin_holy_weapon(user)
+				else
+					to_chat(user, "<span class='warning'>You lost your concentration! Try again.</span>")
 			else
-				to_chat(user, "<span class='warning'>You lost your concentration! Try again.</span>")
+				to_chat(user, "<span class='notice'>You must be in the chapel to gather the power to change [src] now!</span>")
 
 /obj/item/nullrod/examine(mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR allows the chaplain to change their null rod after initially selecting it by being in the chapel and "praying" for two minutes.

## Why It's Good For The Game
There are a few null rods that are situationally very useful but seldom selected because they are not as "Cool" as the swords and other "weapons". Specifically the rosary beads in a cult or vampire round. This would give the chaplain the opportunity to change to something more suited to the situation without letting them easily change their equipment.

## Changelog
:cl:
add: Added the ability for the chaplain to change their null rod after praying for two minutes in the chapel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
