### PR TITLE
Code Standarisation - Tank Distribute Pressure

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -2,9 +2,9 @@
  * Contains:
  *		Oxygen
  *		Anesthetic
- *		Air
+ *		Air Mix
+ *		Nitrogen
  *		Plasma
- *		Emergency Oxygen
  */
 
 /*
@@ -16,7 +16,6 @@
 	icon_state = "oxygen"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 	dog_fashion = /datum/dog_fashion/back
-
 
 /obj/item/tank/oxygen/New()
 	..()
@@ -41,101 +40,6 @@
 	icon_state = "oxygen_fr"
 	dog_fashion = null
 
-
-/*
- * Anesthetic
- */
-/obj/item/tank/anesthetic
-	name = "anesthetic tank"
-	desc = "A tank with an N2O/O2 gas mix."
-	icon_state = "anesthetic"
-	item_state = "an_tank"
-
-/obj/item/tank/anesthetic/New()
-	..()
-	air_contents.oxygen = (3 * ONE_ATMOSPHERE) * 70 / (R_IDEAL_GAS_EQUATION * T20C) * O2STANDARD
-	air_contents.sleeping_agent = (3 * ONE_ATMOSPHERE) * 70 / (R_IDEAL_GAS_EQUATION * T20C) * N2STANDARD
-
-/*
- * Air
- */
-/obj/item/tank/air
-	name = "air tank"
-	desc = "Mixed anyone?"
-	icon_state = "air"
-	item_state = "air"
-
-/obj/item/tank/air/examine(mob/user)
-	. = ..()
-	if(get_dist(user, src) <= 0 && air_contents.oxygen < 1)
-		. += "<span class='danger'>The meter on [src] indicates you are almost out of air!</span>"
-		playsound(user, 'sound/effects/alert.ogg', 50, 1)
-
-/obj/item/tank/air/New()
-	..()
-	air_contents.oxygen = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
-	air_contents.nitrogen = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
-
-/*
- * Plasma
- */
-/obj/item/tank/plasma
-	name = "plasma tank"
-	desc = "Contains dangerous plasma. Do not inhale. Warning: extremely flammable."
-	icon_state = "plasma"
-	flags = CONDUCT
-	slot_flags = null	//they have no straps!
-
-/obj/item/tank/plasma/New()
-	..()
-	air_contents.toxins = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C)
-
-/obj/item/tank/plasma/attackby(obj/item/W as obj, mob/user as mob, params)
-	..()
-
-	if(istype(W, /obj/item/flamethrower))
-		var/obj/item/flamethrower/F = W
-		if((!F.status)||(F.ptank))	return
-		master = F
-		F.ptank = src
-		user.unEquip(src)
-		loc = F
-		F.update_icon()
-
-/obj/item/tank/plasma/full/New()
-	..()
-	air_contents.toxins = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-
-/obj/item/tank/plasma/plasmaman
-	name = "plasma internals tank"
-	desc = "A tank of plasma gas designed specifically for use as internals, particularly for plasma-based lifeforms. If you're not a Plasmaman, you probably shouldn't use this."
-	icon_state = "plasmaman_tank"
-	item_state = "plasmaman_tank"
-	force = 10
-	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
-
-/obj/item/tank/plasma/plasmaman/examine(mob/user)
-	. = ..()
-	if(get_dist(user, src) <= 0 && air_contents.toxins < 0.2)
-		. += "<span class='danger'>The meter on [src] indicates you are almost out of plasma!</span>"
-		playsound(user, 'sound/effects/alert.ogg', 50, 1)
-
-
-/obj/item/tank/plasma/plasmaman/belt
-	icon_state = "plasmaman_tank_belt"
-	item_state = "plasmaman_tank_belt"
-	slot_flags = SLOT_BELT
-	force = 5
-	volume = 25
-	w_class = WEIGHT_CLASS_SMALL
-
-/obj/item/tank/plasma/plasmaman/belt/full/New()
-	..()
-	air_contents.toxins = (10 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C)
-
-/*
- * Emergency Oxygen
- */
 /obj/item/tank/emergency_oxygen
 	name = "emergency oxygen tank"
 	desc = "Used for emergencies. Contains very little oxygen, so try to conserve it until you actually need it."
@@ -202,11 +106,12 @@
 /*
  * Nitrogen
  */
+
 /obj/item/tank/nitrogen
 	name = "nitrogen tank"
 	desc = "A tank of nitrogen."
 	icon_state = "oxygen_fr"
-	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	sprite_sheets = list("Vox Armalis" = 'icons/mob/species/armalis/back.dmi') //Do it for Big Bird.
 
 /obj/item/tank/nitrogen/New()
@@ -241,6 +146,64 @@
 	air_contents.oxygen -= (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	air_contents.nitrogen = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 
+/*
+ Plasma
+*/
+
+/obj/item/tank/plasma
+	name = "plasma tank"
+	desc = "Contains dangerous plasma. Do not inhale. Warning: extremely flammable."
+	icon_state = "plasma"
+	flags = CONDUCT
+	slot_flags = null	//they have no straps!
+
+/obj/item/tank/plasma/New()
+	..()
+	air_contents.toxins = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C)
+
+/obj/item/tank/plasma/attackby(obj/item/W as obj, mob/user as mob, params)
+	..()
+
+	if(istype(W, /obj/item/flamethrower))
+		var/obj/item/flamethrower/F = W
+		if((!F.status)||(F.ptank))	return
+		master = F
+		F.ptank = src
+		user.unEquip(src)
+		loc = F
+		F.update_icon()
+
+/obj/item/tank/plasma/full/New()
+	..()
+	air_contents.toxins = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+
+/obj/item/tank/plasma/plasmaman
+	name = "plasma internals tank"
+	desc = "A tank of plasma gas designed specifically for use as internals, particularly for plasma-based lifeforms. If you're not a Plasmaman, you probably shouldn't use this."
+	icon_state = "plasmaman_tank"
+	item_state = "plasmaman_tank"
+	force = 10
+	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
+
+/obj/item/tank/plasma/plasmaman/examine(mob/user)
+	. = ..()
+	if(get_dist(user, src) <= 0 && air_contents.toxins < 0.2)
+		. += "<span class='danger'>The meter on [src] indicates you are almost out of plasma!</span>"
+		playsound(user, 'sound/effects/alert.ogg', 50, 1)
+
+
+/obj/item/tank/plasma/plasmaman/belt
+	icon_state = "plasmaman_tank_belt"
+	item_state = "plasmaman_tank_belt"
+	slot_flags = SLOT_BELT
+	force = 5
+	volume = 25
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/tank/plasma/plasmaman/belt/full/New()
+	..()
+	air_contents.toxins = (10 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C)
+
 /obj/item/tank/emergency_oxygen/plasma
 	name = "emergency plasma tank"
 	desc = "An emergency tank designed specifically for Plasmamen."
@@ -251,3 +214,39 @@
 	..()
 	air_contents.oxygen -= (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	air_contents.toxins = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+
+/*
+ * Air Mix
+ */
+/obj/item/tank/air
+	name = "air tank"
+	desc = "Mixed anyone?"
+	icon_state = "air"
+	item_state = "air"
+
+/obj/item/tank/air/examine(mob/user)
+	. = ..()
+	if(get_dist(user, src) <= 0 && air_contents.oxygen < 1)
+		. += "<span class='danger'>The meter on [src] indicates you are almost out of air!</span>"
+		playsound(user, 'sound/effects/alert.ogg', 50, 1)
+
+/obj/item/tank/air/New()
+	..()
+	air_contents.oxygen = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
+	air_contents.nitrogen = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
+
+
+/*
+ * Anesthetic
+ */
+/obj/item/tank/anesthetic
+	name = "anesthetic tank"
+	desc = "A tank with an N2O/O2 gas mix."
+	icon_state = "anesthetic"
+	item_state = "an_tank"
+
+/obj/item/tank/anesthetic/New()
+	..()
+	air_contents.oxygen = (3 * ONE_ATMOSPHERE) * 70 / (R_IDEAL_GAS_EQUATION * T20C) * O2STANDARD
+	air_contents.sleeping_agent = (3 * ONE_ATMOSPHERE) * 70 / (R_IDEAL_GAS_EQUATION * T20C) * N2STANDARD
+

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -1,10 +1,10 @@
 /* Types of tanks!
  * Contains:
  *		Oxygen
- *		Anesthetic
- *		Air Mix
  *		Nitrogen
  *		Plasma
+ *		Air Mix
+ *		Anesthetic
  */
 
 /*
@@ -244,6 +244,7 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	item_state = "an_tank"
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 /obj/item/tank/anesthetic/New()
 	..()

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -14,7 +14,6 @@
 	name = "oxygen tank"
 	desc = "A tank of oxygen."
 	icon_state = "oxygen"
-	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	dog_fashion = /datum/dog_fashion/back
 
 /obj/item/tank/oxygen/New()
@@ -48,7 +47,6 @@
 	slot_flags = SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4.0
-	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	volume = 3 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 
@@ -111,7 +109,6 @@
 	name = "nitrogen tank"
 	desc = "A tank of nitrogen."
 	icon_state = "oxygen_fr"
-	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	sprite_sheets = list("Vox Armalis" = 'icons/mob/species/armalis/back.dmi') //Do it for Big Bird.
 
 /obj/item/tank/nitrogen/New()
@@ -183,7 +180,6 @@
 	icon_state = "plasmaman_tank"
 	item_state = "plasmaman_tank"
 	force = 10
-	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 
 /obj/item/tank/plasma/plasmaman/examine(mob/user)
 	. = ..()
@@ -223,7 +219,7 @@
 	desc = "Mixed anyone?"
 	icon_state = "air"
 	item_state = "air"
-	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	distribute_pressure = ONE_ATMOSPHERE
 
 /obj/item/tank/air/examine(mob/user)
 	. = ..()
@@ -245,7 +241,7 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	item_state = "an_tank"
-	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	distribute_pressure = ONE_ATMOSPHERE
 
 /obj/item/tank/anesthetic/New()
 	..()

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -14,7 +14,7 @@
 	name = "oxygen tank"
 	desc = "A tank of oxygen."
 	icon_state = "oxygen"
-	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	dog_fashion = /datum/dog_fashion/back
 
 /obj/item/tank/oxygen/New()
@@ -48,7 +48,7 @@
 	slot_flags = SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4.0
-	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	volume = 3 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -223,6 +223,7 @@
 	desc = "Mixed anyone?"
 	icon_state = "air"
 	item_state = "air"
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 /obj/item/tank/air/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -15,7 +15,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 30)
 	actions_types = list(/datum/action/item_action/set_internals)
 	var/datum/gas_mixture/air_contents = null
-	var/distribute_pressure = 16
+	var/distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	var/integrity = 3
 	var/volume = 70
 

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -15,7 +15,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 30)
 	actions_types = list(/datum/action/item_action/set_internals)
 	var/datum/gas_mixture/air_contents = null
-	var/distribute_pressure = ONE_ATMOSPHERE
+	var/distribute_pressure = 16
 	var/integrity = 3
 	var/volume = 70
 
@@ -25,7 +25,6 @@
 	air_contents = new /datum/gas_mixture()
 	air_contents.volume = volume //liters
 	air_contents.temperature = T20C
-
 	START_PROCESSING(SSobj, src)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the `distribute_pressure` for handheld tanks from `ONE_ATMOSPHERE*O2STANDARD` to `TANK_DEFAULT_RELEASE_PRESSURE`.

Additionally reorganizes the code in `tank_types.dm` to improve flow and reduce separation of related code bits. Gets rid of a section called "Emergency Oxygen" and places its code throughout "Nitrogen", "Oxygen", and "Plasma" respectively.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
`TANK_DEFAULT_RELEASE_PRESSURE` is the `distribute_pressure` used for Plasmaman tanks and is set as #define at `16`. This standardises the `distribute_pressure` across all handheld tank types

This makes it so all internals tanks last, by default, as long they can without causing undue harm to their users. It standardises code with the tank a Plasmaman spawns with.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changes the default distribution pressure for all internals tanks from 21kpa to 16kpa. This allows the gas in internals tanks to last longer. Anesthesic tanks and Air Mix tanks are still at 101kpa as necessary for their functions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
