### PR TITLE
Blurry eyes blur eyes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -429,6 +429,10 @@
 
 // Filters
 #define FILTER_AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, color="#04080FAA")
+#define FILTER_EYE_BLUR filter(type="blur", size=0)
+
+#define AMBIENT_OCCLUSION_FILTER_KEY "ambient occlusion"
+#define EYE_BLUR_FILTER_KEY "eye blur"
 
 //Fullscreen overlay resolution in tiles.
 #define FULLSCREEN_OVERLAY_RESOLUTION_X 15

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -99,11 +99,6 @@
 /obj/screen/fullscreen/impaired
 	icon_state = "impairedoverlay"
 
-/obj/screen/fullscreen/blurry
-	icon = 'icons/mob/screen_gen.dmi'
-	screen_loc = "WEST,SOUTH to EAST,NORTH"
-	icon_state = "blurry"
-
 /obj/screen/fullscreen/flash
 	icon = 'icons/mob/screen_gen.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -5,6 +5,7 @@
 	blend_mode = BLEND_OVERLAY
 	var/show_alpha = 255
 	var/hide_alpha = 0
+	var/current_filters = list()
 
 /obj/screen/plane_master/proc/Show(override)
 	alpha = override || show_alpha
@@ -12,14 +13,21 @@
 /obj/screen/plane_master/proc/Hide(override)
 	alpha = override || hide_alpha
 
-/obj/screen/plane_master/proc/outline(_size, _color)
-	filters += filter(type = "outline", size = _size, color = _color)
+/obj/screen/plane_master/proc/add_filter(key, filter)
+	if(current_filters[key])
+		filters -= current_filters[key]
 
-/obj/screen/plane_master/proc/shadow(_size, _border, _offset = 0, _x = 0, _y = 0, _color = "#04080FAA")
-	filters += filter(type = "drop_shadow", x = _x, y = _y, color = _color, size = _size, offset = _offset)
+	filters += filter
+	current_filters[key] = filters[filters.len] //assigning `filter` will not allow it to work later while animating removal
 
-/obj/screen/plane_master/proc/clear_filters()
-	filters = list()
+/obj/screen/plane_master/proc/remove_filter(key)
+	if(current_filters[key])
+		animate(current_filters[key], size=0, time=5) //not all filters have a size param, but this is good enough for the general case
+		addtimer(CALLBACK(src, .proc/remove_callback, key), 5)
+
+/obj/screen/plane_master/proc/remove_callback(key)
+	filters -= current_filters[key]
+	current_filters -= key
 
 //Why do plane masters need a backdrop sometimes? Read http://www.byond.com/forum/?post=2141928
 //Trust me, you need one. Period. If you don't think you do, you're doing something extremely wrong.
@@ -38,9 +46,8 @@
 	blend_mode = BLEND_OVERLAY
 
 /obj/screen/plane_master/game_world/backdrop(mob/mymob)
-	clear_filters()
 	if(istype(mymob) && mymob.client && mymob.client.prefs && (mymob.client.prefs.toggles & AMBIENT_OCCLUSION))
-		filters += FILTER_AMBIENT_OCCLUSION
+		add_filter(AMBIENT_OCCLUSION_FILTER_KEY, FILTER_AMBIENT_OCCLUSION)
 
 /obj/screen/plane_master/lighting
 	name = "lighting plane master"

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2113,9 +2113,9 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 					toggles ^= AMBIENT_OCCLUSION
 					if(parent && parent.screen && parent.screen.len)
 						var/obj/screen/plane_master/game_world/PM = locate(/obj/screen/plane_master/game_world) in parent.screen
-						PM.filters -= FILTER_AMBIENT_OCCLUSION
+						PM.remove_filter(AMBIENT_OCCLUSION_FILTER_KEY)
 						if(toggles & AMBIENT_OCCLUSION)
-							PM.filters += FILTER_AMBIENT_OCCLUSION
+							PM.add_filter(AMBIENT_OCCLUSION_FILTER_KEY, FILTER_AMBIENT_OCCLUSION)
 
 				if("parallax")
 					var/parallax_styles = list(

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -10,10 +10,10 @@
 
 /mob/living/update_blurry_effects()
 	if(eyes_blurred())
-		overlay_fullscreen("blurry", /obj/screen/fullscreen/blurry)
+		add_eyeblur()
 		return 1
 	else
-		clear_fullscreen("blurry")
+		remove_eyeblur()
 		return 0
 
 /mob/living/update_druggy_effects()
@@ -133,3 +133,19 @@
 			updatehealth("var edit")
 		if("resize")
 			update_transform()
+
+/mob/proc/add_eyeblur()
+	if(client.screen)
+		var/obj/screen/plane_master/game_world/GW = locate(/obj/screen/plane_master/game_world) in client.screen
+		var/obj/screen/plane_master/floor/F = locate(/obj/screen/plane_master/floor) in client.screen
+		GW.add_filter(EYE_BLUR_FILTER_KEY, FILTER_EYE_BLUR)
+		F.add_filter(EYE_BLUR_FILTER_KEY, FILTER_EYE_BLUR)
+		animate(GW.filters[GW.filters.len], size = 3, time = 5)
+		animate(F.filters[F.filters.len], size = 3, time = 5)
+
+/mob/proc/remove_eyeblur()
+	if(client.screen)
+		var/obj/screen/plane_master/game_world/GW = locate(/obj/screen/plane_master/game_world) in client.screen
+		var/obj/screen/plane_master/floor/F = locate(/obj/screen/plane_master/floor) in client.screen
+		GW.remove_filter(EYE_BLUR_FILTER_KEY)
+		F.remove_filter(EYE_BLUR_FILTER_KEY)


### PR DESCRIPTION
![2dQKKrurWp](https://user-images.githubusercontent.com/15747030/95016063-ec819e00-0650-11eb-9dfc-2d67356254ac.gif)



Use a BYOND filter to blur eyes. It only applies to floor and game plane masters. I also put some filter actions behind a proc that will animate their removal (in most cases) properly. 




:cl: Flatty
add: Blurry eyes are now blurrier
/:cl:


