### PR TITLE
Makes laser tags have 0 damage and makes the field generators take nodamage into consideration

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -144,7 +144,7 @@ field_generator power level display
 		..()
 
 /obj/machinery/field/generator/bullet_act(obj/item/projectile/Proj)
-	if(Proj.flag != "bullet")
+	if(Proj.flag != "bullet" && !Proj.nodamage)
 		power = min(power + Proj.damage, field_generator_max_power)
 		check_power_level()
 	return 0

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -85,6 +85,7 @@
 	icon_state = "omnilaser"
 	hitsound = 'sound/weapons/tap.ogg'
 	nodamage = 1
+	damage = 0
 	damage_type = STAMINA
 	flag = "laser"
 	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)


### PR DESCRIPTION
## What Does This PR Do
Fixes laser tags being able to power field generators.

I changed the damage in the laser tags to 0 to make it actually make sense

## Why It's Good For The Game
Bug fix

## Changelog
:cl:
fix: Laser tags have 0 damage now.
fix: Field generators now don't accept power if the projectile has the nodamage flag set to true
/:cl: