### PR TITLE
CQC can no longer be discounted

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -860,6 +860,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CQC"
 	item = /obj/item/CQC_manual
 	cost = 13
+	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/cameraflash
 	name = "Camera Flash"


### PR DESCRIPTION
## What Does This PR Do
You can no longer get CQC discounted in the uplink.

## Why It's Good For The Game
This item is already strong as is, some people would even argue it's "overpowered", the fact that you can have it discounted for 7TC also doesn't help, since it lets you combo it with other stuff on the uplink far easier.

## Changelog
:cl:
tweak: CQC can't be randomly discounted in the uplink anymore.
/:cl: