### PR TITLE
Makes mining vendors drop inserted IDs when destroyed/deconstructed

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -266,7 +266,7 @@
 /obj/machinery/mineral/equipment_vendor/Destroy()
 	if(inserted_id)
 		inserted_id.forceMove(loc)
-	..()
+	return ..()
 
 
 /**********************Mining Equiment Vendor (Golem)**************************/

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -263,6 +263,12 @@
 	if(prob(50 / severity) && severity < 3)
 		qdel(src)
 
+/obj/machinery/mineral/equipment_vendor/Destroy()
+	if(inserted_id)
+		inserted_id.forceMove(loc)
+	..()
+
+
 /**********************Mining Equiment Vendor (Golem)**************************/
 
 /obj/machinery/mineral/equipment_vendor/golem


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes it so that when mining vendors are destroyed they drop any inserted ID cards, rather than just deleting them.

Fixes #14423 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Less ID cards lost to the void.

## Changelog
:cl:
fix: Mining vendors now drop any inserted ID cards when destroyed/deconstructed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
