### PR TITLE
Sling thralling now respects mindshields

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -252,12 +252,11 @@
 				user.visible_message("<span class='warning'>[user]'s palms flare a bright red against [target]'s temples!</span>")
 				to_chat(target, "<span class='danger'>A terrible red light floods your mind. You collapse as conscious thought is wiped away.</span>")
 				target.Weaken(12)
-				sleep(2 SECONDS)
 			if(3)
 				to_chat(user, "<span class='notice'>You begin planting the tumor that will control the new thrall...</span>")
 				user.visible_message("<span class='warning'>A strange energy passes from [user]'s hands into [target]'s head!</span>")
 				to_chat(target, "<span class='boldannounce'>You feel your memories twisting, morphing. A sense of horror dominates your mind.</span>")
-		if(!do_mob(user, target, 7 SECONDS)) //around 21 seconds total for enthralling, 31 for someone with a mindshield implant
+		if(!do_mob(user, target, 9 SECONDS)) //around 21 seconds total for enthralling
 			to_chat(user, "<span class='warning'>The enthralling has been interrupted - your target's mind returns to its previous state.</span>")
 			to_chat(target, "<span class='userdanger'>You wrest yourself away from [user]'s hands and compose yourself</span>")
 			enthralling = FALSE

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -249,12 +249,12 @@
 				user.visible_message("<span class='warning'>[user]'s palms flare a bright red against [target]'s temples!</span>")
 				to_chat(target, "<span class='danger'>A terrible red light floods your mind. You collapse as conscious thought is wiped away.</span>")
 				target.Weaken(12)
-				sleep(20)
+				sleep(2 SECONDS)
 				if(ismindshielded(target))
 					to_chat(user, "<span class='notice'>They have a mindshield implant. You try to overwhelm it!</span>")
 					user.visible_message("<span class='warning'>[user] pauses, then dips [user.p_their()] head in concentration!</span>")
 					to_chat(target, "<span class='boldannounce'>Your mindshield implant becomes hot as it comes under attack!</span>")
-					sleep(100) //10 seconds - not spawn() so the enthralling takes longer
+					sleep(10 SECONDS) //10 seconds - not spawn() so the enthralling takes longer
 					to_chat(user, "<span class='notice'>The nanobots composing the mindshield implant put up a valiant fight but they are about to lose...</span>")
 					to_chat(user, "<span class='boldannounce'>Rather than be disabled, the mindshield superheats, frying your victim's brain!</span>")
 					to_chat(target, "<span class='boldannounce'>You feel a burning, horrible pain in your head!</span>")
@@ -268,7 +268,7 @@
 				to_chat(user, "<span class='notice'>You begin planting the tumor that will control the new thrall...</span>")
 				user.visible_message("<span class='warning'>A strange energy passes from [user]'s hands into [target]'s head!</span>")
 				to_chat(target, "<span class='boldannounce'>You feel your memories twisting, morphing. A sense of horror dominates your mind.</span>")
-		if(!do_mob(user, target, 70)) //around 21 seconds total for enthralling, 31 for someone with a mindshield implant
+		if(!do_mob(user, target, 7 SECONDS)) //around 21 seconds total for enthralling, 31 for someone with a mindshield implant
 			to_chat(user, "<span class='warning'>The enthralling has been interrupted - your target's mind returns to its previous state.</span>")
 			to_chat(target, "<span class='userdanger'>You wrest yourself away from [user]'s hands and compose yourself</span>")
 			enthralling = FALSE

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -235,6 +235,9 @@
 	if(!(ling.mind in SSticker.mode.shadows))
 		return
 	var/mob/living/carbon/human/target = targets[1]
+	if(ismindshielded(target))
+		to_chat(user, "<span class='danger'>This target has a mindshield, blocking your powers! You cannot thrall it!</span>")
+		return
 	enthralling = TRUE
 	to_chat(user, "<span class='danger'>This target is valid. You begin the enthralling.</span>")
 	to_chat(target, "<span class='userdanger'>[user] stares at you. You feel your head begin to pulse.</span>")
@@ -250,20 +253,6 @@
 				to_chat(target, "<span class='danger'>A terrible red light floods your mind. You collapse as conscious thought is wiped away.</span>")
 				target.Weaken(12)
 				sleep(2 SECONDS)
-				if(ismindshielded(target))
-					to_chat(user, "<span class='notice'>They have a mindshield implant. You try to overwhelm it!</span>")
-					user.visible_message("<span class='warning'>[user] pauses, then dips [user.p_their()] head in concentration!</span>")
-					to_chat(target, "<span class='boldannounce'>Your mindshield implant becomes hot as it comes under attack!</span>")
-					sleep(10 SECONDS) //10 seconds - not spawn() so the enthralling takes longer
-					to_chat(user, "<span class='notice'>The nanobots composing the mindshield implant put up a valiant fight but they are about to lose...</span>")
-					to_chat(user, "<span class='boldannounce'>Rather than be disabled, the mindshield superheats, frying your victim's brain!</span>")
-					to_chat(target, "<span class='boldannounce'>You feel a burning, horrible pain in your head!</span>")
-					for(var/obj/item/implant/mindshield/L in target)	//it self-destructs to kill you, after all
-						if(L && L.implanted)
-							qdel(L)
-					target.adjustBrainLoss(120, TRUE, FALSE)
-					enthralling = FALSE
-					return
 			if(3)
 				to_chat(user, "<span class='notice'>You begin planting the tumor that will control the new thrall...</span>")
 				user.visible_message("<span class='warning'>A strange energy passes from [user]'s hands into [target]'s head!</span>")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -251,16 +251,19 @@
 				target.Weaken(12)
 				sleep(20)
 				if(ismindshielded(target))
-					to_chat(user, "<span class='notice'>They have a mindshield implant. You begin to deactivate it - this will take some time.</span>")
+					to_chat(user, "<span class='notice'>They have a mindshield implant. You try to overwhelm it!</span>")
 					user.visible_message("<span class='warning'>[user] pauses, then dips [user.p_their()] head in concentration!</span>")
 					to_chat(target, "<span class='boldannounce'>Your mindshield implant becomes hot as it comes under attack!</span>")
 					sleep(100) //10 seconds - not spawn() so the enthralling takes longer
-					to_chat(user, "<span class='notice'>The nanobots composing the mindshield implant have been rendered inert. Now to continue.</span>")
-					user.visible_message("<span class='warning'>[user] relaxes again.</span>")
-					for(var/obj/item/implant/mindshield/L in target)
+					to_chat(user, "<span class='notice'>The nanobots composing the mindshield implant put up a valiant fight but they are about to lose...</span>")
+					to_chat(user, "<span class='boldannounce'>Rather than be disabled, the mindshield superheats, frying your victim's brain!</span>")
+					to_chat(target, "<span class='boldannounce'>You feel a burning, horrible pain in your head!</span>")
+					for(var/obj/item/implant/mindshield/L in target)	//it self-destructs to kill you, after all
 						if(L && L.implanted)
 							qdel(L)
-					to_chat(target, "<span class='boldannounce'>Your mental protection implant unexpectedly falters, dims, dies.</span>")
+					target.adjustBrainLoss(120, TRUE, FALSE)
+					enthralling = FALSE
+					return
 			if(3)
 				to_chat(user, "<span class='notice'>You begin planting the tumor that will control the new thrall...</span>")
 				user.visible_message("<span class='warning'>A strange energy passes from [user]'s hands into [target]'s head!</span>")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -256,7 +256,7 @@
 				to_chat(user, "<span class='notice'>You begin planting the tumor that will control the new thrall...</span>")
 				user.visible_message("<span class='warning'>A strange energy passes from [user]'s hands into [target]'s head!</span>")
 				to_chat(target, "<span class='boldannounce'>You feel your memories twisting, morphing. A sense of horror dominates your mind.</span>")
-		if(!do_mob(user, target, 9 SECONDS)) //around 21 seconds total for enthralling
+		if(!do_mob(user, target, 7.7 SECONDS)) //around 23 seconds total for enthralling
 			to_chat(user, "<span class='warning'>The enthralling has been interrupted - your target's mind returns to its previous state.</span>")
 			to_chat(target, "<span class='userdanger'>You wrest yourself away from [user]'s hands and compose yourself</span>")
 			enthralling = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It was a resulting proposal from the survey meeting and something I've felt was kind of needed for a while now. 
This PR makes it so a sling that tries to enthrall someone with a mindshield will fail. 

Edit: the mindshield now just completely blocks the thralling with a message explaining why to the sling.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Slings have a ridiculous snowballing component. Every sec officer they get not only removes one of their enemies but gives them one very potent ally that can more or less freely arrest more victims for them to thrall.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Mindshields now protect from Shadowling thralling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
