### PR TITLE
Exos can pass through flaps

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -63,7 +63,7 @@
 			return FALSE
 
 	if(ismecha(A))
-		return FALSE
+		return TRUE
 
 	else if(isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR changes plastic flaps to simply allow exosuits to pass through them unchallenged.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Back in the days of the asteroid there were some special plastic flaps that would allow exosuits to pass through them, this was a handy way of allowing exosuits to pass into areas without fiddling with airlocks or create areas for pilots to access that you wouldn't want the general populous to access. (I.E the mechbay shutters)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Exos can now walk through plastic flaps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
