### PR TITLE
Slip staff removed

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1105,14 +1105,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/clownplanet)
-"iN" = (
-/obj/item/gun/magic/staff/slipping{
-	charges = 5;
-	max_charges = 1;
-	recharge_rate = 10
-	},
-/turf/simulated/floor/plating,
-/area/ruin/powered/clownplanet)
 "pv" = (
 /obj/machinery/light{
 	dir = 4
@@ -1122,9 +1114,6 @@
 "ye" = (
 /turf/simulated/floor/plating/lava/smooth,
 /area/ruin/powered/clownplanet)
-"zS" = (
-/turf/simulated/floor/plating/lava/smooth,
-/area/space)
 "CB" = (
 /obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet/hope,
 /obj/effect/decal/cleanable/blood/old,
@@ -1430,7 +1419,7 @@ bB
 bB
 cc
 ye
-iN
+cu
 ye
 cc
 cc
@@ -1463,8 +1452,8 @@ cc
 bB
 bB
 bB
-cc
-zS
+aU
+ye
 ye
 ye
 cc

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1105,6 +1105,14 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/clownplanet)
+"iN" = (
+/obj/item/gun/magic/staff/slipping{
+	charges = 5;
+	max_charges = 1;
+	recharge_rate = 10
+	},
+/turf/simulated/floor/plating,
+/area/ruin/powered/clownplanet)
 "pv" = (
 /obj/machinery/light{
 	dir = 4
@@ -1114,6 +1122,9 @@
 "ye" = (
 /turf/simulated/floor/plating/lava/smooth,
 /area/ruin/powered/clownplanet)
+"zS" = (
+/turf/simulated/floor/plating/lava/smooth,
+/area/space)
 "CB" = (
 /obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet/hope,
 /obj/effect/decal/cleanable/blood/old,
@@ -1419,7 +1430,7 @@ bB
 bB
 cc
 ye
-cu
+iN
 ye
 cc
 cc
@@ -1452,8 +1463,8 @@ cc
 bB
 bB
 bB
-aU
-ye
+cc
+zS
 ye
 ye
 cc

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -961,6 +961,12 @@
 /area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/table/glass,
+/obj/item/dnainjector/comic{
+	desc = "Honk!!!";
+	name = "Bananium extract";
+	pixel_x = 3;
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bB" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -961,7 +961,6 @@
 /area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/table/glass,
-/obj/item/gun/magic/staff/slipping,
 /turf/simulated/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bB" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes Staff of Slipping from Lavaland Clown ruins and adds a DNA injector (comic) there.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Balance reasons.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![staffOSlippOff](https://user-images.githubusercontent.com/10063083/94623671-0455cc80-02b5-11eb-94ea-56e3d445cfb2.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: DNA injector (comic) at Clown ruins at Lavaland.
del: Staff of Slipping from Lavaland Clown ruins.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
