### PR TITLE
Makes robotic limbs no longer count towards strange reagent gibbing threshold

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -766,7 +766,16 @@
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
-				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
+				var/totalLoss = 0
+				if(ishuman(M))
+					var/mob/living/carbon/human/P = M
+					for(var/obj/item/organ/external/E in P.bodyparts)
+						if(!E.is_robotic())
+							totalLoss += E.brute_dam + E.burn_dam
+					totalLoss += P.getCloneLoss()
+				else
+					totalLoss = M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss()
+				if (totalLoss >= 150)
 					M.delayed_gib()
 					return
 				if(!M.suiciding && !(NOCLONE in M.mutations) && (!M.mind || M.mind && M.mind.is_revivable()))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -767,18 +767,15 @@
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
 				var/totalLoss = 0
-				var/roboticLimbCount = 0
 				if(ishuman(M))
 					var/mob/living/carbon/human/P = M
 					for(var/obj/item/organ/external/E in P.bodyparts)
 						if(!E.is_robotic())
 							totalLoss += E.brute_dam + E.burn_dam
-						else
-							roboticLimbCount += 1
 					totalLoss += P.getCloneLoss()
 				else
 					totalLoss = M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss()
-				if (totalLoss >= 150 - (15*roboticLimbCount))
+				if (totalLoss >= 150 - (15 * roboticLimbCount))
 					M.delayed_gib()
 					return
 				if(!M.suiciding && !(NOCLONE in M.mutations) && (!M.mind || M.mind && M.mind.is_revivable()))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -766,16 +766,7 @@
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
-				var/totalLoss = 0
-				if(ishuman(M))
-					var/mob/living/carbon/human/P = M
-					for(var/obj/item/organ/external/E in P.bodyparts)
-						if(!E.is_robotic())
-							totalLoss += E.brute_dam + E.burn_dam
-					totalLoss += P.getCloneLoss()
-				else
-					totalLoss = M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss()
-				if (totalLoss >= 150)
+				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
 					M.delayed_gib()
 					return
 				if(!M.suiciding && !(NOCLONE in M.mutations) && (!M.mind || M.mind && M.mind.is_revivable()))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -766,7 +766,19 @@
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
-				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
+				var/totalLoss = 0
+				var/roboticLimbCount = 0
+				if(ishuman(M))
+					var/mob/living/carbon/human/P = M
+					for(var/obj/item/organ/external/E in P.bodyparts)
+						if(!E.is_robotic())
+							totalLoss += E.brute_dam + E.burn_dam
+						else
+							roboticLimbCount += 1
+					totalLoss += P.getCloneLoss()
+				else
+					totalLoss = M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss()
+				if (totalLoss >= 150 - (15*roboticLimbCount))
 					M.delayed_gib()
 					return
 				if(!M.suiciding && !(NOCLONE in M.mutations) && (!M.mind || M.mind && M.mind.is_revivable()))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -775,7 +775,7 @@
 					totalLoss += P.getCloneLoss()
 				else
 					totalLoss = M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss()
-				if (totalLoss >= 150 - (15 * roboticLimbCount))
+				if (totalLoss >= 150)
 					M.delayed_gib()
 					return
 				if(!M.suiciding && !(NOCLONE in M.mutations) && (!M.mind || M.mind && M.mind.is_revivable()))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that the threshold for SR gibbing no longer includes burn/brute damage to prosthetic bodyparts. Reduces gibbing threshold per prosthetic bodypart.

fixes: #14653
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It does not make sense for prosthetic bodyparts to inhibit the ability of SR to revive an otherwise organic body.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

~~Currently in the PR, as a balancing measure, the regular gibbing threshold on SR of 150 is reduced by 15 per robotic bodypart. This is very much subject to further tweaking and change.~~

## Changelog
:cl:
tweak: SR gibbing damage threshold no longer count burn/brute damage to prosthetic bodyparts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
