### PR TITLE
Gives engi/medical borgs an abductor tool upgrade from the exosuit fabricator

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -183,7 +183,7 @@
 
 	return TRUE
 
-/obj/item/borg/upgrade/abductorengi
+/obj/item/borg/upgrade/abductor_engi
 	name = "engineering cyborg abductor upgrade"
 	desc = "An experimental upgrade that replaces an engineering cyborgs tools with the abductor version."
 	icon_state = "abductor_mod"
@@ -191,7 +191,7 @@
 	require_module = TRUE
 	module_type = /obj/item/robot_module/engineering
 
-/obj/item/borg/upgrade/abductorengi/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/abductor_engi/action(mob/living/silicon/robot/R)
 	if(..())
 		return
 
@@ -218,7 +218,7 @@
 
 	return TRUE
 
-/obj/item/borg/upgrade/abductormedi
+/obj/item/borg/upgrade/abductor_medi
 	name = "medical cyborg abductor upgrade"
 	desc = "An experimental upgrade that replaces a medical cyborgs tools with the abductor version."
 	icon_state = "abductor_mod"
@@ -226,7 +226,7 @@
 	require_module = TRUE
 	module_type = /obj/item/robot_module/medical
 
-/obj/item/borg/upgrade/abductormedi/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/abductor_medi/action(mob/living/silicon/robot/R)
 	if(..())
 		return
 
@@ -247,7 +247,7 @@
 	for(var/obj/item/surgicaldrill/D in R.module.modules)
 		qdel(D)
 
-	R.module.modules += new /obj/item/scalpel/laser/manager(R.module) //no abductor laser scalpel, so next best thing.
+	R.module.modules += new /obj/item/scalpel/laser/laser3(R.module) //no abductor laser scalpel, so next best thing.
 	R.module.modules += new /obj/item/hemostat/alien(R.module)
 	R.module.modules += new /obj/item/retractor/alien(R.module)
 	R.module.modules += new /obj/item/bonegel/alien(R.module)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -215,7 +215,6 @@
 	R.module.modules += new /obj/item/wirecutters/abductor(R.module)
 	R.module.modules += new /obj/item/multitool/abductor(R.module)
 	R.module.rebuild()
-	R.module.fix_modules()
 
 	return TRUE
 
@@ -257,7 +256,6 @@
 	R.module.modules += new /obj/item/circular_saw/alien(R.module)
 	R.module.modules += new /obj/item/surgicaldrill/alien(R.module)
 	R.module.rebuild()
-	R.module.fix_modules()
 
 	return TRUE
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -183,6 +183,84 @@
 
 	return TRUE
 
+/obj/item/borg/upgrade/abductorengi
+	name = "engineering cyborg abductor upgrade"
+	desc = "An experimental upgrade that replaces an engineering cyborgs tools with the abductor version."
+	icon_state = "abductor_mod"
+	origin_tech = "engineering=6;materials=6;abductor=3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/engineering
+
+/obj/item/borg/upgrade/abductorengi/action(mob/living/silicon/robot/R)
+	if(..())
+		return
+
+	for(var/obj/item/weldingtool/largetank/cyborg/W in R.module.modules)
+		qdel(W)
+	for(var/obj/item/screwdriver/cyborg/S in R.module.modules)
+		qdel(S)
+	for(var/obj/item/wrench/cyborg/E in R.module.modules)
+		qdel(E)
+	for(var/obj/item/crowbar/cyborg/C in R.module.modules)
+		qdel(C)
+	for(var/obj/item/wirecutters/cyborg/I in R.module.modules)
+		qdel(I)
+	for(var/obj/item/multitool/cyborg/M in R.module.modules)
+		qdel(M)
+
+	R.module.modules += new /obj/item/weldingtool/abductor(R.module)
+	R.module.modules += new /obj/item/wrench/abductor(R.module)
+	R.module.modules += new /obj/item/screwdriver/abductor(R.module)
+	R.module.modules += new /obj/item/crowbar/abductor(R.module)
+	R.module.modules += new /obj/item/wirecutters/abductor(R.module)
+	R.module.modules += new /obj/item/multitool/abductor(R.module)
+	R.module.rebuild()
+	R.module.fix_modules()
+
+	return TRUE
+
+/obj/item/borg/upgrade/abductormedi
+	name = "medical cyborg abductor upgrade"
+	desc = "An experimental upgrade that replaces a medical cyborgs tools with the abductor version."
+	icon_state = "abductor_mod"
+	origin_tech = "biotech=6;materials=6;abductor=3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/medical
+
+/obj/item/borg/upgrade/abductormedi/action(mob/living/silicon/robot/R)
+	if(..())
+		return
+
+	for(var/obj/item/scalpel/laser/laser1/L in R.module.modules)
+		qdel(L)
+	for(var/obj/item/hemostat/H in R.module.modules)
+		qdel(H)
+	for(var/obj/item/retractor/E in R.module.modules)
+		qdel(E)
+	for(var/obj/item/bonegel/B in R.module.modules)
+		qdel(B)
+	for(var/obj/item/FixOVein/F in R.module.modules)
+		qdel(F)
+	for(var/obj/item/bonesetter/S in R.module.modules)
+		qdel(S)
+	for(var/obj/item/circular_saw/C in R.module.modules)
+		qdel(C)
+	for(var/obj/item/surgicaldrill/D in R.module.modules)
+		qdel(D)
+
+	R.module.modules += new /obj/item/scalpel/laser/manager(R.module) //no abductor laser scalpel, so next best thing.
+	R.module.modules += new /obj/item/hemostat/alien(R.module)
+	R.module.modules += new /obj/item/retractor/alien(R.module)
+	R.module.modules += new /obj/item/bonegel/alien(R.module)
+	R.module.modules += new /obj/item/FixOVein/alien(R.module)
+	R.module.modules += new /obj/item/bonesetter/alien(R.module)
+	R.module.modules += new /obj/item/circular_saw/alien(R.module)
+	R.module.modules += new /obj/item/surgicaldrill/alien(R.module)
+	R.module.rebuild()
+	R.module.fix_modules()
+
+	return TRUE
+
 /obj/item/borg/upgrade/syndicate
 	name = "safety override module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg. Also prevents emag subversion."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -74,7 +74,7 @@
 	var/list/temp_list = modules
 	modules = list()
 	for(var/obj/O in temp_list)
-		if(O)
+		if(!QDELETED(O)) //so items getting deleted don't stay in module list and haunt you
 			modules += O
 
 /obj/item/robot_module/proc/add_languages(mob/living/silicon/robot/R)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1081,6 +1081,26 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_abductor_engi
+	name = "Cyborg Upgrade (Abdcutor Engineering Equipment)"
+	id = "borg_upgade_abductor_engi"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/abductorengi
+	req_tech = list("engineering" = 7, "materials" = 7, "abductor" = 4)
+	materials = list(MAT_METAL = 25000, MAT_SILVER = 12500, MAT_PLASMA = 5000, MAT_TITANIUM = 10000, MAT_DIAMOND = 10000) //Base abductor engineering tools * 4
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_abductor_medi
+	name = "Cyborg Upgrade (Abdcutor Medical Equipment)"
+	id = "borg_upgade_abductor_medi"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/abductormedi
+	req_tech = list("biotech" = 7, "materials" = 7, "abductor" = 4)
+	materials = list(MAT_METAL = 18000, MAT_GLASS = 1500, MAT_SILVER = 13000, MAT_GOLD = 1000, MAT_PLASMA = 4000, MAT_TITANIUM = 12000, MAT_DIAMOND = 1000) //Base abductor engineering tools *8 + IMS cost
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_lavaproof
 	name = "Cyborg Upgrade (Lavaproof Chassis)"
 	id = "borg_upgrade_lavaproof"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1085,7 +1085,7 @@
 	name = "Cyborg Upgrade (Abdcutor Engineering Equipment)"
 	id = "borg_upgade_abductor_engi"
 	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/abductorengi
+	build_path = /obj/item/borg/upgrade/abductor_engi
 	req_tech = list("engineering" = 7, "materials" = 7, "abductor" = 4)
 	materials = list(MAT_METAL = 25000, MAT_SILVER = 12500, MAT_PLASMA = 5000, MAT_TITANIUM = 10000, MAT_DIAMOND = 10000) //Base abductor engineering tools * 4
 	construction_time = 120
@@ -1095,7 +1095,7 @@
 	name = "Cyborg Upgrade (Abdcutor Medical Equipment)"
 	id = "borg_upgade_abductor_medi"
 	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/abductormedi
+	build_path = /obj/item/borg/upgrade/abductor_medi
 	req_tech = list("biotech" = 7, "materials" = 7, "abductor" = 4)
 	materials = list(MAT_METAL = 18000, MAT_GLASS = 1500, MAT_SILVER = 13000, MAT_GOLD = 1000, MAT_PLASMA = 4000, MAT_TITANIUM = 12000, MAT_DIAMOND = 1000) //Base abductor engineering tools *8 + IMS cost
 	construction_time = 120


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR gives engineering / medical borgs the ability to get an abductor equipment upgrade. This upgrade replaces the tools the borg gets with the equivalent abductor tool, and with the case of medical, replaces the laser scalpel with IMS, due to lack of an abductor laser scalpel. They can be produced in the exosuit fabricator for approximately the price of all the tools if printed for a human.

Also fixes borg upgrades like the diamond drill for mining borg leaving a ghost item slot when upgraded.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This is good for the game as it adds an upgrade to borgs other than security or miner that helps them specifically. It is not something that will happen every round, due to the requirement of abductor 4, which will require either very productive miners with the abductor ruin, traders, or actual abductors.  These tools are not combat oriented, and does not give the security borg the abductor baton either. This does not make borgs stronger then crew in these areas, as they are the exact same tools crew get, for the same price.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Already in the code, but unused, is the new sprite for the module: 
![image](https://user-images.githubusercontent.com/52090703/93403443-85dd4180-f855-11ea-9680-f258259a88fc.png)

## Changelog
:cl:
add: Allows medical / engineering borgs to get abductor tool upgrades from the exosuit fabricator with a new upgrade.
fix: Fixes modules like diamond drill upgrade for mining borgs having a ghost slot filled with the old drill.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
