### PR TITLE
Skrell Shoeless No-Slip on Water

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -81,9 +81,10 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!(M.slip("the wet floor", 4, 2, tilesSlipped = 0, walkSafely = 1)))
-						M.inertia_dir = 0
-						return
+					if(!isskrell(M))
+						if(!(M.slip("the wet floor", 4, 2, tilesSlipped = 0, walkSafely = 1)))
+							M.inertia_dir = 0
+							return
 
 				if(TURF_WET_LUBE) //lube
 					M.slip("the floor", 0, 5, tilesSlipped = 3, walkSafely = 0, slipAny = 1)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -81,7 +81,10 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!isskrell(M) && !M.shoes)
+
+					var/feetCover = (M.wear_suit && (M.wear_suit.body_parts_covered & FEET)) || (M.w_uniform && (M.w_uniform.body_parts_covered & FEET))
+
+					if(!isskrell(M) && (M.shoes || feetCover))
 						if(!(M.slip("the wet floor", 4, 2, tilesSlipped = 0, walkSafely = 1)))
 							M.inertia_dir = 0
 							return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -81,7 +81,7 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!isskrell(M))
+					if(!isskrell(M) && !M.shoes)
 						if(!(M.slip("the wet floor", 4, 2, tilesSlipped = 0, walkSafely = 1)))
 							M.inertia_dir = 0
 							return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -84,7 +84,7 @@
 
 					var/feetCover = (M.wear_suit && (M.wear_suit.body_parts_covered & FEET)) || (M.w_uniform && (M.w_uniform.body_parts_covered & FEET))
 
-					if(!isskrell(M) && (M.shoes || feetCover))
+					if(!isskrell(M) || (isskrell(M) && (M.shoes || feetCover)))
 						if(!(M.slip("the wet floor", 4, 2, tilesSlipped = 0, walkSafely = 1)))
 							M.inertia_dir = 0
 							return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR adds a check to TURF_WET_WATER for Skrell to give them no-slip FOR WATER ONLY. It IS kinda silly that the fish-like Skrell slip on the very thing that they are surrounded with as a species (that, and water breathing is rather useless).
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More racial diversity that reinforces the background of a race seems to be wanted (as per the Community Survey)

## Changelog
:cl:
add: no-slip for Skrell on water'ed tiles when not wearing shoes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
