### PR TITLE
Guardians will die when their host's health reaches -100 again

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -49,7 +49,6 @@
 		return
 	summoner = host
 	host.grant_guardian_actions(src)
-	RegisterSignal(host, COMSIG_MOB_DEATH, .proc/on_host_death)
 
 /mob/living/simple_animal/hostile/guardian/med_hud_set_health()
 	if(summoner)
@@ -66,21 +65,15 @@
 		else
 			holder.icon_state = "hudhealthy"
 
-/**
- * Proc which is called when the guardian's host dies.
- *
- * This will only fire if the guardian was created through a holoparsite injector, or the equivalent.
- */
-/mob/living/simple_animal/hostile/guardian/proc/on_host_death()
-	if(summoner.stat == DEAD || (!summoner.check_death_method() && summoner.health <= HEALTH_THRESHOLD_DEAD))
-		summoner.remove_guardian_actions() // Remove our summoner's action buttons.
-		to_chat(src, "<span class='danger'>Your summoner has died!</span>")
-		visible_message("<span class='danger'>[src] dies along with its user!</span>")
-		ghostize()
-		qdel(src)
-
 /mob/living/simple_animal/hostile/guardian/Life(seconds, times_fired)
 	..()
+	if(summoner)
+		if(summoner.stat == DEAD || (!summoner.check_death_method() && summoner.health <= HEALTH_THRESHOLD_DEAD))
+			summoner.remove_guardian_actions()
+			to_chat(src, "<span class='danger'>Your summoner has died!</span>")
+			visible_message("<span class='danger'>[src] dies along with its user!</span>")
+			ghostize()
+			qdel(src)
 	snapback()
 	if(summoned && !summoner && !admin_spawned)
 		to_chat(src, "<span class='danger'>You somehow lack a summoner! As a result, you dispel!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes guardians die when their host's health reaches -100 again. I forgot because of new crit, we have to have a shitty `Life()` check to see when the host hits -100 HP. This is a revert of some of the code in #14402.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #14450
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Guardians will die when their host's health reaches -100 again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
