### PR TITLE
Makes dead brains able to ghost speak

### DIFF
--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -1,5 +1,7 @@
 //TODO: Convert this over for languages.
-/mob/living/carbon/brain/say(var/message, var/datum/language/speaking = null)
+/mob/living/carbon/brain/say(message, datum/language/speaking = null)
+	if(stat == DEAD)
+		return ..()
 	if(!can_speak(warning = TRUE))
 		return
 


### PR DESCRIPTION
## What Does This PR Do
Makes brain mobs able to talk while dead. So when a ghost is in the brain when they are gibbed for example

## Why It's Good For The Game
Removes some weirdness of not being able to talk in dchat while dead as a brain waiting for surgery

## Changelog
:cl:
tweak: Dead brains (people in brains and not ghosted) can speak in deadchat
/:cl: