### PR TITLE
[DNM] Prevents ghosts from being visable with spectral sword. (working on orbiting ghost orbs)

### DIFF
--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -40,6 +40,8 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	var/summon_cooldown = 0
 	var/list/mob/dead/observer/spirits
+	var/globes_list = list()
+	var/spirit_count = 0
 
 /obj/item/melee/ghost_sword/New()
 	..()
@@ -73,17 +75,46 @@
 
 /obj/item/melee/ghost_sword/process()
 	ghost_check()
+	update_globes()
 
 /obj/item/melee/ghost_sword/proc/ghost_check()
 	var/ghost_counter = 0
 	var/turf/T = get_turf(src)
 	var/list/contents = T.GetAllContents()
+	var/mob/dead/observer/current_spirits = list()
+
 
 	for(var/mob/dead/observer/O in GLOB.player_list)
 		if((O.orbiting in contents))
 			ghost_counter++
+			current_spirits |= O
+
+	for(var/mob/dead/observer/G in spirits - current_spirits)
+
+	spirits = current_spirits
 
 	return ghost_counter
+
+/obj/item/melee/ghost_sword/proc/update_globes()
+	var/old_spirit_count = spirit_count
+	var/new_spirit_count = ghost_check()
+	var/cur_spirit_count = old_spirit_count
+	if(cur_spirit_count < new_spirit_count)
+		var/obj/effect/overlay/ghost_orbs/G = new(loc)
+		G.orbit(src, rand(15, 30), FALSE, rand(15,25)) //bit of randomness to the orbs
+		globes_list |= G
+		cur_spirit_count ++
+	message_admins("[old_spirit_count]")
+	message_admins("[new_spirit_count]")
+	message_admins("[cur_spirit_count]")
+	if(cur_spirit_count > new_spirit_count)
+		message_admins("a")
+		for(var/obj/effect/overlay/ghost_orbs/X in globes_list)
+			message_admins("B")
+			globes_list -= X
+			del(X)
+
+	spirit_count = new_spirit_count
 
 /obj/item/melee/ghost_sword/attack(mob/living/target, mob/living/carbon/human/user)
 	force = 0
@@ -98,6 +129,13 @@
 	final_block_chance += clamp((ghost_counter * 5), 0, 75)
 	owner.visible_message("<span class='danger'>[owner] is protected by a ring of [ghost_counter] ghosts!</span>")
 	return ..()
+
+/obj/effect/overlay/ghost_orbs
+	name = "Spectral orbs"
+	desc = "These strange orbs seem almost incoperal, and weak, but together they seem much stronger."
+	icon = 'icons/obj/projectiles.dmi'
+	icon_state = "magicm"
+	color = "#64bccc"
 
 // Blood
 

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -78,18 +78,10 @@
 	var/ghost_counter = 0
 	var/turf/T = get_turf(src)
 	var/list/contents = T.GetAllContents()
-	var/mob/dead/observer/current_spirits = list()
 
 	for(var/mob/dead/observer/O in GLOB.player_list)
 		if((O.orbiting in contents))
 			ghost_counter++
-			O.invisibility = 0
-			current_spirits |= O
-
-	for(var/mob/dead/observer/G in spirits - current_spirits)
-		G.invisibility = initial(G.invisibility)
-
-	spirits = current_spirits
 
 	return ghost_counter
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Prevents spectral sword from making ghosts visible. You can still call ghosts to orbit you, and it still becomes stronger with more ghosts.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ghosts being visible from spectral sword leads to many problems. They point to antags. They point to security officers for the antag in maint. They orbit other things then the sword user, being visible for a moment before becoming invisible again . And they can reveal way to many things to the crew that they should not know. Be it a swarmer or terror corpse, or the body of the dead captain, while the "captain" is sitting on the bridge. As nice as seeing ghosts with this sword is, the ghosts themselves are not responsible enough to be visible, and thus, should be removed. I would _love_ a visual orbit effect of ghostly orbs orbiting you, thus preventing pointing, seeing dead bodies, or leading to things, but as I am not able to do that, this fix will do for now.


## Changelog
:cl:
tweak: Spectral sword no longer makes ghosts visible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
