### PR TITLE
Saves the runechat preference when the verb is used

### DIFF
--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -312,4 +312,5 @@
 	set category = "Preferences"
 	set desc = "Toggle runechat messages"
 	prefs.toggles2 ^= PREFTOGGLE_2_RUNECHAT
+	prefs.save_preferences(src)
 	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) ? "now see" : "no longer see"] floating chat messages.")


### PR DESCRIPTION
## What Does This PR Do
Makes using the toggle runechat verb save the preferences

## Why It's Good For The Game
Was forgotten to add so it doesn't save the preferences now unless you change another preference

## Changelog
:cl:
fix: Your runechat preference is always saved now
/:cl: