### PR TITLE
Fixes #8006 - simple animals have no attack cooldown on spacepods

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -204,6 +204,7 @@
 	deal_damage(30)
 
 /obj/spacepod/attack_animal(mob/living/simple_animal/user)
+	user.changeNext_move(CLICK_CD_MELEE)
 	if((user.a_intent == INTENT_HELP && user.ckey) || user.melee_damage_upper == 0)
 		user.custom_emote(1, "[user.friendly] [src].")
 		return FALSE


### PR DESCRIPTION
## What Does This PR Do
Fixes #8006 - simple animals have no attack cooldown on spacepods

## Changelog
:cl: Kyep
fix: fixed simple_animals being able to semi-instantly destroy spacepods by spam-clicking them, since their attacks had zero cooldown and could be macroed.
/:cl: