### PR TITLE
Makes cigarettes catch fire if their holder is also on fire

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -66,6 +66,10 @@ LIGHTERS ARE IN LIGHTERS.DM
 	..()
 	light()
 
+/obj/item/clothing/mask/cigarette/catch_fire()
+	if(!lit)
+		light("<span class='warning'>Your [name] is lit by the flames!</span>")
+
 /obj/item/clothing/mask/cigarette/welder_act(mob/user, obj/item/I)
 	. = TRUE
 	if(I.tool_use_check(user, 0)) //Don't need to flash eyes because you are a badass

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -68,7 +68,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 /obj/item/clothing/mask/cigarette/catch_fire()
 	if(!lit)
-		light("<span class='warning'>Your [name] is lit by the flames!</span>")
+		light("<span class='warning'>The [name] is lit by the flames!</span>")
 
 /obj/item/clothing/mask/cigarette/welder_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -120,7 +120,9 @@
 	else
 		icon = initial(icon)
 
-///Used for any clothing interactions when the user is on fire. (e.g. Cigarettes getting lit.)
+/**
+  * Used for any clothing interactions when the user is on fire. (e.g. Cigarettes getting lit.)
+  */
 /obj/item/clothing/proc/catch_fire() //Called in handle_fire()
 	return
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -120,6 +120,7 @@
 	else
 		icon = initial(icon)
 
+///Used for any clothing interactions when the user is on fire. (e.g. Cigarettes getting lit.)
 /obj/item/clothing/proc/catch_fire() //Called in handle_fire()
 	return
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -120,6 +120,9 @@
 	else
 		icon = initial(icon)
 
+/obj/item/clothing/proc/catch_fire() //Called in IgniteMob()
+	return
+
 //Ears: currently only used for headsets and earmuffs
 /obj/item/clothing/ears
 	name = "ears"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -120,7 +120,7 @@
 	else
 		icon = initial(icon)
 
-/obj/item/clothing/proc/catch_fire() //Called in IgniteMob()
+/obj/item/clothing/proc/catch_fire() //Called in handle_fire()
 	return
 
 //Ears: currently only used for headsets and earmuffs

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -186,6 +186,8 @@
 		return 1
 	if(fire_stacks > 0)
 		adjust_fire_stacks(-0.1) //the fire is slowly consumed
+		for(var/obj/item/clothing/C in src.contents)
+			C.catch_fire(src)
 	else
 		ExtinguishMob()
 		return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -186,8 +186,8 @@
 		return 1
 	if(fire_stacks > 0)
 		adjust_fire_stacks(-0.1) //the fire is slowly consumed
-		for(var/obj/item/clothing/C in src.contents)
-			C.catch_fire(src)
+		for(var/obj/item/clothing/C in contents)
+			C.catch_fire()
 	else
 		ExtinguishMob()
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes it so that when you're on fire, any cigarettes or cigarette subtypes in your inventory will also become lit.
*(Top level only, so it doesn't look inside bags and so on.)*

Doing this also adds a framework for any other fire-clothing interactions, throught the `catch_fire()` proc.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
You can already light cigarettes on someone elses burning body, so why not on your own!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![ezgif com-optimize](https://user-images.githubusercontent.com/57483089/92998179-4985aa80-f510-11ea-909f-0746f7200fb6.gif)
![Capture](https://user-images.githubusercontent.com/57483089/92998176-42f73300-f510-11ea-8f96-f07455673a12.PNG)


## Changelog
:cl:
add: Cigarettes and their subtypes will now light when their owner catches fire
add: catch_fire() proc for all clothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
