### PR TITLE
Changes cryoxadone to check external temp instead of internal temp

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -126,7 +126,7 @@
 		var/obj/machinery/atmospherics/unary/cryo_cell/C = M.loc
 		external_temp = C.temperature_archived
 	else
-		var/turf/T = M.loc
+		var/turf/T = get_turf(M)
 		external_temp = T.temperature
 	if(external_temp < TCRYO)
 		update_flags |= M.adjustCloneLoss(-4, FALSE)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -121,7 +121,14 @@
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(M.bodytemperature < TCRYO)
+	var/external_temp
+	if(istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
+		var/obj/machinery/atmospherics/unary/cryo_cell/C = M.loc
+		external_temp = C.temperature_archived
+	else
+		var/turf/T = M.loc
+		external_temp = T.temperature
+	if(external_temp < TCRYO)
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cryoxadone now checks the temperature of the atmosphere or cryo cell around you rather than your body temperature.

## Why It's Good For The Game
The code from dropping or raising your body temp via chems was never designed for cryoxadone pills. It was made to do damage, not to heal. Currently, if you consume a reagent that is at 0 kelvin it drops your body temp by 250 kelvin per chem tick. This system needs to be reworked, but until that happens this PR is a bandaid measure to remove the exploit of 0 kelvin cryoxadone pills.

## Changelog
:cl:
tweak: Cryoxadone checks your external temperature instead of your internal temperature.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
