### PR TITLE
Refactor IsHandgun to a class variable called can_holster

### DIFF
--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -15,7 +15,7 @@
 
 //subtypes can override this to specify what can be holstered
 /obj/item/clothing/accessory/holster/proc/can_holster(obj/item/gun/W)
-	if(!W.isHandgun())
+	if(!W.can_holster)
 		return 0
 	else if(!istype(W,holster_allow))
 		return 0

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -56,6 +56,8 @@
 	var/knife_x_offset = 0
 	var/knife_y_offset = 0
 
+	var/can_holster = TRUE // Can it be holstered?
+
 	var/list/upgrades = list()
 
 	var/ammo_x_offset = 0 //used for positioning ammo count overlay on sprite
@@ -465,9 +467,6 @@
 		chambered.BB.damage *= 5
 
 	process_fire(target, user, 1, params)
-
-/obj/item/gun/proc/isHandgun()
-	return 1
 
 /////////////
 // ZOOMING //

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -56,7 +56,7 @@
 	var/knife_x_offset = 0
 	var/knife_y_offset = 0
 
-	var/can_holster = TRUE // Can it be holstered?
+	var/can_holster = TRUE
 
 	var/list/upgrades = list()
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -73,12 +73,10 @@
 	force = 10
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
+	can_holster = FALSE
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
 	ammo_x_offset = 3
-
-/obj/item/gun/energy/lasercannon/isHandgun()
-	return 0
 
 /obj/item/ammo_casing/energy/laser/accelerator
 	projectile_type = /obj/item/projectile/beam/laser/accelerator

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -4,6 +4,7 @@
 	icon_state = "pulse"
 	item_state = null
 	w_class = WEIGHT_CLASS_BULKY
+	can_holster = FALSE
 	force = 10
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
@@ -12,9 +13,6 @@
 
 /obj/item/gun/energy/pulse/emp_act(severity)
 	return
-
-/obj/item/gun/energy/pulse/isHandgun()
-	return 0
 
 /obj/item/gun/energy/pulse/cyborg
 
@@ -41,11 +39,9 @@
 	slot_flags = SLOT_BELT
 	icon_state = "pulse_pistol"
 	item_state = "gun"
+	can_holster = TRUE
 	cell_type = /obj/item/stock_parts/cell/pulse/pistol
 	can_charge = 0
-
-/obj/item/gun/energy/pulse/pistol/isHandgun()
-	return 1
 
 /obj/item/gun/energy/pulse/destroyer
 	name = "pulse destroyer"
@@ -66,10 +62,8 @@
 	desc = "A compact pulse core in a classic handgun frame for Nanotrasen officers. It's not the size of the gun, it's the size of the hole it puts through people."
 	icon_state = "m1911"
 	item_state = "gun"
+	can_holster = TRUE
 	cell_type = /obj/item/stock_parts/cell/infinite
-
-/obj/item/gun/energy/pulse/pistol/m1911/isHandgun()
-	return 1
 
 /obj/item/gun/energy/pulse/turret
 	name = "pulse turret gun"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -7,6 +7,7 @@
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 	origin_tech = "combat=4;magnets=4"
 	w_class = WEIGHT_CLASS_HUGE
+	can_holster = FALSE
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/ion)
@@ -16,9 +17,6 @@
 
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	return
-
-/obj/item/gun/energy/ionrifle/isHandgun()
-	return 0
 
 /obj/item/gun/energy/ionrifle/carbine
 	name = "ion carbine"
@@ -314,12 +312,10 @@
 	weapon_weight = WEAPON_HEAVY
 	slot_flags = SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
+	can_holster = FALSE
 	zoomable = TRUE
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
 	shaded_charge = 1
-
-/obj/item/gun/energy/sniperrifle/isHandgun()
-	return FALSE // Makes it so no, you cant fit a massive, bulky, sniper under your arm
 
 // Temperature Gun //
 /obj/item/gun/energy/temperature

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -4,12 +4,10 @@
 	var/select = 1
 	can_tactical = TRUE
 	can_suppress = 1
+	can_holster = FALSE
 	burst_size = 3
 	fire_delay = 2
 	actions_types = list(/datum/action/item_action/toggle_firemode)
-
-/obj/item/gun/projectile/automatic/isHandgun()
-	return 0
 
 /obj/item/gun/projectile/automatic/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -37,12 +37,11 @@
 	fire_sound = 'sound/effects/explosion1.ogg'
 	origin_tech = "combat=5"
 	mag_type = /obj/item/ammo_box/magazine/m75
+	can_holster = TRUE // Override default automatic setting since it is a handgun sized gun
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
 
-/obj/item/gun/projectile/automatic/gyropistol/isHandgun()
-	return 1
 
 /obj/item/gun/projectile/automatic/gyropistol/process_chamber(eject_casing = 0, empty_chamber = 1)
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -5,6 +5,7 @@
 	icon_state = "pistol"
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "combat=3;materials=2;syndicate=4"
+	can_holster = TRUE
 	mag_type = /obj/item/ammo_box/magazine/m10mm
 	fire_sound = 'sound/weapons/gunshots/gunshot_pistol.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/pistol_magin.ogg'
@@ -13,9 +14,6 @@
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
-
-/obj/item/gun/projectile/automatic/pistol/isHandgun()
-	return 1
 
 /obj/item/gun/projectile/automatic/pistol/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -336,6 +336,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	fire_sound = 'sound/weapons/gunshots/gunshot_shotgun.ogg'
 	sawn_desc = "Omar's coming!"
+	can_holster = FALSE
 	unique_rename = 1
 	unique_reskin = 1
 
@@ -376,9 +377,6 @@
 		to_chat(user, "<span class = 'notice'>You break open \the [src] and unload [num_unloaded] shell\s.</span>")
 	else
 		to_chat(user, "<span class='notice'>[src] is empty.</span>")
-
-/obj/item/gun/projectile/revolver/doublebarrel/isHandgun() //contrary to popular opinion, double barrels are not, shockingly, handguns
-	return 0
 
 // IMPROVISED SHOTGUN //
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -6,6 +6,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
 	flags = CONDUCT
+	can_holster = FALSE
 	slot_flags = SLOT_BACK
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
@@ -69,9 +70,6 @@
 	. = ..()
 	if(chambered)
 		. += "A [chambered.BB ? "live" : "spent"] one is in the chamber."
-
-/obj/item/gun/projectile/shotgun/isHandgun() //You cannot, in fact, holster a shotgun.
-	return 0
 
 /obj/item/gun/projectile/shotgun/lethal
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/lethal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR is inspired by the previous PR that made the energy sniper (Which inherit from gun/energy, which is a holsterable type) non-holsterable. 

This refactors the IsHandgun() proc, which is only used ever to check whether something is holsterable, into a class level variable called can_holster, which is checked by the can_holster proc to see if it can in fact, be holstered.

This is much more accurate to how the proc is actually used. We've never used the IsHandgun() proc anywhere to distinguish between a handgun vs rifle form factor and it never mattered in more than one case. 

Ideally the holster should be checking for more than that, but that's for another day 

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Code refactor behind the gun holstering code. Report any issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
