### PR TITLE
Makes protector guardians only do 6 object damage in shield mode

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/protector.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/protector.dm
@@ -1,7 +1,6 @@
 /mob/living/simple_animal/hostile/guardian/protector
 	melee_damage_lower = 15
 	melee_damage_upper = 15
-	obj_damage = 40
 	range = 15 //worse for it due to how it leashes
 	damage_transfer = 0.4
 	playstyle_string = "As a <b>Protector</b> type you cause your summoner to leash to you instead of you leashing to them and have two modes; Combat Mode, where you do and take medium damage, and Protection Mode, where you do and take almost no damage, but move slightly slower."

--- a/code/game/gamemodes/miniantags/guardian/types/protector.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/protector.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/guardian/protector
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	obj_damage = 40
 	range = 15 //worse for it due to how it leashes
 	damage_transfer = 0.4
 	playstyle_string = "As a <b>Protector</b> type you cause your summoner to leash to you instead of you leashing to them and have two modes; Combat Mode, where you do and take medium damage, and Protection Mode, where you do and take almost no damage, but move slightly slower."
@@ -25,6 +26,7 @@
 		overlays.Cut()
 		melee_damage_lower = initial(melee_damage_lower)
 		melee_damage_upper = initial(melee_damage_upper)
+		obj_damage = initial(obj_damage)
 		speed = initial(speed)
 		damage_transfer = 0.4
 		to_chat(src, "<span class='danger'>You switch to combat mode.</span>")
@@ -35,6 +37,7 @@
 		overlays.Add(shield_overlay)
 		melee_damage_lower = 2
 		melee_damage_upper = 2
+		obj_damage = 6 //40/7.5 rounded up, we don't want a protector guardian 2 shotting blob tiles while taking 5% damage, thats just silly.
 		speed = 1
 		damage_transfer = 0.05 //damage? what's damage?
 		to_chat(src, "<span class='danger'>You switch to protection mode.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR makes protector guardians only do 6 object damage in shield mode, and returns them back to 40 combat damage in combat mode. 
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Right now, protector guardian in shield mode take 5% of incoming damage. They also only deal 2 damage in melee to balance it out. However, they still have full 40 object damage. Normally, this is fine... except when blobs are involved. When blobs are involved, the guardian does 40 object damage to blob tiles while taking only 5% of damage applied to it, allowing to shred through blob, slowly  push to the core, and kill it with its host barely taking damage. Combine this with legion cores, healing meds, and armor to prevent the host from taking full damage from being attacked, and the guardian pushed to the blob core, unstoppable effectively. By nerfing object damage along with melee damage in defense mode, it can no longer do 40 object damage to blob, and instead only 6. It can keep blob from spreading on a tile, but it can not shred through the blob. If it wants to hurt the blob, it must be in combat mode, and take more damage.

## Changelog
:cl:
tweak: Protector guardians now only do 6 object damage in shield mode, preventing cheesing of blobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
