### PR TITLE
Makes sure voice grenades beep first before they boom

### DIFF
--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -32,9 +32,9 @@
 		var/turf/T = get_turf(src)	//otherwise it won't work in hand
 		T.visible_message("[bicon(src)] beeps, \"Activation message is [type ? "the sound when one [recorded]" : "'[recorded]'."]\"")
 	else if(findtext(msg, recorded) && type == recorded_type)
-		pulse(0)
 		var/turf/T = get_turf(src)  //otherwise it won't work in hand
 		T.visible_message("<span class='warning'>[bicon(src)] beeps!</span>")
+		pulse(0)
 
 /obj/item/assembly/voice/activate()
 	return // previously this toggled listning when not in a holder, that's a little silly.  It was only called in attack_self that way.


### PR DESCRIPTION
## What Does This PR Do
Makes it so that the voice analyser grenades actually beep before booming

Fixes:
```
Runtime in voice.dm,37: Cannot execute null.visible message().
   proc name: hear input (/obj/item/assembly/voice/proc/hear_input)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (140,106,1) (/turf/simulated/floor/plasteel)
   src: the voice analyzer (/obj/item/assembly/voice)
   src.loc: null
   call stack:
   the voice analyzer (/obj/item/assembly/voice): hear input(NAME (/mob/living/carbon/human), "CLean!", 0)
   the voice analyzer (/obj/item/assembly/voice): hear talk(NAME (/mob/living/carbon/human), /list (/list))
   the igniter-voice analyzer ass... (/obj/item/assembly_holder): hear talk(NAME (/mob/living/carbon/human), /list (/list))
   the voice-activated bomb (Clea... (/obj/item/grenade/chem_grenade): hear talk(NAME (/mob/living/carbon/human), /list (/list))
   the satchel (/obj/item/storage/backpack/satchel_norm): hear talk(NAME (/mob/living/carbon/human), /list (/list), "exclaims")
   NAME (/mob/living/carbon/human): say("CLean!", "exclaims", 1, 0, 0)
```

## Why It's Good For The Game
Runtime no funtime


## Changelog
:cl:
fix: Voice activated grenades now properly beep before booming
/:cl: