### PR TITLE
Recycler & Conveyor switch examines

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -42,8 +42,8 @@
 
 /obj/machinery/recycler/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The power light is <b>[(stat & NOPOWER) ? "<b>off</b>" : "<b>on</b>"]</b>."
-	. += "The operation light is [emergency_mode ? "<b>off</b>. \The [src] has detected a forbidden object with its sensors, and has shut down temporarily." : "<b>on</b>. \The [src] is active."]"
+	. += "<span class='notice'>The power light is [(stat & NOPOWER) ? "<b>off</b>" : "<b>on</b>"]."
+	. += "The operation light is [emergency_mode ? "<b>off</b>. [src] has detected a forbidden object with its sensors, and has shut down temporarily." : "<b>on</b>. [src] is active."]"
 	. += "The safety sensor light is [emagged ? "<b>off</b>!" : "<b>on</b>."]</span>"
 
 /obj/machinery/recycler/power_change()

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -9,7 +9,7 @@
 	anchored = 1
 	density = 1
 	damage_deflection = 15
-	var/safety_mode = 0 // Temporarily stops machine if it detects a mob
+	var/emergency_mode = FALSE // Temporarily stops machine if it detects a mob
 	var/icon_name = "grinder-o"
 	var/blood = 0
 	var/eat_dir = WEST
@@ -42,9 +42,9 @@
 
 /obj/machinery/recycler/examine(mob/user)
 	. = ..()
-	. += "The power light is [(stat & NOPOWER) ? "off" : "on"]."
-	. += "The safety-mode light is [safety_mode ? "on" : "off"]."
-	. += "The safety-sensors status light is [emagged ? "off" : "on"]."
+	. += "<span class='notice'>The power light is <b>[(stat & NOPOWER) ? "<b>off</b>" : "<b>on</b>"]</b>."
+	. += "The operation light is [emergency_mode ? "<b>off</b>. \The [src] has detected a forbidden object with its sensors, and has shut down temporarily." : "<b>on</b>. \The [src] is active."]"
+	. += "The safety sensor light is [emagged ? "<b>off</b>!" : "<b>on</b>."]</span>"
 
 /obj/machinery/recycler/power_change()
 	..()
@@ -73,8 +73,8 @@
 /obj/machinery/recycler/emag_act(mob/user)
 	if(!emagged)
 		emagged = 1
-		if(safety_mode)
-			safety_mode = 0
+		if(emergency_mode)
+			emergency_mode = FALSE
 			update_icon()
 		playsound(loc, "sparks", 75, 1, -1)
 		to_chat(user, "<span class='notice'>You use the cryptographic sequencer on the [name].</span>")
@@ -82,7 +82,7 @@
 /obj/machinery/recycler/update_icon()
 	..()
 	var/is_powered = !(stat & (BROKEN|NOPOWER))
-	if(safety_mode)
+	if(emergency_mode)
 		is_powered = 0
 	icon_state = icon_name + "[is_powered]" + "[(blood ? "bld" : "")]" // add the blood tag at the end
 
@@ -98,7 +98,7 @@
 		return
 	if(!anchored)
 		return
-	if(safety_mode)
+	if(emergency_mode)
 		return
 
 	var/move_dir = get_dir(loc, AM.loc)
@@ -145,14 +145,14 @@
 
 /obj/machinery/recycler/proc/emergency_stop(mob/living/L)
 	playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
-	safety_mode = 1
+	emergency_mode = TRUE
 	update_icon()
 	L.loc = loc
 	addtimer(CALLBACK(src, .proc/reboot), SAFETY_COOLDOWN)
 
 /obj/machinery/recycler/proc/reboot()
 	playsound(loc, 'sound/machines/ping.ogg', 50, 0)
-	safety_mode = 0
+	emergency_mode = FALSE
 	update_icon()
 
 /obj/machinery/recycler/proc/crush_living(mob/living/L)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -231,7 +231,10 @@ GLOBAL_LIST_INIT(conveyor_switches, list())
 
 /obj/machinery/conveyor_switch
 	name = "conveyor switch"
-	desc = "This switch controls any and all conveyor belts it is linked to."
+	desc = "This switch controls any and all conveyor belts it is linked to.<br>\
+	<span class='notice'>Use a <b>Multitool</b> on it to toggle <b>One-Way</b> mode.<br>\
+	Use a <b>Crowbar</b> on it to dislodge it.<br>\
+	Dislodge the switch and <b>use</b> it on a section of conveyor belt to link them.</span>"
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
 	var/position = DIRECTION_OFF

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -13,7 +13,9 @@ GLOBAL_LIST_INIT(conveyor_switches, list())
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "conveyor_stopped_cw"
 	name = "conveyor belt"
-	desc = "It's a conveyor belt, commonly used to transport large numbers of items elsewhere quite quickly."
+	desc = "It's a conveyor belt, commonly used to transport large numbers of items elsewhere quite quickly.<br>\
+	<span class='notice'>Use a <b>wrench</b> on the belt to rotate it.<br>\
+	Use a <b>crowbar</b> on the belt to dislodge it.<span>"
 	layer = CONVEYOR_LAYER 		// so they appear under stuff but not below stuff like vents
 	anchored = TRUE
 	move_force = MOVE_FORCE_DEFAULT
@@ -232,9 +234,9 @@ GLOBAL_LIST_INIT(conveyor_switches, list())
 /obj/machinery/conveyor_switch
 	name = "conveyor switch"
 	desc = "This switch controls any and all conveyor belts it is linked to.<br>\
-	<span class='notice'>Use a <b>Multitool</b> on it to toggle <b>One-Way</b> mode.<br>\
-	Use a <b>Crowbar</b> on it to dislodge it.<br>\
-	Dislodge the switch and <b>use</b> it on a section of conveyor belt to link them.</span>"
+	<span class='notice'>Use a <b>multitool</b> to toggle <b>one-way</b> mode.<br>\
+	Use a <b>crowbar</b> to dislodge it.<br>\
+	Dislodge the switch and <b>use</b> it on a section of conveyor belt or conveyor placer to link them.</span>"
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
 	var/position = DIRECTION_OFF
@@ -341,7 +343,9 @@ GLOBAL_LIST_INIT(conveyor_switches, list())
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "conveyor_loose"
 	name = "conveyor belt assembly"
-	desc = "A conveyor belt assembly, used for the assembly of conveyor belt systems."
+	desc = "A conveyor belt assembly, used for the assembly of conveyor belt systems.<br>\
+	<span class='notice'><b>Use</b> the assembly on the ground to finalize it.<br>\
+	Use a <b>conveyor belt switch</b> on the assembly to link them.</span>"
 	w_class = WEIGHT_CLASS_BULKY
 	var/id
 
@@ -372,7 +376,9 @@ GLOBAL_LIST_INIT(conveyor_switches, list())
 
 /obj/item/conveyor_switch_construct
 	name = "conveyor switch assembly"
-	desc = "A conveyor control switch assembly. When set up, it'll control any and all conveyor belts it is linked to."
+	desc = "A conveyor control switch assembly. When set up, it'll control any and all conveyor belts it is linked to.<br>\
+	<span class='notice'><b>Use</b> it on a section of conveyor belt to link them together.<br>\
+	<b>Use</b> the assembly on the ground to finalize it.<span>"
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch"
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
## What Does This PR Do
1. Rejigs the status light messages on the recycler.
2. Explains how to use a conveyor belt switch, conveyor belt, and both their assemblies when examining them.

## Why It's Good For The Game
These two objects are a bit hard to figure out to new players. Who's to know the difference between "safety mode" and "safety sensors"? The way the conveyor switch and belts are set up is also a bit unintuitive, and having it explained can be a big help.

## Images of changes
Recycler:
![recyclernew](https://user-images.githubusercontent.com/67055922/92444888-1bd5f400-f1e6-11ea-856d-b09592a23acf.PNG)

Belt switch:
![switchnew](https://user-images.githubusercontent.com/67055922/92444932-27291f80-f1e6-11ea-8635-30d65d4199d0.PNG)

## Changelog
:cl:
tweak: Made the recycler and conveyor switch examine text a bit clearer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
