### PR TITLE
Fixes issues with wizards refunding spells

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -80,7 +80,7 @@
 			user.mind.spell_list.Remove(aspell)
 			qdel(aspell)
 			if(S) //If we created a temporary spell above, delete it now.
-				qdel(S)
+				QDEL_NULL(S)
 			return cost * (spell_levels + 1)
 	return -1
 


### PR DESCRIPTION
## What Does This PR Do
Dereferences the temporary spell used so a new one will be made when buying the spell again instead of the qdelled one.
Fixes the duping of spell points. Makes refunded spells usable again when rebuying them.

Fixes #14411

## Why It's Good For The Game
Fixes an exploit and other weirdness with refunding

## Changelog
:cl:
fix: You can't dupe wizard spell points anymore
fix: Refunding spells and then buying them again works now
/:cl: