### PR TITLE
Fixes wizard teleportation scroll generating a warning to admins

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -90,14 +90,14 @@
 
 	var/list/tempL = L
 	var/attempt = null
-	var/success = 0
+	var/success = FALSE
 	while(tempL.len)
 		attempt = pick(tempL)
-		success = user.Move(attempt)
-		if(!success)
-			tempL.Remove(attempt)
-		else
+		user.forceMove(attempt)
+		if(get_turf(user) == attempt)
+			success = TRUE
 			break
+		tempL.Remove(attempt)
 
 	if(!success)
 		user.forceMove(pick(L))


### PR DESCRIPTION
Fixes #13702

## Changelog
:cl: Kyep
fix: fixed wizard teleportation scroll generating an admin warning about registered zlevels when used to teleport to the station.
/:cl: