### PR TITLE
Fixes AI Shortcuts

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -145,12 +145,10 @@
 /mob/living/silicon/ai/MiddleClickOn(var/atom/A)
     A.AIMiddleClick(src)
 
-/*
-	The following criminally helpful code is just the previous code cleaned up;
-	I have no idea why it was in atoms.dm instead of respective files.
-*/
 
-/atom/proc/AICtrlShiftClick(var/mob/user)  // Examines
+// DEFAULT PROCS TO OVERRIDE
+
+/atom/proc/AICtrlShiftClick(mob/user)  // Examines
 	if(user.client)
 		user.examinate(src)
 	return
@@ -158,74 +156,82 @@
 /atom/proc/AIAltShiftClick()
 	return
 
-/obj/machinery/door/airlock/AIAltShiftClick()  // Sets/Unsets Emergency Access Override
-	if(density)
-		Topic(src, list("src" = UID(), "command"="emergency", "activate" = "1"), 1) // 1 meaning no window (consistency!)
-	else
-		Topic(src, list("src" = UID(), "command"="emergency", "activate" = "0"), 1)
-	return
-
-/atom/proc/AIShiftClick(var/mob/user)
+/atom/proc/AIShiftClick(mob/living/user) // borgs use this too
 	if(user.client)
 		user.examinate(src)
 	return
 
-/obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!
-	if(density)
-		Topic(src, list("src" = UID(), "command"="open", "activate" = "1"), 1) // 1 meaning no window (consistency!)
-	else
-		Topic(src, list("src" = UID(), "command"="open", "activate" = "0"), 1)
+/atom/proc/AICtrlClick(mob/living/silicon/ai/user)
 	return
 
-/atom/proc/AICtrlClick(var/mob/living/silicon/ai/user)
+/atom/proc/AIAltClick(atom/A)
+	AltClick(A)
+
+/atom/proc/AIMiddleClick(mob/living/user)
 	return
 
-/obj/machinery/door/airlock/AICtrlClick() // Bolts doors
-	if(locked)
-		Topic(src, list("src" = UID(), "command"="bolts", "activate" = "0"), 1)// 1 meaning no window (consistency!)
-	else
-		Topic(src, list("src" = UID(), "command"="bolts", "activate" = "1"), 1)
+/mob/living/silicon/ai/TurfAdjacent(turf/T)
+	return (GLOB.cameranet && GLOB.cameranet.checkTurfVis(T))
 
-/obj/machinery/power/apc/AICtrlClick() // turns off/on APCs.
-	Topic("breaker=1", list("breaker"="1"), 0) // 0 meaning no window (consistency! wait...)
+// APC
+
+/obj/machinery/power/apc/AICtrlClick(mob/living/user) // turns off/on APCs.
+	toggle_breaker(user)
+
+
+// TURRETCONTROL
 
 /obj/machinery/turretid/AICtrlClick() //turns off/on Turrets
 	Topic(src, list("src" = UID(), "command"="enable", "value"="[!enabled]"), 1) // 1 meaning no window (consistency!)
 
-/atom/proc/AIAltClick(var/atom/A)
-	AltClick(A)
-
-/obj/machinery/door/airlock/AIAltClick() // Electrifies doors.
-	if(!electrified_until)
-		// permanent shock
-		Topic(src, list("src" = UID(), "command"="electrify_permanently", "activate" = "1"), 1) // 1 meaning no window (consistency!)
-	else
-		// disable/6 is not in Topic; disable/5 disables both temporary and permanent shock
-		Topic(src, list("src" = UID(), "command"="electrify_permanently", "activate" = "0"), 1)
-	return
-
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
 	Topic(src, list("src" = UID(), "command"="lethal", "value"="[!lethal]"), 1) // 1 meaning no window (consistency!)
 
-/atom/proc/AIMiddleClick()
-	return
 
-/obj/machinery/door/airlock/AIMiddleClick() // Toggles door bolt lights.
-	if(!src.lights)
-		Topic(src, list("src" = UID(), "command"="lights", "activate" = "1"), 1) // 1 meaning no window (consistency!)
+// AIRLOCKS
+
+/obj/machinery/door/airlock/AIAltShiftClick(mob/user)  // Sets/Unsets Emergency Access Override
+	emergency = !emergency
+	update_icon()
+
+/obj/machinery/door/airlock/AIShiftClick(mob/user)  // Opens and closes doors!
+	if(welded)
+		to_chat(user, "<span class='warning'>The airlock has been welded shut!</span>")
+	if(locked)
+		locked = !locked
+	if(density)
+		open()
 	else
-		Topic(src, list("src" = UID(), "command"="lights", "activate" = "0"), 1)
-	return
+		close()
 
-/obj/machinery/ai_slipper/AICtrlClick() //Turns liquid dispenser on or off
+/obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/ai/user) // Bolts doors
+	locked = !locked
+	update_icon()
+
+/obj/machinery/door/airlock/AIAltClick(mob/living/silicon/ai/user) // Electrifies doors.
+	if(wires.is_cut(WIRE_ELECTRIFY))
+		to_chat(user, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
+	if(isElectrified())
+		electrify(0) // un-shock
+	else
+		electrify(-1) // permanent shock
+
+
+/obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.
+	if(wires.is_cut(WIRE_BOLT_LIGHT))
+		to_chat(user, "<span class='warning'>The bolt lights wire has been cut - The door bolt lights are permanently disabled.</span>")
+	else if(lights)
+		lights = FALSE
+		to_chat(user, "<span class='notice'>The door bolt lights have been disabled.</span>")
+	else if(!lights)
+		lights = TRUE
+		to_chat(user, "<span class='notice'>The door bolt lights have been enabled.</span>")
+	update_icon()
+
+// AI-CONTROLLED SLIP GENERATOR IN AI CORE
+
+/obj/machinery/ai_slipper/AICtrlClick(mob/living/silicon/ai/user) //Turns liquid dispenser on or off
 	ToggleOn()
 
 /obj/machinery/ai_slipper/AIAltClick() //Dispenses liquid if on
 	Activate()
-
-//
-// Override AdjacentQuick for AltClicking
-//
-
-/mob/living/silicon/ai/TurfAdjacent(var/turf/T)
-	return (GLOB.cameranet && GLOB.cameranet.checkTurfVis(T))

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -173,6 +173,7 @@
 /mob/living/silicon/ai/TurfAdjacent(turf/T)
 	return (GLOB.cameranet && GLOB.cameranet.checkTurfVis(T))
 
+
 // APC
 
 /obj/machinery/power/apc/AICtrlClick(mob/living/user) // turns off/on APCs.
@@ -181,6 +182,7 @@
 
 // TURRETCONTROL
 
+// These two will be changed with TGUI turrets/turretcontrol.
 /obj/machinery/turretid/AICtrlClick() //turns off/on Turrets
 	Topic(src, list("src" = UID(), "command"="enable", "value"="[!enabled]"), 1) // 1 meaning no window (consistency!)
 
@@ -227,6 +229,7 @@
 		lights = TRUE
 		to_chat(user, "<span class='notice'>The door bolt lights have been enabled.</span>")
 	update_icon()
+
 
 // AI-CONTROLLED SLIP GENERATOR IN AI CORE
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -839,10 +839,10 @@ About the new airlock wires panel:
 			if(wires.is_cut(WIRE_BOLT_LIGHT))
 				to_chat(usr, "<span class='warning'>The bolt lights wire has been cut - The door bolt lights are permanently disabled.</span>")
 			else if(lights)
-				lights = 0
+				lights = FALSE
 				to_chat(usr, "<span class='notice'>The door bolt lights have been disabled.</span>")
 			else if(!lights)
-				lights = 1
+				lights = TRUE
 				to_chat(usr, "<span class='notice'>The door bolt lights have been enabled.</span>")
 			update_icon()
 		if("safe-toggle")


### PR DESCRIPTION
## What Does This PR Do
Makes AI shortcuts for airlocks and APCs work again.
Refactors the AI shortcut code to make it less of an abomination.
Fixes #14310 

## Changelog
:cl: Kyep
fix: fixed AI shortcuts for airlocks and APCs.
/:cl: