### PR TITLE
Fixes zero-G spiderweb weirdness

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -47,6 +47,14 @@
 		if(C.can_inject(null, FALSE, inject_target, FALSE))
 			C.reagents.add_reagent("spidertoxin", venom_per_bite)
 
+/mob/living/simple_animal/hostile/poison/giant_spider/get_spacemove_backup()
+	. = ..()
+	// If we don't find any normal thing to use, attempt to use any nearby spider structure instead.
+	if(!.)
+		for(var/obj/structure/spider/S in range(1, get_turf(src)))
+			. = S
+			break
+
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 	desc = "Furry and black, it makes you shudder to look at it. This one has brilliant green eyes."

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -52,8 +52,7 @@
 	// If we don't find any normal thing to use, attempt to use any nearby spider structure instead.
 	if(!.)
 		for(var/obj/structure/spider/S in range(1, get_turf(src)))
-			. = S
-			break
+			return S
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -396,8 +396,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	// If we don't find any normal thing to use, attempt to use any nearby spider structure instead.
 	if(!.)
 		for(var/obj/structure/spider/S in range(1, get_turf(src)))
-			. = S
-			break
+			return S
 
 /mob/living/simple_animal/hostile/poison/terror_spider/Stat()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -391,6 +391,14 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 		return TRUE
 
 
+/mob/living/simple_animal/hostile/poison/terror_spider/get_spacemove_backup()
+	. = ..()
+	// If we don't find any normal thing to use, attempt to use any nearby spider structure instead.
+	if(!.)
+		for(var/obj/structure/spider/S in range(1, get_turf(src)))
+			. = S
+			break
+
 /mob/living/simple_animal/hostile/poison/terror_spider/Stat()
 	..()
 	// Determines what shows in the "Status" tab for player-controlled spiders. Used to help players understand spider health regeneration mechanics.


### PR DESCRIPTION
## What Does This PR Do
Fixes #12838 and similar cases in zero-gravity where spiders (both terror & giant):
- are unable to push off of webs & similar spider structures, even in cases where normal non-spider crew can do it.
- can get completely stuck in zero-g, floating helplessly forever in the middle of a hallway, unable to move or recover no matter what they do.

The fix is: spiders (both kinds) can now always move in zero-gravity IF they are standing on (or next to) a spider structure (e.g: web).

## Why It's Good For The Game
- Spiderwebs are no longer bizzarely more helpful to the crew in zero-G than they are to the spiders who created them. That was unintended, and made no sense. Worst of all was where a spider floating along and hitting a web would stop the spider BUT not enable them to move - thus causing a web to actively harm the spider, which was extremely illogical.
- Spiders who get stuck in a zero-G location that isn't next to a web (e.g: middle of 3-tile-wide hallway) are no longer forced to either ahelp to get moved, or remain there, stuck forever, until someone comes along to kill them. Or ghost out of their body while alive, which gives up their respawnability. Now, they have another option: spin a web, then use that web to propel themselves to the nearest wall, then cling to that. They're still vulnerable while spinning the web, but at least they're not stuck FOREVER, even while supposedly standing on their own web.

## Changelog
:cl: Kyep
tweak: spiders (both giant, and terror) can now "push off" their own structures to move in zero-G, like normal crew already could "push off" a spider's web to move.
/:cl:
