### PR TITLE
Prevent observe before server is finished starting

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -65,6 +65,8 @@ SUBSYSTEM_DEF(ticker)
 			to_chat(world, "Please, setup your character and select ready. Game will start in [config.pregame_timestart] seconds")
 			current_state = GAME_STATE_PREGAME
 			fire() // TG says this is a good idea
+			for(var/mob/new_player/N in GLOB.player_list)
+				N.new_player_panel_proc() // to enable the observe option
 		if(GAME_STATE_PREGAME)
 			if(!SSticker.ticker_going) // This has to be referenced like this, and I dont know why. If you dont put SSticker. it will break
 				return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -77,7 +77,10 @@
 		else	output += "<p><a href='byond://?src=[UID()];skip_antag=2'>Global Antag Candidacy</A>"
 		output += "<br /><small>You are <b>[client.skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
 
-	output += "<p><a href='byond://?src=[UID()];observe=1'>Observe</A></p>"
+	if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
+		output += "<p>Observe (starting up...)</p>"
+	else
+		output += "<p><a href='byond://?src=[UID()];observe=1'>Observe</A></p>"
 
 	if(GLOB.join_tos)
 		output += "<p><a href='byond://?src=[UID()];tos=1'>Terms of Service</A></p>"
@@ -182,6 +185,10 @@
 	if(href_list["observe"])
 		if(!tos_consent)
 			to_chat(usr, "<span class='warning'>You must consent to the terms of service before you can join!</span>")
+			return 0
+
+		if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
+			to_chat(usr, "<span class='warning'>You must wait for the server to finish starting before you can join!</span>")
 			return 0
 
 		if(alert(src,"Are you sure you wish to observe? You cannot normally join the round after doing this!","Player Setup","Yes","No") == "Yes")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -78,7 +78,7 @@
 		output += "<br /><small>You are <b>[client.skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
 
 	if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
-		output += "<p>Observe (starting up...)</p>"
+		output += "<p>Observe (Please wait...)</p>"
 	else
 		output += "<p><a href='byond://?src=[UID()];observe=1'>Observe</A></p>"
 
@@ -147,7 +147,8 @@
 
 
 /mob/new_player/Topic(href, href_list[])
-	if(!client)	return 0
+	if(!client)
+		return FALSE
 
 	if(href_list["consent_signed"])
 		var/sqltime = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
@@ -165,12 +166,12 @@
 
 	if(href_list["show_preferences"])
 		client.prefs.ShowChoices(src)
-		return 1
+		return TRUE
 
 	if(href_list["ready"])
 		if(!tos_consent)
 			to_chat(usr, "<span class='warning'>You must consent to the terms of service before you can join!</span>")
-			return 0
+			return FALSE
 		ready = !ready
 		new_player_panel_proc()
 
@@ -185,11 +186,11 @@
 	if(href_list["observe"])
 		if(!tos_consent)
 			to_chat(usr, "<span class='warning'>You must consent to the terms of service before you can join!</span>")
-			return 0
+			return FALSE
 
 		if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
 			to_chat(usr, "<span class='warning'>You must wait for the server to finish starting before you can join!</span>")
-			return 0
+			return FALSE
 
 		if(alert(src,"Are you sure you wish to observe? You cannot normally join the round after doing this!","Player Setup","Yes","No") == "Yes")
 			if(!client)
@@ -223,12 +224,12 @@
 			return 1
 	if(href_list["tos"])
 		privacy_consent()
-		return 0
+		return FALSE
 
 	if(href_list["late_join"])
 		if(!tos_consent)
 			to_chat(usr, "<span class='warning'>You must consent to the terms of service before you can join!</span>")
-			return 0
+			return FALSE
 		if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
 			to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 			return
@@ -236,7 +237,7 @@
 
 			if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
 				to_chat(src, alert("You are currently not whitelisted to play [client.prefs.species]."))
-				return 0
+				return FALSE
 
 		LateChoices()
 
@@ -255,7 +256,7 @@
 		if(client.prefs.species in GLOB.whitelisted_species)
 			if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)
 				to_chat(src, alert("You are currently not whitelisted to play [client.prefs.species]."))
-				return 0
+				return FALSE
 
 		AttemptLateSpawn(href_list["SelectedJob"],client.prefs.spawnpoint)
 		return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -106,7 +106,7 @@
 
 	output += "</center>"
 
-	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 220, 290)
+	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 240, 330)
 	popup.set_window_options("can_close=0")
 	popup.set_content(output)
 	popup.open(0)


### PR DESCRIPTION
## What Does This PR Do
Prevents players (including admins) from using "Observe" before the server is finished starting.
Until the server is ready for observers, a "Observe (starting up...)" will be displayed instead of the normal blue "Observe" button.

NOTE: This _doesn't_ stop you using Observe several minutes before roundstart. It just stops you using it for the first 5-20 seconds or so after the server first comes online, while the server is still initializing, loading the map, etc.

## Why It's Good For The Game
1) Various misleading runtimes and other errors can happen if you leap into the round before the server has even finished initializing subsystems and things.
2) This is eventually going to be required in order to support map rotation.

## Images
![TZUcUcszmh](https://user-images.githubusercontent.com/16434066/94362736-03524e80-00ad-11eb-96fe-f444ead1b61c.png)
(yes, its slightly bigger than the options list presented, this is to account for "View the Crew Manifest" appearing for latejoiners)

## Changelog
:cl: Kyep
add: Server no longer lets you Observe before its even finished loading the game.
/:cl:
