### PR TITLE
Fixes infinite loop in Nano-Mob Hunter GO Server subsystem

### DIFF
--- a/code/modules/arcade/mob_hunt/mob_datums.dm
+++ b/code/modules/arcade/mob_hunt/mob_datums.dm
@@ -88,8 +88,9 @@
 		return 0
 	while(possible_areas.len)
 		//randomly select an area from our possible_areas list to try spawning in, then remove it from possible_areas so it won't get picked over and over forever.
-		var/area/spawn_area = locate(pickweight(possible_areas))
-		possible_areas -= spawn_area
+		var/spawn_area_path = pickweight(possible_areas)
+		var/area/spawn_area = locate(spawn_area_path)
+		possible_areas -= spawn_area_path
 		if(!spawn_area)
 			break
 		//clear and generate a fresh list of turfs in the selected area, weighted based on white/black lists


### PR DESCRIPTION
## What Does This PR Do
This fixes an infinite loop bug when the Nano-Mob Hunter GO Server subsystem attempts to spawn Nano-Mobs.

Nano-Mob Hunter GO Server will attempt to spawn Nano-Mobs when the game starts.
This eventually reaches `/datum/mob_hunt/proc/select_spawn()`.
This function first enumerates all of the areas where mobs can spawn.
It then enumerates the turfs where the mob type would prefer to spawn.

When the map has insufficient turfs, it will attempt to remove the area from further consideration.
Due to a bug, this area is not properly removed from the list of possible areas.
If there are insufficient turfs over all areas, the game will go into an infinite loop because the area list will never deplete.

This isn't a security risk; a map with sufficient turfs will avoid the bug entirely.
However, for those working on new maps, when the round starts, Dream Daemon silently locks up and runs at 100% CPU until it is killed.
This can be confusing for mappers who have no idea why their map isn't working.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an infinite loop bug in Nano-Mob Hunter GO Server subsystem.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed infinite loop bug Nano-Mob Hunter GO Server subsystem.
/:cl:
