### PR TITLE
Prevent showing notes to disabled cameras

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -163,6 +163,10 @@
 
 	// OTHER
 	else if((istype(I, /obj/item/paper) || istype(I, /obj/item/pda)) && isliving(user))
+		if (!can_use())
+			to_chat(user, "<span class='warning'>You can't show something to a disabled camera!</span>")
+			return
+
 		var/mob/living/U = user
 		var/obj/item/paper/X = null
 		var/obj/item/pda/PDA = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This change checks whether or not the camera is functional before showing the note pop-up to the AI player.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It doesn't make sense that the AI would be able to see notes on disabled cameras.  Fixes https://github.com/ParadiseSS13/Paradise/issues/14154
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![disabled_camera](https://user-images.githubusercontent.com/41554512/94349881-c418f480-fffd-11ea-9a5a-994f5c2984bf.JPG)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Removed ability to show notes to disabled cameras
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
