### PR TITLE
Fixes cyborgs and drones being unable to use camera console

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -163,8 +163,11 @@
 	tgui_interact(user)
 
 /obj/machinery/computer/security/attack_ai(mob/user)
-	to_chat(user, "<span class='notice'>You realise its kind of stupid to access a camera console when you have the entire camera network at your metaphorical fingertips</span>")
-	return
+	if(isAI(user))
+		to_chat(user, "<span class='notice'>You realise its kind of stupid to access a camera console when you have the entire camera network at your metaphorical fingertips</span>")
+		return
+
+	tgui_interact(user)
 
 
 /obj/machinery/computer/security/proc/show_camera_static()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As the title says, the check in the PR that added TGUI camera consoles to prevent the AI using it, also prevented all other silicon. This excludes it 

## Why It's Good For The Game
It's a bug fix. Bugs are bad. In all seriousness, they should be able to use consoles as a borg or drone.

## Changelog
:cl:
fix: Cyborgs and drones can use camera consoles again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
