### PR TITLE
[orion trail] Check if all crew dead before kill

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -571,23 +571,24 @@
 		event = null
 
 	else if(href_list["killcrew"]) //shoot a crewmember
-		var/sheriff = remove_crewmember() //I shot the sheriff
-		playsound(loc,'sound/weapons/gunshots/gunshot.ogg', 100, 1)
+		if(settlers.len > 0 || alive > 0)
+			var/sheriff = remove_crewmember() //I shot the sheriff
+			playsound(loc,'sound/weapons/gunshots/gunshot.ogg', 100, 1)
 
-		if(settlers.len == 0 || alive == 0)
-			atom_say("The last crewmember [sheriff], shot themselves, GAME OVER!")
-			if(emagged)
-				usr.death(0)
-				emagged = 0
-			gameover = 1
-			event = null
-		else if(emagged)
-			if(usr.name == sheriff)
-				atom_say("The crew of the ship chose to kill [usr.name]!")
-				usr.death(0)
+			if(settlers.len == 0 || alive == 0)
+				atom_say("The last crewmember [sheriff], shot themselves, GAME OVER!")
+				if(emagged)
+					usr.death(0)
+					emagged = 0
+				gameover = 1
+				event = null
+			else if(emagged)
+				if(usr.name == sheriff)
+					atom_say("The crew of the ship chose to kill [usr.name]!")
+					usr.death(0)
 
-		if(event == ORION_TRAIL_LING) //only ends the ORION_TRAIL_LING event, since you can do this action in multiple places
-			event = null
+			if(event == ORION_TRAIL_LING) //only ends the ORION_TRAIL_LING event, since you can do this action in multiple places
+				event = null
 
 	//Spaceport specific interactions
 	//they get a header because most of them don't reset event (because it's a shop, you leave when you want to)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -571,24 +571,25 @@
 		event = null
 
 	else if(href_list["killcrew"]) //shoot a crewmember
-		if(settlers.len > 0 || alive > 0)
-			var/sheriff = remove_crewmember() //I shot the sheriff
-			playsound(loc,'sound/weapons/gunshots/gunshot.ogg', 100, 1)
+		if(length(settlers) <= 0 || alive <= 0)
+			return
+		var/sheriff = remove_crewmember() //I shot the sheriff
+		playsound(loc, 'sound/weapons/gunshots/gunshot.ogg', 100, 1)
 
-			if(settlers.len == 0 || alive == 0)
-				atom_say("The last crewmember [sheriff], shot themselves, GAME OVER!")
-				if(emagged)
-					usr.death(0)
-					emagged = 0
-				gameover = 1
-				event = null
-			else if(emagged)
-				if(usr.name == sheriff)
-					atom_say("The crew of the ship chose to kill [usr.name]!")
-					usr.death(0)
+		if(length(settlers) == 0 || alive == 0)
+			atom_say("The last crewmember [sheriff], shot themselves, GAME OVER!")
+			if(emagged)
+				usr.death(FALSE)
+				emagged = FALSE
+			gameover = TRUE
+			event = null
+		else if(emagged)
+			if(usr.name == sheriff)
+				atom_say("The crew of the ship chose to kill [usr.name]!")
+				usr.death(FALSE)
 
-			if(event == ORION_TRAIL_LING) //only ends the ORION_TRAIL_LING event, since you can do this action in multiple places
-				event = null
+		if(event == ORION_TRAIL_LING) //only ends the ORION_TRAIL_LING event, since you can do this action in multiple places
+			event = null
 
 	//Spaceport specific interactions
 	//they get a header because most of them don't reset event (because it's a shop, you leave when you want to)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a check to Orion Trail to see if there are any living crew members left when the kill crewmember button is pressed.

## Why It's Good For The Game
If clicked fast enough you can get a message saying a person without a name committed suicide. This is bad for immersion as this game would not be bugged if it was on a real space station. fixed https://github.com/ParadiseSS13/Paradise/issues/14303

## Changelog
:cl: further-reading
tweak: Orion trail checks for living crew before killing a crew member.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
