### PR TITLE
Fixes spiders eating the crew alive

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -164,15 +164,23 @@
 
 	if(!cocoon_target)
 		var/list/choices = list()
-		for(var/mob/living/L in view(1,src))
+		for(var/mob/living/L in view(1, src))
 			if(L == src)
+				continue
+			if(L.stat != DEAD)
 				continue
 			if(Adjacent(L))
 				choices += L
-		for(var/obj/O in src.loc)
+		for(var/obj/O in get_turf(src))
+			if(O.anchored)
+				continue
 			if(Adjacent(O))
 				choices += O
-		cocoon_target = input(src,"What do you wish to cocoon?") in null|choices
+		if(length(choices))
+			cocoon_target = input(src,"What do you wish to cocoon?") in null|choices
+		else
+			to_chat(src, "<span class='warning'>No suitable dead prey or wrappable objects found nearby.")
+			return
 
 	if(cocoon_target && busy != SPINNING_COCOON)
 		busy = SPINNING_COCOON
@@ -198,6 +206,8 @@
 							large_cocoon = 1
 					for(var/mob/living/L in C.loc)
 						if(istype(L, /mob/living/simple_animal/hostile/poison/giant_spider))
+							continue
+						if(L.stat != DEAD)
 							continue
 						large_cocoon = 1
 						L.loc = C

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -169,10 +169,14 @@
 				continue
 			if(L.stat != DEAD)
 				continue
+			if(istype(L, /mob/living/simple_animal/hostile/poison/giant_spider))
+				continue
 			if(Adjacent(L))
 				choices += L
 		for(var/obj/O in get_turf(src))
 			if(O.anchored)
+				continue
+			if(!(isitem(O) || isstructure(O) || ismachinery(O)))
 				continue
 			if(Adjacent(O))
 				choices += O


### PR DESCRIPTION
## What Does This PR Do
Fixes several bugs related to nurse giant spiders wrapping things.
- Fixes #14111 - nurse spiders can wrap (and thus, can eat) crew while they're alive
- wrapping objects while they are anchored (e.g. walk up to a light fixture, hit wrap verb, it asks if you want to wrap the light, despite it being secured to the wall)
- not getting an error message if you attempt to use wrap without any suitable target nearby, it was just silently failing
- attempting to wrap the corpse of another giant spider fails, it creates an empty cocoon whilst doing nothing
- same thing happens when you try to wrap an /obj that isn't an item, structure or machinery
Minor refactoring to improve code quality (removing implied src, spacing, etc). Really the whole giant spider wrapping function is badly coded, but this PR just aims to fix the obvious bugs with it, not rewrite the whole function.

## Changelog
:cl:
fix: fixed several bugs with giant spiders (nurse spider) wrapping things, most notably they can no longer wrap living targets.
/:cl: