### PR TITLE
Fixes PDA Power Monitor Bug

### DIFF
--- a/code/modules/tgui/modules/power_monitor.dm
+++ b/code/modules/tgui/modules/power_monitor.dm
@@ -20,6 +20,10 @@
 /datum/tgui_module/power_monitor/tgui_data(mob/user)
 	var/list/data = list()
 
+	// Sanity check
+	if(QDELETED(powermonitor))
+		powermonitor = null
+
 	data["powermonitor"] = powermonitor
 	if(select_monitor)
 		data["select_monitor"] = TRUE


### PR DESCRIPTION
## What Does This PR Do
Fixes #14537 

If a power-monitor has been deleted, it now unsets when you open the PDA or AI app

## Why It's Good For The Game
Bugs bad

## Changelog
:cl: AffectedArc07
fix: PDA and AI power monitors no longer crash if a console gets destroyed
/:cl:
