### PR TITLE
Removes lag for admins connecting at roundstart

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -113,7 +113,7 @@
 	return
 
 /mob/new_player/Stat()
-	statpanel("Lobby")
+	statpanel("Status")
 	if(client.statpanel=="Lobby" && SSticker)
 		if(SSticker.hide_mode)
 			stat("Game Mode:", "Secret")
@@ -143,7 +143,7 @@
 
 	..()
 
-	statpanel("Status")
+	statpanel("Lobby")
 
 
 /mob/new_player/Topic(href, href_list[])


### PR DESCRIPTION
## What Does This PR Do
Makes the default statpanel `Status` instead of `Lobby` when you connect.

## Why It's Good For The Game
Currently, because `Lobby` has a list of every connected player and their ready status, statpanel updates are very client intensive ingame (Try playing with the MC panel open). This can cause the client to hang for **20 seconds**, and goonchat to force-reset itself 5 times. Thats not viable and a pain to deal with when youre trying to connect.

## Changelog
:cl: AffectedArc07
fix: Admins no longer get obliterated with lag when they connect during the lobby phase
/:cl:
