### PR TITLE
Makes silicon clicking shortcuts behave the same as the TGUI interface. Plus fixes

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -161,7 +161,7 @@
 		user.examinate(src)
 	return
 
-/atom/proc/AICtrlClick(mob/living/silicon/ai/user)
+/atom/proc/AICtrlClick(mob/living/silicon/user)
 	return
 
 /atom/proc/AIAltClick(atom/A)
@@ -182,7 +182,7 @@
 
 // TURRETCONTROL
 
-/obj/machinery/turretid/AICtrlClick(mob/living/silicon/ai/user) //turns off/on Turrets
+/obj/machinery/turretid/AICtrlClick(mob/living/silicon/user) //turns off/on Turrets
 	enabled = !enabled
 	updateTurrets()
 
@@ -194,42 +194,25 @@
 // AIRLOCKS
 
 /obj/machinery/door/airlock/AIAltShiftClick(mob/user)  // Sets/Unsets Emergency Access Override
-	emergency = !emergency
-	update_icon()
+	toggle_emergency_status(user)
 
 /obj/machinery/door/airlock/AIShiftClick(mob/user)  // Opens and closes doors!
-	if(welded)
-		to_chat(user, "<span class='warning'>The airlock has been welded shut!</span>")
-	if(locked)
-		locked = !locked
-	if(density)
-		open()
-	else
-		close()
+	open_close(user)
 
-/obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/ai/user) // Bolts doors
-	locked = !locked
-	update_icon()
+/obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
+	toggle_bolt(user)
 
-/obj/machinery/door/airlock/AIAltClick(mob/living/silicon/ai/user) // Electrifies doors.
+/obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
 	if(wires.is_cut(WIRE_ELECTRIFY))
 		to_chat(user, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
 	if(isElectrified())
-		electrify(0) // un-shock
+		electrify(0, user, TRUE) // un-shock
 	else
-		electrify(-1) // permanent shock
+		electrify(-1, user, TRUE) // permanent shock
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.
-	if(wires.is_cut(WIRE_BOLT_LIGHT))
-		to_chat(user, "<span class='warning'>The bolt lights wire has been cut - The door bolt lights are permanently disabled.</span>")
-	else if(lights)
-		lights = FALSE
-		to_chat(user, "<span class='notice'>The door bolt lights have been disabled.</span>")
-	else if(!lights)
-		lights = TRUE
-		to_chat(user, "<span class='notice'>The door bolt lights have been enabled.</span>")
-	update_icon()
+	toggle_light(user)
 
 // FIRE ALARMS
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -131,47 +131,47 @@
 /atom/proc/BorgAltShiftClick()
 	return
 
-/obj/machinery/door/airlock/BorgAltShiftClick()  // Enables emergency override on doors! Forwards to AI code.
-	AIAltShiftClick()
+/obj/machinery/door/airlock/BorgAltShiftClick(mob/living/silicon/robot/user)  // Enables emergency override on doors! Forwards to AI code.
+	AIAltShiftClick(user)
 
 /atom/proc/BorgShiftClick(var/mob/user)
 	if(user.client && user.client.eye == user)
 		user.examinate(src)
 	return
 
-/obj/machinery/door/airlock/BorgShiftClick()  // Opens and closes doors! Forwards to AI code.
-	AIShiftClick()
+/obj/machinery/door/airlock/BorgShiftClick(mob/living/silicon/robot/user)  // Opens and closes doors! Forwards to AI code.
+	AIShiftClick(user)
 
 /atom/proc/BorgCtrlClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlClick(user)
 
-/obj/machinery/door/airlock/BorgCtrlClick() // Bolts doors. Forwards to AI code.
-	AICtrlClick()
+/obj/machinery/door/airlock/BorgCtrlClick(mob/living/silicon/robot/user) // Bolts doors. Forwards to AI code.
+	AICtrlClick(user)
 
-/obj/machinery/power/apc/BorgCtrlClick() // turns off/on APCs. Forwards to AI code.
-	AICtrlClick()
+/obj/machinery/power/apc/BorgCtrlClick(mob/living/silicon/robot/user) // turns off/on APCs. Forwards to AI code.
+	AICtrlClick(user)
 
-/obj/machinery/turretid/BorgCtrlClick() //turret control on/off. Forwards to AI code.
-	AICtrlClick()
+/obj/machinery/turretid/BorgCtrlClick(mob/living/silicon/robot/user) //turret control on/off. Forwards to AI code.
+	AICtrlClick(user)
 
 /atom/proc/BorgAltClick(var/mob/living/silicon/robot/user)
 	AltClick(user)
 	return
 
-/obj/machinery/door/airlock/BorgAltClick() // Eletrifies doors. Forwards to AI code.
-	AIAltClick()
+/obj/machinery/door/airlock/BorgAltClick(mob/living/silicon/robot/user) // Eletrifies doors. Forwards to AI code.
+	AIAltClick(user)
 
-/obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
-	AIAltClick()
+/obj/machinery/turretid/BorgAltClick(mob/living/silicon/robot/user) //turret lethal on/off. Forwards to AI code.
+	AIAltClick(user)
 
-/obj/machinery/ai_slipper/BorgCtrlClick() //Turns liquid dispenser on or off
+/obj/machinery/ai_slipper/BorgCtrlClick(mob/living/silicon/robot/user) //Turns liquid dispenser on or off
 	ToggleOn()
 
-/obj/machinery/ai_slipper/BorgAltClick() //Dispenses liquid if on
+/obj/machinery/ai_slipper/BorgAltClick(mob/living/silicon/robot/user) //Dispenses liquid if on
 	Activate()
 
-/obj/machinery/firealarm/BorgCtrlClick()
-	AICtrlClick()
+/obj/machinery/firealarm/BorgCtrlClick(mob/living/silicon/robot/user)
+	AICtrlClick(user)
 
 /*
 	As with AI, these are not used in click code,

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -254,7 +254,7 @@ About the new airlock wires panel:
 		backup_power_lost_until = main_power_lost_until == 0 ? -1 : 0
 		update_icon()
 
-/obj/machinery/door/airlock/proc/electrify(duration, feedback = 0)
+/obj/machinery/door/airlock/proc/electrify(duration, mob/user = usr, feedback = FALSE)
 	if(electrified_timer)
 		deltimer(electrified_timer)
 		electrified_timer = null
@@ -270,10 +270,10 @@ About the new airlock wires panel:
 		message = "The door is now un-electrified."
 		electrified_until = 0
 	else if(duration)	//electrify door for the given duration seconds
-		if(usr)
-			shockedby += text("\[[time_stamp()]\] - [usr](ckey:[usr.ckey])")
-			usr.create_attack_log("<font color='red'>Electrified the [name] at [x] [y] [z]</font>")
-			add_attack_logs(usr, src, "Electrified", ATKLOG_ALL)
+		if(user)
+			shockedby += text("\[[time_stamp()]\] - [user](ckey:[user.ckey])")
+			user.create_attack_log("<font color='red'>Electrified the [name] at [x] [y] [z]</font>")
+			add_attack_logs(user, src, "Electrified", ATKLOG_ALL)
 		else
 			shockedby += text("\[[time_stamp()]\] - EMP)")
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
@@ -281,7 +281,7 @@ About the new airlock wires panel:
 		if(duration != -1)
 			electrified_timer = addtimer(CALLBACK(src, .proc/electrify, 0), duration SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
 	if(feedback && message)
-		to_chat(usr, message)
+		to_chat(user, message)
 
 // shock user with probability prb (if all connections & power are working)
 // returns 1 if shocked, 0 otherwise
@@ -788,29 +788,20 @@ About the new airlock wires panel:
 			else
 				to_chat(usr, "<span class='warning'>Backup power is already offline.</span>")
 		if("shock-restore")
-			to_chat(usr, "<span class='notice'>The door is now un-electrified.</span>")
-			electrify(0)
+			electrify(0, usr, TRUE)
 		if("shock-temp")
 			if(wires.is_cut(WIRE_ELECTRIFY))
 				to_chat(usr, "<span class='warning'>The electrification wire is cut - Door permanently electrified.</span>")
 				. = FALSE
 			else
 				//electrify door for 30 seconds
-				shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
-				usr.create_attack_log("<font color='red'>Electrified the [name] at [x] [y] [z]</font>")
-				add_attack_logs(usr, src, "Electrified", ATKLOG_ALL)
-				to_chat(usr, "<span class='notice'>The door is now electrified for thirty seconds.</span>")
-				electrify(30)
+				electrify(30, usr, TRUE)
 		if("shock-perm")
 			if(wires.is_cut(WIRE_ELECTRIFY))
 				to_chat(usr, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
 				. = FALSE
 			else
-				shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
-				usr.create_attack_log("<font color='red'>Electrified the [name] at [x] [y] [z]</font>")
-				add_attack_logs(usr, src, "Electrified", ATKLOG_ALL)
-				to_chat(usr, "<span class='notice'>The door is now electrified.</span>")
-				electrify(-1)
+				electrify(-1, usr, TRUE)
 		if("idscan-toggle")
 			if(wires.is_cut(WIRE_IDSCAN))
 				to_chat(usr, "<span class='warning'>The IdScan wire has been cut - IdScan feature permanently disabled.</span>")
@@ -822,29 +813,11 @@ About the new airlock wires panel:
 				aiDisabledIdScanner = TRUE
 				to_chat(usr, "<span class='notice'>IdScan feature has been disabled.</span>")
 		if("emergency-toggle")
-			emergency = !emergency
-			if(emergency)
-				to_chat(usr, "<span class='notice'>Emergency access has been enabled.</span>")
-			else
-				to_chat(usr, "<span class='notice'>Emergency access has been disabled.</span>")
-			update_icon()
+			toggle_emergency_status(usr)
 		if("bolt-toggle")
-			if(wires.is_cut(WIRE_DOOR_BOLTS))
-				to_chat(usr, "<span class='warning'>The door bolt control wire has been cut - Door bolts permanently dropped.</span>")
-			else if(lock())
-				to_chat(usr, "<span class='notice'>The door bolts have been dropped.</span>")
-			else if(unlock())
-				to_chat(usr, "<span class='notice'>The door bolts have been raised.</span>")
+			toggle_bolt(usr)
 		if("light-toggle")
-			if(wires.is_cut(WIRE_BOLT_LIGHT))
-				to_chat(usr, "<span class='warning'>The bolt lights wire has been cut - The door bolt lights are permanently disabled.</span>")
-			else if(lights)
-				lights = FALSE
-				to_chat(usr, "<span class='notice'>The door bolt lights have been disabled.</span>")
-			else if(!lights)
-				lights = TRUE
-				to_chat(usr, "<span class='notice'>The door bolt lights have been enabled.</span>")
-			update_icon()
+			toggle_light(usr)
 		if("safe-toggle")
 			if(wires.is_cut(WIRE_SAFETY))
 				to_chat(usr, "<span class='warning'>The safety wire is cut - Cannot secure the door.</span>")
@@ -862,16 +835,46 @@ About the new airlock wires panel:
 			else
 				normalspeed = 1
 		if("open-close")
-			if(welded)
-				to_chat(usr, "<span class='warning'>The airlock has been welded shut!</span>")
-			else if(locked)
-				to_chat(usr, "<span class='warning'>The door bolts are down!</span>")
-			else if(density)
-				open()
-			else
-				close()
+			open_close(usr)
 		else
 			. = FALSE
+
+/obj/machinery/door/airlock/proc/open_close(mob/user)
+	if(welded)
+		to_chat(user, "<span class='warning'>The airlock has been welded shut!</span>")
+	else if(locked)
+		to_chat(user, "<span class='warning'>The door bolts are down!</span>")
+	else if(density)
+		open()
+	else
+		close()
+
+/obj/machinery/door/airlock/proc/toggle_light(mob/user)
+	if(wires.is_cut(WIRE_BOLT_LIGHT))
+		to_chat(user, "<span class='warning'>The bolt lights wire has been cut - The door bolt lights are permanently disabled.</span>")
+	else if(lights)
+		lights = FALSE
+		to_chat(user, "<span class='notice'>The door bolt lights have been disabled.</span>")
+	else if(!lights)
+		lights = TRUE
+		to_chat(user, "<span class='notice'>The door bolt lights have been enabled.</span>")
+	update_icon()
+
+/obj/machinery/door/airlock/proc/toggle_bolt(mob/user)
+	if(wires.is_cut(WIRE_DOOR_BOLTS))
+		to_chat(user, "<span class='warning'>The door bolt control wire has been cut - Door bolts permanently dropped.</span>")
+	else if(lock())
+		to_chat(user, "<span class='notice'>The door bolts have been dropped.</span>")
+	else if(unlock())
+		to_chat(user, "<span class='notice'>The door bolts have been raised.</span>")
+
+/obj/machinery/door/airlock/proc/toggle_emergency_status(mob/user)
+	emergency = !emergency
+	if(emergency)
+		to_chat(user, "<span class='notice'>Emergency access has been enabled.</span>")
+	else
+		to_chat(user, "<span class='notice'>Emergency access has been disabled.</span>")
+	update_icon()
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
 	add_fingerprint(user)


### PR DESCRIPTION
## What Does This PR Do
Makes the silicon interactions with airlocks behave largely the same as using the tgui_act. Giving them feedback and the like

Removes the double logging when electrifying using the tgui_act proc

Fixes a bug where silicons can bolt/unbolt doors which bolting wire got cut.

Fixes #14361

## Why It's Good For The Game
Makes them consistent and easier to use for silicon players

It was a dupe entry. quite useless

Bug fixes b gut

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/93530324-ac76a780-f93d-11ea-9858-bcbc6940eebf.png)


## Changelog
:cl:
tweak: All the silicon clicking shortcuts with airlocks are now the same as using the TGUI interface
fix: Removed the double logging entries when electrifying doors
fix: You can't bolt/unbolt doors with their bolting wire cut now as silicon
/:cl: