### PR TITLE
spraybottle logging change

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -50,15 +50,20 @@
 	user.changeNext_move(CLICK_CD_RANGE*2)
 	user.newtonian_move(get_dir(A, user))
 
-	if(reagents.reagent_list.len == 1 && reagents.has_reagent("cleaner")) // Only show space cleaner logs if it's burning people from being too hot or cold
-		if(reagents.chem_temp < 300 && reagents.chem_temp > 280) // 280 is the cold threshold for slimes, 300 the hot threshold for drask
+	var/attack_log_type = ATKLOG_ALMOSTALL
+
+	if(reagents.chem_temp > 300 || reagents.chem_temp < 280)	//harmful temperature
+		attack_log_type = ATKLOG_MOST
+
+	if(reagents.reagent_list.len == 1 && reagents.has_reagent("cleaner")) // Only create space cleaner logs if it's burning people from being too hot or cold
+		if(attack_log_type == ATKLOG_ALMOSTALL)
 			return
 
-	var/attack_log_type = ATKLOG_MOST
+	//commonly used for griefing or just very annoying and dangerous
 	if(reagents.has_reagent("sacid") || reagents.has_reagent("facid") || reagents.has_reagent("lube"))
 		attack_log_type = ATKLOG_FEW
 
-	add_attack_logs(user, A, "Used a potentially harmful spray bottle. Contents: [contents_log] - Temperature: [reagents.chem_temp]K", attack_log_type)
+	add_attack_logs(user, A, "Used a spray bottle. Contents: [contents_log] - Temperature: [reagents.chem_temp]K", attack_log_type)
 	return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR changes how attack logs with spraybottles work. In detail:
Spraying space cleaner at a safe (read, harmless) temperature does not generate an attack log (unchanged)
Spraying any other reagent mix generates an attack log at the level of ALMOST_ALL unless one of the below conditions are met. 
Spraying any reagent at a harmful temperature (ie boiling or freezing) generates an attack log at the level of MOST
Spraying acid or lube generates an attack log at the level of FEW

For those less familiar with admin tools, the logging levels are:
ALL, ALMOST_ALL, MOST, FEW, NONE
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Many cases that were log level MOST are now at ALMOST_ALL. This means you mostly don't notice them but can still check someone's attack logs if they get ahelped for being a shitter with random mildly dangerous chems.

You still notice dangerous attacks with boiling liquids as well as lube/acid.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: tweaked spray bottle attack logging to generate less spam.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
