### PR TITLE
Makes TGUI respect advanced admin interaction

### DIFF
--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -57,7 +57,7 @@ GLOBAL_DATUM_INIT(tgui_default_state, /datum/tgui_state/default, new)
 	else
 		return ..()
 
-/mob/dead/observer/default_can_use_tgui_topic()
-	if(can_admin_interact())
+/mob/dead/observer/default_can_use_tgui_topic(src_object)
+	if(can_admin_interact() && client.advanced_admin_interaction)
 		return STATUS_INTERACTIVE				// Admins are more equal
 	return STATUS_UPDATE						// Ghosts can view updates


### PR DESCRIPTION
## What Does This PR Do
Makes TGUI interfaces respect the advanced_admin_interaction variable when ghosted as admin.
The UI will still seem enabled and clickable but if you try it it won't work unless you got the variable on TRUE as admin

## Why It's Good For The Game
It's an oversight/bug

## Changelog
:cl:
fix: Makes TGUI interfaces respect the advanced_admin_interaction variable when ghosted as admin
/:cl: