### PR TITLE
Fix typo in Ablative Armor Vest description

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -236,7 +236,7 @@
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "Ablative Armor Vest"
-	desc = "A vest that excels in protecting the wearer against energy projectiles. Projects an energy field arround the user, allowing a chance of energy projectile deflection no matter where on the user it would hit."
+	desc = "A vest that excels in protecting the wearer against energy projectiles. Projects an energy field around the user, allowing a chance of energy projectile deflection no matter where on the user it would hit."
 	icon_state = "armor_reflec"
 	item_state = "armor_reflec"
 	blood_overlay_type = "armor"


### PR DESCRIPTION
## What Does This PR Do
This PR is not messing arround ...

## Why It's Good For The Game
Descriptions without typos are happy descriptions.

## Changelog
:cl:
spellcheck: Typo fixed in Ablative Armor Vest description
/:cl:
