### PR TITLE
Bluespace Harvester points rebalance

### DIFF
--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -1,7 +1,7 @@
 //Station goal stuff goes here
 /datum/station_goal/bluespace_tap
 	name = "Bluespace Harvester"
-	var/goal = 500000
+	var/goal = 45000
 
 /datum/station_goal/bluespace_tap/get_report()
 	return {"<b>Bluespace Harvester Experiment</b><br>
@@ -169,6 +169,10 @@
 		/obj/item/reagent_containers/food/snacks/sliceable/xenomeatbread //maybe add some dangerous/special food here, ie robobuger?
 	)
 
+#define kW *1000
+#define MW kW *1000
+#define GW MW *1000
+
 /**
   * # Bluespace Harvester
   *
@@ -188,16 +192,20 @@
 	/// For faking having a big machine, dummy 'machines' that are hidden inside the large sprite and make certain tiles dense. See new and destroy.
 	var/list/obj/structure/fillers = list()
 	use_power = NO_POWER_USE	// power usage is handelled manually
-	/// Value that will be multiplied with mining level to generate actual power use
-	active_power_usage = 500
 	density = TRUE
 	interact_offline = TRUE
 	luminosity = 1
 
+	/// Correspond to power required for a mining level, first entry for level 1, etc.
+	var/list/power_needs = list(1 kW, 5 kW, 50 kW, 100 kW, 500 kW,
+								1 MW, 2 MW, 5 MW, 10 MW, 25 MW,
+								50 MW, 75 MW, 125 MW, 200 MW, 500 MW,
+								1 GW, 5 GW, 15 GW, 45 GW, 500 GW)
+
 	/// list of possible products
 	var/static/product_list = list(
-	new /datum/data/bluespace_tap_product("Unknown Exotic Hat", /obj/effect/spawner/lootdrop/bluespace_tap/hat, 10000),
-	new /datum/data/bluespace_tap_product("Unknown Snack", /obj/effect/spawner/lootdrop/bluespace_tap/food, 12000),
+	new /datum/data/bluespace_tap_product("Unknown Exotic Hat", /obj/effect/spawner/lootdrop/bluespace_tap/hat, 5000),
+	new /datum/data/bluespace_tap_product("Unknown Snack", /obj/effect/spawner/lootdrop/bluespace_tap/food, 6000),
 	new /datum/data/bluespace_tap_product("Unknown Cultural Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/cultural, 15000),
 	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/organic, 20000)
 	)
@@ -218,12 +226,10 @@
 
 	/// Max power input level, I don't expect this to be ever reached
 	var/max_level = 20
-	/// Used for power consumption, higher means more power consumed per level
-	var/base_value = 5
 	/// Amount of points to give per mining level
 	var/base_points = 4
 	/// How high the machine can be run before it starts having a chance for dimension breaches.
-	var/safe_levels = 7
+	var/safe_levels = 10
 
 
 /obj/machinery/power/bluespace_tap/New()
@@ -302,7 +308,7 @@
 /obj/machinery/power/bluespace_tap/proc/get_power_use(i_level)
 	if(!i_level)
 		return 0
-	return (base_value ** i_level) * active_power_usage	//each level takes one order of magnitude more power than the previous one
+	return power_needs[i_level]
 
 /obj/machinery/power/bluespace_tap/process()
 	actual_power_usage = get_power_use(input_level)
@@ -443,3 +449,7 @@
 	<p>NT Science Directorate, Extradimensional Exploitation Research Group</p> \
 	<p><small>Device highly experimental. Not for sale. Do not operate near small children or vital NT assets. Do not tamper with machine. In case of existential dread, stop machine immediately. \
 	Please document any and all extradimensional incursions. In case of imminent death, please leave said documentation in plain sight for clean-up teams to recover.</small></p>"
+
+#undef kW
+#undef MW
+#undef GW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR reduces the amount of points needed for the goal to count as completed and redoes the formula for how much power each level needs. It also makes the very fluffy rewards (food and hats) cheaper.

Back when I created the Bluespace Harvester, I did some back of a napkin math after seeing how much points I generated locally in 5 minutes. As it turns out, machines tick less often on the live server because there's more load, which meant that people were getting less points than I expected at every mining level. Where they should have gotten 50k they ended up with just 30k.

Since the numbers were always meant to be tweaked as we see what the crew can actually achieve and how fast they can get the device up, I expected I'd have to make a PR like this eventually, but not this quickly.

The new power costs are balanced roughly as such: With just some SMES output or pacmans, you can get level 4 without issues. A standard singulo or tesla can get you to level 7. With multiple engines, upgraded engine parts or a TEG you can push into levels 10 and maybe a bit up.

Running on level 7 should be enough to get the goal complete, even with lots of tick lag, assuming you get the machine set up reasonably early.

**I encourage everyone to weigh in on those numbers**. Are they achievable but sufficiently hard?

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
At the moment, the goal is much harder to complete than intended. Partially because I typod when setting the goal and accidentally added an extra 0, oops.

I also made (so I hope) more power levels achievable and relevant, which should give more of a different feel between doing well or not, encouraging engineers to go the extra mile.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Bluespace harvester costs and points adjusted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
