### PR TITLE
Adds GPS units to the orbit list

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -16,12 +16,14 @@ GLOBAL_LIST_EMPTY(GPS_list)
 /obj/item/gps/New()
 	..()
 	GLOB.GPS_list.Add(src)
+	GLOB.poi_list.Add(src)
 	if(name == "default gps")	//use default naming scheme
 		name = "global positioning system ([gpstag])"
 	overlays += "working"
 
 /obj/item/gps/Destroy()
 	GLOB.GPS_list.Remove(src)
+	GLOB.poi_list.Remove(src)
 	return ..()
 
 /obj/item/gps/emp_act(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds GPS units to the list of objects that the nuke, nuke disk, and supermatter shard among others are on for jumping and orbiting. 

## Why It's Good For The Game
As a ghost, I have frequently wanted to know where a particular GPS unit is. Particularly when there is a BSA it would be beneficial as a ghost or admin to see exactly where it is aimed before it is fired.

## Changelog
:cl:
add: Added GPS units to the list of objects that can be orbited as a ghost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
