### PR TITLE
Makes slimes immune to tesla

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -185,7 +185,8 @@
 										/obj/structure/sign,
 										/obj/machinery/gateway,
 										/obj/structure/grille,
-										/obj/machinery/the_singularitygen/tesla))
+										/obj/machinery/the_singularitygen/tesla,
+										/mob/living/simple_animal/slime))
 
 
 	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_tesla_types))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes the tesla zap ignore slimes, so that when the tesla eventually makes it way to xenobiology and it's army of slimes, there won't be infinity lag as each slime is shocked by each other slime that is shocked, it's not the 'cleanest' of solutions, but it works.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Everytime tesla gets free, xenobiology had good xenobiologists, and the tesla gets to xenobio, it would create infinity zap logs, this prevents this lag machine from functioning in the first place.
I tested it by spawning 2000 slimes, and the only lag was when they died from space.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: ppi
add: Add simple_mob slimes to the tesla ignore list to avoid lag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
