### PR TITLE
IPCs can properly kill themselves with salt

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -135,7 +135,7 @@
 	user.name = newname
 	user.real_name = newname
 	desc = "Salt. From dead crew, presumably."
-	return TOXLOSS
+	return BRUTELOSS
 
 /obj/item/reagent_containers/food/condiment/peppermill
 	name = "pepper mill"


### PR DESCRIPTION
## What Does This PR Do
Fixes #14682

## Why It's Good For The Game
Suicide should kill you, not only swap your name.

## Changelog
:cl:
fix: IPCs can now suicide with salt shakers properly, instead of only swapping names with it.
/:cl: