### PR TITLE
Terror gateway tweaks

### DIFF
--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -15,8 +15,12 @@
 /turf/simulated/wall/rust,
 /area/awaymission/UO71/plaza)
 "ae" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	tag = "icon-manifold-b-f (EAST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "af" = (
@@ -677,12 +681,10 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bP" = (
@@ -711,14 +713,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"bT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
-	},
-/turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -795,17 +789,9 @@
 	pixel_y = 23;
 	req_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
 "ch" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
-	},
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -830,27 +816,6 @@
 /obj/item/clothing/under/pj/blue,
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
-"cj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
-	},
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_broken = "cabinetdetective_broken";
-	icon_closed = "cabinetdetective";
-	icon_locked = "cabinetdetective_locked";
-	icon_off = "cabinetdetective_broken";
-	icon_opened = "cabinetdetective_open";
-	icon_state = "cabinetdetective";
-	locked = 0;
-	name = "personal closet";
-	req_access_txt = "271"
-	},
-/obj/item/clothing/under/suit_jacket/female,
-/turf/simulated/floor/carpet,
-/area/awaymission/UO71/plaza)
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/wood,
@@ -869,9 +834,6 @@
 	locked = 0;
 	pixel_y = 23;
 	req_access = null
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
 	},
 /obj/structure/chair/wood{
 	tag = "icon-wooden_chair (EAST)";
@@ -911,16 +873,12 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
 "cs" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
-	},
 /obj/structure/chair/wood{
 	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
@@ -934,6 +892,10 @@
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -952,10 +914,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	dir = 4;
+	on = 1
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -1160,9 +1120,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cU" = (
@@ -1178,6 +1136,7 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -1250,10 +1209,12 @@
 	},
 /area/awaymission/UO71/plaza)
 "dd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 7;
+	tag = "icon-manifold-b-f (WEST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "de" = (
@@ -1275,31 +1236,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
-"dg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
 "dh" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
-"di" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
 "dj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sink{
 	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	tag = "icon-manifold-b-f (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1313,6 +1266,9 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "green"
@@ -2895,7 +2851,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
 	pixel_x = -3;
 	pixel_y = 3
@@ -2905,6 +2860,7 @@
 	pixel_y = 2
 	},
 /obj/item/reagent_containers/dropper,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
@@ -2919,6 +2875,11 @@
 	pixel_y = 0;
 	req_access = null
 	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	on = 1
+	},
+/mob/living/simple_animal/hostile/poison/terror_spider/gray,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
 "gD" = (
@@ -2928,6 +2889,11 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 7;
+	tag = "icon-manifold-b-f (WEST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -3186,7 +3152,6 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
 "he" = (
-/obj/structure/table/glass,
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/capacitor,
@@ -3194,18 +3159,15 @@
 /obj/item/stock_parts/micro_laser,
 /obj/item/stock_parts/micro_laser,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	on = 1
+	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
 	},
 /area/awaymission/UO71/science)
-"hf" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	on = 1
-	},
-/mob/living/simple_animal/hostile/poison/terror_spider/gray,
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/centralhall)
 "hg" = (
 /obj/structure/table,
 /obj/item/trash/chips,
@@ -3433,6 +3395,9 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
 "hE" = (
@@ -3444,10 +3409,14 @@
 	pixel_y = 0;
 	req_access = null
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
 "hF" = (
 /obj/machinery/r_n_d/circuit_imprinter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/science)
 "hG" = (
@@ -3458,17 +3427,21 @@
 /area/awaymission/UO71/mother)
 "hH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaymission/UO71/science)
 "hI" = (
-/obj/structure/table/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/matter_bin,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
@@ -3668,6 +3641,9 @@
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
 "ig" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/science)
 "ih" = (
@@ -3947,33 +3923,6 @@
 	icon_state = "white"
 	},
 /area/awaymission/UO71/gateway)
-"iK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
-/area/awaymission/UO71/prince)
-"iL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/wall/r_wall,
-/area/awaymission/UO71/prince)
-"iM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/mineral/random/labormineral,
-/area/awaymission/UO71/outside)
-"iN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/centralhall)
 "iO" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3988,15 +3937,6 @@
 /obj/item/stock_parts/cell/high,
 /obj/machinery/light/small{
 	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/UO71/science)
-"iQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_pump{
-	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -4211,16 +4151,6 @@
 "jl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/mineral/random/labormineral,
-/area/awaymission/UO71/outside)
-"jm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall3"
-	},
 /area/awaymission/UO71/outside)
 "jn" = (
 /turf/simulated/floor/plasteel,
@@ -6062,15 +5992,6 @@
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/mother)
-"my" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_pump{
-	icon_state = "weld";
-	on = 1;
-	welded = 1
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/prince)
 "mz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13504,6 +13425,132 @@
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/science)
+"BU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/mineral/random/labormineral,
+/area/awaymission/UO71/outside)
+"BV" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/plaza)
+"Co" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"DT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"DU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/rust,
+/area/awaymission/UO71/science)
+"FS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/awaymission/UO71/centralhall)
+"Gt" = (
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/UO71/science)
+"KJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/UO71/prince)
+"Oh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/awaymission/UO71/outside)
+"OL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/centralhall)
+"RR" = (
+/obj/structure/spider/cocoon{
+	icon_state = "cocoon_large1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/vault,
+/area/awaymission/UO71/prince)
+"Ux" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	initialize_directions = 14;
+	tag = "icon-manifold-b-f (NORTH)"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"UU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/vault,
+/area/awaymission/UO71/prince)
+"Vq" = (
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/plaza)
+"WZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/awaymission/UO71/plaza)
+"Xj" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	icon_state = "weld";
+	on = 1;
+	welded = 1
+	},
+/turf/simulated/floor/vault,
+/area/awaymission/UO71/prince)
+"XS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
 
 (1,1,1) = {"
 aa
@@ -19112,7 +19159,7 @@ gy
 ah
 ig
 cV
-iQ
+jp
 jp
 jN
 kt
@@ -19410,7 +19457,7 @@ fN
 gj
 gA
 ap
-ap
+Gt
 gZ
 fO
 fO
@@ -19860,7 +19907,7 @@ ab
 fO
 fN
 fN
-fN
+DU
 fN
 fO
 ab
@@ -20010,7 +20057,7 @@ ab
 ab
 ab
 ab
-ab
+BU
 ab
 ab
 ab
@@ -20160,7 +20207,7 @@ zc
 zc
 zc
 zc
-zc
+Oh
 zc
 zc
 zc
@@ -20310,7 +20357,7 @@ fP
 fP
 fP
 fP
-fP
+KJ
 id
 iI
 yX
@@ -20610,7 +20657,7 @@ fP
 gd
 gd
 gd
-ge
+RR
 gd
 fP
 zc
@@ -20760,7 +20807,7 @@ fP
 ge
 ge
 gd
-gd
+UU
 if
 fP
 yY
@@ -20910,7 +20957,7 @@ fP
 gf
 gx
 gd
-ge
+RR
 gd
 iR
 jq
@@ -21060,7 +21107,7 @@ fP
 gd
 gd
 gd
-gd
+UU
 gd
 iR
 jq
@@ -21210,9 +21257,9 @@ fP
 gd
 gd
 ge
-gd
-my
-iK
+UU
+if
+fP
 yY
 jG
 ke
@@ -21359,10 +21406,10 @@ zc
 fP
 gd
 gd
-gd
+Xj
 hE
 ge
-iL
+fP
 zc
 ab
 fO
@@ -21510,9 +21557,9 @@ fP
 fP
 fP
 fP
+KJ
 fP
 fP
-iL
 zc
 ab
 fO
@@ -21643,7 +21690,7 @@ ad
 ad
 ac
 ad
-ba
+BV
 ad
 dx
 at
@@ -21660,9 +21707,9 @@ zc
 zc
 zc
 zc
+Oh
 zc
 zc
-jm
 zc
 ab
 fN
@@ -21789,11 +21836,11 @@ ac
 ad
 bz
 bO
-bY
+ad
 ch
 cs
 ac
-ar
+XS
 af
 al
 dQ
@@ -21810,9 +21857,9 @@ ab
 ab
 ab
 ab
+BU
 ab
 ab
-iM
 ab
 ab
 fO
@@ -21945,14 +21992,14 @@ cr
 cI
 ae
 dd
-al
-al
-al
-al
-al
-al
-eY
-al
+bu
+bu
+bu
+bu
+bu
+bu
+bG
+Co
 ac
 fb
 fb
@@ -21960,9 +22007,9 @@ fb
 fb
 fe
 fb
+FS
 fb
-fb
-iN
+fe
 fe
 fb
 fO
@@ -22094,7 +22141,7 @@ ci
 ct
 ac
 ar
-df
+Ux
 dA
 ay
 ed
@@ -22102,17 +22149,17 @@ em
 ey
 eK
 bH
-al
-cJ
-fF
-fR
-fF
-fR
-gD
-hf
+df
+DT
+OL
 hJ
+OL
+hJ
+gD
 hJ
 iS
+hJ
+hJ
 js
 jP
 ku
@@ -22244,7 +22291,7 @@ ac
 ac
 ad
 al
-al
+bS
 dz
 dR
 dR
@@ -22394,7 +22441,7 @@ ar
 ar
 cJ
 al
-al
+bS
 dz
 dR
 ef
@@ -22544,7 +22591,7 @@ al
 al
 cJ
 al
-al
+bS
 dz
 dR
 ee
@@ -22694,7 +22741,7 @@ ad
 ac
 ac
 cW
-al
+bS
 dC
 dR
 dR
@@ -22838,13 +22885,13 @@ aX
 bo
 bw
 by
-bT
+bL
 bY
-cj
+aF
 cu
 ac
 al
-dg
+Ux
 dB
 dS
 eg
@@ -22994,7 +23041,7 @@ cl
 cr
 cM
 bu
-di
+bR
 dE
 dT
 dT
@@ -23144,7 +23191,7 @@ ck
 cv
 ac
 cX
-dh
+WZ
 dD
 dh
 dh
@@ -23294,7 +23341,7 @@ ac
 ad
 ad
 ac
-at
+Vq
 dG
 dU
 at
@@ -23444,7 +23491,7 @@ cd
 cc
 cN
 ac
-at
+Vq
 dF
 al
 at

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -20,6 +20,10 @@
 	dir = 4;
 	initialize_directions = 11
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	level = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "af" = (
@@ -575,31 +579,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
-"bx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/plaza)
-"by" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/plaza)
-"bz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/plaza)
-"bA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	initialize_directions = 14
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/plaza)
 "bB" = (
 /obj/machinery/door/airlock{
 	id_tag = "awaydormE2";
@@ -614,29 +593,16 @@
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
-"bD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	initialize_directions = 14
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/plaza)
-"bE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/plaza)
 "bF" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "bH" = (
@@ -647,10 +613,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
-"bJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
 "bK" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
@@ -659,10 +621,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/plating,
@@ -672,11 +640,17 @@
 	dir = 4
 	},
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -689,13 +663,19 @@
 	req_access_txt = "0";
 	req_one_access_txt = "0"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	initialize_directions = 14
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bR" = (
@@ -713,6 +693,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bV" = (
@@ -727,8 +710,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	initialize_directions = 14
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "bZ" = (
@@ -737,6 +723,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	level = 1
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "ca" = (
@@ -744,20 +734,26 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "ce" = (
@@ -832,7 +828,6 @@
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
 "cm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/grille,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
@@ -848,6 +843,9 @@
 	},
 /obj/effect/landmark/burnturf,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cp" = (
@@ -859,6 +857,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cr" = (
@@ -929,27 +930,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 14
-	},
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	initialize_directions = 14
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
@@ -958,34 +940,30 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/wall/rust,
+/turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
-/obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	level = 1
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cF" = (
@@ -993,11 +971,6 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cG" = (
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
@@ -1016,18 +989,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
-"cK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/plaza)
-"cL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/plaza)
 "cM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
@@ -1039,17 +1000,11 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "cN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/closet,
 /obj/item/poster/random_contraband,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
@@ -1069,24 +1024,11 @@
 	icon_state = "white"
 	},
 /area/awaymission/UO71/science)
-"cP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/stack/rods,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "cS" = (
@@ -1102,26 +1044,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"cU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall,
 /area/awaymission/UO71/plaza)
 "cV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -1198,6 +1131,7 @@
 	dir = 8;
 	initialize_directions = 7
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "de" = (
@@ -1210,6 +1144,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "df" = (
@@ -1231,9 +1166,8 @@
 /obj/structure/sink{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1318,7 +1252,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sink{
 	pixel_y = 25
 	},
@@ -1375,10 +1308,6 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "dv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 7
-	},
 /obj/structure/chair,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 0;
@@ -1417,12 +1346,6 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "dy" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "red"
@@ -1510,7 +1433,6 @@
 /area/awaymission/UO71/plaza)
 "dJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1537,40 +1459,12 @@
 	},
 /area/awaymission/UO71/plaza)
 "dL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Checkpoint Maintenance";
 	req_access_txt = "271";
 	req_one_access_txt = "0"
 	},
 /turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"dM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"dN" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"dO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 14
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
 /area/awaymission/UO71/plaza)
 "dP" = (
 /turf/simulated/floor/plasteel{
@@ -1617,16 +1511,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
-"dW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
 "dX" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -1636,7 +1520,6 @@
 	},
 /area/awaymission/UO71/plaza)
 "dY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -1651,7 +1534,6 @@
 	pixel_y = 0;
 	req_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/security{
 	network = list("UO71")
@@ -1676,10 +1558,19 @@
 	name = "Security Checkpoint";
 	req_access_txt = "271"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "eb" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -1737,7 +1628,6 @@
 	},
 /area/awaymission/UO71/plaza)
 "ej" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -1838,7 +1728,6 @@
 /area/awaymission/UO71/plaza)
 "eu" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/radio/off,
 /obj/item/screwdriver{
 	pixel_y = 10
@@ -1846,25 +1735,34 @@
 /obj/structure/sign/poster/official/safety_report{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
 /area/awaymission/UO71/plaza)
 "ev" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
 	},
 /area/awaymission/UO71/plaza)
 "ew" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
 	},
 /area/awaymission/UO71/plaza)
 "ex" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -2121,9 +2019,8 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 "eU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -2145,6 +2042,9 @@
 	id_tag = "awaydorm3";
 	name = "Dorm 3"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "eX" = (
@@ -2159,6 +2059,9 @@
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -2328,20 +2231,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/awaymission/UO71/centralhall)
-"fu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/centralhall)
-"fv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	level = 1
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/centralhall)
 "fw" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -2359,6 +2248,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "fy" = (
@@ -2366,6 +2256,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable,
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "fz" = (
@@ -2402,11 +2293,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	level = 1
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "fD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	level = 1
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
@@ -2473,6 +2372,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "fL" = (
@@ -2513,9 +2413,6 @@
 /area/awaymission/UO71/centralhall)
 "fT" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -2586,6 +2483,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "gc" = (
@@ -2666,21 +2564,6 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/awaymission/UO71/centralhall)
-"gm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "gn" = (
 /obj/machinery/gateway{
@@ -3035,9 +2918,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -3244,6 +3124,7 @@
 	dir = 4;
 	initialize_directions = 11
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "hu" = (
@@ -3348,6 +3229,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/science)
 "hG" = (
@@ -3357,9 +3241,11 @@
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/mother)
 "hH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -3545,28 +3431,15 @@
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
-"id" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
-/area/awaymission/UO71/prince)
-"ie" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0;
-	welded = 1
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/prince)
 "if" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
@@ -3595,9 +3468,6 @@
 "ii" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -3712,6 +3582,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "it" = (
@@ -3800,10 +3673,6 @@
 	icon_state = "dark"
 	},
 /area/awaymission/UO71/gateway)
-"iF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/r_wall,
-/area/awaymission/UO71/mother)
 "iG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3827,10 +3696,6 @@
 	icon_state = "white"
 	},
 /area/awaymission/UO71/gateway)
-"iI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall/r_wall,
-/area/awaymission/UO71/prince)
 "iJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -3847,7 +3712,6 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mother)
 "iP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
@@ -3948,6 +3812,7 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "iZ" = (
@@ -4034,10 +3899,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/awaymission/UO71/centralhall)
-"ji" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall,
-/area/awaymission/UO71/science)
 "jj" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -4060,15 +3921,10 @@
 	icon_state = "white"
 	},
 /area/awaymission/UO71/gateway)
-"jl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/mineral/random/labormineral,
-/area/awaymission/UO71/outside)
 "jn" = (
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mother)
 "jo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/disk/tech_disk{
@@ -4083,6 +3939,7 @@
 "jp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -4131,30 +3988,12 @@
 	icon_state = "bar"
 	},
 /area/awaymission/UO71/centralhall)
-"jw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/centralhall)
-"jx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/centralhall)
 "jy" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/cans/beer,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
-/area/awaymission/UO71/centralhall)
-"jz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/wall,
 /area/awaymission/UO71/centralhall)
 "jA" = (
 /obj/machinery/camera{
@@ -4170,14 +4009,11 @@
 "jB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 7
-	},
 /obj/machinery/door/airlock{
 	name = "Kitchen";
 	req_access_txt = "271"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -4195,8 +4031,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "jD" = (
@@ -4269,12 +4105,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mother)
-"jL" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/window/full/basic,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/science)
 "jM" = (
 /obj/structure/grille,
 /obj/structure/window/full/basic,
@@ -4289,6 +4119,7 @@
 	req_access_txt = "271";
 	req_one_access_txt = "0"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -4315,6 +4146,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "jR" = (
@@ -4376,9 +4208,12 @@
 	icon_state = "pipe-j2";
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -4415,6 +4250,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "jY" = (
@@ -4434,6 +4272,9 @@
 	req_access_txt = "0";
 	req_one_access_txt = "0"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "jZ" = (
@@ -4446,9 +4287,14 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "ka" = (
@@ -4465,6 +4311,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "kb" = (
@@ -4481,6 +4330,9 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "kc" = (
@@ -4513,6 +4365,7 @@
 /area/awaymission/UO71/science)
 "kf" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple";
 	dir = 9
@@ -4524,22 +4377,10 @@
 	dir = 5
 	},
 /area/awaymission/UO71/science)
-"kh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/science)
 "ki" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/gateway)
-"kj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
-	dir = 4;
-	heat_capacity = 1e+006
-	},
-/area/awaymission/UO71/science)
 "kk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
@@ -4606,6 +4447,10 @@
 	icon_state = "bulb1";
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	on = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -4613,7 +4458,11 @@
 /area/awaymission/UO71/science)
 "kt" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 7
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -4702,6 +4551,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "kC" = (
@@ -4905,12 +4755,6 @@
 	icon_state = "white"
 	},
 /area/awaymission/UO71/gateway)
-"kV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/UO71/science)
 "kW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4938,14 +4782,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplecorner";
-	dir = 4;
-	heat_capacity = 1e+006
-	},
-/area/awaymission/UO71/science)
-"kY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner";
 	dir = 4;
@@ -5001,9 +4837,7 @@
 "le" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -5419,7 +5253,9 @@
 	pixel_x = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /mob/living/simple_animal/hostile/poison/terror_spider/red{
 	wander = 0
 	},
@@ -5449,21 +5285,6 @@
 	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitepurplecorner"
-	},
-/area/awaymission/UO71/science)
-"lP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -5544,9 +5365,8 @@
 	},
 /area/awaymission/UO71/science)
 "lU" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -5573,6 +5393,9 @@
 	c_tag = "Research Division East";
 	dir = 1;
 	network = list("UO71")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -5680,20 +5503,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
-"mh" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/mother)
-"mi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/mother)
 "mj" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plating,
@@ -5743,6 +5552,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "mo" = (
@@ -5776,10 +5586,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/science)
 "ms" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/science)
@@ -5821,9 +5631,6 @@
 	pixel_x = 23;
 	pixel_y = 0;
 	req_access = null
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/mother)
@@ -6087,6 +5894,7 @@
 	name = "Research Maintenance";
 	req_access_txt = "271"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "mX" = (
@@ -6167,6 +5975,12 @@
 	pixel_x = -30
 	},
 /obj/item/book/manual/security_space_law,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 101.325;
+	on = 1;
+	pressure_checks = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -6350,6 +6164,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "nz" = (
@@ -6453,6 +6268,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "nI" = (
@@ -6468,6 +6286,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "nJ" = (
@@ -6480,6 +6301,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "nK" = (
@@ -6499,6 +6321,9 @@
 	req_access_txt = "0";
 	req_one_access_txt = "0"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "nL" = (
@@ -6511,8 +6336,11 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	initialize_directions = 11
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "neutral"
@@ -6531,6 +6359,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
 	initialize_directions = 11
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -6717,6 +6548,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "oh" = (
@@ -6780,16 +6612,41 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
 "ol" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "om" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/wall/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "on" = (
 /obj/structure/table/reinforced,
@@ -6840,9 +6697,6 @@
 	},
 /area/awaymission/UO71/science)
 "oq" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	on = 1
-	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/science)
 "or" = (
@@ -6880,7 +6734,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	level = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -6891,9 +6748,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/alarm/monitor{
 	dir = 4;
 	frequency = 1439;
@@ -7342,7 +7196,6 @@
 	},
 /area/awaymission/UO71/science)
 "pa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -7378,12 +7231,6 @@
 	},
 /area/awaymission/UO71/science)
 "pd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 2;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -7399,6 +7246,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "pf" = (
@@ -7648,25 +7496,8 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
 "pB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
-/area/awaymission/UO71/science)
-"pC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "pD" = (
 /obj/structure/cable{
@@ -7678,9 +7509,14 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
@@ -7724,19 +7560,7 @@
 	},
 /area/awaymission/UO71/science)
 "pH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/landmark/damageturf,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "pI" = (
@@ -7861,10 +7685,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
 /area/awaymission/UO71/medical)
-"pW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/medical)
 "pX" = (
 /turf/simulated/wall/rust,
 /area/awaymission/UO71/medical)
@@ -7896,8 +7716,9 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "qc" = (
@@ -7944,6 +7765,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "qh" = (
@@ -7968,6 +7792,9 @@
 	req_access_txt = "271"
 	},
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/medical)
 "qj" = (
@@ -8142,6 +7969,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/burnturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "qy" = (
@@ -8221,7 +8051,6 @@
 	pixel_y = 23;
 	req_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/hand_labeler,
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
@@ -8532,15 +8361,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
-"rh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 7
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/medical)
 "ri" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -8574,41 +8397,14 @@
 	icon_state = "dark"
 	},
 /area/awaymission/UO71/science)
-"rl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/science)
-"rm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall3"
-	},
-/area/awaymission/UO71/bridge)
 "rn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "wall3"
 	},
 /area/awaymission/UO71/bridge)
 "ro" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -8634,14 +8430,6 @@
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
 "rr" = (
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/bridge)
-"rs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_Toxins = 1
-	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/bridge)
 "rt" = (
@@ -8973,9 +8761,8 @@
 	},
 /area/awaymission/UO71/medical)
 "rZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9521,12 +9308,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaymission/UO71/medical)
 "sS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
 	dir = 8;
@@ -9541,6 +9330,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitehall"
@@ -9580,6 +9373,10 @@
 	dir = 1;
 	pixel_x = 0;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -9907,73 +9704,12 @@
 	icon_state = "green"
 	},
 /area/awaymission/UO71/eng)
-"tC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/awaymission/UO71/science)
 "tD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/science)
-"tE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/wall,
-/area/awaymission/UO71/medical)
-"tF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 7
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/science)
-"tG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/science)
-"tH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/medical)
-"tI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/medical)
 "tJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9990,9 +9726,6 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "tK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10005,28 +9738,13 @@
 	},
 /area/awaymission/UO71/medical)
 "tL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitehall"
 	},
 /area/awaymission/UO71/medical)
-"tM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/science)
 "tN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/poddoor{
@@ -10226,11 +9944,23 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "uf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
 	level = 1
 	},
-/turf/simulated/wall/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "ug" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -10254,23 +9984,6 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
 "ui" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Maintenance";
-	req_access_txt = "271"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/science)
-"uj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/science)
-"uk" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10280,20 +9993,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/science)
-"ul" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	icon_state = "pipe-c"
+	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10331,7 +10033,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	level = 1
+	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
 "uo" = (
@@ -10349,6 +10054,9 @@
 	req_access_txt = "271"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -10374,6 +10082,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
@@ -10391,6 +10102,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitehall"
@@ -10404,12 +10116,6 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaymission/UO71/mining)
-"us" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/science)
 "ut" = (
 /turf/simulated/wall,
 /area/awaymission/UO71/outside)
@@ -10439,8 +10145,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/item/stack/rods,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
@@ -12742,13 +12451,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/queen)
-"yX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall3"
-	},
-/area/awaymission/UO71/outside)
 "yY" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/shuttle/wall{
@@ -12776,16 +12478,16 @@
 	},
 /area/awaymission/UO71/outside)
 "zd" = (
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall3"
+/turf/unsimulated/wall{
+	icon_state = "rock";
+	name = "rock"
 	},
 /area/awaymission/UO71/queen)
 "ze" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall3"
+/turf/unsimulated/wall{
+	icon_state = "rock";
+	name = "rock"
 	},
 /area/awaymission/UO71/queen)
 "zf" = (
@@ -12907,13 +12609,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
 /area/awaymission/UO71/queen)
-"zH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 7
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/science)
 "zM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/mineral/random/labormineral,
@@ -13040,13 +12735,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/awaymission/UO71/queen)
-"Ai" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/science)
 "AW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13055,6 +12743,33 @@
 	dir = 4;
 	icon_state = "green"
 	},
+/area/awaymission/UO71/plaza)
+"BE" = (
+/obj/machinery/door/poddoor{
+	id_tag = "UO71_Containment";
+	name = "Containment 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/mother)
+"CA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"CE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/science)
+"CI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	initialize_directions = 11
+	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
 "CP" = (
 /obj/structure/grille,
@@ -13072,21 +12787,57 @@
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
+"Fu" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/mother)
+"Gl" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"GY" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Maintenance";
+	req_access_txt = "271"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/science)
 "HH" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/awaymission/UO71/science)
+"Io" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
 "Iq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
 	req_one_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -13097,6 +12848,16 @@
 	},
 /turf/simulated/wall/rust,
 /area/awaymission/UO71/science)
+"IU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	level = 2
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/plaza)
 "Jo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13112,6 +12873,12 @@
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
+"Lf" = (
+/turf/unsimulated/wall{
+	icon_state = "rock";
+	name = "rock"
+	},
+/area/awaymission/UO71/loot)
 "Lw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13142,12 +12909,51 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
+"Pk" = (
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/science)
 "Pv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
 	initialize_directions = 14
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"PS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/mother)
+"Rk" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 101.325;
+	on = 1;
+	pressure_checks = 1
+	},
+/turf/simulated/floor/carpet,
+/area/awaymission/UO71/plaza)
+"Sz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/awaymission/UO71/plaza)
+"Ug" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
@@ -13166,12 +12972,34 @@
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/centralhall)
+"VA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"We" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitepurplecorner"
+	},
+/area/awaymission/UO71/science)
 "Xq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/mineral/random/labormineral,
 /area/awaymission/UO71/outside)
+"ZV" = (
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/science)
 
 (1,1,1) = {"
 aa
@@ -13275,7 +13103,7 @@ aa
 aa
 aa
 aa
-zc
+aa
 aa
 aa
 aa
@@ -13425,7 +13253,7 @@ aa
 aa
 aa
 aa
-zc
+aa
 aa
 aa
 aa
@@ -13575,7 +13403,7 @@ aa
 aa
 aa
 aa
-zc
+aa
 aa
 aa
 aa
@@ -13725,7 +13553,7 @@ aa
 aa
 aa
 aa
-zc
+aa
 aa
 aa
 aa
@@ -13875,7 +13703,7 @@ aa
 aa
 aa
 aa
-zc
+aa
 aa
 aa
 aa
@@ -14025,7 +13853,7 @@ aa
 aa
 aa
 aa
-zc
+aa
 aa
 aa
 aa
@@ -14175,7 +14003,7 @@ aa
 aa
 aa
 aa
-zc
+aa
 aa
 aa
 aa
@@ -14325,7 +14153,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -14475,7 +14303,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -14625,7 +14453,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -14775,7 +14603,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -14925,7 +14753,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -15075,7 +14903,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -15225,7 +15053,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -15375,7 +15203,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -15525,7 +15353,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -15675,7 +15503,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -15825,7 +15653,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -15975,7 +15803,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -16125,7 +15953,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -16275,7 +16103,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -16425,7 +16253,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -16575,7 +16403,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -16725,7 +16553,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -16875,7 +16703,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -17025,7 +16853,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -17175,7 +17003,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -17325,7 +17153,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -17475,7 +17303,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -17576,8 +17404,8 @@ ab
 ab
 ab
 ga
-gp
-gp
+gq
+gU
 gp
 hV
 ga
@@ -17625,7 +17453,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -17726,16 +17554,16 @@ ab
 ab
 ab
 ga
-gq
-gU
-gp
-gp
-iO
-jn
-jK
+hG
+hW
+hW
+hW
+Fu
+PS
+BE
 kf
-kJ
-lH
+kP
+lI
 fO
 fO
 fO
@@ -17775,7 +17603,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -17876,10 +17704,10 @@ ab
 ab
 ab
 ga
-hG
-hW
-hW
-mi
+gp
+gp
+gp
+gp
 iO
 jn
 jK
@@ -17925,7 +17753,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -18029,7 +17857,7 @@ ga
 gp
 gp
 gp
-mh
+hV
 ga
 jg
 jG
@@ -18075,7 +17903,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -18180,11 +18008,11 @@ gp
 gp
 gp
 mx
-iF
-ji
-ji
-kh
-kP
+ga
+fO
+fO
+fN
+kJ
 lN
 fO
 mT
@@ -18225,7 +18053,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -18348,6 +18176,7 @@ fO
 fN
 fN
 fN
+fN
 fO
 fN
 fO
@@ -18374,8 +18203,7 @@ ab
 ab
 ab
 ab
-ab
-zc
+aa
 ab
 ab
 ab
@@ -18484,21 +18312,22 @@ fN
 fO
 fO
 kr
-lc
-lP
+ld
+lH
 ms
-mR
-mR
-km
-km
+fN
+fN
+fO
+fO
 pD
 qb
 mn
 rg
 pe
 rg
-tG
+rg
 uf
+fN
 rP
 sE
 uv
@@ -18524,8 +18353,7 @@ ab
 ab
 ab
 ab
-ab
-zc
+aa
 ab
 ab
 ab
@@ -18632,9 +18460,9 @@ hC
 cO
 iP
 jo
-jL
-kj
-kV
+jM
+lb
+lc
 lO
 mr
 mW
@@ -18642,13 +18470,14 @@ ny
 og
 jQ
 jZ
-ji
-kh
-ji
-kh
-kh
-tF
+fO
+fO
+fO
+fO
+fO
+fO
 ui
+GY
 rR
 vm
 uK
@@ -18674,8 +18503,7 @@ ab
 ab
 ab
 ab
-ab
-zc
+aa
 ab
 ab
 ab
@@ -18797,8 +18625,9 @@ qu
 ra
 qu
 fO
-pC
+fO
 ol
+fO
 rS
 tp
 uO
@@ -18824,8 +18653,7 @@ ab
 ab
 ab
 ab
-ab
-zc
+aa
 ab
 ab
 ab
@@ -18949,6 +18777,7 @@ rQ
 fO
 pH
 om
+fN
 fO
 fO
 fN
@@ -18974,8 +18803,7 @@ ab
 ab
 ab
 ab
-ab
-zc
+aa
 ab
 ab
 ab
@@ -19097,9 +18925,9 @@ mu
 rj
 mu
 fO
-nI
-om
-fO
+CE
+ol
+fN
 ab
 ab
 ab
@@ -19125,7 +18953,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -19247,8 +19075,8 @@ qB
 ri
 rU
 fN
-nI
-uj
+Pk
+ol
 fO
 ab
 ab
@@ -19275,7 +19103,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -19397,8 +19225,8 @@ qC
 rk
 rV
 fN
-tC
-ul
+fO
+ol
 fO
 ab
 ab
@@ -19425,7 +19253,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -19547,8 +19375,8 @@ pT
 pT
 pT
 pT
-tD
-uk
+fO
+ol
 qa
 qa
 qa
@@ -19575,7 +19403,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -19685,7 +19513,7 @@ ab
 ab
 fO
 kJ
-lX
+lU
 fO
 nc
 na
@@ -19697,7 +19525,7 @@ qF
 qF
 rX
 pT
-Ai
+fO
 un
 pV
 vq
@@ -19725,7 +19553,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -19847,7 +19675,7 @@ zO
 qF
 rW
 sN
-tD
+fO
 qg
 pX
 vp
@@ -19875,7 +19703,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -19979,14 +19807,14 @@ fP
 fP
 fP
 Jo
-id
-iI
-yX
-jl
-km
-kY
-lX
-mu
+fP
+fP
+zc
+ab
+fO
+kJ
+We
+ZV
 ne
 nF
 or
@@ -19997,8 +19825,8 @@ pT
 pT
 pT
 pT
-tD
-uk
+fO
+ol
 pX
 vs
 qJ
@@ -20025,7 +19853,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -20129,7 +19957,7 @@ gd
 gd
 gd
 hD
-ie
+gd
 fP
 zc
 ab
@@ -20142,12 +19970,12 @@ nE
 oq
 pa
 pB
-pV
-pV
-rh
-pV
-pV
-tE
+qa
+qa
+qa
+qa
+qa
+qa
 uo
 qa
 vr
@@ -20175,7 +20003,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -20291,8 +20119,8 @@ nf
 nG
 os
 pd
-km
-pW
+fO
+pX
 qH
 ro
 rZ
@@ -20325,7 +20153,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -20475,7 +20303,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -20561,10 +20389,10 @@ ac
 ce
 cn
 cG
-cD
-cb
-cb
-dM
+bK
+bI
+bI
+aY
 ac
 ab
 ab
@@ -20597,7 +20425,7 @@ qJ
 qJ
 sc
 sU
-tH
+qa
 qi
 pX
 pX
@@ -20625,7 +20453,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -20711,7 +20539,7 @@ ac
 bF
 bI
 cF
-ca
+bI
 ac
 ac
 dL
@@ -20747,7 +20575,7 @@ qI
 rp
 sb
 sT
-tI
+qa
 qx
 fN
 ab
@@ -20775,7 +20603,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -20861,14 +20689,14 @@ ac
 cf
 cp
 cG
-bN
+bF
 ac
 dw
-dO
+ec
 dZ
 ej
 ev
-cU
+ac
 eV
 fm
 ad
@@ -20897,8 +20725,8 @@ qa
 qa
 qa
 qa
-tI
-uk
+qa
+ol
 fN
 ab
 ab
@@ -20925,7 +20753,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -21005,20 +20833,20 @@ aQ
 aZ
 bi
 br
-bx
-bJ
-bW
-bW
+ac
+aY
+ac
+ac
 cm
-cH
-bQ
-bW
+cG
+aY
+ac
 dv
-dN
+ar
 dY
-bv
+al
 eu
-bV
+ad
 eU
 fl
 ac
@@ -21047,7 +20875,7 @@ og
 nJ
 kB
 og
-tM
+og
 uw
 fN
 ab
@@ -21075,7 +20903,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -21155,13 +20983,13 @@ aR
 bc
 ac
 ad
-by
+ac
 bM
 cb
 cc
 cd
 cb
-cT
+IU
 ad
 dy
 dP
@@ -21170,7 +20998,7 @@ el
 ew
 ad
 eX
-bC
+Rk
 ac
 ab
 zc
@@ -21189,16 +21017,16 @@ gA
 kR
 mR
 jC
-zH
-mR
-mR
-km
-mR
-rl
-mR
-mR
-km
-us
+fO
+fN
+fN
+fO
+fN
+fN
+fN
+fN
+fO
+fO
 fN
 ab
 ab
@@ -21225,7 +21053,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -21305,7 +21133,7 @@ aQ
 bb
 bj
 bs
-bz
+ad
 bL
 ad
 ad
@@ -21317,7 +21145,7 @@ dx
 at
 ea
 ek
-at
+CP
 ac
 eW
 ac
@@ -21339,12 +21167,12 @@ gA
 lh
 fO
 nI
-ol
 fO
 fO
 fO
 fO
-rm
+fO
+sa
 sa
 sa
 sa
@@ -21375,7 +21203,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -21455,7 +21283,7 @@ ad
 bd
 ac
 ad
-bz
+ad
 bO
 ad
 ch
@@ -21465,11 +21293,11 @@ Of
 af
 al
 dQ
-ec
+Sz
 ec
 ex
 aw
-eY
+Ug
 fn
 ad
 ab
@@ -21489,12 +21317,12 @@ gA
 li
 fO
 nI
-om
+fN
 fO
 fO
 fO
 fO
-rm
+sa
 sg
 rr
 sa
@@ -21525,7 +21353,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -21605,7 +21433,7 @@ aS
 aw
 al
 ar
-by
+ac
 bN
 ac
 cg
@@ -21613,12 +21441,12 @@ cr
 cI
 ae
 dd
-bu
-bu
-bu
-bu
-bu
-bu
+CA
+CA
+CI
+CA
+Gl
+CA
 bG
 Lw
 ac
@@ -21639,12 +21467,12 @@ lZ
 tD
 fN
 nK
-om
+fN
 fb
 fb
 fb
 fb
-rm
+sa
 sf
 rr
 sa
@@ -21675,7 +21503,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -21755,7 +21583,7 @@ aU
 be
 bl
 bt
-bA
+ac
 bQ
 bW
 ci
@@ -21825,7 +21653,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -21905,7 +21733,7 @@ aT
 ac
 bk
 al
-bz
+ad
 bP
 ad
 ac
@@ -21944,7 +21772,7 @@ ll
 pI
 jf
 zP
-rm
+sa
 se
 sa
 sa
@@ -21975,7 +21803,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -22055,8 +21883,8 @@ aW
 ac
 bn
 bv
-bH
-bS
+bv
+Io
 aw
 ar
 ar
@@ -22094,7 +21922,7 @@ ll
 fR
 qk
 zQ
-rs
+rr
 si
 rr
 tO
@@ -22125,7 +21953,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -22205,8 +22033,8 @@ aV
 ac
 bm
 bu
-bG
-bR
+bu
+VA
 al
 al
 al
@@ -22275,7 +22103,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -22355,7 +22183,7 @@ aT
 ac
 bp
 ar
-by
+ac
 bP
 ac
 ad
@@ -22425,7 +22253,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -22505,7 +22333,7 @@ aX
 aX
 bo
 bw
-by
+ac
 bL
 ad
 aF
@@ -22575,7 +22403,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -22655,7 +22483,7 @@ al
 bf
 al
 al
-bz
+ad
 bU
 ac
 cl
@@ -22725,7 +22553,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -22805,7 +22633,7 @@ ac
 ac
 ad
 bB
-bD
+ad
 bX
 bV
 ck
@@ -22875,7 +22703,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -22955,7 +22783,7 @@ ac
 bh
 bq
 bq
-by
+ac
 ca
 ad
 ac
@@ -23025,7 +22853,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -23105,11 +22933,11 @@ ac
 bg
 aH
 bC
-by
+ac
 bZ
 cc
 cd
-cc
+IU
 cN
 ac
 CP
@@ -23175,7 +23003,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -23255,12 +23083,12 @@ ac
 ac
 ac
 ac
-bE
-bV
-bW
-bW
-cx
-ca
+ac
+ad
+ac
+ac
+bL
+bI
 ad
 dk
 dH
@@ -23325,7 +23153,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -23410,8 +23238,8 @@ ab
 ab
 ac
 cw
-cy
-cU
+bK
+ac
 dj
 bu
 dV
@@ -23475,7 +23303,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -23560,7 +23388,7 @@ ab
 ab
 ad
 cw
-cK
+ac
 ac
 dm
 dI
@@ -23625,7 +23453,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -23710,7 +23538,7 @@ ab
 ab
 ac
 cw
-cK
+ac
 cY
 dl
 ar
@@ -23775,7 +23603,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -23860,7 +23688,7 @@ ab
 ab
 ad
 cw
-cK
+ac
 da
 do
 dI
@@ -23925,7 +23753,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -24010,7 +23838,7 @@ ab
 ab
 ac
 cw
-cL
+ad
 cZ
 dn
 al
@@ -24160,7 +23988,7 @@ ab
 ab
 ad
 cw
-cK
+ac
 dc
 do
 dI
@@ -24310,7 +24138,7 @@ ab
 ab
 ad
 co
-cL
+ad
 db
 dp
 al
@@ -24460,7 +24288,7 @@ ab
 ab
 ac
 cA
-cL
+ad
 ad
 dr
 dI
@@ -24609,12 +24437,12 @@ ab
 ab
 ab
 ac
-cz
-cP
-bV
+bL
+cF
+ad
 dq
 dJ
-dW
+dT
 eh
 dT
 eG
@@ -24760,7 +24588,7 @@ ab
 ab
 ad
 cq
-bL
+aY
 ac
 dt
 dh
@@ -24781,7 +24609,7 @@ hq
 hQ
 gk
 gk
-jw
+fb
 jY
 fb
 fb
@@ -24910,7 +24738,7 @@ ab
 ab
 ad
 cC
-bN
+bF
 ad
 ds
 dK
@@ -24931,7 +24759,7 @@ hp
 gk
 gk
 fU
-jw
+fb
 jX
 it
 fb
@@ -25060,7 +24888,7 @@ ab
 ab
 ad
 cC
-bL
+aY
 ac
 ac
 ac
@@ -25081,7 +24909,7 @@ hs
 hR
 ir
 iX
-jx
+fe
 ka
 kD
 fe
@@ -25210,7 +25038,7 @@ ab
 ab
 ac
 cE
-cQ
+cc
 cb
 cR
 cd
@@ -25231,7 +25059,7 @@ hr
 fb
 fe
 fb
-jx
+fe
 is
 kC
 fe
@@ -25359,18 +25187,18 @@ ab
 ab
 ab
 ac
-cB
-bW
-bV
-bV
-bW
-bV
-bV
-bW
-bV
-bV
-fh
-fu
+ad
+ac
+ad
+ad
+ac
+ad
+ad
+ac
+ad
+ad
+fe
+fb
 fD
 fK
 fx
@@ -25381,7 +25209,7 @@ ht
 gb
 fy
 iY
-gm
+de
 kb
 fe
 fe
@@ -25520,18 +25348,18 @@ ab
 ab
 ab
 ab
-fv
-fh
-fh
-fh
-fX
-fX
-fh
-fh
-fh
-fh
-fh
-jz
+fb
+fe
+fe
+fe
+fb
+fb
+fe
+fe
+fe
+fe
+fe
+fb
 fe
 fb
 ab
@@ -26025,7 +25853,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -26175,7 +26003,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -26325,7 +26153,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -26475,7 +26303,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -26625,7 +26453,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -26775,7 +26603,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -26925,7 +26753,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -27075,7 +26903,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -27225,7 +27053,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -27375,7 +27203,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -27525,7 +27353,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -27675,7 +27503,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -27825,7 +27653,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -27975,7 +27803,7 @@ ab
 ab
 ab
 ab
-pT
+Lf
 pT
 pT
 pT
@@ -28125,7 +27953,7 @@ ab
 ab
 ab
 ab
-pT
+Lf
 zo
 zt
 zv
@@ -28275,7 +28103,7 @@ ab
 ab
 ab
 ab
-pT
+Lf
 zn
 zs
 zs
@@ -28425,7 +28253,7 @@ ab
 ab
 ab
 ab
-pT
+Lf
 zp
 zu
 zs
@@ -28575,7 +28403,7 @@ ab
 ab
 ab
 ab
-pT
+Lf
 pT
 pT
 pT
@@ -28725,7 +28553,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -28875,7 +28703,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -29025,7 +28853,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 zr
@@ -29175,7 +29003,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -29325,7 +29153,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -29475,7 +29303,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 uW
@@ -29625,7 +29453,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 zr
 uW
@@ -29775,7 +29603,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 uW
 zr
@@ -29925,7 +29753,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -30075,7 +29903,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -30225,7 +30053,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -30375,7 +30203,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -30525,7 +30353,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -30675,7 +30503,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -30825,7 +30653,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -30975,7 +30803,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -31125,7 +30953,7 @@ ab
 ab
 ab
 ab
-zc
+aa
 ab
 ab
 ab
@@ -31274,8 +31102,8 @@ aa
 aa
 aa
 aa
-ab
-zc
+aa
+aa
 aa
 aa
 aa
@@ -31424,8 +31252,8 @@ aa
 aa
 aa
 aa
-ab
-zc
+aa
+aa
 aa
 aa
 aa
@@ -31574,8 +31402,8 @@ aa
 aa
 aa
 aa
-ab
-zc
+aa
+aa
 aa
 aa
 aa
@@ -31724,8 +31552,8 @@ aa
 aa
 aa
 aa
-ab
-zc
+aa
+aa
 aa
 aa
 aa
@@ -31874,8 +31702,8 @@ aa
 aa
 aa
 aa
-ab
-zc
+aa
+aa
 aa
 aa
 aa
@@ -32024,8 +31852,8 @@ aa
 aa
 aa
 aa
-ab
-zc
+aa
+aa
 aa
 aa
 aa
@@ -32174,8 +32002,8 @@ aa
 aa
 aa
 aa
-ab
-zc
+aa
+aa
 aa
 aa
 aa

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -13047,13 +13047,7 @@
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/science)
-"ED" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/awaymission/UO71/centralhall)
-"Fi" = (
+"AW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13062,7 +13056,15 @@
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
-"Gk" = (
+"CP" = (
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/plaza)
+"Eb" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	icon_state = "weld";
 	on = 1;
@@ -13070,51 +13072,7 @@
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
-"GF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/centralhall)
-"Hu" = (
-/obj/structure/spider/cocoon{
-	icon_state = "cocoon_large1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/prince)
-"HL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/awaymission/UO71/prince)
-"Ip" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"JK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall3"
-	},
-/area/awaymission/UO71/outside)
-"Kf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"LQ" = (
+"HH" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13123,46 +13081,7 @@
 	icon_state = "white"
 	},
 /area/awaymission/UO71/science)
-"Nh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 14
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"NY" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"QR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"Th" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/prince)
-"Vx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/mineral/random/labormineral,
-/area/awaymission/UO71/outside)
-"YR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/science)
-"Ze" = (
+"Iq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
 	req_one_access_txt = "0"
@@ -13172,6 +13091,87 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
+"IL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/rust,
+/area/awaymission/UO71/science)
+"Jo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/UO71/prince)
+"KE" = (
+/obj/structure/spider/cocoon{
+	icon_state = "cocoon_large1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/vault,
+/area/awaymission/UO71/prince)
+"Lw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"LR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/centralhall)
+"Mh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"NA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/vault,
+/area/awaymission/UO71/prince)
+"Of" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"Pv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	initialize_directions = 14
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"UF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/awaymission/UO71/outside)
+"Vz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/awaymission/UO71/centralhall)
+"Xq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/mineral/random/labormineral,
+/area/awaymission/UO71/outside)
 
 (1,1,1) = {"
 aa
@@ -19078,7 +19078,7 @@ fN
 gj
 gA
 ap
-LQ
+HH
 gZ
 fO
 fO
@@ -19528,7 +19528,7 @@ ab
 fO
 fN
 fN
-YR
+IL
 fN
 fO
 ab
@@ -19678,7 +19678,7 @@ ab
 ab
 ab
 ab
-Vx
+Xq
 ab
 ab
 ab
@@ -19828,7 +19828,7 @@ zc
 zc
 zc
 zc
-JK
+UF
 zc
 zc
 zc
@@ -19978,7 +19978,7 @@ fP
 fP
 fP
 fP
-HL
+Jo
 id
 iI
 yX
@@ -20278,7 +20278,7 @@ fP
 gd
 gd
 gd
-Hu
+KE
 gd
 fP
 zc
@@ -20428,7 +20428,7 @@ fP
 ge
 ge
 gd
-Th
+NA
 if
 fP
 yY
@@ -20578,7 +20578,7 @@ fP
 gf
 gx
 gd
-Hu
+KE
 gd
 iR
 jq
@@ -20728,7 +20728,7 @@ fP
 gd
 gd
 gd
-Th
+NA
 gd
 iR
 jq
@@ -20878,7 +20878,7 @@ fP
 gd
 gd
 ge
-Th
+NA
 if
 fP
 yY
@@ -21027,7 +21027,7 @@ zc
 fP
 gd
 gd
-Gk
+Eb
 hE
 ge
 fP
@@ -21178,7 +21178,7 @@ fP
 fP
 fP
 fP
-HL
+Jo
 fP
 fP
 zc
@@ -21311,7 +21311,7 @@ ad
 ad
 ac
 ad
-Ze
+Iq
 ad
 dx
 at
@@ -21328,7 +21328,7 @@ zc
 zc
 zc
 zc
-JK
+UF
 zc
 zc
 zc
@@ -21461,7 +21461,7 @@ ad
 ch
 cs
 ac
-Ip
+Of
 af
 al
 dQ
@@ -21478,7 +21478,7 @@ ab
 ab
 ab
 ab
-Vx
+Xq
 ab
 ab
 ab
@@ -21620,7 +21620,7 @@ bu
 bu
 bu
 bG
-QR
+Lw
 ac
 fb
 fb
@@ -21628,7 +21628,7 @@ fb
 fb
 fe
 fb
-ED
+Vz
 fb
 fe
 fe
@@ -21762,7 +21762,7 @@ ci
 ct
 ac
 ar
-Nh
+Pv
 dA
 ay
 ed
@@ -21771,10 +21771,10 @@ ey
 eK
 bH
 df
-Kf
-GF
+Mh
+LR
 hJ
-GF
+LR
 hJ
 gD
 hJ
@@ -22512,7 +22512,7 @@ aF
 cu
 ac
 al
-Nh
+Pv
 dB
 dS
 eg
@@ -22812,7 +22812,7 @@ ck
 cv
 ac
 cX
-Fi
+AW
 dD
 dh
 dh
@@ -22962,7 +22962,7 @@ ac
 ad
 ad
 ac
-NY
+CP
 dG
 dU
 at
@@ -23112,7 +23112,7 @@ cd
 cc
 cN
 ac
-NY
+CP
 dF
 al
 at

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -6129,10 +6129,13 @@
 	pixel_x = -30;
 	pixel_y = 0
 	},
-/obj/item/reagent_containers/food/pill/haloperidol,
-/obj/item/reagent_containers/food/pill/haloperidol,
-/obj/item/reagent_containers/food/pill/haloperidol,
-/obj/item/reagent_containers/food/pill/haloperidol,
+/obj/item/paper/terrorspiders4,
+/obj/item/reagent_containers/food/pill/charcoal{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/pill/charcoal{
+	pixel_x = -3
+	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/centralhall)
 "mF" = (
@@ -6164,7 +6167,6 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/item/paper/terrorspiders4,
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/centralhall)
 "mH" = (

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -19386,7 +19386,7 @@ ab
 fO
 kN
 lV
-fO
+km
 nb
 nD
 oo

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -3862,10 +3862,6 @@
 /area/awaymission/UO71/gateway)
 "iz" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "UO71_biohazard";
-	name = "biohazard containment door"
-	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -6414,14 +6410,6 @@
 /area/awaymission/UO71/science)
 "nd" = (
 /obj/structure/table,
-/obj/machinery/door_control{
-	desc = "A remote control-switch whichs locks the research division down in the event of a biohazard leak or contamination.";
-	id = "UO71_biohazard";
-	name = "Biohazard Door Control";
-	pixel_x = 0;
-	pixel_y = -6;
-	req_access_txt = "271"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -7631,14 +7619,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/door_control{
-	desc = "A remote control-switch whichs locks the research division down in the event of a biohazard leak or contamination.";
-	id = "UO71_biohazard";
-	name = "Biohazard Door Control";
-	pixel_x = 0;
-	pixel_y = 8;
-	req_access_txt = "271"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria";
@@ -7675,14 +7655,6 @@
 /area/awaymission/UO71/science)
 "pa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door_control{
-	desc = "A remote control-switch whichs locks the research division down in the event of a biohazard leak or contamination.";
-	id = "UO71_biohazard";
-	name = "Biohazard Door Control";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "271"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -737,10 +737,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
-"bY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/plaza)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13425,109 +13421,13 @@
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/science)
-"BU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/mineral/random/labormineral,
-/area/awaymission/UO71/outside)
-"BV" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"Co" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"DT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"DU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/rust,
-/area/awaymission/UO71/science)
-"FS" = (
+"ED" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/centralhall)
-"Gt" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/awaymission/UO71/science)
-"KJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/awaymission/UO71/prince)
-"Oh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall3"
-	},
-/area/awaymission/UO71/outside)
-"OL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/centralhall)
-"RR" = (
-/obj/structure/spider/cocoon{
-	icon_state = "cocoon_large1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/prince)
-"Ux" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/UO71/plaza)
-"UU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/vault,
-/area/awaymission/UO71/prince)
-"Vq" = (
-/obj/structure/grille,
-/obj/structure/window/full/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/UO71/plaza)
-"WZ" = (
+"Fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -13536,7 +13436,7 @@
 	icon_state = "green"
 	},
 /area/awaymission/UO71/plaza)
-"Xj" = (
+"Gk" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	icon_state = "weld";
 	on = 1;
@@ -13544,12 +13444,108 @@
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
-"XS" = (
+"GF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/centralhall)
+"Hu" = (
+/obj/structure/spider/cocoon{
+	icon_state = "cocoon_large1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/vault,
+/area/awaymission/UO71/prince)
+"HL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/UO71/prince)
+"Ip" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"JK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/awaymission/UO71/outside)
+"Kf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"LQ" = (
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/awaymission/UO71/science)
+"Nh" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	initialize_directions = 14;
+	tag = "icon-manifold-b-f (NORTH)"
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"NY" = (
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/UO71/plaza)
+"QR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/awaymission/UO71/plaza)
+"Th" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/vault,
+/area/awaymission/UO71/prince)
+"Vx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/mineral/random/labormineral,
+/area/awaymission/UO71/outside)
+"YR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/rust,
+/area/awaymission/UO71/science)
+"Ze" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
 
 (1,1,1) = {"
@@ -19457,7 +19453,7 @@ fN
 gj
 gA
 ap
-Gt
+LQ
 gZ
 fO
 fO
@@ -19907,7 +19903,7 @@ ab
 fO
 fN
 fN
-DU
+YR
 fN
 fO
 ab
@@ -20057,7 +20053,7 @@ ab
 ab
 ab
 ab
-BU
+Vx
 ab
 ab
 ab
@@ -20207,7 +20203,7 @@ zc
 zc
 zc
 zc
-Oh
+JK
 zc
 zc
 zc
@@ -20357,7 +20353,7 @@ fP
 fP
 fP
 fP
-KJ
+HL
 id
 iI
 yX
@@ -20657,7 +20653,7 @@ fP
 gd
 gd
 gd
-RR
+Hu
 gd
 fP
 zc
@@ -20807,7 +20803,7 @@ fP
 ge
 ge
 gd
-UU
+Th
 if
 fP
 yY
@@ -20957,7 +20953,7 @@ fP
 gf
 gx
 gd
-RR
+Hu
 gd
 iR
 jq
@@ -21107,7 +21103,7 @@ fP
 gd
 gd
 gd
-UU
+Th
 gd
 iR
 jq
@@ -21257,7 +21253,7 @@ fP
 gd
 gd
 ge
-UU
+Th
 if
 fP
 yY
@@ -21406,7 +21402,7 @@ zc
 fP
 gd
 gd
-Xj
+Gk
 hE
 ge
 fP
@@ -21557,7 +21553,7 @@ fP
 fP
 fP
 fP
-KJ
+HL
 fP
 fP
 zc
@@ -21690,7 +21686,7 @@ ad
 ad
 ac
 ad
-BV
+Ze
 ad
 dx
 at
@@ -21707,7 +21703,7 @@ zc
 zc
 zc
 zc
-Oh
+JK
 zc
 zc
 zc
@@ -21840,7 +21836,7 @@ ad
 ch
 cs
 ac
-XS
+Ip
 af
 al
 dQ
@@ -21857,7 +21853,7 @@ ab
 ab
 ab
 ab
-BU
+Vx
 ab
 ab
 ab
@@ -21999,7 +21995,7 @@ bu
 bu
 bu
 bG
-Co
+QR
 ac
 fb
 fb
@@ -22007,7 +22003,7 @@ fb
 fb
 fe
 fb
-FS
+ED
 fb
 fe
 fe
@@ -22141,7 +22137,7 @@ ci
 ct
 ac
 ar
-Ux
+Nh
 dA
 ay
 ed
@@ -22150,10 +22146,10 @@ ey
 eK
 bH
 df
-DT
-OL
+Kf
+GF
 hJ
-OL
+GF
 hJ
 gD
 hJ
@@ -22886,12 +22882,12 @@ bo
 bw
 by
 bL
-bY
+ad
 aF
 cu
 ac
 al
-Ux
+Nh
 dB
 dS
 eg
@@ -23191,7 +23187,7 @@ ck
 cv
 ac
 cX
-WZ
+Fi
 dD
 dh
 dh
@@ -23341,7 +23337,7 @@ ac
 ad
 ad
 ac
-Vq
+NY
 dG
 dU
 at
@@ -23491,7 +23487,7 @@ cd
 cc
 cN
 ac
-Vq
+NY
 dF
 al
 at

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -18,8 +18,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
@@ -57,8 +56,7 @@
 "aj" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO71/plaza)
 "ak" = (
@@ -141,7 +139,6 @@
 /area/awaymission/UO71/plaza)
 "ax" = (
 /obj/structure/chair/comfy/beige{
-	tag = "icon-comfychair (EAST)";
 	icon_state = "comfychair";
 	dir = 4
 	},
@@ -229,7 +226,6 @@
 /area/awaymission/UO71/plaza)
 "aH" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -600,8 +596,7 @@
 "bA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/plaza)
@@ -622,8 +617,7 @@
 "bD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/wall/rust,
 /area/awaymission/UO71/plaza)
@@ -832,7 +826,6 @@
 	req_access = null
 	},
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -876,7 +869,6 @@
 /area/awaymission/UO71/plaza)
 "cs" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -949,8 +941,7 @@
 "cy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
@@ -958,8 +949,7 @@
 "cz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/plaza)
@@ -1103,8 +1093,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -1155,8 +1144,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
-	icon_state = "greencorner";
-	tag = "icon-greencorner"
+	icon_state = "greencorner"
 	},
 /area/awaymission/UO71/plaza)
 "cY" = (
@@ -1208,8 +1196,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
@@ -1218,8 +1205,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1247,8 +1233,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1301,8 +1286,7 @@
 "dn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1393,8 +1377,7 @@
 "dv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/chair,
 /obj/structure/reagent_dispensers/peppertank{
@@ -1531,8 +1514,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO71/plaza)
 "dK" = (
@@ -1583,8 +1565,7 @@
 "dO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1712,7 +1693,6 @@
 /area/awaymission/UO71/plaza)
 "ed" = (
 /obj/structure/chair/office{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
@@ -1731,7 +1711,6 @@
 /area/awaymission/UO71/plaza)
 "eg" = (
 /obj/structure/chair/office{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -1744,8 +1723,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO71/plaza)
 "ei" = (
@@ -1798,7 +1776,6 @@
 /area/awaymission/UO71/plaza)
 "em" = (
 /obj/structure/chair/office{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
@@ -1903,8 +1880,7 @@
 "ez" = (
 /turf/simulated/floor/plasteel{
 	dir = 2;
-	icon_state = "greencorner";
-	tag = "icon-greencorner"
+	icon_state = "greencorner"
 	},
 /area/awaymission/UO71/plaza)
 "eA" = (
@@ -1957,8 +1933,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1971,8 +1946,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -1989,8 +1963,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -2002,8 +1975,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -2014,8 +1986,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -2100,8 +2071,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2119,8 +2089,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2130,8 +2099,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2145,8 +2113,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2156,8 +2123,7 @@
 "eU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO71/plaza)
@@ -2205,8 +2171,7 @@
 "eZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)
@@ -2307,8 +2272,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO71/plaza)
 "fo" = (
@@ -2391,8 +2355,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2433,8 +2396,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2504,8 +2466,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -2566,16 +2527,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "fV" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "fW" = (
@@ -2590,8 +2549,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "fX" = (
@@ -2604,8 +2562,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "fZ" = (
@@ -2613,8 +2570,7 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "ga" = (
@@ -2625,8 +2581,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2698,8 +2653,7 @@
 "gk" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "gl" = (
@@ -2710,8 +2664,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "gm" = (
@@ -2719,8 +2672,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2888,8 +2840,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -2958,8 +2909,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "gN" = (
@@ -2970,8 +2920,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "gO" = (
@@ -2979,8 +2928,7 @@
 /obj/item/reagent_containers/food/snacks/applepie,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "gP" = (
@@ -3004,8 +2952,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "gQ" = (
@@ -3042,7 +2989,6 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3056,7 +3002,6 @@
 /area/awaymission/UO71/mother)
 "gV" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3173,7 +3118,6 @@
 /area/awaymission/UO71/centralhall)
 "hh" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3236,8 +3180,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "ho" = (
@@ -3247,8 +3190,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "hp" = (
@@ -3258,8 +3200,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "hq" = (
@@ -3267,8 +3208,7 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "hr" = (
@@ -3289,8 +3229,7 @@
 /obj/item/book/manual/chef_recipes,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "ht" = (
@@ -3298,14 +3237,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/centralhall)
@@ -3349,7 +3286,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3359,7 +3295,6 @@
 /area/awaymission/UO71/gateway)
 "hy" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3456,7 +3391,6 @@
 /area/awaymission/UO71/centralhall)
 "hL" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3494,8 +3428,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "hQ" = (
@@ -3503,8 +3436,7 @@
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "hR" = (
@@ -3514,8 +3446,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "hS" = (
@@ -3570,8 +3501,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/door/window{
 	dir = 2;
@@ -3588,7 +3518,6 @@
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3734,8 +3663,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "iq" = (
@@ -3745,8 +3673,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "ir" = (
@@ -3768,8 +3695,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "is" = (
@@ -3777,8 +3703,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3813,8 +3738,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
@@ -3869,7 +3793,6 @@
 "iE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3886,7 +3809,6 @@
 	dir = 4
 	},
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -3912,8 +3834,7 @@
 "iJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -3985,8 +3906,7 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "iW" = (
@@ -4002,8 +3922,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "iX" = (
@@ -4019,8 +3938,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/centralhall)
 "iY" = (
@@ -4081,8 +3999,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4110,8 +4027,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4256,8 +4172,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -4272,8 +4187,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4341,8 +4255,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/structure/spider/terrorweb,
 /turf/simulated/floor/plasteel{
@@ -4397,8 +4310,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4407,7 +4319,6 @@
 /area/awaymission/UO71/science)
 "jR" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
@@ -4453,15 +4364,13 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -4480,8 +4389,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -4499,8 +4407,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4515,8 +4422,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4534,8 +4440,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4551,8 +4456,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4567,8 +4471,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4593,8 +4496,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/door/airlock/command{
 	name = "Gateway";
@@ -4612,14 +4514,12 @@
 "kf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHWEST)";
 	icon_state = "whitepurple";
 	dir = 9
 	},
 /area/awaymission/UO71/science)
 "kg" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHEAST)";
 	icon_state = "whitepurple";
 	dir = 5
 	},
@@ -4635,7 +4535,6 @@
 "kj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4667,7 +4566,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/terrorspiders5,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHWEST)";
 	icon_state = "whitepurple";
 	dir = 9
 	},
@@ -4678,7 +4576,6 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHEAST)";
 	icon_state = "whitepurple";
 	dir = 5
 	},
@@ -4706,7 +4603,6 @@
 	layer = 5
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
 	dir = 4
 	},
@@ -4770,14 +4666,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -4802,8 +4696,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4833,7 +4726,6 @@
 /area/awaymission/UO71/gateway)
 "kF" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -4860,7 +4752,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4871,7 +4762,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4886,7 +4776,6 @@
 	},
 /mob/living/simple_animal/hostile/poison/terror_spider/gray,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4903,7 +4792,6 @@
 	req_access = null
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4917,7 +4805,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4926,11 +4813,9 @@
 "kN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4945,7 +4830,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4957,7 +4841,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -4973,7 +4856,6 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -5038,7 +4920,6 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -5058,7 +4939,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -5067,7 +4947,6 @@
 "kY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -5082,7 +4961,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -5091,7 +4969,6 @@
 "la" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -5099,7 +4976,6 @@
 /area/awaymission/UO71/science)
 "lb" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -5108,8 +4984,7 @@
 "lc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -5192,16 +5067,14 @@
 "lm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/sign/science{
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "purplecorner";
-	tag = "icon-purplecorner (WEST)"
+	icon_state = "purplecorner"
 	},
 /area/awaymission/UO71/centralhall)
 "ln" = (
@@ -5285,8 +5158,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5300,8 +5172,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -5323,8 +5194,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "warndark";
-	tag = "icon-warndark (EAST)"
+	icon_state = "warndark"
 	},
 /area/awaymission/UO71/gateway)
 "ly" = (
@@ -5332,8 +5202,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
@@ -5341,8 +5210,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
@@ -5357,8 +5225,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -5370,8 +5237,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -5381,8 +5247,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -5394,14 +5259,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/gateway)
@@ -5411,8 +5274,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5430,8 +5292,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5445,8 +5306,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5461,8 +5321,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -5475,8 +5334,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -5501,8 +5359,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
@@ -5518,8 +5375,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5541,8 +5397,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5561,8 +5416,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5579,14 +5433,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -5594,8 +5446,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5608,8 +5459,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5651,13 +5501,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (EAST)"
+	icon_state = "pipe-j1"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -5677,8 +5525,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -5769,8 +5616,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "purple";
-	tag = "icon-purple (WEST)"
+	icon_state = "purple"
 	},
 /area/awaymission/UO71/centralhall)
 "mc" = (
@@ -5783,7 +5629,6 @@
 /area/awaymission/UO71/centralhall)
 "md" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
@@ -5826,8 +5671,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5862,8 +5706,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "warndark";
-	tag = "icon-warndark (EAST)"
+	icon_state = "warndark"
 	},
 /area/awaymission/UO71/gateway)
 "ml" = (
@@ -5875,8 +5718,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5896,8 +5738,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5931,8 +5772,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5952,8 +5792,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "mu" = (
@@ -6015,8 +5854,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/loot)
 "mC" = (
@@ -6087,8 +5925,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6138,8 +5975,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6243,8 +6079,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6272,8 +6107,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "mY" = (
@@ -6284,8 +6118,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "mZ" = (
@@ -6295,23 +6128,20 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "na" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "nb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "nc" = (
@@ -6321,8 +6151,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "nd" = (
@@ -6387,7 +6216,6 @@
 	specialfunctions = 4
 	},
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -6469,7 +6297,6 @@
 /area/awaymission/UO71/eng)
 "ns" = (
 /obj/structure/chair/comfy/black{
-	tag = "icon-comfychair (EAST)";
 	icon_state = "comfychair";
 	dir = 4
 	},
@@ -6480,7 +6307,6 @@
 /area/awaymission/UO71/centralhall)
 "nt" = (
 /obj/structure/chair/comfy/black{
-	tag = "icon-comfychair (WEST)";
 	icon_state = "comfychair";
 	dir = 8
 	},
@@ -6519,8 +6345,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6537,8 +6362,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "nA" = (
@@ -6550,8 +6374,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "nB" = (
@@ -6575,7 +6398,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4;
 	heat_capacity = 1e+006
@@ -6586,8 +6408,7 @@
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "nE" = (
@@ -6623,8 +6444,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -6640,8 +6460,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6656,8 +6475,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6669,8 +6487,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6688,8 +6505,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -6707,16 +6523,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -6793,14 +6607,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -6837,8 +6649,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -6846,21 +6657,18 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -6868,8 +6676,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -6906,8 +6713,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6930,8 +6736,7 @@
 /obj/item/laser_pointer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oi" = (
@@ -6949,16 +6754,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "ok" = (
@@ -6966,8 +6769,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -7002,8 +6804,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oo" = (
@@ -7016,8 +6817,7 @@
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "op" = (
@@ -7036,8 +6836,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oq" = (
@@ -7075,8 +6874,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -7114,8 +6912,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7133,8 +6930,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7153,8 +6949,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7176,8 +6971,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7198,8 +6992,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -7209,8 +7002,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7223,8 +7015,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7240,8 +7031,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7257,8 +7047,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/alarm/monitor{
 	frequency = 1439;
@@ -7271,8 +7060,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7285,8 +7073,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7305,8 +7092,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7324,8 +7110,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7346,8 +7131,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7374,8 +7158,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7393,8 +7176,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -7426,18 +7208,15 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-y (WEST)";
 	icon_state = "pipe-y";
 	dir = 8
 	},
@@ -7450,16 +7229,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -7468,8 +7245,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -7527,8 +7303,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oW" = (
@@ -7538,16 +7313,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oY" = (
@@ -7558,16 +7331,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "oZ" = (
 /obj/machinery/computer/aifixer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "pa" = (
@@ -7623,8 +7394,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7648,8 +7418,7 @@
 "ph" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -7762,8 +7531,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
@@ -7787,8 +7555,7 @@
 "pt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -7810,8 +7577,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -7859,8 +7625,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -7892,8 +7657,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7908,8 +7672,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7934,8 +7697,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "pF" = (
@@ -7946,8 +7708,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "pG" = (
@@ -7959,8 +7720,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/science)
 "pH" = (
@@ -7968,8 +7728,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8074,8 +7833,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -8090,14 +7848,12 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -8117,8 +7873,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -8126,8 +7881,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/eng)
@@ -8139,8 +7893,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8181,8 +7934,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8203,8 +7955,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8381,8 +8132,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8404,8 +8154,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "SMES Room";
@@ -8452,8 +8201,7 @@
 "qF" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/loot)
 "qG" = (
@@ -8497,13 +8245,11 @@
 "qK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner";
-	tag = "icon-purplecorner (NORTH)"
+	icon_state = "purplecorner"
 	},
 /area/awaymission/UO71/centralhall)
 "qL" = (
@@ -8607,8 +8353,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -8617,14 +8362,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/engine,
@@ -8683,8 +8426,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "arrival";
-	tag = "icon-arrival (NORTHWEST)"
+	icon_state = "arrival"
 	},
 /area/awaymission/UO71/eng)
 "ra" = (
@@ -8786,8 +8528,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8796,8 +8537,7 @@
 "rh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/medical)
@@ -8887,7 +8627,6 @@
 /area/awaymission/UO71/medical)
 "rq" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -9117,14 +8856,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
@@ -9212,8 +8949,7 @@
 /obj/mecha/medical/odysseus,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/loot)
 "rX" = (
@@ -9225,8 +8961,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/loot)
 "rY" = (
@@ -9240,8 +8975,7 @@
 "rZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9348,14 +9082,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -9370,8 +9102,7 @@
 "sm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway";
@@ -9385,8 +9116,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9410,8 +9140,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -9424,8 +9153,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9444,16 +9172,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -9465,8 +9191,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/alarm/monitor{
 	frequency = 1439;
@@ -9490,8 +9215,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9509,8 +9233,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9535,8 +9258,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9556,8 +9278,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9575,8 +9296,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9589,8 +9309,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9614,8 +9333,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -9629,8 +9347,7 @@
 "sA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -9669,8 +9386,7 @@
 "sD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -9706,8 +9422,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/meter{
 	frequency = 1443;
@@ -9910,13 +9625,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -10004,8 +9717,7 @@
 "tj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10017,14 +9729,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -10063,8 +9773,7 @@
 "tn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -10098,8 +9807,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 1
@@ -10203,8 +9911,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -10231,16 +9938,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO71/science)
@@ -10248,8 +9953,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -10315,8 +10019,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10356,16 +10059,14 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/centralhall)
@@ -10390,8 +10091,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "escape";
-	tag = "icon-escape (NORTH)"
+	icon_state = "escape"
 	},
 /area/awaymission/UO71/eng)
 "tT" = (
@@ -10421,8 +10121,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10450,8 +10149,7 @@
 "tX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/item/radio/off,
 /obj/item/screwdriver,
@@ -10493,8 +10191,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4;
@@ -10578,8 +10275,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10593,8 +10289,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -10611,8 +10306,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "UO71_Engineering";
@@ -10629,8 +10323,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10646,8 +10339,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10668,22 +10360,19 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
 	icon_state = "pipe-j1";
 	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10695,8 +10384,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10744,8 +10432,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -10815,8 +10502,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -10838,8 +10524,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10916,8 +10601,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -11003,8 +10687,7 @@
 /turf/simulated/floor/plasteel{
 	burnt = 1;
 	dir = 8;
-	icon_state = "floorscorched2";
-	tag = "icon-floorscorched2 (WEST)"
+	icon_state = "floorscorched2"
 	},
 /area/awaymission/UO71/eng)
 "uU" = (
@@ -11012,8 +10695,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11033,8 +10715,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -11123,14 +10804,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -11147,8 +10826,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -11299,8 +10977,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11407,16 +11084,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -11427,8 +11102,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -11571,8 +11245,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -11600,8 +11273,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11616,8 +11288,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -11641,14 +11312,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -11656,8 +11325,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -11666,8 +11334,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -11712,8 +11379,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/eng)
@@ -11722,8 +11388,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -11745,8 +11410,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -11811,8 +11475,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/mining/glass{
@@ -11848,8 +11511,7 @@
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "caution";
-	tag = "icon-caution (SOUTHWEST)"
+	icon_state = "caution"
 	},
 /area/awaymission/UO71/eng)
 "wF" = (
@@ -11876,8 +11538,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11911,8 +11572,7 @@
 /turf/simulated/floor/plasteel{
 	burnt = 1;
 	dir = 8;
-	icon_state = "floorscorched2";
-	tag = "icon-floorscorched2 (WEST)"
+	icon_state = "floorscorched2"
 	},
 /area/awaymission/UO71/eng)
 "wL" = (
@@ -12059,8 +11719,7 @@
 "xc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal{
@@ -12075,8 +11734,7 @@
 "xd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel,
@@ -12118,15 +11776,13 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -12209,8 +11865,7 @@
 "xp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12260,8 +11915,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -12286,8 +11940,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -12311,8 +11964,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -12351,8 +12003,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -12409,8 +12060,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12471,8 +12121,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -12565,16 +12214,14 @@
 "xS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -12608,8 +12255,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -12646,8 +12292,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -12667,8 +12312,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12795,8 +12439,7 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12850,15 +12493,13 @@
 "yt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12888,8 +12529,7 @@
 /turf/simulated/floor/plasteel{
 	burnt = 1;
 	dir = 8;
-	icon_state = "floorscorched2";
-	tag = "icon-floorscorched2 (WEST)"
+	icon_state = "floorscorched2"
 	},
 /area/awaymission/UO71/mining)
 "yx" = (
@@ -12912,16 +12552,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
 "yB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12940,8 +12578,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12957,8 +12594,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12978,8 +12614,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/mining)
@@ -12987,20 +12622,17 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/awaymission/UO71/mining)
 "yI" = (
 /obj/machinery/mech_bay_recharge_port{
-	tag = "icon-recharge_port (WEST)";
 	icon_state = "recharge_port";
 	dir = 8
 	},
@@ -13172,8 +12804,7 @@
 "zj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -13279,8 +12910,7 @@
 "zH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/wall,
 /area/awaymission/UO71/science)
@@ -13299,8 +12929,7 @@
 /obj/item/paper/researchnotes,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO71/loot)
 "zP" = (
@@ -13348,7 +12977,6 @@
 "zX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -13360,7 +12988,6 @@
 /area/awaymission/UO71/queen)
 "zZ" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -13381,7 +13008,6 @@
 /area/awaymission/UO71/queen)
 "Ac" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -13500,8 +13126,7 @@
 "Nh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO71/plaza)

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -8639,7 +8639,7 @@
 	layer = 2.9
 	},
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(201)
+	req_access = list(271)
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -9095,7 +9095,7 @@
 	name = "UO71 Engineering APC";
 	pixel_x = -25;
 	pixel_y = 0;
-	req_access = list(201);
+	req_access = null;
 	start_charge = 100
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -9819,7 +9819,7 @@
 	name = "UO71 Medical APC";
 	pixel_x = -25;
 	pixel_y = 0;
-	req_access = list(201);
+	req_access = null;
 	start_charge = 100
 	},
 /obj/structure/cable{
@@ -11447,7 +11447,7 @@
 	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/miner{
-	req_access = list(201)
+	req_access = list(271)
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -12543,7 +12543,7 @@
 	icon_state = "miningsec";
 	locked = 0;
 	name = "miner's equipment";
-	req_access = list(201)
+	req_access = list(271)
 	},
 /obj/item/storage/backpack/satchel_eng,
 /obj/item/clothing/gloves/fingerless,

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -90,6 +90,7 @@
 	This facility is sealed shut by order of Commander Marquez. Do not enter.<br>
 	Terror spiders live here. We believe they are a weapon developed by the syndicate.<br>
 	Any surviving personnel are to evacuate immediately via the gateway.<br>
+	Any arriving response team is advised to use the ID Upgrade Machine to obtain local access.<br>
 	"}
 
 /obj/item/paper/terrorspiders2
@@ -134,10 +135,10 @@
 	name = "paper - 'Prescription for Jones, David'"
 	info = {"PRESCRIPTION FOR: David Jones<br>
 	RANK: Miner<br>
-	FOR: Haloperidol<br>
-	REASON FOR TREATMENT: Hallucinations, Paranoia<br>
-	CAUSE: Hallucinations caused by encounter with toxic spit of spider in the caves. Paranoia caused by disappearing staff and suspicions of syndicate infiltration.<br>
-	TREATMENT PLAN: Take as needed. See Dr. Phloxi in one week if symptoms persist. <br>
+	FOR: Charcoal<br>
+	REASON FOR TREATMENT: Toxins in bloodstream<br>
+	CAUSE: Bitten by a black terror spider.<br>
+	TREATMENT PLAN: Take hourly. See Dr. Phloxi if symptoms persist more than three hours.<br>
 	"}
 
 /obj/item/paper/terrorspiders5
@@ -149,7 +150,7 @@
 	<p>Green<br>Will lay eggs on dead bodies, breeding more spiders.</p>
 	<p>Black<br>Even a single bite is enough to kill a humanoid, given time.</p>
 	<p>White<br>Injects a parasitic agent. Deemed to pose too great an infection risk to study.</p>
-	<p>Purple<br>Only seen guarding the nest of the Queen to the south. Appear to be territorial, and very dangerous.</p>
+	<p>Purple<br>Seen guarding key areas and important spiders. Appear to be territorial, and very dangerous.</p>
 	<p>Prince<br>Held in containment 2. Appears to be a sort of super-warrior. Fast, strong, and thickly armored.</p>
 	<p>Mother<br>Carries hordes of spiderlings on its back. Held in containment 1. </p>
 	<p>Queen<br>Unable to contain. Present south of Cargo before contact was lost. Presumed ruler of the local hive.</p>


### PR DESCRIPTION
## What Does This PR Do & Why
Fixes many old / out-of-date / sub-optimal things in the terror spider away mission:
1) Removes all 'tag = "X"' from the map file, which was causing many things in the mission to have implicit refs and thus refuse to GC properly.
2) Reworks many of the air/scrubber vent pipes, to make them neater, reduce the amount of pipes that go through solid walls, and make them better connected. This also discourages people from unwrenching pipes in the mission.
3) Tweaks the mission-start paper to tell players they need to use the ID Upgrade Machine to gain access.
4) Updates the papers/pills you're provided in one of the tutorial rooms, to no longer say the queen's spit is hallucinogenic (that's old info, no longer true) and to provide anti-tox meds instead of anti-hallucinogens.
5) Corrects some out-of-date info on purple terrors.
6) Removed the science blast doors, which were encouraging people to unintended things (like trying to turtle in the science part of the mission, and ignore the rest of it).

## Changelog
:cl: Kyep
tweak: tweaked terror away mission to correct some out-of-date stuff, and improve the pipe/vent layout.
/:cl:
