### PR TITLE
Fixes humans trapped in xeno nests being able to attack

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -17,6 +17,11 @@
 			if(A.attack_hulk(src))
 				return
 
+	if(buckled && isstructure(buckled))
+		var/obj/structure/S = buckled
+		if(S.prevents_buckled_mobs_attacking())
+			return
+
 	A.attack_hand(src)
 
 /atom/proc/attack_hand(mob/user as mob)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -163,3 +163,6 @@
 		if(0 to 25)
 			if(!broken)
 				return  "<span class='warning'>It's falling apart!</span>"
+
+/obj/structure/proc/prevents_buckled_mobs_attacking()
+	return FALSE

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -89,3 +89,6 @@
 		return attack_hand(user)
 	else
 		return ..()
+
+/obj/structure/bed/nest/prevents_buckled_mobs_attacking()
+	return TRUE


### PR DESCRIPTION
## What Does This PR Do
Fixes #9174 - humans buckled to xeno nests can still attack.
Specifically stops unarmed attacks: help/disarm/harm/grab.
Does NOT stop them resisting out of the nest.

## Why It's Good For The Game
Captured humans punching/disarming the queen into crit, while they're supposedly trapped in the nest, is not cool.

## Changelog
:cl: Kyep
fix: fixed humans who are captured and sealed into a xeno nest still being able to attack nearby xenos with punches and disarms.
/:cl: