### PR TITLE
Removes /obj/machinery/microwave

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -1829,7 +1829,7 @@
 /area/security/permabrig)
 "adC" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -7485,7 +7485,7 @@
 /area/security/main)
 "amU" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -8750,7 +8750,7 @@
 /area/security/warden)
 "apq" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -16798,7 +16798,7 @@
 	})
 "aDz" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -45830,7 +45830,7 @@
 	},
 /area/engine/break_room)
 "bAs" = (
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_y = 4
 	},
 /obj/machinery/camera{
@@ -50995,7 +50995,7 @@
 	name = "\improper Command Hallway"
 	})
 "bJl" = (
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_y = 4
 	},
 /obj/structure/table/wood,
@@ -71117,7 +71117,7 @@
 	},
 /area/medical/reception)
 "crX" = (
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -82047,7 +82047,7 @@
 	},
 /area/medical/medbreak)
 "cKk" = (
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -85941,7 +85941,7 @@
 	pixel_x = 29
 	},
 /obj/structure/table/glass,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -182,7 +182,7 @@
 /area/ruin/powered/beach)
 "aI" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "aJ" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -337,7 +337,7 @@
 /area/ruin/powered/snow_biodome)
 "JZ" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "KS" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -5766,7 +5766,7 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "mx" = (
 /obj/structure/table/wood,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "my" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -622,7 +622,7 @@
 /area/ruin/unpowered)
 "br" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;

--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -648,7 +648,7 @@
 /area/ruin/unpowered)
 "bA" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	tag = "icon-bar";
 	icon_state = "bar"

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -189,7 +189,7 @@
 "aG" = (
 /obj/machinery/light/small,
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"

--- a/_maps/map_files/RandomZLevels/academy.dmm
+++ b/_maps/map_files/RandomZLevels/academy.dmm
@@ -1850,7 +1850,7 @@
 /area/awaymission/academy/classrooms)
 "fl" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"

--- a/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
+++ b/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
@@ -962,7 +962,7 @@
 /area/awaymission/BMPship/Midship)
 "cQ" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	tag = "icon-barber";
 	icon_state = "barber"

--- a/_maps/map_files/RandomZLevels/centcomAway.dmm
+++ b/_maps/map_files/RandomZLevels/centcomAway.dmm
@@ -299,7 +299,7 @@
 /area/awaymission/centcomAway/cafe)
 "aO" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -1785,7 +1785,7 @@
 /area/awaymission/centcomAway/hangar)
 "ey" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -916,7 +916,7 @@
 	})
 "bo" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -6360,7 +6360,7 @@
 	})
 "iW" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -6371,7 +6371,7 @@
 	})
 "iX" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},

--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -920,7 +920,7 @@
 /area/awaymission/spacebattle/cruiser)
 "cF" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
 	dir = 2

--- a/_maps/map_files/RandomZLevels/spacehotel.dmm
+++ b/_maps/map_files/RandomZLevels/spacehotel.dmm
@@ -3298,7 +3298,7 @@
 /area/awaymission/spacehotel/kitchen)
 "hh" = (
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/unsimulated/floor{
 	icon_state = "cafeteria"
 	},

--- a/_maps/map_files/RandomZLevels/stationCollision.dmm
+++ b/_maps/map_files/RandomZLevels/stationCollision.dmm
@@ -3199,7 +3199,7 @@
 	},
 /area/awaymission/arrivalblock)
 "ie" = (
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -2;
 	pixel_y = 7
 	},

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -2556,7 +2556,7 @@
 /area/awaymission/UO71/centralhall)
 "gl" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -2829,7 +2829,7 @@
 	network = list("UO71")
 	},
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},

--- a/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
@@ -4095,7 +4095,7 @@
 	})
 "gQ" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -4457,7 +4457,7 @@
 	network = list("UO45")
 	},
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},

--- a/_maps/map_files/RandomZLevels/wildwest.dmm
+++ b/_maps/map_files/RandomZLevels/wildwest.dmm
@@ -564,7 +564,7 @@
 	},
 /area/awaymission/wwmines)
 "bR" = (
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	tag = "icon-cafeteria (NORTHEAST)";
 	icon_state = "cafeteria";
@@ -955,7 +955,7 @@
 	},
 /area/awaymission/wwgov)
 "cQ" = (
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /obj/machinery/light/small{
 	tag = "icon-bulb1 (NORTH)";
 	icon_state = "bulb1";

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -2495,7 +2495,7 @@
 /area/mine/living_quarters)
 "fD" = (
 /obj/structure/table,
-/obj/machinery/microwave{
+/obj/machinery/kitchen_machine/microwave{
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/tile/bar{

--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -60,7 +60,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/obj/machinery/microwave,
+/obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/carpet/black,
 /area/survivalpod)
 "l" = (

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -42,15 +42,3 @@
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		E += M.rating
 	efficiency = E
-
-// The following code is present as temporary assurance for compatibility and to avoid merge conflicts for the TG mining port
-// Please delete this portion once all maps are updated to use the new object path: /obj/machinery/kitchen_machine/microwave
-
-/obj/machinery/microwave
-	name = "Microwave spawner"
-	icon = 'icons/obj/kitchen.dmi'
-	icon_state = "mw"
-
-/obj/machinery/microwave/New()
-	new /obj/machinery/kitchen_machine/microwave(get_turf(src))
-	qdel(src)


### PR DESCRIPTION
## What Does This PR Do
Removes /obj/machinery/microwave

It was a temporary spawner for the real /obj/machinery/kitchen_machiner/microwave which was meant to be cleaned up **four years ago**

## Why It's Good For The Game
Old shitcode bad

## Images of changes
MDB will render them, but its going to be images of mostly the same stuff. *Lord have mercy on my database*

## Changelog
:cl: AffectedArc07
del: Removed microwave spawners. Yes, you read that correctly.
/:cl:
