### PR TITLE
[WIP] Different Bleeding for Slippery Exotic Blood

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -30,6 +30,7 @@
 	var/drink_icon = null
 	var/drink_name = "Glass of ..what?"
 	var/drink_desc = "You can't really tell what this is."
+	var/slippery = FALSE
 	var/taste_mult = 1 //how easy it is to taste - the more the easier
 	var/taste_description = "metaphorical salt"
 

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -385,6 +385,7 @@
 	name = "Corn Oil"
 	id = "cornoil"
 	description = "An oil derived from various types of corn."
+	slippery = TRUE
 	reagent_state = LIQUID
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" // rgb: 48, 32, 0

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -25,6 +25,7 @@
 	M.water_act(volume, water_temperature, src, method)
 
 /datum/reagent/water/reaction_turf(turf/T, volume)
+	slippery = TRUE
 	T.water_act(volume, water_temperature, src)
 	var/obj/effect/acid/A = (locate(/obj/effect/acid) in T)
 	if(A)
@@ -40,6 +41,7 @@
 	reagent_state = LIQUID
 	color = "#1BB1AB"
 	harmless = TRUE
+	slippery = TRUE
 	taste_description = "cherry"
 
 /datum/reagent/lube/reaction_turf(turf/simulated/T, volume)
@@ -54,6 +56,7 @@
 	reagent_state = LIQUID
 	color = "#61C2C2"
 	harmless = TRUE
+	slippery = TRUE
 	taste_description = "floor cleaner"
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, volume)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -264,8 +264,8 @@
 			var/list/b_data = get_blood_data(get_blood_id())
 			drop.transfer_mob_blood_dna(src)
 			drop.basecolor = b_data["blood_color"]
-		else
-			drop.blood_DNA["Exotic Species DNA"] = "Belongs to an exotic crewmember *"
+		//else
+			//drop.blood_DNA["Exotic Species DNA"] = "Belongs to an exotic crewmember *"
 		if(drop)
 			if(drop.drips < 5)
 				drop.drips++
@@ -292,8 +292,8 @@
 			B.bloodiness += BLOOD_AMOUNT_PER_DECAL
 		if(has_dna)
 			B.transfer_mob_blood_dna(src) //give blood info to the blood decal.
-		else
-			B.blood_DNA["Exotic Species DNA"] = "Belongs to an exotic crewmember *"
+	//	else
+	//		B.blood_DNA["Exotic Species DNA"] = "Belongs to an exotic crewmember *"
 		if(temp_blood_DNA)
 			B.blood_DNA |= temp_blood_DNA
 		B.pixel_x = (shift_x)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## Please Note
Alternative to https://github.com/ParadiseSS13/Paradise/pull/14665 PR
This is not intended to "compete" with that PR and is not intended to be an attack or send any sort of "message". @Qwertytoforty and I were both involved in a conversation regarding Slime People blood and concerns over balance issues related to it a few days ago. I am in no way disagreeing with Qwerty's approach - in my honest opinion, I think it's a very pragmatic and fair way to go about addressing the concerns folks have raised.
 
It's become clear that, one way or another, several people are unhappy with the current status of Slime People's blood. However, it is also unclear how _many_  people are upset. Either way, the comments on Qwerty's PR and the discussion that ensued in #coding_chat on the Discord server following the posting of this WIP PR made it clear that this is **quite** a controversial issue.

The this PR addresses one of the issues raised (Slime Blood is Water and Water is slippery) with a different approach than https://github.com/ParadiseSS13/Paradise/pull/14665 (Qwerty's replaces the blood with Slime Jelly and mine makes it so a "fake" blood splatter is placed on the floor instead of any slippery reagent. Qwerty's PR also addresses other claims of balance issues related to Slime People blood.

This was originally meant for my own fork as a Proof of Concept to @SteelSlayer in discussion regarding Slime People blood - I I like to use projects to learn better ways of coding. I'm sure there are plenty of improvements to be made.

## What Does This PR Do
1.) Labels Reagents which make turf slippery (e.g. cause `MakeSlippery()`) with a new flag called `slippery`.
2.) Prevents `blood.dm` from affecting the turf when a species with an `exotic_blood` reagent that is `slippery` bleeds.
3.) Otherwise retains the turf reaction for `exotic_blood` species' blood (Slime People currently the only species using it)
4.) Creates new variable inside the `add_splatter_floor()` proc called `has_dna` which is used to prevent `exotic_blood` from putting DNA information into its blood splatters (i.e. forensic analyzers cannot detect dna from it, the "blood" cannot be used for Stable Mutagen or anything)
 TL;DR: Slime People retain water as blood, but bleeding produces blood splatter, not wet floor tiles.

To do: have blood color based on the body color (can do this on the species), make the fake blood decals for Slime People blood translucent (add alpha layer)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Okay, look, it makes Slime People not bleed Water, but they keep Water as blood. The fake blood they bleed doesn't contain DNA, so you can't yeet that blood into your syringe or whatnot and try to clone them with Stable Mutagen. Does it address other issues people see as unbalanced regarding Slime People blood being Water? No. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/69871346/96389236-5b481680-117c-11eb-8394-8ede6ea9e396.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: New Reagent flag for "slippery" reagents
tweak: Changed how bleeding for exotic blood species. Because Slime People are the only species with exotic blood right now, the only effects are seen on their bleeding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
