### PR TITLE
Gives syndicate consoles syndicate bubbles

### DIFF
--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -13,6 +13,7 @@
 	icon_screen = "tcboss"
 	light_color = LIGHT_COLOR_PURE_CYAN
 	req_access = list(ACCESS_SYNDICATE)
+	bubble_icon = "syndibot"
 	var/security_lockout = FALSE
 	var/sound_yes = 'sound/machines/twobeep.ogg'
 	var/sound_no = 'sound/machines/buzz-sigh.ogg'

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -17,6 +17,7 @@ GLOBAL_VAR_INIT(syndicate_elite_shuttle_timeleft, 0)
 	icon_screen = "syndishuttle"
 	light_color = LIGHT_COLOR_PURE_CYAN
 	req_access = list(ACCESS_SYNDICATE)
+	bubble_icon = "syndibot"
 	var/temp = null
 	var/hacked = 0
 	var/allowedtocall = 0

--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -24,6 +24,7 @@
 
 /mob/living/silicon/decoy/syndicate
 	faction = list("syndicate")
+	bubble_icon = "syndibot"
 	name = "R.O.D.G.E.R"
 	desc = "Red Operations, Depot General Emission Regulator"
 	icon_state = "ai-magma"

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -5,6 +5,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
+	bubble_icon = "syndibot"
 	circuit = /obj/item/circuitboard/shuttle/syndicate
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_z3;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"
@@ -46,6 +47,7 @@
 	icon_keyboard = "syndie_key"
 	icon_screen = "syndishuttle"
 	req_access = list(ACCESS_SYNDICATE)
+	bubble_icon = "syndibot"
 	shuttleId = "sst"
 	possible_destinations = "sst_home;sst_away;sst_custom"
 	resistance_flags = INDESTRUCTIBLE
@@ -56,6 +58,7 @@
 	icon_keyboard = "syndie_key"
 	icon_screen = "syndishuttle"
 	req_access = list(ACCESS_SYNDICATE)
+	bubble_icon = "syndibot"
 	shuttleId = "sit"
 	possible_destinations = "sit_arrivals;sit_engshuttle;sit_away;sit_custom"
 	resistance_flags = INDESTRUCTIBLE
@@ -67,6 +70,7 @@
 	icon_keyboard = "syndie_key"
 	shuttleId = "syndicate"
 	shuttlePortId = "syndicate_custom"
+	bubble_icon = "syndibot"
 	view_range = 13
 	x_offset = -5
 	y_offset = -1
@@ -78,6 +82,7 @@
 	desc = "Used to designate a precise transit location for the SST shuttle."
 	shuttleId = "sst"
 	shuttlePortId = "sst_custom"
+	bubble_icon = "syndibot"
 	view_range = 13
 	x_offset = 0
 	y_offset = 0
@@ -87,6 +92,7 @@
 	desc = "Used to designate a precise transit location for the SIT shuttle."
 	shuttleId = "sit"
 	shuttlePortId = "sit_custom"
+	bubble_icon = "syndibot"
 	view_range = 13
 	x_offset = 0
 	y_offset = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR changes the bubble_icon of the syndicate shuttle consoles, depot consoles, and R.O.D.G.E.R, to the bubble icon of "syndibot".

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Evil syndicate computer speech bubbles for evil syndicate computers is good.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

Before:

![image](https://user-images.githubusercontent.com/52090703/96500761-57b89c00-121d-11eb-9d80-8f07868d29c1.png)

After:

![image](https://user-images.githubusercontent.com/52090703/96500727-4a031680-121d-11eb-9464-d58aa0a4bab2.png)

## Changelog
:cl:
tweak: Syndicate consoles use syndicate robotic speech bubbles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
