### PR TITLE
TM NEEDED - Structures no longer /New()

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -12,7 +12,8 @@
 	var/is_offspring = null
 	var/selecting = 0
 
-/obj/structure/blob/core/Initialize(mapload, loc, h = 200, client/new_overmind = null, new_rate = 2, offspring)
+/obj/structure/blob/core/Initialize(mapload, h = 200, client/new_overmind = null, new_rate = 2, offspring)
+	. = ..()
 	GLOB.blob_cores += src
 	START_PROCESSING(SSobj, src)
 	GLOB.poi_list |= src
@@ -24,7 +25,6 @@
 	if(!overmind)
 		create_overmind(new_overmind)
 	point_rate = new_rate
-	..(mapload, loc, h)
 
 
 /obj/structure/blob/core/adjustcolors(var/a_color)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -12,7 +12,7 @@
 	var/is_offspring = null
 	var/selecting = 0
 
-/obj/structure/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring)
+/obj/structure/blob/core/Initialize(mapload, loc, h = 200, client/new_overmind = null, new_rate = 2, offspring)
 	GLOB.blob_cores += src
 	START_PROCESSING(SSobj, src)
 	GLOB.poi_list |= src
@@ -24,7 +24,7 @@
 	if(!overmind)
 		create_overmind(new_overmind)
 	point_rate = new_rate
-	..(loc, h)
+	..(mapload, loc, h)
 
 
 /obj/structure/blob/core/adjustcolors(var/a_color)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -6,10 +6,10 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 65, "acid" = 90)
 	point_return = 18
 
-/obj/structure/blob/node/New(loc, var/h = 100)
+/obj/structure/blob/node/Initialize(mapload, loc, h = 100)
 	GLOB.blob_nodes += src
 	START_PROCESSING(SSobj, src)
-	..(loc, h)
+	..(mapload, loc, h)
 
 /obj/structure/blob/node/adjustcolors(var/a_color)
 	overlays.Cut()

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -6,10 +6,10 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 65, "acid" = 90)
 	point_return = 18
 
-/obj/structure/blob/node/Initialize(mapload, loc, h = 100)
+/obj/structure/blob/node/Initialize(mapload, h = 100)
+	. = ..()
 	GLOB.blob_nodes += src
 	START_PROCESSING(SSobj, src)
-	..(mapload, loc, h)
 
 /obj/structure/blob/node/adjustcolors(var/a_color)
 	overlays.Cut()

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -389,7 +389,7 @@
 		return
 
 	split_used = TRUE
-	new /obj/structure/blob/core/ (get_turf(N), 200, null, blob_core.point_rate, offspring = TRUE)
+	new /obj/structure/blob/core(get_turf(N), 200, null, blob_core.point_rate, TRUE)
 	qdel(N)
 
 	if(SSticker && SSticker.mode.name == "blob")

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -16,7 +16,7 @@
 	var/atmosblock = FALSE //if the blob blocks atmos and heat spread
 	var/mob/camera/blob/overmind
 
-/obj/structure/blob/Initialize(mapload, loc)
+/obj/structure/blob/Initialize(mapload)
 	. = ..()
 	GLOB.blobs += src
 	setDir(pick(GLOB.cardinal))

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -16,8 +16,8 @@
 	var/atmosblock = FALSE //if the blob blocks atmos and heat spread
 	var/mob/camera/blob/overmind
 
-/obj/structure/blob/New(loc)
-	..()
+/obj/structure/blob/Initialize(mapload, loc)
+	. = ..()
 	GLOB.blobs += src
 	setDir(pick(GLOB.cardinal))
 	update_icon()

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -105,7 +105,7 @@
 	choosable_items = list("Eldritch Whetstone"= /obj/item/whetstone/cult, "Zealot's Blindfold" = /obj/item/clothing/glasses/night/cultblind, \
 							"Flask of Unholy Water" = /obj/item/reagent_containers/food/drinks/bottle/unholywater, "Cultist Dagger" = /obj/item/melee/cultblade/dagger)
 
-/obj/structure/cult/functional/altar/New()
+/obj/structure/cult/functional/altar/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.altar_icon_state
 
@@ -123,7 +123,7 @@
 	choosable_items = list("Shielded Robe" = /obj/item/clothing/suit/hooded/cultrobes/cult_shield, "Flagellant's Robe" = /obj/item/clothing/suit/hooded/cultrobes/flagellant_robe, \
 							"Cultist Hardsuit" = /obj/item/storage/box/cult)
 
-/obj/structure/cult/functional/forge/New()
+/obj/structure/cult/functional/forge/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.forge_icon_state
 
@@ -177,16 +177,16 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 	var/corrupt_delay = 50
 	var/last_corrupt = 0
 
-/obj/structure/cult/functional/pylon/New()
+/obj/structure/cult/functional/pylon/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.pylon_icon_state
 
 /obj/structure/cult/functional/pylon/attack_hand(mob/living/user)//override as it should not create anything
 	return
 
-/obj/structure/cult/functional/pylon/New()
+/obj/structure/cult/functional/pylon/Initialize(mapload)
+	. = ..()
 	START_PROCESSING(SSobj, src)
-	..()
 
 /obj/structure/cult/functional/pylon/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -252,7 +252,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 	choosable_items = list("Supply Talisman" = /obj/item/paper/talisman/supply/weak, "Shuttle Curse" = /obj/item/shuttle_curse, \
 							"Veil Shifter" = /obj/item/cult_shift)
 
-/obj/structure/cult/functional/archives/New()
+/obj/structure/cult/functional/archives/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.archives_icon_state
 

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -242,8 +242,8 @@
 	anchored = TRUE
 	state = AI_READY_CORE
 
-/obj/structure/AIcore/deactivated/New()
-	..()
+/obj/structure/AIcore/deactivated/Initialize(mapload)
+	. = ..()
 	circuit = new(src)
 
 /obj/structure/AIcore/deactivated/Destroy()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -179,13 +179,12 @@
 	orient_right = 1
 	icon_state = "cryo_rear-r"
 
-/obj/structure/cryofeed/New()
-
+/obj/structure/cryofeed/Initialize(mapload)
+	. = ..()
 	if(orient_right)
 		icon_state = "cryo_rear-r"
 	else
 		icon_state = "cryo_rear"
-	..()
 
 //Cryopods themselves.
 /obj/machinery/cryopod

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -130,8 +130,8 @@
 	var/deploy_time = 40
 	var/deploy_message = TRUE
 
-/obj/structure/barricade/security/New()
-	..()
+/obj/structure/barricade/security/Initialize(mapload)
+	. = ..()
 	addtimer(CALLBACK(src, .proc/deploy), deploy_time)
 
 /obj/structure/barricade/security/proc/deploy()

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -58,8 +58,8 @@
 	var/poster_item_desc = "This hypothetical poster item should not exist, let's be honest here."
 	var/poster_item_icon_state = "rolled_poster"
 
-/obj/structure/sign/poster/New()
-	..()
+/obj/structure/sign/poster/Initialize(mapload)
+	. = ..()
 	if(random_basetype)
 		randomise(random_basetype)
 	if(!ruined)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -904,8 +904,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	var/metal = 0
 
 
-/obj/structure/foam/Initialize(mapload, loc, ismetal = FALSE)
-	..(mapload, loc)
+/obj/structure/foam/Initialize(mapload, ismetal = FALSE)
+	. = ..()
 	icon_state = "[ismetal ? "m":""]foam"
 	if(!ismetal && reagents)
 		color = mix_color_from_reagents(reagents.reagent_list)
@@ -925,7 +925,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 				MF.metal = metal
 				MF.update_icon()
 
-			var/obj/structure/foamedmetal/M = new(src.loc)
+			var/obj/structure/foamedmetal/M = new(loc)
 			M.metal = metal
 			M.updateicon()
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -904,8 +904,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	var/metal = 0
 
 
-/obj/structure/foam/New(loc, var/ismetal=0)
-	..(loc)
+/obj/structure/foam/Initialize(mapload, loc, ismetal = FALSE)
+	..(mapload, loc)
 	icon_state = "[ismetal ? "m":""]foam"
 	if(!ismetal && reagents)
 		color = mix_color_from_reagents(reagents.reagent_list)
@@ -930,8 +930,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 			M.updateicon()
 
 		flick("[icon_state]-disolve", src)
-		sleep(5)
-		qdel(src)
+		QDEL_IN(src, 5)
 	return
 
 // on delete, transfer any reagents to the floor

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -39,7 +39,7 @@
 	QDEL_NULL(myseed)
 	return ..()
 
-/obj/structure/glowshroom/Initialize(mapload, loc, obj/item/seeds/newseed, mutate_stats)
+/obj/structure/glowshroom/Initialize(mapload, obj/item/seeds/newseed, mutate_stats)
 	. = ..()
 	if(newseed)
 		myseed = newseed.Copy()

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -39,8 +39,8 @@
 	QDEL_NULL(myseed)
 	return ..()
 
-/obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats)
-	..()
+/obj/structure/glowshroom/Initialize(mapload, loc, obj/item/seeds/newseed, mutate_stats)
+	. = ..()
 	if(newseed)
 		myseed = newseed.Copy()
 		myseed.forceMove(src)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -34,8 +34,8 @@
 /obj/structure/spider/stickyweb
 	icon_state = "stickyweb1"
 
-/obj/structure/spider/stickyweb/New()
-	..()
+/obj/structure/spider/stickyweb/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		icon_state = "stickyweb2"
 
@@ -60,8 +60,8 @@
 	var/player_spiders = 0
 	var/list/faction = list("spiders")
 
-/obj/structure/spider/eggcluster/New()
-	..()
+/obj/structure/spider/eggcluster/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(3,-3)
 	pixel_y = rand(3,-3)
 	START_PROCESSING(SSobj, src)
@@ -93,8 +93,8 @@
 	var/list/faction = list("spiders")
 	var/selecting_player = 0
 
-/obj/structure/spider/spiderling/New()
-	..()
+/obj/structure/spider/spiderling/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(6,-6)
 	pixel_y = rand(6,-6)
 	START_PROCESSING(SSobj, src)
@@ -213,8 +213,8 @@
 	icon_state = "cocoon1"
 	max_integrity = 60
 
-/obj/structure/spider/cocoon/New()
-	..()
+/obj/structure/spider/cocoon/Initialize(mapload)
+	. = ..()
 	icon_state = pick("cocoon1","cocoon2","cocoon3")
 
 /obj/structure/spider/cocoon/Destroy()

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -162,8 +162,8 @@
 	desc = "Crate full of chemicals of unknown type and value from a 'trusted' source."
 	req_one_access = list(ACCESS_CHEMISTRY,ACCESS_RESEARCH,ACCESS_QM) // the qm knows a guy, you see.
 
-/obj/structure/closet/crate/secure/unknownchemicals/New()
-	..()
+/obj/structure/closet/crate/secure/unknownchemicals/Initialize(mapload)
+	. = ..()
 	for(var/i in 1 to 7)
 		new/obj/item/reagent_containers/glass/bottle/random_base_chem(src)
 	for(var/i in 1 to 3)
@@ -180,8 +180,8 @@
 	desc = "Full of basic chemistry supplies."
 	req_one_access = list(ACCESS_CHEMISTRY,ACCESS_RESEARCH)
 
-/obj/structure/closet/crate/secure/chemicals/New()
-	..()
+/obj/structure/closet/crate/secure/chemicals/Initialize(mapload)
+	. = ..()
 	for(var/chem in GLOB.standard_chemicals)
 		var/obj/item/reagent_containers/glass/bottle/B = new(src)
 		B.reagents.add_reagent(chem, B.volume)
@@ -241,8 +241,8 @@
 	icon_broken = "cabinetdetective_broken"
 	icon_off = "cabinetdetective_broken"
 
-/obj/structure/closet/secure_closet/random_drinks/New()
-	..()
+/obj/structure/closet/secure_closet/random_drinks/Initialize(mapload)
+	. = ..()
 	for(var/i in 1 to 5)
 		new/obj/item/reagent_containers/food/drinks/bottle/random_drink(src)
 	while(prob(25))

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -163,7 +163,7 @@
 	var/preloaded = 0
 	var/RPpos = null
 
-/obj/structure/chrono_field/Initialize(mapload, loc, mob/living/target, obj/item/gun/energy/chrono_gun/G)
+/obj/structure/chrono_field/Initialize(mapload, mob/living/target, obj/item/gun/energy/chrono_gun/G)
 	if(target && isliving(target) && G)
 		target.forceMove(src)
 		captured = target

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -163,7 +163,7 @@
 	var/preloaded = 0
 	var/RPpos = null
 
-/obj/structure/chrono_field/New(loc, mob/living/target, obj/item/gun/energy/chrono_gun/G)
+/obj/structure/chrono_field/Initialize(mapload, loc, mob/living/target, obj/item/gun/energy/chrono_gun/G)
 	if(target && isliving(target) && G)
 		target.forceMove(src)
 		captured = target

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -120,8 +120,8 @@
 	var/static/list/weedImageCache
 
 
-/obj/structure/alien/weeds/New(pos, node)
-	..()
+/obj/structure/alien/weeds/Initialize(mapload, pos, node)
+	. = ..()
 	linked_node = node
 	if(istype(loc, /turf/space))
 		qdel(src)
@@ -204,10 +204,6 @@
 	light_range = 1
 	var/node_range = NODERANGE
 
-
-/obj/structure/alien/weeds/node/New()
-	..(loc, src)
-
 #undef NODERANGE
 
 
@@ -242,9 +238,9 @@
 	status = BURST
 	icon_state = "egg_hatched"
 
-/obj/structure/alien/egg/New()
+/obj/structure/alien/egg/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/mask/facehugger(src)
-	..()
 	if(status == BURST)
 		obj_integrity = integrity_failure
 	else if(status != GROWN)

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -14,18 +14,15 @@
 	var/prev_sign = ""
 	var/panel_open = 0
 
-/obj/structure/sign/barsign/New()
-	..()
-
-
-//filling the barsigns list
+/obj/structure/sign/barsign/Initialize(mapload)
+	. = ..()
+	//filling the barsigns list
 	for(var/bartype in subtypesof(/datum/barsign))
 		var/datum/barsign/signinfo = new bartype
 		if(!signinfo.hidden)
 			barsigns += signinfo
 
-
-//randomly assigning a sign
+	//randomly assigning a sign
 	set_sign(pick(barsigns))
 
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -21,17 +21,16 @@
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
 
-/obj/structure/closet/New()
-	..()
-	spawn(1)
-		if(!opened)		// if closed, any item at the crate's loc is put in the contents
-			var/itemcount = 0
-			for(var/obj/item/I in loc)
-				if(I.density || I.anchored || I == src) continue
-				I.forceMove(src)
-				// Ensure the storage cap is respected
-				if(++itemcount >= storage_capacity)
-					break
+/obj/structure/closet/Initialize(mapload)
+	. = ..()
+	if(!opened)		// if closed, any item at the crate's loc is put in the contents
+		var/itemcount = 0
+		for(var/obj/item/I in loc)
+			if(I.density || I.anchored || I == src) continue
+			I.forceMove(src)
+			// Ensure the storage cap is respected
+			if(++itemcount >= storage_capacity)
+				break
 
 // Fix for #383 - C4 deleting fridges with corpses
 /obj/structure/closet/Destroy()

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -4,8 +4,8 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/athletic_mixed/New()
-	..()
+/obj/structure/closet/athletic_mixed/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/shorts/grey(src)
 	new /obj/item/clothing/under/shorts/black(src)
 	new /obj/item/clothing/under/shorts/red(src)
@@ -22,8 +22,8 @@
 	name = "boxing gloves"
 	desc = "It's a storage unit for gloves for use in the boxing ring."
 
-/obj/structure/closet/boxinggloves/New()
-	..()
+/obj/structure/closet/boxinggloves/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/gloves/boxing/blue(src)
 	new /obj/item/clothing/gloves/boxing/green(src)
 	new /obj/item/clothing/gloves/boxing/yellow(src)
@@ -34,8 +34,8 @@
 	name = "mask closet"
 	desc = "IT'S A STORAGE UNIT FOR FIGHTER MASKS OLE!"
 
-/obj/structure/closet/masks/New()
-	..()
+/obj/structure/closet/masks/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/mask/luchador(src)
 	new /obj/item/clothing/mask/luchador/rudos(src)
 	new /obj/item/clothing/mask/luchador/tecnicos(src)
@@ -47,8 +47,8 @@
 	icon_state = "red"
 	icon_closed = "red"
 
-/obj/structure/closet/lasertag/red/New()
-	..()
+/obj/structure/closet/lasertag/red/Initialize(mapload)
+	. = ..()
 	new /obj/item/gun/energy/laser/tag/red(src)
 	new /obj/item/gun/energy/laser/tag/red(src)
 	new /obj/item/gun/energy/laser/tag/red(src)
@@ -63,8 +63,8 @@
 	icon_state = "blue"
 	icon_closed = "blue"
 
-/obj/structure/closet/lasertag/blue/New()
-	..()
+/obj/structure/closet/lasertag/blue/Initialize(mapload)
+	. = ..()
 	new /obj/item/gun/energy/laser/tag/blue(src)
 	new /obj/item/gun/energy/laser/tag/blue(src)
 	new /obj/item/gun/energy/laser/tag/blue(src)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -36,8 +36,8 @@
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
 
-/obj/structure/closet/gimmick/russian/New()
-	..()
+/obj/structure/closet/gimmick/russian/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
@@ -57,8 +57,8 @@
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
 
-/obj/structure/closet/gimmick/tacticool/New()
-	..()
+/obj/structure/closet/gimmick/tacticool/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/glasses/eyepatch(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/clothing/gloves/combat(src)
@@ -86,8 +86,8 @@
 /obj/structure/closet/thunderdome/tdred
 	name = "red-team Thunderdome closet"
 
-/obj/structure/closet/thunderdome/tdred/New()
-	..()
+/obj/structure/closet/thunderdome/tdred/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/armor/tdome/red(src)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
@@ -113,8 +113,8 @@
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
 
-/obj/structure/closet/thunderdome/tdgreen/New()
-	..()
+/obj/structure/closet/thunderdome/tdgreen/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/armor/tdome/green(src)
 	new /obj/item/clothing/suit/armor/tdome/green(src)
 	new /obj/item/clothing/suit/armor/tdome/green(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -14,8 +14,8 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/gmcloset/New()
-	..()
+/obj/structure/closet/gmcloset/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/radio/headset/headset_service(src)
@@ -42,8 +42,8 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/chefcloset/New()
-	..()
+/obj/structure/closet/chefcloset/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/waiter(src)
 	new /obj/item/clothing/under/waiter(src)
 	new /obj/item/radio/headset/headset_service(src)
@@ -70,8 +70,8 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/jcloset/New()
-	..()
+/obj/structure/closet/jcloset/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/janitor(src)
 	new /obj/item/radio/headset/headset_service(src)
 	new /obj/item/cartridge/janitor(src)
@@ -100,8 +100,8 @@
 	icon_state = "blue"
 	icon_closed = "blue"
 
-/obj/structure/closet/lawcloset/New()
-	..()
+/obj/structure/closet/lawcloset/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/box/tapes(src)
 	new /obj/item/book/manual/faxes(src)
 	new /obj/item/clothing/under/lawyer/female(src)
@@ -127,7 +127,8 @@
 	icon_closed = "blue"
 
 
-/obj/structure/closet/paramedic/New()
+/obj/structure/closet/paramedic/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/medical/paramedic(src)
 	new /obj/item/clothing/under/rank/medical/paramedic(src)
 	new /obj/item/radio/headset/headset_med(src)

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -5,8 +5,8 @@
 	icon_closed = "bio"
 	icon_opened = "bioopen"
 
-/obj/structure/closet/l3closet/New()
-	..()
+/obj/structure/closet/l3closet/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/bag/bio( src )
 	new /obj/item/clothing/suit/bio_suit/general( src )
 	new /obj/item/clothing/head/bio_hood/general( src )
@@ -17,8 +17,8 @@
 	icon_closed = "bio_general"
 	icon_opened = "bio_generalopen"
 
-/obj/structure/closet/l3closet/general/New()
-	..()
+/obj/structure/closet/l3closet/general/Initialize(mapload)
+	. = ..()
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/general( src )
 	new /obj/item/clothing/head/bio_hood/general( src )
@@ -29,8 +29,8 @@
 	icon_closed = "bio_virology"
 	icon_opened = "bio_virologyopen"
 
-/obj/structure/closet/l3closet/virology/New()
-	..()
+/obj/structure/closet/l3closet/virology/Initialize(mapload)
+	. = ..()
 	contents = list()
 	new /obj/item/storage/bag/bio( src )
 	new /obj/item/clothing/suit/bio_suit/virology( src )
@@ -44,8 +44,8 @@
 	icon_closed = "bio_security"
 	icon_opened = "bio_securityopen"
 
-/obj/structure/closet/l3closet/security/New()
-	..()
+/obj/structure/closet/l3closet/security/Initialize(mapload)
+	. = ..()
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/security( src )
 	new /obj/item/clothing/head/bio_hood/security( src )
@@ -56,8 +56,8 @@
 	icon_closed = "bio_janitor"
 	icon_opened = "bio_janitoropen"
 
-/obj/structure/closet/l3closet/janitor/New()
-	..()
+/obj/structure/closet/l3closet/janitor/Initialize(mapload)
+	. = ..()
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/janitor( src )
 	new /obj/item/clothing/head/bio_hood/janitor( src )
@@ -68,8 +68,8 @@
 	icon_closed = "bio_scientist"
 	icon_opened = "bio_scientistopen"
 
-/obj/structure/closet/l3closet/scientist/New()
-	..()
+/obj/structure/closet/l3closet/scientist/Initialize(mapload)
+	. = ..()
 	contents = list()
 	new /obj/item/storage/bag/bio( src )
 	new /obj/item/clothing/suit/bio_suit/scientist( src )

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -5,8 +5,8 @@
 	icon_closed = "syndicate"
 	icon_opened = "syndicateopen"
 
-/obj/structure/closet/malf/suits/New()
-	..()
+/obj/structure/closet/malf/suits/Initialize(mapload)
+	. = ..()
 	new /obj/item/tank/jetpack/void(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/effect/nasavoidsuitspawner(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -10,8 +10,8 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
 
-/obj/structure/closet/secure_closet/bar/New()
-	..()
+/obj/structure/closet/secure_closet/bar/Initialize(mapload)
+	. = ..()
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -8,16 +8,14 @@
 	icon_broken = "securecargobroken"
 	icon_off = "securecargooff"
 
-/obj/structure/closet/secure_closet/cargotech/New()
-	..()
+/obj/structure/closet/secure_closet/cargotech/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/cargotech(src)
 	new /obj/item/clothing/under/rank/cargotech/skirt(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/radio/headset/headset_cargo(src)
 	new /obj/item/clothing/gloves/fingerless(src)
 	new /obj/item/clothing/head/soft(src)
-//		new /obj/item/cartridge/quartermaster(src)
-
 
 /obj/structure/closet/secure_closet/quartermaster
 	name = "quartermaster's locker"
@@ -29,8 +27,8 @@
 	icon_broken = "secureqmbroken"
 	icon_off = "secureqmoff"
 
-/obj/structure/closet/secure_closet/quartermaster/New()
-	..()
+/obj/structure/closet/secure_closet/quartermaster/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/cargo(src)
 	new /obj/item/clothing/under/rank/cargo/skirt(src)
 	new /obj/item/clothing/shoes/brown(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -9,8 +9,8 @@
 	icon_broken = "chaplainsecurebroken"
 	icon_off = "chaplainsecureoff"
 
-/obj/structure/closet/secure_closet/chaplain/New()
-	..()
+/obj/structure/closet/secure_closet/chaplain/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/chaplain(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/suit/hooded/nun(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
@@ -10,7 +10,7 @@
 	var/ignore_use = FALSE
 
 
-/obj/structure/closet/secure_closet/syndicate/depot/New()
+/obj/structure/closet/secure_closet/syndicate/depot/Initialize(mapload)
 	. = ..()
 	update_icon()
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -8,8 +8,8 @@
 	icon_broken = "securecebroken"
 	icon_off = "secureceoff"
 
-/obj/structure/closet/secure_closet/engineering_chief/New()
-	..()
+/obj/structure/closet/secure_closet/engineering_chief/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/industrial(src)
 	else
@@ -53,8 +53,8 @@
 	icon_broken = "secureengelecbroken"
 	icon_off = "secureengelecoff"
 
-/obj/structure/closet/secure_closet/engineering_electrical/New()
-	..()
+/obj/structure/closet/secure_closet/engineering_electrical/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/gloves/color/yellow(src)
 	new /obj/item/clothing/gloves/color/yellow(src)
 	new /obj/item/storage/toolbox/electrical(src)
@@ -79,8 +79,8 @@
 	icon_broken = "secureengweldbroken"
 	icon_off = "secureengweldoff"
 
-/obj/structure/closet/secure_closet/engineering_welding/New()
-	..()
+/obj/structure/closet/secure_closet/engineering_welding/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
@@ -99,8 +99,8 @@
 	icon_broken = "secureengbroken"
 	icon_off = "secureengoff"
 
-/obj/structure/closet/secure_closet/engineering_personal/New()
-	..()
+/obj/structure/closet/secure_closet/engineering_personal/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/industrial(src)
 	else
@@ -128,8 +128,8 @@
 	icon_broken = "secureatmbroken"
 	icon_off = "secureatmoff"
 
-/obj/structure/closet/secure_closet/atmos_personal/New()
-	..()
+/obj/structure/closet/secure_closet/atmos_personal/Initialize(mapload)
+	. = ..()
 	new /obj/item/radio/headset/headset_eng(src)
 	new /obj/item/cartridge/atmos(src)
 	new /obj/item/storage/toolbox/mechanical(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -28,8 +28,8 @@
 	name = "kitchen cabinet"
 	req_access = list(ACCESS_KITCHEN)
 
-/obj/structure/closet/secure_closet/freezer/kitchen/New()
-	..()
+/obj/structure/closet/secure_closet/freezer/kitchen/Initialize(mapload)
+	. = ..()
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/food/condiment/flour(src)
 	new /obj/item/reagent_containers/food/condiment/rice(src)
@@ -44,8 +44,8 @@
 	desc = "This refrigerator looks quite dusty, is there anything edible still inside?"
 	req_access = list()
 
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance/New()
-	..()
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance/Initialize(mapload)
+	. = ..()
 	for(var/i = 0, i < 5, i++)
 		new /obj/item/reagent_containers/food/condiment/milk(src)
 	for(var/i = 0, i < 5, i++)
@@ -62,8 +62,8 @@
 	icon_broken = "fridgebroken"
 	icon_off = "fridge1"
 
-/obj/structure/closet/secure_closet/freezer/meat/New()
-	..()
+/obj/structure/closet/secure_closet/freezer/meat/Initialize(mapload)
+	. = ..()
 	for(var/i in 1 to 4)
 		new /obj/item/reagent_containers/food/snacks/meat/monkey(src)
 
@@ -80,8 +80,8 @@
 	icon_broken = "fridgebroken"
 	icon_off = "fridge1"
 
-/obj/structure/closet/secure_closet/freezer/fridge/New()
-	..()
+/obj/structure/closet/secure_closet/freezer/fridge/Initialize(mapload)
+	. = ..()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/food/condiment/milk(src)
 		new /obj/item/reagent_containers/food/condiment/soymilk(src)
@@ -102,8 +102,8 @@
 	icon_off = "fridge1"
 	req_access = list(ACCESS_HEADS_VAULT)
 
-/obj/structure/closet/secure_closet/freezer/money/New()
-	..()
+/obj/structure/closet/secure_closet/freezer/money/Initialize(mapload)
+	. = ..()
 	for(var/i in 1 to 3)
 		new /obj/item/stack/spacecash/c1000(src)
 	for(var/i in 1 to 5)

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -9,11 +9,9 @@
 	icon_broken = "base"
 	icon_off = "base"
 
-/obj/structure/closet/secure_closet/guncabinet/New()
-	..()
+/obj/structure/closet/secure_closet/guncabinet/Initialize(mapload)
+	. = ..()
 	update_icon()
-
-
 
 /obj/structure/closet/secure_closet/guncabinet/toggle()
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -9,8 +9,8 @@
 	icon_off = "hydrosecureoff"
 
 
-/obj/structure/closet/secure_closet/hydroponics/New()
-	..()
+/obj/structure/closet/secure_closet/hydroponics/Initialize(mapload)
+	. = ..()
 	switch(rand(1,2))
 		if(1)
 			new /obj/item/clothing/suit/apron(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -9,8 +9,8 @@
 	icon_off = "medicaloff"
 	req_access = list(ACCESS_MEDICAL)
 
-/obj/structure/closet/secure_closet/medical1/New()
-	..()
+/obj/structure/closet/secure_closet/medical1/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/box/autoinjectors(src)
 	new /obj/item/storage/box/syringes(src)
 	new /obj/item/storage/box/pillbottles(src)
@@ -37,8 +37,8 @@
 	icon_off = "medicaloff"
 	req_access = list(ACCESS_SURGERY)
 
-/obj/structure/closet/secure_closet/medical2/New()
-	..()
+/obj/structure/closet/secure_closet/medical2/Initialize(mapload)
+	. = ..()
 	new /obj/item/tank/anesthetic(src)
 	new /obj/item/tank/anesthetic(src)
 	new /obj/item/tank/anesthetic(src)
@@ -57,8 +57,8 @@
 	icon_broken = "securemedbroken"
 	icon_off = "securemedoff"
 
-/obj/structure/closet/secure_closet/medical3/New()
-	..()
+/obj/structure/closet/secure_closet/medical3/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medic(src)
 	else
@@ -89,8 +89,8 @@
 	icon_off = "medicaloff"
 	req_access = list(ACCESS_MEDICAL)
 
-/obj/structure/closet/secure_closet/exam/New()
-	..()
+/obj/structure/closet/secure_closet/exam/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/box/syringes(src)
 	new /obj/item/reagent_containers/dropper(src)
 	new /obj/item/storage/belt/medical(src)
@@ -137,8 +137,8 @@
 	icon_broken = "securemedbroken"
 	icon_off = "securemedoff"
 
-/obj/structure/closet/secure_closet/psychiatrist/New()
-	..()
+/obj/structure/closet/secure_closet/psychiatrist/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/reagent_containers/syringe(src)
 	new /obj/item/reagent_containers/glass/bottle/ether(src)
@@ -161,8 +161,8 @@
 	icon_broken = "cmosecurebroken"
 	icon_off = "cmosecureoff"
 
-/obj/structure/closet/secure_closet/CMO/New()
-	..()
+/obj/structure/closet/secure_closet/CMO/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medic(src)
 	else
@@ -202,8 +202,8 @@
 	name = "animal control locker"
 	req_access = list(ACCESS_SURGERY)
 
-/obj/structure/closet/secure_closet/animal/New()
-	..()
+/obj/structure/closet/secure_closet/animal/Initialize(mapload)
+	. = ..()
 	new /obj/item/assembly/signaler(src)
 	new /obj/item/radio/electropack(src)
 	new /obj/item/radio/electropack(src)
@@ -221,8 +221,8 @@
 	icon_off = "medicaloff"
 	req_access = list(ACCESS_CHEMISTRY)
 
-/obj/structure/closet/secure_closet/chemical/New()
-	..()
+/obj/structure/closet/secure_closet/chemical/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/patch_packs(src)
@@ -266,8 +266,8 @@
 	icon_off = "medicaloff"
 	req_access = list(ACCESS_PARAMEDIC)
 
-/obj/structure/closet/secure_closet/paramedic/New()
-	..()
+/obj/structure/closet/secure_closet/paramedic/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/space/eva/paramedic(src)
 	new /obj/item/clothing/head/helmet/space/eva/paramedic(src)
 	new /obj/item/sensor_device(src)
@@ -286,8 +286,8 @@
 	icon_off = "chemicaloff"
 	req_access = list(ACCESS_CHEMISTRY)
 
-/obj/structure/closet/secure_closet/reagents/New()
-	..()
+/obj/structure/closet/secure_closet/reagents/Initialize(mapload)
+	. = ..()
 	new /obj/item/reagent_containers/glass/bottle/reagent/phenol(src)
 	new /obj/item/reagent_containers/glass/bottle/reagent/ammonia(src)
 	new /obj/item/reagent_containers/glass/bottle/reagent/oil(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/miscjobs.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/miscjobs.dm
@@ -8,8 +8,8 @@
 	icon_broken = "clownsecurebroken"
 	icon_off = "clownsecureoff"
 
-/obj/structure/closet/secure_closet/clown/New()
-	..()
+/obj/structure/closet/secure_closet/clown/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/backpack/clown(src)
 	new /obj/item/clothing/under/rank/clown(src)
 	new /obj/item/clothing/shoes/clown_shoes(src)
@@ -34,8 +34,8 @@
 	icon_broken = "mimesecurebroken"
 	icon_off = "mimesecureoff"
 
-/obj/structure/closet/secure_closet/mime/New()
-	..()
+/obj/structure/closet/secure_closet/mime/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/head/beret(src)
 	new /obj/item/clothing/mask/gas/mime(src)
 	new /obj/item/radio/headset/headset_service(src)
@@ -52,8 +52,8 @@
 	name = "officer's locker"
 	req_access = list(ACCESS_SYNDICATE_COMMAND)
 
-/obj/structure/closet/secure_closet/syndicate_officer/New()
-	..()
+/obj/structure/closet/secure_closet/syndicate_officer/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/space/hardsuit/syndi/elite(src)
 	new /obj/item/gun/projectile/automatic/sniper_rifle/syndicate(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -4,8 +4,8 @@
 	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 	var/registered_name = null
 
-/obj/structure/closet/secure_closet/personal/New()
-	..()
+/obj/structure/closet/secure_closet/personal/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/duffel(src)
 	if(prob(50))
@@ -18,8 +18,8 @@
 /obj/structure/closet/secure_closet/personal/patient
 	name = "patient's closet"
 
-/obj/structure/closet/secure_closet/personal/patient/New()
-	..()
+/obj/structure/closet/secure_closet/personal/patient/Initialize(mapload)
+	. = ..()
 	contents.Cut()
 	new /obj/item/clothing/under/color/white( src )
 	new /obj/item/clothing/shoes/white( src )
@@ -48,8 +48,8 @@
 		else
 			icon_state = icon_opened
 
-/obj/structure/closet/secure_closet/personal/cabinet/New()
-	..()
+/obj/structure/closet/secure_closet/personal/cabinet/Initialize(mapload)
+	. = ..()
 	contents.Cut()
 	new /obj/item/storage/backpack/satchel/withwallet( src )
 	new /obj/item/radio/headset( src )

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -8,8 +8,8 @@
 	icon_broken = "secureresbroken"
 	icon_off = "secureresoff"
 
-/obj/structure/closet/secure_closet/scientist/New()
-	..()
+/obj/structure/closet/secure_closet/scientist/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/backpack/science(src)
 	new /obj/item/storage/backpack/satchel_tox(src)
 	new /obj/item/clothing/under/rank/scientist(src)
@@ -33,8 +33,8 @@
 	icon_broken = "secureresbroken"
 	icon_off = "secureresoff"
 
-/obj/structure/closet/secure_closet/roboticist/New()
-	..()
+/obj/structure/closet/secure_closet/roboticist/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/backpack(src)
 	new /obj/item/storage/backpack(src)
 	new /obj/item/storage/backpack/satchel_norm(src)
@@ -56,8 +56,8 @@
 	icon_broken = "rdsecurebroken"
 	icon_off = "rdsecureoff"
 
-/obj/structure/closet/secure_closet/RD/New()
-	..()
+/obj/structure/closet/secure_closet/RD/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/bio_suit/scientist(src)
 	new /obj/item/clothing/head/bio_hood/scientist(src)
 	new /obj/item/clothing/under/rank/research_director(src)
@@ -88,8 +88,8 @@
 	icon_off = "rchemicaloff"
 	req_access = list(ACCESS_TOX_STORAGE)
 
-/obj/structure/closet/secure_closet/research_reagents/New()
-	..()
+/obj/structure/closet/secure_closet/research_reagents/Initialize(mapload)
+	. = ..()
 	new /obj/item/reagent_containers/glass/bottle/reagent/morphine(src)
 	new /obj/item/reagent_containers/glass/bottle/reagent/morphine(src)
 	new /obj/item/reagent_containers/glass/bottle/reagent/morphine(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -8,8 +8,8 @@
 	icon_broken = "capsecurebroken"
 	icon_off = "capsecureoff"
 
-/obj/structure/closet/secure_closet/captains/New()
-	..()
+/obj/structure/closet/secure_closet/captains/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/captain(src)
 	else
@@ -46,8 +46,8 @@
 	icon_broken = "hopsecurebroken"
 	icon_off = "hopsecureoff"
 
-/obj/structure/closet/secure_closet/hop/New()
-	..()
+/obj/structure/closet/secure_closet/hop/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/glasses/hud/skills/sunglasses(src)
 	new /obj/item/clothing/head/hopcap(src)
 	new /obj/item/cartridge/hop(src)
@@ -72,8 +72,8 @@
 	icon_broken = "hopsecurebroken"
 	icon_off = "hopsecureoff"
 
-/obj/structure/closet/secure_closet/hop2/New()
-	..()
+/obj/structure/closet/secure_closet/hop2/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/head_of_personnel(src)
 	new /obj/item/clothing/suit/mantle/armor/head_of_personnel(src)
 	new /obj/item/clothing/under/dress/dress_hop(src)
@@ -99,8 +99,8 @@
 	icon_broken = "hossecurebroken"
 	icon_off = "hossecureoff"
 
-/obj/structure/closet/secure_closet/hos/New()
-	..()
+/obj/structure/closet/secure_closet/hos/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/security(src)
 	else
@@ -140,8 +140,8 @@
 	icon_broken = "wardensecurebroken"
 	icon_off = "wardensecureoff"
 
-/obj/structure/closet/secure_closet/warden/New()
-	..()
+/obj/structure/closet/secure_closet/warden/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/security(src)
 	else
@@ -178,8 +178,8 @@
 	icon_broken = "secbroken"
 	icon_off = "secoff"
 
-/obj/structure/closet/secure_closet/security/New()
-	..()
+/obj/structure/closet/secure_closet/security/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/security(src)
 	else
@@ -209,8 +209,8 @@
 	icon_broken = "securemedbroken"
 	icon_off = "securemedoff"
 
-/obj/structure/closet/secure_closet/brigdoc/New()
-	..()
+/obj/structure/closet/secure_closet/brigdoc/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medic(src)
 	else
@@ -239,8 +239,8 @@
 	icon_broken = "bssecurebroken"
 	icon_off = "bssecureoff"
 
-/obj/structure/closet/secure_closet/blueshield/New()
-	..()
+/obj/structure/closet/secure_closet/blueshield/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/briefcase(src)
 	new	/obj/item/storage/firstaid/adv(src)
 	new /obj/item/pinpointer/crew(src)
@@ -274,8 +274,8 @@
 	icon_broken = "ntsecurebroken"
 	icon_off = "ntsecureoff"
 
-/obj/structure/closet/secure_closet/ntrep/New()
-	..()
+/obj/structure/closet/secure_closet/ntrep/Initialize(mapload)
+	. = ..()
 	new /obj/item/book/manual/faxes(src)
 	new /obj/item/storage/briefcase(src)
 	new /obj/item/paicard(src)
@@ -295,32 +295,32 @@
 
 /obj/structure/closet/secure_closet/security/cargo
 
-/obj/structure/closet/secure_closet/security/cargo/New()
-	..()
+/obj/structure/closet/secure_closet/security/cargo/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/accessory/armband/cargo(src)
 	new /obj/item/encryptionkey/headset_cargo(src)
 
 
 /obj/structure/closet/secure_closet/security/engine
 
-/obj/structure/closet/secure_closet/security/engine/New()
-	..()
+/obj/structure/closet/secure_closet/security/engine/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/accessory/armband/engine(src)
 	new /obj/item/encryptionkey/headset_eng(src)
 
 
 /obj/structure/closet/secure_closet/security/science
 
-/obj/structure/closet/secure_closet/security/science/New()
-	..()
+/obj/structure/closet/secure_closet/security/science/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/accessory/armband/science(src)
 	new /obj/item/encryptionkey/headset_sci(src)
 
 
 /obj/structure/closet/secure_closet/security/med
 
-/obj/structure/closet/secure_closet/security/med/New()
-	..()
+/obj/structure/closet/secure_closet/security/med/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/accessory/armband/medgreen(src)
 	new /obj/item/encryptionkey/headset_med(src)
 
@@ -337,8 +337,8 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
 
-/obj/structure/closet/secure_closet/detective/New()
-	..()
+/obj/structure/closet/secure_closet/detective/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/det(src)
 	new /obj/item/clothing/suit/storage/det_suit(src)
 	new /obj/item/clothing/suit/storage/det_suit/forensics/blue(src)
@@ -379,8 +379,8 @@
 	name = "lethal injections locker"
 	req_access = list(ACCESS_SECURITY)
 
-/obj/structure/closet/secure_closet/injection/New()
-	..()
+/obj/structure/closet/secure_closet/injection/Initialize(mapload)
+	. = ..()
 	new /obj/item/reagent_containers/syringe/lethal(src)
 	new /obj/item/reagent_containers/syringe/lethal(src)
 
@@ -391,8 +391,8 @@
 	anchored = 1
 	var/id = null
 
-/obj/structure/closet/secure_closet/brig/New()
-	..()
+/obj/structure/closet/secure_closet/brig/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/shoes/orange(src)
 	new /obj/item/card/id/prisoner/random(src)
@@ -403,8 +403,8 @@
 	name = "courtroom locker"
 	req_access = list(ACCESS_COURT)
 
-/obj/structure/closet/secure_closet/courtroom/New()
-	..()
+/obj/structure/closet/secure_closet/courtroom/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/shoes/brown(src)
 	new /obj/item/paper/Court (src)
 	new /obj/item/paper/Court (src)
@@ -451,8 +451,8 @@
 	icon_broken = "magistratesecurebroken"
 	icon_off = "magistratesecureoff"
 
-/obj/structure/closet/secure_closet/magistrate/New()
-	..()
+/obj/structure/closet/secure_closet/magistrate/Initialize(mapload)
+	. = ..()
 	new /obj/item/book/manual/faxes(src)
 	new /obj/item/storage/secure/briefcase(src)
 	new /obj/item/flash(src)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -12,7 +12,7 @@
 	var/intialOxy = 0
 	var/timer = 240 //eventually the person will be freed
 
-/obj/structure/closet/statue/Initialize(mapload, loc, var/mob/living/L)
+/obj/structure/closet/statue/Initialize(mapload, var/mob/living/L)
 	. = ..()
 	if(ishuman(L) || iscorgi(L))
 		if(L.buckled)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -12,8 +12,8 @@
 	var/intialOxy = 0
 	var/timer = 240 //eventually the person will be freed
 
-/obj/structure/closet/statue/New(loc, var/mob/living/L)
-
+/obj/structure/closet/statue/Initialize(mapload, loc, var/mob/living/L)
+	. = ..()
 	if(ishuman(L) || iscorgi(L))
 		if(L.buckled)
 			L.buckled = 0

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -9,8 +9,8 @@
 /obj/structure/closet/syndicate/personal
 	desc = "It's a storage unit for operative gear."
 
-/obj/structure/closet/syndicate/personal/New()
-	..()
+/obj/structure/closet/syndicate/personal/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/syndicate(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
@@ -21,8 +21,8 @@
 /obj/structure/closet/syndicate/suits
 	desc = "It's a storage unit for operative space gear."
 
-/obj/structure/closet/syndicate/suits/New()
-	..()
+/obj/structure/closet/syndicate/suits/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
 	new /obj/item/tank/jetpack/oxygen/harness(src)
@@ -30,8 +30,8 @@
 /obj/structure/closet/syndicate/nuclear
 	desc = "It's a storage unit for a Syndicate boarding party."
 
-/obj/structure/closet/syndicate/nuclear/New()
-	..()
+/obj/structure/closet/syndicate/nuclear/Initialize(mapload)
+	. = ..()
 	new /obj/item/ammo_box/magazine/m10mm(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
@@ -50,8 +50,8 @@
 /obj/structure/closet/syndicate/sst
 	desc = "It's a storage unit for an elite syndicate strike team's gear."
 
-/obj/structure/closet/syndicate/sst/New()
-	..()
+/obj/structure/closet/syndicate/sst/Initialize(mapload)
+	. = ..()
 	new /obj/item/ammo_box/magazine/mm556x45(src)
 	new /obj/item/gun/projectile/automatic/l6_saw(src)
 	new /obj/item/tank/jetpack/oxygen/harness(src)
@@ -64,8 +64,8 @@
 /obj/structure/closet/syndicate/resources
 	desc = "An old, dusty locker."
 
-/obj/structure/closet/syndicate/resources/New()
-	..()
+/obj/structure/closet/syndicate/resources/Initialize(mapload)
+	. = ..()
 	var/common_min = 30 //Minimum amount of minerals in the stack for common minerals
 	var/common_max = 50 //Maximum amount of HONK in the stack for HONK common minerals
 	var/rare_min = 5  //Minimum HONK of HONK in the stack HONK HONK rare minerals
@@ -126,8 +126,8 @@
 /obj/structure/closet/syndicate/resources/everything
 	desc = "It's an emergency storage closet for repairs."
 
-/obj/structure/closet/syndicate/resources/everything/New()
-	..()
+/obj/structure/closet/syndicate/resources/everything/Initialize(mapload)
+	. = ..()
 	var/list/resources = list(
 	/obj/item/stack/sheet/metal,
 	/obj/item/stack/sheet/glass,

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -22,9 +22,8 @@
 /obj/structure/closet/emcloset/anchored
 	anchored = TRUE
 
-/obj/structure/closet/emcloset/New()
-	..()
-
+/obj/structure/closet/emcloset/Initialize(mapload)
+	. = ..()
 	switch(pickweight(list("small" = 55, "aid" = 25, "tank" = 10, "both" = 10, "nothing" = 0, "delete" = 0)))
 		if("small")
 			new /obj/item/tank/emergency_oxygen(src)
@@ -58,7 +57,8 @@
 			new /obj/structure/closet/firecloset(src.loc)
 			qdel(src)*/
 
-/obj/structure/closet/emcloset/legacy/New()
+/obj/structure/closet/emcloset/legacy/Initialize(mapload)
+	. = ..()
 	new /obj/item/tank/oxygen(src)
 	new /obj/item/clothing/mask/gas(src)
 
@@ -72,8 +72,8 @@
 	icon_closed = "firecloset"
 	icon_opened = "fireclosetopen"
 
-/obj/structure/closet/firecloset/New()
-	..()
+/obj/structure/closet/firecloset/Initialize(mapload)
+	. = ..()
 
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/mask/gas(src)
@@ -81,8 +81,8 @@
 	new /obj/item/extinguisher(src)
 	new /obj/item/clothing/head/hardhat/red(src)
 
-/obj/structure/closet/firecloset/full/New()
-	..()
+/obj/structure/closet/firecloset/full/Initialize(mapload)
+	. = ..()
 	contents.Cut()
 
 	new /obj/item/clothing/suit/fire/firefighter(src)
@@ -103,8 +103,8 @@
 	icon_closed = "toolcloset"
 	icon_opened = "toolclosetopen"
 
-/obj/structure/closet/toolcloset/New()
-	..()
+/obj/structure/closet/toolcloset/Initialize(mapload)
+	. = ..()
 	if(prob(40))
 		new /obj/item/clothing/suit/storage/hazardvest(src)
 	if(prob(70))
@@ -147,8 +147,8 @@
 	icon_opened = "toolclosetopen"
 	icon_closed = "radsuitcloset"
 
-/obj/structure/closet/radiation/New()
-	..()
+/obj/structure/closet/radiation/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 
@@ -162,8 +162,8 @@
 	icon_closed = "bombsuit"
 	icon_opened = "bombsuitopen"
 
-/obj/structure/closet/bombcloset/New()
-	..()
+/obj/structure/closet/bombcloset/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/bomb_suit( src )
 	new /obj/item/clothing/under/color/black( src )
 	new /obj/item/clothing/shoes/black( src )
@@ -177,8 +177,8 @@
 	icon_closed = "bombsuitsec"
 	icon_opened = "bombsuitsecopen"
 
-/obj/structure/closet/bombclosetsecurity/New()
-	..()
+/obj/structure/closet/bombclosetsecurity/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/bomb_suit/security( src )
 	new /obj/item/clothing/under/rank/security( src )
 	new /obj/item/clothing/shoes/brown( src )
@@ -197,8 +197,8 @@
 	density = 0
 	wall_mounted = 1
 
-/obj/structure/closet/hydrant/New()
-	..()
+/obj/structure/closet/hydrant/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/flashlight(src)

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -7,8 +7,8 @@
 /obj/structure/closet/wardrobe/generic
 	// Identical to the base wardrobe, aside from containing some stuff.
 
-/obj/structure/closet/wardrobe/generic/New()
-	..()
+/obj/structure/closet/wardrobe/generic/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/blue(src)
@@ -25,8 +25,8 @@
 	icon_state = "red"
 	icon_closed = "red"
 
-/obj/structure/closet/wardrobe/red/New()
-	..()
+/obj/structure/closet/wardrobe/red/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/backpack/duffel/security(src)
 	new /obj/item/storage/backpack/duffel/security(src)
 	new /obj/item/clothing/mask/bandana/red(src)
@@ -62,8 +62,8 @@
 	icon_state = "red"
 	icon_closed = "red"
 
-/obj/structure/closet/redcorp/New()
-	..()
+/obj/structure/closet/redcorp/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/security/corp(src)
 	new /obj/item/clothing/under/rank/security/corp(src)
 	new /obj/item/clothing/under/rank/security/corp(src)
@@ -76,8 +76,8 @@
 	icon_state = "pink"
 	icon_closed = "pink"
 
-/obj/structure/closet/wardrobe/pink/New()
-	..()
+/obj/structure/closet/wardrobe/pink/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/color/pink(src)
@@ -90,8 +90,8 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/wardrobe/black/New()
-	..()
+/obj/structure/closet/wardrobe/black/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/color/black(src)
@@ -112,8 +112,8 @@
 	icon_state = "green"
 	icon_closed = "green"
 
-/obj/structure/closet/wardrobe/green/New()
-	..()
+/obj/structure/closet/wardrobe/green/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/color/green(src)
@@ -126,8 +126,8 @@
 	icon_state = "green"
 	icon_closed = "green"
 
-/obj/structure/closet/wardrobe/xenos/New()
-	..()
+/obj/structure/closet/wardrobe/xenos/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/unathi/mantle(src)
 	new /obj/item/clothing/suit/unathi/robe(src)
 	new /obj/item/clothing/shoes/sandal(src)
@@ -144,8 +144,8 @@
 	icon_state = "orange"
 	icon_closed = "orange"
 
-/obj/structure/closet/wardrobe/orange/New()
-	..()
+/obj/structure/closet/wardrobe/orange/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/under/color/orange/prison(src)
@@ -159,8 +159,8 @@
 	icon_state = "yellow"
 	icon_closed = "yellow"
 
-/obj/structure/closet/wardrobe/yellow/New()
-	..()
+/obj/structure/closet/wardrobe/yellow/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/yellow(src)
 	new /obj/item/clothing/under/color/yellow(src)
 	new /obj/item/clothing/under/color/yellow(src)
@@ -174,8 +174,8 @@
 	icon_state = "atmostech"
 	icon_closed = "atmostech"
 
-/obj/structure/closet/wardrobe/atmospherics_yellow/New()
-	..()
+/obj/structure/closet/wardrobe/atmospherics_yellow/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/atmospheric_technician(src)
 	new /obj/item/clothing/under/rank/atmospheric_technician(src)
 	new /obj/item/clothing/under/rank/atmospheric_technician(src)
@@ -199,8 +199,8 @@
 	icon_state = "engineer"
 	icon_closed = "engineer"
 
-/obj/structure/closet/wardrobe/engineering_yellow/New()
-	..()
+/obj/structure/closet/wardrobe/engineering_yellow/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
@@ -223,8 +223,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/white/New()
-	..()
+/obj/structure/closet/wardrobe/white/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/color/white(src)
@@ -237,8 +237,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/medical_white/New()
-	..()
+/obj/structure/closet/wardrobe/medical_white/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/nursesuit (src)
 	new /obj/item/clothing/head/nursehat (src)
 	new /obj/item/clothing/under/rank/nurse(src)
@@ -267,8 +267,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/pjs/New()
-	..()
+/obj/structure/closet/wardrobe/pjs/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/pj/red(src)
 	new /obj/item/clothing/under/pj/red(src)
 	new /obj/item/clothing/under/pj/blue(src)
@@ -284,8 +284,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/toxins_white/New()
-	..()
+/obj/structure/closet/wardrobe/toxins_white/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
@@ -308,8 +308,8 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/wardrobe/robotics_black/New()
-	..()
+/obj/structure/closet/wardrobe/robotics_black/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/roboticist(src)
 	new /obj/item/clothing/under/rank/roboticist(src)
 	new /obj/item/clothing/under/rank/roboticist/skirt(src)
@@ -327,8 +327,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/chemistry_white/New()
-	..()
+/obj/structure/closet/wardrobe/chemistry_white/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/under/rank/chemist/skirt(src)
@@ -352,8 +352,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/genetics_white/New()
-	..()
+/obj/structure/closet/wardrobe/genetics_white/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/geneticist(src)
 	new /obj/item/clothing/under/rank/geneticist(src)
 	new /obj/item/clothing/shoes/white(src)
@@ -371,8 +371,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/virology_white/New()
-	..()
+/obj/structure/closet/wardrobe/virology_white/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/under/rank/virologist/skirt(src)
@@ -394,8 +394,8 @@
 	icon_state = "white"
 	icon_closed = "white"
 
-/obj/structure/closet/wardrobe/medic_white/New()
-	..()
+/obj/structure/closet/wardrobe/medic_white/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/rank/medical/skirt(src)
@@ -422,8 +422,8 @@
 	icon_state = "grey"
 	icon_closed = "grey"
 
-/obj/structure/closet/wardrobe/grey/New()
-	..()
+/obj/structure/closet/wardrobe/grey/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/grey(src)
 	new /obj/item/clothing/under/color/grey(src)
 	new /obj/item/clothing/under/color/grey(src)
@@ -446,8 +446,8 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/wardrobe/mixed/New()
-	..()
+/obj/structure/closet/wardrobe/mixed/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/yellow(src)
 	new /obj/item/clothing/under/color/green(src)
@@ -468,8 +468,8 @@
 	icon_state = "black"
 	icon_closed = "black"
 
-/obj/structure/closet/wardrobe/coroner/New()
-	..()
+/obj/structure/closet/wardrobe/coroner/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medic(src)
 	else

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -12,8 +12,8 @@
 	// A list of beacon names that the crate will announce the arrival of, when delivered.
 	var/list/announce_beacons = list()
 
-/obj/structure/closet/crate/New()
-	..()
+/obj/structure/closet/crate/Initialize(mapload)
+	. = ..()
 	update_icon()
 
 /obj/structure/closet/crate/update_icon()
@@ -323,8 +323,8 @@
 	icon_opened = "crateopen"
 	icon_closed = "crate"
 
-/obj/structure/closet/crate/rcd/New()
-	..()
+/obj/structure/closet/crate/rcd/Initialize(mapload)
+	. = ..()
 	new /obj/item/rcd_ammo(src)
 	new /obj/item/rcd_ammo(src)
 	new /obj/item/rcd_ammo(src)
@@ -378,8 +378,8 @@
 	icon_opened = "radiationopen"
 	icon_closed = "radiation"
 
-/obj/structure/closet/crate/radiation/New()
-	..()
+/obj/structure/closet/crate/radiation/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/clothing/suit/radiation(src)
@@ -497,8 +497,8 @@
 	//This exists so the prespawned hydro crates spawn with their contents.
 
 // Do I need the definition above? Who knows!
-/obj/structure/closet/crate/hydroponics/prespawned/New()
-	..()
+/obj/structure/closet/crate/hydroponics/prespawned/Initialize(mapload)
+	. = ..()
 	new /obj/item/reagent_containers/glass/bucket(src)
 	new /obj/item/reagent_containers/glass/bucket(src)
 	new /obj/item/screwdriver(src)
@@ -549,14 +549,14 @@
 	icon_opened = "electricalcrateopen"
 	icon_closed = "electricalcrate"
 
-/obj/structure/closet/crate/tape/New()
+/obj/structure/closet/crate/tape/Initialize(mapload)
+	. = ..()
 	if(prob(10))
 		new /obj/item/bikehorn/rubberducky(src)
-	..()
 
 //crates of gear in the free golem ship
-/obj/structure/closet/crate/golemgear/New()
-	..()
+/obj/structure/closet/crate/golemgear/Initialize(mapload)
+	. = ..()
 	new /obj/item/storage/backpack/industrial(src)
 	new /obj/item/shovel(src)
 	new /obj/item/pickaxe(src)

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -35,10 +35,10 @@
 	name = "corgi crate"
 	content_mob = /mob/living/simple_animal/pet/dog/corgi
 
-/obj/structure/closet/critter/corgi/New()
+/obj/structure/closet/critter/corgi/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		content_mob = /mob/living/simple_animal/pet/dog/corgi/Lisa
-	..()
 
 /obj/structure/closet/critter/cow
 	name = "cow crate"
@@ -60,18 +60,18 @@
 	name = "chicken crate"
 	content_mob = /mob/living/simple_animal/chick
 
-/obj/structure/closet/critter/chick/New()
+/obj/structure/closet/critter/chick/Initialize(mapload)
+	. = ..()
 	amount = rand(1, 3)
-	..()
 
 /obj/structure/closet/critter/cat
 	name = "cat crate"
 	content_mob = /mob/living/simple_animal/pet/cat
 
-/obj/structure/closet/critter/cat/New()
+/obj/structure/closet/critter/cat/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		content_mob = /mob/living/simple_animal/pet/cat/Proc
-	..()
 
 /obj/structure/closet/critter/pug
 	name = "pug crate"

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -6,8 +6,8 @@
 	density = 1
 	var/obj/item/paper/manifest/manifest
 
-/obj/structure/largecrate/New()
-	..()
+/obj/structure/largecrate/Initialize(mapload)
+	. = ..()
 	update_icon()
 
 /obj/structure/largecrate/update_icon()

--- a/code/game/objects/structures/depot.dm
+++ b/code/game/objects/structures/depot.dm
@@ -12,7 +12,6 @@
 /obj/structure/fusionreactor/New()
 	. = ..()
 	// Do not attempt to put the code below into Initialize() or even LateInitialize() with a "return INITIALIZE_HINT_LATELOAD". It won't work!
-	// ^ I will prove this wrong some day, -AA
 	depotarea = areaMaster
 	if(istype(depotarea))
 		depotarea.reactor = src

--- a/code/game/objects/structures/depot.dm
+++ b/code/game/objects/structures/depot.dm
@@ -12,6 +12,7 @@
 /obj/structure/fusionreactor/New()
 	. = ..()
 	// Do not attempt to put the code below into Initialize() or even LateInitialize() with a "return INITIALIZE_HINT_LATELOAD". It won't work!
+	// ^ I will prove this wrong some day, -AA
 	depotarea = areaMaster
 	if(istype(depotarea))
 		depotarea.reactor = src

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -20,10 +20,10 @@
 	var/material_type = /obj/item/stack/sheet/metal
 	var/material_amt = 4
 
-/obj/structure/door_assembly/New()
+/obj/structure/door_assembly/Initialize(mapload)
+	. = ..()
 	update_icon()
 	update_name()
-	..()
 
 /obj/structure/door_assembly/Destroy()
 	QDEL_NULL(electronics)

--- a/code/game/objects/structures/door_assembly_types.dm
+++ b/code/game/objects/structures/door_assembly_types.dm
@@ -143,14 +143,14 @@
 	glass_type = /obj/machinery/door/airlock/multi_tile/glass
 	material_amt = 8
 
-/obj/structure/door_assembly/multi_tile/New()
+/obj/structure/door_assembly/multi_tile/Initialize(mapload)
+	. = ..()
 	if(dir in list(EAST, WEST))
 		bound_width = width * world.icon_size
 		bound_height = world.icon_size
 	else
 		bound_width = world.icon_size
 		bound_height = width * world.icon_size
-	..()
 
 /obj/structure/door_assembly/multi_tile/Move()
 	. = ..()
@@ -169,7 +169,7 @@
 	airlock_type = /obj/machinery/door/airlock/cult
 	glass_type = /obj/machinery/door/airlock/cult/glass
 
-/obj/structure/door_assembly/door_assembly_cult/New()
+/obj/structure/door_assembly/door_assembly_cult/Initialize(mapload)
 	. = ..()
 	icon = SSticker.cultdat?.airlock_runed_icon_file
 	overlays_file = SSticker.cultdat?.airlock_runed_overlays_file
@@ -181,7 +181,7 @@
 	airlock_type = /obj/machinery/door/airlock/cult/unruned
 	glass_type = /obj/machinery/door/airlock/cult/unruned/glass
 
-/obj/structure/door_assembly/door_assembly_cult/unruned/New()
+/obj/structure/door_assembly/door_assembly_cult/unruned/Initialize(mapload)
 	. = ..()
 	icon = SSticker.cultdat?.airlock_unruned_icon_file
 	overlays_file = SSticker.cultdat?.airlock_unruned_overlays_file

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -7,19 +7,18 @@
 	var/last_time = 1.0
 	var/delay_time = 50
 
-/obj/structure/chair/e_chair/New()
-	..()
+/obj/structure/chair/e_chair/Initialize(mapload)
+	. = ..()
 	overlays += image('icons/obj/chairs.dmi', src, "echair_over", MOB_LAYER + 1, dir)
-	spawn(2)
-		if(isnull(part)) //This e-chair was not custom built
-			part = new(src)
-			var/obj/item/clothing/head/helmet/part1 = new(part)
-			var/obj/item/radio/electropack/part2 = new(part)
-			part2.frequency = 1445
-			part2.code = 6
-			part2.master = part
-			part.part1 = part1
-			part.part2 = part2
+	if(isnull(part)) //This e-chair was not custom built
+		part = new(src)
+		var/obj/item/clothing/head/helmet/part1 = new(part)
+		var/obj/item/radio/electropack/part2 = new(part)
+		part2.frequency = 1445
+		part2.code = 6
+		part2.master = part
+		part.part1 = part1
+		part.part2 = part2
 
 /obj/structure/chair/e_chair/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/wrench))

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -17,8 +17,8 @@
 	var/opened = 0
 	var/material_drop = /obj/item/stack/sheet/metal
 
-/obj/structure/extinguisher_cabinet/New(turf/loc, direction = null)
-	..()
+/obj/structure/extinguisher_cabinet/Initialize(mapload, turf/loc, direction = null)
+	. = ..()
 	if(direction)
 		setDir(direction)
 		set_pixel_offsets_from_dir(28, -28, 30, -30)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -17,7 +17,7 @@
 	var/opened = 0
 	var/material_drop = /obj/item/stack/sheet/metal
 
-/obj/structure/extinguisher_cabinet/Initialize(mapload, turf/loc, direction = null)
+/obj/structure/extinguisher_cabinet/Initialize(mapload, direction = null)
 	. = ..()
 	if(direction)
 		setDir(direction)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -33,8 +33,8 @@
 	/turf/simulated/wall/r_wall/rust)
 	smooth = SMOOTH_TRUE
 
-/obj/structure/falsewall/New(loc)
-	..()
+/obj/structure/falsewall/Initialize(mapload)
+	. = ..()
 	air_update_turf(1)
 
 /obj/structure/falsewall/ratvar_act()
@@ -349,8 +349,8 @@
 	walltype = /turf/simulated/wall/clockwork
 	mineral = /obj/item/stack/tile/brass
 
-/obj/structure/falsewall/brass/New(loc)
-	..()
+/obj/structure/falsewall/brass/Initialize(mapload)
+	. = ..()
 	var/turf/T = get_turf(src)
 	new /obj/effect/temp_visual/ratvar/wall/false(T)
 	new /obj/effect/temp_visual/ratvar/beam/falsewall(T)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -15,8 +15,8 @@
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_1"
 
-/obj/structure/flora/tree/pine/New()
-	..()
+/obj/structure/flora/tree/pine/Initialize(mapload)
+	. = ..()
 	icon_state = "pine_[rand(1, 3)]"
 
 /obj/structure/flora/tree/pine/xmas
@@ -24,24 +24,20 @@
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_c"
 
-/obj/structure/flora/tree/pine/xmas/New()
-	..()
-	icon_state = "pine_c"
-
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/flora/deadtrees.dmi'
 	icon_state = "tree_1"
 
-/obj/structure/flora/tree/dead/New()
-	..()
+/obj/structure/flora/tree/dead/Initialize(mapload)
+	. = ..()
 	icon_state = "tree_[rand(1, 6)]"
 
 /obj/structure/flora/tree/palm
 	icon = 'icons/misc/beach2.dmi'
 	icon_state = "palm1"
 
-/obj/structure/flora/tree/palm/New()
-	..()
+/obj/structure/flora/tree/palm/Initialize(mapload)
+	. = ..()
 	icon_state = pick("palm1","palm2")
 	pixel_x = 0
 
@@ -54,23 +50,23 @@
 /obj/structure/flora/grass/brown
 	icon_state = "snowgrass1bb"
 
-/obj/structure/flora/grass/brown/New()
-	..()
+/obj/structure/flora/grass/brown/Initialize(mapload)
+	. = ..()
 	icon_state = "snowgrass[rand(1, 3)]bb"
 
 
 /obj/structure/flora/grass/green
 	icon_state = "snowgrass1gb"
 
-/obj/structure/flora/grass/green/New()
-	..()
+/obj/structure/flora/grass/green/Initialize(mapload)
+	. = ..()
 	icon_state = "snowgrass[rand(1, 3)]gb"
 
 /obj/structure/flora/grass/both
 	icon_state = "snowgrassall1"
 
-/obj/structure/flora/grass/both/New()
-	..()
+/obj/structure/flora/grass/both/Initialize(mapload)
+	. = ..()
 	icon_state = "snowgrassall[rand(1, 3)]"
 
 
@@ -81,8 +77,8 @@
 	icon_state = "snowbush1"
 	anchored = 1
 
-/obj/structure/flora/bush/New()
-	..()
+/obj/structure/flora/bush/Initialize(mapload)
+	. = ..()
 	icon_state = "snowbush[rand(1, 6)]"
 
 //newbushes
@@ -93,113 +89,113 @@
 	icon_state = "firstbush_1"
 	anchored = 1
 
-/obj/structure/flora/ausbushes/New()
-	..()
+/obj/structure/flora/ausbushes/Initialize(mapload)
+	. = ..()
 	icon_state = "firstbush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/reedbush
 	icon_state = "reedbush_1"
 
-/obj/structure/flora/ausbushes/reedbush/New()
-	..()
+/obj/structure/flora/ausbushes/reedbush/Initialize(mapload)
+	. = ..()
 	icon_state = "reedbush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/leafybush
 	icon_state = "leafybush_1"
 
-/obj/structure/flora/ausbushes/leafybush/New()
-	..()
+/obj/structure/flora/ausbushes/leafybush/Initialize(mapload)
+	. = ..()
 	icon_state = "leafybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/palebush
 	icon_state = "palebush_1"
 
-/obj/structure/flora/ausbushes/palebush/New()
-	..()
+/obj/structure/flora/ausbushes/palebush/Initialize(mapload)
+	. = ..()
 	icon_state = "palebush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/stalkybush
 	icon_state = "stalkybush_1"
 
-/obj/structure/flora/ausbushes/stalkybush/New()
-	..()
+/obj/structure/flora/ausbushes/stalkybush/Initialize(mapload)
+	. = ..()
 	icon_state = "stalkybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/grassybush
 	icon_state = "grassybush_1"
 
-/obj/structure/flora/ausbushes/grassybush/New()
-	..()
+/obj/structure/flora/ausbushes/grassybush/Initialize(mapload)
+	. = ..()
 	icon_state = "grassybush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/fernybush
 	icon_state = "fernybush_1"
 
-/obj/structure/flora/ausbushes/fernybush/New()
-	..()
+/obj/structure/flora/ausbushes/fernybush/Initialize(mapload)
+	. = ..()
 	icon_state = "fernybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/sunnybush
 	icon_state = "sunnybush_1"
 
-/obj/structure/flora/ausbushes/sunnybush/New()
-	..()
+/obj/structure/flora/ausbushes/sunnybush/Initialize(mapload)
+	. = ..()
 	icon_state = "sunnybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/genericbush
 	icon_state = "genericbush_1"
 
-/obj/structure/flora/ausbushes/genericbush/New()
-	..()
+/obj/structure/flora/ausbushes/genericbush/Initialize(mapload)
+	. = ..()
 	icon_state = "genericbush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/pointybush
 	icon_state = "pointybush_1"
 
-/obj/structure/flora/ausbushes/pointybush/New()
-	..()
+/obj/structure/flora/ausbushes/pointybush/Initialize(mapload)
+	. = ..()
 	icon_state = "pointybush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/lavendergrass
 	icon_state = "lavendergrass_1"
 
-/obj/structure/flora/ausbushes/lavendergrass/New()
-	..()
+/obj/structure/flora/ausbushes/lavendergrass/Initialize(mapload)
+	. = ..()
 	icon_state = "lavendergrass_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/ywflowers
 	icon_state = "ywflowers_1"
 
-/obj/structure/flora/ausbushes/ywflowers/New()
-	..()
+/obj/structure/flora/ausbushes/ywflowers/Initialize(mapload)
+	. = ..()
 	icon_state = "ywflowers_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/brflowers
 	icon_state = "brflowers_1"
 
-/obj/structure/flora/ausbushes/brflowers/New()
-	..()
+/obj/structure/flora/ausbushes/brflowers/Initialize(mapload)
+	. = ..()
 	icon_state = "brflowers_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/ppflowers
 	icon_state = "ppflowers_1"
 
-/obj/structure/flora/ausbushes/ppflowers/New()
-	..()
+/obj/structure/flora/ausbushes/ppflowers/Initialize(mapload)
+	. = ..()
 	icon_state = "ppflowers_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/sparsegrass
 	icon_state = "sparsegrass_1"
 
-/obj/structure/flora/ausbushes/sparsegrass/New()
-	..()
+/obj/structure/flora/ausbushes/sparsegrass/Initialize(mapload)
+	. = ..()
 	icon_state = "sparsegrass_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/fullgrass
 	icon_state = "fullgrass_1"
 
-/obj/structure/flora/ausbushes/fullgrass/New()
-	..()
+/obj/structure/flora/ausbushes/fullgrass/Initialize(mapload)
+	. = ..()
 	icon_state = "fullgrass_[rand(1, 3)]"
 
 
@@ -247,8 +243,8 @@
 	resistance_flags = FIRE_PROOF
 	anchored = 1
 
-/obj/structure/flora/rock/New()
-	..()
+/obj/structure/flora/rock/Initialize(mapload)
+	. = ..()
 	icon_state = "rock[rand(1,5)]"
 
 /obj/structure/flora/rock/pile
@@ -256,8 +252,8 @@
 	desc = "some rocks"
 	icon_state = "rockpile1"
 
-/obj/structure/flora/rock/pile/New()
-	..()
+/obj/structure/flora/rock/pile/Initialize(mapload)
+	. = ..()
 	icon_state = "rockpile[rand(1,5)]"
 
 /obj/structure/flora/rock/icy
@@ -305,9 +301,10 @@
 	var/indestructable = 0
 	var/stump = 0
 
-/obj/structure/bush/New()
+/obj/structure/bush/Initialize(mapload)
+	. = ..()
 	if(prob(20))
-		opacity = 1
+		opacity = TRUE
 
 /*
 /obj/structure/bush/Bumped(M as mob)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -413,7 +413,7 @@
 	metalUsed = 1
 	metal_type = /obj/item/stack/sheet/runed_metal
 
-/obj/structure/girder/cult/New()
+/obj/structure/girder/cult/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.cult_girder_icon_state
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -20,10 +20,11 @@
 	var/shockcooldown = 0
 	var/my_shockcooldown = 1 SECONDS
 
-/obj/structure/grille/fence/
+/obj/structure/grille/fence
 	var/width = 3
 
-/obj/structure/grille/fence/New()
+/obj/structure/grille/fence/Initialize(mapload)
+	. = ..()
 	if(width > 1)
 		if(dir in list(EAST, WEST))
 			bound_width = width * world.icon_size
@@ -289,8 +290,8 @@
 	desc = "A strangely-shaped grille."
 	broken_type = /obj/structure/grille/ratvar/broken
 
-/obj/structure/grille/ratvar/New()
-	..()
+/obj/structure/grille/ratvar/Initialize(mapload)
+	. = ..()
 	if(broken)
 		new /obj/effect/temp_visual/ratvar/grille/broken(get_turf(src))
 	else

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -9,11 +9,11 @@
 	armor = list("melee" = 0, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 20)
 	var/obj/item/holosign_creator/projector
 
-/obj/structure/holosign/New(loc, source_projector)
+/obj/structure/holosign/Initialize(mapload, loc, source_projector)
+	. = ..()
 	if(source_projector)
 		projector = source_projector
 		projector.signs += src
-	..()
 
 /obj/structure/holosign/Destroy()
 	if(projector)
@@ -73,8 +73,8 @@
 	layer = ABOVE_MOB_LAYER
 	alpha = 150
 
-/obj/structure/holosign/barrier/atmos/New()
-	..()
+/obj/structure/holosign/barrier/atmos/Initialize(mapload)
+	. = ..()
 	air_update_turf(TRUE)
 
 /obj/structure/holosign/barrier/atmos/CanAtmosPass(turf/T)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -9,7 +9,7 @@
 	armor = list("melee" = 0, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 20)
 	var/obj/item/holosign_creator/projector
 
-/obj/structure/holosign/Initialize(mapload, loc, source_projector)
+/obj/structure/holosign/Initialize(mapload, source_projector)
 	. = ..()
 	if(source_projector)
 		projector = source_projector

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -18,8 +18,8 @@
 	var/const/max_signs = 4
 
 
-/obj/structure/janitorialcart/New()
-	..()
+/obj/structure/janitorialcart/Initialize(mapload)
+	. = ..()
 	create_reagents(100)
 	GLOB.janitorial_equipment += src
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -21,7 +21,7 @@
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/damageSound = null
 
-/obj/structure/mineral_door/Initialize(mapload, location)
+/obj/structure/mineral_door/Initialize(mapload)
 	. = ..()
 	initial_state = icon_state
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -21,8 +21,8 @@
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/damageSound = null
 
-/obj/structure/mineral_door/New(location)
-	..()
+/obj/structure/mineral_door/Initialize(mapload, location)
+	. = ..()
 	initial_state = icon_state
 
 /obj/structure/mineral_door/Initialize()

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -10,7 +10,7 @@
 	integrity_failure = 100
 	var/list/ui_users = list()
 
-/obj/structure/mirror/Initialize(mapload, turf/T, newdir = SOUTH, building = FALSE)
+/obj/structure/mirror/Initialize(mapload, newdir = SOUTH, building = FALSE)
 	. = ..()
 	if(building)
 		switch(newdir)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -10,8 +10,8 @@
 	integrity_failure = 100
 	var/list/ui_users = list()
 
-/obj/structure/mirror/New(turf/T, newdir = SOUTH, building = FALSE)
-	..()
+/obj/structure/mirror/Initialize(mapload, turf/T, newdir = SOUTH, building = FALSE)
+	. = ..()
 	if(building)
 		switch(newdir)
 			if(NORTH)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -7,13 +7,13 @@
 	container_type = OPENCONTAINER
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 
-/obj/structure/mopbucket/New()
-	..()
+/obj/structure/mopbucket/Initialize(mapload)
+	. = ..()
 	create_reagents(100)
 	GLOB.janitorial_equipment += src
 
-/obj/structure/mopbucket/full/New()
-	..()
+/obj/structure/mopbucket/full/Initialize(mapload)
+	. = ..()
 	reagents.add_reagent("water", 100)
 
 /obj/structure/mopbucket/Destroy()

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -10,9 +10,9 @@
 	comfort = 0
 	flags = NODECONSTRUCT
 
-/obj/structure/bed/nest/New()
+/obj/structure/bed/nest/Initialize(mapload)
+	. = ..()
 	nest_overlay = image('icons/mob/alien.dmi', "nestoverlay", layer=MOB_LAYER - 0.2)
-	return ..()
 
 /obj/structure/bed/nest/user_unbuckle_mob(mob/living/user)
 	if(has_buckled_mobs())

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -18,10 +18,9 @@
 	var/propelled = FALSE // Check for fire-extinguisher-driven chairs
 	var/comfort = 0
 
-/obj/structure/chair/New()
-	..()
-	spawn(3)	//sorry. i don't think there's a better way to do this.
-		handle_rotation()
+/obj/structure/chair/Initialize(mapload)
+	. = ..()
+	handle_rotation()
 	return
 
 /obj/structure/chair/narsie_act()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -35,8 +35,8 @@
 	var/deconstruction_ready = TRUE
 	var/flipped = 0
 
-/obj/structure/table/New()
-	..()
+/obj/structure/table/Initialize(mapload)
+	. = ..()
 	if(flipped)
 		update_icon()
 
@@ -388,7 +388,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 100)
 	var/list/debris = list()
 
-/obj/structure/table/glass/New()
+/obj/structure/table/glass/Initialize(mapload)
 	. = ..()
 	debris += new frame
 	debris += new /obj/item/shard
@@ -497,16 +497,16 @@
 	buildstack = /obj/item/stack/tile/carpet
 	canSmoothWith = list(/obj/structure/table/wood/fancy, /obj/structure/table/wood/fancy/black)
 
-/obj/structure/table/wood/fancy/New()
+/obj/structure/table/wood/fancy/Initialize(mapload)
+	. = ..()
 	icon = 'icons/obj/smooth_structures/fancy_table.dmi' //so that the tables place correctly in the map editor
-	..()
 
 /obj/structure/table/wood/fancy/black
 	icon_state = "fancy_table_black"
 	buildstack = /obj/item/stack/tile/carpet/black
 
-/obj/structure/table/wood/fancy/black/New()
-	..()
+/obj/structure/table/wood/fancy/black/Initialize(mapload)
+	. = ..()
 	icon = 'icons/obj/smooth_structures/fancy_table_black.dmi' //so that the tables place correctly in the map editor
 
 /*

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -18,8 +18,8 @@
 /obj/structure/dispenser/plasma
 	starting_oxygen_tanks = 0
 
-/obj/structure/dispenser/New()
-	..()
+/obj/structure/dispenser/Initialize(mapload)
+	. = ..()
 	initialize_tanks()
 	update_icon()
 

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -17,8 +17,8 @@
 	var/const/CLOSE_DURATION = 6
 	var/list/disallowed_mobs = list(/mob/living/silicon/ai)
 
-/obj/structure/transit_tube/station/New()
-	..()
+/obj/structure/transit_tube/station/Initialize(mapload)
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/transit_tube/station/Destroy()

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -47,9 +47,8 @@
 			return
 
 
-/obj/structure/transit_tube/New(loc)
-	..(loc)
-
+/obj/structure/transit_tube/Initialize(mapload)
+	. = ..()
 	if(tube_dirs == null)
 		init_dirs()
 

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -8,16 +8,20 @@
 	var/datum/gas_mixture/air_contents = new()
 
 
-/obj/structure/transit_tube_pod/New(loc)
-	..(loc)
+/obj/structure/transit_tube_pod/Initialize(mapload, loc)
+	. = ..()
 
 	air_contents.oxygen = MOLES_O2STANDARD * 2
 	air_contents.nitrogen = MOLES_N2STANDARD
 	air_contents.temperature = T20C
 
-	// Give auto tubes time to align before trying to start moving
-	spawn(5)
-		follow_tube()
+	// Lateinitialize to allow things to connect up
+	if(mapload)
+		return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/transit_tube_pod/LateInitialize()
+	. = ..()
+	follow_tube()
 
 /obj/structure/transit_tube_pod/Destroy()
 	for(var/atom/movable/AM in contents)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -8,7 +8,7 @@
 	var/datum/gas_mixture/air_contents = new()
 
 
-/obj/structure/transit_tube_pod/Initialize(mapload, loc)
+/obj/structure/transit_tube_pod/Initialize(mapload)
 	. = ..()
 
 	air_contents.oxygen = MOLES_O2STANDARD * 2

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -13,8 +13,8 @@
 	var/mob/living/swirlie = null	//the mob being given a swirlie
 
 
-/obj/structure/toilet/New()
-	..()
+/obj/structure/toilet/Initialize(mapload)
+	. = ..()
 	open = round(rand(0, 1))
 	update_icon()
 
@@ -181,7 +181,7 @@
 /obj/structure/toilet/secret
 	var/secret_type = null
 
-/obj/structure/toilet/secret/New()
+/obj/structure/toilet/secret/Initialize(mapload)
 	. = ..()
 	if(secret_type)
 		var/obj/item/secret = new secret_type(src)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -31,7 +31,7 @@
 	. = ..()
 	. += "<span class='notice'>Alt-click to rotate it clockwise.</span>"
 
-/obj/structure/windoor_assembly/Initialize(mapload, loc, set_dir)
+/obj/structure/windoor_assembly/Initialize(mapload, set_dir)
 	. = ..()
 	if(set_dir)
 		dir = set_dir

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -31,8 +31,8 @@
 	. = ..()
 	. += "<span class='notice'>Alt-click to rotate it clockwise.</span>"
 
-/obj/structure/windoor_assembly/New(loc, set_dir)
-	..()
+/obj/structure/windoor_assembly/Initialize(mapload, loc, set_dir)
+	. = ..()
 	if(set_dir)
 		dir = set_dir
 	ini_dir = dir

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	if(!anchored && !fulltile)
 		. += "<span class='notice'>Alt-click to rotate it.</span>"
 
-/obj/structure/window/Initialize(mapload, Loc, direct)
+/obj/structure/window/Initialize(mapload, direct)
 	. = ..()
 	if(direct)
 		setDir(direct)
@@ -725,7 +725,7 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	cancolor = FALSE
 	var/made_glow = FALSE
 
-/obj/structure/window/reinforced/clockwork/Initialize(mapload, loc, direct)
+/obj/structure/window/reinforced/clockwork/Initialize(mapload, direct)
 	. = ..()
 	if(fulltile)
 		made_glow = TRUE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -69,8 +69,8 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	if(!anchored && !fulltile)
 		. += "<span class='notice'>Alt-click to rotate it.</span>"
 
-/obj/structure/window/New(Loc, direct)
-	..()
+/obj/structure/window/Initialize(mapload, Loc, direct)
+	. = ..()
 	if(direct)
 		setDir(direct)
 	if(reinf && anchored)
@@ -725,10 +725,10 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	cancolor = FALSE
 	var/made_glow = FALSE
 
-/obj/structure/window/reinforced/clockwork/New(loc, direct)
+/obj/structure/window/reinforced/clockwork/Initialize(mapload, loc, direct)
+	. = ..()
 	if(fulltile)
 		made_glow = TRUE
-	..()
 	QDEL_LIST(debris)
 	if(fulltile)
 		new /obj/effect/temp_visual/ratvar/window(get_turf(src))

--- a/code/modules/awaymissions/exile.dm
+++ b/code/modules/awaymissions/exile.dm
@@ -34,8 +34,8 @@
 	name = "exile implants"
 	req_access = list(ACCESS_ARMORY)
 
-/obj/structure/closet/secure_closet/exile/New()
-	..()
+/obj/structure/closet/secure_closet/exile/Initialize(mapload)
+	. = ..()
 	new /obj/item/implanter/exile(src)
 	new /obj/item/implantcase/exile(src)
 	new /obj/item/implantcase/exile(src)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -536,7 +536,7 @@
 	var/list/mutations_list = list()
 	var/mutativeness = 1
 
-/obj/structure/spacevine_controller/Initialize(mapload, loc, list/muts, potency, production)
+/obj/structure/spacevine_controller/Initialize(mapload, list/muts, potency, production)
 	. = ..()
 	color = "#ffffff"
 	spawn_spacevine_piece(loc, , muts)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -418,8 +418,8 @@
 	var/obj/structure/spacevine_controller/master = null
 	var/list/mutations = list()
 
-/obj/structure/spacevine/New()
-	..()
+/obj/structure/spacevine/Initialize(mapload)
+	. = ..()
 	color = "#ffffff"
 
 /obj/structure/spacevine/examine(mob/user)
@@ -536,7 +536,8 @@
 	var/list/mutations_list = list()
 	var/mutativeness = 1
 
-/obj/structure/spacevine_controller/New(loc, list/muts, potency, production)
+/obj/structure/spacevine_controller/Initialize(mapload, loc, list/muts, potency, production)
+	. = ..()
 	color = "#ffffff"
 	spawn_spacevine_piece(loc, , muts)
 	START_PROCESSING(SSobj, src)
@@ -554,8 +555,6 @@
 		// 6 vines/spread at 6 production
 		// ~2.5 vines/spread at 1 production
 		spread_multiplier /= spread_value / 5
-	..()
-
 
 /obj/structure/spacevine_controller/ex_act() //only killing all vines will end this suffering
 	return

--- a/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
@@ -165,8 +165,8 @@
 		if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 			break
 
-/obj/structure/closet/crate/juice/New()
-	..()
+/obj/structure/closet/crate/juice/Initialize(mapload)
+	. = ..()
 	new/obj/machinery/juicer(src)
 	new/obj/item/reagent_containers/food/snacks/grown/tomato(src)
 	new/obj/item/reagent_containers/food/snacks/grown/carrot(src)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -101,8 +101,8 @@
 /obj/structure/bookcase/manuals/medical
 	name = "Medical Manuals bookcase"
 
-/obj/structure/bookcase/manuals/medical/New()
-	..()
+/obj/structure/bookcase/manuals/medical/Initialize()
+	. = ..()
 	new /obj/item/book/manual/medical_cloning(src)
 	update_icon()
 
@@ -110,8 +110,8 @@
 /obj/structure/bookcase/manuals/engineering
 	name = "Engineering Manuals bookcase"
 
-/obj/structure/bookcase/manuals/engineering/New()
-	..()
+/obj/structure/bookcase/manuals/engineering/Initialize()
+	. = ..()
 	new /obj/item/book/manual/engineering_construction(src)
 	new /obj/item/book/manual/engineering_particle_accelerator(src)
 	new /obj/item/book/manual/engineering_hacking(src)
@@ -123,8 +123,8 @@
 /obj/structure/bookcase/manuals/research_and_development
 	name = "R&D Manuals bookcase"
 
-/obj/structure/bookcase/manuals/research_and_development/New()
-	..()
+/obj/structure/bookcase/manuals/research_and_development/Initialize()
+	. = ..()
 	new /obj/item/book/manual/research_and_development(src)
 	update_icon()
 

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -27,7 +27,7 @@
 	icon_state = "random_bookcase"
 	anchored = TRUE
 
-/obj/structure/bookcase/random/New()
+/obj/structure/bookcase/random/Initialize()
 	. = ..()
 	if(!book_count || !isnum(book_count))
 		update_icon()

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -10,8 +10,8 @@
 	var/codelen = 4
 	integrity_failure = 0 //no breaking open the crate
 
-/obj/structure/closet/crate/secure/loot/New()
-	..()
+/obj/structure/closet/crate/secure/loot/Initialize(mapload)
+	. = ..()
 	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 	code = ""
 	for(var/i = 0, i < codelen, i++)

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -162,8 +162,8 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	density = FALSE
 	var/beacon_network = "station"
 
-/obj/structure/extraction_point/New()
-	..()
+/obj/structure/extraction_point/Initialize(mapload)
+	. = ..()
 	name += " ([rand(100,999)]) ([get_location_name(src)])"
 	GLOB.total_extraction_beacons += src
 

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -1,8 +1,8 @@
 /obj/structure/closet/crate/necropolis/dragon
 	name = "dragon chest"
 
-/obj/structure/closet/crate/necropolis/dragon/New()
-	..()
+/obj/structure/closet/crate/necropolis/dragon/Initialize(mapload)
+	. = ..()
 	var/loot = rand(1,4)
 	switch(loot)
 		if(1)
@@ -19,8 +19,8 @@
 /obj/structure/closet/crate/necropolis/dragon/crusher
 	name = "firey dragon chest"
 
-/obj/structure/closet/crate/necropolis/dragon/crusher/New()
-	..()
+/obj/structure/closet/crate/necropolis/dragon/crusher/Initialize(mapload)
+	. = ..()
 	new /obj/item/crusher_trophy/tail_spike(src)
 
 

--- a/code/modules/mining/lavaland/loot/bubblegum_loot.dm
+++ b/code/modules/mining/lavaland/loot/bubblegum_loot.dm
@@ -1,8 +1,8 @@
 /obj/structure/closet/crate/necropolis/bubblegum
 	name = "bubblegum chest"
 
-/obj/structure/closet/crate/necropolis/bubblegum/New()
-	..()
+/obj/structure/closet/crate/necropolis/bubblegum/Initialize(mapload)
+	. = ..()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
 	var/loot = rand(1,3)
@@ -17,8 +17,8 @@
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"
 
-/obj/structure/closet/crate/necropolis/bubblegum/crusher/New()
-	..()
+/obj/structure/closet/crate/necropolis/bubblegum/crusher/Initialize(mapload)
+	. = ..()
 	new /obj/item/crusher_trophy/demon_claws(src)
 
 // Mayhem

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -2,8 +2,8 @@
 /obj/structure/closet/crate/necropolis/colossus
 	name = "colossus chest"
 
-/obj/structure/closet/crate/necropolis/colossus/New()
-	..()
+/obj/structure/closet/crate/necropolis/colossus/Initialize(mapload)
+	. = ..()
 	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
 	var/random_crystal = pick(choices)
 	new random_crystal(src)
@@ -12,8 +12,8 @@
 /obj/structure/closet/crate/necropolis/colossus/crusher
 	name = "angelic colossus chest"
 
-/obj/structure/closet/crate/necropolis/colossus/crusher/New()
-	..()
+/obj/structure/closet/crate/necropolis/colossus/crusher/Initialize(mapload)
+	. = ..()
 	new /obj/item/crusher_trophy/blaster_tubes(src)
 
 
@@ -449,8 +449,8 @@
 			holder_animal.gib()
 			return
 
-/obj/structure/closet/stasis/New()
-	..()
+/obj/structure/closet/stasis/Initialize(mapload)
+	. = ..()
 	if(isanimal(loc))
 		holder_animal = loc
 	START_PROCESSING(SSobj, src)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -11,8 +11,8 @@
 /obj/structure/closet/crate/necropolis/tendril
 	desc = "It's watching you suspiciously."
 
-/obj/structure/closet/crate/necropolis/tendril/New(add_loot = TRUE)
-	..()
+/obj/structure/closet/crate/necropolis/tendril/Initialize(mapload, add_loot = TRUE)
+	. = ..()
 
 	if(!add_loot)
 		return
@@ -87,9 +87,8 @@
 /obj/structure/closet/crate/necropolis/puzzle
 	name = "puzzling chest"
 
-/obj/structure/closet/crate/necropolis/puzzle/New()
-	..(FALSE)
-
+/obj/structure/closet/crate/necropolis/puzzle/Initialize(mapload)
+	. = ..() // This used to have a FALSE arg which went nowhere. I am just as confused.
 	var/loot = rand(1,3)
 	switch(loot)
 		if(1)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -25,8 +25,8 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
-/obj/structure/closet/wardrobe/miner/New()
-	..()
+/obj/structure/closet/wardrobe/miner/Initialize(mapload)
+	. = ..()
 	contents = list()
 	new /obj/item/storage/backpack/duffel(src)
 	new /obj/item/storage/backpack/explorer(src)
@@ -51,8 +51,8 @@
 	icon_off = "miningsecoff"
 	req_access = list(ACCESS_MINING)
 
-/obj/structure/closet/secure_closet/miner/New()
-	..()
+/obj/structure/closet/secure_closet/miner/Initialize(mapload)
+	. = ..()
 	new /obj/item/stack/sheet/mineral/sandbags(src, 5)
 	new /obj/item/storage/box/emptysandbags(src)
 	new /obj/item/shovel(src)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -124,8 +124,8 @@
 	icon_state = "stickyweb1"
 	var/creator_ckey = null
 
-/obj/structure/spider/terrorweb/New()
-	..()
+/obj/structure/spider/terrorweb/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		icon_state = "stickyweb2"
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -361,7 +361,7 @@
 	desc = "This multi-layered web seems to be able to resist air pressure."
 
 
-/obj/structure/spider/terrorweb/queen/New()
+/obj/structure/spider/terrorweb/queen/Initialize(mapload)
 	. = ..()
 	air_update_turf(TRUE)
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -21,8 +21,8 @@
 	var/frustration = 0
 	var/debug_ai_choices = FALSE
 
-/obj/structure/spider/spiderling/terror_spiderling/New()
-	..()
+/obj/structure/spider/spiderling/terror_spiderling/Initialize(mapload)
+	. = ..()
 	GLOB.ts_spiderling_list += src
 	if(is_away_level(z))
 		spider_awaymission = TRUE
@@ -203,8 +203,8 @@
 	var/spiderling_number = 1
 	var/list/enemies = list()
 
-/obj/structure/spider/eggcluster/terror_eggcluster/New()
-	..()
+/obj/structure/spider/eggcluster/terror_eggcluster/Initialize(mapload)
+	. = ..()
 	GLOB.ts_egg_list += src
 	spawn(50)
 		if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/red)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -11,8 +11,8 @@
 	smooth = SMOOTH_FALSE
 	var/growth_time = 1200
 
-/obj/structure/alien/resin/flower_bud_enemy/New()
-	..()
+/obj/structure/alien/resin/flower_bud_enemy/Initialize()
+	. = ..()
 	var/list/anchors = list()
 	anchors += locate(x-2,y+2,z)
 	anchors += locate(x+2,y+2,z)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -187,9 +187,9 @@ GLOBAL_LIST_EMPTY(employmentCabinets)
 	icon_state = "employmentcabinet"
 	var/populated = FALSE
 
-/obj/structure/filingcabinet/employment/New()
+/obj/structure/filingcabinet/employment/Initialize(mapload)
+	. = ..()
 	GLOB.employmentCabinets += src
-	return ..()
 
 /obj/structure/filingcabinet/employment/Destroy()
 	GLOB.employmentCabinets -= src

--- a/code/modules/paperwork/frames.dm
+++ b/code/modules/paperwork/frames.dm
@@ -177,8 +177,8 @@
 	var/tilted = 0
 	var/tilt_transform = null
 
-/obj/structure/sign/picture_frame/New(loc, F)
-	..()
+/obj/structure/sign/picture_frame/Initialize(mapload, loc, F)
+	. = ..()
 	frame = F
 	frame.pixel_x = 0
 	frame.pixel_y = 0

--- a/code/modules/paperwork/frames.dm
+++ b/code/modules/paperwork/frames.dm
@@ -177,7 +177,7 @@
 	var/tilted = 0
 	var/tilt_transform = null
 
-/obj/structure/sign/picture_frame/Initialize(mapload, loc, F)
+/obj/structure/sign/picture_frame/Initialize(mapload, F)
 	. = ..()
 	frame = F
 	frame.pixel_x = 0

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -23,10 +23,10 @@
 		return FALSE //so we can refill them via their afterattack.
 	return ..()
 
-/obj/structure/reagent_dispensers/New()
+/obj/structure/reagent_dispensers/Initialize(mapload)
+	. = ..()
 	create_reagents(tank_volume)
 	reagents.add_reagent(reagent_id, tank_volume)
-	..()
 
 /obj/structure/reagent_dispensers/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -16,7 +16,7 @@
 	var/base_state
 	var/dpdir = 0	// directions as disposalpipe
 
-/obj/structure/disposalconstruct/Initialize(mapload, loc, pipe_type, direction)
+/obj/structure/disposalconstruct/Initialize(mapload, pipe_type, direction)
 	. = ..()
 	if(pipe_type)
 		ptype = pipe_type

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -16,8 +16,8 @@
 	var/base_state
 	var/dpdir = 0	// directions as disposalpipe
 
-/obj/structure/disposalconstruct/New(loc, pipe_type, direction)
-	..()
+/obj/structure/disposalconstruct/Initialize(mapload, loc, pipe_type, direction)
+	. = ..()
 	if(pipe_type)
 		ptype = pipe_type
 	if(dir)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -690,8 +690,8 @@
 	var/base_icon_state	// initial icon state on map
 
 	// new pipe, set the icon_state as on map
-/obj/structure/disposalpipe/New()
-	..()
+/obj/structure/disposalpipe/Initialize(mapload)
+	. = ..()
 	base_icon_state = icon_state
 
 
@@ -932,8 +932,8 @@
 /obj/structure/disposalpipe/segment
 	icon_state = "pipe-s"
 
-/obj/structure/disposalpipe/segment/New()
-	..()
+/obj/structure/disposalpipe/segment/Initialize(mapload)
+	. = ..()
 	if(icon_state == "pipe-s")
 		dpdir = dir | turn(dir, 180)
 	else
@@ -947,8 +947,8 @@
 /obj/structure/disposalpipe/junction
 	icon_state = "pipe-j1"
 
-/obj/structure/disposalpipe/junction/New()
-	..()
+/obj/structure/disposalpipe/junction/Initialize(mapload)
+	. = ..()
 	if(icon_state == "pipe-j1")
 		dpdir = dir | turn(dir, -90) | turn(dir,180)
 	else if(icon_state == "pipe-j2")
@@ -1013,8 +1013,8 @@
 
 	dpdir = sortdir | posdir | negdir
 
-/obj/structure/disposalpipe/sortjunction/New()
-	..()
+/obj/structure/disposalpipe/sortjunction/Initialize(mapload)
+	. = ..()
 	updatedir()
 	updatedesc()
 	update()
@@ -1080,8 +1080,8 @@
 	var/negdir = 0
 	var/sortdir = 0
 
-/obj/structure/disposalpipe/wrapsortjunction/New()
-	..()
+/obj/structure/disposalpipe/wrapsortjunction/Initialize(mapload)
+	. = ..()
 	posdir = dir
 	if(icon_state == "pipe-j1s")
 		sortdir = turn(posdir, -90)
@@ -1135,8 +1135,8 @@
 	icon_state = "pipe-t"
 	var/obj/linked 	// the linked obj/machinery/disposal or obj/disposaloutlet
 
-/obj/structure/disposalpipe/trunk/New()
-	..()
+/obj/structure/disposalpipe/trunk/Initialize(mapload)
+	. = ..()
 	dpdir = dir
 	spawn(1)
 		getlinked()
@@ -1241,8 +1241,8 @@
 					// i.e. will be treated as an empty turf
 	desc = "A broken piece of disposal pipe."
 
-/obj/structure/disposalpipe/broken/New()
-	..()
+/obj/structure/disposalpipe/broken/Initialize(mapload)
+	. = ..()
 	update()
 	return
 
@@ -1267,13 +1267,23 @@
 	var/obj/structure/disposalpipe/trunk/linkedtrunk
 	var/mode = 0
 
-/obj/structure/disposaloutlet/New()
-	..()
-	spawn(1)
-		target = get_ranged_target_turf(src, dir, 10)
-		var/obj/structure/disposalpipe/trunk/T = locate() in loc
-		if(T)
-			T.nicely_link_to_other_stuff(src)
+/obj/structure/disposaloutlet/Initialize(mapload)
+	. = ..()
+	// Latelaod so that it can connect to trunks underneath
+	if(mapload)
+		return INITIALIZE_HINT_LATELOAD
+	else
+		connect_to_trunk()
+
+/obj/structure/disposaloutlet/LateInitialize()
+	. = ..()
+	connect_to_trunk()
+
+/obj/structure/disposaloutlet/proc/connect_to_trunk()
+	target = get_ranged_target_turf(src, dir, 10)
+	var/obj/structure/disposalpipe/trunk/T = locate() in loc
+	if(T)
+		T.nicely_link_to_other_stuff(src)
 
 /obj/structure/disposaloutlet/Destroy()
 	if(linkedtrunk)

--- a/code/modules/spacepods/construction.dm
+++ b/code/modules/spacepods/construction.dm
@@ -10,8 +10,8 @@
 
 	var/datum/construction/construct
 
-/obj/structure/spacepod_frame/New()
-	..()
+/obj/structure/spacepod_frame/Initialize(mapload)
+	. = ..()
 	bound_width = 64
 	bound_height = 64
 


### PR DESCRIPTION
## What Does This PR Do
Kills off all `/New()` instances for `/obj/structure` in favour of `Initialize()`, and also substituting in `/LateInitialize()` where needed instead of unreliable `spawn()` use. 

*I am not sure on 100% of my ..() calls here and whether I need args or not. Feel free to correct me in review*

The one structure that hanst been converted is the `/obj/structure/fusion_reactor` used on the syndicate depot, since @Kyep is certain that needs to use `/New()`, so I will have to find a way to make that work at some point, which is out the scope of this PR.

Reasons for moving to Initialize() are as follows:
- Less lag when initially starting up DD, which reduces the time period between test restarts and reconnection delay
- Atoms which `/New()` call that as soon as they are placed into the map, which could cause complications with map rotation and how I plan to load the maps in
- Initialize() gives us a lot more control of when and how atoms initialize [See LateInitialize() and Initialization hints]

I didnt encounter any weird issues when testing this locally, but a full TM is **definitely** in order due to the sheer scope of this, and how `Initialize()` can have unintended side effects if not done properly. 

## Why It's Good For The Game
See above reasons

## Changelog
:cl: AffectedArc07
tweak: All /obj/structure types now use Initialize() instead of New()
/:cl:
