### PR TITLE
Foam darts should fall to the ground, not into nullspace.

### DIFF
--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -42,7 +42,7 @@
 	if(dropped)
 		return
 	dropped = 1
-	var/obj/item/ammo_casing/caseless/foam_dart/newdart = new ammo_type(loc)
+	var/obj/item/ammo_casing/caseless/foam_dart/newdart = new ammo_type(get_turf(src))
 	var/obj/item/ammo_casing/caseless/foam_dart/old_dart = ammo_casing
 	newdart.modified = old_dart.modified
 	if(pen)


### PR DESCRIPTION
## What Does This PR Do
Fixes #14581 
When you shoot at someone point-blank, the projectile hits them while it is still in the casing. The foam dart code creates a new replacement dart at the location of the projectile - which works fine for projectiles actually in flight, but breaks for those still in the gun (we create a new casing inside the casing, and then the casing gets garbage-collected).
But what we actually want is create the replacement dart on the floor (turf). This pr fixes that.

## Why It's Good For The Game
bugfix, consistency

## Changelog
:cl:
fix: foam darts no longer get lost when shot point-blank
/:cl:
