### PR TITLE
Makes ablative armor always have a chance to reflect lasers

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -244,9 +244,7 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/hit_reflect_chance = 40
 
-/obj/item/clothing/suit/armor/laserproof/IsReflect(var/def_zone)
-	if(!(def_zone in list("chest", "groin"))) //If not shot where ablative is covering you, you don't get the reflection bonus!
-		return 0
+/obj/item/clothing/suit/armor/laserproof/IsReflect()
 	if(prob(hit_reflect_chance))
 		return 1
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -236,7 +236,7 @@
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "Ablative Armor Vest"
-	desc = "A vest that excels in protecting the wearer against energy projectiles."
+	desc = "A vest that excels in protecting the wearer against energy projectiles. Projects an energy field arround the user, allowing a chance of energy projectile deflection no matter where on the user it would hit."
 	icon_state = "armor_reflec"
 	item_state = "armor_reflec"
 	blood_overlay_type = "armor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR removes the defense zone check of ablative armor when it comes to reflecting energy projectiles. This means all incoming energy attacks have a chance to be reflected, instead of just chest. This does not change the areas that it gives armor protection, it still only reduces damage to the chest and lower body. 

Also adds a description that it has a chance to reflect energy projectiles anywhere on the user in the description of the armor.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ablative armor is well, not used much. Most people prefer ballistics, which this armor barely even protects against, and even if someone is using energy weapons on you, they aim for your head, or hands, or literally anywhere else than your torso, and the armor has no affect. Syndicate are also interested in this piece of armor, despite its current little to no use. 

This PR makes the armor a bit more valuable in combat, by making it similar in activation to reactive armor, which activates wherever the host is hit, and applying such an idea to the ablative. Now, you can avoid hitting their armored torso that halfs the energy / laser damage, but there is still the 40% chance the reflective armor reflects it. This also will not make the user unstoppable by any means, as shotguns and other ballistics will not be blocked and still do 90% of their original damage. 


## Changelog
:cl:
tweak: Ablative armor now has a 40% chance chance to reflect energy projectiles no matter where you are targeted, instead of just the torso and lower body.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
