### PR TITLE
Fixes reset cyborgs keeping special vision modes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -450,6 +450,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	SSnanoui.close_user_uis(src)
 	SStgui.close_user_uis(src)
 	sight_mode = null
+	update_sight()
 	hands.icon_state = "nomod"
 	icon_state = "robot"
 	module.remove_subsystems_and_actions(src)


### PR DESCRIPTION
## What Does This PR Do
Fixes #6843

## Changelog
:cl:
fix: fixed cyborgs not losing special vision modes (e.g: mesons) when their module is reset.
/:cl:
