### PR TITLE
Prevents flash / sonic powder from working on blob tiles again.

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -17,10 +17,10 @@
 		do_sparks(rand(5, 9), FALSE, src)
 		playsound(T, 'sound/effects/bang.ogg', 100, TRUE)
 		new /obj/effect/dummy/lighting_obj(T, light_color, range + 2, light_power, light_time)
-	// Blob damage
-	for(var/obj/structure/blob/B in hear(range + 1, T))
-		var/damage = round(30 / (get_dist(B, T) + 1))
-		B.take_damage(damage, BURN, "melee", FALSE)
+		// Blob damage
+		for(var/obj/structure/blob/B in hear(range + 1, T))
+			var/damage = round(30 / (get_dist(B, T) + 1))
+			B.take_damage(damage, BURN, "melee", FALSE)
 
 		// Stunning & damaging mechanic
 		bang(T, src, range)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -17,6 +17,10 @@
 		do_sparks(rand(5, 9), FALSE, src)
 		playsound(T, 'sound/effects/bang.ogg', 100, TRUE)
 		new /obj/effect/dummy/lighting_obj(T, light_color, range + 2, light_power, light_time)
+	// Blob damage
+	for(var/obj/structure/blob/B in hear(range + 1, T))
+		var/damage = round(30 / (get_dist(B, T) + 1))
+		B.take_damage(damage, BURN, "melee", FALSE)
 
 		// Stunning & damaging mechanic
 		bang(T, src, range)
@@ -25,7 +29,6 @@
 /**
   * Creates a flashing effect that blinds and deafens mobs within range
   *
-  * Also damages blobs
   * Arguments:
   * * T - The turf to flash
   * * A - The flashing atom
@@ -34,10 +37,6 @@
   * * bang - Whether to bang (deafen)
   */
 /proc/bang(turf/T, atom/A, range = 7, flash = TRUE, bang = TRUE)
-	// Blob damage
-	for(var/obj/structure/blob/B in hear(range + 1, T))
-		var/damage = round(30 / (get_dist(B, T) + 1))
-		B.take_damage(damage, BURN, "melee", FALSE)
 
 	// Flashing mechanic
 	var/source_turf = get_turf(A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR reverts the change of #13899 not in the changelog, that allowed flash powder and sonic powder to affect blob tiles. This moves it back up to the base flashbang code. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> 

Logically, flash powder or sonic powder should damage blobs. Logically. The problem is that this is not balanced. Flashbangs take 5 seconds to arm by default, and if they are on your person when detonating, stun you. Flash powder does not stun the user when detonating, and can be mixed rapidly by an advanced release grenade, or heaven forbid, mixing them rapidly in hand in beakers, decimating entire blobs in seconds. Since major midrounds should not be decimated by 4 chemicals 2 beakers and a bored scientist causing no damage to the station in seconds, it should be changed back to only flashbangs affecting blobs.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

Before this PR: (Flashpowder working) 

https://imgur.com/a/goIU6U6

After this PR: (Flashpowder not working) 

https://imgur.com/a/hqYraQ7

## Changelog
:cl:
tweak: Flash powder and Sonic powder no longer work on blobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
