### PR TITLE
Legion Core - Burn Damage Fix

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -221,7 +221,7 @@
 	owner.remove_CC()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.bodytemperature = H.dna.species.heat_level_1
+		H.bodytemperature = H.dna.species.body_temperature
 		for(var/thing in H.bodyparts)
 			var/obj/item/organ/external/E = thing
 			E.internal_bleeding = FALSE

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -219,7 +219,7 @@
 	owner.adjustBruteLoss(-25)
 	owner.adjustFireLoss(-25)
 	owner.remove_CC()
-	owner.bodytemperature = BODYTEMP_NORMAL
+	owner.bodytemperature = owner.dna.species.heat_level_1
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		for(var/thing in H.bodyparts)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -219,13 +219,15 @@
 	owner.adjustBruteLoss(-25)
 	owner.adjustFireLoss(-25)
 	owner.remove_CC()
-	owner.bodytemperature = owner.dna.species.heat_level_1
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
+		H.bodytemperature = H.dna.species.heat_level_1
 		for(var/thing in H.bodyparts)
 			var/obj/item/organ/external/E = thing
 			E.internal_bleeding = FALSE
 			E.mend_fracture()
+	else
+		owner.bodytemperature = BODYTEMP_NORMAL
 	return TRUE
 
 /datum/status_effect/regenerative_core/on_remove()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the Body Temp setting when using the Legion Core to set to the Owner Species' `heat_level_1` threshhold instead of `BODYTEMP_NORMAL`. Ensures that non-human mobs continue to use `BODYTEMP_NORMAL`.

Fixes https://github.com/ParadiseSS13/Paradise/issues/14362
, spoke with @Medium-Salad.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
`BODYTEMP_NORMAL` is a static `#define` of `310.15`. This value is greater than the `heat_level_1` of some races. As such, using the Legion Core as a these races would induce burn damage. This goes against the purpose of the Legion Core which is to heal brute and burn damage.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Footage: https://imgur.com/a/YP21VRu
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Stopped burn damage from Legion Core on species
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
