### PR TITLE
Silicons can't interact with emagged or AI wire cut airlocks anymore through shortcuts

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -194,15 +194,27 @@
 // AIRLOCKS
 
 /obj/machinery/door/airlock/AIAltShiftClick(mob/user)  // Sets/Unsets Emergency Access Override
+	if(emagged)
+		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+		return
 	toggle_emergency_status(user)
 
 /obj/machinery/door/airlock/AIShiftClick(mob/user)  // Opens and closes doors!
+	if(emagged)
+		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+		return
 	open_close(user)
 
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
+	if(emagged)
+		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+		return
 	toggle_bolt(user)
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
+	if(emagged)
+		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+		return
 	if(wires.is_cut(WIRE_ELECTRIFY))
 		to_chat(user, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
 	if(isElectrified())
@@ -212,6 +224,9 @@
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.
+	if(emagged)
+		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+		return
 	toggle_light(user)
 
 // FIRE ALARMS

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -194,26 +194,22 @@
 // AIRLOCKS
 
 /obj/machinery/door/airlock/AIAltShiftClick(mob/user)  // Sets/Unsets Emergency Access Override
-	if(emagged)
-		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+	if(!ai_control_check(user))
 		return
 	toggle_emergency_status(user)
 
 /obj/machinery/door/airlock/AIShiftClick(mob/user)  // Opens and closes doors!
-	if(emagged)
-		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+	if(!ai_control_check(user))
 		return
 	open_close(user)
 
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
-	if(emagged)
-		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+	if(!ai_control_check(user))
 		return
 	toggle_bolt(user)
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
-	if(emagged)
-		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+	if(!ai_control_check(user))
 		return
 	if(wires.is_cut(WIRE_ELECTRIFY))
 		to_chat(user, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
@@ -224,8 +220,7 @@
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.
-	if(emagged)
-		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+	if(!ai_control_check(user))
 		return
 	toggle_light(user)
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -757,6 +757,22 @@ About the new airlock wires panel:
 	else
 		try_to_activate_door(user)
 
+/obj/machinery/door/airlock/proc/ai_control_check(mob/user)
+	if(!issilicon(user))
+		return TRUE
+	if(emagged)
+		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
+		return FALSE
+	if(!canAIControl())
+		if(canAIHack(user))
+			hack(user)
+		else
+			if(isAllPowerLoss())
+				to_chat(user, "<span class='warning'>Unable to interface: Connection timed out.</span>")
+			else
+				to_chat(user, "<span class='warning'>Unable to interface: Connection refused.</span>")
+		return FALSE
+	return TRUE
 
 /obj/machinery/door/airlock/tgui_act(action, params)
 	if(..())
@@ -764,17 +780,7 @@ About the new airlock wires panel:
 	if(!issilicon(usr) && !usr.can_admin_interact())
 		to_chat(usr, "<span class='warning'>Access denied. Only silicons may use this interface.</span>")
 		return
-	if(issilicon(usr) && emagged)
-		to_chat(usr, "<span class='warning'>Unable to interface: Internal error.</span>")
-		return
-	if(!canAIControl() && !isobserver(usr))
-		if(canAIHack(usr))
-			hack(usr)
-		else
-			if(isAllPowerLoss())
-				to_chat(usr, "<span class='warning'>Unable to interface: Connection timed out.</span>")
-			else
-				to_chat(usr, "<span class='warning'>Unable to interface: Connection refused.</span>")
+	if(!ai_control_check(usr))
 		return
 	. = TRUE
 	switch(action)


### PR DESCRIPTION
## What Does This PR Do
As the title says. Bug left over from the silicon interaction refactor

## Why It's Good For The Game
Bug fix

## Changelog
:cl:
fix: Silicons can't interact with emagged doors anymore though shortcuts
fix: Silicons can't interact with AI wire cut doors anymore though shortcuts
/:cl: