### PR TITLE
Adds abstract meat to silver slime blacklist

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -146,7 +146,8 @@
 		/obj/item/reagent_containers/food/snacks/meat/slab,
 		/obj/item/reagent_containers/food/snacks/grown,
 		/obj/item/reagent_containers/food/snacks/grown/mushroom,
-		/obj/item/reagent_containers/food/snacks/deepfryholder
+		/obj/item/reagent_containers/food/snacks/deepfryholder,
+		/obj/item/reagent_containers/food/snacks/monstermeat
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 


### PR DESCRIPTION
## What Does This PR Do
Adds abstract monster meat to the blacklist for silver slime, fixing [this issue.](https://github.com/ParadiseSS13/Paradise/issues/14063)

## Changelog
:cl:
add: /obj/item/reagent_containers/food/snacks/monstermeat to silver slime blacklist in slime_extracts.dm
/:cl: