### PR TITLE
Uplink rebalancing: Syndicate Hardsuit

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1338,7 +1338,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Nanotrasen crew who spot these suits are known to panic."
 	reference = "BRHS"
 	item = /obj/item/storage/box/syndie_kit/hardsuit
-	cost = 8
+	cost = 6
 	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/suits/hardsuit/elite


### PR DESCRIPTION
## What Does This PR Do
Lowers the syndicate hardsuits' cost from 8 to 6.

## Why It's Good For The Game
Currently, this item sucks ass. This is what you're getting differently from the softsuit's purchase (which is 4TC cheaper):
S-class status. (which is bad)
Built-in jetpack.
Combat mode (no slowdown while not in space).
Helmet built-in with the suit. (which in rare cases you don't want).
...that's it, that's all you're getting for an extra 4TC, a jetpack and no slowdown, and you'll be super valided when wearing it.
This PR aims to make the purchase not hot garbage. (it's not the best deal, but atleast you aren't robbed).

## Changelog
:cl:
tweak: The Syndicate Hardsuit costs 6TC instead of 8TC.
/:cl: