### PR TITLE
Fixes "Invisible" Suit Sprites for Grey

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -12,7 +12,6 @@
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi',
-		"Grey" = 'icons/mob/species/grey/suit.dmi'
 		)
 	w_class = WEIGHT_CLASS_NORMAL
 
@@ -41,6 +40,10 @@
 /obj/item/clothing/suit/armor/vest/security
 	name = "security armor"
 	desc = "An armored vest that protects against some damage. This one has a clip for a holobadge."
+	sprite_sheets = list(
+		"Vox" = 'icons/mob/species/vox/suit.dmi',
+		"Grey" = 'icons/mob/species/grey/suit.dmi'
+	)
 	icon_state = "armor"
 	item_state = "armor"
 	var/obj/item/clothing/accessory/holobadge/attached_badge
@@ -51,9 +54,12 @@
 			add_fingerprint(user)
 			W.forceMove(src)
 			attached_badge = W
-
 			var/datum/action/A = new /datum/action/item_action/remove_badge(src)
 			A.Grant(user)
+			sprite_sheets = list(
+				"Vox" = 'icons/mob/species/vox/suit.dmi',
+				"Grey" = 'icons/mob/species/grey/suit.dmi'
+			)
 			icon_state = "armorsec"
 			user.update_inv_wear_suit()
 			desc = "An armored vest that protects against some damage. This one has [attached_badge] attached to it."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -55,9 +55,6 @@
 			attached_badge = W
 			var/datum/action/A = new /datum/action/item_action/remove_badge(src)
 			A.Grant(user)
-			sprite_sheets = list(
-				"Grey" = 'icons/mob/species/grey/suit.dmi'
-			)
 			icon_state = "armorsec"
 			user.update_inv_wear_suit()
 			desc = "An armored vest that protects against some damage. This one has [attached_badge] attached to it."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -41,7 +41,6 @@
 	name = "security armor"
 	desc = "An armored vest that protects against some damage. This one has a clip for a holobadge."
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/suit.dmi',
 		"Grey" = 'icons/mob/species/grey/suit.dmi'
 	)
 	icon_state = "armor"
@@ -57,7 +56,6 @@
 			var/datum/action/A = new /datum/action/item_action/remove_badge(src)
 			A.Grant(user)
 			sprite_sheets = list(
-				"Vox" = 'icons/mob/species/vox/suit.dmi',
 				"Grey" = 'icons/mob/species/grey/suit.dmi'
 			)
 			icon_state = "armorsec"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks code changes made in #14240 which had the unintended side effect of rendering several Grey clothing items "invisible". 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
For some reason, `/icons/mobs/species/grey/suits.dmi` is less multiple suit sprites. I moved the `sprite_sheet` overrides for @kugamo neat new sprites for the two security armor types into the code instantiating the security armors.

Addresses issue raised in #14276 

Overrode `sprite_list = list()` instead of using `sprite_list +=` so we wouldn't have to worry about removing items from the list at other points.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
See Security Jacket not being invisible and Kugamo's sprites still working!
https://imgur.com/a/gdbAsKo
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Moved override of `sprite_sheet` in `/code/modules/clothing/suits/armor.dm`
fix: Fixed "invisible" Grey suit sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
