### PR TITLE
Fixes not being able to link Monkey Recyclers to Xenobio Camera Consoles

### DIFF
--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -25,7 +25,7 @@
 	var/shows_wire_information = FALSE // shows what a wire does if set to TRUE
 	var/obj/machinery/buffer // simple machine buffer for device linkage
 
-/obj/item/multitool/proc/IsBufferA(var/typepath)
+/obj/item/multitool/proc/IsBufferA(typepath)
 	if(!buffer)
 		return 0
 	return istype(buffer,typepath)
@@ -41,12 +41,11 @@
 	to_chat(user, "<span class='notice'>You load [M] into [src]'s internal buffer.</span>")
 	return TRUE
 
-// Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
-
 /obj/item/multitool/Destroy()
 	buffer = null
 	return ..()
 
+// Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 /obj/item/multitool/ai_detect
 	var/track_cooldown = 0
 	var/track_delay = 10 //How often it checks for proximity

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -18,7 +18,7 @@
 		return
 
 /obj/machinery/computer/camera_advanced/xenobio
-	name = "Slime management console"
+	name = "slime management console"
 	desc = "A computer used for remotely handling slimes."
 	networks = list("SS13")
 	circuit = /obj/item/circuitboard/xenobiology
@@ -174,9 +174,9 @@
 		return
 	var/obj/item/multitool/M = I
 	if(istype(M.buffer, /obj/machinery/monkey_recycler))
-		M.set_multitool_buffer(user, src)
 		connected_recycler = M.buffer
 		connected_recycler.connected += src
+		to_chat(user, "<span class='notice'>You link [src] to the recycler stored in the [M]'s buffer.</span>")
 
 /datum/action/innate/slime_place
 	name = "Place Slimes"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes this runtime:
`Runtime in xenobio_camera.dm,179: undefined variable /obj/machinery/computer/camera_advanced/xenobio/var/connected`
Which stopped you from linking a Monkey Recycler to a Xenobio Camera Console.

Also made the name `slime management console` improper.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
🐛 🛠️ 

## Changelog
:cl:
fix: Fixed a runtime stopping you from linking monkey recyclers to xenobio consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
