### PR TITLE
DMAPI Update GitHub Action

### DIFF
--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -1,0 +1,44 @@
+name: Update TGS DMAPI
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-dmapi:
+    runs-on: ubuntu-latest
+    name: Update the TGS DMAPI
+    steps:
+    - name: Clone
+      uses: actions/checkout@v2
+
+    - name: Branch
+      run: |
+        git branch -f tgs-dmapi-update
+        git checkout tgs-dmapi-update
+        git reset --hard master
+
+    - name: Apply DMAPI update
+      uses: tgstation/tgs-dmapi-updater@v2
+      with:
+        header-path: 'code/__DEFINES/tgs.dm'
+        library-path: 'code/modules/tgs'
+
+    - name: Commit and Push
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "DMAPI Update"
+        git add .
+        git commit -m 'Update TGS DMAPI'
+        git push -f -u origin tgs-dmapi-update
+
+    - name: Create Pull Request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: "tgs-dmapi-update"
+        destination_branch: "master"
+        pr_title: "Automatic TGS DMAPI Update"
+        pr_body: "This pull request updates the TGS DMAPI to the latest version. Please note any breaking or unimplemented changes before merging."
+        pr_label: "Infrastructure"
+        pr_allow_empty: false
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What Does This PR Do
Adds in a GitHub action which can auto-create PRs for DMAPI version updates for TGS compatibility. 

**It does not directly push to master. It makes pull requests**

*heavily* based on https://github.com/tgstation/tgstation/blob/master/.github/workflows/update_tgs_dmapi.yml

## Why It's Good For The Repository
Keeps external libraries up to date for tooling w may use some day, also without this I guarantee you that DMAPI would get ignored, even by me
