### PR TITLE
Fixes incorrect TS gibbing

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
@@ -47,7 +47,7 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/purple/Life(seconds, times_fired)
 	. = ..()
-	if(.) // if mob is NOT dead
+	if(stat != DEAD) // Can't use if(.) for this due to the fact it can sometimes return FALSE even when mob is alive.
 		if(!degenerate && spider_myqueen)
 			if(dcheck_counter >= 10)
 				dcheck_counter = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -66,7 +66,7 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/Life(seconds, times_fired)
 	. = ..()
-	if(.) // if mob is NOT dead
+	if(stat != DEAD) // Can't use if(.) for this due to the fact it can sometimes return FALSE even when mob is alive.
 		if(ckey && canlay < 12 && hasnested) // max 12 eggs worth stored at any one time, realistically that's tons.
 			if(world.time > (spider_lastspawn + spider_spawnfrequency))
 				if(eggslaid >= 20)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -297,8 +297,10 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	return ..()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/Life(seconds, times_fired)
-	. = ..()
-	if(!.) // if mob is dead
+	if(QDELETED(src))
+		return
+	..()
+	if(stat == DEAD) // Can't use if(.) for this due to the fact it can sometimes return FALSE even when mob is alive.
 		if(prob(2))
 			// 2% chance every cycle to decompose
 			visible_message("<span class='notice'>\The dead body of the [src] decomposes!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -297,9 +297,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	return ..()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/Life(seconds, times_fired)
-	if(QDELETED(src))
-		return
-	..()
+	. = ..()
 	if(stat == DEAD) // Can't use if(.) for this due to the fact it can sometimes return FALSE even when mob is alive.
 		if(prob(2))
 			// 2% chance every cycle to decompose


### PR DESCRIPTION
## What Does This PR Do
Attempts to fix an issue where sometimes, terror spiders can gib while being alive, due to Life() being relied upon to always return TRUE if the mob is alive, but apparently it no longer does this, leading to the TS code thinking the spider is dead when it isn't.

## Changelog
:cl: Kyep
fix: fixed terrors sometimes wrongly decomposing(gibbing) for no good reason while alive.
/:cl: