### PR TITLE
Fixes princesses/queens getting incorrect chat message on death

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -102,6 +102,8 @@
 			var/mob/living/simple_animal/hostile/poison/terror_spider/T = thing
 			if(!T.spider_myqueen)
 				continue
+			if(T == src)
+				continue
 			if(T.spider_myqueen != src)
 				continue
 			if(prob(50) || T.spider_tier >= spider_tier)


### PR DESCRIPTION
## Changelog
:cl: Kyep
fix: Terror queens/princesses who die no longer get an incorrect message that they're getting psychic backlash but "Somehow... you find a way to keep going!"
/:cl: