### PR TITLE
Makes camera bugs actually work

### DIFF
--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -10,11 +10,14 @@
 	throw_range	= 20
 	origin_tech = "syndicate=1;engineering=3"
 	/// Integrated camera console to serve UI data
-	var/obj/machinery/computer/security/integrated_console
+	var/obj/machinery/computer/security/camera_bug/integrated_console
+
+/obj/machinery/computer/security/camera_bug
+	use_power = NO_POWER_USE
 
 /obj/item/camera_bug/Initialize(mapload)
 	. = ..()
-	integrated_console = new
+	integrated_console = new(src)
 	integrated_console.parent = src
 	integrated_console.network = list("SS13")
 

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -13,6 +13,8 @@
 	var/obj/machinery/computer/security/camera_bug/integrated_console
 
 /obj/machinery/computer/security/camera_bug
+	name = "invasive camera utility"
+	desc = "How did this get here?! Please report this as a bug to github"
 	use_power = NO_POWER_USE
 
 /obj/item/camera_bug/Initialize(mapload)


### PR DESCRIPTION
## What Does This PR Do
Makes camera bugs have their own special type of sec camera console which doesn't require power thus works.
I've gave it the name "Invasive Camera Utility name". Danke MattTheFicus for the name

Fixes #14512

## Why It's Good For The Game
Bug fix b gut

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/94963524-900b6b00-04f8-11eb-82e6-a2dae5618713.png)


## Changelog
:cl:
fix: Camera bugs work now
/:cl: