### PR TITLE
Stops the crew from preforming the darkest magical art, metamancy

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -206,7 +206,7 @@
 			if(able_to_check)
 				able_to_check = FALSE
 				message_admins("final countdown")
-				addtimer(CALLBACK(src, .proc/metamancy), 1 MINUTES)
+				addtimer(CALLBACK(src, .proc/metamancy), 5 MINUTES)
 			else
 				message_admins("this check is failing")
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -199,21 +199,17 @@
 		return ..()
 	else
 		if(really_finished)
-			message_admins("END THIS SHITTTTTTE")
 			finished = TRUE
 			return TRUE
 		else
 			if(able_to_check)
 				able_to_check = FALSE
-				message_admins("final countdown")
 				addtimer(CALLBACK(src, .proc/metamancy), 5 MINUTES)
 			else
-				message_admins("this check is failing")
 
 /datum/game_mode/wizard/proc/metamancy()
 	really_finished = TRUE
 	able_to_check = TRUE
-	message_admins("yeet")
 
 /datum/game_mode/wizard/declare_completion(var/ragin = FALSE)
 	if(finished && !ragin)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR replaces most 1's and 0's in the wizard file to TRUE and FALSE, and makes it so in the default wizard gamemode, the round does not end unless the wizard and all of his apprentices have been dead for 5 minutes. If the wizard dies, but is revived, the 5 minute counter will fail, and the timer will be able to trigger again when he dies again. Theoretically, he could be killed, revived, and killed again in 5 minutes, but that is fine. 

This does not affect raging mages. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Crew preforms a dark art almost every wizard round. The dark art of metamancy, or metaknowledge, is practiced by the crew. The wizard is beating to crit, and then dies. 1 of 3 things happens. He is a lich, and revives. He is a normal wizard, and dies, and there is much celebration. Or, the 3rd option. The wizard has an apprentice, mind swap, or is an adminbussed wizard. If the 3rd option is picked, crew will either: Call out that an apprentice must be alive, or even if the wizard does not have mind swap, or is adminbussed, declare the wizard must have mind swap, and begin interrogating, or beating to death, all of the crew around him.

Why does this happen? Because the crew knows when the wizard is dead that the round ends. They know, that since the "wizard" is dead, that there must be a mind swap. Time and time again, we see this happen. Last night we had a round where we gave a traitor some magical powers, and when he died and the crew noticed the round was still going, CE, HOS, and AI said that mind swap almost certainly happened. They said this, as the round did not end. Said traitor did not have mind swap, the only evidence of mind swap was the lack of round ending.

By adding a 5 minute timer, the crew can no longer say that, a mind-swap must have happened, because the round is still going. They no longer can kill a bunch of people in a row to find out who the wizard is by seeing the round ending. Crew must now actually commit to their options, and no longer meta know who the wizard is by death. I considered making this only happen when the wizard does have mind swap, but this then again, leads to crew knowing mind swap happened. Does this mean the round continues for 5 extra minutes on normal wizard rounds? Yes. But the cost of those 5 extra minutes are worth the benefit of stopping the mind swap meta checks.

## Changelog
:cl:
tweak: The wizard and apprentices now have to stay dead for 5 minutes for a wizard round to end.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
