### PR TITLE
Gives the gravitational catapult a 3 second cooldown per use

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -87,10 +87,14 @@
 	energy_drain = 100
 	range = MECHA_MELEE | MECHA_RANGED
 	var/atom/movable/locked
+	var/cooldown_timer = 0
 	var/mode = 1 //1 - gravsling 2 - gravpush
 
 /obj/item/mecha_parts/mecha_equipment/gravcatapult/action(atom/movable/target)
 	if(!action_checks(target))
+		return
+	if(cooldown_timer > world.time)
+		occupant_message("<span class='warning'>[src] is still recharging.</span>")
 		return
 	switch(mode)
 		if(1)
@@ -106,6 +110,7 @@
 					locked.throw_at(target, 14, 1.5)
 					locked = null
 					send_byjax(chassis.occupant,"exosuit.browser","\ref[src]",get_equip_info())
+					cooldown_timer = world.time + 3 SECONDS
 					return 1
 				else
 					locked = null
@@ -125,6 +130,7 @@
 						step_away(A,target)
 						sleep(2)
 			var/turf/T = get_turf(target)
+			cooldown_timer = world.time + 3 SECONDS
 			log_game("[key_name(chassis.occupant)] used a Gravitational Catapult in ([T.x],[T.y],[T.z])")
 			return 1
 


### PR DESCRIPTION
## What Does This PR Do
As the title says.
Each time you use the catapult it will go on a 3 second cooldown.
Locking on won't set the cooldown

## Why It's Good For The Game
Currently you can use it to mass spam people into each other. Creating an effect similar to what atmos used to do.
It will also stunlock them till they die

## Changelog
:cl:
tweak: The gravitational catapult now has a 3 second cooldown per use
/:cl: