### PR TITLE
Fixes being able to toggle fire alarms without 'Advanced Admin Interaction' enabled

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -83,7 +83,7 @@ FIRE ALARM
 	return attack_hand(user)
 
 /obj/machinery/firealarm/attack_ghost(mob/user)
-	if(user.can_admin_interact())
+	if(user.can_advanced_admin_interact())
 		toggle_alarm(user)
 
 /obj/machinery/firealarm/emp_act(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes it so that admins can no longer accidentally lock a room down by clicking on a fire alarm.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Individual firelocks already check for Advanced admin interaction, rather than just regular. Fire alarms certainly should too.

## Changelog
:cl:
fix: Fixed admins being able to toggle fire alarms without 'Advanced Admin Interaction' enabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
