### PR TITLE
Stops maintenance drones from clicking stuff while ventcrawling

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -242,6 +242,9 @@
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
 
+// Locations
+#define is_ventcrawling(A)  (istype(A.loc, /obj/machinery/atmospherics))
+
 // Hearing protection
 #define HEARING_PROTECTION_NONE	0
 #define HEARING_PROTECTION_MINOR	1

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -9,7 +9,7 @@
 
 	Note that AI have no need for the adjacency proc, and so this proc is a lot cleaner.
 */
-/mob/living/silicon/ai/DblClickOn(var/atom/A, params)
+/mob/living/silicon/ai/DblClickOn(atom/A, params)
 	if(client.click_intercept)
 		// Not doing a click intercept here, because otherwise we double-tap with the `ClickOn` proc.
 		// But we return here since we don't want to do regular dblclick handling
@@ -23,7 +23,7 @@
 		A.move_camera_by_click()
 
 
-/mob/living/silicon/ai/ClickOn(var/atom/A, params)
+/mob/living/silicon/ai/ClickOn(atom/A, params)
 	if(client.click_intercept)
 		client.click_intercept.InterceptClickOn(src, params, A)
 		return
@@ -123,7 +123,7 @@
 /mob/living/silicon/ai/RangedAttack(atom/A, params)
 	A.attack_ai(src)
 
-/atom/proc/attack_ai(mob/user as mob)
+/atom/proc/attack_ai(mob/user)
 	return
 
 /*
@@ -132,17 +132,17 @@
 	for AI shift, ctrl, and alt clicking.
 */
 
-/mob/living/silicon/ai/CtrlShiftClickOn(var/atom/A)
+/mob/living/silicon/ai/CtrlShiftClickOn(atom/A)
 	A.AICtrlShiftClick(src)
-/mob/living/silicon/ai/AltShiftClickOn(var/atom/A)
+/mob/living/silicon/ai/AltShiftClickOn(atom/A)
 	A.AIAltShiftClick(src)
-/mob/living/silicon/ai/ShiftClickOn(var/atom/A)
+/mob/living/silicon/ai/ShiftClickOn(atom/A)
 	A.AIShiftClick(src)
-/mob/living/silicon/ai/CtrlClickOn(var/atom/A)
+/mob/living/silicon/ai/CtrlClickOn(atom/A)
 	A.AICtrlClick(src)
-/mob/living/silicon/ai/AltClickOn(var/atom/A)
+/mob/living/silicon/ai/AltClickOn(atom/A)
 	A.AIAltClick(src)
-/mob/living/silicon/ai/MiddleClickOn(var/atom/A)
+/mob/living/silicon/ai/MiddleClickOn(atom/A)
     A.AIMiddleClick(src)
 
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -214,14 +214,6 @@
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.
 	toggle_light(user)
 
-// FIRE ALARMS
-
-/obj/machinery/firealarm/AICtrlClick()
-	if(enabled)
-		reset()
-	else
-		alarm()
-
 // AI-CONTROLLED SLIP GENERATOR IN AI CORE
 
 /obj/machinery/ai_slipper/AICtrlClick(mob/living/silicon/ai/user) //Turns liquid dispenser on or off

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -185,12 +185,6 @@
 /obj/machinery/turretid/BorgAltClick(mob/living/silicon/robot/user) //turret lethal on/off. Forwards to AI code.
 	AIAltClick(user)
 
-
-// FIRE ALARMS
-
-/obj/machinery/firealarm/BorgCtrlClick(mob/living/silicon/robot/user) // Turns on/off fire alarms. Forwards to AI code.
-	AICtrlClick(user)
-
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -6,7 +6,7 @@
 	adjacency code.
 */
 
-/mob/living/silicon/robot/ClickOn(var/atom/A, var/params)
+/mob/living/silicon/robot/ClickOn(atom/A, params)
 	if(client.click_intercept)
 		client.click_intercept.InterceptClickOn(src, params, A)
 		return
@@ -98,12 +98,12 @@
 	return
 
 //Ctrl+Middle click cycles through modules
-/mob/living/silicon/robot/proc/CtrlMiddleClickOn(var/atom/A)
+/mob/living/silicon/robot/proc/CtrlMiddleClickOn(atom/A)
 	cycle_modules()
 	return
 
 //Middle click points
-/mob/living/silicon/robot/MiddleClickOn(var/atom/A)
+/mob/living/silicon/robot/MiddleClickOn(atom/A)
 	if(istype(src, /mob/living/silicon/robot/drone))
 		// Drones cannot point.
 		return
@@ -112,18 +112,31 @@
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
-/mob/living/silicon/robot/CtrlShiftClickOn(var/atom/A)
-	A.BorgCtrlShiftClick(src)
-/mob/living/silicon/robot/AltShiftClickOn(var/atom/A)
-	A.BorgAltShiftClick(src)
-/mob/living/silicon/robot/ShiftClickOn(var/atom/A)
+/mob/living/silicon/robot/ShiftClickOn(atom/A)
 	A.BorgShiftClick(src)
-/mob/living/silicon/robot/CtrlClickOn(var/atom/A)
+/mob/living/silicon/robot/CtrlClickOn(atom/A)
 	A.BorgCtrlClick(src)
-/mob/living/silicon/robot/AltClickOn(var/atom/A)
+/mob/living/silicon/robot/AltClickOn(atom/A)
 	A.BorgAltClick(src)
+/mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
+	A.BorgCtrlShiftClick(src)
+/mob/living/silicon/robot/AltShiftClickOn(atom/A)
+	A.BorgAltShiftClick(src)
 
-/atom/proc/BorgCtrlShiftClick(var/mob/user) // Examines
+
+/atom/proc/BorgShiftClick(mob/user)
+	if(user.client && user.client.eye == user)
+		user.examinate(src)
+	return
+
+/atom/proc/BorgCtrlClick(mob/living/silicon/robot/user) //forward to human click if not overriden
+	CtrlClick(user)
+
+/atom/proc/BorgAltClick(mob/living/silicon/robot/user)
+	AltClick(user)
+	return
+
+/atom/proc/BorgCtrlShiftClick(mob/user) // Examines
 	if(user.client && user.client.eye == user)
 		user.examinate(src)
 	return
@@ -131,38 +144,29 @@
 /atom/proc/BorgAltShiftClick()
 	return
 
-/obj/machinery/door/airlock/BorgAltShiftClick(mob/living/silicon/robot/user)  // Enables emergency override on doors! Forwards to AI code.
-	AIAltShiftClick(user)
 
-/atom/proc/BorgShiftClick(var/mob/user)
-	if(user.client && user.client.eye == user)
-		user.examinate(src)
-	return
+// AIRLOCKS
 
 /obj/machinery/door/airlock/BorgShiftClick(mob/living/silicon/robot/user)  // Opens and closes doors! Forwards to AI code.
 	AIShiftClick(user)
 
-/atom/proc/BorgCtrlClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
-	CtrlClick(user)
-
 /obj/machinery/door/airlock/BorgCtrlClick(mob/living/silicon/robot/user) // Bolts doors. Forwards to AI code.
 	AICtrlClick(user)
-
-/obj/machinery/power/apc/BorgCtrlClick(mob/living/silicon/robot/user) // turns off/on APCs. Forwards to AI code.
-	AICtrlClick(user)
-
-/obj/machinery/turretid/BorgCtrlClick(mob/living/silicon/robot/user) //turret control on/off. Forwards to AI code.
-	AICtrlClick(user)
-
-/atom/proc/BorgAltClick(var/mob/living/silicon/robot/user)
-	AltClick(user)
-	return
 
 /obj/machinery/door/airlock/BorgAltClick(mob/living/silicon/robot/user) // Eletrifies doors. Forwards to AI code.
 	AIAltClick(user)
 
-/obj/machinery/turretid/BorgAltClick(mob/living/silicon/robot/user) //turret lethal on/off. Forwards to AI code.
-	AIAltClick(user)
+/obj/machinery/door/airlock/BorgAltShiftClick(mob/living/silicon/robot/user)  // Enables emergency override on doors! Forwards to AI code.
+	AIAltShiftClick(user)
+
+
+// APC
+
+/obj/machinery/power/apc/BorgCtrlClick(mob/living/silicon/robot/user) // turns off/on APCs. Forwards to AI code.
+	AICtrlClick(user)
+
+
+// AI SLIPPER
 
 /obj/machinery/ai_slipper/BorgCtrlClick(mob/living/silicon/robot/user) //Turns liquid dispenser on or off
 	ToggleOn()
@@ -170,7 +174,19 @@
 /obj/machinery/ai_slipper/BorgAltClick(mob/living/silicon/robot/user) //Dispenses liquid if on
 	Activate()
 
-/obj/machinery/firealarm/BorgCtrlClick(mob/living/silicon/robot/user)
+
+// TURRETCONTROL
+
+/obj/machinery/turretid/BorgCtrlClick(mob/living/silicon/robot/user) //turret control on/off. Forwards to AI code.
+	AICtrlClick(user)
+
+/obj/machinery/turretid/BorgAltClick(mob/living/silicon/robot/user) //turret lethal on/off. Forwards to AI code.
+	AIAltClick(user)
+
+
+// FIRE ALARMS
+
+/obj/machinery/firealarm/BorgCtrlClick(mob/living/silicon/robot/user) // Turns on/off fire alarms. Forwards to AI code.
 	AICtrlClick(user)
 
 /*
@@ -187,6 +203,6 @@
 /mob/living/silicon/robot/RangedAttack(atom/A, params)
 	A.attack_robot(src)
 
-/atom/proc/attack_robot(mob/user as mob)
+/atom/proc/attack_robot(mob/user)
 	attack_ai(user)
 	return

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -15,6 +15,8 @@
 		return
 	changeNext_click(1)
 
+	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
+		return
 
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -32,7 +32,6 @@ FIRE ALARM
 
 	var/wiresexposed = 0
 	var/buildstage = 2 // 2 = complete, 1 = no wires,  0 = circuit gone
-	var/enabled = FALSE
 
 	var/report_fire_alarms = TRUE // Should triggered fire alarms also trigger an actual alarm?
 	var/show_alert_level = TRUE // Should fire alarms display the current alert level?

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -234,7 +234,7 @@
 	add_fingerprint(user)
 
 /obj/structure/closet/attack_ai(mob/user)
-	if(isrobot(user) && Adjacent(user) && !istype(user.loc, /obj/machinery/atmospherics)) //Robots can open/close it, but not the AI
+	if(isrobot(user) && Adjacent(user)) //Robots can open/close it, but not the AI
 		attack_hand(user)
 
 /obj/structure/closet/relaymove(mob/user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -514,10 +514,10 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 /mob/living/update_pipe_vision()
 	if(pipes_shown.len)
-		if(!istype(loc, /obj/machinery/atmospherics))
+		if(!is_ventcrawling(src))
 			remove_ventcrawl()
 	else
-		if(istype(loc, /obj/machinery/atmospherics))
+		if(is_ventcrawling(src))
 			add_ventcrawl(loc)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Stops maintenance drones from using any click-based interactions when ventcrawling, since afaik none of them are intentional.
This includes (but is probably not limited to):

**1: Doors
2: Firelocks
3: Fire alarms
4: Fire extinguisher cabinets
5: Light bulbs/tubes
6: Door buttons *(e.g. Medbay/Security Lockdown)*
6.5: Actually all buttons *(Mass driver, toxins/turbine ignition switch, etc)*
7: Robotics bots**

Also adds `is_ventcrawling()` as a define, as shorthand for `(istype(A.loc, /obj/machinery/atmospherics))`.

Also also removes the ability to ctrl-click fire alarms for silicons, since now you can just click normally to toggle it.

*(and technically reverts #13758)*

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfixes!

## Changelog
:cl:
del: Removes ctrl-clicking fire alarms for silicons, since you can now just click them to toggle.
fix: Maintenance drones can no longer interact with objects while ventcrawling (e.g. Firelocks, Airlocks, Light bulbs, etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
