### PR TITLE
Adds a name for the Chef's pet Goat

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -30989,7 +30989,7 @@
 	},
 /area/hydroponics)
 "bfE" = (
-/mob/living/simple_animal/hostile/retaliate/goat/chef,
+/mob/living/simple_animal/hostile/retaliate/goat,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -30989,7 +30989,11 @@
 	},
 /area/hydroponics)
 "bfE" = (
-/mob/living/simple_animal/hostile/retaliate/goat,
+/mob/living/simple_animal/hostile/retaliate/goat{
+	desc = "Pete, the Chef's pet goat from the Caribbean. Not known for their pleasant disposition.";
+	name = "Pete";
+	unique_pet = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -30989,7 +30989,7 @@
 	},
 /area/hydroponics)
 "bfE" = (
-/mob/living/simple_animal/hostile/retaliate/goat,
+/mob/living/simple_animal/hostile/retaliate/goat/chef,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -30989,11 +30989,7 @@
 	},
 /area/hydroponics)
 "bfE" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	desc = "Pete, the Chef's pet goat from the Caribbean. Not known for their pleasant disposition.";
-	name = "Pete";
-	unique_pet = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/chef,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -99,13 +99,6 @@
 		H.visible_message("<span class='warning'>[src] takes a big chomp out of [H]!</span>", "<span class='userdanger'>[src] takes a big chomp out of your [NB.name]!</span>")
 		NB.droplimb()
 
-/mob/living/simple_animal/hostile/retaliate/goat/chef
-
-/mob/living/simple_animal/hostile/retaliate/goat/chef/New()
-	. = ..()
-	name = pick("Kyet", prob(25);"Kyep")
-	desc = "[name], the Chef's bloodthirsty goat. Not known for their pleasant disposition."
-
 //cow
 /mob/living/simple_animal/cow
 	name = "cow"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -102,7 +102,7 @@
 /mob/living/simple_animal/hostile/retaliate/goat/chef
 	name = "Pete"
 	desc = "Pete, the Chef's pet goat from the Caribbean. Not known for their pleasant disposition."
-	unique_pet = 1
+	unique_pet = TRUE
 
 //cow
 /mob/living/simple_animal/cow

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -99,6 +99,13 @@
 		H.visible_message("<span class='warning'>[src] takes a big chomp out of [H]!</span>", "<span class='userdanger'>[src] takes a big chomp out of your [NB.name]!</span>")
 		NB.droplimb()
 
+/mob/living/simple_animal/hostile/retaliate/goat/chef
+
+/mob/living/simple_animal/hostile/retaliate/goat/chef/New()
+	. = ..()
+	name = pick("Kyet", prob(25);"Kyep")
+	desc = "[name], the Chef's bloodthirsty goat. Not known for their pleasant disposition."
+
 //cow
 /mob/living/simple_animal/cow
 	name = "cow"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -100,9 +100,8 @@
 		NB.droplimb()
 
 /mob/living/simple_animal/hostile/retaliate/goat/chef
-	unique_pet = TRUE
 
-/mob/living/simple_animal/hostile/retaliate/goat/chef/Initialize()
+/mob/living/simple_animal/hostile/retaliate/goat/chef/New()
 	. = ..()
 	name = pick("Kyet", prob(25);"Kyep")
 	desc = "[name], the Chef's bloodthirsty goat. Not known for their pleasant disposition."

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -100,8 +100,9 @@
 		NB.droplimb()
 
 /mob/living/simple_animal/hostile/retaliate/goat/chef
+	unique_pet = TRUE
 
-/mob/living/simple_animal/hostile/retaliate/goat/chef/New()
+/mob/living/simple_animal/hostile/retaliate/goat/chef/Initialize()
 	. = ..()
 	name = pick("Kyet", prob(25);"Kyep")
 	desc = "[name], the Chef's bloodthirsty goat. Not known for their pleasant disposition."

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -99,6 +99,11 @@
 		H.visible_message("<span class='warning'>[src] takes a big chomp out of [H]!</span>", "<span class='userdanger'>[src] takes a big chomp out of your [NB.name]!</span>")
 		NB.droplimb()
 
+/mob/living/simple_animal/hostile/retaliate/goat/chef
+	name = "Pete"
+	desc = "Pete, the Chef's pet goat from the Caribbean. Not known for their pleasant disposition."
+	unique_pet = 1
+
 //cow
 /mob/living/simple_animal/cow
 	name = "cow"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
The Chef's goat in the freezer now has a custom name and description. It also has `unique_pet = 1`, in order to prevent renaming via collars.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Most of the other animals have names. e.g. Betsy, Commander Clucky.
Surely the Goat should have one too, considering how iconic it's become.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Old:
![Capture](https://user-images.githubusercontent.com/57483089/92016648-8c929180-ed4a-11ea-821a-7bb3cf797105.PNG)

New:
![Capture](https://user-images.githubusercontent.com/57483089/92050625-8e794680-ed84-11ea-84de-2c8f7d64b5d7.PNG)


## Changelog
:cl:
add: The Chef's goat is now named Pete
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
