### PR TITLE
Fixes emagged photocopiers cooldown handling

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -59,6 +59,10 @@
 		if(stat & (BROKEN|NOPOWER))
 			return
 
+		if(emag_cooldown > world.time)
+			to_chat(usr, "<span class='warning'>[src] is busy, try again in a few seconds.</span>")
+			return
+
 		playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 		for(var/i = 0, i < copies, i++)
 			if(toner <= 0)
@@ -73,9 +77,6 @@
 					message_admins("Photocopier cap of [GLOB.copier_max_items] papers reached, all photocopiers are now disabled. This may be the cause of any lag.")
 					GLOB.copier_items_printed_logged = TRUE
 				break
-
-			if(emag_cooldown > world.time)
-				return
 
 			if(istype(copyitem, /obj/item/paper))
 				copy(copyitem)


### PR DESCRIPTION
## What Does This PR Do
Fixes #6846 - emagged photocopiers play a sound and seem like they're being used even when they can't be due to cooldown.
Attempting to use one too fast now gives a to_chat message to the user, telling them they need to wait a couple of seconds.

## Changelog
:cl: Kyep
fix: fixed emagged photocopiers playing a sound on use even when their cooldown prevents them being used successfully.
/:cl:
