### PR TITLE
Makes the vox spikethrower more like a cyborg LMG, fixes bugs with it.

### DIFF
--- a/code/modules/admin/verbs/vox_raiders.dm
+++ b/code/modules/admin/verbs/vox_raiders.dm
@@ -18,7 +18,7 @@ GLOBAL_VAR_INIT(vox_tick, 1)
 			equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/monocle(src), slot_glasses) // REPLACE WITH CODED VOX ALTERNATIVE.
 			equip_to_slot_or_del(new /obj/item/chameleon(src), slot_l_store)
 
-			var/obj/item/gun/projectile/automatic/spikethrower/W = new(src)
+			var/obj/item/gun/energy/spikethrower/W = new(src)
 			equip_to_slot_or_del(W, slot_r_hand)
 
 

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -8,8 +8,8 @@
 	fire_sound_text = "a strange noise"
 	can_suppress = 0
 	burst_size = 2 // burst has to be stored here
-	can_charge = 0
-	selfcharge = 1
+	can_charge = FALSE
+	selfcharge = TRUE
 	charge_delay = 10
 	restricted_species = list(/datum/species/vox)
 	ammo_type = list(/obj/item/ammo_casing/energy/spike)

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -1,59 +1,30 @@
-/obj/item/gun/projectile/automatic/spikethrower
+/obj/item/gun/energy/spikethrower //It's like the cyborg LMG, uses energy to make spikes
 	name = "\improper Vox spike thrower"
 	desc = "A vicious alien projectile weapon. Parts of it quiver gelatinously, as though the thing is insectile and alive."
+	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "spikethrower"
 	item_state = "spikethrower"
 	w_class = WEIGHT_CLASS_SMALL
 	fire_sound_text = "a strange noise"
-	mag_type = /obj/item/ammo_box/magazine/internal/spikethrower
-	burst_size = 2
-	fire_delay = 3
 	can_suppress = 0
-	var/charge_tick = 0
-	var/charge_delay = 15
+	burst_size = 2 // burst has to be stored here
+	can_charge = 0
+	selfcharge = 1
+	charge_delay = 10
 	restricted_species = list(/datum/species/vox)
+	ammo_type = list(/obj/item/ammo_casing/energy/spike)
 
-/obj/item/gun/projectile/automatic/spikethrower/New()
-	..()
-	START_PROCESSING(SSobj, src)
-
-/obj/item/gun/projectile/automatic/spikethrower/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
-/obj/item/gun/projectile/automatic/spikethrower/update_icon()
+/obj/item/gun/energy/spikethrower/emp_act()
 	return
 
-/obj/item/gun/projectile/automatic/spikethrower/process()
-	charge_tick++
-	if(charge_tick < charge_delay || !magazine)
-		return
-	charge_tick = 0
-	var/obj/item/ammo_casing/caseless/spike/S = new(get_turf(src))
-	magazine.give_round(S)
-	return 1
-
-/obj/item/gun/projectile/automatic/spikethrower/attack_self()
-	return
-
-/obj/item/gun/projectile/automatic/spikethrower/process_chamber(eject_casing = 0, empty_chamber = 1)
-	..()
-
-/obj/item/ammo_box/magazine/internal/spikethrower
-	name = "\improper Vox spikethrower internal magazine"
-	ammo_type = /obj/item/ammo_casing/caseless/spike
-	caliber = "spike"
-	max_ammo = 10
-
-/obj/item/ammo_casing/caseless/spike
+/obj/item/ammo_casing/energy/spike
 	name = "alloy spike"
 	desc = "A broadhead spike made out of a weird silvery metal."
 	projectile_type = /obj/item/projectile/bullet/spike
 	muzzle_flash_effect = null
-	throwforce = 5
-	w_class = WEIGHT_CLASS_NORMAL
-	caliber = "spike"
-	icon_state = "bolt"
+	e_cost = 100
+	delay = 3 //and delay has to be stored here on energy guns
+	select_name = "spike"
 	fire_sound = 'sound/weapons/bladeslice.ogg'
 
 /obj/item/projectile/bullet/spike


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR makes the vox spike thrower an energy gun instead of a physical gun that attempts to reload itself with ammo but just makes ammo casings on the ground, sort of similar to the cyborg LMG on syndicate borgs. It can not be put in a charger to replenish ammo. Also makes it "recharge" slightly faster. Repaths it to go along with the fact it is no longer an energy gun. It still shoots physical projectiles like before.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Hot buggy messes are not good, like making invisible ammo on the ground, and not actually gaining ammo, making the gun simpler code wise is good. Also makes it recharge slightly faster, as 1 bullet per 30 seconds is not very useful, vs 1 bullet per 20 seconds.

## Changelog
:cl:
tweak: Vox spike thrower is now an energy gun instead of a physical gun.
tweak: Vox spike thrower now recharges 1 shot every 20 seconds instead of 30.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
