### PR TITLE
Reduce Water Stun/Weaken Time

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -81,7 +81,7 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!(M.slip("the wet floor", 1, 0, tilesSlipped = 0, walkSafely = 1)))
+					if(!(M.slip("the wet floor", 1, 1, tilesSlipped = 0, walkSafely = 1)))
 						M.inertia_dir = 0
 						return
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -1,3 +1,5 @@
+#define WATER_STUN_TIME 2 //Stun time for water, to edit/find easier
+#define WATER_WEAKEN_TIME 1 //Weaken time for water, to edit/find easier
 /turf/simulated
 	name = "station"
 	var/wet = 0
@@ -81,7 +83,7 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!(M.slip("the wet floor", 2, 1, tilesSlipped = 0, walkSafely = 1)))
+					if(!(M.slip("the wet floor", WATER_STUN_TIME, WATER_WEAKEN_TIME, tilesSlipped = 0, walkSafely = 1)))
 						M.inertia_dir = 0
 						return
 
@@ -107,3 +109,6 @@
 	queue_smooth_neighbors(src)
 
 /turf/simulated/proc/is_shielded()
+
+#undef WATER_STUN_TIME
+#undef WATER_WEAKEN_TIME

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -81,7 +81,7 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!(M.slip("the wet floor", 1, 1, tilesSlipped = 0, walkSafely = 1)))
+					if(!(M.slip("the wet floor", 2, 1, tilesSlipped = 0, walkSafely = 1)))
 						M.inertia_dir = 0
 						return
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -81,7 +81,7 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!(M.slip("the wet floor", 4, 2, tilesSlipped = 0, walkSafely = 1)))
+					if(!(M.slip("the wet floor", 1, 0, tilesSlipped = 0, walkSafely = 1)))
 						M.inertia_dir = 0
 						return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reduces the stun time and weaken time of TURF_WET_WATER by half.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Water is basically as good as slapping somebody with a baton in some cases, which logically makes absolutely zero sense. Should it knock you over and make you drop items? Yes. But should it knock you down for 6-8 seconds? No.

While this also nerfs the usage of water tanks by simplemobs (such as Terrors) there REALLY shouldnt be a reason that they can use a free 8x8 tile stun for 6-8 seconds.

edit: Slimes (the race) being able to leave stun-like landmines behind them when bleeding is also INSANELY silly from an Antag perspective.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked stun and weaken amounts in TURF_WET_WATER (Stun: 4 -> 2, Weaken: 2 -> 1)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
