### PR TITLE
Helpful intent prevents harm

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -12,6 +12,8 @@
 
 
 /obj/item/melee/cultblade/attack(mob/living/target as mob, mob/living/carbon/human/user as mob)
+	if(user.a_intent == INTENT_HELP)
+		return ..()
 	if(!iscultist(user))
 		user.Weaken(5)
 		user.unEquip(src, 1)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -153,7 +153,7 @@
 			to_chat(user, "<span class='notice'>Nothing happens.</span>")
 
 /obj/machinery/portable_atmospherics/attacked_by(obj/item/I, mob/user)
-	if(I.force < 10 && !(stat & BROKEN))
+	if(I.force < 10 && !(stat & BROKEN) || user.a_intent == INTENT_HELP)
 		take_damage(0)
 	else
 		add_fingerprint(user)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -384,6 +384,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		else
 			to_chat(user, "<span class='notice'>Access denied.</span>")
 
+	else if(user.a_intent == INTENT_HELP)
+		return ..()
 	else
 		//if the turret was attacked with the intention of harming it:
 		user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -40,6 +40,8 @@
 /obj/machinery/shield/attackby(obj/item/I, mob/user, params)
 	if(!istype(I))
 		return
+	if(user.a_intent == INTENT_HELP)
+		return ..()
 
 	//Calculate damage
 	var/aforce = I.force

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -46,7 +46,7 @@
 	// Why yes, this does closely resemble mob and object attack code.
 	if(I.flags & NOBLUDGEON)
 		return
-	if(!I.force)
+	if(!I.force || user.a_intent == INTENT_HELP)
 		playsound(loc, 'sound/weapons/tap.ogg', 20, 1, -1)
 	else if(I.hitsound)
 		playsound(loc, I.hitsound, 20, 1, -1)
@@ -54,7 +54,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src)
 
-	if(I.force)
+	if(I.force && user.a_intent != INTENT_HELP)
 		user.visible_message("<span class='danger'>[user] has hit \
 			[src] with [I]!</span>", "<span class='danger'>You hit [src] \
 			with [I]!</span>")

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -82,6 +82,8 @@
 
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)
+	if(user.a_intent == INTENT_HELP)
+		return ..()
 	if(!tank)
 		to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
 		return

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -29,7 +29,7 @@
 				to_chat(user, "<span class = 'caution'> You disable the locking modules.</span>")
 				update_icon()
 			return
-		else if(istype(O, /obj/item))
+		else if(user.a_intent != INTENT_HELP && istype(O, /obj/item))
 			user.changeNext_move(CLICK_CD_MELEE)
 			var/obj/item/W = O
 			if(smashed || localopened)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -481,6 +481,8 @@
 		wither()
 
 /obj/structure/spacevine/attacked_by(obj/item/I, mob/living/user)
+	if(user.a_intent == INTENT_HELP)
+		return ..()
 	var/damage_dealt = I.force
 	if(istype(I, /obj/item/scythe))
 		var/obj/item/scythe/S = I

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -197,9 +197,11 @@
 			message_admins("[key_name_admin(user)] set [key_name_admin(M)] on fire")
 			log_game("[key_name(user)] set [key_name(M)] on fire")
 
-/obj/item/grown/novaflower/afterattack(atom/A as mob|obj, mob/user,proximity)
+/obj/item/grown/novaflower/afterattack(atom/A as mob|obj, mob/user, proximity)
 	if(!proximity)
 		return
+	if(user.a_intent != INTENT_HELP)
+		return ..()
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1)
 	else

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -69,6 +69,11 @@
 /obj/item/grown/nettle/afterattack(atom/A as mob|obj, mob/user,proximity)
 	if(!proximity)
 		return
+	if(user.a_intent == INTENT_HELP)
+		// This is stupid - we should definitely be hitting folks even if we don't mean to.
+		// However nettles are pretty much the only example of the thing where INTENT_HELP
+		// should not - "realistically" - help, and I'd rather not snowflake that.
+		return ..()
 	if(force > 0)
 		force -= rand(1, (force / 3) + 1) // When you whack someone with it, leaves fall off
 	else
@@ -106,6 +111,8 @@
 
 /obj/item/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
 	..()
+	if(user.a_intent == INTENT_HELP)
+		return
 	if(isliving(M))
 		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of the Deathnettle!</span>")
 		add_attack_logs(user, M, "Hit with [src]")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -24,7 +24,7 @@ emp_act
 			var/list/safe_list = list(/obj/item/projectile/beam/lasertag, /obj/item/projectile/beam/practice)
 			if(is_type_in_list(P, safe_list)) //And it's safe
 				visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
-				   "<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")		
+				   "<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
 				P.reflect_back(src)
 				return -1 // complete projectile permutation
 
@@ -423,7 +423,7 @@ emp_act
 
 	var/weakness = check_weakness(I,user)
 
-	if(!I.force)
+	if(!I.force || user.a_intent == INTENT_HELP)
 		return 0 //item force is zero
 
 	var/armor = run_armor_check(affecting, "melee", "<span class='warning'>Your armour has protected your [hit_area].</span>", "<span class='warning'>Your armour has softened hit to your [hit_area].</span>", armour_penetration = I.armour_penetration)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -367,7 +367,7 @@
 			to_chat(user, "<span class='notice'>All [name]'s systems are nominal.</span>")
 
 		return
-	else if(W.force)
+	else if(W.force && user.a_intent != INTENT_HELP)
 		visible_message("<span class='danger'>[user.name] attacks [src] with [W]!</span>")
 		adjustBruteLoss(W.force)
 	else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -903,7 +903,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 
 
 /mob/living/silicon/robot/attacked_by(obj/item/I, mob/living/user, def_zone)
-	if(I.force && I.damtype != STAMINA && stat != DEAD) //only sparks if real damage is dealt.
+	if(I.force && I.damtype != STAMINA && stat != DEAD && user.a_intent != INTENT_HELP) //only sparks if real damage is dealt.
 		spark_system.start()
 	..()
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -178,7 +178,8 @@
 	if(istype(W, /obj/item/weldingtool) && user.a_intent != INTENT_HARM) // Any intent but harm will heal, so we shouldn't get angry.
 		return
 	if(!istype(W, /obj/item/screwdriver) && (!target)) // Added check for welding tool to fix #2432. Welding tool behavior is handled in superclass.
-		if(W.force && W.damtype != STAMINA)//If force is non-zero and damage type isn't stamina.
+		// If the user means to and able to do harm
+		if(user.a_intent != INTENT_HELP && W.force && W.damtype != STAMINA)
 			retaliate(user)
 			if(lasercolor)//To make up for the fact that lasertag bots don't hunt
 				shootAt(user)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -183,7 +183,11 @@ Auto Patrol: []"},
 	..()
 	if(istype(W, /obj/item/weldingtool) && user.a_intent != INTENT_HARM) // Any intent but harm will heal, so we shouldn't get angry.
 		return
-	if(!istype(W, /obj/item/screwdriver) && (W.force) && (!target) && (W.damtype != STAMINA) ) // Added check for welding tool to fix #2432. Welding tool behavior is handled in superclass.
+	if(istype(W, /obj/item/screwdriver))
+		return
+	if(user.a_intent == INTENT_HELP)
+		return
+	if(!target && W.force && W.damtype != STAMINA ) // Added check for welding tool to fix #2432. Welding tool behavior is handled in superclass.
 		retaliate(user)
 
 /mob/living/simple_animal/bot/secbot/emag_act(mob/user)

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -158,7 +158,7 @@
 		else
 			to_chat(user, "<span class='notice'>[src] won't eat it!</span>")
 		return
-	if(I.force)
+	if(user.a_intent != INTENT_HELP && I.force)
 		Bruise()
 	..()
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -46,7 +46,10 @@
 /mob/living/simple_animal/hostile/syndicate/melee/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src)
-	if(O.force)
+	if(user.a_intent == INTENT_HELP)
+		visible_message("<span class='warning'>[user] gently taps [src] with the [O]. </span>",
+						"<span class='warning'>You gently tap [src] with the [O]. </span>")
+	else if(O.force)
 		if(prob(melee_block_chance))
 			visible_message("<span class='boldwarning'>[src] blocks the [O] with its shield! </span>")
 		else
@@ -60,8 +63,8 @@
 			visible_message("<span class='boldwarning'>[src] has been attacked with the [O] by [user]. </span>")
 		playsound(loc, O.hitsound, 25, 1, -1)
 	else
-		to_chat(usr, "<span class='warning'>This weapon is ineffective, it does no damage.</span>")
-		visible_message("<span class='warning'>[user] gently taps [src] with the [O]. </span>")
+		visible_message("<span class='warning'>[user] gently taps [src] with the [O]. </span>",
+						"<span class='warning'>This weapon is ineffective, it does no damage.</span>")
 
 
 /mob/living/simple_animal/hostile/syndicate/melee/bullet_act(var/obj/item/projectile/Proj)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -250,7 +250,7 @@
 /mob/living/simple_animal/parrot/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	..()
 	if(!stat && !client && !istype(O, /obj/item/stack/medical))
-		if(O.force)
+		if(O.force)  // even on help intent
 			if(parrot_state == PARROT_PERCH)
 				parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
 

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -37,7 +37,10 @@
 	if(istype(O, /obj/item/soulstone))
 		O.transfer_soul("SHADE", src, user)
 	else
-		if(O.force)
+		if(user.a_intent == INTENT_HELP)
+			user.visible_message("<span class='warning'>[user] gently taps [src] with the [O]. </span>",
+								"<span class='warning'>You gently tap [src] with the [O]. </span>")
+		else if(O.force)
 			var/damage = O.force
 			if(O.damtype == STAMINA)
 				damage = 0

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -363,6 +363,8 @@
 		var/obj/item/stack/sheet/mineral/plasma/S = I
 		S.use(1)
 		return
+	if(user.a_intent == INTENT_HELP)
+		return ..()
 	if(I.force > 0)
 		attacked += 10
 		if(prob(25))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -428,7 +428,7 @@
 	else if(status != LIGHT_BROKEN && status != LIGHT_EMPTY)
 
 		user.do_attack_animation(src)
-		if(prob(1 + W.force * 5))
+		if(user.a_intent != INTENT_HELP && prob(1 + W.force * 5))
 
 			user.visible_message("<span class='danger'>[user] smashed the light!</span>", "<span class='danger'>You hit the light, and it smashes!</span>", \
 			"<span class='danger'>You hear the tinkle of breaking glass.</span>")


### PR DESCRIPTION
## What Does This PR Do
Prevents damaging things when on help intent.

## Why It's Good For The Game
Accidentally hitting someone feels bad for both parties.
How often have you swung at a bystander when replacing the floors? How many times have you seen a new doctor robust a dying patient with a defib? Do you remember that time when you wanted to hug your friend, but forgot that you have an desword in hand, and sliced them in half instead?
Well, with this PR all of those nightmares are a things of the past!

And, after all, why do we even need 4 intents, when they are exactly the same 95% of the time?

In action:
![oO2G8XaB8w](https://user-images.githubusercontent.com/7831163/96688890-35d02e00-1371-11eb-865a-eded362c3653.gif)
![IMLTU8DPMD](https://user-images.githubusercontent.com/7831163/96691081-ff47e280-1373-11eb-8823-572a57e3089a.gif)


Tested:
- On Renault (see above)
- Equipment (cameras, ipcs, lights) no longer break on help intent
- Equipment still does break on harm intent
- Terror spiders AI still works, and they still consistently kill hapless dummies

Concerns:
- This only changes melee behavior, not guns (to limit the scope of change, mostly, and also because it's rarer to accidentally fire those, IMO)
- I did *not* remove attack admin logging, out of an abundance of caution (since the attack logs and damage application are handled in separate places. It's possible i've missed a proc or two)
- The attack message on help intent is smaller now, but still might be mistake for a real deal. I don't know if this is a problem. The reason I keep text content as is, is so that we still can see the flavorful on-hit verbs ("cut"/"sliced"/"smacked"/"robusted"/...) even in otherwise peaceful rounds.
- Since this changes such a fundamental aspect of the game, it should probably go through a test merge first.

## Changelog
:cl:
tweak: Hitting things in melee when on Help intent no longer damages them.
/:cl: