### PR TITLE
Refactors how targeted changeling stings are handled

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -242,11 +242,11 @@
 	return
 
 // See click_override.dm
-/mob/living/MiddleClickOn(var/atom/A)
- if(src.middleClickOverride)
- 	middleClickOverride.onClick(A, src)
- else
- 	..()
+/mob/living/MiddleClickOn(atom/A)
+	if(middleClickOverride)
+		middleClickOverride.onClick(A, src)
+	else
+		..()
 
 
 /*
@@ -325,11 +325,11 @@
 	return
 
 // See click_override.dm
-/mob/living/AltClickOn(var/atom/A)
- if(src.middleClickOverride)
- 	middleClickOverride.onClick(A, src)
- else
- 	..()
+/mob/living/AltClickOn(atom/A)
+	if(middleClickOverride)
+		middleClickOverride.onClick(A, src)
+	else
+		..()
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -60,7 +60,7 @@
 	* item/afterattack(atom,user,adjacent,params) - used both ranged and adjacent
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
-/mob/proc/ClickOn( var/atom/A, var/params )
+/mob/proc/ClickOn(atom/A, params)
 	if(client.click_intercept)
 		client.click_intercept.InterceptClickOn(src, params, A)
 		return
@@ -248,12 +248,6 @@
  else
  	..()
 
-/mob/living/carbon/MiddleClickOn(var/atom/A)
-	if(!src.stat && src.mind && src.mind.changeling && src.mind.changeling.chosen_sting && (istype(A, /mob/living/carbon)) && (A != src))
-		changeNext_click(5)
-		mind.changeling.chosen_sting.try_to_sting(src, A)
-	else
-		..()
 
 /*
 	Middle shift-click
@@ -336,13 +330,6 @@
  	middleClickOverride.onClick(A, src)
  else
  	..()
-
-/mob/living/carbon/AltClickOn(var/atom/A)
-	if(!src.stat && src.mind && src.mind.changeling && src.mind.changeling.chosen_sting && (istype(A, /mob/living/carbon)) && (A != src))
-		changeNext_click(5)
-		mind.changeling.chosen_sting.try_to_sting(src, A)
-	else
-		..()
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -94,7 +94,7 @@
 /**
  * # Callback invoker middle click override datum
  *
- * Middle click override datum which accepts a callback when during `New()`.
+ * Middle click override which accepts a callback as an arugment in the `New()` proc.
  * When the living mob that has this datum middle-clicks or alt-clicks on something, the callback will be invoked.
  */
 /datum/middleClickOverride/callback_invoker

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -90,3 +90,19 @@
 		next_shocked.Cut()
 
 	P.last_shocked = world.time
+
+/**
+ * # Callback invoker middle click override datum
+ *
+ * Middle click override datum which accepts a callback when during `New()`.
+ * When the living mob that has this datum middle-clicks or alt-clicks on something, the callback will be invoked.
+ */
+/datum/middleClickOverride/callback_invoker
+	var/datum/callback/callback
+
+/datum/middleClickOverride/callback_invoker/New(datum/callback/_callback)
+	. = ..()
+	callback = _callback
+
+/datum/middleClickOverride/callback_invoker/onClick(atom/A, mob/living/user)
+	callback.Invoke(user, A)

--- a/code/datums/click_intercept.dm
+++ b/code/datums/click_intercept.dm
@@ -51,18 +51,3 @@
  */
 /datum/click_intercept/proc/InterceptClickOn(mob/user, params, atom/object)
 	return
-
-/**
- * # Callback invoker datum
- *
- * A basic `click_intercept` datum which when created, stores a callback that will be invoked after a client clicks on something.
- */
-/datum/click_intercept/callback_invoker
-	var/datum/callback/callback
-
-/datum/click_intercept/callback_invoker/New(client/C, datum/callback/_callback)
-	. = ..()
-	callback = _callback
-
-/datum/click_intercept/callback_invoker/InterceptClickOn(mob/user, params, atom/object)
-	callback.Invoke(user, object)

--- a/code/datums/click_intercept.dm
+++ b/code/datums/click_intercept.dm
@@ -1,10 +1,22 @@
+/**
+ * # Click intercept datum
+ *
+ * Datum which is intended to be stored by a client's `click_intercept` variable.
+ * Used to override normal clicking behavior when clicking on an object.
+ * While active, a mob's `ClickOn` proc will redirect to the `InterceptClickOn()` proc instead.
+ */
 /datum/click_intercept
+	/// A reference to the client which is assigned this click intercept datum.
 	var/client/holder = null
+	/// Any `obj/screen/buttons` the client is meant to receive when assigned this click intercept datum.
 	var/list/obj/screen/buttons = list()
 
 /datum/click_intercept/New(client/C)
 	create_buttons()
-	enter(C)
+	holder = C
+	holder.click_intercept = src
+	holder.show_popup_menus = FALSE
+	holder.screen += buttons
 	return ..()
 
 /datum/click_intercept/Destroy()
@@ -15,17 +27,42 @@
 	QDEL_LIST(buttons)
 	return ..()
 
-/datum/click_intercept/proc/enter(client/C)
-	holder = C
-	holder.click_intercept = src
-	holder.show_popup_menus = FALSE
-	holder.screen += buttons
-
+/**
+ * Called when you want to cancel a client's click intercept and return to normal clicking.
+ */
 /datum/click_intercept/proc/quit()
 	qdel(src)
 
+/**
+ * Base proc, intended to be overriden. Code that adds datum specific buttons to the list of `buttons`, should go here.
+ */
 /datum/click_intercept/proc/create_buttons()
 	return
 
-/datum/click_intercept/proc/InterceptClickOn(user,params,atom/object)
+/**
+ * Called in various mob's `ClickOn` procs, which happens when they click on an object in the world.
+ *
+ * If the mob's `client.click_intercept` variable is set to something other than null, calls the `InterceptClickOn` proc for that click intercept datum. Aka, this proc.
+ *
+ * Arguments:
+ * * user - the mob which just clicked on something.
+ * * params - the `params` arguemnt passed from the `ClickOn` proc.
+ * * object - the atom that was just clicked.
+ */
+/datum/click_intercept/proc/InterceptClickOn(mob/user, params, atom/object)
 	return
+
+/**
+ * # Callback invoker datum
+ *
+ * A basic `click_intercept` datum which when created, stores a callback that will be invoked after a client clicks on something.
+ */
+/datum/click_intercept/callback_invoker
+	var/datum/callback/callback
+
+/datum/click_intercept/callback_invoker/New(client/C, datum/callback/_callback)
+	. = ..()
+	callback = _callback
+
+/datum/click_intercept/callback_invoker/InterceptClickOn(mob/user, params, atom/object)
+	callback.Invoke(user, object)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -939,6 +939,8 @@
 					special_role = null
 					if(changeling)
 						current.remove_changeling_powers()
+						qdel(current.middleClickOverride) // In case the old changeling has a targeted sting prepared (`datum/middleClickOverride`), delete it.
+						current.middleClickOverride = null
 						qdel(changeling)
 						changeling = null
 					SSticker.mode.update_change_icons_removed(src)

--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -35,7 +35,8 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 		return
 	try_to_sting(user)
 
-/datum/action/changeling/proc/try_to_sting(var/mob/user, var/mob/target)
+/datum/action/changeling/proc/try_to_sting(mob/user, mob/target)
+	user.changeNext_click(5)
 	if(!user.mind || !user.mind.changeling)
 		return
 	if(!can_sting(user, target))

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -404,7 +404,6 @@ GLOBAL_LIST_EMPTY(sting_paths)
 /mob/proc/remove_changeling_powers(var/keep_free_powers=0)
 	if(ishuman(src))
 		if(mind && mind.changeling)
-			qdel(client.click_intercept) // In case the old changeling has a targeted sting prepared (a click intercept), delete it.
 			digitalcamo = 0
 			mind.changeling.changeling_speak = 0
 			mind.changeling.reset()

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -404,6 +404,7 @@ GLOBAL_LIST_EMPTY(sting_paths)
 /mob/proc/remove_changeling_powers(var/keep_free_powers=0)
 	if(ishuman(src))
 		if(mind && mind.changeling)
+			qdel(client.click_intercept) // In case the old changeling has a targeted sting prepared (a click intercept), delete it.
 			digitalcamo = 0
 			mind.changeling.changeling_speak = 0
 			mind.changeling.reset()

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -13,16 +13,17 @@
 		unset_sting(user)
 	return
 
-/datum/action/changeling/sting/proc/set_sting(var/mob/user)
-	to_chat(user, "<span class='notice'>We prepare our sting. Left click on a target to sting them.</span>")
-	user.client.click_intercept = new /datum/click_intercept/callback_invoker(user.client, CALLBACK(src, .proc/try_to_sting))
+/datum/action/changeling/sting/proc/set_sting(mob/living/user)
+	to_chat(user, "<span class='notice'>We prepare our sting, use alt+click or middle mouse button on target to sting them.</span>")
+	user.middleClickOverride = new /datum/middleClickOverride/callback_invoker(CALLBACK(src, .proc/try_to_sting))
 	user.mind.changeling.chosen_sting = src
 	user.hud_used.lingstingdisplay.icon_state = sting_icon
 	user.hud_used.lingstingdisplay.invisibility = 0
 
-/datum/action/changeling/sting/proc/unset_sting(var/mob/user)
+/datum/action/changeling/sting/proc/unset_sting(mob/living/user)
 	to_chat(user, "<span class='warning'>We retract our sting, we can't sting anyone for now.</span>")
-	qdel(user.client.click_intercept)
+	qdel(user.middleClickOverride)
+	user.middleClickOverride = null
 	user.mind.changeling.chosen_sting = null
 	user.hud_used.lingstingdisplay.icon_state = null
 	user.hud_used.lingstingdisplay.invisibility = 101

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -14,13 +14,15 @@
 	return
 
 /datum/action/changeling/sting/proc/set_sting(var/mob/user)
-	to_chat(user, "<span class='notice'>We prepare our sting, use alt+click or middle mouse button on target to sting them.</span>")
+	to_chat(user, "<span class='notice'>We prepare our sting. Left click on a target to sting them.</span>")
+	user.client.click_intercept = new /datum/click_intercept/callback_invoker(user.client, CALLBACK(src, .proc/try_to_sting))
 	user.mind.changeling.chosen_sting = src
 	user.hud_used.lingstingdisplay.icon_state = sting_icon
 	user.hud_used.lingstingdisplay.invisibility = 0
 
 /datum/action/changeling/sting/proc/unset_sting(var/mob/user)
 	to_chat(user, "<span class='warning'>We retract our sting, we can't sting anyone for now.</span>")
+	qdel(user.client.click_intercept)
 	user.mind.changeling.chosen_sting = null
 	user.hud_used.lingstingdisplay.icon_state = null
 	user.hud_used.lingstingdisplay.invisibility = 101

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -2,6 +2,12 @@
 	name = "Tiny Prick"
 	desc = "Stabby stabby"
 	var/sting_icon = null
+	/// A middle click override used to intercept changeling stings performed on a target.
+	var/datum/middleClickOverride/callback_invoker/click_override
+
+/datum/action/changeling/sting/New(Target)
+	. = ..()
+	click_override = new /datum/middleClickOverride/callback_invoker(CALLBACK(src, .proc/try_to_sting))
 
 /datum/action/changeling/sting/Trigger()
 	var/mob/user = owner
@@ -15,14 +21,13 @@
 
 /datum/action/changeling/sting/proc/set_sting(mob/living/user)
 	to_chat(user, "<span class='notice'>We prepare our sting, use alt+click or middle mouse button on target to sting them.</span>")
-	user.middleClickOverride = new /datum/middleClickOverride/callback_invoker(CALLBACK(src, .proc/try_to_sting))
+	user.middleClickOverride = click_override
 	user.mind.changeling.chosen_sting = src
 	user.hud_used.lingstingdisplay.icon_state = sting_icon
 	user.hud_used.lingstingdisplay.invisibility = 0
 
 /datum/action/changeling/sting/proc/unset_sting(mob/living/user)
 	to_chat(user, "<span class='warning'>We retract our sting, we can't sting anyone for now.</span>")
-	qdel(user.middleClickOverride)
 	user.middleClickOverride = null
 	user.mind.changeling.chosen_sting = null
 	user.hud_used.lingstingdisplay.icon_state = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes snowflake changeling checks on the `/mob/living/carbon/MiddleClickOn` and `/mob/living/carbon/AltClickOn` procs, and creates a new `middleClickOverride` that can be used to invoke any callback, which I'm now using with changeling stings. 

Changeling sting functionality remains the same.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
None, backend change only.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
