### PR TITLE
Sentient minebots are no longer convertable to cult

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -336,6 +336,8 @@
 		M.move_to_delay = initial(M.move_to_delay) + base_speed_add
 		if(M.stored_gun)
 			M.stored_gun.overheat_time += base_cooldown_add
+		if(M.mind)
+			M.mind.offstation_role = TRUE
 
 /**********************Mining drone cube**********************/
 


### PR DESCRIPTION
## What Does This PR Do
Attempting to use a cultist convert rune on a sentient minebot no longer converts the minebot to cult.
Instead, it simply destroys (sacrifices) the minebot.

## Why It's Good For The Game
A single cultist miner being able to make many minebots, make them all sentient, and then turn them all into permanent cultists, is overpowered.

## Changelog
:cl: Kyep
tweak: sentient minebots can no longer be converted to cult.
/:cl: