### PR TITLE
Makes mindscan and remotetalk logged using SAY_LOG

### DIFF
--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -241,6 +241,7 @@
 
 	for(var/mob/living/target in targets)
 		log_say("(TPATH to [key_name(target)]) [say]", user)
+		user.create_log(SAY_LOG, "Telepathically said '[say]' using [src]", target)
 		if(REMOTE_TALK in target.mutations)
 			target.show_message("<span class='abductor'>You hear [user.real_name]'s voice: [say]</span>")
 		else
@@ -314,7 +315,7 @@
 			return
 		say = strip_html(say)
 		say = pencode_to_html(say, target, format = 0, fields = 0)
-
+		user.create_log(SAY_LOG, "Telepathically responded '[say]' using [src]", target)
 		log_say("(TPATH to [key_name(target)]) [say]", user)
 		if(REMOTE_TALK in target.mutations)
 			target.show_message("<span class='abductor'>You project your mind into [user.name]: [say]</span>")


### PR DESCRIPTION
## What Does This PR Do
Makes the remote talk abilities greys have actually log the messages using the new logging system

## Why It's Good For The Game
It's missing logging

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/96179528-4461b400-0f31-11eb-949f-50fcf30223c5.png)


## Changelog
:cl:
tweak: Scan mind is now logged using the new logging system
tweak: Project mind is now logged using the new logging system
/:cl: