### PR TITLE
Auto cleanup gitattributes from DMAPI updater

### DIFF
--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -37,6 +37,9 @@ jobs:
         git config --local user.name "DMAPI Update"
         git add .
         git commit -m 'Update TGS DMAPI'
+        rm .gitattributes
+        git add .
+        git commit -m 'Cleanup attributes'
         git push -f -u origin tgs-dmapi-update
 
     - name: Create Pull Request


### PR DESCRIPTION
## What Does This PR Do
Makes DMAPI action not commit its `.gitattributes` during a run

I still hate GitHub actions