### PR TITLE
Update hoslaser objective text

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -43,7 +43,7 @@
 	protected_jobs = list("Captain")
 
 /datum/theft_objective/hoslaser
-	name = "the head of security's recreated antique laser gun"
+	name = "the head of security's X-01 multiphase energy gun"
 	typepath = /obj/item/gun/energy/gun/hos
 	protected_jobs = list("Head Of Security")
 


### PR DESCRIPTION
## What Does This PR Do
Changes the objective text when stealing the HOS' laser from:
"the head of security's recreated antique laser gun"
to:
"the head of security's X-01 multiphase energy gun"

## Why It's Good For The Game
Yes, apparently we do actually get ahelps where players confuse "recreated antique laser gun" with the captain's antique lasergun.
Even ignoring those, though, it just makes more sense for the objective text to use the actual name of the item. It is much clearer.

## Changelog
:cl: Kyep
tweak: clarified exactly which gun the HOS laser theft objective is talking about.
/:cl: