### PR TITLE
Fixes the immovable filing cabinet in the Law Office

### DIFF
--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -15,7 +15,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "filingcabinet"
 	density = 1
-	anchored = 1
+	anchored = TRUE
 
 
 /obj/structure/filingcabinet/chestdrawer
@@ -30,14 +30,14 @@
 	icon_state = "tallcabinet"
 
 
-/obj/structure/filingcabinet/Initialize()
+/obj/structure/filingcabinet/Initialize(mapload)
 	..()
 	for(var/obj/item/I in loc)
 		if(istype(I, /obj/item/paper) || istype(I, /obj/item/folder) || istype(I, /obj/item/photo))
 			I.loc = src
 
 
-/obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob, params)
+/obj/structure/filingcabinet/attackby(obj/item/P, mob/user, params)
 	if(istype(P, /obj/item/paper) || istype(P, /obj/item/folder) || istype(P, /obj/item/photo) || istype(P, /obj/item/paper_bundle) || istype(P, /obj/item/documents))
 		to_chat(user, "<span class='notice'>You put [P] in [src].</span>")
 		user.drop_item()
@@ -46,14 +46,14 @@
 		sleep(5)
 		icon_state = initial(icon_state)
 		updateUsrDialog()
-	else if(istype(P, /obj/item/wrench))
-		playsound(loc, P.usesound, 50, 1)
-		anchored = !anchored
-		to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
 	else if(user.a_intent != INTENT_HARM)
 		to_chat(user, "<span class='warning'>You can't put [P] in [src]!</span>")
 	else
 		return ..()
+
+/obj/structure/filingcabinet/wrench_act(mob/living/user, obj/item/I)
+	. = TRUE
+	default_unfasten_wrench(user, I)
 
 /obj/structure/filingcabinet/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))
@@ -62,9 +62,9 @@
 			I.forceMove(loc)
 	qdel(src)
 
-/obj/structure/filingcabinet/attack_hand(mob/user as mob)
-	if(contents.len <= 0)
-		to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
+/obj/structure/filingcabinet/attack_hand(mob/user)
+	if(!length(contents))
+		to_chat(user, "<span class='notice'>[src] is empty.</span>")
 		return
 
 	user.set_machine(src)
@@ -74,7 +74,7 @@
 	dat += "</table></center>"
 	var/datum/browser/popup = new(user, "filingcabinet", name, 350, 300)
 	popup.set_content(dat)
-	popup.open(0)
+	popup.open(FALSE)
 
 	return
 
@@ -85,8 +85,8 @@
 		..()
 
 /obj/structure/filingcabinet/attack_self_tk(mob/user)
-	if(contents.len)
-		if(prob(40 + contents.len * 5))
+	if(length(contents))
+		if(prob(40 + (length(contents) * 5)))
 			var/obj/item/I = pick(contents)
 			I.loc = loc
 			if(prob(25))
@@ -105,16 +105,15 @@
 			usr.put_in_hands(P)
 			updateUsrDialog()
 			icon_state = "[initial(icon_state)]-open"
-			spawn(0)
-				sleep(5)
-				icon_state = initial(icon_state)
+			sleep(5)
+			icon_state = initial(icon_state)
 
 
 /*
  * Security Record Cabinets
  */
 /obj/structure/filingcabinet/security
-	var/virgin = 1
+	var/virgin = TRUE
 
 
 /obj/structure/filingcabinet/security/proc/populate()
@@ -133,7 +132,7 @@
 				P.info += "[c]<BR>"
 			P.info += "</TT>"
 			P.name = "paper - '[G.fields["name"]]'"
-			virgin = 0	//tabbing here is correct- it's possible for people to try and use it
+			virgin = FALSE	//tabbing here is correct- it's possible for people to try and use it
 						//before the records have been generated, so we do this inside the loop.
 
 /obj/structure/filingcabinet/security/attack_hand()
@@ -148,7 +147,7 @@
  * Medical Record Cabinets
  */
 /obj/structure/filingcabinet/medical
-	var/virgin = 1
+	var/virgin = TRUE
 
 /obj/structure/filingcabinet/medical/proc/populate()
 	if(virgin)
@@ -166,7 +165,7 @@
 				P.info += "[c]<BR>"
 			P.info += "</TT>"
 			P.name = "paper - '[G.fields["name"]]'"
-			virgin = 0	//tabbing here is correct- it's possible for people to try and use it
+			virgin = FALSE	//tabbing here is correct- it's possible for people to try and use it
 						//before the records have been generated, so we do this inside the loop.
 
 /obj/structure/filingcabinet/medical/attack_hand()
@@ -184,9 +183,9 @@
 GLOBAL_LIST_EMPTY(employmentCabinets)
 
 /obj/structure/filingcabinet/employment
-	var/cooldown = 0
+	var/cooldown = FALSE // Only used for devils
 	icon_state = "employmentcabinet"
-	var/virgin = 1
+	var/virgin = TRUE
 
 /obj/structure/filingcabinet/employment/New()
 	GLOB.employmentCabinets += src
@@ -210,23 +209,17 @@ GLOBAL_LIST_EMPTY(employmentCabinets)
 	new /obj/item/paper/contract/employment(src, employee)
 
 /obj/structure/filingcabinet/employment/attack_hand(mob/user)
-	if(!cooldown)
+	if(cooldown)
+		to_chat(user, "<span class='warning'>[src] is jammed, give it a few seconds.</span>")
+	else
 		if(virgin)
 			fillCurrent()
-			virgin = 0
-		cooldown = 1
-		..()
-		sleep(100) // prevents the devil from just instantly emptying the cabinet, ensuring an easy win.
-		cooldown = 0
-	else
-		to_chat(user, "<span class='warning'>The [src] is jammed, give it a few seconds.</span>")
+			virgin = FALSE
+		if(user.mind.special_role != "devil")
+			return ..()
 
-/obj/structure/filingcabinet/employment/attackby(obj/item/P, mob/user, params)
-	if(istype(P, /obj/item/wrench))
-		to_chat(user, "<span class='notice'>You begin to [anchored ? "wrench" : "unwrench"] [src].</span>")
-		if (do_after(user,300,user))
-			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-			anchored = !anchored
-			to_chat(user, "<span class='notice'>You successfully [anchored ? "wrench" : "unwrench"] [src].</span>")
-	else
-		return ..()
+		else
+			cooldown = TRUE
+			..()
+			sleep(10 SECONDS) // prevents the devil from just instantly emptying the cabinet, ensuring an easy win.
+			cooldown = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes being unable to wrench/unwrench the 'Employment filing cabinet', and disables the use cooldown unless you are a Devil.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Immovable objects are bad.

## Changelog
:cl:
tweak: The delay for the Employment filing cabinet now only applies to Devils
fix: The Employment filing cabinet in the Law Office can now be wrenched/unwrenched
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
