### PR TITLE
Sniper Holster Fix

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -316,6 +316,9 @@
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
 	shaded_charge = 1
 
+/obj/item/gun/energy/sniperrifle/isHandgun()
+	return FALSE // Makes it so no, you cant fit a massive, bulky, sniper under your arm
+
 // Temperature Gun //
 /obj/item/gun/energy/temperature
 	name = "temperature gun"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -20,6 +20,9 @@
 	slot_flags = SLOT_BACK
 	actions_types = list()
 
+/obj/item/gun/projectile/automatic/sniper_rifle/isHandgun() // Is it a handgun?
+	return 0 // False
+
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
 	desc = "Syndicate flavoured sniper rifle, it packs quite a punch, a punch to your face."

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -20,9 +20,6 @@
 	slot_flags = SLOT_BACK
 	actions_types = list()
 
-/obj/item/gun/projectile/automatic/sniper_rifle/isHandgun() // Is it a handgun?
-	return FALSE
-
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
 	desc = "Syndicate flavoured sniper rifle, it packs quite a punch, a punch to your face."

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -21,7 +21,7 @@
 	actions_types = list()
 
 /obj/item/gun/projectile/automatic/sniper_rifle/isHandgun() // Is it a handgun?
-	return FALSE // False
+	return FALSE
 
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -21,7 +21,7 @@
 	actions_types = list()
 
 /obj/item/gun/projectile/automatic/sniper_rifle/isHandgun() // Is it a handgun?
-	return 0 // False
+	return FALSE // False
 
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops you from placing a sniper in your holster, because you shouldnt be able to put a 60 inch gun in your iphone sized pocket under your armpit.

## Why It's Good For The Game
Just no.
## Changelog
:cl:
add: You can no longer holster LWAP sniper rifles.
/:cl:
