### PR TITLE
ERT Commander Rework

### DIFF
--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -32,3 +32,13 @@
 
 /obj/item/camera_bug/tgui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/tgui_state/state = GLOB.tgui_inventory_state)
 	integrated_console.tgui_interact(user, ui_key, ui, force_open, master_ui, state)
+
+
+/obj/item/camera_bug/ert
+	name = "ERT Camera Monitor"
+	desc = "A small handheld device used by ERT commanders to view camera feeds remotely."
+
+/obj/item/camera_bug/ert/Initialize(mapload)
+	. = ..()
+	integrated_console.network = list("ERT")
+

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -289,19 +289,25 @@
 	freqlock = TRUE
 
 /obj/item/radio/headset/ert/alt
-	name = "\proper emergency response team's bowman headset"
+	name = "emergency response team's bowman headset"
 	desc = "The headset of the boss. Protects ears from flashbangs."
 	flags = EARBANGPROTECT
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 
+/obj/item/radio/headset/ert/alt/commander
+	name = "ERT commander's bowman headset"
+	desc = "The headset of the boss. Protects ears from flashbangs. Can transmit even if telecomms are down."
+	requires_tcomms = FALSE
+
 /obj/item/radio/headset/centcom
 	name = "\proper centcom officer's bowman headset"
-	desc = "The headset of final authority. Protects ears from flashbangs."
+	desc = "The headset of final authority. Protects ears from flashbangs. Can transmit even if telecomms are down."
 	flags = EARBANGPROTECT
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 	ks2type = /obj/item/encryptionkey/centcom
+	requires_tcomms = FALSE
 
 /obj/item/radio/headset/heads/ai_integrated //No need to care about icons, it should be hidden inside the AI anyway.
 	name = "\improper AI subspace transceiver"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -299,6 +299,7 @@
 	name = "ERT commander's bowman headset"
 	desc = "The headset of the boss. Protects ears from flashbangs. Can transmit even if telecomms are down."
 	requires_tcomms = FALSE
+	instant = TRUE
 
 /obj/item/radio/headset/centcom
 	name = "\proper centcom officer's bowman headset"
@@ -308,6 +309,7 @@
 	item_state = "com_headset_alt"
 	ks2type = /obj/item/encryptionkey/centcom
 	requires_tcomms = FALSE
+	instant = TRUE
 
 /obj/item/radio/headset/heads/ai_integrated //No need to care about icons, it should be hidden inside the AI anyway.
 	name = "\improper AI subspace transceiver"

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -38,6 +38,7 @@
 
 	uniform = /obj/item/clothing/under/rank/centcom_officer/sensor
 	back = /obj/item/storage/backpack/ert/commander
+	l_ear = /obj/item/radio/headset/ert/alt/commander
 
 	id = /obj/item/card/id/ert/commander
 
@@ -81,7 +82,8 @@
 	belt = /obj/item/gun/energy/gun/blueshield/pdw9
 
 	backpack_contents = list(
-		/obj/item/gun/energy/ionrifle/carbine = 1,
+		/obj/item/camera_bug/ert = 1,
+		/obj/item/door_remote/omni = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/clothing/shoes/magboots = 1,
 		/obj/item/storage/lockbox/mindshield = 1
@@ -100,7 +102,8 @@
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
-		/obj/item/gun/energy/ionrifle/carbine = 1,
+		/obj/item/camera_bug/ert = 1,
+		/obj/item/door_remote/omni = 1,
 		/obj/item/ammo_box/magazine/enforcer/lethal = 2
 		)
 


### PR DESCRIPTION
## What Does This PR Do
ERT commanders no longer get an ion rifle.
ERT commander headsets (and admin CC officer headsets) now work even if telecomms is down.
Red/Gamma ERT commanders now get two new items, to replace the ion rifle they lost: 
- An omni door remote, which works like the Captain's door remote, but on any station airlock.
- An ERT camera monitor, which works like a camera bug, except that it only shows camera feeds from ERT hardsuit cams and the ERT starting area. It does NOT show normal station cams.

## Why this is good for the game.
The ion rifle is a liability. ERT commanders, right now, do more damage to their own team with the ion rifle than they do to enemies. There's no reason for them to get an ion rifle - if they need one they can already get one from the armory or R&D.

ERT commanders need the ability to issue orders to their team, especially in emergencies like downed comms. So, tweaking their headset this way makes sense.

Giving ERT commanders the ability to remotely monitor their team, and support them by opening bolted doors for them (or bolting doors for them to help lock down an area) gives them not just the ability to give informed orders, but also perform a support role that makes their team more effective.

Effectively, this rework transforms the ERT commander from a role that's mainly a liability (due to their ion rifle) into a role that's actually useful in keeping an eye on, commanding, and assisting their team.

## Changelog
:cl: Kyep
tweak: reworked ERT commander gear. They no longer get an ion rifle. Their headset now works even if telecomms is down. Red/Gamma ERT commanders also get an ERT camera monitor and an omni door remote.
/:cl: