### PR TITLE
Reduces Buckshot Armor Penetration

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -85,6 +85,7 @@
 	damage = 12.5
 	tile_dropoff = 0.75
 	tile_dropoff_s = 1.25
+	armour_penetration = -30
 
 /obj/item/projectile/bullet/pellet/rubber
 	name = "rubber pellet"


### PR DESCRIPTION
## What Does This PR Do
Adds a -30 armor penetration modifier to buckshot pellets.

## Why It's Good For The Game
Shotguns - especially loaded with buckshot - stand head and shoulders above other ballistic weapons because of how quickly they turn even nasty opponents into pulled pork with a meaty shot or two. I don't think it's great for the game, and it's certainly not "realistic". This PR makes buckshot reflect more how it actually behaves - that is to say, unarmored targets are in deep trouble, armored targets stand a much better chance.

After these changes an unarmored human at point blank takes ~180 brute from three shots to the chest. With a sec vest on that's reduced to ~120. With a bulletproof vest on that's reduced to ~45.

I'm not sure this will get merged in its current state, but I hope to start a discussion about what we can do to improve this at very least.

## Changelog
:cl: Dave
tweak: Buckshot now has a harder time punching armor.
/:cl:
