### PR TITLE
Fix highlights breaking the DOM

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -1049,7 +1049,7 @@ $(function() {
 		if ($('.popup .highlightTerm').is(':visible')) {return;}
 		var termInputs = '';
 		for (var i = 0; i < opts.highlightLimit; i++) {
-			termInputs += '<div><input type="text" name="highlightTermInput'+i+'" id="highlightTermInput'+i+'" class="highlightTermInput'+i+'" value="" /></div>';
+			termInputs += '<div><input type="text" name="highlightTermInput'+i+'" id="highlightTermInput'+i+'" class="highlightTermInput'+i+'" maxlength="255" value="" /></div>';
 		}
 		var popupContent = '<div class="head">String Highlighting</div>' +
 			'<div class="highlightPopup" id="highlightPopup">' +

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -1049,7 +1049,7 @@ $(function() {
 		if ($('.popup .highlightTerm').is(':visible')) {return;}
 		var termInputs = '';
 		for (var i = 0; i < opts.highlightLimit; i++) {
-			termInputs += '<div><input type="text" name="highlightTermInput'+i+'" id="highlightTermInput'+i+'" class="highlightTermInput'+i+'" maxlength="255" value="'+(opts.highlightTerms[i] ? opts.highlightTerms[i] : '')+'" /></div>';
+			termInputs += '<div><input type="text" name="highlightTermInput'+i+'" id="highlightTermInput'+i+'" class="highlightTermInput'+i+'" value="" /></div>';
 		}
 		var popupContent = '<div class="head">String Highlighting</div>' +
 			'<div class="highlightPopup" id="highlightPopup">' +
@@ -1064,6 +1064,9 @@ $(function() {
 				'</form>' +
 			'</div>';
 		createPopup(popupContent, 250);
+		for(var i = 0; i < opts.highlightLimit; i++){
+			document.querySelector(".highlightTermInput"+i).setAttribute("value",(opts.highlightTerms[i] ? opts.highlightTerms[i] : ''));
+		}
 		document.querySelector(".popup #highlightRegexEnable").checked = opts.highlightRegexEnable;
 	});
 	$('body').on('keyup', '#highlightColor', function() {


### PR DESCRIPTION
## What Does This PR Do
Stops highlights containing " from breaking the DOM.

## Why It's Good For The Game
The way the highlight popup was originally written, inserted highlight terms as text into the DOM, instead of setting the value of their input boxes, This caused any highlight containing " to cut off when the highlight panel was opened, and could, in theory, break the DOM if other special characters such as > were placed after it. This has now been fixed by manipulating the input box elements in code.

## Changelog
:cl:
fix: Highlight terms being able to break the DOM when the highlight panel opens.
/:cl:

This is practically the same PR as #14066, but without the maxlength attribute removed.