### PR TITLE
IPC First Aid Kit No Longer Has Oil

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -180,7 +180,6 @@
 	new /obj/item/stack/cable_coil(src)
 	new /obj/item/stack/cable_coil(src)
 	new /obj/item/stack/cable_coil(src)
-	new /obj/item/reagent_containers/food/drinks/oilcan/full(src)
 	new /obj/item/robotanalyzer(src)
 
 /obj/item/storage/firstaid/machine/empty


### PR DESCRIPTION
## What Does This PR Do
Fixes  #14570

## Changelog
:cl: Dave
del: IPC first aid kits no longer get oil, which they don't need anymore.
/:cl: