### PR TITLE
Fix eyeblur runtimes

### DIFF
--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -135,7 +135,7 @@
 			update_transform()
 
 /mob/proc/add_eyeblur()
-	if(client.screen)
+	if(client?.screen)
 		var/obj/screen/plane_master/game_world/GW = locate(/obj/screen/plane_master/game_world) in client.screen
 		var/obj/screen/plane_master/floor/F = locate(/obj/screen/plane_master/floor) in client.screen
 		GW.add_filter(EYE_BLUR_FILTER_KEY, FILTER_EYE_BLUR)
@@ -144,7 +144,7 @@
 		animate(F.filters[F.filters.len], size = 3, time = 5)
 
 /mob/proc/remove_eyeblur()
-	if(client.screen)
+	if(client?.screen)
 		var/obj/screen/plane_master/game_world/GW = locate(/obj/screen/plane_master/game_world) in client.screen
 		var/obj/screen/plane_master/floor/F = locate(/obj/screen/plane_master/floor) in client.screen
 		GW.remove_filter(EYE_BLUR_FILTER_KEY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes possible runtime on `mob/add_eyeblur` and `mob/remove_eyeblur` by checking if client is valid first

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
```
[2020-10-06T12:11:02] Runtime in update_status.dm,147: Cannot read null.screen
  proc name: remove eyeblur (/mob/proc/remove_eyeblur)
  src: the space carp (/mob/living/simple_animal/hostile/carp)
  src.loc: space (79,45,4) (/turf/space)
  call stack:
  the space carp (/mob/living/simple_animal/hostile/carp): remove eyeblur()
  the space carp (/mob/living/simple_animal/hostile/carp): update blurry effects()
  the space carp (/mob/living/simple_animal/hostile/carp): SetEyeBlurry(0, 1)
  the space carp (/mob/living/simple_animal/hostile/carp): AdjustEyeBlurry(-1, 0, 1e+31, 1)
  the space carp (/mob/living/simple_animal/hostile/carp): handle disabilities()
  the space carp (/mob/living/simple_animal/hostile/carp): Life(2, 1)
  the space carp (/mob/living/simple_animal/hostile/carp): Life(2, 1)
  Mobs (/datum/controller/subsystem/mobs): fire(0)
  Mobs (/datum/controller/subsystem/mobs): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
```

## Changelog
:cl:
fix: Fix possible error related to eye blur and client-less mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
