### PR TITLE
Fixes [Huge Air Scrubber] wrenching bug

### DIFF
--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -204,9 +204,7 @@
 		return
 
 	anchored = !anchored
-	playsound(loc, I.usesound, 50, 1)
-	to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
-	return
+	to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] [src].</span>")
 
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary
 	name = "Stationary Air Scrubber"

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -187,23 +187,26 @@
 		icon_state = "scrubber:0"
 
 /obj/machinery/portable_atmospherics/scrubber/huge/attackby(var/obj/item/W as obj, var/mob/user as mob, params)
-	if(istype(W, /obj/item/wrench))
-		if(stationary)
-			to_chat(user, "<span class='warning'>The bolts are too tight for you to unscrew!</span>")
-			return
-		if(on)
-			to_chat(user, "<span class='warning'>Turn it off first!</span>")
-			return
-
-		anchored = !anchored
-		playsound(loc, W.usesound, 50, 1)
-		to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
-		return
-
 	if((istype(W, /obj/item/analyzer)) && get_dist(user, src) <= 1)
 		atmosanalyzer_scan(air_contents, user)
 		return
 	return ..()
+
+/obj/machinery/portable_atmospherics/scrubber/huge/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(stationary)
+		to_chat(user, "<span class='warning'>The bolts are too tight for you to unscrew!</span>")
+		return
+	if(on)
+		to_chat(user, "<span class='warning'>Turn it off first!</span>")
+		return
+
+	anchored = !anchored
+	playsound(loc, I.usesound, 50, 1)
+	to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
+	return
 
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary
 	name = "Stationary Air Scrubber"

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -194,15 +194,14 @@
 
 /obj/machinery/portable_atmospherics/scrubber/huge/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
 	if(stationary)
 		to_chat(user, "<span class='warning'>The bolts are too tight for you to unscrew!</span>")
 		return
 	if(on)
 		to_chat(user, "<span class='warning'>Turn it off first!</span>")
 		return
-
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
 	anchored = !anchored
 	to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] [src].</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes a bug that didnt allow Huge Air Scrubbers to be wrenched. A proc in its parent was overriding the logic that determined how wrenches interacted with the device.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to use the huge air scrubbers outside of just the toxins storage room is good, and was the intended design of the objects.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
**Before:**
![jHMqnCY2Vq](https://user-images.githubusercontent.com/16618648/92149757-0dea3280-ede4-11ea-8df9-fd5888a5d615.gif)

**After:**
![38kW8T5fih](https://user-images.githubusercontent.com/16618648/92149784-15114080-ede4-11ea-888e-a0e90990d6c8.gif)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Fixes bug preventing wrenching of the Huge Air Scrubbers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
