### PR TITLE
AutoDrobe fixes

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -239,6 +239,7 @@ to destroy them and players will be able to make replacements.
 		/obj/machinery/vending/hatdispenser = "Hatlord 9000",
 		/obj/machinery/vending/suitdispenser = "Suitlord 9000",
 		/obj/machinery/vending/shoedispenser = "Shoelord 9000",
+		/obj/machinery/vending/autodrobe = "AutoDrobe",
 		/obj/machinery/vending/clothing = "ClothesMate",
 		/obj/machinery/vending/medical = "NanoMed Plus",
 		/obj/machinery/vending/wallmed = "NanoMed",


### PR DESCRIPTION
## What Does This PR Do
Fixes #14758

## Why It's Good For The Game
No reason for this vendor to be excluded from the list, also nameless circuit boards = bad.

## Changelog
:cl:
fix: AutoDrobe vendors can now be properly constructed.
/:cl: