### PR TITLE
Solar Flares

### DIFF
--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(sun)
 	var/dy
 	var/rate
 	var/list/solars	= list()
+	var/solar_gen_rate = 1500
 
 /datum/controller/subsystem/sun/Initialize(start_timeofday)
 	// Lets work out an angle for the "sun" to rotate around the station

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -45,10 +45,7 @@
 	..()
 	impacted_z_levels = z_levels
 
-/datum/weather/proc/telegraph()
-	if(stage == STARTUP_STAGE)
-		return
-	stage = STARTUP_STAGE
+/datum/weather/proc/generate_area_list()
 	var/list/affectareas = list()
 	for(var/V in get_areas(area_type))
 		affectareas += V
@@ -58,6 +55,12 @@
 		var/area/A = V
 		if(A.z in impacted_z_levels)
 			impacted_areas |= A
+
+/datum/weather/proc/telegraph()
+	if(stage == STARTUP_STAGE)
+		return
+	stage = STARTUP_STAGE
+	generate_area_list()
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
 	START_PROCESSING(SSweather, src)
 	update_areas()

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -1,0 +1,50 @@
+/datum/weather/solar_flare
+	name = "solar flare"
+	desc = "An intense blast of light and heat from the sun, affecting all space around the station."
+
+	telegraph_duration = 300 // 30 seconds
+	telegraph_message = null // handled via event announcement
+
+	weather_message = "<span class='userdanger'><i>A solar flare has arrived! Find shelter!</i></span>"
+	weather_overlay = "light_ash"
+	weather_duration_lower = 3000 // 5-15 minutes
+	weather_duration_upper = 9000
+	weather_color = "#ffff00" // bright yellow
+	weather_sound = 'sound/misc/bloblarm.ogg' // also used by radiation storm and SM
+
+	end_duration = 10 // wind_down() does not do anything for this event, so we just trigger end() semi-immediately
+	end_message = null
+	area_type = /area/space // read generate_area_list() as well below
+	protected_areas = list()
+	target_trait = STATION_LEVEL
+	immunity_type = "burn"
+
+/datum/weather/solar_flare/generate_area_list()
+	..()
+	var/list/bonus_areas = list()
+	for(var/V in get_areas(/area/solar))
+		// no, solars in space are NOT a subtype of /area/space.
+		// no, we don't want to re-path every reference to all the subtypes of /area/solar across every map file.
+		// no, we don't want to change /datum/weather/var/area_type into a list as that requires changing every item that touches weather
+		bonus_areas += V
+	for(var/V in bonus_areas)
+		var/area/A = V
+		if(A.z in impacted_z_levels)
+			impacted_areas |= A
+
+/datum/weather/solar_flare/start()
+	..()
+	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
+	SSsun.solar_gen_rate = 1500 * 40
+
+/datum/weather/solar_flare/weather_act(mob/living/L)
+	L.adjustFireLoss(1)
+	if(prob(10))
+		to_chat(L, "<span class='warning'>The solar flare burns you! Seek shelter!")
+
+/datum/weather/solar_flare/end()
+	if(..())
+		return
+	GLOB.event_announcement.Announce("The solar flare has passed.", "Solar Flare Advisory")
+	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
+	SSsun.solar_gen_rate = 1500

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -46,5 +46,5 @@
 	if(..())
 		return
 	GLOB.event_announcement.Announce("The solar flare has passed.", "Solar Flare Advisory")
-	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
+	// Ends the temporary 40x increase that happened during the weather event
 	SSsun.solar_gen_rate = 1500

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -8,7 +8,7 @@
 	weather_message = "<span class='userdanger'><i>A solar flare has arrived! Find shelter!</i></span>"
 	weather_overlay = "light_ash"
 	weather_duration_lower = 5 MINUTES
-	weather_duration_upper = 15 MINUTES
+	weather_duration_upper = 10 MINUTES
 	weather_color = COLOR_YELLOW
 	weather_sound = 'sound/misc/bloblarm.ogg' // also used by radiation storm and SM
 

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -21,12 +21,10 @@
 
 /datum/weather/solar_flare/generate_area_list()
 	..()
-	var/list/bonus_areas = list()
-	for(var/V in get_areas(/area/solar))
-		// no, solars in space are NOT a subtype of /area/space.
-		// no, we don't want to re-path every reference to all the subtypes of /area/solar across every map file.
-		// no, we don't want to change /datum/weather/var/area_type into a list as that requires changing every item that touches weather
-		bonus_areas += V
+	var/list/bonus_areas = get_areas(/area/solar)
+	// no, solars in space are NOT a subtype of /area/space.
+	// no, we don't want to re-path every reference to all the subtypes of /area/solar across every map file.
+	// no, we don't want to change /datum/weather/var/area_type into a list as that requires changing every item that touches weather
 	for(var/V in bonus_areas)
 		var/area/A = V
 		if(A.z in impacted_z_levels)
@@ -40,7 +38,7 @@
 /datum/weather/solar_flare/weather_act(mob/living/L)
 	L.adjustFireLoss(1)
 	if(prob(10))
-		to_chat(L, "<span class='warning'>The solar flare burns you! Seek shelter!")
+		to_chat(L, "<span class='warning'>The solar flare burns you! Seek shelter!</span>")
 
 /datum/weather/solar_flare/end()
 	if(..())

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -2,14 +2,14 @@
 	name = "solar flare"
 	desc = "An intense blast of light and heat from the sun, affecting all space around the station."
 
-	telegraph_duration = 300 // 30 seconds
+	telegraph_duration = 30 SECONDS
 	telegraph_message = null // handled via event announcement
 
 	weather_message = "<span class='userdanger'><i>A solar flare has arrived! Find shelter!</i></span>"
 	weather_overlay = "light_ash"
-	weather_duration_lower = 3000 // 5-15 minutes
-	weather_duration_upper = 9000
-	weather_color = "#ffff00" // bright yellow
+	weather_duration_lower = 5 MINUTES
+	weather_duration_upper = 15 MINUTES
+	weather_color = COLOR_YELLOW
 	weather_sound = 'sound/misc/bloblarm.ogg' // also used by radiation storm and SM
 
 	end_duration = 10 // wind_down() does not do anything for this event, so we just trigger end() semi-immediately
@@ -35,7 +35,7 @@
 /datum/weather/solar_flare/start()
 	..()
 	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
-	SSsun.solar_gen_rate = 1500 * 40
+	SSsun.solar_gen_rate = initial(SSsun.solar_gen_rate) * 40
 
 /datum/weather/solar_flare/weather_act(mob/living/L)
 	L.adjustFireLoss(1)
@@ -47,4 +47,4 @@
 		return
 	GLOB.event_announcement.Announce("The solar flare has passed.", "Solar Flare Advisory")
 	// Ends the temporary 40x increase that happened during the weather event
-	SSsun.solar_gen_rate = 1500
+	SSsun.solar_gen_rate = initial(SSsun.solar_gen_rate)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -152,6 +152,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				0,		list(ASSIGNMENT_SECURITY = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Vines",				/datum/event/spacevine, 				250,	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_wave,				0,		list(ASSIGNMENT_ENGINEER = 25)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Flare",				/datum/event/solar_flare,				0,		list(ASSIGNMENT_ENGINEER = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meaty Ores",				/datum/event/dust/meaty,				0,		list(ASSIGNMENT_ENGINEER = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	500,	list(ASSIGNMENT_AI = 150, ASSIGNMENT_SECURITY = 120)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				0,		list(ASSIGNMENT_SECURITY = 100)),

--- a/code/modules/events/solarflare.dm
+++ b/code/modules/events/solarflare.dm
@@ -7,7 +7,7 @@
 
 /datum/event/solar_flare/start()
 	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
-	GLOB.solar_gen_rate = 1500 * 40
+	SSsun.solar_gen_rate = 1500 * 40
 
 /datum/event/solar_flare/tick()
 	// Constant burn damage to anyone in space on the station zlevel.
@@ -25,5 +25,5 @@
 			to_chat(L, "<span class='warning'>The solar flare burns you! Seek shelter!")
 
 /datum/event/solar_flare/end()
-	GLOB.solar_gen_rate = 1500
+	SSsun.solar_gen_rate = 1500
 	GLOB.event_announcement.Announce("The solar flare has ended.", "Flare Alert", new_sound = 'sound/AI/attention.ogg')

--- a/code/modules/events/solarflare.dm
+++ b/code/modules/events/solarflare.dm
@@ -1,29 +1,10 @@
 /datum/event/solar_flare
-	startWhen = 10
-	endWhen = 500 // = ~500x2 seconds or ~16m40s
+	startWhen = 2
+	endWhen = 3
+	announceWhen = 1
 
 /datum/event/solar_flare/announce()
-	GLOB.event_announcement.Announce("A solar flare has been detected on collision course with the station.", "Flare Alert", new_sound = 'sound/AI/attention.ogg')
+	GLOB.event_announcement.Announce("A solar flare has been detected on collision course with the station.", "Incoming Solar Flare", 'sound/AI/attention.ogg')
 
 /datum/event/solar_flare/start()
-	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
-	SSsun.solar_gen_rate = 1500 * 40
-
-/datum/event/solar_flare/tick()
-	// Constant burn damage to anyone in space on the station zlevel.
-	// Not instantly fatal (5dmg/10s = 0.5damage/second) but you should go find shelter.
-	if(activeFor % 5 == 0)
-		for(var/mob/living/L in GLOB.alive_mob_list)
-			var/turf/T = get_turf(L)
-			if(!istype(T))
-				continue
-			if(!isspaceturf(T))
-				continue
-			if(!is_station_level(T.z))
-				continue
-			L.adjustFireLoss(5)
-			to_chat(L, "<span class='warning'>The solar flare burns you! Seek shelter!")
-
-/datum/event/solar_flare/end()
-	SSsun.solar_gen_rate = 1500
-	GLOB.event_announcement.Announce("The solar flare has ended.", "Flare Alert", new_sound = 'sound/AI/attention.ogg')
+	SSweather.run_weather(/datum/weather/solar_flare)

--- a/code/modules/events/solarflare.dm
+++ b/code/modules/events/solarflare.dm
@@ -1,0 +1,30 @@
+/datum/event/solar_flare
+	startWhen = 10
+	endWhen = 500 // = ~500x2 seconds or ~16m40s
+
+/datum/event/solar_flare/announce()
+	GLOB.event_announcement.Announce("A solar flare has been detected on collision course with the station.", "Flare Alert", new_sound = 'sound/AI/attention.ogg')
+
+//meteor showers are lighter and more common,
+/datum/event/solar_flare/start()
+	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
+	GLOB.solar_gen_rate = 1500 * 40
+
+/datum/event/solar_flare/tick()
+	// Constant burn damage to anyone in space on the station zlevel.
+	// Not instantly fatal (5dmg/10s = 0.5damage/second) but you should go find shelter.
+	if(activeFor % 5 == 0)
+		for(var/mob/living/L in GLOB.alive_mob_list)
+			var/turf/T = get_turf(L)
+			if(!istype(T))
+				continue
+			if(!isspaceturf(T))
+				continue
+			if(!is_station_level(T.z))
+				continue
+			L.adjustFireLoss(5)
+			to_chat(L, "<span class='warning'>The solar flare burns you! Seek shelter!")
+
+/datum/event/solar_flare/end()
+	GLOB.solar_gen_rate = 1500
+	GLOB.event_announcement.Announce("The solar flare has ended.", "Flare Alert", new_sound = 'sound/AI/attention.ogg')

--- a/code/modules/events/solarflare.dm
+++ b/code/modules/events/solarflare.dm
@@ -5,7 +5,6 @@
 /datum/event/solar_flare/announce()
 	GLOB.event_announcement.Announce("A solar flare has been detected on collision course with the station.", "Flare Alert", new_sound = 'sound/AI/attention.ogg')
 
-//meteor showers are lighter and more common,
 /datum/event/solar_flare/start()
 	// Solars produce 40x as much power. 240KW becomes 9.6MW. Enough to cause APCs to arc all over the station if >=2 solars are hotwired.
 	GLOB.solar_gen_rate = 1500 * 40

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1195,8 +1195,14 @@
 			charging = 0
 			chargecount = 0
 
-		if(excess >= 5000000 && !shock_proof) //If there's more than 5,000,000 watts in the grid, start arcing and shocking people.
-			if(prob(5))
+		if(excess >= 2500000 && !shock_proof)
+			var/shock_chance = 5 // 5%
+			if(excess >= 5000000)
+				if(excess >= 7500000)
+					shock_chance = 15
+				else
+					shock_chance = 10
+			if(prob(shock_chance))
 				var/list/shock_mobs = list()
 				for(var/C in view(get_turf(src), 5)) //We only want to shock a single random mob in range, not every one.
 					if(isliving(C))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1197,11 +1197,10 @@
 
 		if(excess >= 2500000 && !shock_proof)
 			var/shock_chance = 5 // 5%
-			if(excess >= 5000000)
-				if(excess >= 7500000)
-					shock_chance = 15
-				else
-					shock_chance = 10
+			if(excess >= 7500000)
+				shock_chance = 15
+			else if(excess >= 5000000)
+				shock_chance = 10
 			if(prob(shock_chance))
 				var/list/shock_mobs = list()
 				for(var/C in view(get_turf(src), 5)) //We only want to shock a single random mob in range, not every one.

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -1,7 +1,5 @@
 #define SOLAR_MAX_DIST 40
 
-GLOBAL_VAR_INIT(solar_gen_rate, 1500)
-
 /obj/machinery/power/solar
 	name = "solar panel"
 	desc = "A solar panel. Generates electricity when in contact with sunlight."
@@ -132,7 +130,7 @@ GLOBAL_VAR_INIT(solar_gen_rate, 1500)
 		if(powernet == control.powernet)//check if the panel is still connected to the computer
 			if(obscured) //get no light from the sun, so don't generate power
 				return
-			var/sgen = GLOB.solar_gen_rate * sunfrac
+			var/sgen = SSsun.solar_gen_rate * sunfrac
 			add_avail(sgen)
 			control.gen += sgen
 		else //if we're no longer on the same powernet, remove from control computer
@@ -380,7 +378,7 @@ GLOBAL_VAR_INIT(solar_gen_rate, 1500)
 /obj/machinery/power/solar_control/tgui_data(mob/user)
 	var/list/data = list()
 	data["generated"] = round(lastgen) //generated power by all connected panels
-	data["generated_ratio"] = data["generated"] / round(max(connected_panels.len, 1) * GLOB.solar_gen_rate) //power generation ratio. Used for the power bar
+	data["generated_ratio"] = data["generated"] / round(max(connected_panels.len, 1) * SSsun.solar_gen_rate) //power generation ratio. Used for the power bar
 	data["direction"] = angle2text(cdir)	//current orientation of the panels
 	data["cdir"] = cdir	//current orientation of the of the panels in degrees
 	data["tracking_state"] = track	//tracker status: TRACKER_OFF, TRACKER_TIMED, TRACKER_AUTO

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -1,5 +1,6 @@
 #define SOLAR_MAX_DIST 40
-#define SOLARGENRATE 1500
+
+GLOBAL_VAR_INIT(solar_gen_rate, 1500)
 
 /obj/machinery/power/solar
 	name = "solar panel"
@@ -131,7 +132,7 @@
 		if(powernet == control.powernet)//check if the panel is still connected to the computer
 			if(obscured) //get no light from the sun, so don't generate power
 				return
-			var/sgen = SOLARGENRATE * sunfrac
+			var/sgen = GLOB.solar_gen_rate * sunfrac
 			add_avail(sgen)
 			control.gen += sgen
 		else //if we're no longer on the same powernet, remove from control computer
@@ -379,7 +380,7 @@
 /obj/machinery/power/solar_control/tgui_data(mob/user)
 	var/list/data = list()
 	data["generated"] = round(lastgen) //generated power by all connected panels
-	data["generated_ratio"] = data["generated"] / round(max(connected_panels.len, 1) * SOLARGENRATE) //power generation ratio. Used for the power bar
+	data["generated_ratio"] = data["generated"] / round(max(connected_panels.len, 1) * GLOB.solar_gen_rate) //power generation ratio. Used for the power bar
 	data["direction"] = angle2text(cdir)	//current orientation of the panels
 	data["cdir"] = cdir	//current orientation of the of the panels in degrees
 	data["tracking_state"] = track	//tracker status: TRACKER_OFF, TRACKER_TIMED, TRACKER_AUTO

--- a/paradise.dme
+++ b/paradise.dme
@@ -1475,6 +1475,7 @@
 #include "code\modules\events\rogue_drones.dm"
 #include "code\modules\events\sentience.dm"
 #include "code\modules\events\slaughterevent.dm"
+#include "code\modules\events\solarflare.dm"
 #include "code\modules\events\spacevine.dm"
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spider_terror.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -435,6 +435,7 @@
 #include "code\datums\weather\weather_types\floor_is_lava.dm"
 #include "code\datums\weather\weather_types\radiation_storm.dm"
 #include "code\datums\weather\weather_types\snow_storm.dm"
+#include "code\datums\weather\weather_types\solar_flare.dm"
 #include "code\datums\wires\airlock.dm"
 #include "code\datums\wires\alarm.dm"
 #include "code\datums\wires\apc.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds the medium event "Solar Flare".
The event lasts 5-15 minutes, and has two effects:
- Everyone located in the space around the station takes 1 burn damage per second they are in space.
- Solars produce 40x as much power as normal.

The first one is a mixed blessing. It can kill off huge carp swarms, but it can also make space travel around the station very dangerous.

The second one is also a mixed blessing. If you have solars set up correctly, you can fill up your SMES very fast. If, on the other hand, you have violated every safety protocol, and hotwired the solars directly into the powergrid... suddenly there's 9MW of power in the grid and APCs start spitting lightning all over the station.

Secondly, it re-scales the shock chance of APCs.
- It used to be a flat 5% if there was >=5M power in the grid.
- Now its 5% between 2.5M and 5.0M, 10% between 5.0M and 7.5M, and 15% over 7.5M power in the grid. 

## Why It's Good For The Game
- Provides a disincentive against just hotwiring the solars and running the entire shift on a risk-free engine that can never cause any problems.
- Provides an extra incentive for people to learn to use the upcoming SM, instead of just always relying on solars.
- Occasionally makes spacewalks more dangerous.
- Makes overcharging the grid significantly more dangerous - an actual hazard, not just a mild annoyance. It also has a gradual transition from "annoyance" to "really dangerous" instead of just being binary on/off.

## Images
Kentucky Fried Cargotech:
![cargo_tech_bbq](https://user-images.githubusercontent.com/16434066/93977063-75ebc300-fd69-11ea-8d1a-99685ec03ba5.png)
For full effect, imagine screams of "LET ME IN!!!".

## Changelog
:cl: Kyep
add: Added Solar Flares, a new medium event which makes space more dangerous and provides a disincentive against hotwiring solars.
/:cl: