### PR TITLE
AFK cryoing and window flashing preferences are respected again

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -469,7 +469,7 @@
 		var/mob/M = C
 		if(M.client)
 			C = M.client
-	if(!C || !C.prefs.toggles2 & PREFTOGGLE_2_WINDOWFLASHING)
+	if(!C || !(C.prefs.toggles2 & PREFTOGGLE_2_WINDOWFLASHING))
 		return
 	winset(C, "mainwindow", "flash=5")
 

--- a/code/controllers/subsystem/afk.dm
+++ b/code/controllers/subsystem/afk.dm
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(afk)
 		var/turf/T
 		// Only players and players with the AFK watch enabled
 		// No dead, unconcious, restrained, people without jobs or people on other Z levels than the station
-		if(!H.client || !H.client.prefs.toggles2 & PREFTOGGLE_2_AFKWATCH || !H.mind || \
+		if(!H.client || !(H.client.prefs.toggles2 & PREFTOGGLE_2_AFKWATCH) || !H.mind || \
 			H.stat || H.restrained() || !H.job || !is_station_level((T = get_turf(H)).z)) // Assign the turf as last. Small optimization
 			if(afk_players[H.ckey])
 				toRemove += H.ckey


### PR DESCRIPTION
## What Does This PR Do
Makes it so that the AFK cryoing and window flashing preferences are respected again.
Mistake made by the toggles2 PR. Order of operations breaks the current logic.

## Why It's Good For The Game
Bug fixes are good

## Changelog
:cl:
fix: The AFK cryoing preference is respected again by the game
fix: The window flashing preference is respected again by the game
/:cl: