### PR TITLE
Fixes runtimes with the changeling evolution menu

### DIFF
--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -31,7 +31,7 @@
 			"cost" = initial(C.dna_cost)
 		))
 
-/datum/action/changeling/evolution_menu/Trigger()
+/datum/action/changeling/evolution_menu/try_to_sting(mob/user, mob/target)
 	tgui_interact(owner)
 
 /datum/action/changeling/evolution_menu/tgui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/tgui_state/state = GLOB.tgui_always_state)

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -32,7 +32,7 @@
 		))
 
 /datum/action/changeling/evolution_menu/try_to_sting(mob/user, mob/target)
-	tgui_interact(owner)
+	tgui_interact(user)
 
 /datum/action/changeling/evolution_menu/tgui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/tgui_state/state = GLOB.tgui_always_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the changeling evolution menu use its parent `/changeling/Trigger()` proc instead, which has several sanity checks such as making sure `owner` exists before opening the UI.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops runtimes from happening:
```
[2020-10-29T20:49:37] Runtime in tgui.dm,93: Cannot read null.client
   proc name: open (/datum/tgui/proc/open)
   usr: [CHARACTER] ([CKEY]) (/mob/living/carbon/human)
   usr.loc: The floor (72,131,1) (/turf/simulated/floor/plasteel)
   src: /datum/tgui (/datum/tgui)
   call stack:
   /datum/tgui (/datum/tgui): open()
   -Evolution Menu- (/datum/action/changeling/evolution_menu): tgui interact(null, "main", /datum/tgui (/datum/tgui), 0, null, /datum/tgui_state/always_state (/datum/tgui_state/always_state))
   -Evolution Menu- (/datum/action/changeling/evolution_menu): Trigger()
   -Evolution Menu- (/obj/screen/movable/action_button): Click(the floor (71,131,1) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=12;icon-y=14;left=1;scr...")
```
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes runtimes with the changeling evolution menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
