### PR TITLE
Makes robotics bots go under vehicles rather than pushing them

### DIFF
--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -33,6 +33,13 @@
 	QDEL_NULL(inserted_key)
 	return ..()
 
+// So that beepsky can't push the janicart
+/obj/vehicle/CanPass(atom/movable/mover, turf/target, height)
+	if(istype(mover) && mover.checkpass(PASSMOB))
+		return TRUE
+	else
+		return ..()
+
 /obj/vehicle/examine(mob/user)
 	. = ..()
 	if(key_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds `CanPass()` to `vehicle.dm` in order to stop robotics bots (Beepsky, janibots, etc) being able to push vehicles around when walking into them.

Another solution would be to make them repath around the vehicles, but I'm not touching that with a ten foot pole.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Seems like an oversight. 🤷 

Fixes #14368

## Changelog
:cl:
tweak: Stopped robotics bots being able to push vehicles around (Janicart, Ambulance, etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
