### PR TITLE
The skrell buff we really needed

### DIFF
--- a/code/modules/surgery/organs/subtypes/skrell.dm
+++ b/code/modules/surgery/organs/subtypes/skrell.dm
@@ -28,7 +28,7 @@
 /obj/item/organ/internal/headpocket/on_life()
 	..()
 	var/obj/item/organ/external/head/head = owner.get_organ("head")
-	if(pocket.contents.len && (owner.stunned || !findtextEx(head.h_style, "Tentacles")))
+	if(pocket.contents.len && !findtextEx(head.h_style, "Tentacles"))
 		owner.visible_message("<span class='notice'>Something falls from [owner]'s head!</span>",
 													"<span class='notice'>Something falls from your head!</span>")
 		empty_contents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR buffs the skrell head pocket. It no longer drops whatever it was holding as soon as you get stunned, slipped, have to vomit, etc. 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Head pockets are one of the few things setting skrell apart from other species, but they're very impractical to use at the moment. You're never going to put anything valuable or important there because it's so easy to just lose the item because you slipped on some water and a greytide grabbed it on reflex or whatever.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Skrell have been working out and training their tentacles, their head pockets now no longer drop items when they're stunned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
