### PR TITLE
Adds auto-reconnect chat feature on server reboot

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -340,6 +340,8 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 	#endif
 
 	for(var/client/C in GLOB.clients)
+		var/secs_before_auto_reconnect = 10 // TODO: make it higher if server is due for an update @AffectedArc07
+		C << output(list2params(list(secs_before_auto_reconnect)), "browseroutput:reboot")
 		if(config.server)       //if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 			C << link("byond://[config.server]")
 

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -401,6 +401,10 @@ h1.alert, h2.alert			{color: #FFF;}
 .connectionClosed.restored {background: green;}
 .internal.boldnshit {color: #6685f5; font-weight: bold;}
 
+.rebooting {background: #2979AF; color: white; padding: 5px;}
+.rebooting a {color: white !important; text-decoration-color: white !important;}
+#reconnectTimer {font-weight: bold;}
+
 /* HELPER CLASSES */
 .text-normal {font-weight: normal; font-style: normal;}
 .hidden {display: none; visibility: hidden;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -400,6 +400,10 @@ h1.alert, h2.alert			{color: #000000;}
 .connectionClosed.restored {background: green;}
 .internal.boldnshit {color: blue; font-weight: bold;}
 
+.rebooting {background: #2979AF; color: white; padding: 5px;}
+.rebooting a {color: white !important; text-decoration-color: white !important;}
+#reconnectTimer {font-weight: bold;}
+
 /* HELPER CLASSES */
 .text-normal {font-weight: normal; font-style: normal;}
 .hidden {display: none; visibility: hidden;}

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -69,10 +69,13 @@ var opts = {
 	'macros': {},
 
 	// Emoji toggle
-	'enableEmoji': true
+	'enableEmoji': true,
+
+	// Reboot message stuff
+	'rebootIntervalHandler': null
 };
 
-var regexHasError = false; //variable to check if regex has excepted 
+var regexHasError = false; //variable to check if regex has excepted
 
 function outerHTML(el) {
     var wrap = document.createElement('div');
@@ -97,10 +100,10 @@ if (typeof String.prototype.trim !== 'function') {
 if (!String.prototype.includes) {
 	String.prototype.includes = function(search, start) {
 	  'use strict';
-  
+
 	  if (search instanceof RegExp) {
 		throw TypeError('first argument must not be a RegExp');
-	  } 
+	  }
 	  if (start === undefined) { start = 0; }
 	  return this.indexOf(search, start) !== -1;
 	};
@@ -124,7 +127,7 @@ function byondDecode(message) {
 	// The replace for + is because FOR SOME REASON, BYOND replaces spaces with a + instead of %20, and a plus with %2b.
 	// Marvelous.
 	message = message.replace(/\+/g, "%20");
-	try { 
+	try {
 		// This is a workaround for the above not always working when BYOND's shitty url encoding breaks.
 		// Basically, sometimes BYOND's double encoding trick just arbitrarily produces something that makes decodeURIComponent
 		// throw an "Invalid Encoding URI" URIError... the simplest way to work around this is to just ignore it and use unescape instead
@@ -217,10 +220,10 @@ function highlightTerms(el) {
 				ind = next_tag;
 			}
 		}
-		
+
 		element.innerHTML = s;
 	}
-	
+
 	for (var i = 0; i < opts.highlightTerms.length; i++) { //Each highlight term
 		if(opts.highlightTerms[i]) {
 			if(!opts.highlightRegexEnable){
@@ -573,6 +576,34 @@ function toggleWasd(state) {
 	opts.wasd = (state == 'on' ? true : false);
 }
 
+function reboot(timeRaw) {
+	var timeLeftSecs = parseInt(timeRaw);
+	const intervalSecs = 1; // tick every 1 second
+
+	rebootFinished();
+	internalOutput('<div class="rebooting internal">The server is restarting. <a href="byond://winset?command=.reconnect" id="reconnectTimer">Reconnect (' + timeLeftSecs + ')</a></div>', 'internal');
+
+	opts.rebootIntervalHandler = setInterval(function() {
+		timeLeftSecs -= intervalSecs;
+		if (timeLeftSecs <= 0) {
+			$("#reconnectTimer").text('Reconnecting...');
+			window.location.href = 'byond://winset?command=.reconnect';
+			clearInterval(opts.rebootIntervalHandler)
+			opts.rebootIntervalHandler = null;
+		} else {
+			$("#reconnectTimer").text('Reconnect (' + timeLeftSecs + ')');
+		}
+	}, intervalSecs * 1000);
+}
+
+function rebootFinished() {
+	if (opts.rebootIntervalHandler != null) {
+		clearInterval(opts.rebootIntervalHandler)
+	}
+	$("<span> Reconnected automatically!</span>").insertBefore("#reconnectTimer");
+	$("#reconnectTimer").remove();
+}
+
 /*****************************************
 *
 * MAKE MACRO DICTIONARY
@@ -652,7 +683,7 @@ $(function() {
 		'shideSpam': getCookie('hidespam'),
 		'darkChat': getCookie('darkChat'),
 	};
-	
+
 	if (savedConfig.sfontSize) {
 		$messages.css('font-size', savedConfig.sfontSize);
 		internalOutput('<span class="internal boldnshit">Loaded font size setting of: '+savedConfig.sfontSize+'</span>', 'internal');
@@ -1010,18 +1041,18 @@ $(function() {
 		} else {
 			xmlHttp = new ActiveXObject("Microsoft.XMLHTTP");
 		}
-		
+
 		// synchronous requests are depricated in modern browsers
-		xmlHttp.open('GET', 'browserOutput.css', true);			
+		xmlHttp.open('GET', 'browserOutput.css', true);
 		xmlHttp.onload = function (e) {
 			if (xmlHttp.status === 200) {	// request successful
-				
+
 				// Generate Log
 				var saved = '<style>'+xmlHttp.responseText+'</style>';
 				saved += $messages.html();
 				saved = saved.replace(/&/g, '&amp;');
 				saved = saved.replace(/</g, '&lt;');
-				
+
 				// Generate final output and open the window
 				var finalText = '<head><title>Chat Log</title></head> \
 					<iframe src="saveInstructions.html" id="instructions" style="border:none;" height="220" width="100%"></iframe>'+
@@ -1031,7 +1062,7 @@ $(function() {
 				openWindow('Style Doc Retrieve Error: '+xmlHttp.statusText);
 			}
 		}
-		
+
 		// timeout and request errors
 		xmlHttp.timeout = 300;
 		xmlHttp.ontimeout = function (e) {

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -109,6 +109,7 @@ var/list/chatResources = list(
 
 	loaded = TRUE
 	winset(owner, "browseroutput", "is-disabled=false")
+	owner << output(null, "browseroutput:rebootFinished")
 	if(owner.holder)
 		loadAdmin()
 	for(var/message in messageQueue)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
When the server is rebooted (through `/world/Reboot`), a chat message now appears saying the server is rebooting. That message includes a link to manually reconnect as well as a timer that automatically reconnects the client after a while. 
That timer can be adjusted on the DM side to be longer if an update is pending, or something.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Removes the need for players to wait some time and manually reconnect after a server reboot.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![fFaXef0AIk](https://user-images.githubusercontent.com/1496804/92325085-23f82d00-f048-11ea-9d71-5762d6791873.gif)

## Changelog
:cl:
add: Add auto-reconnect feature for when the server restarts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
