### PR TITLE
Omega Weed Balance Changes

### DIFF
--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -72,7 +72,7 @@
 						"ephedrine" = 0.05,
 						"haloperidol" = 0.05,
 						"methamphetamine" = 0.05,
-						"thc" = 005,
+						"thc" = 0.05,
 						"cbd" = 0.05,
 						"psilocybin" = 0.05,
 						"hairgrownium" = 0.05,

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -1,3 +1,5 @@
+
+      
 // Cannabis
 /obj/item/seeds/cannabis
 	name = "pack of cannabis seeds"
@@ -14,9 +16,7 @@
 	icon_dead = "cannabis-dead" // Same for the dead icon
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/cannabis/rainbow,
-						/obj/item/seeds/cannabis/death,
-						/obj/item/seeds/cannabis/white,
-						/obj/item/seeds/cannabis/ultimate)
+						/obj/item/seeds/cannabis/white)
 	reagents_add = list("thc" = 0.15, "cbd" = 0.15)
 
 
@@ -27,7 +27,8 @@
 	species = "megacannabis"
 	plantname = "Rainbow Weed"
 	product = /obj/item/reagent_containers/food/snacks/grown/cannabis/rainbow
-	mutatelist = list()
+	mutatelist = list(/obj/item/seeds/cannabis/death,
+						/obj/item/seeds/cannabis/ultimate)
 	reagents_add = list("lsd" = 0.15, "thc" = 0.15, "cbd" = 0.15)
 	rarity = 40
 
@@ -49,7 +50,8 @@
 	species = "whitecannabis"
 	plantname = "Lifeweed"
 	product = /obj/item/reagent_containers/food/snacks/grown/cannabis/white
-	mutatelist = list()
+	mutatelist = list(/obj/item/seeds/cannabis/death,
+						/obj/item/seeds/cannabis/ultimate)
 	reagents_add = list("omnizine" = 0.35, "thc" = 0.15, "cbd" = 0.15)
 	rarity = 40
 
@@ -62,25 +64,24 @@
 	plantname = "Omega Weed"
 	product = /obj/item/reagent_containers/food/snacks/grown/cannabis/ultimate
 	mutatelist = list()
-	reagents_add = list("lsd" = 0.15,
-						"suicider" = 0.15,
-						"space_drugs" = 0.15,
-						"mercury" = 0.15,
-						"lithium" = 0.15,
-						"atropine" = 0.15,
-						"ephedrine" = 0.15,
-						"haloperidol" = 0.15,
-						"methamphetamine" = 0.15,
-						"thc" = 0.15,
-						"cbd" = 0.15,
-						"psilocybin" = 0.15,
-						"hairgrownium" = 0.15,
-						"ectoplasm" = 0.15,
-						"bath_salts" = 0.15,
-						"itching_powder" = 0.15,
-						"crank" = 0.15,
-						"krokodil" = 0.15,
-						"histamine" = 0.15)
+	reagents_add = list("lsd" = 0.05,
+						"suicider" = 0.05,
+						"space_drugs" = 0.05,
+						"mercury" = 0.05,
+						"lithium" = 0.05,
+						"ephedrine" = 0.05,
+						"haloperidol" = 0.05,
+						"methamphetamine" = 0.05,
+						"thc" = 005,
+						"cbd" = 0.05,
+						"psilocybin" = 0.05,
+						"hairgrownium" = 0.05,
+						"ectoplasm" = 0.05,
+						"bath_salts" = 0.05,
+						"itching_powder" = 0.05,
+						"crank" = 0.05,
+						"krokodil" = 0.05,
+						"histamine" = 0.05)
 	rarity = 69
 
 
@@ -124,5 +125,4 @@
 	name = "omega cannibas leaf"
 	desc = "You feel dizzy looking at it. What the fuck?"
 	icon_state = "ocannabis"
-	volume = 420
 	wine_power = 0.9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR aims at accomplishing two things : 
**1) Bringing Omega Weed more in line with other plants by removing its snowflakey-memey volume**
     _- Removed 420 volume._ Other plants being 100.
**2) Making it harder overall to produce insanely strong stimulants/Initropidril**
     _- Changed every reagent from 15% to 5%._  Creates a lot of conflict with other chems with OD thresholds at 10% or 15%, and demands more plant harvesting/mid fight micromanagement
     _- Changed the mutation order so that Cannabis can mutate into Lifeweed or Rainbow weed, which then can themselves mutate into Death Weed or Omega weed._ While, yes, this gives a lucky botanist better chances at getting them, it increases the time commitment and amount of Unstable Mutagen required to do so in most cases.
     _- Removed Atropine._ Requires more chem work to actually produce Initropidril, and in smaller amounts.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Botany nerfs have been asked for a long time, and I think this is a pretty good and simple way to bring it down a peg without taking all the fun stuff away from that department. Yes, this only affects a single plant, but it truly is really good for pretty much everything at the moment. By itself, it has three stimulants, 90% of the chems for initropidril, one of the biggest meme chem in the game, and has the insanely big content volume to contain all of this without ever even needing densified chemicals.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed Omega Weed's volume from 420 to 100
tweak: Changed every reagent in Omega Weed from 15% to 5%
del: Removed atropine from Omega Weed
tweak: Made it so cannabis can only mutate into Rainbow or Life Weed
add: Added the possibility for Rainbow Weed to mutate into Death or Omega Weed
add: Added the possibility for Life Weed to mutate into Death or Omega Weed
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
