### PR TITLE
Floor cluwnes fixes. Can't hide in lockers no more + limits the speed of stage changes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -169,7 +169,16 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 /////////////////////////////////////////////////////////////////////////
 
-/proc/getline(atom/M,atom/N)//Ultra-Fast Bresenham Line-Drawing Algorithm
+/**
+ * Gets the turfs which are between the two given atoms. Including their positions
+ * Only works for atoms on the same Z level which is not 0. So an atom located in a non turf won't work
+ * Arguments:
+ * * M - The source atom
+ * * N - The target atom
+ */
+/proc/getline(atom/M, atom/N)//Ultra-Fast Bresenham Line-Drawing Algorithm
+	if(!M.z || M.z != N.z)	// Same Z level and not 0. Else all below breaks
+		return list()
 	var/px=M.x		//starting x
 	var/py=M.y
 	var/line[] = list(locate(px,py,M.z))

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -15,6 +15,7 @@
 	health = 200
 	speed = -1
 	attacktext = "attacks"
+	anchored = TRUE
 	attack_sound = 'sound/items/bikehorn.ogg'
 	del_on_death = TRUE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB | LETPASSTHROW | PASSGLASS | PASSBLOB//it's practically a ghost when unmanifested (under the floor)
@@ -32,6 +33,7 @@
 	var/mob/living/carbon/human/current_victim
 	var/manifested = FALSE
 	var/switch_stage = 60
+	var/switch_stage_min = 20
 	var/stage = STAGE_HAUNT
 	var/interest = 0
 	var/target_area
@@ -302,12 +304,12 @@
 		if(STAGE_ATTACK)
 
 			if(!eating)
-				for(var/I in getline(src,H))
+				for(var/I in getline(src, get_turf(H)))
 					var/turf/T = I
 					for(var/obj/structure/O in T)
 						if(istype(O, /obj/structure/closet))
 							var/obj/structure/closet/locker = O
-							locker.dump_contents()
+							locker.bust_open()
 						if(O.density || istype(O, /obj/machinery/door/airlock))
 							forceMove(H.loc)
 					if(T.density)
@@ -366,17 +368,12 @@
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/Kill(mob/living/carbon/human/H)
 	playsound(H, 'sound/spookoween/scary_horn2.ogg', 100, 0)
-	var/old_color = H.client.color
-	var/red_splash = list(1,0,0,0.8,0.2,0, 0.8,0,0.2,0.1,0,0)
-	var/pure_red = list(0,0,0,0,0,0,0,0,0,1,0,0)
-	H.client.color = pure_red
+	var/old_color = H.client?.color
+	client_kill_animation(H)
 
-	animate(H.client, color = red_splash, time = 10, easing = SINE_EASING|EASE_OUT)
 	for(var/turf/T in orange(H, 4))
 		H.add_splatter_floor(T)
 	if(do_after(src, 50, target = H))
-
-
 		if(prob(50) || smiting)
 			H.makeCluwne()
 
@@ -400,7 +397,7 @@
 
 	eating = FALSE
 	if(prob(2))
-		switch_stage = switch_stage * 0.75 //he gets a chance to be faster after each feast
+		switch_stage = max(switch_stage * 0.75, switch_stage_min) //he gets a chance to be faster after each feast
 	if(smiting)
 		playsound(loc, 'sound/spookoween/scary_horn2.ogg', 100, 0, -4)
 		qdel(src)
@@ -408,6 +405,15 @@
 		Acquire_Victim()
 
 		interest = 0
+
+/mob/living/simple_animal/hostile/floor_cluwne/proc/client_kill_animation(mob/living/carbon/human/H)
+	if(!H.client)
+		return
+	var/red_splash = list(1,0,0,0.8,0.2,0, 0.8,0,0.2,0.1,0,0)
+	var/pure_red = list(0,0,0,0,0,0,0,0,0,1,0,0)
+	H.client.color = pure_red
+
+	animate(H.client, color = red_splash, time = 10, easing = SINE_EASING|EASE_OUT)
 
 //manifestation animation
 /obj/effect/temp_visual/fcluwne_manifest


### PR DESCRIPTION
## What Does This PR Do
- Makes floor cluwnes unable to get trapped in a locker etc. Breaking a ton of their logic
- Makes floor cluwnes properly deal with lockered targets
- Makes floor cluwnes break open lockers instead of just magically dump their contents
- Makes floor cluwnes be limited in their stage change speed. Currently after enough luck and killing they could have near 0 speed. Meaning people were fucked

Fixes: which happens when a cluwn gets locked in a locker
```
[2020-10-27T13:46:46] Runtime in floorcluwne.dm,313: Cannot read null.density
[2020-10-27T13:46:46]   proc name: On Stage (/mob/living/simple_animal/hostile/floor_cluwne/proc/On_Stage)
[2020-10-27T13:46:46]   src: ??? (/mob/living/simple_animal/hostile/floor_cluwne)
[2020-10-27T13:46:46]   src.loc: the closet (/obj/structure/closet)
[2020-10-27T13:46:46]   call stack:
[2020-10-27T13:46:46]   ??? (/mob/living/simple_animal/hostile/floor_cluwne): On Stage()
[2020-10-27T13:46:46]   ??? (/mob/living/simple_animal/hostile/floor_cluwne): Life(2, 2898)
[2020-10-27T13:46:46]   Mobs (/datum/controller/subsystem/mobs): fire(0)
[2020-10-27T13:46:46]   Mobs (/datum/controller/subsystem/mobs): ignite(0)
[2020-10-27T13:46:46]   Master (/datum/controller/master): RunQueue()
[2020-10-27T13:46:46]   Master (/datum/controller/master): Loop()
[2020-10-27T13:46:46]   Master (/datum/controller/master): StartProcessing(0)
```

I know there is still one bug when they cluwne people. A runtime happens when they delimb the victims due to the nodrop mask etc. That one requires a refactor of how limbs behave when detached and how the inventory should update accordingly

## Why It's Good For The Game
Bug fixes mostly since the intention for them was to deal with lockers in this way.

## Images
![RwRMzqqFgE](https://user-images.githubusercontent.com/15887760/97355816-c211b200-1897-11eb-9b78-3f3c0363680c.gif)
(Cluwne made visible for debugging before he manifested)

## Changelog
:cl:
fix: Floor Cluwnes now properly break open lockers in the way of their victim on the last stage.
fix: Floor Cluwnes can't get trapped in lockers. Uno reverso!
fix: Floor Cluwnes now bust open lockers instead of magically dropped their content on the floor while the locker is still closed.
tweak: Floor Cluwnes now have a limit on their minimum stage change time. No more terror floor cluwnes killing people one after another within seconds
/:cl: