### PR TITLE
Fixes terror princesses/queens firebending with airtight webs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -366,3 +366,7 @@
 /obj/structure/spider/terrorweb/queen/CanAtmosPass(turf/T)
 	return FALSE
 
+/obj/structure/spider/terrorweb/queen/Destroy()
+	var/turf/T = get_turf(src)
+	. = ..()
+	T.air_update_turf(TRUE)


### PR DESCRIPTION
## What Does This PR Do
Fixes the airtight webs created by terror queens/princesses. While they did correctly block atmos on creation, they did not stop blocking atmos when they were destroyed.
This led to plasma that stayed on certain tiles and mysteriously would not move into adjacent ones, even though it should have.
This was also exploitable, as a princess or queen who was aware of exactly how this worked could effectively firebend, creating a wall of airtight webs and then detonating a plasma tank on the other side, forcing the plasma to move where the spider wanted and burn just their targets while leaving the spider untouched. 
In extreme cases, it might have been possible for queens/princesses to create a firewall around their nest, outside of which there's a raging plasma fire but the nest itself is totally immune to that fire.

To be fair... nobody has actually deliberately exploited this (that I know of).
I only know of one situation where this bug even came up, and even then it was by accident, and had no impact on the round beyond a cloud of plasma just floating somewhere and not moving.
But when I realized actual firebending was possible, I decided I needed to instantly shut it down before it became an actual technique.

With this PR, every time an airtight web is destroyed, it stops blocking atmos.
That means a plasma fire will actually burn through even airtight webs. Not instantly... but it will. Even multiple layers of them.
That means a plasma fire started outside a queen/princess nest has a good chance of burning the entire nest to the ground.

## Changelog
:cl: Kyep
fix: fixed an exploitable bug where terror princess/queen webs did not stop blocking air when they were destroyed. This makes queen/princess nests much more vulnerable to plasma fire.
/:cl: