### PR TITLE
Fixes ghosts unable to pass gateway

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -84,17 +84,13 @@
 		user.forceMove(get_turf(target))
 
 /obj/machinery/gateway/centerstation/attack_ghost(mob/user as mob)
-	if(!awaygate)
-		awaygate = locate(/obj/machinery/gateway/centeraway) in GLOB.machines
-		if(!awaygate)
-			to_chat(user, "<span class='warning'>Error: No destination found.</span>")
-			return
-	user.forceMove(awaygate.loc)
+	if(awaygate)
+		user.forceMove(awaygate.loc)
+	else
+		to_chat(user, "[src] has no destination.")
 
 /obj/machinery/gateway/centeraway/attack_ghost(mob/user as mob)
-	if(!stationgate)
-		stationgate = locate(/obj/machinery/gateway/centerstation) in GLOB.machines
-		if(!stationgate)
-			to_chat(user, "<span class='warning'>Error: No destination found.</span>")
-			return
-	user.forceMove(stationgate.loc)
+	if(stationgate)
+		user.forceMove(stationgate.loc)
+	else
+		to_chat(user, "[src] has no destination.")

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -86,11 +86,15 @@
 /obj/machinery/gateway/centerstation/attack_ghost(mob/user as mob)
 	if(awaygate)
 		user.forceMove(awaygate.loc)
+	else if(user.can_admin_interact())
+		attack_hand(user)
 	else
 		to_chat(user, "[src] has no destination.")
 
 /obj/machinery/gateway/centeraway/attack_ghost(mob/user as mob)
 	if(stationgate)
 		user.forceMove(stationgate.loc)
+	else if(user.can_admin_interact())
+		attack_hand(user)
 	else
 		to_chat(user, "[src] has no destination.")

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -84,17 +84,17 @@
 		user.forceMove(get_turf(target))
 
 /obj/machinery/gateway/centerstation/attack_ghost(mob/user as mob)
-	if(awaygate)
-		user.forceMove(awaygate.loc)
-	else if(user.can_admin_interact())
-		attack_hand(user)
-	else
-		to_chat(user, "[src] has no destination.")
+	if(!awaygate)
+		awaygate = locate(/obj/machinery/gateway/centeraway) in GLOB.machines
+		if(!awaygate)
+			to_chat(user, "<span class='warning'>Error: No destination found.</span>")
+			return
+	user.forceMove(awaygate.loc)
 
 /obj/machinery/gateway/centeraway/attack_ghost(mob/user as mob)
-	if(stationgate)
-		user.forceMove(stationgate.loc)
-	else if(user.can_admin_interact())
-		attack_hand(user)
-	else
-		to_chat(user, "[src] has no destination.")
+	if(!stationgate)
+		stationgate = locate(/obj/machinery/gateway/centerstation) in GLOB.machines
+		if(!stationgate)
+			to_chat(user, "<span class='warning'>Error: No destination found.</span>")
+			return
+	user.forceMove(stationgate.loc)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -159,7 +159,7 @@
 	var/simultaneous_pm_warning_timeout = 100
 
 	var/assistant_maint = 0 //Do assistants get maint access?
-	var/gateway_delay = 6000 //How long the gateway takes before it activates. Default is half an hour.
+	var/gateway_delay = 6000
 	var/ghost_interaction = 0
 
 	var/comms_password = ""

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -47,7 +47,10 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 /obj/machinery/gateway/centerstation/Initialize()
 	..()
 	update_icon()
-	wait = world.time + config.gateway_delay	//+ thirty minutes default
+	wait = world.time + config.gateway_delay
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/gateway/centerstation/LateInitialize()
 	awaygate = locate(/obj/machinery/gateway/centeraway) in GLOB.machines
 
 /obj/machinery/gateway/centerstation/update_density_from_dir()

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -107,7 +107,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 		if(!awaygate)
 			to_chat(user, "<span class='notice'>Error: No destination found.</span>")
 			return
-	if(world.time < wait && !user.can_admin_interact())
+	if(world.time < wait)
 		to_chat(user, "<span class='notice'>Error: Warpspace triangulation in progress. Estimated time to completion: [round(((wait - world.time) / 10) / 60)] minutes.</span>")
 		return
 

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -107,7 +107,7 @@ GLOBAL_DATUM_INIT(the_gateway, /obj/machinery/gateway/centerstation, null)
 		if(!awaygate)
 			to_chat(user, "<span class='notice'>Error: No destination found.</span>")
 			return
-	if(world.time < wait)
+	if(world.time < wait && !user.can_admin_interact())
 		to_chat(user, "<span class='notice'>Error: Warpspace triangulation in progress. Estimated time to completion: [round(((wait - world.time) / 10) / 60)] minutes.</span>")
 		return
 


### PR DESCRIPTION
## What Does This PR Do
Ghosts can now always pass through the gateway, so long as an away mission is loaded.
Previously, they could get "the gateway has no destination" if they clicked the gate before a human touched it.

## Changelog
:cl: Kyep
fix: ghosts can now pass through the gateway to/from away missions even if a human has not touched it yet.
/:cl: