### PR TITLE
Fixes a jobs.dm runtime when an explorer is transferred

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -458,6 +458,7 @@
 	total_positions = 0
 	spawn_positions = 0
 	supervisors = "the head of personnel"
+	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_GATEWAY, ACCESS_EVA, ACCESS_EXTERNAL_AIRLOCKS)
 	minimal_access = list(ACCESS_MAINT_TUNNELS, ACCESS_GATEWAY, ACCESS_EVA, ACCESS_EXTERNAL_AIRLOCKS)


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime in jobs.dm:666 which can occur when a job with no department_head = list("title here") value is set.

## Changelog
:cl: Kyep
fix: fixed a runtime in jobs.dm that happened when explorers were transferred.
/:cl: