### PR TITLE
No more DIY xeno outbreaks

### DIFF
--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -393,7 +393,8 @@
 	activation_method = "touch"
 	cooldown_add = 50
 	activation_sound = 'sound/magic/timeparadox2.ogg'
-	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/item/projectile, /obj/item/spellbook)
+	var/list/banned_items_typecache = list(	/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear,
+											/obj/item/projectile, /obj/item/spellbook, /obj/item/clothing/mask/facehugger/)
 
 /obj/machinery/anomalous_crystal/refresher/New()
 	..()

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -393,8 +393,8 @@
 	activation_method = "touch"
 	cooldown_add = 50
 	activation_sound = 'sound/magic/timeparadox2.ogg'
-	var/list/banned_items_typecache = list(	/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear,
-											/obj/item/projectile, /obj/item/spellbook, /obj/item/clothing/mask/facehugger/)
+	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear,
+										   /obj/item/projectile, /obj/item/spellbook, /obj/item/clothing/mask/facehugger)
 
 /obj/machinery/anomalous_crystal/refresher/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it so you can no longer revive dead facehuggers from ruins to create your own xeno outbreak as a non-antag miner, using the refresher crystal.
fixes #14266
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players shouldn't be able to deliberately trigger a major biohazard, especially not this early into the round.  While this does rob hijack antags of a potential route, a hijack antag can always try and ask for a TC trade if he really wants to go for a xeno outbreak and can convince the responding admin.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: refresher anomalous crystals can no longer revive facehuggers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
