### PR TITLE
Makes the healing guardian not take more damage in healing mode

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/healer.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/healer.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/guardian/healer
 	friendly = "heals"
 	speed = 0
+	damage_transfer = 0.7
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	playstyle_string = "As a <b>Support</b> type, you may toggle your basic attacks to a healing mode. In addition, Alt-Clicking on an adjacent mob will warp them to your bluespace beacon after a short delay."
@@ -67,9 +68,6 @@
 			a_intent = INTENT_HARM
 			hud_used.action_intent.icon_state = a_intent
 			speed = 0
-			damage_transfer = 0.7
-			if(admin_spawned)
-				damage_transfer = 0
 			melee_damage_lower = 15
 			melee_damage_upper = 15
 			to_chat(src, "<span class='danger'>You switch to combat mode.</span>")
@@ -78,9 +76,6 @@
 			a_intent = INTENT_HELP
 			hud_used.action_intent.icon_state = a_intent
 			speed = 1
-			damage_transfer = 1
-			if(admin_spawned)
-				damage_transfer = 0
 			melee_damage_lower = 0
 			melee_damage_upper = 0
 			to_chat(src, "<span class='danger'>You switch to healing mode.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR makes healing guardian always have a flat damage transfer rate of 0.7, or 70%, instead of becoming 1, or 100% damage transfer, when in heal mode.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Healing guardian is a nice guardian that could use a little love to make it a bit more common, and a nice way to make it do that is to not make it loose armor in heal mode. Why did it loose armor in heal mode? Probably so it could heal and drag away the user, but, 30% is not that much in the end. In any case, this means it's a little more sturdy when healing, and this wont overly change its combat abilities, as you do not heal in combat, and it's healing rate is unchanged.

## Changelog
:cl:
tweak: Healing guardian now always has a damage transfer rate of 70%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
