### PR TITLE
Save atklog preference only once

### DIFF
--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -88,7 +88,6 @@
 					volume='[volume]',
 					lastchangelog='[lastchangelog]',
 					clientfps='[clientfps]',
-					atklog='[atklog]',
 					parallax='[parallax]'
 					WHERE ckey='[C.ckey]'"}
 					)


### PR DESCRIPTION
## What Does This PR Do
This PR removes a doubled up line in the query to save player preferences.
`atklog` doesn't need to be saved on Line 91 because it's saved on Line 86

## Why It's Good For The Game
This PR doesn't modify the game, it's a simple tidy of backend query stuff.
