### PR TITLE
Makes honkbots not think they are secbots. Fixing a runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -91,11 +91,9 @@
 	return	dat
 
 /mob/living/simple_animal/bot/honkbot/proc/retaliate(mob/living/carbon/human/H)
-	threatlevel = H.assess_threat(src)
-	threatlevel += 6
-	if(threatlevel >= 4)
-		target = H
-		mode = BOT_HUNT
+	threatlevel = 6
+	target = H
+	mode = BOT_HUNT
 
 /mob/living/simple_animal/bot/honkbot/attack_hand(mob/living/carbon/human/H)
 	if(H.a_intent == INTENT_HARM)


### PR DESCRIPTION
## What Does This PR Do
Fixes honk bots copy pasta causing runtimes because they copy pastad secbots

fixes:
```
Runtime in human.dm,1549: undefined variable /mob/living/simple_animal/bot/honkbot/var/idcheck
   proc name: assess threat (/mob/living/carbon/human/assess_threat)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (141,111,1) (/turf/simulated/floor/plasteel)
   src: NAME (/mob/living/carbon/human)
   src.loc: the floor (141,111,1) (/turf/simulated/floor/plasteel)
   call stack:
   NAME (/mob/living/carbon/human): assess threat(Honkdalf, Herald Of The Honkmo... (/mob/living/simple_animal/bot/honkbot), null)
   Honkdalf, Herald Of The Honkmo... (/mob/living/simple_animal/bot/honkbot): retaliate(NAME (/mob/living/carbon/human))
   Honkdalf, Herald Of The Honkmo... (/mob/living/simple_animal/bot/honkbot): attack hand(NAME (/mob/living/carbon/human))
   NAME (/mob/living/carbon/human): UnarmedAttack(Honkdalf, Herald Of The Honkmo... (/mob/living/simple_animal/bot/honkbot), 1)
   NAME (/mob/living/carbon/human): ClickOn(Honkdalf, Herald Of The Honkmo... (/mob/living/simple_animal/bot/honkbot), "icon-x=18;icon-y=14;left=1;scr...")
   Honkdalf, Herald Of The Honkmo... (/mob/living/simple_animal/bot/honkbot): Click(the floor (141,112,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=18;icon-y=14;left=1;scr...")
```

## Why It's Good For The Game
Fuck honkbots

## Changelog
Won't change anything functionally