### PR TITLE
Fixes hallucination mutation

### DIFF
--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -50,7 +50,7 @@
 
 /datum/dna/gene/disability/hallucinate/OnMobLife(mob/living/carbon/human/H)
 	if(prob(1))
-		H.Hallucinate(20)
+		H.AdjustHallucinate(45)
 
 /datum/dna/gene/disability/epilepsy
 	name = "Epilepsy"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #14721
Since more than 20 hallucination stacks are needed for any hallucination to occur, this PR adds more than that at a hallucination mutation proc. It shouldn't last too long by default, but you can get unlucky and have two procs for a slightly longer bit of hallucination.

Hallucination decays fairly quickly. Still, numbers are fairly arbitrary, could easily be corrected up or down. But 45 seems to be in the right ballpark looking at other things that adjust hallucinations.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hallucination mutation actually doing things is good.

Also, using adjust rather than directly setting values is very good, too. This also prevents a hallucination mutation being triggered from potentially lowering your hallucination stacks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: hallucination mutation now works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
