### PR TITLE
No longer shows flavour text when examining someone who's mutilated

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -388,7 +388,7 @@
 		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=[UID()];medical=1'>\[[medical]\]</a>\n"
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=[UID()];medrecord=`'>\[View\]</a> <a href='?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
-	if(print_flavor_text() && !is_destroyed["head"])
+	if(print_flavor_text() && get_organ("head"))
 		if(!(skipface || get_organ("head").disfigured || src.cloneloss > 50 || (HUSK in src.mutations)))
 			msg += "[print_flavor_text()]\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -388,9 +388,11 @@
 		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=[UID()];medical=1'>\[[medical]\]</a>\n"
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=[UID()];medrecord=`'>\[View\]</a> <a href='?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
-	if(print_flavor_text() && get_organ("head"))
-		if(!(skipface || get_organ("head").disfigured || src.cloneloss > 50 || (HUSK in src.mutations)))
-			msg += "[print_flavor_text()]\n"
+	if(print_flavor_text() && !skipface)
+		if(get_organ("head"))
+			var/obj/item/organ/external/head/H = get_organ("head")
+			if(!(H.disfigured || cloneloss > 50 || (HUSK in mutations)))
+				msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"
 	if(pose)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -391,7 +391,7 @@
 	if(print_flavor_text() && !skipface)
 		if(get_organ("head"))
 			var/obj/item/organ/external/head/H = get_organ("head")
-			if(!(H.disfigured || cloneloss > 50 || (HUSK in mutations)))
+			if(!H.disfigured)
 				msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -388,8 +388,7 @@
 		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=[UID()];medical=1'>\[[medical]\]</a>\n"
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=[UID()];medrecord=`'>\[View\]</a> <a href='?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
-
-	if(print_flavor_text() && !skipface)
+	if(print_flavor_text() && !(skipface || get_organ("head").disfigured || src.cloneloss > 50 || (HUSK in src.mutations)))
 		msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -388,7 +388,7 @@
 		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=[UID()];medical=1'>\[[medical]\]</a>\n"
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=[UID()];medrecord=`'>\[View\]</a> <a href='?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
-	if(print_flavor_text() && head)
+	if(print_flavor_text() && !is_destroyed["head"])
 		if(!(skipface || get_organ("head").disfigured || src.cloneloss > 50 || (HUSK in src.mutations)))
 			msg += "[print_flavor_text()]\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -388,8 +388,9 @@
 		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=[UID()];medical=1'>\[[medical]\]</a>\n"
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=[UID()];medrecord=`'>\[View\]</a> <a href='?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
-	if(print_flavor_text() && !(skipface || get_organ("head").disfigured || src.cloneloss > 50 || (HUSK in src.mutations)))
-		msg += "[print_flavor_text()]\n"
+	if(print_flavor_text() && head)
+		if(!(skipface || get_organ("head").disfigured || src.cloneloss > 50 || (HUSK in src.mutations)))
+			msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"
 	if(pose)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that when someone becomes unknown due to facial damage, flavour text no longer shows up upon examining.

fixes: #7164
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Someone who's mutilated/husked/facially disfigured should not be easily identifiable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: People with a disfigured face no longer have flavour text upon examination.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
