### PR TITLE
Makes Canes Bigger

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -29,7 +29,7 @@
 	flags = CONDUCT
 	force = 5.0
 	throwforce = 7.0
-	w_class = WEIGHT_CLASS_MEDIUM
+	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=50)
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed", "Vaudevilled")
 

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -29,7 +29,7 @@
 	flags = CONDUCT
 	force = 5.0
 	throwforce = 7.0
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_MEDIUM
 	materials = list(MAT_METAL=50)
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed", "Vaudevilled")
 


### PR DESCRIPTION
## What Does This PR Do
It's come to my attention that canes, for some reason, are WEIGHT_CLASS_SMALL which allows them to fit in your pockets, a box, a skrell headpocket, and a cheesewheel among other things. Canes are....realistically not that small, ever. 

## Why It's Good For The Game
Rectifies the tragedy that is canes being a size barely suitable for a vox to use. No more smuggling a cane to permabrig in a cheesewheel for your friends' grand escape.

## Changelog
:cl:
tweak: Canes no longer fit in pockets, boxes, cheesewheels, skrell headpockets, or other containers that only accept small or tiny items.
/:cl:
