### PR TITLE
Fixes UIs breaking from running out of UIDs

### DIFF
--- a/code/__HELPERS/unique_ids.dm
+++ b/code/__HELPERS/unique_ids.dm
@@ -1,7 +1,3 @@
-/// At what number do we roll UIDs over for the next ground.
-#define UID_ROLLOVER_COUNT 950000
-// ^ This needs to exist because BYOND will print a number in scientific notation if its big enough, breaking all hrefs
-
 // Unique Datum Identifiers
 
 // Basically, a replacement for plain \refs that ensure the reference still
@@ -20,13 +16,11 @@
 
 /// The next UID to be used (Increments by 1 for each UID)
 GLOBAL_VAR_INIT(next_unique_datum_id, 1)
-/// The next UID group to be used (Increments by 1 every time UID goes above a certain number [UID_ROLLOVER_COUNT])
-GLOBAL_VAR_INIT(next_uid_group, 1)
-/// Log of all UIDs created in the round
+/// Log of all UIDs created in the round. Assoc list with type as key and amount as value
 GLOBAL_LIST_EMPTY(uid_log)
 
 /**
-  * Gets the UID of a datum
+  * Gets or creates the UID of a datum
   *
   * BYOND refs are recycled, so this system prevents that. If a datum does not have a UID when this proc is ran, one will be created
   * Returns the UID of the datum
@@ -35,11 +29,8 @@ GLOBAL_LIST_EMPTY(uid_log)
 	if(!unique_datum_id)
 		var/tag_backup = tag
 		tag = null // Grab the raw ref, not the tag
-		if(GLOB.next_unique_datum_id >= UID_ROLLOVER_COUNT)
-			GLOB.next_unique_datum_id = 1
-			GLOB.next_uid_group++ // Increase by 1 for next group
-			log_debug("UID() encountered a UID greater than the rollover count ([UID_ROLLOVER_COUNT]). Incrementing UID group.")
-		unique_datum_id = "\ref[src]_[GLOB.next_unique_datum_id++]-[GLOB.next_uid_group]"
+		// num2text can output 8 significant figures max. If we go above 10 million UIDs in a round, shit breaks
+		unique_datum_id = "\ref[src]_[num2text(GLOB.next_unique_datum_id++, 8)]"
 		tag = tag_backup
 		GLOB.uid_log[type]++
 	return unique_datum_id
@@ -65,10 +56,15 @@ GLOBAL_LIST_EMPTY(uid_log)
 		return D
 	return null
 
-/client/verb/uid_testing()
+/**
+  * Opens a lof of UIDs
+  *
+  * In-round ability to view what has created a UID, and how many times a UID for that path has been declared
+  */
+/client/proc/uid_log()
 	set name = "View UID Log"
 	set category = "Debug"
-	set desc = "If this got merged in, please scream at someone"
+	set desc = "Shows the log of created UIDs this round"
 
 	if(!check_rights(R_DEBUG))
 		return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -166,6 +166,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/admin_serialize,
 	/client/proc/jump_to_ruin,
 	/client/proc/toggle_medal_disable,
+	/client/proc/uid_log
 	))
 GLOBAL_LIST_INIT(admin_verbs_possess, list(
 	/proc/possess,


### PR DESCRIPTION
## What Does This PR Do
Makes UIDs render above 1 million. The new cap is now 10 million due to a BYOND bug which caps num2text to 8 significant figures. New UIDs above 1 mil
![image](https://user-images.githubusercontent.com/25063394/94359316-3b9e6080-009e-11eb-9282-9ab7fdce71f0.png)

Theres also a new debug verb to show UID logs
![image](https://user-images.githubusercontent.com/25063394/94359318-422cd800-009e-11eb-9408-8aea615906f5.png)

## Why It's Good For The Game
UIs shouldnt break after we hit 1 million UIDs

## Changelog
:cl: AffectedArc07
fix: UIs no longer break due to running out of UIDs
/:cl:
