### PR TITLE
Voodoo doll isn't a scam anymore

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -241,7 +241,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A doll created by Syndicate Witch Doctors. Ingredients: Something of the Thread, Something of the Head, Something of the Body, Something of the Dead, Secret Voodoo herbs, and Monosodium glutamate."
 	reference = "VD"
 	item = /obj/item/voodoo
-	cost = 13
+	cost = 4
 	job = list("Chaplain")
 
 /datum/uplink_item/jobspecific/missionary_kit

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -778,7 +778,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	var/mob/living/carbon/human/target = null
 	var/list/mob/living/carbon/human/possible = list()
 	var/obj/item/link = null
-	var/cooldown_time = 70 //7s
+	var/cooldown_time = 7 SECONDS
 	var/cooldown = 0
 	max_integrity = 10
 	resistance_flags = FLAMMABLE

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -778,7 +778,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	var/mob/living/carbon/human/target = null
 	var/list/mob/living/carbon/human/possible = list()
 	var/obj/item/link = null
-	var/cooldown_time = 30 //3s
+	var/cooldown_time = 70 //7s
 	var/cooldown = 0
 	max_integrity = 10
 	resistance_flags = FLAMMABLE
@@ -787,16 +787,16 @@ GLOBAL_LIST_EMPTY(multiverse)
 	if(target && cooldown < world.time)
 		if(is_hot(I))
 			to_chat(target, "<span class='userdanger'>You suddenly feel very hot</span>")
-			target.bodytemperature += 50
+			target.bodytemperature += 60
 			GiveHint(target)
 		else if(is_pointed(I))
 			to_chat(target, "<span class='userdanger'>You feel a stabbing pain in [parse_zone(user.zone_selected)]!</span>")
-			target.Weaken(2)
+			target.Weaken(4)
 			GiveHint(target)
 		else if(istype(I,/obj/item/bikehorn))
 			to_chat(target, "<span class='userdanger'>HONK</span>")
 			target << 'sound/items/airhorn.ogg'
-			target.MinimumDeafTicks(3)
+			target.MinimumDeafTicks(10)
 			GiveHint(target)
 		cooldown = world.time +cooldown_time
 		return
@@ -863,7 +863,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 					GiveHint(target)
 			if("head")
 				to_chat(user, "<span class='notice'>You smack the doll's head with your hand.</span>")
-				target.Dizzy(10)
+				target.Dizzy(20)
 				to_chat(target, "<span class='warning'>You suddenly feel as if your head was hit with a hammer!</span>")
 				GiveHint(target,user)
 		cooldown = world.time + cooldown_time
@@ -878,12 +878,9 @@ GLOBAL_LIST_EMPTY(multiverse)
 			possible |= H
 
 /obj/item/voodoo/proc/GiveHint(mob/victim,force=0)
-	if(prob(50) || force)
+	if(prob(20) || force)
 		var/way = dir2text(get_dir(victim,get_turf(src)))
 		to_chat(victim, "<span class='notice'>You feel a dark presence from [way]</span>")
-	if(prob(20) || force)
-		var/area/A = get_area(src)
-		to_chat(victim, "<span class='notice'>You feel a dark presence from [A.name]</span>")
 
 /obj/item/voodoo/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	if(target)


### PR DESCRIPTION
## What Does This PR Do
Lowers the cost of the voodoo doll dramatically from 13TC to 4TC
Removes the 20% chance for the doll to reveal your name when using it on someone.
Lowered the 50% chance of the doll revealing your location to 20%.
Upped the cooldown from 3 seconds to 7 seconds.
Buffed some effects of the doll:
- Rises the body temperature by 60 instead of 50.
- Weaken time was doubled.
- Deaf time was tripled.
- Dizzy time was doubled.

## Why It's Good For The Game
This item is probably the worst item in the uplink, with it's only redeeming quality being you can forcibly biblefart people if done correctly.
Now it's a cheap way to keep a close eye on your target, and the punishments don't suck that much anymore (they aren't the best though)

## Changelog
:cl:
tweak: Voodoo Doll costs 4TC instead of 13TC.
del: Voodoo Doll  no longer has a chance to reveal the name of the user.
tweak: Voodoo Doll's cooldown is now 7 seconds instead of 3.
tweak: Voodoo Doll's chance to reveal the location of the user is now 20% instead of 50%.
tweak: The stunning, deafening, dizzying and temperature-rising effects of the Voodoo Doll are now stronger.
/:cl: