### PR TITLE
Removes the plasmaman brute weakness

### DIFF
--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -20,7 +20,6 @@
 
 	burn_mod = 1.5
 	heatmod = 1.5
-	brute_mod = 1.5
 
 	//Has default darksight of 2.
 


### PR DESCRIPTION
## What Does This PR Do
Removed the 50% brute weakness on plasmaman.

## Why It's Good For The Game
This species has zero reason to take the same damage as IPCs.
Their upsides are:

- They have their own internals, therefore aren’t affected by air gases. (anyone can do this, just fill the emergency tank in your o2 box and set it to 16kpa)
-  Immune to radiation
- Doesnt need to eat.
- No blood (this isn’t even that good of an upside, since blood trails kind of guide people to where you are being murdered).

As far as I can tell, that’s it.
If you might’ve noticed, almost all of those upsides are... situational, which is even worse considering they have a 50% brute and burn damage vulnerability, which will be present always.
Due to their current balance, nobody plays them, since they’re just flesh IPCs; this PR aims to change that by removing the biggest downside, their brute weakness.

## Changelog
:cl:
tweak: Plasmaman no longer take 50% more brute damage.
/:cl: