### PR TITLE
Makes dead chat logged in the file when you're in a body. Makes say_dead handle all the logic. Whispering while dead won't do anything now

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -1,20 +1,10 @@
-/mob/dead/observer/say(var/message)
+/mob/dead/observer/say(message)
 	message = sanitize(copytext(message, 1, MAX_MESSAGE_LEN))
 
 	if(!message)
 		return
 
-	log_ghostsay(message, src)
-
-	if(src.client)
-		if(src.client.prefs.muted & MUTE_DEADCHAT)
-			to_chat(src, "<span class='warning'>You cannot talk in deadchat (muted).</span>")
-			return
-
-		if(src.client.handle_spam_prevention(message,MUTE_DEADCHAT))
-			return
-
-	. = src.say_dead(message)
+	return say_dead(message)
 
 
 /mob/dead/observer/emote(act, type, message, force)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -351,8 +351,6 @@ proc/get_radio_key_from_channel(var/channel)
 			return
 
 	if(stat)
-		if(stat == DEAD)
-			return say_dead(message_pieces)
 		return
 
 	if(is_muzzled())

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -44,18 +44,27 @@
 		usr.emote(message)
 
 
-/mob/proc/say_dead(var/message)
-	if(!(client && client.holder))
-		if(!config.dsay_allowed)
-			to_chat(src, "<span class='danger'>Deadchat is globally muted.</span>")
+/mob/proc/say_dead(message)
+	if(client)
+		if(!client.holder)
+			if(!config.dsay_allowed)
+				to_chat(src, "<span class='danger'>Deadchat is globally muted.</span>")
+				return
+
+		if(client.prefs.muted & MUTE_DEADCHAT)
+			to_chat(src, "<span class='warning'>You cannot talk in deadchat (muted).</span>")
 			return
 
-	if(client && !(client.prefs.toggles & CHAT_DEAD))
-		to_chat(usr, "<span class='danger'>You have deadchat muted.</span>")
-		return
+		if(!(client.prefs.toggles & CHAT_DEAD))
+			to_chat(src, "<span class='danger'>You have deadchat muted.</span>")
+			return
+
+		if(client.handle_spam_prevention(message, MUTE_DEADCHAT))
+			return
 
 	say_dead_direct("[pick("complains", "moans", "whines", "laments", "blubbers", "salts")], <span class='message'>\"[message]\"</span>", src)
 	create_log(DEADCHAT_LOG, message)
+	log_ghostsay(message, src)
 
 /mob/proc/say_understands(var/mob/other, var/datum/language/speaking = null)
 	if(stat == DEAD)


### PR DESCRIPTION
## What Does This PR Do
Consolidates the dead say logic into the say_dead proc. This means that the logging is also fully done there. And the spam prevention. Also ensures that you can't evade the deadchat mute when you are in a dead body
Whispering while in a dead body now won't do anything. Conform to what observers have. If you do it now using the whisper verb you will get "/list" in chat.

## Why It's Good For The Game
Bug fixing and handling things in one spot where it should be handled is always a good thing.


## Changelog
:cl:
fix: You now can't avoid the dead say spam suppression while in a dead body.
fix: Whispering when dead won't say "/list" now. Instead it won't do anything. Don't whisper when dead weirdos
fix: You now can't avoid a deadchat mute by going into a dead body and talking in dead chat.
fix: Talking to deadchat in a dead body now logs it to the log file
/:cl: