### PR TITLE
Fixes a runtime in the netherworld link

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -101,7 +101,7 @@
 		if(M)
 			playsound(src, 'sound/magic/demon_consume.ogg', 50, TRUE)
 			M.adjustBruteLoss(60)
-			new /obj/effect/gibspawner/generic(get_turf(M), M)
+			new /obj/effect/gibspawner/generic(get_turf(M), M.dna)
 			if(M.stat == DEAD)
 				var/mob/living/simple_animal/hostile/netherworld/blankbody/blank
 				blank = new(loc)


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime when somebody goes into the netherworld link and should get devoured but instead causes a runtime each process tick

## Why It's Good For The Game
Bugs be gone

## Changelog
:cl:
fix: Netherworld links now properly kill people inside of it and spawn mobs based on the dead inside
/:cl: