### PR TITLE
Fixes aghosting makes your inventory invisible

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -331,6 +331,9 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 		ghost.reenter_corpse()
 		log_admin("[key_name(usr)] re-entered their body")
 		feedback_add_details("admin_verb","P") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		if(ishuman(mob))
+			var/mob/living/carbon/human/H = mob
+			H.regenerate_icons() // workaround for #13269
 	else if(isnewplayer(mob))
 		to_chat(src, "<font color='red'>Error: Aghost: Can't admin-ghost whilst in the lobby. Join or observe first.</font>")
 	else


### PR DESCRIPTION
## What Does This PR Do
Fixes #13269 - aghosting then returning to your body, makes your inventory invisible.
This is a bandaid fix, because the underlying issue is a byond issue that we can't fix directly.
So, this PR just bandaids over it... forcing an icon regeneration that means, in practice, when you aghost back to your body, your inventory is visible now.

## Changelog
:cl: Kyep
fix: fixed aghosting then returning your body, making your inventory invisible.
/:cl: