### PR TITLE
Removes ert suit runtime

### DIFF
--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -17,9 +17,10 @@
 		)
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/Initialize()
-	var/mob/living/carbon/human/wearer = loc.loc	//loc is the hardsuit, so its loc is the wearer
-	if(ishuman(wearer))
-		register_camera(wearer)
+	if(loc)
+		var/mob/living/carbon/human/wearer = loc.loc	//loc is the hardsuit, so its loc is the wearer
+		if(ishuman(wearer))
+			register_camera(wearer)
 	..()
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/attack_self(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime when you tried to turn a chameleon outfit into an ert outfit, since the ert outfit tried to get its location and the cham outfit spawns a full copy of the ert outfit in nullspace before deleting it again.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
runtimes bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: chameleon outfits no longer cause a runtime when turningthem into ert hardsuits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
