### PR TITLE
Makes gibtonite check if it has wires before closing TGUI windows

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -220,8 +220,9 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	var/datum/wires/explosive/gibtonite/wires
 
 /obj/item/twohanded/required/gibtonite/Destroy()
-	SStgui.close_uis(wires)
-	QDEL_NULL(wires)
+	if(wires)
+		SStgui.close_uis(wires)
+		QDEL_NULL(wires)
 	return ..()
 
 /obj/item/twohanded/required/gibtonite/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## What Does This PR Do
As the title says.
Fixes:
```
Runtime in tgui.dm,129: Cannot read null.unique_datum_id
   proc name: close uis (/datum/controller/subsystem/tgui/proc/close_uis)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The volcanic floor (90,90,3) (/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface)
   src: TGUI (/datum/controller/subsystem/tgui)
   call stack:
   TGUI (/datum/controller/subsystem/tgui): close uis(null)
   the gibtonite ore (/obj/item/twohanded/required/gibtonite): Destroy(0)
   qdel(the gibtonite ore (/obj/item/twohanded/required/gibtonite), 0)
   the gibtonite ore (/obj/item/twohanded/required/gibtonite): GibtoniteReaction(NAME (/mob/living/carbon/human), 0)
```

## Why It's Good For The Game
It's a weird runtime

## Changelog
:cl:
fix: Makes gibtonite check if it has wires before closing their windows. Yes they have wires.. somehow
/:cl: