### PR TITLE
[DNM] Summon Ghosts Allows Ghosts to Possess Items

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -75,6 +75,9 @@
 #define ORGANIC 1
 #define SYNTHETIC 2
 
+#define GHOST_POWER_NORMAL 0
+#define GHOST_POWER_SPOOKY 1
+
 // Appearance change flags
 #define APPEARANCE_UPDATE_DNA 1
 #define APPEARANCE_RACE	2|APPEARANCE_UPDATE_DNA

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -5,7 +5,7 @@
 	var/panel = "Debug"//What panel the proc holder needs to go on.
 	var/active = FALSE //Used by toggle based abilities.
 	var/ranged_mousepointer
-	var/mob/living/ranged_ability_user
+	var/mob/ranged_ability_user
 
 /obj/effect/proc_holder/singularity_act()
 	return
@@ -15,7 +15,7 @@
 
 GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 
-/obj/effect/proc_holder/proc/InterceptClickOn(mob/living/user, params, atom/A)
+/obj/effect/proc_holder/proc/InterceptClickOn(mob/user, params, atom/A)
 	if(user.ranged_ability != src)
 		to_chat(user, "<span class='warning'><b>[user.ranged_ability.name]</b> has been disabled.")
 		user.ranged_ability.remove_ranged_ability(user)
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	spell.remove_ranged_ability(spell.ranged_ability_user)
 	return ..()
 
-/obj/effect/proc_holder/proc/add_ranged_ability(mob/living/user, var/msg)
+/obj/effect/proc_holder/proc/add_ranged_ability(mob/user, var/msg)
 	if(!user || !user.client)
 		return
 	if(user.ranged_ability && user.ranged_ability != src)
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	if(C && ranged_mousepointer && C.mouse_pointer_icon == ranged_mousepointer)
 		C.mouse_pointer_icon = initial(C.mouse_pointer_icon)
 
-/obj/effect/proc_holder/proc/remove_ranged_ability(mob/living/user, var/msg)
+/obj/effect/proc_holder/proc/remove_ranged_ability(mob/user, var/msg)
 	if(!user || (user.ranged_ability && user.ranged_ability != src)) //To avoid removing the wrong ability
 		return
 	user.ranged_ability = null
@@ -135,7 +135,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
  * @param start_recharge If the proc should set the cooldown
  * @param user The caster of the spell
 */
-/obj/effect/proc_holder/spell/proc/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
+/obj/effect/proc_holder/spell/proc/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/user = usr) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
 	if(!can_cast(user, charge_check, TRUE))
 		return FALSE
 
@@ -428,7 +428,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	var/auto_target_single = TRUE	// If the spell should auto select a target if only one is found
 
 /obj/effect/proc_holder/spell/targeted/click/Click()
-	var/mob/living/user = usr
+	// biased goddamn variable types assuming that we're alive. eat shit.
+	var/mob/user = usr
 	if(!istype(user))
 		return
 
@@ -511,7 +512,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 	return istype(target, allowed_type) && (include_user || target != user) && \
 		(target in view_or_range(range, user, selection_type))
 
-/obj/effect/proc_holder/spell/targeted/click/choose_targets(mob/living/user, atom/A) // Not used
+/obj/effect/proc_holder/spell/targeted/click/choose_targets(mob/user, atom/A) // Not used
 	return
 
 /obj/effect/proc_holder/spell/aoe_turf/choose_targets(mob/user = usr)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -422,7 +422,7 @@
  * some way done a spooky thing. Current usage is so that Boo knows if it needs to cool
  * down or not, but this could be expanded upon if you were a bad enough dude.
  */
-/atom/proc/get_spooked()
+/atom/proc/get_spooked(mob/user)
 	return FALSE
 
 /**

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -415,8 +415,15 @@
 	if(AM && isturf(AM.loc))
 		step(AM, turn(AM.dir, 180))
 
+/*
+ * Base proc, terribly named but it's all over the code so who cares I guess right?
+ *
+ * Returns FALSE by default, if a child returns TRUE it is implied that the atom has in
+ * some way done a spooky thing. Current usage is so that Boo knows if it needs to cool
+ * down or not, but this could be expanded upon if you were a bad enough dude.
+ */
 /atom/proc/get_spooked()
-	return
+	return FALSE
 
 /**
 	Base proc, intended to be overriden.

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -313,7 +313,7 @@
 
 /datum/spellbook_entry/summon/ghosts
 	name = "Summon Ghosts"
-	desc = "Spook the crew out by making them see dead people. Be warned, ghosts are capricious and occasionally vindicative, and some will use their incredibly minor abilities to frustrate you."
+	desc = "Summon ghosts from beyond the veil. They'll be seen by mortals, and be able to possess items. Be warned, ghosts are capricious and occasionally vindicative."
 	cost = 0
 	log_name = "SGH"
 	is_ragin_restricted = TRUE

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -17,6 +17,8 @@
 	var/light_range_on = 2
 	var/light_power_on = 1
 	var/overlay_layer
+	var/flickering = FALSE
+	var/force_no_power_icon_state = FALSE
 
 /obj/machinery/computer/New()
 	overlay_layer = layer
@@ -36,9 +38,32 @@
 	set_light(0)
 	visible_message("<span class='danger'>[src] grows dim, its screen barely readable.</span>")
 
+/obj/machinery/computer/flicker()
+	var/amount = rand(5, 15)
+
+	if(flickering)
+		return FALSE
+
+	if(stat & (BROKEN|NOPOWER))
+		return FALSE
+
+	flickering = TRUE
+	spawn(0)
+		for(var/i = 0; i < amount; i++)
+			force_no_power_icon_state = TRUE
+			update_icon()
+			sleep(rand(1, 3))
+
+			force_no_power_icon_state = FALSE
+			update_icon()
+			sleep(rand(1, 10))
+		update_icon()
+		flickering = FALSE
+	return TRUE
+
 /obj/machinery/computer/update_icon()
 	overlays.Cut()
-	if(stat & NOPOWER)
+	if(stat & NOPOWER || force_no_power_icon_state)
 		if(icon_keyboard)
 			overlays += image(icon,"[icon_keyboard]_off",overlay_layer)
 		return

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -17,7 +17,9 @@
 	var/light_range_on = 2
 	var/light_power_on = 1
 	var/overlay_layer
+	/// Are we in the middle of a flicker event?
 	var/flickering = FALSE
+	/// Are we forcing the icon to be represented in a no-power state?
 	var/force_no_power_icon_state = FALSE
 
 /obj/machinery/computer/New()
@@ -38,9 +40,10 @@
 	set_light(0)
 	visible_message("<span class='danger'>[src] grows dim, its screen barely readable.</span>")
 
+/*
+ * Reimp, flash the screen on and off repeatedly.
+ */
 /obj/machinery/computer/flicker()
-	var/amount = rand(5, 15)
-
 	if(flickering)
 		return FALSE
 
@@ -48,18 +51,26 @@
 		return FALSE
 
 	flickering = TRUE
-	spawn(0)
-		for(var/i = 0; i < amount; i++)
-			force_no_power_icon_state = TRUE
-			update_icon()
-			sleep(rand(1, 3))
+	INVOKE_ASYNC(src, /obj/machinery/computer/.proc/flicker_event)
 
-			force_no_power_icon_state = FALSE
-			update_icon()
-			sleep(rand(1, 10))
-		update_icon()
-		flickering = FALSE
 	return TRUE
+
+/*
+ * Proc to be called by invoke_async in the above flicker() proc.
+ */
+/obj/machinery/computer/proc/flicker_event()
+	var/amount = rand(5, 15)
+
+	for(var/i = 0; i < amount; i++)
+		force_no_power_icon_state = TRUE
+		update_icon()
+		sleep(rand(1, 3))
+
+		force_no_power_icon_state = FALSE
+		update_icon()
+		sleep(rand(1, 10))
+	update_icon()
+	flickering = FALSE
 
 /obj/machinery/computer/update_icon()
 	overlays.Cut()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -123,6 +123,15 @@ About the new airlock wires panel:
 	..()
 	wires = new(src)
 
+/*
+ * reimp, imitate an access denied event.
+ */
+/obj/machinery/door/airlock/flicker()
+	if(arePowerSystemsOn())
+		do_animate("deny")
+		return TRUE
+	return FALSE
+
 /obj/machinery/door/airlock/Initialize()
 	. = ..()
 	if(closeOtherId != null)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -207,7 +207,7 @@ Class Procs:
 		use_power(idle_power_usage,power_channel, 1)
 	else if(use_power >= ACTIVE_POWER_USE)
 		use_power(active_power_usage,power_channel, 1)
-	if (prob(MACHINE_FLICKER_CHANCE))
+	if(prob(MACHINE_FLICKER_CHANCE))
 		flicker()
 	return 1
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -93,6 +93,8 @@ Class Procs:
 	Compiled by Aygar
 */
 
+#define MACHINE_FLICKER_CHANCE 0.05 // roughly 1/2000 chance of a machine flickering on any given tick. That means in a two hour round each machine will flicker on average a little less than two times.
+
 /obj/machinery
 	name = "machinery"
 	icon = 'icons/obj/stationobjs.dmi'
@@ -120,6 +122,19 @@ Class Procs:
 	var/list/settagwhitelist // (Init this list if needed) WHITELIST OF VARIABLES THAT THE set_tag HREF CAN MODIFY, DON'T PUT SHIT YOU DON'T NEED ON HERE, AND IF YOU'RE GONNA USE set_tag (format_tag() proc), ADD TO THIS LIST.
 	atom_say_verb = "beeps"
 	var/siemens_strength = 0.7 // how badly will it shock you?
+
+/*
+ * reimp, attempts to flicker this machinery if the behavior is supported.
+ */
+/obj/machinery/get_spooked()
+	return flicker()
+
+/*
+ * Base class, attempt to flicker. Returns TRUE if we complete our 'flicker
+ * behavior', false otherwise.
+ */
+/obj/machinery/proc/flicker()
+	return FALSE
 
 /obj/machinery/Initialize(mapload)
 	if(!armor)
@@ -192,6 +207,8 @@ Class Procs:
 		use_power(idle_power_usage,power_channel, 1)
 	else if(use_power >= ACTIVE_POWER_USE)
 		use_power(active_power_usage,power_channel, 1)
+	if (prob(MACHINE_FLICKER_CHANCE))
+		flicker()
 	return 1
 
 /obj/machinery/proc/multitool_topic(var/mob/user,var/list/href_list,var/obj/O)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -78,8 +78,12 @@
 	set_picture("ai_bsod")
 	..(severity)
 
-/obj/machinery/status_display/get_spooked()
+/obj/machinery/status_display/flicker()
+	if(stat & (NOPOWER | BROKEN))
+		return FALSE
+
 	spookymode = TRUE
+	return TRUE
 
 // set what is displayed
 /obj/machinery/status_display/proc/update()
@@ -230,8 +234,12 @@
 	set_picture("ai_bsod")
 	..(severity)
 
-/obj/machinery/ai_status_display/get_spooked()
+/obj/machinery/ai_status_display/flicker()
+	if(stat & (NOPOWER | BROKEN))
+		return FALSE
+
 	spookymode = TRUE
+	return TRUE
 
 /obj/machinery/ai_status_display/proc/update()
 	if(mode==0) //Blank

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -678,3 +678,24 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	if(flags & SLOT_PDA)
 		owner.update_inv_wear_pda()
 
+/*
+ * If things are spooky enough, ghosts can boo items to possess them.
+ */
+/obj/item/get_spooked(mob/user)
+	if (GLOB.ghost_power_level != GHOST_POWER_SPOOKY || is_admin_level(src.z))
+		return FALSE
+
+	var/ask = alert(user, "Would you like to possess [src.name]?", "You reach from across the veil...", "Yes", "No")
+	if(ask != "Yes")
+		return FALSE
+
+	// if someone is missing or someone beat you to the punch, time to abort before things get weird
+	if (!user || !src || istype(src.loc, /mob/living/simple_animal/possessed_object))
+		return FALSE
+
+	var/mob/living/simple_animal/possessed_object/possession_target = new(src)
+
+	possession_target.ckey = user.ckey
+	qdel(user)
+
+	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -330,10 +330,6 @@
 /turf/proc/Bless()
 	flags |= NOJAUNT
 
-/turf/get_spooked()
-	for(var/atom/movable/AM in contents)
-		AM.get_spooked()
-
 // Defined here to avoid runtimes
 /turf/proc/MakeDry(wet_setting = TURF_WET_WATER)
 	return

--- a/code/modules/events/wizard/ghost.dm
+++ b/code/modules/events/wizard/ghost.dm
@@ -1,5 +1,7 @@
 /datum/event/wizard/ghost //The spook is real
 
 /datum/event/wizard/ghost/start()
-	var/msg = "<span class='warning'>You suddenly feel extremely obvious...</span>"
+	var/msg = "<span class='warning'>You suddenly feel extremely obvious...<br><b>Cast Boo! on an item to possess it!</b></span>"
 	set_observer_default_invisibility(0, msg)
+	set_ghost_power_level(GHOST_POWER_SPOOKY)
+

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -41,7 +41,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		/mob/dead/observer/proc/open_spawners_menu)
 
 	// Our new boo spell.
-	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/boo(null))
+	AddSpell(new /obj/effect/proc_holder/spell/targeted/click/boo(null))
 
 	can_reenter_corpse = flags & GHOST_CAN_REENTER
 	started_as_observer = flags & GHOST_IS_OBSERVER

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -4,6 +4,7 @@
 GLOBAL_LIST_EMPTY(ghost_images)
 
 GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
+GLOBAL_VAR_INIT(ghost_power_level, GHOST_POWER_NORMAL)
 
 /mob/dead/observer
 	name = "ghost"
@@ -773,6 +774,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(message)
 			to_chat(G, message)
 	GLOB.observer_default_invisibility = amount
+
+/*
+ * Setter for the global "ghost power level" variable.
+ * If set to GHOST_POWER_SPOOKY ghosts are able to boo
+ * items to possess them.
+ */
+/proc/set_ghost_power_level(power)
+	ASSERT(power == GHOST_POWER_NORMAL || power == GHOST_POWER_SPOOKY)
+	GLOB.ghost_power_level = power
 
 /mob/dead/observer/proc/open_spawners_menu()
 	set name = "Mob spawners menu"

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -9,22 +9,31 @@ GLOBAL_LIST_INIT(boo_phrases, list(
 	"It feels like someone's standing behind you.",
 ))
 
-/obj/effect/proc_holder/spell/aoe_turf/boo
+/obj/effect/proc_holder/spell/targeted/click/boo
 	name = "Boo!"
 	desc = "Fuck with the living."
+	selection_activated_message		= "<span class='notice'>You prepare to reach across the veil. <b>Left-click to influence a target!</b></span>"
+	selection_deactivated_message	= "<span class='notice'>Your presence will not be known. For now.</span>"
+	auto_target_single = FALSE
+	allowed_type = /atom // No subtypes are safe from spookage.
 
 	ghost = TRUE
 
 	action_icon_state = "boo"
 	school = "transmutation"
-	charge_max = 600
+	charge_max = 1200
 	starts_charged = FALSE
 	clothes_req = 0
 	stat_allowed = 1
 	invocation = ""
 	invocation_type = "none"
-	range = 1 // Or maybe 3?
+	range = 20
 
-/obj/effect/proc_holder/spell/aoe_turf/boo/cast(list/targets, mob/user = usr)
-	for(var/turf/T in targets)
-		T.get_spooked()
+/obj/effect/proc_holder/spell/targeted/click/boo/cast(list/targets, mob/user = usr)
+	var/atom/target = targets[1]
+	ASSERT(istype(target))
+
+	if(target.get_spooked())
+		return
+
+	charge_counter = charge_max * 0.9 // We've targetted a non-spookable object! Try again fast!

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_INIT(boo_phrases, list(
 
 	action_icon_state = "boo"
 	school = "transmutation"
-	charge_max = 1200
+	charge_max = 2 MINUTES
 	starts_charged = FALSE
 	clothes_req = 0
 	stat_allowed = 1

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(boo_phrases, list(
 	var/atom/target = targets[1]
 	ASSERT(istype(target))
 
-	if(target.get_spooked())
+	if(target.get_spooked(user))
 		return
 
 	charge_counter = charge_max * 0.9 // We've targetted a non-spookable object! Try again fast!

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1928,6 +1928,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 /mob/living/carbon/human/get_spooked()
 	to_chat(src, "<span class='whisper'>[pick(GLOB.boo_phrases)]</span>")
+	return TRUE
 
 /mob/living/carbon/human/extinguish_light()
 	// Parent function handles stuff the human may be holding

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -57,7 +57,6 @@
 	var/gene_stability = DEFAULT_GENE_STABILITY
 	var/ignore_gene_stability = 0
 
-	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
 
 	var/tesla_ignore = FALSE
 

--- a/code/modules/mob/living/simple_animal/posessed_object.dm
+++ b/code/modules/mob/living/simple_animal/posessed_object.dm
@@ -59,6 +59,7 @@
 	..()
 
 	if(!possessed_item) // If we're a donut and someone's eaten us, for instance.
+		ghostize(GHOST_CAN_REENTER)
 		death(1)
 
 	if( possessed_item.loc != src )
@@ -154,3 +155,6 @@
 	color = possessed_item.color
 	overlays = possessed_item.overlays
 	set_opacity(possessed_item.opacity)
+
+/mob/living/simple_animal/possessed_object/say()
+	to_chat(src, "<span class='warning'>You cannot speak!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1,6 +1,3 @@
-/mob
-	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
-
 /mob/Destroy()//This makes sure that mobs with clients/keys are not just deleted from the game.
 	GLOB.mob_list -= src
 	GLOB.dead_mob_list -= src

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1,3 +1,6 @@
+/mob
+	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
+
 /mob/Destroy()//This makes sure that mobs with clients/keys are not just deleted from the game.
 	GLOB.mob_list -= src
 	GLOB.dead_mob_list -= src

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -199,3 +199,5 @@
 
 	var/forced_look = null // This can either be a numerical direction or a soft object reference (UID). It makes the mob always face towards the selected thing.
 	var/registered_z
+
+	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -419,17 +419,26 @@
 			update_icon()
 			updating_icon = 0
 
-/obj/machinery/power/apc/get_spooked(second_pass = FALSE)
+/obj/machinery/power/apc/flicker(second_pass = FALSE)
 	if(opened || panel_open)
-		return
+		return FALSE
 	if(stat & (NOPOWER | BROKEN))
-		return
+		return FALSE
 	if(!second_pass) //The first time, we just cut overlays
-		addtimer(CALLBACK(src, /obj/machinery/power/apc/proc.get_spooked, TRUE), 1)
+		addtimer(CALLBACK(src, /obj/machinery/power/apc/proc.flicker, TRUE), 1)
 		cut_overlays()
+		// APC power distruptions have a chance to propogate to other machines on its network
+		for(var/obj/machinery/M in area)
+			// Please don't cascade, thanks
+			if (M == src)
+				continue
+			if (prob(10))
+				M.flicker()
 	else
 		flick("apcemag", src) //Second time we cause the APC to update its icon, then add a timer to update icon later
 		addtimer(CALLBACK(src, /obj/machinery/power/apc/proc.update_icon, TRUE), 10)
+
+	return TRUE
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 /obj/machinery/power/apc/attackby(obj/item/W, mob/living/user, params)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -430,9 +430,9 @@
 		// APC power distruptions have a chance to propogate to other machines on its network
 		for(var/obj/machinery/M in area)
 			// Please don't cascade, thanks
-			if (M == src)
+			if(M == src)
 				continue
-			if (prob(10))
+			if(prob(10))
 				M.flicker()
 	else
 		flick("apcemag", src) //Second time we cause the APC to update its icon, then add a timer to update icon later
@@ -1234,6 +1234,21 @@
 		update()
 	else if(last_ch != charging)
 		queue_icon_update()
+
+	if(prob(MACHINE_FLICKER_CHANCE))
+		flicker()
+
+	// lights don't have their own processing loop, so APCs will be the father they never had. 3x as likely to cause a light flicker in a particular area, pick a light to flicker at random
+	if(prob(MACHINE_FLICKER_CHANCE) * 3)
+		var/list/lights = list()
+		for(var/obj/machinery/light/L in area)
+			lights += L
+
+		if(lights.len > 0)
+			var/obj/machinery/light/picked_light = pick(lights)
+			ASSERT(istype(picked_light))
+			picked_light.flicker()
+
 
 /obj/machinery/power/apc/proc/autoset(var/val, var/on)
 	if(on==0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -485,7 +485,7 @@
 				sleep(rand(1, 3))
 
 				on = (status == LIGHT_OK)
-				update(0)
+				update(FALSE)
 				sleep(rand(1, 10))
 			on = (status == LIGHT_OK)
 			update(0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -256,9 +256,6 @@
 			on = FALSE
 	return
 
-/obj/machinery/light/get_spooked()
-	flicker()
-
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(var/trigger = TRUE)
 	switch(status)
@@ -469,19 +466,31 @@
 	var/area/A = get_area(src)
 	return A.lightswitch && A.power_light
 
-/obj/machinery/light/proc/flicker(var/amount = rand(10, 20))
-	if(flickering) return
+/obj/machinery/light/flicker(var/amount = rand(20, 30))
+	if(flickering)
+		return FALSE
+
+	if(!on || status != LIGHT_OK)
+		return FALSE
+
 	flickering = 1
 	spawn(0)
 		if(on && status == LIGHT_OK)
 			for(var/i = 0; i < amount; i++)
-				if(status != LIGHT_OK) break
-				on = !on
+				if(status != LIGHT_OK)
+					break
+
+				on = FALSE
 				update(0)
-				sleep(rand(5, 15))
+				sleep(rand(1, 3))
+
+				on = (status == LIGHT_OK)
+				update(0)
+				sleep(rand(1, 10))
 			on = (status == LIGHT_OK)
 			update(0)
 		flickering = 0
+	return TRUE
 
 // ai attack - make lights flicker, because why not
 /obj/machinery/light/attack_ai(mob/user)


### PR DESCRIPTION
## What Does This PR Do
The Wizard's "summon ghosts" ritual now allows ghosts to Boo! an item to possess it and cause it to float around very spookily. Possessed items may be used by their possessor in most ways that you could normally use the item in a human's hand. Donuts may be forcefed to people, clothes can put themselves on targets, syringes can inject, guns (Or disarmed wizard staves) can fire, etcetera. For obvious reasons, you cannot possess items on Z2.
**NOTE:** This PR is branched off of #14543 and requires that framework for these changes.

## Why It's Good For The Game
Wizard rounds are about tomfoolery, and keeping ghosts involved in the round is cool and fun.

## Changelog
:cl: Dave
add: Summon ghosts now allows ghosts to possess items by casting Boo! on them.
/:cl:
