### PR TITLE
Server awareness of pending updates

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -92,6 +92,7 @@ GLOBAL_VAR(map_name) // Self explanatory
 GLOBAL_DATUM_INIT(data_core, /datum/datacore, new) // Station datacore, manifest, etc
 
 GLOBAL_VAR_INIT(panic_bunker_enabled, FALSE) // Is the panic bunker enabled
+GLOBAL_VAR_INIT(pending_server_update, FALSE)
 
 //Database connections
 //A connection is established on world creation. Ideally, the connection dies when the server restarts (After feedback logging.).

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -223,7 +223,7 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 				return "Bad Key"
 			else
 				var/prtext = input["announce"]
-				if(findtext(prtext, "Pull request merged by") != 0)
+				if(copytext(prtext, 1, 25) == "Pull requested merged by")
 					GLOB.pending_server_update = TRUE
 				for(var/client/C in GLOB.clients)
 					to_chat(C, "<span class='announce'>PR: [prtext]</span>")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -223,7 +223,8 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 				return "Bad Key"
 			else
 				var/prtext = input["announce"]
-				if(copytext(prtext, 1, 23) == "Pull+Request+merged+by") // its urlencoded
+				var/pr_substring = copytext(prtext, 1, 23)
+				if(pr_substring == "Pull Request merged by")
 					GLOB.pending_server_update = TRUE
 				for(var/client/C in GLOB.clients)
 					to_chat(C, "<span class='announce'>PR: [prtext]</span>")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -223,7 +223,7 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 				return "Bad Key"
 			else
 				var/prtext = input["announce"]
-				if(copytext(prtext, 1, 25) == "Pull requested merged by")
+				if(copytext(prtext, 1, 23) == "Pull request merged by")
 					GLOB.pending_server_update = TRUE
 				for(var/client/C in GLOB.clients)
 					to_chat(C, "<span class='announce'>PR: [prtext]</span>")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -222,8 +222,11 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 			if(input["key"] != config.comms_password)
 				return "Bad Key"
 			else
+				var/prtext = input["announce"]
+				if(findtext(prtext, "Pull request merged by") != 0)
+					GLOB.pending_server_update = TRUE
 				for(var/client/C in GLOB.clients)
-					to_chat(C, "<span class='announce'>PR: [input["announce"]]</span>")
+					to_chat(C, "<span class='announce'>PR: [prtext]</span>")
 
 	else if("kick" in input)
 		/*
@@ -270,7 +273,7 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 	else if("hostannounce" in input)
 		if(!key_valid)
 			return keySpamProtect(addr)
-
+		GLOB.pending_server_update = TRUE
 		to_chat(world, "<hr><span style='color: #12A5F4'><b>Server Announcement:</b> [input["message"]]</span><hr>")
 
 /proc/keySpamProtect(var/addr)
@@ -339,8 +342,12 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 	return
 	#endif
 
+	var/secs_before_auto_reconnect = 10
+	if(GLOB.pending_server_update)
+		secs_before_auto_reconnect = 60
+		to_chat(world, "<span class='boldannounce'>Reboot will take a little longer, due to pending updates.</span>")
 	for(var/client/C in GLOB.clients)
-		var/secs_before_auto_reconnect = 10 // TODO: make it higher if server is due for an update @AffectedArc07
+
 		C << output(list2params(list(secs_before_auto_reconnect)), "browseroutput:reboot")
 		if(config.server)       //if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 			C << link("byond://[config.server]")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -223,7 +223,7 @@ GLOBAL_VAR_INIT(world_topic_spam_protect_time, world.timeofday)
 				return "Bad Key"
 			else
 				var/prtext = input["announce"]
-				if(copytext(prtext, 1, 23) == "Pull request merged by")
+				if(copytext(prtext, 1, 23) == "Pull+Request+merged+by") // its urlencoded
 					GLOB.pending_server_update = TRUE
 				for(var/client/C in GLOB.clients)
 					to_chat(C, "<span class='announce'>PR: [prtext]</span>")


### PR DESCRIPTION
## What Does This PR Do
If a PR is merged, OR hostannounce is used to send a message to the server, clients will wait 60s before reconnecting to the server, instead of the normal 10s.
Extends #14246 


## Why It's Good For The Game
Means clients can autoreconnect successfully after the server is patched.

## Changelog
:cl: Kyep
tweak: server auto-reconnect now accounts for when downtime is a bit longer due to pending updates.
/:cl: