### PR TITLE
Adds Sol Gov cap and tacticool turtleneck to the loadout menu

### DIFF
--- a/code/modules/client/preference/loadout/loadout_hat.dm
+++ b/code/modules/client/preference/loadout/loadout_hat.dm
@@ -178,3 +178,7 @@
 /datum/gear/hat/flowerpin
 	display_name = "hair flower"
 	path = /obj/item/clothing/head/hairflower
+
+/datum/gear/hat/capsolgov
+	display_name = "cap, Sol Gov"
+	path = /obj/item/clothing/head/soft/solgov

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -320,3 +320,7 @@
 	display_name = "pants, camo"
 	path = /obj/item/clothing/under/pants/camo
 
+/datum/gear/uniform/suit/tacticool
+	display_name = "tacticool turtleneck"
+	description = "A sleek black turtleneck paired with some khakis (WARNING DOES NOT HAVE SUIT SENSORS)"
+	path = /obj/item/clothing/under/syndicate/tacticool


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds both the Tacticool Turtleneck and Sol Gov cap to the loadout menu
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Both of these items effectively have no mechanical impact on the game aside from style, though the turtleneck does not have sensors, in the loadout menu I made a large disclaimer stating that fact, other than that these two items are harmless for players to have
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![Screenshot (279)](https://user-images.githubusercontent.com/52841396/97049010-f5c3a380-1548-11eb-9f09-02f5f064c888.png)
![Screenshot (280)](https://user-images.githubusercontent.com/52841396/97049014-f9572a80-1548-11eb-87ff-db9277f6255e.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Added tacticool turtleneck and sol gov cap to the loadout menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
