### PR TITLE
Allows Shadowlings to disable 'Light Floor' tiles

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -112,9 +112,7 @@
 		G.visible_message("<span class='warning'>[G] withers away!</span>")
 		qdel(G)
 	for(var/turf/T in targets)
-		if(istype(T, /turf/simulated/floor/light))
-			var/turf/simulated/floor/light/L = T
-			L.toggle_light(0)
+		T.extinguish_light()
 		for(var/atom/A in T.contents)
 			A.extinguish_light()
 

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -109,9 +109,12 @@
 		return
 	to_chat(user, "<span class='shadowling'>You silently disable all nearby lights.</span>")
 	for(var/obj/structure/glowshroom/G in orange(2, user)) //Why the fuck was this in the loop below?
-		G.visible_message("<span class='warning'>\The [G] withers away!</span>")
+		G.visible_message("<span class='warning'>[G] withers away!</span>")
 		qdel(G)
 	for(var/turf/T in targets)
+		if(istype(T, /turf/simulated/floor/light))
+			var/turf/simulated/floor/light/L = T
+			L.toggle_light(0)
 		for(var/atom/A in T.contents)
 			A.extinguish_light()
 

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -146,3 +146,4 @@
 /obj/machinery/floodlight/extinguish_light()
 	on = 0
 	set_light(0)
+	update_icon()

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -11,7 +11,7 @@
 #define LIGHTFLOOR_CYCLEB 10
 
 /turf/simulated/floor/light
-	name = "Light floor"
+	name = "\improper light floor"
 	light_range = 5
 	icon_state = "light_on"
 	floor_tile = /obj/item/stack/tile/light
@@ -69,12 +69,12 @@
 	set_light(0)
 	..()
 
-/turf/simulated/floor/light/attack_hand()
+/turf/simulated/floor/light/attack_hand(mob/user)
 	if(!can_modify_colour)
 		return
-	toggle_light(state = !on)
+	toggle_light(!on)
 
-/turf/simulated/floor/light/attackby(obj/item/C, mob/user)
+/turf/simulated/floor/light/attackby(obj/item/C, mob/user, params)
 	if(istype(C, /obj/item/light/bulb)) //only for light tiles
 		if(!state)
 			qdel(C)
@@ -102,17 +102,14 @@
 	else
 		to_chat(user, "<span class='warning'>[src]'s light bulb appears to have burned out.</span>")
 
-/turf/simulated/floor/light/proc/toggle_light(state)
-	// 1 = ON
-	if(state == 1)
-		on = TRUE
+/turf/simulated/floor/light/proc/toggle_light(light)
 	// 0 = OFF
-	else if(state == 0)
-		on = FALSE
+	// 1 = ON
+	on = light
 	update_icon()
 
 /turf/simulated/floor/light/extinguish_light()
-	toggle_light(0)
+	toggle_light(FALSE)
 	visible_message("<span class='danger'>[src] flickers and falls dark.</span>")
 
 //Cycles through all of the colours

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -16,7 +16,7 @@
 	icon_state = "light_on"
 	floor_tile = /obj/item/stack/tile/light
 	broken_states = list("light_broken")
-	var/on = 1
+	var/on = TRUE
 	var/state = LIGHTFLOOR_ON
 	var/can_modify_colour = TRUE
 
@@ -30,34 +30,34 @@
 		switch(state)
 			if(LIGHTFLOOR_ON)
 				icon_state = "light_on"
-				set_light(5,null,LIGHT_COLOR_LIGHTBLUE)
+				set_light(5, null,LIGHT_COLOR_LIGHTBLUE)
 			if(LIGHTFLOOR_WHITE)
 				icon_state = "light_on-w"
-				set_light(5,null,LIGHT_COLOR_WHITE)
+				set_light(5, null,LIGHT_COLOR_WHITE)
 			if(LIGHTFLOOR_RED)
 				icon_state = "light_on-r"
-				set_light(5,null,LIGHT_COLOR_RED)
+				set_light(5, null,LIGHT_COLOR_RED)
 			if(LIGHTFLOOR_GREEN)
 				icon_state = "light_on-g"
-				set_light(5,null,LIGHT_COLOR_PURE_GREEN)
+				set_light(5, null,LIGHT_COLOR_PURE_GREEN)
 			if(LIGHTFLOOR_YELLOW)
 				icon_state = "light_on-y"
-				set_light(5,null,"#FFFF00")
+				set_light(5, null,"#FFFF00")
 			if(LIGHTFLOOR_BLUE)
 				icon_state = "light_on-b"
-				set_light(5,null,LIGHT_COLOR_DARKBLUE)
+				set_light(5, null,LIGHT_COLOR_DARKBLUE)
 			if(LIGHTFLOOR_PURPLE)
 				icon_state = "light_on-p"
-				set_light(5,null,LIGHT_COLOR_PURPLE)
+				set_light(5, null,LIGHT_COLOR_PURPLE)
 			if(LIGHTFLOOR_GENERICCYCLE)
 				icon_state = "light_on-cycle_all"
-				set_light(5,null,LIGHT_COLOR_WHITE)
+				set_light(5, null,LIGHT_COLOR_WHITE)
 			if(LIGHTFLOOR_CYCLEA)
 				icon_state = "light_on-dancefloor_A"
 				set_light(5,null,LIGHT_COLOR_RED)
 			if(LIGHTFLOOR_CYCLEB)
 				icon_state = "light_on-dancefloor_B"
-				set_light(5,null,LIGHT_COLOR_DARKBLUE)
+				set_light(5, null,LIGHT_COLOR_DARKBLUE)
 			else
 				icon_state = "light_off"
 				set_light(0)
@@ -69,14 +69,13 @@
 	set_light(0)
 	..()
 
-/turf/simulated/floor/light/attack_hand(mob/user)
+/turf/simulated/floor/light/attack_hand()
 	if(!can_modify_colour)
 		return
-	on = !on
-	update_icon()
+	toggle_light(state = !on)
 
-/turf/simulated/floor/light/attackby(obj/item/C, mob/user, params)
-	if(istype(C,/obj/item/light/bulb)) //only for light tiles
+/turf/simulated/floor/light/attackby(obj/item/C, mob/user)
+	if(istype(C, /obj/item/light/bulb)) //only for light tiles
 		if(!state)
 			qdel(C)
 			state = LIGHTFLOOR_ON
@@ -103,6 +102,19 @@
 	else
 		to_chat(user, "<span class='warning'>[src]'s light bulb appears to have burned out.</span>")
 
+/turf/simulated/floor/light/proc/toggle_light(state)
+	// 1 = ON
+	if(state == 1)
+		on = TRUE
+	// 0 = OFF
+	else if(state == 0)
+		on = FALSE
+	update_icon()
+
+/turf/simulated/floor/light/extinguish_light()
+	toggle_light(0)
+	visible_message("<span class='danger'>[src] flickers and falls dark.</span>")
+
 //Cycles through all of the colours
 /turf/simulated/floor/light/colour_cycle
 	state = LIGHTFLOOR_GENERICCYCLE
@@ -119,3 +131,16 @@
 	name = "dancefloor"
 	desc = "Funky floor."
 	state = LIGHTFLOOR_CYCLEB
+
+
+#undef LIGHTFLOOR_ON
+#undef LIGHTFLOOR_WHITE
+#undef LIGHTFLOOR_RED
+#undef LIGHTFLOOR_GREEN
+#undef LIGHTFLOOR_YELLOW
+#undef LIGHTFLOOR_BLUE
+#undef LIGHTFLOOR_PURPLE
+
+#undef LIGHTFLOOR_GENERICCYCLE
+#undef LIGHTFLOOR_CYCLEA
+#undef LIGHTFLOOR_CYCLEB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This allows Shadowlings to disable 'Light Floor' tiles by using their 'Veil' ability.

Also fixes a bug where floodlights would keep their 'on' sprite after being disabled by a sling.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Shadowlings can, as far as I know, turn off all electronic light sources *except* for floor lights. Which really seems like an oversight to me.

## Changelog
:cl:
tweak: Shadowlings can now disable floor lights with their 'Veil' ability
fix: Fixed floodlights disabled by slings keeping their 'on' sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
