### PR TITLE
Fixes borgs retaining access to interfaces post-reset

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -447,6 +447,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	notify_ai(2)
 
 	uneq_all()
+	SSnanoui.close_user_uis(src)
 	SStgui.close_user_uis(src)
 	sight_mode = null
 	hands.icon_state = "nomod"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -447,6 +447,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	notify_ai(2)
 
 	uneq_all()
+	SStgui.close_user_uis(src)
 	sight_mode = null
 	hands.icon_state = "nomod"
 	icon_state = "robot"


### PR DESCRIPTION
## What Does This PR Do
Fixes #14438 
Upon a borg's module being reset, all of its interfaces are closed, thus preventing any situation where it keeps open old interfaces it no longer has access to after reset.

## Changelog
:cl: Kyep
fix: fixed borgs keeping access to old interfaces after reset.
/:cl: