### PR TITLE
corrected blind message when knocking someone off a table

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -90,7 +90,7 @@
 	..()
 	if(climber)
 		climber.Weaken(2)
-		climber.visible_message("<span class='warning'>[climber.name] has been knocked off the table", "You've been knocked off the table", "You see [climber.name] get knocked off the table</span>")
+		climber.visible_message("<span class='warning'>[climber.name] has been knocked off the table", "You've been knocked off the table", "You hear [climber.name] get knocked off the table</span>")
 	else if(Adjacent(user) && user.pulling && user.pulling.pass_flags & PASSTABLE)
 		user.Move_Pulled(src)
 		if(user.pulling.loc == loc)


### PR DESCRIPTION
## What Does This PR Do
Fixes #14338

## Changelog
:cl:
spellcheck: corrected blind message when knocking someone off a table
/:cl:
