### PR TITLE
Makes pods work with the force_eject_occupant proc. Fixing stuck ssd people in pods

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -59,7 +59,7 @@
 			W.dropped(affected_mob)
 		if(isobj(affected_mob.loc))
 			var/obj/O = affected_mob.loc
-			O.force_eject_occupant()
+			O.force_eject_occupant(affected_mob)
 		var/mob/living/new_mob = new new_form(affected_mob.loc)
 		if(istype(new_mob))
 			new_mob.a_intent = "harm"

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -291,7 +291,7 @@
 	icon_state = "scanner_open"
 	SStgui.update_uis(src)
 
-/obj/machinery/dna_scannernew/force_eject_occupant()
+/obj/machinery/dna_scannernew/force_eject_occupant(mob/target)
 	go_out(null, TRUE)
 
 /obj/machinery/dna_scannernew/ex_act(severity)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -421,7 +421,7 @@
 		A.forceMove(loc)
 	SStgui.update_uis(src)
 
-/obj/machinery/sleeper/force_eject_occupant()
+/obj/machinery/sleeper/force_eject_occupant(mob/target)
 	go_out()
 
 /obj/machinery/sleeper/proc/inject_chemical(mob/living/user, chemical, amount)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -175,7 +175,7 @@
 		A.forceMove(loc)
 	SStgui.update_uis(src)
 
-/obj/machinery/bodyscanner/force_eject_occupant()
+/obj/machinery/bodyscanner/force_eject_occupant(mob/target)
 	go_out()
 
 /obj/machinery/bodyscanner/ex_act(severity)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -424,7 +424,7 @@
 	for(var/atom/movable/A in contents - component_parts - list(beaker))
 		A.forceMove(get_step(loc, SOUTH))
 
-/obj/machinery/atmospherics/unary/cryo_cell/force_eject_occupant()
+/obj/machinery/atmospherics/unary/cryo_cell/force_eject_occupant(mob/target)
 	go_out()
 
 /// Called when either the occupant is dead and the AUTO_EJECT_DEAD flag is present, OR the occupant is alive, has no external damage, and the AUTO_EJECT_HEALTHY flag is present.

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -775,7 +775,7 @@
 		return 0
 	if(isobj(person_to_cryo.loc))
 		var/obj/O = person_to_cryo.loc
-		O.force_eject_occupant()
+		O.force_eject_occupant(person_to_cryo)
 	var/list/free_cryopods = list()
 	for(var/obj/machinery/cryopod/P in GLOB.machines)
 		if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -753,7 +753,7 @@
 	update_icon()
 	return
 
-/obj/machinery/suit_storage_unit/force_eject_occupant()
+/obj/machinery/suit_storage_unit/force_eject_occupant(mob/target)
 	eject_occupant()
 
 /obj/machinery/suit_storage_unit/verb/get_out()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1276,7 +1276,7 @@
 		var/mob/living/carbon/human/H = L
 		H.regenerate_icons() // workaround for 14457
 
-/obj/mecha/force_eject_occupant()
+/obj/mecha/force_eject_occupant(mob/target)
 	go_out()
 
 /////////////////////////

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -353,7 +353,7 @@ a {
 /obj/proc/check_uplink_validity()
 	return TRUE
 
-/obj/proc/force_eject_occupant()
+/obj/proc/force_eject_occupant(mob/target)
 	// This proc handles safely removing occupant mobs from the object if they must be teleported out (due to being SSD/AFK, by admin teleport, etc) or transformed.
 	// In the event that the object doesn't have an overriden version of this proc to do it, log a runtime so one can be added.
 	CRASH("Proc force_eject_occupant() is not overriden on a machine containing a mob.")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -358,7 +358,7 @@
 /obj/structure/closet/AllowDrop()
 	return TRUE
 
-/obj/structure/closet/force_eject_occupant()
+/obj/structure/closet/force_eject_occupant(mob/target)
 	// Its okay to silently teleport mobs out of lockers, since the only thing affected is their contents list.
 	return
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -24,7 +24,7 @@
 
 	if(isobj(usr.loc))
 		var/obj/O = usr.loc
-		O.force_eject_occupant()
+		O.force_eject_occupant(usr)
 
 	admin_forcemove(usr, T)
 	log_admin("[key_name(usr)] jumped to [A]")
@@ -41,7 +41,7 @@
 
 	if(isobj(usr.loc))
 		var/obj/O = usr.loc
-		O.force_eject_occupant()
+		O.force_eject_occupant(usr)
 	log_admin("[key_name(usr)] jumped to [T.x], [T.y], [T.z] in [T.loc]")
 	if(!isobserver(usr))
 		message_admins("[key_name_admin(usr)] jumped to [T.x], [T.y], [T.z] in [T.loc]", 1)
@@ -61,7 +61,7 @@
 		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
 	if(isobj(usr.loc))
 		var/obj/O = usr.loc
-		O.force_eject_occupant()
+		O.force_eject_occupant(usr)
 	if(src.mob)
 		var/mob/A = src.mob
 		var/turf/T = get_turf(M)
@@ -82,7 +82,7 @@
 	if(T)
 		if(isobj(usr.loc))
 			var/obj/O = usr.loc
-			O.force_eject_occupant()
+			O.force_eject_occupant(usr)
 		admin_forcemove(usr, T)
 		if(isobserver(usr))
 			var/mob/dead/observer/O = usr
@@ -111,7 +111,7 @@
 		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
 	if(isobj(usr.loc))
 		var/obj/O = usr.loc
-		O.force_eject_occupant()
+		O.force_eject_occupant(usr)
 	admin_forcemove(usr, M.loc)
 
 	feedback_add_details("admin_verb","JK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -129,7 +129,7 @@
 
 	if(isobj(M.loc))
 		var/obj/O = M.loc
-		O.force_eject_occupant()
+		O.force_eject_occupant(M)
 	admin_forcemove(M, get_turf(usr))
 	feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -156,7 +156,7 @@
 	if(M)
 		if(isobj(M.loc))
 			var/obj/O = M.loc
-			O.force_eject_occupant()
+			O.force_eject_occupant(M)
 		admin_forcemove(M, get_turf(usr))
 		admin_forcemove(usr, M.loc)
 		feedback_add_details("admin_verb","GK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -172,7 +172,7 @@
 	if(A)
 		if(isobj(M.loc))
 			var/obj/O = M.loc
-			O.force_eject_occupant()
+			O.force_eject_occupant(M)
 		admin_forcemove(M, pick(get_area_turfs(A)))
 		feedback_add_details("admin_verb","SMOB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		log_admin("[key_name(usr)] teleported [key_name(M)] to [A]")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -904,7 +904,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		var/datum/map_template/ruin/template = landmark.ruin_template
 		if(isobj(usr.loc))
 			var/obj/O = usr.loc
-			O.force_eject_occupant()
+			O.force_eject_occupant(usr)
 		admin_forcemove(usr, get_turf(landmark))
 
 		to_chat(usr, "<span class='name'>[template.name]</span>")

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -136,12 +136,10 @@
 	QDEL_NULL(ion_trail)
 	occupant_sanity_check()
 	if(pilot)
-		pilot.forceMove(get_turf(src))
-		pilot = null
+		eject_pilot()
 	if(passengers)
 		for(var/mob/M in passengers)
-			M.forceMove(get_turf(src))
-			passengers -= M
+			eject_passenger(M)
 	GLOB.spacepods_list -= src
 	STOP_PROCESSING(SSobj, src)
 	return ..()
@@ -202,6 +200,20 @@
 
 /obj/spacepod/blob_act(obj/structure/blob/B)
 	deal_damage(30)
+
+/obj/spacepod/force_eject_occupant(mob/target)
+	if(target == pilot)
+		eject_pilot()
+	else
+		eject_passenger(target)
+
+/obj/spacepod/proc/eject_pilot()
+	pilot.forceMove(get_turf(src))
+	pilot = null
+
+/obj/spacepod/proc/eject_passenger(mob/passenger)
+	passenger.forceMove(get_turf(src))
+	passengers -= passenger
 
 /obj/spacepod/attack_animal(mob/living/simple_animal/user)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -439,12 +451,11 @@
 			src.visible_message("<span class='warning'>[user] is trying to rip the door open and pull [target] out of the [src]!</span>",
 				"<span class='warning'>You see [user] outside the door trying to rip it open!</span>")
 			if(do_after(user, 50, target = src))
-				target.forceMove(get_turf(src))
 				target.Stun(1)
 				if(pilot)
-					pilot = null
+					eject_pilot()
 				else
-					passengers -= target
+					eject_passenger(target)
 				target.visible_message("<span class='warning'>[user] flings the door open and tears [target] out of the [src]</span>",
 					"<span class='warning'>The door flies open and you are thrown out of the [src] and to the ground!</span>")
 				return


### PR DESCRIPTION
## What Does This PR Do
Makes pods work with the `force_eject_occupant` proc allowing them to eject SSD people and properly cryo them

fixes:
```
Runtime in objs.dm,359: Proc force_eject_occupant() is not overriden on a machine containing a mob.
   proc name: force eject occupant (/obj/proc/force_eject_occupant)
   src: the space pod (/obj/spacepod/civilian)
   src.loc: the floor (85,91,1) (/turf/simulated/floor/plasteel)
   call stack:
   the space pod (/obj/spacepod/civilian): force eject occupant()
   cryo ssd(NAME (/mob/living/carbon/human))
   NAME (/mob/living/carbon/human): handle ssd()
   NAME (/mob/living/carbon/human): Life(2, 2612)
   Mobs (/datum/controller/subsystem/mobs): fire(1)
   Mobs (/datum/controller/subsystem/mobs): ignite(1)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```


## Why It's Good For The Game
Runtimes be gone

## Changelog
:cl:
fix: Makes pods able to force eject occupants
/:cl: