### PR TITLE
Terror princess egg / wrap fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -167,13 +167,26 @@
 
 // ---------- WRAP
 
+/mob/living/simple_animal/hostile/poison/terror_spider/proc/mobIsWrappable(mob/living/M)
+	if(!istype(M))
+		return FALSE
+	if(M.stat != DEAD)
+		return FALSE
+	if(M.anchored)
+		return FALSE
+	if(!Adjacent(M))
+		return FALSE
+	if(isterrorspider(M))
+		return FALSE
+	return TRUE
+
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/FindWrapTarget()
 	if(!cocoon_target)
 		var/list/choices = list()
 		for(var/mob/living/L in oview(1,src))
-			if(Adjacent(L) && !L.anchored)
-				if(L.stat == DEAD)
-					choices += L
+			if(!mobIsWrappable(L))
+				continue
+			choices += L
 		for(var/obj/O in oview(1,src))
 			if(Adjacent(O) && !O.anchored)
 				if(!istype(O, /obj/structure/spider/terrorweb) && !istype(O, /obj/structure/spider/cocoon) && !istype(O, /obj/structure/spider/spiderling/terror_spiderling))
@@ -207,9 +220,7 @@
 								O.loc = C
 								large_cocoon = 1
 					for(var/mob/living/L in C.loc)
-						if(istype(L, /mob/living/simple_animal/hostile/poison/terror_spider))
-							continue
-						if(L.stat != DEAD)
+						if(!mobIsWrappable(L))
 							continue
 						if(iscarbon(L))
 							regen_points += regen_points_per_kill

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
@@ -59,6 +59,10 @@
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess/grant_eggs()
 	spider_lastspawn = world.time
 
+	if(!isturf(loc))
+		to_chat(src, "<span class='danger'>You cannot generate eggs while hiding in [loc].</span>")
+		return
+
 	if(!prob(grant_prob))
 		return
 
@@ -81,10 +85,6 @@
 		icon_living = "terror_princess3"
 		icon_dead = "terror_princess3_dead"
 		desc = "An enormous spider. Its entire body looks to be the color of dried blood."
-
-	if(!isturf(loc))
-		to_chat(src, "<span class='danger'>You cannot generate eggs while hiding in [loc].</span>")
-		return
 
 	if((brood_count + canlay) >= spider_max_children)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
@@ -94,6 +94,9 @@
 	else
 		to_chat(src, "<span class='notice'>You have [canlay] eggs available to lay.</span>")
 
+/mob/living/simple_animal/hostile/poison/terror_spider/queen/princess/show_egg_timer()
+	var/average_timer = (1 / (grant_prob / 100)) * (spider_spawnfrequency / 10)
+	to_chat(src, "<span class='danger'>Too soon to attempt that again. You generate a new egg every [average_timer] seconds, on average.</span>")
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/princess/NestMode()
 	// Princesses don't nest. However, we still need to override this in case an AI princess calls it.

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -248,11 +248,7 @@
 		to_chat(src, "<span class='danger'>You must nest before doing this.</span>")
 		return
 	if(canlay < 1)
-		var/remainingtime = round(((spider_lastspawn + spider_spawnfrequency) - world.time) / 10, 1)
-		if(remainingtime > 0)
-			to_chat(src, "<span class='danger'>Too soon to attempt that again. Wait another [num2text(remainingtime)] seconds.</span>")
-		else
-			to_chat(src, "<span class='danger'>Too soon to attempt that again. Wait just a few more seconds...</span>")
+		show_egg_timer()
 		return
 	var/list/eggtypes = ListAvailableEggTypes()
 	var/list/eggtypes_uncapped = list(TS_DESC_RED, TS_DESC_GRAY, TS_DESC_GREEN)
@@ -307,6 +303,12 @@
 		else
 			to_chat(src, "<span class='danger'>Unrecognized egg type.</span>")
 
+/mob/living/simple_animal/hostile/poison/terror_spider/queen/proc/show_egg_timer()
+	var/remainingtime = round(((spider_lastspawn + spider_spawnfrequency) - world.time) / 10, 1)
+	if(remainingtime > 0)
+		to_chat(src, "<span class='danger'>Too soon to attempt that again. Wait another [num2text(remainingtime)] seconds.</span>")
+	else
+		to_chat(src, "<span class='danger'>Too soon to attempt that again. Wait just a few more seconds...</span>")
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/proc/ListAvailableEggTypes()
 	if(MinutesAlive() >= 20)


### PR DESCRIPTION
## Changelog
:cl: Kyep
fix: fixed terror princesses being incorrectly told they get an egg every 30 seconds, when in fact there's only a 25% chance per 30s cycle. It now correctly says they get one "every 2 minutes, on average".
fix: fixed terrors sometimes being able to attempt to wrap the corpses of other terrors, which failed and generated an empty cocoon.
tweak: princesses now get told every 30s they're in a vent that they cannot generate eggs while hiding in there. Previously it only told them if they in fact failed to generate an egg because they were in a vent. This helps them understand that ventcrawling blocks egg generation - before they start missing eggs from it.
/:cl: