### PR TITLE
Adds an alert to the ghosts before people borg a playerless MMI. Will prevent borging till the ghost is in the MMI

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -226,20 +226,25 @@
 				to_chat(user, "<span class='warning'>Sticking an empty [M] into the frame would sort of defeat the purpose.</span>")
 				return
 
+			if(jobban_isbanned(M.brainmob, "Cyborg") || jobban_isbanned(M.brainmob,"nonhumandept"))
+				to_chat(user, "<span class='warning'>This [W] is not fit to serve as a cyborg!</span>")
+				return
+
 			if(!M.brainmob.key)
-				var/ghost_can_reenter = 0
+				var/ghost_can_reenter = FALSE
 				if(M.brainmob.mind)
 					for(var/mob/dead/observer/G in GLOB.player_list)
 						if(G.can_reenter_corpse && G.mind == M.brainmob.mind)
-							ghost_can_reenter = 1
-							break
-					for(var/mob/living/simple_animal/S in GLOB.player_list)
-						if(S in GLOB.respawnable_list)
-							ghost_can_reenter = 1
+							ghost_can_reenter = TRUE
+							if(M.next_possible_ghost_ping < world.time)
+								G.notify_cloning("Somebody is trying to borg you! Re-enter your corpse if you want to be borged!", 'sound/voice/liveagain.ogg', src)
+								M.next_possible_ghost_ping = world.time + 30 SECONDS // Avoid spam
 							break
 				if(!ghost_can_reenter)
 					to_chat(user, "<span class='notice'>[M] is completely unresponsive; there's no point.</span>")
-					return
+				else
+					to_chat(user, "<span class='warning'>[M] is currently inactive. Try again later.</span>")
+				return
 
 			if(M.brainmob.stat == DEAD)
 				to_chat(user, "<span class='warning'>Sticking a dead [M] into the frame would sort of defeat the purpose.</span>")
@@ -249,9 +254,6 @@
 				to_chat(user, "<span class='warning'>The frame's firmware lets out a shrill sound, and flashes 'Abnormal Memory Engram'. It refuses to accept the [M].</span>")
 				return
 
-			if(jobban_isbanned(M.brainmob, "Cyborg") || jobban_isbanned(M.brainmob,"nonhumandept"))
-				to_chat(user, "<span class='warning'>This [W] does not seem to fit.</span>")
-				return
 
 			var/datum/ai_laws/laws_to_give
 			if(M.syndiemmi)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -23,6 +23,9 @@
 	// Needed to fix a rather insane bug when a posibrain/robotic brain commits suicide
 	var/dead_icon = "mmi_dead"
 
+	/// Time at which the ghost belonging to the mind in the mmi can be pinged again to be borged
+	var/next_possible_ghost_ping
+
 /obj/item/mmi/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if(istype(O, /obj/item/organ/internal/brain/crystal))
 		to_chat(user, "<span class='warning'> This brain is too malformed to be able to use with the [src].</span>")


### PR DESCRIPTION
## What Does This PR Do
Makes it so that players know that people are attempting to borg them. It will also prevent borging till the ghost is in the mmi.
I gave it a 30 second cooldown per notification to prevent spamming.

Also removed a weird check with animals in the borging logic... didn't make much sense to me especially since it didn't check the mind of the animal it checked

## Why It's Good For The Game
Reduces waste and unwanted borgings when people just want to observe after being executed

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/95517455-512a5900-09c1-11eb-8a2c-8a9dfcd20e27.png)
Alert for the ghost

![image](https://user-images.githubusercontent.com/15887760/95517483-5e474800-09c1-11eb-8319-d6ad8f8757ae.png)
Message for the roboticist

## Changelog
:cl:
tweak: Makes it so that trying to borg a MMI whose player is a ghost will notify the ghost and will block the making of the borg till the ghost is in the MMI.
/:cl: