### PR TITLE
chameleon flag fix

### DIFF
--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -269,12 +269,15 @@
 /obj/item/flag/chameleon/burn()
 	if(boobytrap)
 		fire_act()
-		spawn(boobytrap.det_time)
-			boobytrap.loc = get_turf(loc)
-			boobytrap.prime()
-			..()
+		addtimer(CALLBACK(src, .proc/prime_boobytrap), boobytrap.det_time)
 	else
 		..()
+
+/obj/item/flag/chameleon/proc/prime_boobytrap()
+	boobytrap.forceMove(get_turf(loc))
+	boobytrap.prime()
+	boobytrap = null
+	burn()
 
 /obj/item/flag/chameleon/updateFlagIcon()
 	icon_state = updated_icon_state

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -251,6 +251,7 @@
 		message_admins("[key_name_admin(user)] has lit the [src] trapped with [boobytrap] by [key_name_admin(trapper)] at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name] (JMP)</a>.")
 		log_game("[key_name_admin(user)] has lit the [src] trapped with [boobytrap] by [key_name_admin(trapper)] at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]).")
 		investigate_log("[key_name_admin(user)] has lit the [src] trapped with [boobytrap] by [key_name_admin(trapper)] at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]).", INVESTIGATE_BOMB)
+		burn()
 	else
 		return ..()
 
@@ -267,8 +268,13 @@
 
 /obj/item/flag/chameleon/burn()
 	if(boobytrap)
-		boobytrap.prime()
-	..()
+		fire_act()
+		spawn(boobytrap.det_time)
+			boobytrap.loc = get_turf(loc)
+			boobytrap.prime()
+			..()
+	else
+		..()
 
 /obj/item/flag/chameleon/updateFlagIcon()
 	icon_state = updated_icon_state

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -19,7 +19,7 @@
 
 /obj/item/grenade/smokebomb/prime()
 	playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
-	src.smoke.set_up(10, 0, usr.loc)
+	smoke.set_up(10, 0)
 	spawn(0)
 		src.smoke.start()
 		sleep(10)


### PR DESCRIPTION
## What Does This PR Do
Fixes #14138. Chameleon flags with boobytraps in them can now be set on fire which will trigger the boobytrap
Fixes a runtime error in smoke grenades

## Why It's Good For The Game
Bugs are bad

## Changelog
:cl:
fix: Chameleon flags with booby traps can now be set on fire which will trigger the boobytrap
fix: Runtime error in smoke grenades
/:cl:
