### PR TITLE
Nerfs the bluespace wormhole projector

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -187,7 +187,8 @@
 /obj/item/ammo_casing/energy/wormhole
 	projectile_type = /obj/item/projectile/beam/wormhole
 	muzzle_flash_color = "#33CCFF"
-	e_cost = 0
+	delay = 10
+	e_cost = 100
 	fire_sound = 'sound/weapons/pulse3.ogg'
 	var/obj/item/gun/energy/wormhole_projector/gun = null
 	select_name = "blue"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -201,7 +201,7 @@
 	icon_state = "wormhole_projector1"
 	origin_tech = "combat=4;bluespace=6;plasmatech=4;engineering=4"
 	charge_delay = 5
-	selfcharge = 1
+	selfcharge = TRUE
 	var/obj/effect/portal/blue
 	var/obj/effect/portal/orange
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -200,6 +200,8 @@
 	item_state = null
 	icon_state = "wormhole_projector1"
 	origin_tech = "combat=4;bluespace=6;plasmatech=4;engineering=4"
+	charge_delay = 5
+	selfcharge = 1
 	var/obj/effect/portal/blue
 	var/obj/effect/portal/orange
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Nerfs the bluespace wormhole projector (portal gun) by giving it a 1 second fire delay, and 10 shots. However, allows it to self charge one shot every 10 seconds.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The bluespace wormhole is a fun tool. A nice portal reference, can be used cleverly. The issue is, people have been abusing it heavily in 2 ways. One: Due to its infinite ammo and low fire rate, you can spam fire it everywhere without it ever running out. This is problematic, as you can not reach a person spam fireing this gun, as anyone hit by one of its shots is randomly teleported in a 6 tile radius, often into another room, or space nearby, preventing them from reaching the person with a gun. 
Two: If you enter the portal, you get teleported to the other portal. Simple. However, if you have a bag of holding, you get teleported a large distance away from where you should end up. This may seem like a downside, but it is not. If you willingly enter a portal while security is chasing you, you will teleport a large distance away from security, with them having no way of telling where you have gone, and no way to follow, even if they have a bag of holding on as well, they go somewhere else.

This PR attempts to fix this, by lowering fire rate and giving it a power cause, so it can not be spammed, and if you do want to use this in combat, you have to aim carefully.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Gave the bluespace wormhole projector a 1 second fire delay, and changes it from infinite ammo to 10 shots, with a 1 shot per second recharge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
