### PR TITLE
Close storage UI when item becomes inaccessible

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -147,6 +147,7 @@
 		else
 			if((href_list["type"] == "R") && (emagged == 0) && (!l_setshort))
 				locked = 1
+				hide_from_all()
 				overlays = null
 				code = null
 				close(usr)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -23,6 +23,7 @@
 	var/allow_quick_gather	//Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
 	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
+	var/list/active_users = list() // list of ckey(user.key), who is viewing the inventory?
 
 /obj/item/storage/MouseDrop(obj/over_object as obj)
 	if(ishuman(usr)) //so monkeys can take off their backpacks -- Urist
@@ -124,6 +125,8 @@
 	user.client.screen += src.closer
 	user.client.screen += src.contents
 	user.s_active = src
+	if(user.key)
+		active_users[ckey(user.key)] = TRUE
 	return
 
 /obj/item/storage/proc/hide_from(mob/user as mob)
@@ -135,7 +138,18 @@
 	user.client.screen -= src.contents
 	if(user.s_active == src)
 		user.s_active = null
+	if(user.key)
+		active_users.Remove(ckey(user.key))
 	return
+
+/obj/item/storage/proc/hide_from_all()
+	for(var/K in active_users)
+		var/client/C = get_client_by_ckey(K)
+		if(C)
+			var/mob/M = C.mob
+			if(M)
+				hide_from(M)
+
 
 /obj/item/storage/proc/open(mob/user as mob)
 	if(src.use_sound)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -103,6 +103,9 @@
 		if(!I.anchored)
 			I.forceMove(src)
 			itemcount++
+			if(istype(I, /obj/item/storage))
+				var/obj/item/storage/S = I
+				S.hide_from_all()
 
 	for(var/mob/M in loc)
 		if(itemcount >= storage_capacity)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -73,6 +73,9 @@
 				continue
 		O.forceMove(src)
 		itemcount++
+		if(istype(O, /obj/item/storage))
+			var/obj/item/storage/S = O
+			S.hide_from_all()
 
 	icon_state = icon_closed
 	src.opened = FALSE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -608,6 +608,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 			return
 
 	if(thrown_thing)
+		if(istype(thrown_thing, /obj/item/storage))
+			var/obj/item/storage/S = thrown_thing
+			S.hide_from_all()
 		visible_message("<span class='danger'>[src] has thrown [thrown_thing].</span>")
 		newtonian_move(get_dir(target, src))
 		thrown_thing.throw_at(target, thrown_thing.throw_range, thrown_thing.throw_speed, src, null, null, null, move_force)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -103,8 +103,8 @@
 		to_chat(user, "You can't place that item inside the disposal unit.")
 		return
 
-	if(istype(I, /obj/item/storage))
-		var/obj/item/storage/S = I
+	var/obj/item/storage/S = I
+	if(istype(S))
 		if((S.allow_quick_empty || S.allow_quick_gather) && S.contents.len)
 			S.hide_from(user)
 			user.visible_message("[user] empties \the [S] into \the [src].", "You empty \the [S] into \the [src].")
@@ -134,6 +134,8 @@
 	if(!user.drop_item())
 		return
 	if(I)
+		if(istype(S))
+			S.hide_from_all()
 		I.forceMove(src)
 
 	to_chat(user, "You place \the [I] into the [src].")

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -81,6 +81,9 @@ Note: Must be placed within 3 tiles of the R&D Console
 		busy = 1
 		loaded_item = O
 		O.loc = src
+		if(istype(O, /obj/item/storage))
+			var/obj/item/storage/S = O
+			S.hide_from_all()
 		to_chat(user, "<span class='notice'>You add the [O.name] to the [src.name]!</span>")
 		flick("d_analyzer_la", src)
 		spawn(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a proc called hide_from_all on obj/item/storage to hide the UI from all users who opened it. It should be called in places where an action makes objects unavailable. I added it to throwing, lockers closing, safes locking, and storage insertion, and disposal chutes. Any other places to add anyone can think of?
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's confusing to be able to see storage in certain situations. Especially when the storage already has checks that you can take items, but clicking them does nothing. For example, if you unlock and open the storage of the secure safe in the captains office, then lock it, you can still see the contents even though you can't interact with it. With this change the storage window would close once you lock the safe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Some storage objects hide their UI after becoming inaccessible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
