### PR TITLE
Improved OOC Manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -36,13 +36,14 @@
 		var/real_rank = t.fields["real_rank"]
 		if(OOC)
 			var/activetext = "Inactive"
-			for(var/mob/M in GLOB.human_list)
-				if(M.real_name != name)
+			for(var/thing in GLOB.human_list)
+				var/mob/living/carbon/human/H = thing
+				if(H.real_name != name)
 					continue
-				if(M.client && M.client.inactivity <= 10 * 60 * 10)
+				if(H.client && H.client.inactivity <= 6000)
 					activetext = "Active"
 					break
-				if(isLivingSSD(M))
+				if(isLivingSSD(H))
 					activetext = "SSD"
 					break
 			isactive[name] = activetext

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -35,12 +35,17 @@
 		var/rank = t.fields["rank"]
 		var/real_rank = t.fields["real_rank"]
 		if(OOC)
-			var/active = 0
-			for(var/mob/M in GLOB.player_list)
-				if(M.real_name == name && M.client && M.client.inactivity <= 10 * 60 * 10)
-					active = 1
+			var/activetext = "Inactive"
+			for(var/mob/M in GLOB.human_list)
+				if(M.real_name != name)
+					continue
+				if(M.client && M.client.inactivity <= 10 * 60 * 10)
+					activetext = "Active"
 					break
-			isactive[name] = active ? "Active" : "Inactive"
+				if(isLivingSSD(M))
+					activetext = "SSD"
+					break
+			isactive[name] = activetext
 		else
 			isactive[name] = t.fields["p_stat"]
 		var/department = 0

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -576,7 +576,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/dat
 	dat += "<h4>Crew Manifest</h4>"
-	dat += GLOB.data_core.get_manifest()
+	dat += GLOB.data_core.get_manifest(OOC = TRUE)
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
 


### PR DESCRIPTION
## What Does This PR Do
1. Observers using the Ghost - > Show Manifest verb now get the OOC version of the manifest, which lists people who are AFK as "Inactive".
2. The OOC version of the manifest (shown to players in lobby, and now to ghosts as well) now also shows players as "SSD" if they're SSD but alive.

## Why It's Good For The Game
The OOC manifest already detects and lists inactive/AFK players. It makes sense for it to also handle SSD players, rather than reacting to one but ignoring the other.
Ghosts and players in lobby should get the OOC manifest, because they're not in the round, and it might make a substantial difference (e.g: noticing a command member went SSD).

## Changelog
:cl: Kyep
add: Ghosts and players in the lobby can now see if someone is SSD on the crew manifest.
/:cl: