### PR TITLE
Makes autodoc show path instead of name in trees

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -4,3 +4,6 @@ dreamchecker = true
 [code_standards]
 disallow_relative_type_definitions = true
 disallow_relative_proc_definitions = true
+
+[dmdoc]
+use_typepath_names = true


### PR DESCRIPTION
## What Does This PR Do
Minor tweak to the autodoc configuration. basically turns this
![image](https://user-images.githubusercontent.com/25063394/94369343-167f1180-00e1-11eb-83be-0cd5fc00a633.png)

Into
![image](https://user-images.githubusercontent.com/25063394/94369349-226ad380-00e1-11eb-808e-d08b5dbd0939.png)

Makes following the tree easier

## Why It's Good For The Game
Makes following the tree easier

## Changelog
N/A