### PR TITLE
Fix runtime when activating internals while smoking

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -55,7 +55,7 @@
 
 			var/obj/item/clothing/mask/M = C.wear_mask
 			// If the "mask" isn't actually a mask OR That mask isn't internals compatible AND Their headgear isn't internals compatible
-			if(!istype(M) || (!(initial(M.flags) & AIRTIGHT) && !(C.head.flags & AIRTIGHT)))
+			if(!istype(M) || (!(initial(M.flags) & AIRTIGHT) && !(C.head && C.head.flags & AIRTIGHT)))
 				if(!silent)
 					to_chat(C, "<span class='warning'>You are not wearing a suitable mask or helmet.</span>")
 				return FALSE


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime that can happen when:
- You are holding a tank in your hand
- You use the 'activate internals' option in the tank's TGUI
- You are smoking a cigarette (or otherwise have a 'mask' item that isn't suitable for use as internals and doesn't occupy the head slot)

Source of the problem is that it assumes C.head exists when it might not.
Runtime in tanks.dm,58: Cannot read null.flags
proc name: toggle internals (/obj/item/tank/proc/toggle_internals)

## Changelog
:cl: Kyep
fix: Fixed a runtime when trying to activate internals in the tank TGUI while wearing a mask.
/:cl: