### PR TITLE
Fixes welder step of AI Core deconstruction

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -225,7 +225,7 @@
 	qdel(src)
 
 /obj/structure/AIcore/welder_act(mob/user, obj/item/I)
-	if(!state)
+	if(state)
 		return
 	. = TRUE
 	if(!I.tool_use_check(user, 0))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently, you can use the welder to cut the frame for plasteel at any point BUT the last step. This is clearly backward.

## Why It's Good For The Game
Bugs are bad.


## Changelog
:cl:
fix: Fixes welder step in AI core deconstruction to properly be the last step.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
