### PR TITLE
Fix runtime in eyes_shine

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -549,14 +549,14 @@
 	var/obj/item/storage/wallet/W
 	var/active_hand = get_active_hand()
 	var/inactive_hand = get_inactive_hand()
-	
+
 	//ID
 	if(istype(active_hand, /obj/item/card/id) || istype(inactive_hand, /obj/item/card/id))
 		if(istype(active_hand, ID))
 			ID = active_hand
 		else
 			ID = inactive_hand
-	
+
 	//PDA
 	else if(istype(active_hand, /obj/item/pda) || istype(inactive_hand, /obj/item/pda))
 		if(istype(active_hand, PDA))
@@ -1510,14 +1510,13 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 /mob/living/carbon/human/proc/eyes_shine()
 	var/obj/item/organ/internal/eyes/eyes = get_int_organ(/obj/item/organ/internal/eyes)
 	var/obj/item/organ/internal/cyberimp/eyes/eye_implant = get_int_organ(/obj/item/organ/internal/cyberimp/eyes)
-	if(!(istype(eyes) || istype(eye_implant)))
-		return FALSE
 	if(!get_location_accessible(src, "eyes"))
 		return FALSE
-	if(!(eyes.shine()) && !istype(eye_implant) && !(XRAY in mutations)) //If their eyes don't shine, they don't have other augs, nor do they have X-RAY vision
-		return FALSE
+	// Natural eyeshine, any implants, and XRAY - all give shiny appearance.
+	if((istype(eyes) && eyes.shine()) || istype(eye_implant) || (XRAY in mutations))
+		return TRUE
 
-	return TRUE
+	return FALSE
 
 /mob/living/carbon/human/assess_threat(var/mob/living/simple_animal/bot/secbot/judgebot, var/lasercolor)
 	if(judgebot.emagged == 2)


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime. Currently, if you are a slime, have no eyewear and get any eye implant - you'd trigger this runtime, and your eyes won't shine. Have you ever seen a slime with shining eyes? Well, that's why.

## Why It's Good For The Game
Bugfix.
This is honestly very small and irrelevant. I thought about rolling it up with other small and easy runtime fixes, but those others happened to not be small and easy...

## Images of changes
Shiny!
![dreamseeker-20201020-005321](https://user-images.githubusercontent.com/7831163/96535058-8caa0a80-1280-11eb-821d-0fb1e2c600c1.png)


## Changelog
:cl:
/:cl:
(not worth mentioning in CL)