### PR TITLE
Gives better feedback to the AI when opening doors from chat. Fixes a runtime

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -846,12 +846,14 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/open_close(mob/user)
 	if(welded)
 		to_chat(user, "<span class='warning'>The airlock has been welded shut!</span>")
+		return FALSE
 	else if(locked)
 		to_chat(user, "<span class='warning'>The door bolts are down!</span>")
+		return FALSE
 	else if(density)
-		open()
+		return open()
 	else
-		close()
+		return close()
 
 /obj/machinery/door/airlock/proc/toggle_light(mob/user)
 	if(wires.is_cut(WIRE_BOLT_LIGHT))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1332,8 +1332,10 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		if(istype(A))
 			switch(alert(src, "Do you want to open \the [A] for [target]?", "Doorknob_v2a.exe", "Yes", "No"))
 				if("Yes")
-					A.AIShiftClick()
-					to_chat(src, "<span class='notice'>You open \the [A] for [target].</span>")
+					if(!A.density)
+						to_chat(src, "<span class='notice'>[A] was already opened.</span>")
+					else if(A.open_close(src))
+						to_chat(src, "<span class='notice'>You open \the [A] for [target].</span>")
 				else
 					to_chat(src, "<span class='warning'>You deny the request.</span>")
 		else


### PR DESCRIPTION
## What Does This PR Do
Gives the AI better feedback when opening doors from the chat. When they actually open a door and when it's bolted and the like.
Fixes a bug where a bolted door would result in a runtime due to the user not being passed.
```
[2020-09-21T10:58:47] Runtime in ,: DEBUG: to_chat called with invalid message/target.
[2020-09-21T10:58:47]   Message: '<span class='warning'>The door bolts are down!</span>'
[2020-09-21T10:58:47]   Target: ''
[2020-09-21T10:58:47]   usr: NAME (ckey) (/mob/living/silicon/ai)
[2020-09-21T10:58:47]   usr.loc: The floor (143,23,1) (/turf/simulated/floor/bluegrid)
```

## Why It's Good For The Game
Better feedback for the AI when opening doors from the chat.
Bug fix b gut

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/93780767-d7f0df00-fc28-11ea-8422-b8d1e7521671.png)


## Changelog
:cl:
tweak: The AI will now get feedback when a door is already opened for somebody when they try to open the door via chat
fix: An AI trying to open a bolted door now won't tell the AI that it succeeded.
fix: An AI trying to open a bolted door via chat now won't result in a runtime with no feedback
/:cl: