### PR TITLE
Morgue destroy fix

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -155,8 +155,12 @@
 	return
 
 /obj/structure/morgue/Destroy()
-	QDEL_NULL(connected)
+	var/turf/T = src.loc
+	if(!connected)
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(T)
 	return ..()
+
 
 /obj/structure/morgue/container_resist(var/mob/living/L)
 	var/mob/living/carbon/CM = L
@@ -389,7 +393,10 @@
 	return
 
 /obj/structure/crematorium/Destroy()
-	QDEL_NULL(connected)
+	var/turf/T = src.loc
+	if(!connected)
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(T)
 	return ..()
 
 /obj/structure/crematorium/container_resist(var/mob/living/L)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -155,12 +155,13 @@
 	return
 
 /obj/structure/morgue/Destroy()
-	var/turf/T = src.loc
 	if(!connected)
+		var/turf/T = src.loc
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(T)
+	else
+		QDEL_NULL(connected)
 	return ..()
-
 
 /obj/structure/morgue/container_resist(var/mob/living/L)
 	var/mob/living/carbon/CM = L
@@ -393,10 +394,12 @@
 	return
 
 /obj/structure/crematorium/Destroy()
-	var/turf/T = src.loc
 	if(!connected)
+		var/turf/T = src.loc
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(T)
+	else
+		QDEL_NULL(connected)
 	return ..()
 
 /obj/structure/crematorium/container_resist(var/mob/living/L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR stops the destruction of a Morgue/Crematorium structure from deleting all of its contents, including any living mobs, and instead ejects them onto the same time the structure previously existed prior to its destruction.

Ensures destruction of the Morgue/Crematorium tray as well if the tray is open.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is a bug fix. Destroying a Morgue/Crematorium structure deletes any mob inside, whether they are dead or alive. If their mob is deleted, a player can no longer be returned to the game. Certain items should be protected from destruction this way as well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before the Fix:
https://imgur.com/a/Vfsf9XC

After the Fix (walls are not necessary):
https://imgur.com/a/sNfywBy

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Morgue/Crematorium structure destruction no longer deletes anything inside
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
