### PR TITLE
Prevents reviving emagged maint drone

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -1,4 +1,4 @@
-#define EMAG_TIMER 30
+#define EMAG_TIMER 3000
 /mob/living/silicon/robot/drone
 	name = "drone"
 	real_name = "drone"

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -1,4 +1,4 @@
-#define EMAG_TIMER 3000
+#define EMAG_TIMER 30
 /mob/living/silicon/robot/drone
 	name = "drone"
 	real_name = "drone"
@@ -125,6 +125,11 @@
 
 /mob/living/silicon/robot/drone/pick_module()
 	return
+
+/mob/living/silicon/robot/drone/can_be_revived()
+	. = ..()
+	if(emagged)
+		return FALSE
 
 //Drones cannot be upgraded with borg modules so we need to catch some items before they get used in ..().
 /mob/living/silicon/robot/drone/attackby(obj/item/W as obj, mob/user as mob, params)


### PR DESCRIPTION
## What Does This PR Do
Prevents reviving an emagged maint drone. Stops getting around the emag death timer. Fixes #14261.

## Why It's Good For The Game
Emagged maint drones are supposed to die after 5 minutes and stay dead.

## Changelog
:cl:
fix: Emagged drones can no longer be revived.
/:cl:
