### PR TITLE
Changling Swap forms now takes 10 seconds to pull off.

### DIFF
--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -38,7 +38,7 @@
 	target.do_jitter_animation(500)
 	user.do_jitter_animation(500)
 
-	if(!do_mob(user,target,100))
+	if(!do_mob(user, target, 10 SECONDS))
 		to_chat(user, "<span class='warning'>The body swap has been interrupted!</span>")
 		return
 

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -27,9 +27,6 @@
 	if(target.has_brain_worms() || user.has_brain_worms())
 		to_chat(user, "<span class='warning'>A foreign presence repels us from this body!</span>")
 		return
-	if(ismindshielded(target))
-		to_chat(user, "<span class='warning'>We are unable to bypass the implant protecting their mind!</span>")
-		return
 	return 1
 
 /datum/action/changeling/swap_form/sting_action(var/mob/living/carbon/user)
@@ -41,7 +38,7 @@
 	target.do_jitter_animation(500)
 	user.do_jitter_animation(500)
 
-	if(!do_mob(user,target,20))
+	if(!do_mob(user,target,100))
 		to_chat(user, "<span class='warning'>The body swap has been interrupted!</span>")
 		return
 

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -27,6 +27,9 @@
 	if(target.has_brain_worms() || user.has_brain_worms())
 		to_chat(user, "<span class='warning'>A foreign presence repels us from this body!</span>")
 		return
+	if(ismindshielded(target))
+		to_chat(user, "<span class='warning'>We are unable to bypass the implant protecting their mind!</span>")
+		return
 	return 1
 
 /datum/action/changeling/swap_form/sting_action(var/mob/living/carbon/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR makes changeling swap forms take 10 seconds to happen, instead of 2

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It's a bit too easy to mindswap into a sec officer. Tentacle to grab to swap, then stun and mutesting target, or just pre remove your headset, or hell, even a water slip into a grab. After you swap, you kill them, hide the body, and you are a mindshielded sec officer. This PR makes it that it now takes 10 seconds to swap forms with someone, meaning you need a better plan than slip grab and swap to swap forms with people, and either trap your target or get the help of a second changeling.

## Changelog
:cl:
tweak: Changelings swap forms now takes 10 seconds to pull off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
