### PR TITLE
PR - SM fix for Vox - Change to toxins.dm

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -245,7 +245,7 @@
 					if((tail_marks > 0) && (tail_marks <= GLOB.marking_styles_list.len))
 						H.m_styles["tail"] = GLOB.marking_styles_list[tail_marks]
 
-					H.dna.species.handle_dna(H) //<-- FOR SCORPIO ONLY - REMOVE THIS ONE LINE FOR PARADISE SERVER 
+					H.dna.species.handle_dna(H)
 					H.regenerate_icons() //Refresh the Sprite with the new Icons
 				else 
 					H.UpdateAppearance()

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -216,7 +216,39 @@
 				H.dna.UpdateSE()
 				H.dna.UpdateUI()
 				H.sync_organ_dna(TRUE)
-				H.UpdateAppearance()
+				if(istype(H.dna.species, /datum/species/vox)) //Reason: UpdateAppearance() requires different level datum. 
+					switch(D.GetUIValue(13)) //Set H.s_tone based on the UI Value for Skintone
+						if(632) //Vox Skintone 1, Green Vox, Hex278 = 632 Log10
+							H.s_tone = 1
+						if(614) //Vox Skintone 2, Dark Green Vox, Hex266 = 614 Log10
+							H.s_tone = 2
+						if(595) //Vox Skintone 3, Brown Vox, Hex253 = 595 Log10
+							H.s_tone = 3
+						if(577) //Vox Skintone 4, Grey Vox, Hex241 = 577 Log10
+							H.s_tone = 4
+						if(558) //Vox Skintone 5, Emerald Vox, Hex22E = 558 Log10
+							H.s_tone = 5
+						if(539) //Vox Skintone 6, Azure Vox, Hex21B = 539 Log10
+							H.s_tone = 6
+						else //Vox Skintone 0, Default Green Vox
+							H.s_tone = 0
+
+					H.change_gender(data["gender"]) //Get Vox Gender from Blood
+
+					//Vox Body & Tail Marking - lifted from UpdateAppearance()
+					var/body_marks = D.GetUIValueRange(DNA_UI_BODY_MARK_STYLE, GLOB.marking_styles_list.len)
+					var/tail_marks = D.GetUIValueRange(DNA_UI_TAIL_MARK_STYLE, GLOB.marking_styles_list.len)
+					H.m_colours["body"] = rgb(D.GetUIValueRange(DNA_UI_BODY_MARK_R, 255), D.GetUIValueRange(DNA_UI_BODY_MARK_G, 255), D.GetUIValueRange(DNA_UI_BODY_MARK_B, 255))
+					H.m_colours["tail"] = rgb(D.GetUIValueRange(DNA_UI_TAIL_MARK_R, 255), D.GetUIValueRange(DNA_UI_TAIL_MARK_G, 255), D.GetUIValueRange(DNA_UI_TAIL_MARK_B, 255))
+					if((body_marks > 0) && (body_marks <= GLOB.marking_styles_list.len))
+						H.m_styles["body"] = GLOB.marking_styles_list[body_marks]
+					if((tail_marks > 0) && (tail_marks <= GLOB.marking_styles_list.len))
+						H.m_styles["tail"] = GLOB.marking_styles_list[tail_marks]
+
+					H.dna.species.handle_dna(H) //<-- FOR SCORPIO ONLY - REMOVE THIS ONE LINE FOR PARADISE SERVER 
+					H.regenerate_icons() //Refresh the Sprite with the new Icons
+				else 
+					H.UpdateAppearance()
 
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
UpdateAppearance() does not work for Vox species. The way vox.dm is scripted makes it so it does store all of its "genetic" data on the "dna" like other races (e.g. DNA_UI_GENDER is randomized for Vox since HAS_GENDER is FALSE for Vox). This PR submits a fix to toxins.dm to check if the clone's species is Vox. From there, it assigns s_tone based on static raw UI codes consistent across game-rounds. Gender is taken from the donor's blood. Sprites are refreshed using regenerate_icons().

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This allows for Vox clones to be more precise clones of their donors. I will also be submitting these changes to changeling_power.dm so that Changelings can match any Vox they extract DNA from. There is the counterpoint that "NT doesn't understand Vox DNA well enough" which I think is pretty valid! It's up to admins to decide whether they want to implement this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Vox SM not changing clone Vox's colors and gender
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
