### PR TITLE
Highfive changes and fixes

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -40,8 +40,8 @@
 
 /datum/status_effect/high_five
 	id = "high_five"
-	duration = 40
+	duration = 200
 	alert_type = null
 
 /datum/status_effect/high_five/on_remove()
-	owner.visible_message("[owner] was left hanging....")
+	return

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -40,7 +40,7 @@
 
 /datum/status_effect/high_five
 	id = "high_five"
-	duration = 200
+	duration = 100
 	alert_type = null
 
 /datum/status_effect/high_five/on_remove()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -912,11 +912,7 @@
 				if(L.has_status_effect(STATUS_EFFECT_HIGHFIVE))
 					if((mind && mind.special_role == SPECIAL_ROLE_WIZARD) && (L.mind && L.mind.special_role == SPECIAL_ROLE_WIZARD))
 						visible_message("<span class='danger'><b>[name]</b> and <b>[L.name]</b> high-five EPICALLY!</span>")
-						status_flags |= GODMODE
-						L.status_flags |= GODMODE
-						explosion(loc,5,2,1,3)
-						status_flags &= ~GODMODE
-						L.status_flags &= ~GODMODE
+						playsound('sound/arcade/boom.ogg', 50)
 						return
 					visible_message("<b>[name]</b> and <b>[L.name]</b> high-five!")
 					playsound('sound/effects/snap.ogg', 50)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -912,7 +912,7 @@
 				if(L.has_status_effect(STATUS_EFFECT_HIGHFIVE))
 					if((mind && mind.special_role == SPECIAL_ROLE_WIZARD) && (L.mind && L.mind.special_role == SPECIAL_ROLE_WIZARD))
 						visible_message("<span class='danger'><b>[name]</b> and <b>[L.name]</b> high-five EPICALLY!</span>")
-						playsound('sound/arcade/boom.ogg', 50)
+						playsound('sound/magic/fireball.ogg', 50)
 						return
 					visible_message("<b>[name]</b> and <b>[L.name]</b> high-five!")
 					playsound('sound/effects/snap.ogg', 50)


### PR DESCRIPTION
## What Does This PR Do
Fixes #13207
Removes the explosion and godmode from the wizard highfive, now it plays a cool fireball sound instead
You now have ten seconds to react to a *highfive instead of four seconds

## Why It's Good For The Game
Bugs bad
Spammable godmode on demand bad
Human reaction time for high-fives good


## Changelog
:cl:
tweak: Wizards' high-five no longer makes you immortal and explodes, but instead plays a cool fireball sound.
tweak: High-five prompts last for ten seconds instead of four.
fix: High-fives no longer fail after succeeding.
/:cl:
