### PR TITLE
Makes it so that not every datum uses an UID everytime it gets destroyed

### DIFF
--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -126,6 +126,8 @@ SUBSYSTEM_DEF(tgui)
   * return int The number of UIs closed.
  **/
 /datum/controller/subsystem/tgui/proc/close_uis(datum/src_object)
+	if(!src_object.unique_datum_id) // First check if the datum has an UID set
+		return 0
 	var/src_object_key = "[src_object.UID()]"
 	if(isnull(open_uis[src_object_key]) || !istype(open_uis[src_object_key], /list))
 		return 0 // Couldn't find any UIs for this object.


### PR DESCRIPTION
## What Does This PR Do
Fixes the issue where we run out of UIDs for no reason

## Why It's Good For The Game
Bug fix


## Changelog
:cl:
fix: Makes datums that have no UID not make one to try and close non existing TGUI windows
/:cl: