### PR TITLE
Allows lockers to be locked/unlocked by Alt Clicking

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -69,6 +69,11 @@
 /obj/structure/closet/secure_closet/closed_item_click(mob/user)
 	togglelock(user)
 
+/obj/structure/closet/secure_closet/AltClick(mob/user)
+	..()
+	if(Adjacent(user))
+		togglelock(user)
+
 /obj/structure/closet/secure_closet/emag_act(mob/user)
 	if(!broken)
 		broken = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This allows you to lock or unlock a secure locker by Alt Clicking on it.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
You no longer need to be holding an item to lock a locker.

## Changelog
:cl:
tweak: You can now Alt Click a locker to lock/unlock it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
