### PR TITLE
New traitor item: The Doppelganger Armor

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1187,6 +1187,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "DGRA"
 	item = /obj/item/clothing/suit/chameleon/doppel
 	cost = 11
+	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/camera_bug
 	name = "Camera Bug"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1181,6 +1181,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/chameleon
 	cost = 7
 
+/datum/uplink_item/stealthy_tools/doppelarmor
+	name = "Doppelganger Reactive Armor"
+	desc = "After being activated by hand, this chameleon armor will turn the user invisible and project a fake copy of the user when hit, both of these effects end after five seconds, afterwards the armor enters a cooldown until it can be used again."
+	reference = "DGRA"
+	item = /obj/item/clothing/suit/chameleon/doppel
+	cost = 11
+
 /datum/uplink_item/stealthy_tools/camera_bug
 	name = "Camera Bug"
 	desc = "Enables you to view all cameras on the network to track a target."

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -292,17 +292,16 @@
 /obj/item/clothing/suit/chameleon/doppel/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active | cooldown == TRUE)
 		return FALSE
-	else
-		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
-		E.Copy_Parent(owner, 70)
-		E.GiveTarget(owner) //so it starts running right away
-		E.Goto(owner, E.move_to_delay, E.minimum_distance)
-		owner.alpha = 0
-		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		addtimer(CALLBACK(src, .proc/doppel_cloaking, owner), 70)
-		cooldown = TRUE
-		addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)
-		return TRUE
+	var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
+	E.Copy_Parent(owner, 70)
+	E.GiveTarget(owner) //so it starts running right away
+	E.Goto(owner, E.move_to_delay, E.minimum_distance)
+	owner.alpha = 0
+	owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
+	addtimer(CALLBACK(src, .proc/doppel_cloaking, owner), 70)
+	cooldown = TRUE
+	addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)
+	return TRUE
 
 /obj/item/clothing/glasses/chameleon
 	name = "Optical Meson Scanner"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -257,6 +257,51 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+// Traitor item "Doppelganger Suit", behaves the same way as the reactive stealth armor, but has the added bonus of chameleon disguise.
+/obj/item/clothing/suit/chameleon/doppel
+	var/active = 0
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+
+/obj/item/clothing/suit/chameleon/doppel/proc/doppel_cooldown(mob/user)
+	cooldown = FALSE
+
+/obj/item/clothing/suit/chameleon/doppel/attack_self(mob/user)
+	active = !(active)
+	if(active)
+		to_chat(user, "<span class='notice'>[src] is now active.</span>")
+	else
+		to_chat(user, "<span class='notice'>[src] is now inactive.</span>")
+		add_fingerprint(user)
+	user.update_inv_wear_suit()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
+
+/obj/item/clothing/suit/chameleon/doppel/emp_act(severity)
+	active = 0
+	cooldown = TRUE
+	addtimer(CALLBACK(src, .proc/doppel_cooldown), 400)
+	if(istype(loc, /mob/living/carbon/human))
+		var/mob/living/carbon/human/C = loc
+		C.update_inv_wear_suit()
+	..()
+
+/obj/item/clothing/suit/chameleon/doppel/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(!active | cooldown == TRUE)
+		return 0
+	else
+		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
+		E.Copy_Parent(owner, 50)
+		E.GiveTarget(owner) //so it starts running right away
+		E.Goto(owner, E.move_to_delay, E.minimum_distance)
+		owner.alpha = 0
+		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
+		spawn(50)
+			owner.alpha = initial(owner.alpha)
+		cooldown = TRUE
+		addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)
+		return 1
+
 /obj/item/clothing/glasses/chameleon
 	name = "Optical Meson Scanner"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -265,7 +265,7 @@
 /obj/item/clothing/suit/chameleon/doppel/proc/doppel_cooldown(mob/user)
 	cooldown = FALSE
 
-/obj/item/clothing/suit/chameleon/doppel/proc/doppel_cloaking(mob/user)
+/obj/item/clothing/suit/chameleon/doppel/proc/doppel_cloaking(mob/living/carbon/human/owner)
 	owner.alpha = initial(owner.alpha)
 
 /obj/item/clothing/suit/chameleon/doppel/attack_self(mob/user)
@@ -299,7 +299,7 @@
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.alpha = 0
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		addtimer(CALLBACK(src, .proc/doppel_cloaking), 70)
+		addtimer(CALLBACK(src, .proc/doppel_cloaking, owner), 70)
 		cooldown = TRUE
 		addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)
 		return TRUE

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -291,12 +291,12 @@
 		return 0
 	else
 		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
-		E.Copy_Parent(owner, 50)
+		E.Copy_Parent(owner, 70)
 		E.GiveTarget(owner) //so it starts running right away
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.alpha = 0
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		spawn(50)
+		spawn(65)
 			owner.alpha = initial(owner.alpha)
 		cooldown = TRUE
 		addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -298,7 +298,6 @@
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
 		spawn(65)
 			owner.alpha = initial(owner.alpha)
-			new /obj/effect/temp_visual/dir_setting/ninja(get_turf(owner), owner.dir)
 		cooldown = TRUE
 		addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)
 		return 1

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -298,6 +298,7 @@
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
 		spawn(65)
 			owner.alpha = initial(owner.alpha)
+			new /obj/effect/temp_visual/dir_setting/ninja(get_turf(owner), owner.dir)
 		cooldown = TRUE
 		addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)
 		return 1

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -284,7 +284,7 @@
 	active = FALSE
 	cooldown = TRUE
 	addtimer(CALLBACK(src, .proc/doppel_cooldown), 400)
-	if(istype(loc, /mob/living/carbon/human))
+	if(ishuman(loc))
 		var/mob/living/carbon/human/C = loc
 		C.update_inv_wear_suit()
 	..()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -259,14 +259,17 @@
 
 // Traitor item "Doppelganger Suit", behaves the same way as the reactive stealth armor, but has the added bonus of chameleon disguise.
 /obj/item/clothing/suit/chameleon/doppel
-	var/active = 0
+	var/active = FALSE
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/suit/chameleon/doppel/proc/doppel_cooldown(mob/user)
 	cooldown = FALSE
 
+/obj/item/clothing/suit/chameleon/doppel/proc/doppel_cloaking(mob/user)
+	owner.alpha = initial(owner.alpha)
+
 /obj/item/clothing/suit/chameleon/doppel/attack_self(mob/user)
-	active = !(active)
+	active = !active
 	if(active)
 		to_chat(user, "<span class='notice'>[src] is now active.</span>")
 	else
@@ -278,7 +281,7 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/suit/chameleon/doppel/emp_act(severity)
-	active = 0
+	active = FALSE
 	cooldown = TRUE
 	addtimer(CALLBACK(src, .proc/doppel_cooldown), 400)
 	if(istype(loc, /mob/living/carbon/human))
@@ -288,7 +291,7 @@
 
 /obj/item/clothing/suit/chameleon/doppel/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active | cooldown == TRUE)
-		return 0
+		return FALSE
 	else
 		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
 		E.Copy_Parent(owner, 70)
@@ -296,11 +299,10 @@
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.alpha = 0
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		spawn(65)
-			owner.alpha = initial(owner.alpha)
+		addtimer(CALLBACK(src, .proc/doppel_cloaking), 70)
 		cooldown = TRUE
 		addtimer(CALLBACK(src, .proc/doppel_cooldown), 300)
-		return 1
+		return TRUE
 
 /obj/item/clothing/glasses/chameleon
 	name = "Optical Meson Scanner"


### PR DESCRIPTION
## What Does This PR Do
Adds a new 11TC item in the stealthy-tools section of the uplink, the doppelganger armor!

The armor has two abilities:
 1- Chameleon armor slot, you can change the sprite to whatever you want to disguise it.
 2- The Doppelganger: After you activate the armor on-hand, you will be protected by the reactive armor! When hit, you will turn invisible and a fake-copy of the user will manifest and start running away from the aggressor, which will drive away security forces off your tail! Five seconds after activation, the clone will disappear and you will turn back visible again. This ability has a cooldown, so you can't spam it endlessly at once. Don't get EMPd!

## Why It's Good For The Game
Traitors are severely lacking in anti-stun tools, as the only ones currently are the adrenalin implant (only three uses) and the stimulants (only one use). This item aims for an anti-stun that will last the traitor for as long as they are wearing it, that's why it has the following downsides:
       - 11 Telecrystals cost, so it will zap away most of your budget unless you get lucky with discounts (item is banned for nukies)
       - Invisible does not mean Invulnerable, although you will not take damage from the activating hit, any hits while invisible will still affect you, same as items like the energy-bola, flashbangs and the like.
       - Being EMP'd will turn off your armor for a long time, so security can disable it with an ion rifle as an opening move if they know what's up.
       - The armor only works while you have it equipped, and the armor stats are not great, so you won't be able to stack a lot of armor to go with this.

![CYVOEO65qz](https://user-images.githubusercontent.com/48032385/94368943-592ef280-00bd-11eb-8915-5b8868352966.gif)

## Changelog
:cl:
add: Adds The Doppelganger Armor to the uplink, an 11TC chameleon suit that will turn you invisible and create a fake clone of yourself when hit!
/:cl: