### PR TITLE
Fixes cyborg radios

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -230,6 +230,9 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	if(!(freq in internal_channels))
 		return FALSE
 
+	if(isrobot(user))
+		return FALSE // cyborgs and drones are not allowed to remotely re-tune intercomms, etc
+
 	return user.has_internal_radio_channel_access(user, internal_channels[freq])
 
 /mob/proc/has_internal_radio_channel_access(var/mob/user, var/list/req_one_accesses)
@@ -606,13 +609,14 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 /obj/item/radio/borg
 	name = "Cyborg Radio"
 	var/mob/living/silicon/robot/myborg = null // Cyborg which owns this radio. Used for power checks
-	var/obj/item/encryptionkey/keyslot = new /obj/item/encryptionkey/heads/ai_integrated //Borg radios can handle a single encryption key
+	var/obj/item/encryptionkey/keyslot // Borg radios can handle a single encryption key
 	icon = 'icons/obj/robot_component.dmi' // Cyborgs radio icons should look like the component.
 	icon_state = "radio"
 	has_loudspeaker = TRUE
 	loudspeaker = FALSE
 	canhear_range = 0
 	dog_fashion = null
+	freqlock = TRUE // don't let cyborgs change the default channel of their internal radio away from common
 
 /obj/item/radio/borg/syndicate
 	keyslot = new /obj/item/encryptionkey/syndicate/nukeops

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -131,7 +131,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	update_headlamp()
 
 	radio = new /obj/item/radio/borg(src)
-	radio.recalculateChannels()
 	common_radio = radio
 
 	init(alien, connect_to_AI, ai_to_sync_to)


### PR DESCRIPTION
## Changelog
:cl: Kyep
fix: Cyborgs no longer get access to all station radio frequencies until they pick their module.
fix: Cyborgs can no longer change the default channel of either their internal radio or any other radio (e.g: intercom) they touch.
/:cl: