### PR TITLE
Re-adds back CQC to the traitor uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -238,15 +238,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	job = list("Chef")
 
-/datum/uplink_item/jobspecific/Chef_CQC
-	name = " A chefs manual to CQC"
-	desc = "An old manual teaching you how to bring your home advantage outside the kitchen."
-	reference = "CCQC"
-	item = /obj/item/CQC_manual/chef
-	cost = 12
-	job = list("Chef")
-	surplus = 0
-
 //Chaplain
 
 /datum/uplink_item/jobspecific/voodoo

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -245,6 +245,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/CQC_manual/chef
 	cost = 12
 	job = list("Chef")
+	surplus = 0
 
 //Chaplain
 
@@ -873,7 +874,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/CQC_manual
 	gamemodes = list(/datum/game_mode/nuclear)
 	cost = 13
-	surplus = 0
 
 /datum/uplink_item/stealthy_weapons/cameraflash
 	name = "Camera Flash"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -872,7 +872,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. Does not restrict weapon usage, but cannot be used alongside Gloves of the North Star."
 	reference = "CQC"
 	item = /obj/item/CQC_manual
-	gamemodes = list(/datum/game_mode/nuclear)
 	cost = 13
 
 /datum/uplink_item/stealthy_weapons/cameraflash

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -274,9 +274,6 @@
 	icon = 'icons/obj/library.dmi'
 	icon_state = "cqcmanual"
 
-/obj/item/CQC_manual/chef
-	desc = "A small, black manual. Written on the back it says: Bringing the home advantage with you."
-
 /obj/item/CQC_manual/attack_self(mob/living/carbon/human/user)
 	if(!istype(user) || !user)
 		return


### PR DESCRIPTION
## What Does This PR Do
Re-adds the 13TC CQC manual back to the traitor uplink, and allows it to roll for surplus.
Removes the Chef_CQC manual (FROM THE UPLINK, NOT THE CHEF HIMSELF) since the regular manual will replace it.

## Why It's Good For The Game
There is really no real reason to keep this outside of traitor hands (although they can already get it through bond bundle), since the martial arts rework passed, they can no longer prepare the sleep combo to apply it on one hit.
I also removed the chef_CQC from the uplink since it's the same as the CQC we're adding back, only real difference is from 12TC to 13TC.

## Changelog
:cl:
add: Adds the CQC manual back to the traitor uplink.
tweak: Allows the CQC manual to roll for surplus crates.
del: Removes the CCQC from the chef section from the traitor uplink.
/:cl: