### PR TITLE
Fixes borgs in charger not showing on robotics console

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -46,7 +46,7 @@
 		return FALSE
 	if(R.scrambledcodes)
 		return FALSE
-	if(!atoms_share_level(src, R))
+	if(!atoms_share_level(get_turf(src), get_turf(R)))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #14342 
Fixes #14321
 - bugs where borgs inside a recharger don't show up on the robotics console.

## Changelog
:cl: Kyep
fix: fixed a bug where borgs inside a recharger don't show up on the robotics console.
/:cl: