### PR TITLE
Makes the TGUI error window more lore friendly

### DIFF
--- a/tgui/packages/tgui/public/tgui.html
+++ b/tgui/packages/tgui/public/tgui.html
@@ -150,7 +150,7 @@ and send the copy of the following stack trace to:
 </marquee>
 <div id="FatalError__stack" class="FatalError__stack"></div>
 <div class="FatalError__footer">
-Nanotrasen (c) 2525-2559
+Nanotrasen (c) 2223-2564
 </div>
 </div>
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Changes the Nanotrasen copyright dates on the TGUI error screen to be accurate to Paradise lore.

The [Wiki Timeline](https://www.paradisestation.org/wiki/index.php/Timeline) states that Nanotrasen was incorporated in 2223, and that the current year is 2564.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Lore is clearly a *very* important part of the Paradise Station experience, and we don't want someone losing their Immersion:tm: because of an error message!

## Changelog
:cl:
tweak: The Nanotrasen copyright dates in the TGUI bluescreen have been corrected to conform to Paradise lore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
