### PR TITLE
Makes revenants not able to interact with TGUI interfaces

### DIFF
--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -45,6 +45,9 @@ GLOBAL_DATUM_INIT(tgui_default_state, /datum/tgui_state/default, new)
 		return STATUS_INTERACTIVE
 	return STATUS_CLOSE
 
+/mob/living/simple_animal/revenant/default_can_use_tgui_topic(src_object)
+	return STATUS_UPDATE
+
 /mob/living/simple_animal/default_can_use_tgui_topic(src_object)
 	. = shared_tgui_interaction(src_object)
 	if(. > STATUS_CLOSE)

--- a/code/modules/tgui/states/hands.dm
+++ b/code/modules/tgui/states/hands.dm
@@ -19,6 +19,9 @@ GLOBAL_DATUM_INIT(tgui_hands_state, /datum/tgui_state/hands_state, new)
 		return STATUS_INTERACTIVE
 	return STATUS_CLOSE
 
+/mob/living/simple_animal/revenant/hands_can_use_tgui_topic(src_object)
+	return STATUS_UPDATE
+
 /mob/living/silicon/robot/hands_can_use_tgui_topic(src_object)
 	if(activated(src_object))
 		return STATUS_INTERACTIVE

--- a/code/modules/tgui/states/physical.dm
+++ b/code/modules/tgui/states/physical.dm
@@ -14,6 +14,9 @@ GLOBAL_DATUM_INIT(tgui_physical_state, /datum/tgui_state/physical, new)
 /mob/proc/physical_can_use_tgui_topic(src_object)
 	return STATUS_CLOSE
 
+/mob/living/simple_animal/revenant/physical_can_use_tgui_topic(src_object)
+	return STATUS_UPDATE
+
 /mob/living/physical_can_use_tgui_topic(src_object)
 	return shared_living_tgui_distance(src_object)
 


### PR DESCRIPTION
## What Does This PR Do
Makes the grief ghost unable to interact with TGUI interfaces. They can only see them

fixes: #13328
fixes: #14593 

## Why It's Good For The Game
Less grief ghost more spoopy ghost

## Changelog
:cl:
tweak: Makes revenants not able to interact with TGUI interfaces
/:cl: