### PR TITLE
Fixes some issue with being cloned while having martial arts

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -113,6 +113,11 @@
 		A.on_body_transfer(old_current, current)
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
+	if(martial_art)
+		if(martial_art.temporary)
+			martial_art.remove(current)
+		else
+			martial_art.teach(current)
 
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -140,9 +140,10 @@
 		return
 	if(H.mind.martial_art != src)
 		return
-	H.mind.martial_art = base
-	if(has_explaination_verb && !(base && base.has_explaination_verb))
-		H.verbs -= /mob/living/carbon/human/proc/martial_arts_help
+	H.mind.martial_art = null // Remove reference
+	H.verbs -= /mob/living/carbon/human/proc/martial_arts_help
+	if(base)
+		base.teach(H)
 
 /mob/living/carbon/human/proc/martial_arts_help()
 	set name = "Show Info"


### PR DESCRIPTION
## What Does This PR Do
- Makes it so that being cloned or transferred to another body properly re-teaches you the martial arts. Which will give you the verb.
- Makes it so that being cloned or transferred to another body removes temporary martial arts and relearns the old one you might have had. Example, Having CQC while wearing the krav maga gloves and then being cloned.

## Why It's Good For The Game
Bug fixes b gut

## Changelog
:cl:
fix: Properly removes temp martial arts when transferring minds
fix: Properly reteaches martial arts when transferring minds
/:cl: