### PR TITLE
Fixes recursive loop in client/Topic

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -264,6 +264,7 @@
 		to_chat(src, "<span class='notice'>SSD warning acknowledged.</span>")
 	if(href_list["link_forum_account"])
 		link_forum_account()
+		return // prevents a recursive loop where the ..() 5 lines after this makes the proc endlessly re-call itself
 	switch(href_list["action"])
 		if("openLink")
 			src << link(href_list["link"])


### PR DESCRIPTION
## What Does This PR Do
Fixes an loop that can happen in client/Topic() when linking a forum account by clicking the "VERIFY FORUM ACCOUNT" which pops up when you connect to the server.

From stepping through it with a debugger, I've determined that the "..()" on client/Topic line 242 is calling client/Topic() itself somehow. That can result in a loop where client/Topic() is called 9-200 times for a single user button press.

## Changelog
:cl: Kyep
fix: fixed an recursive loop that could happen while linking a forum account.
/:cl: