### PR TITLE
Improvements to singulo logging

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -310,16 +310,25 @@ field_generator power level display
 	//This is here to help fight the "hurr durr, release singulo cos nobody will notice before the
 	//singulo eats the evidence". It's not fool-proof but better than nothing.
 	//I want to avoid using global variables.
-	spawn(1)
-		var/temp = 1 //stops spam
-		for(var/thing in GLOB.singularities)
-			var/obj/singularity/O = thing
-			if(O.last_warning && temp)
-				if((world.time - O.last_warning) > 50) //to stop message-spam
-					temp = 0
-					message_admins("A singulo exists and a containment field has failed. Location: [get_area(src)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</A>)",1)
-					investigate_log("has <font color='red'>failed</font> whilst a singulo exists.","singulo")
-			O.last_warning = world.time
+	INVOKE_ASYNC(src, .proc/admin_alert)
+
+/obj/machinery/field/generator/proc/admin_alert()
+	var/temp = TRUE //stops spam
+	for(var/thing in GLOB.singularities)
+		var/obj/singularity/O = thing
+		if(O.last_warning && temp && atoms_share_level(O, src))
+			if((world.time - O.last_warning) > 50) //to stop message-spam
+				temp = FALSE
+				// To the person who asks "Hey affected, why are you using this massive operator when you can use AREACOORD?" Well, ill tell you
+				// get_area_name is fucking broken and uses a for(x in world) search
+				// It doesnt even work, is expensive, and returns 0
+				// Im not refactoring one thing which could risk breaking all admin location logs
+				// Fight me
+				// [src ? "[get_location_name(src, TRUE)] [COORD(src)]" : "nonexistent location"] [ADMIN_JMP(src)] works much better and actually works at all
+				// Oh and yes, this exact comment was pasted from the exact same thing I did to tcomms code. Dont at me.
+				message_admins("A singularity exists and a containment field has failed on the same Z-Level. Singulo location: [O ? "[get_location_name(O, TRUE)] [COORD(O)]" : "nonexistent location"] [ADMIN_JMP(O)] | Field generator location: [src ? "[get_location_name(src, TRUE)] [COORD(src)]" : "nonexistent location"] [ADMIN_JMP(src)]")
+				investigate_log("has <font color='red'>failed</font> whilst a singulo exists.","singulo")
+		O.last_warning = world.time
 
 /obj/machinery/field/generator/shock_field(mob/living/user)
 	if(fields.len)


### PR DESCRIPTION
## What Does This PR Do
Preamble: Singulo applies to tesla and singularity in here

This PR changes the log messages for singularities being loose from field generator failure. Only singulos on the same z-level as the failing generator will give alerts. This stops us getting alerts from singulos on the wizard shuttle ruin. It also provides details on the singulo location and field generator location.

Before: 
![image](https://user-images.githubusercontent.com/25063394/92307763-93aae100-ef90-11ea-929b-515c5d12c690.png)

After:
![image](https://user-images.githubusercontent.com/25063394/92307769-9a395880-ef90-11ea-9669-b66318c4f092.png)


## Why It's Good For The Game
I am fed up of spurious log messages from singulos on Z6 and other ruins

## Changelog
:cl: AffectedArc07
tweak: Singulos will only trigger field generator failure alerts for field generators on the same z-level
/:cl:
