### PR TITLE
Crabwalking now causes slowdown similar to walk speed

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -927,6 +927,8 @@
 		. += T.slowdown
 	if(slowed)
 		. += 10
+	if(forced_look)
+		. += 3
 	if(ignorewalk)
 		. += config.run_speed
 	else

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -319,10 +319,9 @@
 	return verb
 
 /mob/living/simple_animal/movement_delay()
-	. = ..()
-
 	. = speed
-
+	if(forced_look)
+		. += 3
 	. += config.animal_delay
 
 /mob/living/simple_animal/Stat()


### PR DESCRIPTION
## What Does This PR Do
While crabwalking (ie: using direction lock to keep your sprite looking at a certain object / in a certain direction) your movement speed will be reduced by the same amount its reduced by being on walk intent instead of run intent.

## Why It's Good For The Game
Discourages people from crabwalking for a long period of time, while still allowing direction locking to be used for things like slowly backing away from a threat.

## Design Questions
Does this stack with walk intent? Yes. If you use walk intent with this as well, the penalty stacks.
Why not just lock the mob to walk intent? Because this also applies to simple_animals who don't support move intents or changing intents.

## Coding Questions
Why do you delete the . = ..() in simple_animal/movement_delay()? Because the very next line overwrites . with something else, so functionally it did nothing. I chose to remove it for the sake of clarity and not running /mob/living/movement_delay() every life tick for every simple mob for no purpose. If desired, I can change it to ..(), though it would still do nothing as written.

## Changelog
:cl: Kyep
tweak: using direction lock to make your character always face one direction, now reduces your movement speed.
/:cl: