### PR TITLE
Allow mass drivers and mass driver buttons to be linked again

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -89,18 +89,6 @@
 	<li><b>Logic ID Tag:</b> [format_tag("Logic ID Tag", "logic_id_tag")]</li>
 	</ul>"}
 
-/obj/machinery/driver_button/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
-	if("set_id" in href_list)
-		var/newid = copytext(reject_bad_text(input(user, "Specify the new ID tag for this machine", name, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
-		if(!newid)
-			return
-		
-		id_tag = newid
-
-		return TRUE
-
-	return ..()
-
 /obj/machinery/driver_button/attack_hand(mob/user as mob)
 
 	add_fingerprint(usr)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -91,7 +91,7 @@
 
 /obj/machinery/driver_button/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
 	if("set_id" in href_list)
-		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, src.id_tag) as null|text), 1, MAX_MESSAGE_LEN)
+		var/newid = copytext(reject_bad_text(input(user, "Specify the new ID tag for this machine", name, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
 		if(!newid)
 			return
 		

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -84,10 +84,22 @@
 /obj/machinery/driver_button/multitool_menu(var/mob/user, var/obj/item/multitool/P)
 	return {"
 	<ul>
-	<li><b>ID Tag:</b> [format_tag("ID Tag","id_tag")]</li>
+	<li><b>ID Tag:</b> [format_tag("ID Tag","id_tag","set_id")]</li>
 	<li><b>Logic Connection:</b> <a href='?src=[UID()];toggle_logic=1'>[logic_connect ? "On" : "Off"]</a></li>
 	<li><b>Logic ID Tag:</b> [format_tag("Logic ID Tag", "logic_id_tag")]</li>
 	</ul>"}
+
+/obj/machinery/driver_button/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
+	if("set_id" in href_list)
+		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, src.id_tag) as null|text), 1, MAX_MESSAGE_LEN)
+		if(!newid)
+			return
+		
+		id_tag = newid
+
+		return TRUE
+
+	return ..()
 
 /obj/machinery/driver_button/attack_hand(mob/user as mob)
 

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -37,8 +37,20 @@
 /obj/machinery/mass_driver/multitool_menu(var/mob/user, var/obj/item/multitool/P)
 	return {"
 	<ul>
-	<li>[format_tag("ID Tag","id_tag")]</li>
+	<li>[format_tag("ID Tag","id_tag","set_id")]</li>
 	</ul>"}
+
+/obj/machinery/mass_driver/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
+	if("set_id" in href_list)
+		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, src.id_tag) as null|text), 1, MAX_MESSAGE_LEN)
+		if(!newid)
+			return
+		
+		id_tag = newid
+
+		return TRUE
+
+	return ..()
 
 /obj/machinery/mass_driver/proc/drive(amount)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -40,18 +40,6 @@
 	<li>[format_tag("ID Tag","id_tag","set_id")]</li>
 	</ul>"}
 
-/obj/machinery/mass_driver/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
-	if("set_id" in href_list)
-		var/newid = copytext(reject_bad_text(input(user, "Specify the new ID tag for this machine", name, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
-		if(!newid)
-			return
-		
-		id_tag = newid
-
-		return TRUE
-
-	return ..()
-
 /obj/machinery/mass_driver/proc/drive(amount)
 	if(stat & (BROKEN|NOPOWER))
 		return

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -42,7 +42,7 @@
 
 /obj/machinery/mass_driver/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
 	if("set_id" in href_list)
-		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, src.id_tag) as null|text), 1, MAX_MESSAGE_LEN)
+		var/newid = copytext(reject_bad_text(input(user, "Specify the new ID tag for this machine", name, id_tag) as null|text), 1, MAX_MESSAGE_LEN)
 		if(!newid)
 			return
 		


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows you to edit mass driver and mass driver button tags again.

fixes: #14723
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tags should be editable so you can actually properly link these.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mass driver and mass driver button id tags are now editable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
