### PR TITLE
Fixes terrible text formatting with the end of round traitor info

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -119,10 +119,10 @@
 
 
 			if(traitorwin)
-				text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
+				text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font><br>"
 				feedback_add_details("traitor_success","SUCCESS")
 			else
-				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
+				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font><br>"
 				feedback_add_details("traitor_success","FAIL")
 
 		if(length(SSticker.mode.implanted))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds line breaks after "The traitor has failed!" and "The traitor was successful!" messages, which makes it much easier to read.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
### Before:


![image](https://user-images.githubusercontent.com/42044220/93517359-f5ecd580-f8f0-11ea-9726-23b2403b7b41.png)


### After:


![Untitled-1](https://user-images.githubusercontent.com/42044220/93517402-043af180-f8f1-11ea-9881-d612d5b3fc2e.jpg)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
Fix: Fixes terrible formatting with the traitor end of round information
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
