### PR TITLE
Tweaks Wiki Button

### DIFF
--- a/code/controllers/subsystem/changelog.dm
+++ b/code/controllers/subsystem/changelog.dm
@@ -245,7 +245,7 @@ SUBSYSTEM_DEF(changelog)
 				if(config.wikiurl)
 					if(alert("This will open the wiki in your browser. Are you sure?",,"Yes","No")=="No")
 						return
-					usr.client.wiki("") // Blank arg is important here
+					usr.client.wiki()
 				else
 					to_chat(usr, "<span class='danger'>The Wiki URL is not set in the server configuration. Please inform the server host.</span>")
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -15,7 +15,7 @@
 	set desc = "Visit the forum."
 	set hidden = 1
 	if(config.forumurl)
-		if(alert("Open the forum in your browser?",,"Yes","No")=="Yes")
+		if(alert("Open the forum in your browser?", null, "Yes", "No") == "Yes")
 			if(config.forum_link_url && prefs && !prefs.fuid)
 				link_forum_account()
 			src << link(config.forumurl)
@@ -27,7 +27,7 @@
 	set desc = "View the server rules."
 	set hidden = 1
 	if(config.rulesurl)
-		if(alert("This will open the rules in your browser. Are you sure?",,"Yes","No")=="No")
+		if(alert("This will open the rules in your browser. Are you sure?", null, "Yes", "No") == "No")
 			return
 		src << link(config.rulesurl)
 	else
@@ -38,7 +38,7 @@
 	set desc = "Visit the GitHub page."
 	set hidden = 1
 	if(config.githuburl)
-		if(alert("This will open our GitHub repository in your browser. Are you sure?",,"Yes","No")=="No")
+		if(alert("This will open our GitHub repository in your browser. Are you sure?", null, "Yes", "No") == "No")
 			return
 		src << link(config.githuburl)
 	else
@@ -55,7 +55,7 @@
 	if(!durl)
 		to_chat(src, "<span class='danger'>The Discord URL is not set in the server configuration.</span>")
 		return
-	if(alert("This will invite you to our Discord server. Are you sure?",,"Yes","No")=="No")
+	if(alert("This will invite you to our Discord server. Are you sure?", null, "Yes", "No") == "No")
 		return
 	src << link(durl)
 
@@ -64,7 +64,7 @@
 	set desc = "Donate to help with hosting costs."
 	set hidden = 1
 	if(config.donationsurl)
-		if(alert("This will open the donation page in your browser. Are you sure?",,"Yes","No")=="No")
+		if(alert("This will open the donation page in your browser. Are you sure?", null, "Yes", "No") == "No")
 			return
 		src << link(config.donationsurl)
 	else

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -1,13 +1,10 @@
 //Please use mob or src (not usr) in these procs. This way they can be called in the same fashion as procs.
-/client/verb/wiki(query as text)
+/client/verb/wiki()
 	set name = "wiki"
 	set desc = "Type what you want to know about.  This will open the wiki in your web browser."
 	set hidden = 1
 	if(config.wikiurl)
-		if(query)
-			var/output = config.wikiurl + "/index.php?title=Special%3ASearch&profile=default&search=" + query
-			src << link(output)
-		else
+		if(alert("Open the wiki in your browser?", null, "Yes", "No") == "Yes")
 			src << link(config.wikiurl)
 	else
 		to_chat(src, "<span class='danger'>The wiki URL is not set in the server configuration.</span>")


### PR DESCRIPTION
## What Does This PR Do
1) Changes the behavior of the "Wiki" button in-game.
- Old behavior: it asked you for a query. If you entered nothing, it opened the wiki homepage. If you entered something, it sent that query to the search page on the wiki and took you to the results page.
- New behavior: it asks you if you want to open the wiki in your browser. If you say "yes", it opens the wiki homepage.
2) Fixes the spacing in some of the alert() calls in this file.

## Why It's Good For The Game
The old behavior (asking the user in-game for search terms, which are then passed to the wiki software in the URL) no longer works as of Byond 513.1535, because Byond no longer allows you to open links containing the "&" character, which is needed for our wiki software to parse submissions. While in theory I could try to force our webserver to handle another character (like ";") I'm worried that might break other things (e.g. what if you submit a post/page/etc that contains ;?). I'd rather just link the user directly to the wiki homepage, since the homepage also has a search box on it and they can enter their query there (and, given that many wiki queries are for basic stuff like job info, they may not have to type anything at all as the homepage already has the most-used pages linked on it).

## Changelog
:cl: Kyep
tweak: changed wiki button to open wiki homepage instead of asking for search terms, a workaround for the latest version of Byond not passing URLs correctly. 
/:cl: