### PR TITLE
Stops shadowlings dividing by zero

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -322,6 +322,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))
 		if("recharge")
 			if(charge_counter == 0)
 				return 0
+			if(charge_max == 0)
+				return 1
 			return charge_counter / charge_max
 		if("charges")
 			if(charge_counter)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -1,20 +1,21 @@
 #define EMPOWERED_THRALL_LIMIT 5
 
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
-	if(!H || !istype(H)) return
+	if(!H || !istype(H))
+		return
 	if(H.incorporeal_move == 1)
-		to_chat(usr, "<span class='warning'>You can't use abilities affecting others while you are traversing between worlds!</span>")
+		to_chat(H, "<span class='warning'>You can't use abilities affecting others while you are traversing between worlds!</span>")
 		return FALSE
 	if(isshadowling(H) && is_shadow(H))
 		return 1
 	if(isshadowlinglesser(H) && is_thrall(H))
 		return 1
-	if(!is_shadow_or_thrall(usr))
-		to_chat(usr, "<span class='warning'>You can't wrap your head around how to do this.</span>")
-	else if(is_thrall(usr))
-		to_chat(usr, "<span class='warning'>You aren't powerful enough to do this.</span>")
-	else if(is_shadow(usr))
-		to_chat(usr, "<span class='warning'>Your telepathic ability is suppressed. Hatch or use Rapid Re-Hatch first.</span>")
+	if(!is_shadow_or_thrall(H))
+		to_chat(H, "<span class='warning'>You can't wrap your head around how to do this.</span>")
+	else if(is_thrall(H))
+		to_chat(H, "<span class='warning'>You aren't powerful enough to do this.</span>")
+	else if(is_shadow(H))
+		to_chat(H, "<span class='warning'>Your telepathic ability is suppressed. Hatch or use Rapid Re-Hatch first.</span>")
 	return 0
 
 


### PR DESCRIPTION
## What Does This PR Do
1) Fixes this runtime:
[2020-10-14T10:59:15] Runtime in spell.dm,325: Division by zero
   proc name: get availability percentage (/obj/effect/proc_holder/spell/proc/get_availability_percentage)
   src: Enthrall (/obj/effect/proc_holder/spell/targeted/click/enthrall)
   src.loc: null
   call stack:
   Enthrall (/obj/effect/proc_holder/spell/targeted/click/enthrall): get availability percentage()
   Enthrall (/datum/action/spell_action): UpdateButtonIcon()
   Enthrall (/obj/effect/proc_holder/spell/targeted/click/enthrall): process(2)
The fix is to check for charge_max==0 and return a value in this case, instead of just letting it divide by a number that might be zero.

1) Fixes this runtime:
[2020-10-14T10:52:22] Runtime in ,: DEBUG: to_chat called with invalid message/target.
   Message: '<span class='warning'>You can't use abilities affecting others while you are traversing between worlds!</span>'
   Target: ''
The fix is to change spell/proc/shadowling_check(...H) to actually use H in all cases instead of trying to use the possibly non-existent usr var in some cases.

## Changelog
:cl: Kyep
fix: fixed some shadowling spells generating runtime errors.
/:cl: