### PR TITLE
Operating Computer - Patient Status

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -51,17 +51,14 @@
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
 	if(!ishuman(user) && !isrobot(user)) //Only Humanoids and Cyborgs can put things on this table
 		return
-	if(!check_table()) //Is the Operating Table empty?
+	if(!check_table()) //If the Operating Table is occupied, you cannot put someone else on it
 		return
 	if(user.restrained() || user.buckled || user.IsWeakened() || user.stunned || user.incapacitated()) //Is the person trying to use the table incapacitated or restrained?
 		return
-	if(!ishuman(O)) //Only Humanoids can go on this table
+	var/mob/living/carbon/C = O
+	if(!C) //Only Carbon mobs can go on this table, if C is null, get out of here
 		return
-	if(isanimal(O) || isrobot(O)) //Animals and Cyborgs do not go on the table
-		return
-	var/mob/living/L = O
-	take_patient(L, user)
-	return
+	take_patient(C, user)
 
 /obj/machinery/optable/proc/check_patient()
 	if(locate(/mob/living/carbon/human, loc))

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -48,19 +48,19 @@
 		return FALSE
 
 
-/obj/machinery/optable/MouseDrop_T(atom/movable/O as mob|obj, var/mob/P)
-	if(usr.stat || (!ishuman(P) && !isrobot(P)) || !check_table())
+/obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
+	if(!ishuman(user) && !isrobot(user)) //Only Humanoids and Cyborgs can put things on this table
 		return
-	if(!check_table()) //Is the Operating Table currently occupied?
+	if(!check_table()) //Is the Operating Table empty?
 		return
-	if(P.restrained() || P.buckled || P.incapacitated()) //Folks who are restrained or otherwise incapacitated cannot get on the table
+	if(user.restrained() || user.buckled || user.IsWeakened() || user.stunned || user.incapacitated()) //Is the person trying to use the table incapacitated or restrained?
 		return
-	if(!ismob(O)) //Humans only
+	if(!ishuman(O) //Only Humanoids can go on this table
 		return
-	if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon)) //animals and robots dont fit
+	if(isanimal(O)) || isrobot(O)) //Animals and Cyborgs do not go on the table
 		return
 	var/mob/living/L = O
-	take_patient(L, usr)
+	take_patient(L, user)
 	return
 
 /obj/machinery/optable/proc/check_patient()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -55,7 +55,7 @@
 		return
 	if(user.restrained() || user.buckled || user.IsWeakened() || user.stunned || user.incapacitated()) //Is the person trying to use the table incapacitated or restrained?
 		return
-	if(!ishuman(O) //Only Humanoids can go on this table
+	if(!ishuman(O)) //Only Humanoids can go on this table
 		return
 	if(isanimal(O)) || isrobot(O)) //Animals and Cyborgs do not go on the table
 		return

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -57,7 +57,7 @@
 		return
 	if(!ishuman(O)) //Only Humanoids can go on this table
 		return
-	if(isanimal(O)) || isrobot(O)) //Animals and Cyborgs do not go on the table
+	if(isanimal(O) || isrobot(O)) //Animals and Cyborgs do not go on the table
 		return
 	var/mob/living/L = O
 	take_patient(L, user)
@@ -94,8 +94,6 @@
 		user.visible_message("[user] climbs on the operating table.","You climb on the operating table.")
 	else
 		visible_message("<span class='alert'>[C] has been laid on the operating table by [user].</span>")
-	computer.newPat = TRUE
-	computer.patStatHolder = null
 	C.resting = TRUE
 	C.update_canmove()
 	C.forceMove(loc)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -28,8 +28,7 @@
 	if(computer)
 		computer.table = null
 		computer = null
-	if(patient)
-		patient = null
+	patient = null
 	return ..()
 
 /obj/machinery/optable/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)
@@ -40,34 +39,33 @@
 		return TRUE
 
 /obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0)
-	if(height==0)
+	if(height == 0)
 		return TRUE
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return TRUE
 	else
 		return FALSE
 
-
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
 	if(!ishuman(user) && !isrobot(user)) //Only Humanoids and Cyborgs can put things on this table
 		return
 	if(!check_table()) //If the Operating Table is occupied, you cannot put someone else on it
 		return
-	if(user.restrained() || user.buckled || user.IsWeakened() || user.stunned || user.incapacitated()) //Is the person trying to use the table incapacitated or restrained?
+	if(user.buckled || user.incapacitated()) //Is the person trying to use the table incapacitated or restrained?
 		return
-	var/mob/living/carbon/C = O
-	if(!C) //Only Carbon mobs can go on this table, if C is null, get out of here
+	if(!ismob(O) || !iscarbon(O)) //Only Mobs and Carbons can go on this table (no syptic patches please)
 		return
-	take_patient(C, user)
+	take_patient(O, user)
 
 /obj/machinery/optable/proc/check_patient()
-	if(locate(/mob/living/carbon/human, loc))
-		var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, loc)
-		if(M.lying)
-			patient = M
-			if(!no_icon_updates)
-				icon_state = M.pulse ? "table2-active" : "table2-idle"
-			return TRUE
+	var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, loc)
+	if(!M)
+		return FALSE
+	if(M.lying)
+		patient = M
+		if(!no_icon_updates)
+			icon_state = M.pulse ? "table2-active" : "table2-idle"
+		return TRUE
 	patient = null
 	if(!no_icon_updates)
 		icon_state = "table2-idle"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -53,7 +53,7 @@
 		return
 	if(!check_table()) //Is the Operating Table currently occupied?
 		return
-	if(user.restrained() || user.buckled || user.incapacitated()) //Folks who are restrained or otherwise incapacitated cannot get on the table
+	if(P.restrained() || P.buckled || P.incapacitated()) //Folks who are restrained or otherwise incapacitated cannot get on the table
 		return
 	if(!ismob(O)) //Humans only
 		return

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -172,7 +172,7 @@
 /obj/machinery/computer/operating/process()
 	if(table && table.check_patient())
 		if(verbose)
-			var/static/patientStatus
+			var/patientStatus
 			if((table.patient.stat != patientStatusHolder) || newPat)
 				if(table.patient.stat == DEAD || table.patient.status_flags & FAKEDEATH)
 					patientStatus = "Dead"

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -17,7 +17,7 @@
 	var/nextTick = OP_COMPUTER_COOLDOWN
 	var/healthAlarm = 50
 	var/oxy = TRUE //oxygen beeping toggle
-	var/currentPatient //Who is on the Operating Table connected to the respective Operating Computer?
+	var/mob/living/carbon/currentPatient //Who is on the Operating Table connected to the respective Operating Computer?
 	var/patientStatusHolder //Hold the last instance of table.patient.status. When table.patient.status no longer matches this variable, the computer should tell the doctor
 
 /obj/machinery/computer/operating/New()
@@ -32,6 +32,8 @@
 	if(table)
 		table.computer = null
 		table = null
+	if(currentPatient)
+		currentPatient = null
 	return ..()
 
 /obj/machinery/computer/operating/attack_ai(mob/user)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -18,8 +18,7 @@
 	var/healthAlarm = 50
 	var/oxy = TRUE //oxygen beeping toggle
 	var/newPat = TRUE
-	var/patStat
-	var/patStatHolder
+	var/patientStatusHolder //Patient Status Holder
 
 /obj/machinery/computer/operating/New()
 	..()
@@ -173,18 +172,19 @@
 /obj/machinery/computer/operating/process()
 	if(table && table.check_patient())
 		if(verbose)
-			if((table.patient.stat != patStatHolder) || newPat)
+			var/static/patientStatus
+			if((table.patient.stat != patientStatusHolder) || newPat)
 				if(table.patient.stat == DEAD || table.patient.status_flags & FAKEDEATH)
-					patStat = "Dead"
+					patientStatus = "Dead"
 				else if(table.patient.stat == CONSCIOUS)
-					patStat = "Awake"
+					patientStatus = "Awake"
 				else if(table.patient.stat == UNCONSCIOUS)
-					patStat = "Asleep"
+					patientStatus = "Asleep"
 			if(newPat)
 				atom_say("New patient detected, loading stats")
-				atom_say("[table.patient], [table.patient.dna.blood_type] blood, [patStat]")
+				atom_say("[table.patient], [table.patient.dna.blood_type] blood, [patientStatus]")
 				SStgui.update_uis(src)
-				patStatHolder = table.patient.stat
+				patientStatusHolder = table.patient.stat
 				newPat = FALSE
 			if(nextTick < world.time)
 				nextTick=world.time + OP_COMPUTER_COOLDOWN
@@ -194,6 +194,6 @@
 					playsound(src.loc, 'sound/machines/defib_saftyoff.ogg', 50, 0)
 				if(healthAnnounce && table.patient.health <= healthAlarm)
 					atom_say("[round(table.patient.health)]")
-				if(table.patient.stat != patStatHolder)
-					atom_say("Patient is currently: [patStat]")
-					patStatHolder = table.patient.stat
+				if(table.patient.stat != patientStatusHolder)
+					atom_say("Patient is currently [patientStatus]")
+					patientStatusHolder = table.patient.stat


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Special Thanks
**HUGE thanks to @moxian for helping with this PR!**
Their feedback has been invaluable in cleaning this code up and making the new code much neater and more efficient. I definitely consider them a co-author on this project since they gave me "snippets" of code that I then implemented in the design.
Credit also to @farie82 for helping out with the initial thought process around this.

## What Does This PR Do
Operating Computers now give updates when the patient's status changes in terms of being awake, asleep, or dead.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When you're operating on a patient, it's often important to know if they're awake or asleep. This is particularly handy when you're operating on patients who cannot use anesthesia, such as Vox and Plasmamen - if they are using the Sleep verb, they can wake up and it's good to know when this changes. The "dead" status also accounts for Changeling fake death. No meta here, please!

This PR also goes through and tries to clean up old code in `OpTable.dm` and `Operating.dm`.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
**Note:** "currently" has been changed to "now" // _"Patient is currently Awake"_ will read as _"Patient is **now** Awake"_
\-
Awake:
![image](https://user-images.githubusercontent.com/69871346/97191546-60f5bb80-177d-11eb-94b5-a90f555d555c.png)
\-
Then the patient fell Asleep:
![image](https://user-images.githubusercontent.com/69871346/97191630-7539b880-177d-11eb-9986-f4707867e7ee.png)
\-
After a brief nap, they became Awake, then returned to being Asleep, then were suddenly Dead.
Here's Dead:
![image](https://user-images.githubusercontent.com/69871346/97191782-98fcfe80-177d-11eb-8694-ba63ce2cea6c.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: A check on an Operating Table's patient's awake/asleep/dead status. The Operating Computer will now alert doctors when this changes.
tweak: Clean-up of the Operating Table and Operating Computer codes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
