### PR TITLE
Adds periods to some emotes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -592,7 +592,7 @@
 					message = "<B>[src]</B> sighs[M ? " at [M]" : ""]."
 					m_type = 2
 				else
-					message = "<B>[src]</B> makes a weak noise"
+					message = "<B>[src]</B> makes a weak noise."
 					m_type = 2
 
 		if("hsigh", "hsighs")
@@ -600,7 +600,7 @@
 				message = "<B>[src]</B> sighs contentedly."
 				m_type = 2
 			else
-				message = "<B>[src]</B> makes a [pick("chill", "relaxed")] noise"
+				message = "<B>[src]</B> makes a [pick("chill", "relaxed")] noise."
 				m_type = 2
 
 		if("laugh", "laughs")

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -9,7 +9,7 @@
 	response_disarm = "bops"
 	response_harm   = "kicks"
 	speak = list("YAP", "Woof!", "Bark!", "AUUUUUU")
-	speak_emote = list("barks", "woofs")
+	speak_emote = list("barks.", "woofs.")
 	emote_hear = list("barks!", "woofs!", "yaps.","pants.")
 	emote_see = list("shakes its head.", "chases its tail.","shivers.")
 	faction = list("neutral")


### PR DESCRIPTION
## What Does This PR Do
Adds periods to some emotes.

## Why It's Good For The Game
OCD triggering.
emotes without periods at the end look bad, and the rest of them already have emotes. 

## Changelog
:cl:
tweak: Added periods at the end of some emotes.
/:cl: