### PR TITLE
Makes mindslaves appear on the round end antagonist listing

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -131,7 +131,7 @@
 				text += printplayer(mindslave)
 				var/datum/mind/master_mind = SSticker.mode.implanted[mindslave]
 				var/mob/living/carbon/human/master = master_mind.current
-				text += " (slaved by: <b>[master]</b>)"
+				text += " (slaved by: <b>[master]</b>)<br>"
 
 		var/phrases = jointext(GLOB.syndicate_code_phrase, ", ")
 		var/responses = jointext(GLOB.syndicate_code_response, ", ")

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -129,6 +129,9 @@
 			text += "<br><br><b>The mindslaves were:</b><br>"
 			for(var/datum/mind/mindslave in SSticker.mode.implanted)
 				text += printplayer(mindslave)
+				var/datum/mind/master_mind = SSticker.mode.implanted[mindslave]
+				var/mob/living/carbon/human/master = master_mind.current
+				text += " (slaved by: <b>[master]</b>)"
 
 		var/phrases = jointext(GLOB.syndicate_code_phrase, ", ")
 		var/responses = jointext(GLOB.syndicate_code_response, ", ")

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -126,7 +126,7 @@
 				feedback_add_details("traitor_success","FAIL")
 
 		if(length(SSticker.mode.implanted))
-			text += "<br><br><b>The mindslaves were:</b><br>"
+			text += "<br><br><FONT size = 2><B>The mindslaves were:</B></FONT><br>"
 			for(var/datum/mind/mindslave in SSticker.mode.implanted)
 				text += printplayer(mindslave)
 				var/datum/mind/master_mind = SSticker.mode.implanted[mindslave]

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -82,22 +82,10 @@
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)
-		var/text = "<FONT size = 2><B>The traitors were:</B></FONT>"
+		var/text = "<FONT size = 2><B>The traitors were:</B></FONT><br>"
 		for(var/datum/mind/traitor in traitors)
 			var/traitorwin = 1
-
-			text += "<br>[traitor.key] was [traitor.name] ("
-			if(traitor.current)
-				if(traitor.current.stat == DEAD)
-					text += "died"
-				else
-					text += "survived"
-				if(traitor.current.real_name != traitor.name)
-					text += " as [traitor.current.real_name]"
-			else
-				text += "body destroyed"
-			text += ")"
-
+			text += printplayer(traitor)
 
 			var/TC_uses = 0
 			var/uplink_true = 0
@@ -136,6 +124,11 @@
 			else
 				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
 				feedback_add_details("traitor_success","FAIL")
+
+		if(length(SSticker.mode.implanted))
+			text += "<br><br><b>The mindslaves were:</b><br>"
+			for(var/datum/mind/mindslave in SSticker.mode.implanted)
+				text += printplayer(mindslave)
 
 		var/phrases = jointext(GLOB.syndicate_code_phrase, ", ")
 		var/responses = jointext(GLOB.syndicate_code_response, ", ")


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes mindslaves appear on the round end antagonist listing. Also, slightly tweaks the look of the end of round traitor name listing. It now includes their starting job as well as colored text for the "survived" or "died" bit. 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Other game modes with potential thralls/mindslaves also list them out at the end of the round, such as vampire thralls.

Closes #14156. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dreamseeker_ghYqjUN0A8](https://user-images.githubusercontent.com/42044220/92134457-2ac83b00-edcf-11ea-9ce1-1f0624768560.png)

Edit: Updated PR to make the "The mindslaves were" text the same size as the traitor text, as I realized it was too big. I'm not going to take another picture though because I'm lazy.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Slightly tweaked the look of the end of round traitor name listing. It now includes their starting job.
tweak: Syndicate mindslaves will now show up in the end of round antagonist listing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
