### PR TITLE
IPC - Vomit Tweak

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -92,6 +92,8 @@
 
 
 /mob/living/carbon/proc/vomit(var/lost_nutrition = 10, var/blood = 0, var/stun = 1, var/distance = 0, var/message = 1)
+	if(ismachineperson(src)) //IPCs do not vomit.
+		return 0
 	if(src.is_muzzled())
 		if(message)
 			to_chat(src, "<span class='warning'>The muzzle prevents you from vomiting!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -92,14 +92,14 @@
 
 
 /mob/living/carbon/proc/vomit(var/lost_nutrition = 10, var/blood = 0, var/stun = 1, var/distance = 0, var/message = 1)
+	if(ismachineperson(src)) //IPCs do not vomit particulates
+		return 0
 	if(src.is_muzzled())
 		if(message)
 			to_chat(src, "<span class='warning'>The muzzle prevents you from vomiting!</span>")
 		return 0
 	if(stun)
 		Stun(4)
-	if(ismachineperson(src)) //IPCs do not vomit particulates
-		return 0
 	if(nutrition < 100 && !blood)
 		if(message)
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -92,14 +92,14 @@
 
 
 /mob/living/carbon/proc/vomit(var/lost_nutrition = 10, var/blood = 0, var/stun = 1, var/distance = 0, var/message = 1)
-	if(ismachineperson(src)) //IPCs do not vomit.
-		return 0
 	if(src.is_muzzled())
 		if(message)
 			to_chat(src, "<span class='warning'>The muzzle prevents you from vomiting!</span>")
 		return 0
 	if(stun)
 		Stun(4)
+	if(ismachineperson(src)) //IPCs do not vomit particulates
+		return 0
 	if(nutrition < 100 && !blood)
 		if(message)
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -93,11 +93,11 @@
 
 /mob/living/carbon/proc/vomit(var/lost_nutrition = 10, var/blood = 0, var/stun = 1, var/distance = 0, var/message = 1)
 	if(ismachineperson(src)) //IPCs do not vomit particulates
-		return 0
-	if(src.is_muzzled())
+		return FALSE
+	if(is_muzzled())
 		if(message)
 			to_chat(src, "<span class='warning'>The muzzle prevents you from vomiting!</span>")
-		return 0
+		return FALSE
 	if(stun)
 		Stun(4)
 	if(nutrition < 100 && !blood)
@@ -127,7 +127,7 @@
 			T = get_step(T, dir)
 			if(is_blocked_turf(T))
 				break
-	return 1
+	return TRUE
 
 /mob/living/carbon/gib()
 	. = death(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks `/mob/living/carbon/proc/vomit()` to do a _**cough** species check **cough**_ and stop IPCs from creating vomit splatters on the floor.

Fixes #14381

@AffectedArc07 Please beat me for "snowflake"

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
IPCs don't eat food and don't have stomachs. There aren't any particulates for them to vomit.

## Images of changes
https://imgur.com/a/ECRY4Mi
Update: Removed the stun, so that gif doesn't completely apply. 
IPCs _separately_ get stunned from getting too drunk already, so we're good.

## Changelog
:cl:
tweak: Added "snowflake" for IPC vomtting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
