### PR TITLE
Turn off xenobiology camera acceleration

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -68,6 +68,7 @@
 	eyeobj = new /mob/camera/aiEye/remote/xenobio(get_turf(src))
 	eyeobj.origin = src
 	eyeobj.visible_icon = 1
+	eyeobj.acceleration = 0
 	eyeobj.icon = 'icons/obj/abductor.dmi'
 	eyeobj.icon_state = "camera_target"
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -68,7 +68,7 @@
 	eyeobj = new /mob/camera/aiEye/remote/xenobio(get_turf(src))
 	eyeobj.origin = src
 	eyeobj.visible_icon = 1
-	eyeobj.acceleration = 0
+	eyeobj.acceleration = FALSE
 	eyeobj.icon = 'icons/obj/abductor.dmi'
 	eyeobj.icon_state = "camera_target"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
By default, the eye that the console derives itself from has acceleration turned on, this overrides that default to turn it off. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Acceleration makes sense for the station AI due to A. the large distance it has to cover and B. most AI interactions (opening doors, bolting, etc.) will involve the use of their mouse, requiring less eye precision.

Xenobiology lacks both of those justifications, the space is small, and it seems pretty common for people to operate it by moving over slimes and clicking on the top buttons. If you do it in that manner, you want precise movement, and that's where acceleration causes unnecessary problems. 

## Changelog
:cl:Froststahr
tweak: Disable default camera acceleration for Xenobiology's Management Console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
