### PR TITLE
Adds proper snake cases to SSPersistence

### DIFF
--- a/code/controllers/subsystem/persistent_data.dm
+++ b/code/controllers/subsystem/persistent_data.dm
@@ -17,20 +17,20 @@ SUBSYSTEM_DEF(persistent_data)
 /datum/controller/subsystem/persistent_data/Initialize()
 	// Load all the data of registered atoms
 	for(var/atom/A in registered_atoms)
-		A.PersistentLoad()
+		A.persistent_load()
 	return ..()
 
 /datum/controller/subsystem/persistent_data/Shutdown()
 	// Save all the data of registered atoms
 	for(var/atom/A in registered_atoms)
-		A.PersistentSave()
+		A.persistent_save()
 
 
 /**
   * Proc to register an atom with SSpersistent_data
   *
   * This will add any provided atom to the list of registered atoms, and add it to the Initialization queue
-  * If the system has already initialized, it calls PersistentLoad() at that moment
+  * If the system has already initialized, it calls persistent_load() at that moment
   *
   * Arguments:
   * * A - Atom to register
@@ -38,21 +38,21 @@ SUBSYSTEM_DEF(persistent_data)
 /datum/controller/subsystem/persistent_data/proc/register(atom/A)
 	registered_atoms |= A
 	if(initialized)
-		A.PersistentLoad()
+		A.persistent_load()
 
 /**
   * Atom Persistent Loader
   *
   * Overridden on every atom which needs to load persistent data
   */
-/atom/proc/PersistentLoad()
-	stack_trace("PeristentLoad() called on an atom which does not have persistent data storage!")
+/atom/proc/persistent_load()
+	stack_trace("peristent_load() called on an atom which does not have persistent data storage!")
 
 /**
   * Atom Persistent Saver
   *
   * Overridden on every atom which needs to save persistent data
   */
-/atom/proc/PersistentSave()
-	stack_trace("PeristentSave() called on an atom which does not have persistent data storage!")
+/atom/proc/persistent_save()
+	stack_trace("peristent_save() called on an atom which does not have persistent data storage!")
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -46,12 +46,12 @@
 	SSpersistent_data.register(src)
 	..()
 
-/mob/living/simple_animal/pet/cat/Runtime/PersistentLoad()
-	Read_Memory()
-	Deploy_The_Cats()
+/mob/living/simple_animal/pet/cat/Runtime/persistent_load()
+	read_memory()
+	deploy_the_cats()
 
-/mob/living/simple_animal/pet/cat/Runtime/PersistentSave()
-	Write_Memory(FALSE)
+/mob/living/simple_animal/pet/cat/Runtime/persistent_save()
+	write_memory(FALSE)
 
 /mob/living/simple_animal/pet/cat/Runtime/make_babies()
 	var/mob/baby = ..()
@@ -61,11 +61,11 @@
 
 /mob/living/simple_animal/pet/cat/Runtime/death()
 	if(can_die())
-		Write_Memory(TRUE)
+		write_memory(TRUE)
 		SSpersistent_data.registered_atoms -= src // We just saved. Dont save at round end
 	return ..()
 
-/mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
+/mob/living/simple_animal/pet/cat/Runtime/proc/read_memory()
 	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
 	S["family"] 			>> family
 
@@ -73,7 +73,7 @@
 		family = list()
 	log_debug("Persistent data for [src] loaded (family: [list2params(family)])")
 
-/mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
+/mob/living/simple_animal/pet/cat/Runtime/proc/write_memory(dead)
 	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
 	family = list()
 	if(!dead)
@@ -87,7 +87,7 @@
 	S["family"]				<< family
 	log_debug("Persistent data for [src] saved (family: [list2params(family)])")
 
-/mob/living/simple_animal/pet/cat/Runtime/proc/Deploy_The_Cats()
+/mob/living/simple_animal/pet/cat/Runtime/proc/deploy_the_cats()
 	for(var/cat_type in family)
 		if(family[cat_type] > 0)
 			for(var/i in 1 to min(family[cat_type],100)) //Limits to about 500 cats, you wouldn't think this would be needed (BUT IT IS)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -71,7 +71,7 @@
 
 	if(isnull(family))
 		family = list()
-	log_debug("Persistent data for [src] loaded (family: [list2params(family)])")
+	log_debug("Persistent data for [src] loaded (family: [family ? list2params(family) : "None"])")
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/write_memory(dead)
 	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
@@ -85,7 +85,7 @@
 			else
 				family[C.type] = 1
 	S["family"]				<< family
-	log_debug("Persistent data for [src] saved (family: [list2params(family)])")
+	log_debug("Persistent data for [src] saved (family: [family ? list2params(family) : "None"])")
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/deploy_the_cats()
 	for(var/cat_type in family)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -476,7 +476,7 @@
 		record_age = 1
 	if(saved_head)
 		place_on_head(new saved_head)
-	log_debug("Persistent data for [src] loaded (age: [age] | record_age: [record_age] | saved_head: [saved_head])")
+	log_debug("Persistent data for [src] loaded (age: [age] | record_age: [record_age] | saved_head: [saved_head ? saved_head : "None"])")
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/proc/write_memory(dead)
 	var/json_file = file("data/npc_saves/Ian.json")
@@ -497,7 +497,7 @@
 		file_data["saved_head"] = null
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
-	log_debug("Persistent data for [src] saved (age: [age] | record_age: [record_age] | saved_head: [saved_head])")
+	log_debug("Persistent data for [src] saved (age: [age] | record_age: [record_age] | saved_head: [saved_head ? saved_head : "None"])")
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/handle_automated_movement()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -427,12 +427,12 @@
 	SSpersistent_data.register(src)
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/death()
-	Write_Memory(TRUE)
+	write_memory(TRUE)
 	SSpersistent_data.registered_atoms -= src // We already wrote here, dont overwrite!
 	..()
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/PersistentLoad()
-	Read_Memory()
+/mob/living/simple_animal/pet/dog/corgi/Ian/persistent_load()
+	read_memory()
 	if(age == 0)
 		var/turf/target = get_turf(loc)
 		if(target)
@@ -441,7 +441,7 @@
 			P.real_name = "Ian"
 			P.gender = MALE
 			P.desc = "It's the HoP's beloved corgi puppy."
-			Write_Memory(FALSE)
+			write_memory(FALSE)
 			SSpersistent_data.registered_atoms -= src // We already wrote here, dont overwrite!
 			qdel(src)
 			return
@@ -452,10 +452,10 @@
 		desc = "At a ripe old age of [record_age], Ian's not as spry as he used to be, but he'll always be the HoP's beloved corgi." //RIP
 		turns_per_move = 20
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/PersistentSave()
-	Write_Memory(FALSE)
+/mob/living/simple_animal/pet/dog/corgi/Ian/persistent_save()
+	write_memory(FALSE)
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/proc/Read_Memory()
+/mob/living/simple_animal/pet/dog/corgi/Ian/proc/read_memory()
 	if(fexists("data/npc_saves/Ian.sav")) //legacy compatability to convert old format to new
 		var/savefile/S = new /savefile("data/npc_saves/Ian.sav")
 		S["age"] 		>> age
@@ -478,7 +478,7 @@
 		place_on_head(new saved_head)
 	log_debug("Persistent data for [src] loaded (age: [age] | record_age: [record_age] | saved_head: [saved_head])")
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/proc/Write_Memory(dead)
+/mob/living/simple_animal/pet/dog/corgi/Ian/proc/write_memory(dead)
 	var/json_file = file("data/npc_saves/Ian.json")
 	var/list/file_data = list()
 	if(!dead)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds consistent, snake_cased proc names to the persistence subsystem.

I normally wouldn't bother with such a minor thing but I was working on something related to persistence anyway, decided to fix this stuff while I was there, then discovered I don't need the actual persistence system for what I'm working on, so I'm splitting those changes off.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More consistent cases. 
Seeing 
```
PersistentSave()
Read_Memory()
make_babies()
```
all in the same file is just disgusting.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
no changelog because purely backend with no gameplay impact at all.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
