### PR TITLE
Makes the speed gene and other ignoreslowdown buffs take speedups into account

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -36,6 +36,7 @@
 #define PASSEMOTES	16      //Mob has a cortical borer or holders inside of it that need to see emotes.
 #define GOTTAGOFAST	32
 #define IGNORESLOWDOWN	128
+#define IGNORE_SPEED_CHANGES	256
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define XENO_HOST	16384	//Tracks whether we're gonna be a baby alien's mummy.

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -215,7 +215,7 @@
 	alert_type = /obj/screen/alert/status_effect/regenerative_core
 
 /datum/status_effect/regenerative_core/on_apply()
-	owner.status_flags |= IGNORESLOWDOWN
+	owner.status_flags |= IGNORE_SPEED_CHANGES
 	owner.adjustBruteLoss(-25)
 	owner.adjustFireLoss(-25)
 	owner.remove_CC()
@@ -229,4 +229,4 @@
 	return TRUE
 
 /datum/status_effect/regenerative_core/on_remove()
-	owner.status_flags &= ~IGNORESLOWDOWN
+	owner.status_flags &= ~IGNORE_SPEED_CHANGES

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -222,6 +222,8 @@
 
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
+	if(H.status_flags & IGNORE_SPEED_CHANGES)
+		return .
 
 	if(has_gravity(H))
 		if(H.status_flags & GOTTAGOFAST)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -221,20 +221,24 @@
 
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
-	var/ignoreslow = FALSE
 
+	if(has_gravity(H))
+		if(H.status_flags & GOTTAGOFAST)
+			. -= 1
 
-	if((H.status_flags & IGNORESLOWDOWN) || (RUN in H.mutations))
-		ignoreslow = TRUE
+		var/ignoreslow = FALSE
+		if((H.status_flags & IGNORESLOWDOWN) || (RUN in H.mutations))
+			ignoreslow = TRUE
 
-	if(ignoreslow)
-		if(speed_mod < 0)	// Apply the speed_mod if it's negative. Meaning it's a speedup
-			. = speed_mod
-	else if(has_gravity(H))
+		if(ignoreslow)
+			if(speed_mod < 0)	// Apply the speed_mod if it's negative. Meaning it's a speedup
+				. += speed_mod
+			return .
+
 		var/flight = H.flying	//Check for flight and flying items
 
 		if(speed_mod)
-			. = speed_mod
+			. += speed_mod
 
 		if(H.wear_suit)
 			. += H.wear_suit.slowdown
@@ -267,9 +271,6 @@
 			. += (1.5 - flight)
 		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
-
-	if(H.status_flags & GOTTAGOFAST)
-		. -= 1
 
 	return .
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -218,6 +218,7 @@
 ////////////////
 // MOVE SPEED //
 ////////////////
+#define ADD_SLOWDOWN(__value) if(!ignoreslow || __value < 0) . += __value
 
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
@@ -230,27 +231,23 @@
 		if((H.status_flags & IGNORESLOWDOWN) || (RUN in H.mutations))
 			ignoreslow = TRUE
 
-		if(ignoreslow)
-			if(speed_mod < 0)	// Apply the speed_mod if it's negative. Meaning it's a speedup
-				. += speed_mod
-			return .
-
 		var/flight = H.flying	//Check for flight and flying items
 
-		if(speed_mod)
-			. += speed_mod
+		ADD_SLOWDOWN(speed_mod)
 
 		if(H.wear_suit)
-			. += H.wear_suit.slowdown
-		if(!H.buckled)
-			if(H.shoes)
-				. += H.shoes.slowdown
+			ADD_SLOWDOWN(H.wear_suit.slowdown)
+		if(!H.buckled && H.shoes)
+			ADD_SLOWDOWN(H.shoes.slowdown)
 		if(H.back)
-			. += H.back.slowdown
+			ADD_SLOWDOWN(H.back.slowdown)
 		if(H.l_hand && (H.l_hand.flags & HANDSLOW))
-			. += H.l_hand.slowdown
+			ADD_SLOWDOWN(H.l_hand.slowdown)
 		if(H.r_hand && (H.r_hand.flags & HANDSLOW))
-			. += H.r_hand.slowdown
+			ADD_SLOWDOWN(H.r_hand.slowdown)
+
+		if(ignoreslow)
+			return . // Only malusses after here
 
 		var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
 		var/hungry = (500 - H.nutrition)/5 // So overeat would be 100 and default level would be 80
@@ -273,6 +270,8 @@
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
 
 	return .
+
+#undef ADD_SLOWDOWN
 
 /datum/species/proc/on_species_gain(mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.
 	for(var/slot_id in no_equip)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -221,20 +221,18 @@
 
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
-	var/flight = 0	//Check for flight and flying items
-	var/ignoreslow = 0
-	var/gravity = 0
+	var/ignoreslow = FALSE
 
-	if(H.flying)
-		flight = 1
 
 	if((H.status_flags & IGNORESLOWDOWN) || (RUN in H.mutations))
-		ignoreslow = 1
+		ignoreslow = TRUE
 
-	if(has_gravity(H))
-		gravity = 1
+	if(ignoreslow)
+		if(speed_mod < 0)	// Apply the speed_mod if it's negative. Meaning it's a speedup
+			. = speed_mod
+	else if(has_gravity(H))
+		var/flight = H.flying	//Check for flight and flying items
 
-	if(!ignoreslow && gravity)
 		if(speed_mod)
 			. = speed_mod
 
@@ -270,8 +268,9 @@
 		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
 
-		if(H.status_flags & GOTTAGOFAST)
-			. -= 1
+	if(H.status_flags & GOTTAGOFAST)
+		. -= 1
+
 	return .
 
 /datum/species/proc/on_species_gain(mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.


### PR DESCRIPTION
## What Does This PR Do
Makes the `IGNORESLOWDOWN` flag and `RUN` mtuation only ignore slowdown and take speedups from `speed_mod` and the `GOTTAGOFAST` flag into account.

Also makes clothing such as the cult flagellant's robes work with the flag and mutation

Adds the IGNORE_SPEED_CHANGES status flag for the legion cores which makes the affected player ignore all speed changes. Be it good or bad. This doesn't change anything functionally from the previous workings

Fixes #14090

## Why It's Good For The Game
The speed gene now actually makes you faster if you take meth or such

## Changelog
:cl:
tweak: Makes the genetics super speed mutation not ignore speedups
/:cl: