### PR TITLE
PR - Gender Update

### DIFF
--- a/code/__DEFINES/dna.dm
+++ b/code/__DEFINES/dna.dm
@@ -55,3 +55,8 @@
 #define DNA_UI_LENGTH		38 // Update this when you add something, or you WILL break shit.
 
 #define DNA_SE_LENGTH 55 // Was STRUCDNASIZE, size 27. 15 new blocks added = 42, plus room to grow.
+
+//Trinary State Values for DNA_UI_GENDER
+#define DNA_GENDER_FEMALE	0
+#define DNA_GENDER_MALE		1
+#define DNA_GENDER_PLURAL	2

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -196,11 +196,11 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 		return
 	var/val = GetUIValue(block)
 	switch(val)
-		if(>= 1395 && <= 2760)
+		if(1395 to 2760)
 			return 0
-		if(>= 1 &&  <= 1395)
+		if(1 to 1395)
 			return 1
-		if(>= 2076 && <= 4095)
+		if(2076 to 4095)
 			return 2
 
 // Set Trinary UI Block State

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -194,16 +194,14 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 /datum/dna/proc/GetUITriState(block)
 	if(block <= 0)
 		return
-	else
-		var/val = GetUIValue(block)
-		if(val >= 1395 && val <= 2760) //female
+	var/val = GetUIValue(block)
+	switch(val)
+		if(>= 1395 && <= 2760)
 			return 0
-		if(val >= 1 && val <= 1395) //male
+		if(>= 1 &&  <= 1395)
 			return 1
-		if(val >= 2076 && val <= 4095) //plural
+		if(>= 2076 && <= 4095)
 			return 2
-		else
-			return
 
 // Set Trinary UI Block State
 /datum/dna/proc/SetUITriState(block, value, defer = FALSE)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -120,17 +120,19 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 
 	SetUIValueRange(DNA_UI_SKIN_TONE,	35-character.s_tone,	220,	1) // Value can be negative.
 
-	if(character.gender == MALE)
-		SetUITriState(DNA_UI_GENDER, 1, 1)
-	if(character.gender == FEMALE)
-		SetUITriState(DNA_UI_GENDER, 0, 1)
-	if(character.gender == PLURAL)
-		SetUITriState(DNA_UI_GENDER, 2, 1)
-
 	/*SetUIValueRange(DNA_UI_BACC_STYLE,	bodyacc,	GLOB.facial_hair_styles_list.len,	1)*/
 	SetUIValueRange(DNA_UI_HEAD_MARK_STYLE,	head_marks,		GLOB.marking_styles_list.len,		1)
 	SetUIValueRange(DNA_UI_BODY_MARK_STYLE,	body_marks,		GLOB.marking_styles_list.len,		1)
 	SetUIValueRange(DNA_UI_TAIL_MARK_STYLE,	tail_marks,		GLOB.marking_styles_list.len,		1)
+
+	//Set the Gender
+	switch(character.gender)
+		if(FEMALE)
+			SetUITriState(DNA_UI_GENDER, DNA_GENDER_FEMALE, 1)
+		if(MALE)
+			SetUITriState(DNA_UI_GENDER, DNA_GENDER_MALE, 1)
+		if(PLURAL)
+			SetUITriState(DNA_UI_GENDER, DNA_GENDER_PLURAL, 1)
 
 
 	UpdateUI()
@@ -197,11 +199,11 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	var/val = GetUIValue(block)
 	switch(val)
 		if(1395 to 2760)
-			return 0
+			return DNA_GENDER_FEMALE
 		if(1 to 1395)
-			return 1
+			return DNA_GENDER_MALE
 		if(2076 to 4095)
-			return 2
+			return DNA_GENDER_PLURAL
 
 // Set Trinary UI Block State
 /datum/dna/proc/SetUITriState(block, value, defer = FALSE)
@@ -211,11 +213,11 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	ASSERT(value <= 2)
 	var/val
 	switch(value)
-		if(0)
+		if(DNA_GENDER_FEMALE)
 			val = rand(1395, 2760)
-		if(1)
+		if(DNA_GENDER_MALE)
 			val = rand(1, 1395)
-		if(2) //plural
+		if(DNA_GENDER_PLURAL)
 			val = rand(2760,4095)
 		else
 			val = rand(1, 4095)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -211,9 +211,9 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	ASSERT(value <= 2)
 	var/val
 	switch(value)
-		if(0) //female
+		if(0)
 			val = rand(1395, 2760)
-		if(1) //male
+		if(1)
 			val = rand(1, 1395)
 		if(2) //plural
 			val = rand(2760,4095)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -85,7 +85,6 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	// FIXME:  Species-specific defaults pls
 	var/obj/item/organ/external/head/H = character.get_organ("head")
 	var/obj/item/organ/internal/eyes/eyes_organ = character.get_int_organ(/obj/item/organ/internal/eyes)
-	var/datum/species/S = character.dna.species
 
 	/*// Body Accessory
 	if(!character.body_accessory)
@@ -121,10 +120,12 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 
 	SetUIValueRange(DNA_UI_SKIN_TONE,	35-character.s_tone,	220,	1) // Value can be negative.
 
-	if(S.has_gender)
-		SetUIState(DNA_UI_GENDER, character.gender!=MALE, 1)
-	else
-		SetUIState(DNA_UI_GENDER, pick(0,1), 1)
+	if(character.gender == MALE)
+		SetUITriState(DNA_UI_GENDER, 1, 1)
+	if(character.gender == FEMALE)
+		SetUITriState(DNA_UI_GENDER, 0, 1)
+	if(character.gender == PLURAL)
+		SetUITriState(DNA_UI_GENDER, 2, 1)
 
 	/*SetUIValueRange(DNA_UI_BACC_STYLE,	bodyacc,	GLOB.facial_hair_styles_list.len,	1)*/
 	SetUIValueRange(DNA_UI_HEAD_MARK_STYLE,	head_marks,		GLOB.marking_styles_list.len,		1)
@@ -188,6 +189,40 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	else
 		val=rand(1, 2049)
 	SetUIValue(block, val, defer)
+
+//Get Tri State Block State
+/datum/dna/proc/GetUITriState(block)
+	if(block <= 0)
+		return
+	else
+		var/val = GetUIValue(block)
+		if(val >= 1395 && val <= 2760) //female
+			return 0
+		if(val >= 1 && val <= 1395) //male
+			return 1
+		if(val >= 2076 && val <= 4095) //plural
+			return 2
+		else
+			return
+
+// Set Trinary UI Block State
+/datum/dna/proc/SetUITriState(block, value, defer = FALSE)
+	if(block <= 0)
+		return
+	ASSERT(value >= 0)
+	ASSERT(value <= 2)
+	var/val
+	switch(value)
+		if(0) //female
+			val = rand(1395, 2760)
+		if(1) //male
+			val = rand(1, 1395)
+		if(2) //plural
+			val = rand(2760,4095)
+		else
+			val = rand(1, 4095)
+	SetUIValue(block, val, defer)
+
 
 // Get a hex-encoded UI block.
 /datum/dna/proc/GetUIBlock(block)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -198,12 +198,12 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 		return
 	var/val = GetUIValue(block)
 	switch(val)
-		if(1395 to 2760)
-			return DNA_GENDER_FEMALE
 		if(1 to 1395)
-			return DNA_GENDER_MALE
-		if(2076 to 4095)
-			return DNA_GENDER_PLURAL
+			return 0
+		if(1396 to 2760)
+			return 1
+		if(2761 to 4095)
+			return 2
 
 // Set Trinary UI Block State
 /datum/dna/proc/SetUITriState(block, value, defer = FALSE)
@@ -213,14 +213,12 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	ASSERT(value <= 2)
 	var/val
 	switch(value)
-		if(DNA_GENDER_FEMALE)
-			val = rand(1395, 2760)
-		if(DNA_GENDER_MALE)
+		if(0)
 			val = rand(1, 1395)
-		if(DNA_GENDER_PLURAL)
-			val = rand(2760,4095)
-		else
-			val = rand(1, 4095)
+		if(1)
+			val = rand(1396, 2760)
+		if(2)
+			val = rand(2761, 4095)
 	SetUIValue(block, val, defer)
 
 

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -151,11 +151,11 @@
 		H.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
 
 		switch(dna.GetUITriState(DNA_UI_GENDER))
-			if(0)
+			if(DNA_GENDER_FEMALE)
 				H.change_gender(FEMALE, FALSE)
-			if(1)
+			if(DNA_GENDER_MALE)
 				H.change_gender(MALE, FALSE)
-			if(2)
+			if(DNA_GENDER_PLURAL)
 				H.change_gender(PLURAL, FALSE)
 
 		//Head Markings

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -136,7 +136,6 @@
 		var/mob/living/carbon/human/H = src
 		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
 		var/obj/item/organ/internal/eyes/eye_organ = H.get_int_organ(/obj/item/organ/internal/eyes)
-		var/datum/species/S = H.dna.species
 		if(istype(head_organ))
 			dna.write_head_attributes(head_organ)
 		if(istype(eye_organ))
@@ -151,11 +150,13 @@
 
 		H.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
 
-		if(S.has_gender)
-			if(dna.GetUIState(DNA_UI_GENDER))
-				H.change_gender(FEMALE, 0)
-			else
+		switch(dna.GetUITriState(DNA_UI_GENDER))
+			if(0)
+				H.change_gender(FEMALE,0)
+			if(1)
 				H.change_gender(MALE, 0)
+			if(2)
+				H.change_gender(PLURAL, 0)
 
 		//Head Markings
 		var/head_marks = dna.GetUIValueRange(DNA_UI_HEAD_MARK_STYLE, GLOB.marking_styles_list.len)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -152,11 +152,11 @@
 
 		switch(dna.GetUITriState(DNA_UI_GENDER))
 			if(0)
-				H.change_gender(FEMALE,0)
+				H.change_gender(FEMALE, FALSE)
 			if(1)
-				H.change_gender(MALE, 0)
+				H.change_gender(MALE, FALSE)
 			if(2)
-				H.change_gender(PLURAL, 0)
+				H.change_gender(PLURAL, FALSE)
 
 		//Head Markings
 		var/head_marks = dna.GetUIValueRange(DNA_UI_HEAD_MARK_STYLE, GLOB.marking_styles_list.len)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -43,7 +43,7 @@
 	if(buf.types & DNA2_BUF_SE)
 		return buf.dna.GetSEState(real_block)
 	else
-		return buf.dna.GetUITriState(real_block)
+		return buf.dna.GetUIState(real_block)
 
 /obj/item/dnainjector/proc/SetState(on, selblock = 0)
 	var/real_block = GetRealBlock(selblock)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -43,7 +43,7 @@
 	if(buf.types & DNA2_BUF_SE)
 		return buf.dna.GetSEState(real_block)
 	else
-		return buf.dna.GetUIState(real_block)
+		return buf.dna.GetUITriState(real_block)
 
 /obj/item/dnainjector/proc/SetState(on, selblock = 0)
 	var/real_block = GetRealBlock(selblock)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1291,7 +1291,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	var/skeleton = (SKELETON in mutations)
 	var/g = dna.GetUITriState(DNA_UI_GENDER)
 	if(g == 2)
-		g = pick(0,1)
+		g = 0
 		
 	. = ""
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1290,9 +1290,9 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	var/hulk = (HULK in mutations)
 	var/skeleton = (SKELETON in mutations)
 	var/g = dna.GetUITriState(DNA_UI_GENDER)
-	if(g == 2)
-		g = 0
-		
+	if(g == DNA_GENDER_PLURAL)
+		g = DNA_GENDER_FEMALE
+
 	. = ""
 
 	var/obj/item/organ/internal/eyes/eyes = get_int_organ(/obj/item/organ/internal/eyes)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1317,8 +1317,11 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(part)
 			var/datum/species/S = GLOB.all_species[part.dna.species.name]
 			. += "[S.race_key]"
-			. += "[part.dna.GetUIState(DNA_UI_GENDER)]"
 			. += "[part.dna.GetUIValue(DNA_UI_SKIN_TONE)]"
+			if(part.dna.GetUITriState(DNA_UI_GENDER) ==2)
+				. += "[pick(0,1)]"
+			else
+				. += "[part.dna.GetUITriState(DNA_UI_GENDER)]"
 			if(part.s_col)
 				. += "[part.s_col]"
 			if(part.s_tone)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1289,7 +1289,10 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	var/husk = (HUSK in mutations)
 	var/hulk = (HULK in mutations)
 	var/skeleton = (SKELETON in mutations)
-
+	var/g = dna.GetUITriState(DNA_UI_GENDER)
+	if(g == 2)
+		g = pick(0,1)
+		
 	. = ""
 
 	var/obj/item/organ/internal/eyes/eyes = get_int_organ(/obj/item/organ/internal/eyes)
@@ -1318,10 +1321,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			var/datum/species/S = GLOB.all_species[part.dna.species.name]
 			. += "[S.race_key]"
 			. += "[part.dna.GetUIValue(DNA_UI_SKIN_TONE)]"
-			if(part.dna.GetUITriState(DNA_UI_GENDER) ==2)
-				. += "[pick(0,1)]"
-			else
-				. += "[part.dna.GetUITriState(DNA_UI_GENDER)]"
+			. += "[g]"
 			if(part.s_col)
 				. += "[part.s_col]"
 			if(part.s_tone)

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 				if(1)
 					gender ="m"
 				else
-					gender = pick("f", "m")
+					gender = "f"
 		if(limb_name == "head")
 			var/obj/item/organ/external/head/head_organ = src
 			head_organ.handle_alt_icon()

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -162,10 +162,13 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 		new_icon_state = "[icon_name][gendered_icon ? "_f" : ""]"
 	else
 		if(gendered_icon)
-			if(dna.GetUIState(DNA_UI_GENDER))
-				gender = "f"
-			else
-				gender = "m"
+			switch(dna.GetUITriState(DNA_UI_GENDER))
+				if(0)
+					gender ="f"
+				if(1)
+					gender ="m"
+				else
+					gender = pick("f", "m")
 		if(limb_name == "head")
 			var/obj/item/organ/external/head/head_organ = src
 			head_organ.handle_alt_icon()

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -163,12 +163,12 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 	else
 		if(gendered_icon)
 			switch(dna.GetUITriState(DNA_UI_GENDER))
-				if(0)
+				if(DNA_GENDER_FEMALE)
 					gender = "f"
-				if(1)
+				if(DNA_GENDER_MALE)
 					gender = "m"
 				else
-					gender = "f"
+					gender = "f"	//Default to "f" (per line 162). Using a pick("m", "f") will make different body parts different genders for the same character.
 		if(limb_name == "head")
 			var/obj/item/organ/external/head/head_organ = src
 			head_organ.handle_alt_icon()

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -164,9 +164,9 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 		if(gendered_icon)
 			switch(dna.GetUITriState(DNA_UI_GENDER))
 				if(0)
-					gender ="f"
+					gender = "f"
 				if(1)
-					gender ="m"
+					gender = "m"
 				else
 					gender = "f"
 		if(limb_name == "head")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the DNA's Gender state three values instead of two. 

Not sure why a binary state for gender existed in the DNA code since it could have easily been scripted otherwise. Now see the **trinary** state for gender - IPCs, rejoice!
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This allows clones of tri-gendered species to properly carry their genders over to new bodies (e.g. Greys, Drask, etc.). It also makes it so tri-gendered species can store their gender _on_ the DNA. I mean, why wouldn't you want it there? That's where it is for bi-gendered species.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: GetUITriState(), SetUITriState()
tweak: Replace the GetUIState() -- only ever used for gender -- instances with GetUITriState() coding. Proofed for bi-gendered species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
