### PR TITLE
Prevents Curare from being synthesized 

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -917,6 +917,7 @@
 	reagent_state = LIQUID
 	color = "#191919"
 	metabolization_rate = 0.1
+	can_synth = FALSE
 	penetrates_skin = TRUE
 	taste_mult = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This pr gives Curare, a chemical normally only avaible in traitor bottles, can_synth = false, preventing it from being synthesized.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Traitor bottle chemicals generaly have the no synth flag if their only source is from the traitor bottle, to prevent bees / medical mechs / strange plants from making them, due to their strong chemical abilities that would be bad to have an unlimited supply of. Curare acts very similarly to Pancuronium, a chemical that has no recipe that can be synthasized, however, Curare can only be found in traitor bottles and not medbots and NanoMeds, unlike Pancuronium, and also unlike pancuronium, it deals one toxin per cycle, lasts twice as long in a persons system and has penetrates_skin = TRUE, which means it can be splashed on someone, or used in a gas, and affect them even if they have a gas mask on. In effect it is a Pancuronium plus, and for all the previously listed reasons, it should not be able to be synthesized. 
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Curare can no longer be synthesized. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
