### PR TITLE
Command amplification on telecomms no longer allows for empty messages (Now with 99% less sprites)

### DIFF
--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -226,7 +226,7 @@
 /datum/nttc_configuration/proc/modify_message(datum/tcomms_message/tcm)
 	// Check if they should be blacklisted right off the bat. We can save CPU if the message wont even be processed
 	if(tcm.sender_name in filtering)
-		tcm.pass = FALSE	
+		tcm.pass = FALSE
 	// All job and coloring shit
 	if(toggle_job_color || toggle_name_color)
 		var/job = tcm.sender_job

--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -226,7 +226,7 @@
 /datum/nttc_configuration/proc/modify_message(datum/tcomms_message/tcm)
 	// Check if they should be blacklisted right off the bat. We can save CPU if the message wont even be processed
 	if(tcm.sender_name in filtering)
-		tcm.pass = FALSE
+		tcm.pass = FALSE	
 	// All job and coloring shit
 	if(toggle_job_color || toggle_name_color)
 		var/job = tcm.sender_job
@@ -276,7 +276,8 @@
 		var/job = tcm.sender_job
 		if((job in ert_jobs) || (job in heads))
 			for(var/datum/multilingual_say_piece/S in message_pieces)
-				S.message = "<b>[capitalize(S.message)]</b>" // This only capitalizes the first word
+				if(S.message != "")
+					S.message = "<b>[capitalize(S.message)]</b>" // This only capitalizes the first word
 
 	// Language Conversion
 	if(setting_language && valid_languages[setting_language])

--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -276,7 +276,7 @@
 		var/job = tcm.sender_job
 		if((job in ert_jobs) || (job in heads))
 			for(var/datum/multilingual_say_piece/S in message_pieces)
-				if(S.message != "")
+				if(S.message)
 					S.message = "<b>[capitalize(S.message)]</b>" // This only capitalizes the first word
 
 	// Language Conversion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When you try to speak over radio as a member of command while silenced by mute sting/slingglare/chems/etc. you will no longer broadcast an empty message like `[Common] [Captain] Praxis Chailer says, ""`

fixes: #14133
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes muting abilities less useless against department heads.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Silenced department head radio messages are no longer broadcast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
