### PR TITLE
Gives admins a way to smoothly end a round

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -614,7 +614,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 /datum/admins/proc/smoothend()
 	set category = "Server"
 	set name = "Annouce game over"
-	set desc = "Instantly ends round and brings up objectives like shadowlings or slings dying."
+	set desc = "Instantly ends round and brings up objectives like shadowlings or wizards dying."
 
 	if(!check_rights(R_SERVER))
 		return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -624,7 +624,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	if(SSticker.force_ending)
 		return
 	message_admins("[key_name_admin(usr)] has admin ended the round with message: '[input]'")
-	log_admin("[key_name(usr)] has admin ended the round  with message: '[input]'")
+	log_admin("[key_name(usr)] has admin ended the round with message: '[input]'")
 	SSticker.force_ending = TRUE
 	to_chat(world, "<span class='warning'><big><b>[input]</b></big></span>")
 	feedback_add_details("admin_verb", "END") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -611,23 +611,24 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	feedback_add_details("admin_verb","R") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	world.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "end_error", "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", delay)
 
-/datum/admins/proc/smoothend()
+/datum/admins/proc/end_round()
 	set category = "Server"
-	set name = "Annouce game over"
-	set desc = "Instantly ends round and brings up objectives like shadowlings or wizards dying."
-
+	set name = "End Round"
+	set desc = "Instantly ends the round and brings up the scoreboard, like shadowlings or wizards dying."
 	if(!check_rights(R_SERVER))
 		return
+	var/input = sanitize(copytext(input(usr, "What text should players see announcing the round end? Input nothing to cancel.", "Specify Announcement Text", "Shift Has Ended!"), 1, MAX_MESSAGE_LEN))
 
-	if(alert(usr, "Are you sure you want to admin end the round and bring up objectives?", "End the game", "Yes", "No") != "Yes")
+	if(!input)
 		return
-
-	message_admins("[key_name_admin(usr)] has admin ended the round.")
-	log_admin("[key_name(usr)] has admin ended the round")
-	SSticker.force_ending = 1
-	to_chat(world, "<span class='warning'><FONT size = 3><b>The administrators have declared the round over and have ended the round!</b></FONT></span>")
-	feedback_add_details("admin_verb","S") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	feedback_set_details("round_end_result","Admin ended")
+	if(SSticker.force_ending)
+		return
+	message_admins("[key_name_admin(usr)] has admin ended the round with message: '[input]'")
+	log_admin("[key_name(usr)] has admin ended the round  with message: '[input]'")
+	SSticker.force_ending = TRUE
+	to_chat(world, "<span class='warning'><big><b>[input]</b></big></span>")
+	feedback_add_details("admin_verb", "END") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	feedback_set_details("round_end_result", "Admin ended")
 
 /datum/admins/proc/announce()
 	set category = "Admin"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -611,6 +611,24 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	feedback_add_details("admin_verb","R") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	world.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "end_error", "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", delay)
 
+/datum/admins/proc/smoothend()
+	set category = "Server"
+	set name = "Annouce game over"
+	set desc = "Instantly ends round and brings up objectives like shadowlings or slings dying."
+
+	if(!check_rights(R_SERVER))
+		return
+
+	if(alert(usr, "Are you sure you want to admin end the round and bring up objectives?", "End the game", "Yes", "No") != "Yes")
+		return
+
+	message_admins("[key_name_admin(usr)] has admin ended the round.")
+	log_admin("[key_name(usr)] has admin ended the round")
+	SSticker.force_ending = 1
+	to_chat(world, "<span class='warning'><FONT size = 3><b>The administrators have declared the round over and have ended the round!</b></FONT></span>")
+	feedback_add_details("admin_verb","S") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	feedback_set_details("round_end_result","Admin ended")
+
 /datum/admins/proc/announce()
 	set category = "Admin"
 	set name = "Announce"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -123,6 +123,7 @@ GLOBAL_LIST_INIT(admin_verbs_server, list(
 	/client/proc/Set_Holiday,
 	/datum/admins/proc/startnow,
 	/datum/admins/proc/restart,
+	/datum/admins/proc/smoothend,
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -123,7 +123,7 @@ GLOBAL_LIST_INIT(admin_verbs_server, list(
 	/client/proc/Set_Holiday,
 	/datum/admins/proc/startnow,
 	/datum/admins/proc/restart,
-	/datum/admins/proc/smoothend,
+	/datum/admins/proc/end_round,
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR gives admins a way to smoothly end the round, without having to call shuttle, or nuke the station. Shows up in server tab, requires SERVER rights, same as restarting the server.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Sometimes a nuke is not the right ending. Whether the theme of an event means the station is destroyed in another way, or if nuking the station normally is failing, or if the wizard is dead but the round is not ending, it would be nice to have a button to end the round and bring up objectives. This PR adds that.

Like when the station is nuked or the AI doomsdays, **If you are alive when the round is force ended, you count as escaping greentext wise.**

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

![image](https://user-images.githubusercontent.com/52090703/95128778-eca09d00-0727-11eb-8422-3a349cb6ca94.png)


## Changelog
:cl:
add: Allows admins to end the round instantly and bring up objectives with the press of a button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
