### PR TITLE
Adds Atmospheric Anomaly

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -3,6 +3,7 @@
 #define GAS_PL	(1 << 2)
 #define GAS_CO2	(1 << 3)
 #define GAS_N2O	(1 << 4)
+#define GAS_A_B	(1 << 5)
 
 //ATMOS
 //stuff you should probably leave well alone!

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -3,7 +3,6 @@
 #define GAS_PL	(1 << 2)
 #define GAS_CO2	(1 << 3)
 #define GAS_N2O	(1 << 4)
-#define GAS_A_B	(1 << 5)
 
 //ATMOS
 //stuff you should probably leave well alone!

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -3,6 +3,7 @@
 #define GAS_PL	(1 << 2)
 #define GAS_CO2	(1 << 3)
 #define GAS_N2O	(1 << 4)
+#define GAS_A_B (1 << 5)
 
 //ATMOS
 //stuff you should probably leave well alone!

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -3,7 +3,7 @@
 #define GAS_PL	(1 << 2)
 #define GAS_CO2	(1 << 3)
 #define GAS_N2O	(1 << 4)
-#define GAS_A_B (1 << 5)
+#define GAS_A_B	(1 << 5)
 
 //ATMOS
 //stuff you should probably leave well alone!

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -193,7 +193,7 @@
 
 /obj/effect/anomaly/atmos/New()
 	..()
-	gas_type = pick(GAS_N2O, GAS_CO2, GAS_N2, GAS_A_B)
+	gas_type = pick(GAS_N2O, GAS_CO2, GAS_N2)
 	aSignal.origin_tech = "materials=7"	//turning gas into another gas has some interesting implications for material science
 										//might also work as biotech maybe? Since there's no anomaly for that.
 
@@ -207,8 +207,6 @@
 				flag = LINDA_SPAWN_CO2
 			if(GAS_N2O)
 				flag = LINDA_SPAWN_N2O
-			if(GAS_A_B)
-				flag = LINDA_SPAWN_AGENT_B
 			else
 				flag = LINDA_SPAWN_NITROGEN
 		T.atmos_spawn_air(LINDA_SPAWN_20C | flag, 10)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -26,7 +26,7 @@
 
 /obj/effect/anomaly/proc/anomalyEffect()
 	if(prob(50))
-		step(src,pick(GLOB.alldirs))
+		step(src, pick(GLOB.alldirs))
 
 
 /obj/effect/anomaly/proc/anomalyNeutralize()
@@ -183,3 +183,32 @@
 	if( T && istype(T,/turf/simulated) && prob(turf_removal_chance) )
 		T.ex_act(ex_act_force)
 	return
+
+/////////////////////
+
+/obj/effect/anomaly/atmos
+	name = "transformative gas anomaly"
+	icon_state = "electricity2"
+	var/gas_type
+
+/obj/effect/anomaly/atmos/New()
+	..()
+	gas_type = pick(GAS_N2O, GAS_CO2, GAS_N2, GAS_A_B)
+	aSignal.origin_tech = "materials=7"	//turning gas into another gas has some interesting implications for material science
+										//might also work as biotech maybe? Since there's no anomaly for that.
+
+/obj/effect/anomaly/atmos/anomalyEffect()
+	..()
+	var/turf/simulated/T = get_turf(src)
+	if(istype(T))
+		var/flag
+		switch(gas_type)
+			if(GAS_CO2)
+				flag = LINDA_SPAWN_CO2
+			if(GAS_N2O)
+				flag = LINDA_SPAWN_N2O
+			if(GAS_A_B)
+				flag = LINDA_SPAWN_AGENT_B
+			else
+				flag = LINDA_SPAWN_NITROGEN
+		T.atmos_spawn_air(LINDA_SPAWN_20C | flag, 10)

--- a/code/modules/events/anomaly_atmos.dm
+++ b/code/modules/events/anomaly_atmos.dm
@@ -1,0 +1,54 @@
+/datum/event/anomaly/anomaly_atmos
+	startWhen = 30
+	announceWhen = 3
+	endWhen = 100
+
+/datum/event/anomaly/anomaly_atmos/announce()
+	GLOB.event_announcement.Announce("Transformative gas anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
+
+/datum/event/anomaly/anomaly_atmos/start()
+	var/turf/T = pick(get_area_turfs(impact_area))
+	if(T)
+		newAnomaly = new /obj/effect/anomaly/atmos(T.loc)
+
+
+/datum/event/anomaly/anomaly_atmos/tick()
+	if(!newAnomaly)
+		kill()
+		return
+	if(ISMULTIPLE(activeFor, 5))
+		newAnomaly.anomalyEffect()
+
+/datum/event/anomaly/anomaly_atmos/end()
+	if(!newAnomaly || !newAnomaly.loc)	//no anomaly or it is in nullspace
+		return
+	var/obj/effect/anomaly/atmos/A = newAnomaly
+	var/gas_type = A.gas_type
+	var/area/t_area = get_area(A)
+	for(var/turf/T in t_area)
+		if(istype(T, /turf/simulated))	//should not occur on unsimulated turfs without admemery
+			var/turf/simulated/S = T
+			fill_with_gas(gas_type, S)
+	explosion(get_turf(newAnomaly), -1, 0, 2)	// a small boom so people know something happened.
+	..()
+
+/**
+  * Replaces all oxygen and nitrogen on the simulated turf S with the gas type specified in gas, taking N2, N20, CO2 and agent B
+  */
+/datum/event/anomaly/anomaly_atmos/proc/fill_with_gas(gas, turf/simulated/S)
+	if(!S.air)//no air to transform
+		return
+	var/amount_to_add = S.air.oxygen + S.air.nitrogen
+	S.air.oxygen = 0
+	S.air.nitrogen = 0
+	switch(gas)
+		if(GAS_A_B)
+			S.air.agent_b += amount_to_add
+		if(GAS_N2)
+			S.air.nitrogen += amount_to_add
+		if(GAS_N2O)
+			S.air.sleeping_agent += amount_to_add
+		if(GAS_CO2)
+			S.air.carbon_dioxide += amount_to_add
+	S.update_visuals()
+	S.air_update_turf()

--- a/code/modules/events/anomaly_atmos.dm
+++ b/code/modules/events/anomaly_atmos.dm
@@ -42,8 +42,6 @@
 	S.air.oxygen = 0
 	S.air.nitrogen = 0
 	switch(gas)
-		if(GAS_A_B)
-			S.air.agent_b += amount_to_add
 		if(GAS_N2)
 			S.air.nitrogen += amount_to_add
 		if(GAS_N2O)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -170,10 +170,11 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Brand Intelligence",		/datum/event/brand_intelligence,		50, 	list(ASSIGNMENT_ENGINEER = 25),	TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,						50,		list(ASSIGNMENT_ENGINEER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Dimensional Tear",			/datum/event/tear,						0,		list(ASSIGNMENT_SECURITY = 35)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Honknomoly",					/datum/event/tear/honk,						0),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Honknomoly",				/datum/event/tear/honk,						0),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Vent Clog",				/datum/event/vent_clog,					250),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Wormholes",				/datum/event/wormholes,					150),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Pyro Anomaly",				/datum/event/anomaly/anomaly_pyro,		75,	list(ASSIGNMENT_ENGINEER = 60)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Pyro Anomaly",				/datum/event/anomaly/anomaly_pyro,		75,		list(ASSIGNMENT_ENGINEER = 60)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Atmos Anomaly", 			/datum/event/anomaly/anomaly_atmos,		75, 	list(ASSIGNMENT_ENGINEER = 60)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Vortex Anomaly",			/datum/event/anomaly/anomaly_vortex,	75,		list(ASSIGNMENT_ENGINEER = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Bluespace Anomaly",		/datum/event/anomaly/anomaly_bluespace,	75,		list(ASSIGNMENT_ENGINEER = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Flux Anomaly",				/datum/event/anomaly/anomaly_flux,		75,		list(ASSIGNMENT_ENGINEER = 50)),
@@ -182,7 +183,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Swarmer Spawn", 			/datum/event/spawn_swarmer, 			150, is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn", 				/datum/event/spawn_morph, 				40, is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Disease Outbreak",			/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Headcrabs",				/datum/event/headcrabs, 				0, list(ASSIGNMENT_SECURITY = 20))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Headcrabs",				/datum/event/headcrabs, 				0,		list(ASSIGNMENT_SECURITY = 20))
 	)
 
 /datum/event_container/major

--- a/paradise.dme
+++ b/paradise.dme
@@ -1438,6 +1438,7 @@
 #include "code\modules\events\abductor.dm"
 #include "code\modules\events\alien_infestation.dm"
 #include "code\modules\events\anomaly.dm"
+#include "code\modules\events\anomaly_atmos.dm"
 #include "code\modules\events\anomaly_bluespace.dm"
 #include "code\modules\events\anomaly_flux.dm"
 #include "code\modules\events\anomaly_grav.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a new anomaly type, the atmos transformation anomaly. Like other anomalies, it first spawns and has a rather minor affect while warning crew via an announcement. It can be scanned and neutralized as usual during this time, yielding an anomaly core.
Each anomaly randomly picks a gas from among Nitrogen, N2O and CO2 on creation. The anomaly produces small amounts of its chosen gas until it explodes.

When it explodes in a small boom, it transforms **all** Oxygen and Nitrogen in its current area into its chosen gas. This presents a danger to any unprepared crew, but can easily be survived by simply putting on internals. Roundstart atmos should generally fix the issue without player intervention eventually, though atmos techs with portable scrubbers and co can of course speed this up a lot. In my tests, chapel (a fairly large area) was completely cleaned up automatically in 20 minutes.

I considered also having it produce plasma, but decided against it, since a potential plasma flood followed by a fire sounds like more than a medium event generally should be.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The station's air supply system is in most cases totally unnecessary. Rooms contain enough air to last an entire shift, distro is unneeded unless rooms need to be completely refilled following sabotage or breaches. Since it is mostly unnecessary, crew also doesn't hesitate to unwrench pipes against vent-crawlers without suffering any negative consequences from it.

This event is fairly harmless and easily dealt with as long as nobody has unwrenched pipes or otherwise messed with the roundstart setup.

It is also generally a good thing to have more variety in potential events, since they are one way that the regular rounds are kept fresh without any admin intervention.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: A new anomaly, the atmos transformation anomaly transforms breathable air into something quite different.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
