### PR TITLE
Removes mech weapon log spam

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -59,7 +59,6 @@
 		sleep(max(0, projectile_delay))
 	set_ready_state(0)
 	log_message("Fired from [name], targeting [target].")
-	var/turf/T = get_turf(src)
 	add_attack_logs(chassis.occupant, target, "fired a [src]")
 	do_after_cooldown()
 	return

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -60,8 +60,7 @@
 	set_ready_state(0)
 	log_message("Fired from [name], targeting [target].")
 	var/turf/T = get_turf(src)
-	add_attack_logs(chassis.occupant, target, "fired a [src]", ATKLOG_FEW)
-	log_game("[key_name(chassis.occupant)] fired a [src] in [T.x], [T.y], [T.z]")
+	add_attack_logs(chassis.occupant, target, "fired a [src]")
 	do_after_cooldown()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes the logging level override of mech weapons. This means miners using a ripley or people shooting npcs won't spam admins who have their attack logs set to FEW, which should contain only the most important messages.
I also removed a log_game which seems pointless, since add_attack_logs already logs location and everything.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ADmins are no longer spammed with weapons being fired at empty air or mining mobs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: tweaks to mech weapon logging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
