### PR TITLE
Stops diona vampires from getting nutrient effects from light

### DIFF
--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -85,9 +85,8 @@
 	return ..()
 
 /datum/species/diona/handle_life(mob/living/carbon/human/H)
-	if(H.stat == DEAD)
-		return
 	var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing
+	var/is_vamp = H.mind?.vampire != null
 	if(isturf(H.loc)) //else, there's considered to be no light
 		var/turf/T = H.loc
 		light_amount = min(1, T.get_lumcount()) - 0.5
@@ -95,9 +94,12 @@
 			H.clear_alert("nolight")
 		else
 			H.throw_alert("nolight", /obj/screen/alert/nolight)
-		H.adjust_nutrition(light_amount * 10)
-		if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL)
-			H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
+
+		if(!is_vamp)
+			H.adjust_nutrition(light_amount * 10)
+			if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL)
+				H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
+
 		if(light_amount > 0.2 && !H.suiciding) //if there's enough light, heal
 			if(!pod && H.health <= 0)
 				return
@@ -106,7 +108,7 @@
 			H.adjustToxLoss(-1)
 			H.adjustOxyLoss(-1)
 
-	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
+	if(!is_vamp && H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		H.adjustBruteLoss(2)
 	..()
 


### PR DESCRIPTION
## What Does This PR Do
Makes diona vampires not get nutrients from light and they won't get added brute damage from being hungry. Being a hungry vampire already hurts them plenty

Fixes #14252

Also removed the useless dead check in handle_life. This never happens or should ever happen

## Why It's Good For The Game
It's quite a thing that diona vampires can be pure pacifists and not have to ever succ somebody.

## Changelog
:cl:
tweak: Diona vampires won't get nutrients from light.
tweak: Diona vampires don't get extra brute damage from being hungry
/:cl: