### PR TITLE
Fixes meteor sat emag oversight and cleans event code a bit

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -40,7 +40,7 @@ SUBSYSTEM_DEF(events)
 		var/datum/event_container/EC = event_containers[i]
 		EC.process()
 
-/datum/controller/subsystem/events/proc/event_complete(var/datum/event/E)
+/datum/controller/subsystem/events/proc/event_complete(datum/event/E)
 	if(!E.event_meta)	// datum/event is used here and there for random reasons, maintaining "backwards compatibility"
 		log_debug("Event of '[E.type]' with missing meta-data has completed.")
 		return
@@ -65,11 +65,11 @@ SUBSYSTEM_DEF(events)
 
 	log_debug("Event '[EM.name]' has completed at [station_time_timestamp()].")
 
-/datum/controller/subsystem/events/proc/delay_events(var/severity, var/delay)
+/datum/controller/subsystem/events/proc/delay_events(severity, delay)
 	var/datum/event_container/EC = event_containers[severity]
 	EC.next_event_time += delay
 
-/datum/controller/subsystem/events/proc/Interact(var/mob/living/user)
+/datum/controller/subsystem/events/proc/Interact(mob/living/user)
 
 	var/html = GetInteractWindow()
 
@@ -113,7 +113,7 @@ SUBSYSTEM_DEF(events)
 			html += "<td>[EM.name]</td>"
 			html += "<td><A align='right' href='?src=[UID()];set_weight=\ref[EM]'>[EM.weight]</A></td>"
 			html += "<td>[EM.min_weight]</td>"
-			html += "<td>[EM.max_weight]</td>"
+			html += "<td>[EM.max_weight == INFINITY ? "No max" : EM.max_weight]</td>"
 			html += "<td><A align='right' href='?src=[UID()];toggle_oneshot=\ref[EM]'>[EM.one_shot]</A></td>"
 			html += "<td><A align='right' href='?src=[UID()];toggle_enabled=\ref[EM]'>[EM.enabled]</A></td>"
 			html += "<td><span class='alert'>[EM.get_weight(number_active_with_role())]</span></td>"

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -63,13 +63,13 @@
 	/// How long the event has existed. You don't need to change this.
 	var/activeFor		= 0
 	/// If this event is currently running. You should not change this.
-	var/isRunning		= 1
+	var/isRunning		= TRUE
 	/// When this event started.
 	var/startedAt		= 0
 	/// When this event ended.
 	var/endedAt			= 0
 	/// Does the event end automatically after endWhen passes?
-	var/noAutoEnd       = 0
+	var/noAutoEnd       = FALSE
 	/// The area the event will hit
 	var/area/impact_area
 	var/datum/event_meta/event_meta = null
@@ -145,14 +145,14 @@
 		tick()
 
 	if(activeFor == startWhen)
-		isRunning = 1
+		isRunning = TRUE
 		start()
 
 	if(activeFor == announceWhen)
 		announce()
 
 	if(activeFor == endWhen && !noAutoEnd)
-		isRunning = 0
+		isRunning = FALSE
 		end()
 
 	// Everything is done, let's clean up.
@@ -167,7 +167,7 @@
 /datum/event/proc/kill()
 	// If this event was forcefully killed run end() for individual cleanup
 	if(isRunning)
-		isRunning = 0
+		isRunning = FALSE
 		end()
 
 	endedAt = world.time

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -5,11 +5,12 @@
 	var/min_weight	= 0 // The minimum weight that this event will have. Only used if non-zero.
 	var/max_weight	= 0 // The maximum weight that this event will have. Only use if non-zero.
 	var/severity 	= 0 // The current severity of this event
-	var/one_shot	= 0	//If true, then the event will not be re-added to the list of available events
+	var/one_shot	= 0	// If true, then the event will not be re-added to the list of available events
+	var/weight_mod	= 1	// A modifier applied to all event weights (role or base), respects min and max
 	var/list/role_weights = list()
 	var/datum/event/event_type
 
-/datum/event_meta/New(var/event_severity, var/event_name, var/datum/event/type, var/event_weight, var/list/job_weights, var/is_one_shot = 0, var/min_event_weight = 0, var/max_event_weight = 0)
+/datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = 0, min_event_weight = 0, max_event_weight = INFINITY)
 	name = event_name
 	severity = event_severity
 	event_type = type
@@ -20,7 +21,7 @@
 	if(job_weights)
 		role_weights = job_weights
 
-/datum/event_meta/proc/get_weight(var/list/active_with_role)
+/datum/event_meta/proc/get_weight(list/active_with_role)
 	if(!enabled)
 		return 0
 
@@ -29,15 +30,9 @@
 		if(role in active_with_role)
 			job_weight += active_with_role[role] * role_weights[role]
 
-	var/total_weight = weight + job_weight
+	return clamp((weight + job_weight) * weight_mod, min_weight, max_weight)
 
-	// Only min/max the weight if the values are non-zero
-	if(min_weight && total_weight < min_weight) total_weight = min_weight
-	if(max_weight && total_weight > max_weight) total_weight = max_weight
-
-	return total_weight
-
-/datum/event_meta/alien/get_weight(var/list/active_with_role)
+/datum/event_meta/alien/get_weight(list/active_with_role)
 	if(GLOB.aliens_allowed)
 		return ..(active_with_role)
 	return 0

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -1,12 +1,20 @@
 /datum/event_meta
 	var/name 		= ""
-	var/enabled 	= TRUE	// Whether or not the event is available for random selection at all
-	var/weight		// The base weight of this event. A zero means it may never fire, but see get_weight()
-	var/min_weight	// The minimum weight that this event will have. Only used if non-zero.
-	var/max_weight	// The maximum weight that this event will have.
-	var/severity	// The current severity of this event
-	var/one_shot	// If true, then the event will not be re-added to the list of available events
-	var/weight_mod	= 1	// A modifier applied to all event weights (role or base), respects min and max
+	/// Whether or not the event is available for random selection at all.
+	var/enabled 	= TRUE
+	/// The base weight of this event. A zero means it may never fire, but see get_weight()
+	var/weight
+	/// The minimum weight that this event will have. Only used if non-zero.
+	var/min_weight
+	/// The maximum weight that this event will have.
+	var/max_weight
+	/// the current severity of this event
+	var/severity
+	/// If true, then the event will not be re-added to the list of available events
+	var/one_shot
+	/// A modifier applied to all event weights (role and base), respects min and max
+	var/weight_mod	= 1
+	/// A list of roles that add weight to the event
 	var/list/role_weights = list()
 	var/datum/event/event_type
 
@@ -44,62 +52,91 @@
 
 /datum/event	//NOTE: Times are measured in master controller ticks!
 	var/processing = 1
-	var/startWhen		= 0	//When in the lifetime to call start().
-	var/announceWhen	= 0	//When in the lifetime to call announce().
-	var/endWhen			= 0	//When in the lifetime the event should end.
-
-	var/severity		= 0 //Severity. Lower means less severe, higher means more severe. Does not have to be supported. Is set on New().
-	var/activeFor		= 0	//How long the event has existed. You don't need to change this.
-	var/isRunning		= 1 //If this event is currently running. You should not change this.
-	var/startedAt		= 0 //When this event started.
-	var/endedAt			= 0 //When this event ended.
-	var/noAutoEnd       = 0 //Does the event end automatically after endWhen passes?
-	var/area/impact_area    //The area the event will hit
+	/// When in the lifetime to call start().
+	var/startWhen		= 0
+	/// When in the lifetime to call announce().
+	var/announceWhen	= 0
+	/// When in the lifetime the event should end.
+	var/endWhen			= 0
+	/// Severity. Lower means less severe, higher means more severe. Does not have to be supported. Is set on New().
+	var/severity		= 0
+	/// How long the event has existed. You don't need to change this.
+	var/activeFor		= 0
+	/// If this event is currently running. You should not change this.
+	var/isRunning		= 1
+	/// When this event started.
+	var/startedAt		= 0
+	/// When this event ended.
+	var/endedAt			= 0
+	/// Does the event end automatically after endWhen passes?
+	var/noAutoEnd       = 0
+	/// The area the event will hit
+	var/area/impact_area
 	var/datum/event_meta/event_meta = null
 
 /datum/event/nothing
 
-//Called first before processing.
-//Allows you to setup your event, such as randomly
-//setting the startWhen and or announceWhen variables.
-//Only called once.
+/**
+  * Called first before processing.
+  *
+  * Allows you to setup your event, such as randomly
+  * setting the startWhen and or announceWhen variables.
+  * Only called once.
+  */
 /datum/event/proc/setup()
 	return
 
-//Called when the tick is equal to the startWhen variable.
-//Allows you to start before announcing or vice versa.
-//Only called once.
+/**
+  * Called when the tick is equal to the startWhen variable.
+  *
+  * Allows you to start before announcing or vice versa.
+  * Only called once.
+  */
 /datum/event/proc/start()
 	return
 
-//Called when the tick is equal to the announceWhen variable.
-//Allows you to announce before starting or vice versa.
-//Only called once.
+/**
+  * Called when the tick is equal to the announceWhen variable.
+  *
+  * Allows you to announce before starting or vice versa.
+  * Only called once.
+  */
 /datum/event/proc/announce()
 	return
 
-//Called on or after the tick counter is equal to startWhen.
-//You can include code related to your event or add your own
-//time stamped events.
-//Called more than once.
+/**
+  * Called on or after the tick counter is equal to startWhen.
+  *
+  * You can include code related to your event or add your own
+  * time stamped events.
+  * Called more than once.
+  */
 /datum/event/proc/tick()
 	return
 
-//Called on or after the tick is equal or more than endWhen
-//You can include code related to the event ending.
-//Do not place spawn() in here, instead use tick() to check for
-//the activeFor variable.
-//For example: if(activeFor == myOwnVariable + 30) doStuff()
-//Only called once.
+/**
+  * Called on or after the tick is equal or more than endWhen
+  *
+  * You can include code related to the event ending.
+  * Do not place spawn() in here, instead use tick() to check for
+  * the activeFor variable.
+  * For example: if(activeFor == myOwnVariable + 30) doStuff()
+  * Only called once.
+  */
 /datum/event/proc/end()
 	return
 
-//Returns the latest point of event processing.
+/**
+  *Returns the latest point of event processing.
+  */
 /datum/event/proc/lastProcessAt()
 	return max(startWhen, max(announceWhen, endWhen))
 
-//Do not override this proc, instead use the appropiate procs.
-//This proc will handle the calls to the appropiate procs.
+/**
+  * Do not override this proc, instead use the appropiate procs.
+  *
+  * This proc will handle the calls to the appropiate procs.
+  */
 /datum/event/process()
 	if(!processing)
 		return
@@ -124,7 +161,9 @@
 
 	activeFor++
 
-//Called when start(), announce() and end() has all been called.
+/**
+  * Called when start(), announce() and end() has all been called.
+  */
 /datum/event/proc/kill()
 	// If this event was forcefully killed run end() for individual cleanup
 	if(isRunning)

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -127,7 +127,7 @@
 	return
 
 /**
-  *Returns the latest point of event processing.
+  * Returns the latest point of event processing.
   */
 /datum/event/proc/lastProcessAt()
 	return max(startWhen, max(announceWhen, endWhen))

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -1,16 +1,16 @@
 /datum/event_meta
 	var/name 		= ""
-	var/enabled 	= 1	// Whether or not the event is available for random selection at all
-	var/weight 		= 0 // The base weight of this event. A zero means it may never fire, but see get_weight()
-	var/min_weight	= 0 // The minimum weight that this event will have. Only used if non-zero.
-	var/max_weight	= 0 // The maximum weight that this event will have. Only use if non-zero.
-	var/severity 	= 0 // The current severity of this event
-	var/one_shot	= 0	// If true, then the event will not be re-added to the list of available events
+	var/enabled 	= TRUE	// Whether or not the event is available for random selection at all
+	var/weight		// The base weight of this event. A zero means it may never fire, but see get_weight()
+	var/min_weight	// The minimum weight that this event will have. Only used if non-zero.
+	var/max_weight	// The maximum weight that this event will have.
+	var/severity	// The current severity of this event
+	var/one_shot	// If true, then the event will not be re-added to the list of available events
 	var/weight_mod	= 1	// A modifier applied to all event weights (role or base), respects min and max
 	var/list/role_weights = list()
 	var/datum/event/event_type
 
-/datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = 0, min_event_weight = 0, max_event_weight = INFINITY)
+/datum/event_meta/New(event_severity, event_name, datum/event/type, event_weight, list/job_weights, is_one_shot = FALSE, min_event_weight = 0, max_event_weight = INFINITY)
 	name = event_name
 	severity = event_severity
 	event_type = type

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 /datum/event_container/mundane
 	severity = EVENT_LEVEL_MUNDANE
 	available_events = list(
-		// Severity level, event name, event type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and not 0.
+		// Severity level, event name, event type, base weight, role weights, one shot, min weight, max weight. Last two only used if set.
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",			/datum/event/nothing,			1100),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",			/datum/event/pda_spam, 			0, 		list(ASSIGNMENT_ANY = 4), FALSE, 25, 50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 		list(ASSIGNMENT_ANY = 1), TRUE, 5,  15),

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -128,11 +128,11 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 /datum/event_container/mundane
 	severity = EVENT_LEVEL_MUNDANE
 	available_events = list(
-		// Severity level, event name, event type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and non-zero
+		// Severity level, event name, event type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and not 0.
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",			/datum/event/nothing,			1100),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",			/datum/event/pda_spam, 			0, 		list(ASSIGNMENT_ANY = 4), 0, 25, 50),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 		list(ASSIGNMENT_ANY = 1), 1, 5,  15),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",		/datum/event/money_hacker, 		0, 		list(ASSIGNMENT_ANY = 4), 1, 10, 25),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",			/datum/event/pda_spam, 			0, 		list(ASSIGNMENT_ANY = 4), FALSE, 25, 50),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 		list(ASSIGNMENT_ANY = 1), TRUE, 5,  15),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",		/datum/event/money_hacker, 		0, 		list(ASSIGNMENT_ANY = 4), TRUE, 10, 25),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",		/datum/event/economic_event,	300),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",		/datum/event/trivial_news, 		400),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 		/datum/event/mundane_news, 		300),
@@ -147,8 +147,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	severity = EVENT_LEVEL_MODERATE
 	available_events = list(
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					1230),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			200, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 10), TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			200, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 20), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				0,		list(ASSIGNMENT_SECURITY = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Vines",				/datum/event/spacevine, 				250,	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_wave,				0,		list(ASSIGNMENT_ENGINEER = 25)),
@@ -159,15 +159,15 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		//new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",		/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "APC Short",				/datum/event/apc_short, 				200,	list(ASSIGNMENT_ENGINEER = 60)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			250,	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_JANITOR = 150)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			25,		list(ASSIGNMENT_MEDICAL = 50), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		100,	list(ASSIGNMENT_SECURITY = 30), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			25,		list(ASSIGNMENT_MEDICAL = 50), TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		100,	list(ASSIGNMENT_SECURITY = 30), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ion_storm, 				0,		list(ASSIGNMENT_AI = 50, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Borer Infestation",		/datum/event/borer_infestation, 		40,		list(ASSIGNMENT_SECURITY = 30), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Immovable Rod",			/datum/event/immovable_rod,				0,		list(ASSIGNMENT_ENGINEER = 30), 1),
-		//new /datum/event_meta/ninja(EVENT_LEVEL_MODERATE, "Space Ninja",		/datum/event/space_ninja, 				0,		list(ASSIGNMENT_SECURITY = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Borer Infestation",		/datum/event/borer_infestation, 		40,		list(ASSIGNMENT_SECURITY = 30), TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Immovable Rod",			/datum/event/immovable_rod,				0,		list(ASSIGNMENT_ENGINEER = 30), TRUE),
+		//new /datum/event_meta/ninja(EVENT_LEVEL_MODERATE, "Space Ninja",		/datum/event/space_ninja, 				0,		list(ASSIGNMENT_SECURITY = 15), TRUE),
 		// NON-BAY EVENTS
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Mass Hallucination",		/datum/event/mass_hallucination,		300),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Brand Intelligence",		/datum/event/brand_intelligence,		50, 	list(ASSIGNMENT_ENGINEER = 25),	1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Brand Intelligence",		/datum/event/brand_intelligence,		50, 	list(ASSIGNMENT_ENGINEER = 25),	TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,						50,		list(ASSIGNMENT_ENGINEER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Dimensional Tear",			/datum/event/tear,						0,		list(ASSIGNMENT_SECURITY = 35)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Honknomoly",					/datum/event/tear/honk,						0),
@@ -179,9 +179,9 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Flux Anomaly",				/datum/event/anomaly/anomaly_flux,		75,		list(ASSIGNMENT_ENGINEER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravitational Anomaly",	/datum/event/anomaly/anomaly_grav,		200),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Revenant", 				/datum/event/revenant, 					150),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Swarmer Spawn", 			/datum/event/spawn_swarmer, 			150, is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn", 				/datum/event/spawn_morph, 				40, is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Disease Outbreak",			/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Swarmer Spawn", 			/datum/event/spawn_swarmer, 			150, is_one_shot = TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn", 				/datum/event/spawn_morph, 				40, is_one_shot = TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Disease Outbreak",			/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Headcrabs",				/datum/event/headcrabs, 				0, list(ASSIGNMENT_SECURITY = 20))
 	)
 
@@ -189,17 +189,17 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	severity = EVENT_LEVEL_MAJOR
 	available_events = list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",			/datum/event/nothing,			1320),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	0,						list(ASSIGNMENT_SECURITY =  3), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	0,						list(ASSIGNMENT_SECURITY =  3), TRUE),
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,	0,			list(ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "APC Overload",	/datum/event/apc_overload,		0),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				0,						list(ASSIGNMENT_ENGINEER = 30), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,						list(ASSIGNMENT_ENGINEER =  5),	1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",	/datum/event/abductor, 		    80, is_one_shot = 1),
-		//new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			180, is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",			/datum/event/spider_terror, 		0,			list(ASSIGNMENT_SECURITY = 15), is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	15, is_one_shot = 1)
-		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = 1)
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",			/datum/event/blob, 				0,						list(ASSIGNMENT_ENGINEER = 30), TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,						list(ASSIGNMENT_ENGINEER =  5),	TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",	/datum/event/abductor, 		    80, is_one_shot = TRUE),
+		//new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			180, is_one_shot = TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",			/datum/event/spider_terror, 		0,			list(ASSIGNMENT_SECURITY = 15), is_one_shot = TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	15, is_one_shot = TRUE)
+		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = TRUE)
 	)
 
 

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -178,7 +178,7 @@
 	for(var/datum/event_container/container in SSevents.event_containers)
 		for(var/datum/event_meta/M in container.available_events)
 			if(M.event_type == /datum/event/meteor_wave)
-				M.weight *= mod
+				M.weight_mod *= mod
 
 /obj/machinery/satellite/meteor_shield/Destroy()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR does two things. It
fixes #14413
by introducing a system letting you modify the weight of events in general, taking into account both normal weight and job-weight.
Secondly, it does some clean-up and light refactoring in event code while I was there.  Replacing 1 with TRUE and making it so that, if no max weight is set, the event listing actually says that instead of displaying a 0. Using 0 as a max weight that's not set seems pretty confusing to me.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs are bad, refactors are good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: light event refactor
fix: emagged meteor sats now increase meteor event chance as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
