### PR TITLE
Makes advanced viruses not runtime when they are cured

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -89,6 +89,8 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 	if(disease_flags & CURABLE)
 		if(cure && prob(cure_chance))
 			cure()
+			return FALSE
+	return TRUE
 
 
 /datum/disease/proc/has_cure()

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 	var/cure = has_cure()
 
 	if(carrier && !cure)
-		return
+		return TRUE
 
 	stage = min(stage, max_stages)
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -69,7 +69,8 @@ GLOBAL_LIST_INIT(advance_cures, list(
 
 // Randomly pick a symptom to activate.
 /datum/disease/advance/stage_act()
-	..()
+	if(!..())
+		return FALSE
 	if(symptoms && symptoms.len)
 
 		if(!processing)
@@ -81,6 +82,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 			S.Activate(src)
 	else
 		CRASH("We do not have any symptoms during stage_act()!")
+	return TRUE
 
 // Compares type then ID.
 /datum/disease/advance/IsSame(datum/disease/advance/D)


### PR DESCRIPTION
## What Does This PR Do
Fixes (and all other runtimes like this one):
```
Runtime in sneeze.dm,35: Cannot execute null.emote().
   proc name: Activate (/datum/symptom/sneeze/Activate)
   src: Sneezing (/datum/symptom/sneeze)
   call stack:
   Sneezing (/datum/symptom/sneeze): Activate(Cold (/datum/disease/advance/cold))
   Cold (/datum/disease/advance/cold): stage act()
   NAME (/mob/living/carbon/human): handle diseases()
   NAME (/mob/living/carbon/human): Life(2, 1385)
   NAME (/mob/living/carbon/human): Life(2, 1385)
   NAME (/mob/living/carbon/human): Life(2, 1385)
   Mobs (/datum/controller/subsystem/mobs): fire(0)
   Mobs (/datum/controller/subsystem/mobs): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game
Virus B GONE

## Changelog
No CL since no functional impact