### PR TITLE
Alphabetize items in debug equipment selection menu.

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -772,7 +772,7 @@
 		apply_to_card(I, H, get_all_accesses(), "Space Explorer")
 
 /datum/outfit/admin/hardsuit
-	name = "Hardsuit Generic"
+	name = "Hardsuit - Generic"
 	back = /obj/item/tank/jetpack/oxygen
 	mask = /obj/item/clothing/mask/breath
 	shoes = /obj/item/clothing/shoes/magboots
@@ -793,34 +793,34 @@
 		apply_to_card(I, H, get_all_accesses(), "Hardsuit Tester")
 
 /datum/outfit/admin/hardsuit/engineer
-	name = "Engineer Hardsuit"
+	name = "Hardsuit - Engineer"
 	suit = /obj/item/clothing/suit/space/hardsuit/engine
 
 /datum/outfit/admin/hardsuit/ce
-	name = "CE Hardsuit"
+	name = "Hardsuit - CE"
 	suit = /obj/item/clothing/suit/space/hardsuit/engine/elite
 	shoes = /obj/item/clothing/shoes/magboots/advance
 
 /datum/outfit/admin/hardsuit/mining
-	name = "Mining Hardsuit"
+	name = "Hardsuit - Mining"
 	suit = /obj/item/clothing/suit/space/hardsuit/mining
 
 /datum/outfit/admin/hardsuit/syndi
-	name = "Syndi Hardsuit"
+	name = "Hardsuit - Syndi"
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	shoes = /obj/item/clothing/shoes/magboots/syndie
 
 /datum/outfit/admin/hardsuit/wizard
-	name = "Wizard Hardsuit"
+	name = "Hardsuit - Wizard"
 	suit = /obj/item/clothing/suit/space/hardsuit/shielded/wizard
 	shoes = /obj/item/clothing/shoes/magboots
 
 /datum/outfit/admin/hardsuit/medical
-	name = "Medical Hardsuit"
+	name = "Hardsuit - Medical"
 	suit = /obj/item/clothing/suit/space/hardsuit/medical
 
 /datum/outfit/admin/hardsuit/atmos
-	name = "Atmos Hardsuit"
+	name = "Hardsuit - Atmos"
 	suit = /obj/item/clothing/suit/space/hardsuit/engine/atmos
 
 
@@ -1082,20 +1082,20 @@
 		apply_to_card(I, H, get_all_accesses(), "Wizard")
 
 /datum/outfit/admin/wizard/red
-	name = "Red Wizard"
+	name = "Wizard - Red Wizard"
 
 	suit = /obj/item/clothing/suit/wizrobe/red
 	head = /obj/item/clothing/head/wizard/red
 
 /datum/outfit/admin/wizard/marisa
-	name = "Marisa Wizard"
+	name = "Wizard - Marisa Wizard"
 
 	suit = /obj/item/clothing/suit/wizrobe/marisa
 	shoes = /obj/item/clothing/shoes/sandal/marisa
 	head = /obj/item/clothing/head/wizard/marisa
 
 /datum/outfit/admin/wizard/arch
-	name = "Arch Wizard"
+	name = "Wizard - Arch Wizard"
 
 	suit = /obj/item/clothing/suit/wizrobe/magusred
 	head = /obj/item/clothing/head/wizard/magus

--- a/code/datums/outfits/plasmamen.dm
+++ b/code/datums/outfits/plasmamen.dm
@@ -7,140 +7,140 @@
 	mask = /obj/item/clothing/mask/breath
 
 /datum/outfit/plasmaman/bar
-	name = "Bartender Plasmaman"
+	name = "Plasmaman Bartender"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/white
 	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
 
 /datum/outfit/plasmaman/chef
-	name = "Chef Plasmaman"
+	name = "Plasmaman Chef"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/chef
 	uniform = /obj/item/clothing/under/plasmaman/chef
 
 /datum/outfit/plasmaman/botany
-	name = "Botany Plasmaman"
+	name = "Plasmaman Botany"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/botany
 	uniform = /obj/item/clothing/under/plasmaman/botany
 
 /datum/outfit/plasmaman/librarian
-	name = "Librarian Plasmaman"
+	name = "Plasmaman Librarian"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/librarian
 	uniform = /obj/item/clothing/under/plasmaman/librarian
 
 /datum/outfit/plasmaman/chaplain
-	name = "Chaplain Plasmaman"
+	name = "Plasmaman Chaplain"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/chaplain
 	uniform = /obj/item/clothing/under/plasmaman/chaplain
 
 /datum/outfit/plasmaman/janitor
-	name = "Janitor Plasmaman"
+	name = "Plasmaman Janitor"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/janitor
 	uniform = /obj/item/clothing/under/plasmaman/janitor
 
 /datum/outfit/plasmaman/security
-	name = "Security Plasmaman"
+	name = "Plasmaman Security"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	uniform = /obj/item/clothing/under/plasmaman/security
 
 /datum/outfit/plasmaman/detective
-	name = "Detective Plasmaman"
+	name = "Plasmaman Detective"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/white
 	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
 	l_ear = /obj/item/radio/headset/headset_sec
 
 /datum/outfit/plasmaman/warden
-	name = "Warden Plasmaman"
+	name = "Plasmaman Warden"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security/warden
 	uniform = /obj/item/clothing/under/plasmaman/security/warden
 
 /datum/outfit/plasmaman/hos
-	name = "Head of Security Plasmaman"
+	name = "Plasmaman Head of Security"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security/hos
 	uniform = /obj/item/clothing/under/plasmaman/security/hos
 
 /datum/outfit/plasmaman/cargo
-	name = "Cargo Plasmaman"
+	name = "Plasmaman Cargo"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/cargo
 	uniform = /obj/item/clothing/under/plasmaman/cargo
 
 /datum/outfit/plasmaman/mining
-	name = "Mining Plasmaman"
+	name = "Plasmaman Mining"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/mining
 	uniform = /obj/item/clothing/under/plasmaman/mining
 
 /datum/outfit/plasmaman/medical
-	name = "Medical Plasmaman"
+	name = "Plasmaman Medical"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/medical
 	uniform = /obj/item/clothing/under/plasmaman/medical
 
 /datum/outfit/plasmaman/cmo
-	name = "Chief Medical Officer Plasmaman"
+	name = "Plasmaman Chief Medical Officer"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/cmo
 	uniform = /obj/item/clothing/under/plasmaman/cmo
 
 /datum/outfit/plasmaman/viro
-	name = "Virology Plasmaman"
+	name = "Plasmaman Virology"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/viro
 	uniform = /obj/item/clothing/under/plasmaman/viro
 
 /datum/outfit/plasmaman/chemist
-	name = "Chemist Plasmaman"
+	name = "Plasmaman Chemist"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/chemist
 	uniform = /obj/item/clothing/under/plasmaman/chemist
 
 /datum/outfit/plasmaman/genetics
-	name = "Genetics Plasmaman"
+	name = "Plasmaman Genetics"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/genetics
 	uniform = /obj/item/clothing/under/plasmaman/genetics
 
 /datum/outfit/plasmaman/science
-	name = "Science Plasmaman"
+	name = "Plasmaman Science"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/science
 	uniform = /obj/item/clothing/under/plasmaman/science
 
 /datum/outfit/plasmaman/rd
-	name = "Research Director Plasmaman"
+	name = "Plasmaman Research Director"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/rd
 	uniform = /obj/item/clothing/under/plasmaman/rd
 
 /datum/outfit/plasmaman/robotics
-	name = "Robotics Plasmaman"
+	name = "Plasmaman Robotics"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/robotics
 	uniform = /obj/item/clothing/under/plasmaman/robotics
 
 /datum/outfit/plasmaman/engineering
-	name = "Engineering Plasmaman"
+	name = "Plasmaman Engineering"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	uniform = /obj/item/clothing/under/plasmaman/engineering
 
 /datum/outfit/plasmaman/ce
-	name = "Chief Engineer Plasmaman"
+	name = "Plasmaman Chief Engineer"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering/ce
 	uniform = /obj/item/clothing/under/plasmaman/engineering/ce
 
 /datum/outfit/plasmaman/atmospherics
-	name = "Atmospherics Plasmaman"
+	name = "Plasmaman Atmospherics"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/atmospherics
 	uniform = /obj/item/clothing/under/plasmaman/atmospherics
@@ -160,25 +160,25 @@
 	mask = /obj/item/clothing/mask/gas/clown_hat
 
 /datum/outfit/plasmaman/hop
-	name = "Head of Personnel Plasmaman"
+	name = "Plasmaman Head of Personnel"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/hop
 	uniform = /obj/item/clothing/under/plasmaman/hop
 
 /datum/outfit/plasmaman/captain
-	name = "Captain Plasmaman"
+	name = "Plasmaman Captain"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/captain
 	uniform = /obj/item/clothing/under/plasmaman/captain
 
 /datum/outfit/plasmaman/blueshield
-	name = "Blueshield Plasmaman"
+	name = "Plasmaman Blueshield"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blueshield
 	uniform = /obj/item/clothing/under/plasmaman/blueshield
 
 /datum/outfit/plasmaman/wizard
-	name = "Wizard Plasmaman"
+	name = "Plasmaman Wizard"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/wizard
 	uniform = /obj/item/clothing/under/plasmaman/wizard

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -666,17 +666,19 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	message_admins("<span class='notice'>[key_name_admin(usr)] changed the equipment of [key_name_admin(M)] to [dresscode].</span>", 1)
 
 /client/proc/robust_dress_shop()
-	var/list/outfits = list(
+	var/list/special_outfits = list(
 		"Naked",
 		"As Job...",
 		"Custom..."
 	)
 
+	var/list/outfits = list()
 	var/list/paths = subtypesof(/datum/outfit) - typesof(/datum/outfit/job)
 	for(var/path in paths)
 		var/datum/outfit/O = path //not much to initalize here but whatever
 		if(initial(O.can_be_admin_equipped))
 			outfits[initial(O.name)] = path
+	outfits = special_outfits + sortTim(outfits, cmp=/proc/cmp_text_asc)
 
 	var/dresscode = input("Select outfit", "Robust quick dress shop") as null|anything in outfits
 	if(isnull(dresscode))
@@ -692,6 +694,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 			var/datum/outfit/O = path
 			if(initial(O.can_be_admin_equipped))
 				job_outfits[initial(O.name)] = path
+		job_outfits = sortTim(job_outfits, cmp=/proc/cmp_text_asc)
 
 		dresscode = input("Select job equipment", "Robust quick dress shop") as null|anything in job_outfits
 		dresscode = job_outfits[dresscode]

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -678,7 +678,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		var/datum/outfit/O = path //not much to initalize here but whatever
 		if(initial(O.can_be_admin_equipped))
 			outfits[initial(O.name)] = path
-	outfits = special_outfits + sortTim(outfits, cmp=/proc/cmp_text_asc)
+	outfits = special_outfits + sortTim(outfits, /proc/cmp_text_asc)
 
 	var/dresscode = input("Select outfit", "Robust quick dress shop") as null|anything in outfits
 	if(isnull(dresscode))
@@ -694,7 +694,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 			var/datum/outfit/O = path
 			if(initial(O.can_be_admin_equipped))
 				job_outfits[initial(O.name)] = path
-		job_outfits = sortTim(job_outfits, cmp=/proc/cmp_text_asc)
+		job_outfits = sortTim(job_outfits, /proc/cmp_text_asc)
 
 		dresscode = input("Select job equipment", "Robust quick dress shop") as null|anything in job_outfits
 		dresscode = job_outfits[dresscode]

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -9,7 +9,7 @@
 	outfit = /datum/outfit/syndicatesoldiercorpse
 
 /datum/outfit/syndicatesoldiercorpse
-	name = "Syndicate Operative Corpse"
+	name = "Corpse of a Syndicate Operative"
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/combat
@@ -31,7 +31,7 @@
 	outfit = /datum/outfit/syndicatecommandocorpse
 
 /datum/outfit/syndicatecommandocorpse
-	name = "Syndicate Commando Corpse"
+	name = "Corpse of a Syndicate Commando"
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	shoes = /obj/item/clothing/shoes/combat
@@ -59,7 +59,7 @@
 	outfit = /datum/outfit/piratecorpse
 
 /datum/outfit/piratecorpse
-	name = "Pirate Corpse"
+	name = "Corpse of a Pirate"
 	uniform = /obj/item/clothing/under/pirate
 	shoes = /obj/item/clothing/shoes/jackboots
 	glasses = /obj/item/clothing/glasses/eyepatch
@@ -72,7 +72,7 @@
 	outfit = /datum/outfit/piratecorpse/ranged
 
 /datum/outfit/piratecorpse/ranged
-	name = "Pirate Gunner Corpse"
+	name = "Corpse of a Pirate Gunner"
 	suit = /obj/item/clothing/suit/pirate_black
 	head = /obj/item/clothing/head/pirate
 
@@ -85,7 +85,7 @@
 	outfit = /datum/outfit/russiancorpse
 
 /datum/outfit/russiancorpse
-	name = "Russian Corpse"
+	name = "Corpse of a Russian"
 	uniform = /obj/item/clothing/under/soviet
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/bearpelt
@@ -95,12 +95,12 @@
 	outfit = /datum/outfit/russiancorpse/ranged
 
 /datum/outfit/russiancorpse/ranged
-	name = "Ranged Russian Corpse"
+	name = "Corpse of a Ranged Russian"
 	head = /obj/item/clothing/head/ushanka
 
 
 /obj/effect/mob_spawn/human/corpse/wizard
-	name = "Space Wizard Corpse"
+	name = "Corpse of a Space Wizard"
 	outfit = /datum/outfit/wizardcorpse
 
 /obj/effect/mob_spawn/human/corpse/clownoff/Initialize(mapload)
@@ -108,7 +108,7 @@
 	. = ..()
 
 /datum/outfit/wizardcorpse
-	name = "Space Wizard Corpse"
+	name = "Corpse of a Space Wizard"
 	uniform = /obj/item/clothing/under/color/lightpurple
 	suit = /obj/item/clothing/suit/wizrobe
 	shoes = /obj/item/clothing/shoes/sandal


### PR DESCRIPTION
## What Does This PR Do
Presents outfits in "select equipment" debug menu in alphabetical order

## Why It's Good For The Game
Simplifies debugging. You would no longer need to spend 10 seconds per run trying to get yourself dressed.

## Images of changes
![o9ZiDMOOtZ](https://user-images.githubusercontent.com/7831163/96354634-3f833880-10c8-11eb-813c-33143707c0b8.gif)


## Changelog
:cl:
tweak: 'Select equipment' debug menu is alphabetized now.
/:cl: