### PR TITLE
Fixes NO_SCAN cloning exploit through replica pods

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -29,7 +29,8 @@
 	if(istype(W,/obj/item/reagent_containers/syringe))
 		if(!contains_sample)
 			for(var/datum/reagent/blood/bloodSample in W.reagents.reagent_list)
-				if(bloodSample.data["mind"] && bloodSample.data["cloneable"] == 1)
+				var/datum/dna/dna = bloodSample.data["dna"]
+				if(bloodSample.data["mind"] && bloodSample.data["cloneable"] && !(NO_SCAN in dna.species.species_traits))
 					var/datum/mind/tempmind = bloodSample.data["mind"]
 					if(tempmind.is_revivable())
 						mind = bloodSample.data["mind"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes the ability to clone species that have the `NO_SCAN` trait (namely Vox) using replica pods. Upon trying to inject the seeds with such blood, the client will get a generic rejection message.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This method differs from Stable Mutagen cloning which requires the original brain. Replica pods don't require the brain for the client to be moved into their new body, and that's an exploit.

## Changelog
:cl:
fix: Fix an exploit allowing the cloning of unclonable species through the use of replica pods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
