### PR TITLE
Remove redundant ghost_radio preference handler

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2055,9 +2055,6 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				if("ghost_radio")
 					toggles ^= PREFTOGGLE_CHAT_GHOSTRADIO
 
-				if("ghost_radio")
-					toggles ^= PREFTOGGLE_CHAT_GHOSTRADIO
-
 				if("ghost_pda")
 					toggles ^= PREFTOGGLE_CHAT_GHOSTPDA
 


### PR DESCRIPTION
## What Does This PR Do
This PR removes a redundant `"ghost_radio"` case in the handling of preference toggles.
It is a duplicate of the lines immediately above.

## Why It's Good For The Game
This PR does not modify the game. It is a simple tidy of backend preference handling code.
