### PR TITLE
[Bugfix] Orange cables

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -11,7 +11,7 @@
 	slot_flags = SLOT_BELT | SLOT_EARS
 	attack_verb = list("attacked", "coloured")
 	toolspeed = 1
-	var/colour = "#FF0000" //RGB
+	var/colour = COLOR_RED
 	var/drawtype = "rune"
 	var/list/graffiti = list("body","amyjon","face","matt","revolution","engie","guy","end","dwarf","uboa","up","down","left","right","heart","borgsrogue","voxpox","shitcurity","catbeast","hieroglyphs1","hieroglyphs2","hieroglyphs3","security","syndicate1","syndicate2","nanotrasen","lie","valid","arrowleft","arrowright","arrowup","arrowdown","chicken","hailcrab","brokenheart","peace","scribble","scribble2","scribble3","skrek","squish","tunnelsnake","yip","youaredead")
 	var/list/letters = list("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z")
@@ -123,54 +123,54 @@
 
 /obj/item/toy/crayon/red
 	icon_state = "crayonred"
-	colour = "#DA0000"
+	colour = COLOR_RED
 	colourName = "red"
 
 /obj/item/toy/crayon/orange
 	icon_state = "crayonorange"
-	colour = "#FF9300"
+	colour = COLOR_ORANGE
 	colourName = "orange"
 
 /obj/item/toy/crayon/yellow
 	icon_state = "crayonyellow"
-	colour = "#FFF200"
+	colour = COLOR_YELLOW
 	colourName = "yellow"
 
 /obj/item/toy/crayon/green
 	icon_state = "crayongreen"
-	colour = "#A8E61D"
+	colour = COLOR_GREEN
 	colourName = "green"
 
 /obj/item/toy/crayon/blue
 	icon_state = "crayonblue"
-	colour = "#00B7EF"
+	colour = COLOR_BLUE
 	colourName = "blue"
 
 /obj/item/toy/crayon/purple
 	icon_state = "crayonpurple"
-	colour = "#DA00FF"
+	colour = COLOR_PURPLE
 	colourName = "purple"
 
 /obj/item/toy/crayon/random/New()
 	icon_state = pick(list("crayonred", "crayonorange", "crayonyellow", "crayongreen", "crayonblue", "crayonpurple"))
 	switch(icon_state)
 		if("crayonred")
-			colour = "#DA0000"
+			colour = COLOR_RED
 			colourName = "red"
 		if("crayonorange")
-			colour = "#FF9300"
+			colour = COLOR_ORANGE
 			colourName = "orange"
 		if("crayonyellow")
-			colour = "#FFF200"
+			colour = COLOR_YELLOW
 			colourName = "yellow"
 		if("crayongreen")
-			colour = "#A8E61D"
+			colour =COLOR_GREEN
 			colourName = "green"
 		if("crayonblue")
-			colour = "#00B7EF"
+			colour = COLOR_BLUE
 			colourName = "blue"
 		if("crayonpurple")
-			colour = "#DA00FF"
+			colour = COLOR_PURPLE
 			colourName = "purple"
 	..()
 
@@ -197,10 +197,10 @@
 	if(!Adjacent(usr) || usr.incapacitated())
 		return
 	if(href_list["color"])
-		if(colour != "#FFFFFF")
-			colour = "#FFFFFF"
+		if(colour != COLOR_WHITE)
+			colour = COLOR_WHITE
 		else
-			colour = "#000000"
+			colour = COLOR_BLACK
 		update_window(usr)
 	else
 		..()

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -126,13 +126,15 @@
 	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
 	..()
 
-/obj/item/restraints/handcuffs/cable/proc/cable_color(var/colorC)
-	if(colorC)
-		if(colorC == "rainbow")
-			colorC = color_rainbow()
-		color = colorC
-	else
+/obj/item/restraints/handcuffs/cable/proc/cable_color(colorC)
+	if(!colorC)
 		color = COLOR_RED
+	else if(colorC == "rainbow")
+		color = color_rainbow()
+	else if(colorC == "orange") //byond only knows 16 colors by name, and orange isn't one of them
+		color = COLOR_ORANGE
+	else
+		color = colorC
 
 /obj/item/restraints/handcuffs/cable/proc/color_rainbow()
 	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -229,14 +229,15 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(current_size >= STAGE_FIVE)
 		deconstruct()
 
-obj/structure/cable/proc/cable_color(var/colorC)
-	if(colorC)
-		if(colorC == "rainbow")
-			color = color_rainbow()
-		else
-			color = colorC
+obj/structure/cable/proc/cable_color(colorC)
+	if(!colorC)
+		color = COLOR_RED
+	else if(colorC == "rainbow")
+		color = color_rainbow()
+	else if(colorC == "orange") //byond only knows 16 colors by name, and orange isn't one of them
+		color = COLOR_ORANGE
 	else
-		color = "#DD0000"
+		color = colorC
 
 /obj/structure/cable/proc/color_rainbow()
 	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
@@ -845,13 +846,15 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
 	..()
 
-/obj/item/stack/cable_coil/proc/cable_color(var/colorC)
-	if(colorC)
-		if(colorC == "rainbow")
-			colorC = color_rainbow()
-		color = colorC
-	else
+/obj/item/stack/cable_coil/proc/cable_color(colorC)
+	if(!colorC)
 		color = COLOR_RED
+	else if(colorC == "rainbow")
+		color = color_rainbow()
+	else if(colorC == "orange") //byond only knows 16 colors by name, and orange isn't one of them
+		color = COLOR_ORANGE
+	else
+		color = colorC
 
 /obj/item/stack/cable_coil/proc/color_rainbow()
 	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)


### PR DESCRIPTION
## What Does This PR Do
Fixes #14204. Using an orange crayon on a cable no longer turns the cable white. Also replaced some magic values in crayons.dm

## Changelog
:cl:
fix: Using an orange crayon on a cable no longer turns the cable white
/:cl:
