### PR TITLE
Fixes canister admin alerts

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -352,7 +352,7 @@ update_flag
 			valve_open = !valve_open
 			if(valve_open)
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into the [holding || "air"].<br>"
-				if(!holding && !connected_port)
+				if(!holding)
 					logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into the air.<br>"
 					if(air_contents.toxins > 0)
 						message_admins("[key_name_admin(usr)] opened a canister that contains plasma in [get_area(src)]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -352,8 +352,8 @@ update_flag
 			valve_open = !valve_open
 			if(valve_open)
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into the [holding || "air"].<br>"
-				if(!holding)
-					logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into the [holding || "air"].<br>"
+				if(!holding && !connected_port)
+					logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into the air.<br>"
 					if(air_contents.toxins > 0)
 						message_admins("[key_name_admin(usr)] opened a canister that contains plasma in [get_area(src)]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 						log_admin("[key_name(usr)] opened a canister that contains plasma at [get_area(src)]: [x], [y], [z]")
@@ -367,8 +367,9 @@ update_flag
 		if("eject")
 			if(holding)
 				if(valve_open)
+					if(air_contents && (air_contents.toxins > 0 || air_contents.sleeping_agent > 0))
+						message_admins("[ADMIN_LOOKUPFLW(usr)] removed [holding] from [src] with valve still open at [ADMIN_VERBOSEJMP(src)] releasing contents into the <span class='boldannounce'>air</span>.")
 					release_log += "[key_name(usr)] removed the [holding], leaving the valve open and transferring into the air<br>"
-					message_admins("[ADMIN_LOOKUPFLW(usr)] removed [holding] from [src] with valve still open at [ADMIN_VERBOSEJMP(src)] releasing contents into the <span class='boldannounce'>air</span>.")
 					investigate_log("[key_name(usr)] removed the [holding], leaving the valve open and transferring into the <span class='boldannounce'>air</span>.", "atmos")
 				replace_tank(usr, FALSE)
 		if("recolor")


### PR DESCRIPTION
## What Does This PR Do
1) ~~Stops admins getting an alert about someone opening the valve on a canister - if the canister is currently connected to a floor canister port. This is a common event (toxins, atmos, etc) and not worthy of an alert.~~ Removed due to AA request.
2) Stops admins getting an alert about someone removing their tank from a canister with an open valve - if the canister does not contain any plasma or N2O. Again, people forgetting to actually close the valve before removing their tank is a common event, and its not worthy of an admin alert. While it might overpressurize the room, that's not a big issue. Only cases where someone is doing this deliberately to release N2O/plasma are worthy of an alert to admins.

## Changelog
:cl: Kyep
fix: stopped admins getting alerts about perfectly innocent/harmless interactions with canisters.
/:cl: