### PR TITLE
Box changes n additions

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -302,11 +302,12 @@ GLOBAL_LIST_INIT(durathread_recipes, list ( \
  */
 GLOBAL_LIST_INIT(cardboard_recipes, list (
 	new /datum/stack_recipe("box", /obj/item/storage/box),
+	new /datum/stack_recipe("black and red box", /obj/item/storage/box/syndievil),
 	new /datum/stack_recipe("large box", /obj/item/storage/box/large, 4),
 	new /datum/stack_recipe("patch pack", /obj/item/storage/pill_bottle/patch_pack, 2),
-	new /datum/stack_recipe("light tubes", /obj/item/storage/box/lights/tubes),
-	new /datum/stack_recipe("light bulbs", /obj/item/storage/box/lights/bulbs),
-	new /datum/stack_recipe("mouse traps", /obj/item/storage/box/mousetraps),
+	new /datum/stack_recipe("light tubes box", /obj/item/storage/box/lights/tubes),
+	new /datum/stack_recipe("light bulbs box", /obj/item/storage/box/lights/bulbs),
+	new /datum/stack_recipe("mouse traps box", /obj/item/storage/box/mousetraps),
 	new /datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),
 	new /datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),
 	new /datum/stack_recipe("pizza box", /obj/item/pizzabox),

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -55,6 +55,19 @@
 	user.put_in_hands(I)
 	qdel(src)
 
+/obj/item/storage/box/verb/rename()
+	set name = "Rename box"
+	set category = "Object"
+	set src in usr
+
+	var/n_name = sanitize(copytext(input(usr, "What would you like to label the box?", "Box Labelling", name) as text, 1, MAX_MESSAGE_LEN))
+	if((loc == usr && usr.stat == 0))
+		name = "[(n_name ? text("[n_name]") : initial(name))]"
+	if(name != "box")
+		desc = "This is a paper titled '" + name + "'."
+	add_fingerprint(usr)
+	return
+
 /obj/item/storage/box/large
 	name = "large box"
 	desc = "You could build a fort with this."

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -61,7 +61,7 @@
 	set src in usr
 
 	var/n_name = sanitize(copytext(input(usr, "What would you like to label the box?", "Box Labelling", name) as text, 1, MAX_MESSAGE_LEN))
-	if((loc == usr && usr.stat == 0))
+	if((loc == usr && usr.stat == CONSCIOUS))
 		name = "[(n_name ? text("[n_name]") : initial(name))]"
 	add_fingerprint(usr)
 	return

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -14,7 +14,8 @@
  *		ID and security PDA cart boxes,
  *		Handcuff, mousetrap, and pillbottle boxes,
  *		Snap-pops and matchboxes,
- *		Replacement light boxes.
+ *		Replacement light boxes,
+ *		Empty syndicate-coloured boxes.
  *
  *		For syndicate call-ins see uplink_kits.dm
  */
@@ -1065,6 +1066,10 @@
 	desc = "A colorful cardboard box for the clown"
 	icon_state = "box_clown"
 	var/robot_arm // This exists for bot construction
+
+/obj/item/storage/box/syndievil
+	desc = "It's just an unordinary box."
+	icon_state = "box_of_doom"
 
 /obj/item/storage/box/emptysandbags
 	name = "box of empty sandbags"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -62,7 +62,7 @@
 
 	var/n_name = sanitize(copytext(input(usr, "What would you like to label the box?", "Box Labelling", name) as text, 1, MAX_MESSAGE_LEN))
 	if((loc == usr && usr.stat == CONSCIOUS))
-		name = "[(n_name ? text("[n_name]") : initial(name))]"
+		name = "[n_name ? text("[n_name]") : initial(name)]"
 	add_fingerprint(usr)
 	return
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -63,8 +63,6 @@
 	var/n_name = sanitize(copytext(input(usr, "What would you like to label the box?", "Box Labelling", name) as text, 1, MAX_MESSAGE_LEN))
 	if((loc == usr && usr.stat == 0))
 		name = "[(n_name ? text("[n_name]") : initial(name))]"
-	if(name != "box")
-		desc = "This is a paper titled '" + name + "'."
 	add_fingerprint(usr)
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Adds a verb to rename boxes.
You can now craft black and red boxes with one cardboard.
Also spelling-checks some other boxes.

## Why It's Good For The Game
Renaming boxes allows for some !!FUN!! pranks for everyone.
As we all know, syndicate fashion is just better than nanotrasen fashion, not allowing us to craft these OUTSTANDING boxes is an outrage, we deserve better.
Also spellchecking = good.

## Changelog
:cl:
add: Boxes can now be renamed.
add: Black and red boxes can now be crafted with cardboard.
spellcheck: Added the word "box" on mouse traps, light bulbs and light tubes' cardboard crafting option.
/:cl: