### PR TITLE
Service borgs drop their trays inventory upon death. Cyborg tray can't pick up the NAD

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -380,6 +380,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	flags = CONDUCT
 	materials = list(MAT_METAL=3000)
+	cant_hold = list(/obj/item/disk/nuclear) // Prevents some cheesing
 
 /obj/item/storage/bag/tray/attack(mob/living/M, mob/living/user)
 	..()
@@ -418,7 +419,6 @@
 	..()
 
 /obj/item/storage/bag/tray/cyborg
-	cant_hold = list(/obj/item/disk/nuclear) // Prevents some cheesing
 
 /obj/item/storage/bag/tray/cyborg/afterattack(atom/target, mob/user as mob)
 	if( isturf(target) || istype(target,/obj/structure/table) )

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -381,11 +381,11 @@
 	flags = CONDUCT
 	materials = list(MAT_METAL=3000)
 
-/obj/item/storage/bag/tray/attack(mob/living/M as mob, mob/living/user as mob)
-	..()
+/obj/item/storage/bag/tray/attack(mob/living/M, mob/living/user)
+	. = ..()
 	// Drop all the things. All of them.
 	var/list/obj/item/oldContents = contents.Copy()
-	quick_empty()
+	drop_inventory(user)
 
 	// Make each item scatter a bit
 	for(var/obj/item/I in oldContents)
@@ -418,6 +418,7 @@
 	..()
 
 /obj/item/storage/bag/tray/cyborg
+	cant_hold = list(/obj/item/disk/nuclear) // Prevents some cheesing
 
 /obj/item/storage/bag/tray/cyborg/afterattack(atom/target, mob/user as mob)
 	if( isturf(target) || istype(target,/obj/structure/table) )

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -382,7 +382,7 @@
 	materials = list(MAT_METAL=3000)
 
 /obj/item/storage/bag/tray/attack(mob/living/M, mob/living/user)
-	. = ..()
+	..()
 	// Drop all the things. All of them.
 	var/list/obj/item/oldContents = contents.Copy()
 	drop_inventory(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -438,8 +438,11 @@
 	if((!ishuman(usr) && (src.loc != usr)) || usr.stat || usr.restrained())
 		return
 
+	drop_inventory(usr)
+
+/obj/item/storage/proc/drop_inventory(user)
 	var/turf/T = get_turf(src)
-	hide_from(usr)
+	hide_from(user)
 	for(var/obj/item/I in contents)
 		remove_from_storage(I, T)
 		CHECK_TICK
@@ -499,10 +502,9 @@
 
 /obj/item/storage/attack_self(mob/user)
 
-	//Clicking on itself will empty it, if it has the verb to do that.
-	if(user.is_in_active_hand(src))
-		if(verbs.Find(/obj/item/storage/verb/quick_empty))
-			quick_empty()
+	//Clicking on itself will empty it, if allow_quick_empty is TRUE
+	if(allow_quick_empty && user.is_in_active_hand(src))
+		drop_inventory(user)
 
 //Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
 //Returns -1 if the atom was not found on container.

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -53,7 +53,7 @@
 			emote("deathgasp", force = TRUE)
 
 		if(module)
-			module.handle_death(gibbed)
+			module.handle_death(src, gibbed)
 
 	// Only execute the below if we successfully died
 	. = ..(gibbed)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -114,7 +114,7 @@
 /obj/item/robot_module/proc/handle_custom_removal(component_id, mob/living/user, obj/item/W)
 	return FALSE
 
-/obj/item/robot_module/proc/handle_death(gibbed)
+/obj/item/robot_module/proc/handle_death(mob/living/silicon/robot/R, gibbed)
 	return
 
 /obj/item/robot_module/standard
@@ -255,7 +255,7 @@
 
 	fix_modules()
 
-/obj/item/robot_module/engineering/handle_death()
+/obj/item/robot_module/engineering/handle_death(mob/living/silicon/robot/R, gibbed)
 	var/obj/item/gripper/G = locate(/obj/item/gripper) in modules
 	if(G)
 		G.drop_gripped_item(silent = TRUE)
@@ -367,6 +367,11 @@
 	R.add_language("Bubblish", 1)
 	R.add_language("Clownish",1)
 	R.add_language("Neo-Russkiya", 1)
+
+/obj/item/robot_module/butler/handle_death(mob/living/silicon/robot/R, gibbed)
+	var/obj/item/storage/bag/tray/cyborg/T = locate(/obj/item/storage/bag/tray/cyborg) in modules
+	if(istype(T))
+		T.drop_inventory(R)
 
 
 /obj/item/robot_module/miner
@@ -623,7 +628,7 @@
 	..()
 
 
-/obj/item/robot_module/drone/handle_death()
+/obj/item/robot_module/drone/handle_death(mob/living/silicon/robot/R, gibbed)
 	var/obj/item/gripper/G = locate(/obj/item/gripper) in modules
 	if(G)
 		G.drop_gripped_item(silent = TRUE)


### PR DESCRIPTION
## What Does This PR Do
- Makes service cyborgs drop their trays inventory upon death
- Makes cyborg trays unable to pick up the NAD
- Refactors a bit of code surrounding the dropping of the inventory

Fixes #14281

## Why It's Good For The Game
- Prevents stuff to be in the void when a borg dies. Also prevents cheese cheesing
- Prevents certain cheesing. 
- Results in better, Reusable code

## Changelog
:cl:
tweak: Service borgs will drop their trays inventory upon death.
tweak: The cyborg tray can't pick up the NAD now
/:cl: