### PR TITLE
made emagged drones obey their death timer

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -361,12 +361,13 @@
 
 /mob/living/silicon/robot/drone/update_canmove(delay_action_updates = 0)
 	. = ..()
+	density = emagged ? TRUE : FALSE //this is reset every canmove update otherwise
+
+/mob/living/silicon/robot/drone/Life(seconds, times_fired)
+	. = ..()
 	if(emagged)
-		density = 1
 		if(world.time - emagged_time > EMAG_TIMER)
 			shut_down(TRUE)
-		return
-	density = 0 //this is reset every canmove update otherwise
 
 /mob/living/simple_animal/drone/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	if(affect_silicon)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -35,7 +35,6 @@
 	var/mail_destination = 0
 	var/reboot_cooldown = 60 // one minute
 	var/last_reboot
-	var/emagged_time
 	var/list/pullable_drone_items = list(
 		/obj/item/pipe,
 		/obj/structure/disposalconstruct,
@@ -208,8 +207,8 @@
 	log_game("[key_name(user)] emagged drone [key_name(src)].  Laws overridden.")
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	GLOB.lawchanges.Add("[time] <B>:</B> [H.name]([H.key]) emagged [name]([key])")
+	addtimer(CALLBACK(src, .proc/shut_down, TRUE), EMAG_TIMER)
 
-	emagged_time = world.time
 	emagged = 1
 	density = 1
 	pass_flags = 0
@@ -362,12 +361,6 @@
 /mob/living/silicon/robot/drone/update_canmove(delay_action_updates = 0)
 	. = ..()
 	density = emagged ? TRUE : FALSE //this is reset every canmove update otherwise
-
-/mob/living/silicon/robot/drone/Life(seconds, times_fired)
-	. = ..()
-	if(emagged)
-		if(world.time - emagged_time > EMAG_TIMER)
-			shut_down(TRUE)
 
 /mob/living/simple_animal/drone/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	if(affect_silicon)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -360,7 +360,7 @@
 
 /mob/living/silicon/robot/drone/update_canmove(delay_action_updates = 0)
 	. = ..()
-	density = emagged ? TRUE : FALSE //this is reset every canmove update otherwise
+	density = emagged //this is reset every canmove update otherwise
 
 /mob/living/simple_animal/drone/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	if(affect_silicon)


### PR DESCRIPTION
## What Does This PR Do
Emagged drones have a timer of 5 minutes, but it was only checked on update_canmove, which doesn't get called very often and made it unpredictable. I changed it to check on Life instead.

## Why It's Good For The Game
Fixes a bug

## Changelog
:cl:
fix: made emagged drones obey their death timer
/:cl: