### PR TITLE
Pinpointers can now point to their respective nuke.

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -13,7 +13,7 @@
 	var/obj/item/disk/nuclear/the_disk = null
 	var/obj/machinery/nuclearbomb/the_bomb = null
 	var/obj/machinery/nuclearbomb/syndicate/the_s_bomb = null // used by syndicate pinpointers.
-	var/active = FALSE
+	var/active = 0
 	var/mode = FALSE // Mode 0 locates disk, mode 1 does something else.
 	var/shows_nuke_timer = TRUE
 	var/syndicate = FALSE // Indicates pointer is syndicate, and points to the syndicate nuke.
@@ -30,7 +30,7 @@
 
 /obj/item/pinpointer/Destroy()
 	GLOB.pinpointer_list -= src
-	active = FALSE
+	active = 0
 	the_disk = null
 	return ..()
 
@@ -125,7 +125,7 @@
 
 /obj/item/pinpointer/advpinpointer/attack_self()
 	if(!active)
-		active = TRUE
+		active = 1
 		if(mode == 0)
 			workdisk()
 		if(mode == 1)
@@ -157,7 +157,7 @@
 		to_chat(usr, "<span class='warning'>[src] is locked. It can only track one specific target.</span>")
 		return
 
-	active = FALSE
+	active = 0
 	icon_state = icon_off
 	target = null
 	location = null
@@ -233,7 +233,7 @@
 	syndicate = TRUE
 
 /obj/item/pinpointer/nukeop/attack_self(mob/user as mob)
-	if(active == FALSE && !mode)
+	if(active == 0 && !mode)
 		active = 1
 		workdisk()
 		to_chat(user, "<span class='notice'>Authentication Disk Locator active.</span>")
@@ -241,12 +241,12 @@
 		active = 2
 		workbomb()
 		to_chat(user, "<span class='notice'>Nuclear Device Locator active.</span>")
-	else if(mode && !active == 1)
+	else if(mode && !active)
 		active = 1
 		worklocation()
 		to_chat(user, "<span class='notice'>Shuttle Locator active.</span>")
 	else
-		active = FALSE
+		active = 0
 		icon_state = icon_off
 		to_chat(user, "<span class='notice'>You deactivate the pinpointer.</span>")
 
@@ -287,7 +287,7 @@
 		.()
 
 /obj/item/pinpointer/nukeop/proc/worklocation()
-	if(active == FALSE)
+	if(active == 0)
 		return
 	if(!mode)
 		active = 1
@@ -322,11 +322,11 @@
 		to_chat(usr, "<span class='danger'>AUTHENTICATION FAILURE. ACCESS DENIED.</span>")
 		return FALSE
 	if(!active)
-		active = TRUE
+		active = 1
 		workop()
 		to_chat(usr, "<span class='notice'>You activate the pinpointer.</span>")
 	else
-		active = FALSE
+		active = 0
 		icon_state = icon_off
 		to_chat(usr, "<span class='notice'>You deactivate the pinpointer.</span>")
 
@@ -384,7 +384,7 @@
 
 /obj/item/pinpointer/crew/attack_self(mob/living/user)
 	if(active)
-		active = FALSE
+		active = 0
 		icon_state = icon_off
 		user.visible_message("<span class='notice'>[user] deactivates [user.p_their()] pinpointer.</span>", "<span class='notice'>You deactivate your pinpointer.</span>")
 		return
@@ -418,7 +418,7 @@
 		return
 
 	var/target = names[A]
-	active = TRUE
+	active = 1
 	user.visible_message("<span class='notice'>[user] activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You activate your pinpointer.</span>")
 	point_at(target)
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -141,7 +141,7 @@
 /obj/item/pinpointer/advpinpointer/workdisk()
 	if(mode == FALSE)
 		scandisk()
-		point_at(the_disk, 0)
+		point_at(the_disk, FALSE)
 		spawn(5)
 			.()
 
@@ -257,7 +257,7 @@
 		worklocation()
 		return
 	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
-		mode = 1	//Ensures worklocation() continues to work
+		mode = TRUE	//Ensures worklocation() continues to work
 		worklocation()
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
 		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
@@ -275,7 +275,7 @@
 		worklocation()
 		return
 	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
-		mode = 1	//Ensures worklocation() continues to work
+		mode = TRUE	//Ensures worklocation() continues to work
 		worklocation()
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
 		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
@@ -294,7 +294,7 @@
 		workdisk()
 		return
 	if(!GLOB.bomb_set)
-		mode = 0
+		mode = FALSE
 		workdisk()
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)
 		visible_message("<span class='notice'>Authentication Disk Locator mode actived.</span>")
@@ -346,7 +346,7 @@
 		spawn(5)
 			.()
 	else
-		return 0
+		return FALSE
 
 /obj/item/pinpointer/operative/examine(mob/user)
 	. = ..()
@@ -422,7 +422,7 @@
 	user.visible_message("<span class='notice'>[user] activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You activate your pinpointer.</span>")
 	point_at(target)
 
-/obj/item/pinpointer/crew/point_at(atom/target, spawnself = 1)
+/obj/item/pinpointer/crew/point_at(atom/target, spawnself = TRUE)
 	if(!active)
 		return
 
@@ -430,7 +430,7 @@
 		icon_state = icon_null
 		return
 
-	..(target, spawnself = 0)
+	..(target, spawnself = FALSE)
 	if(spawnself)
 		spawn(5)
 			.()

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -27,7 +27,6 @@
 /obj/item/pinpointer/New()
 	..()
 	GLOB.pinpointer_list += src
-	START_PROCESSING(SSfastprocess, src)
 
 /obj/item/pinpointer/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
@@ -50,6 +49,7 @@
 		mode = FALSE
 		workdisk()
 		to_chat(usr, "<span class='notice'>Authentication Disk Locator active.</span>")
+		START_PROCESSING(SSfastprocess, src)
 	else if(active == 1 && shows_nuke_timer)
 		active = 2
 		mode = TRUE
@@ -59,6 +59,7 @@
 		active = 0
 		icon_state = icon_off
 		to_chat(usr, "<span class='notice'>You deactivate the pinpointer.</span>")
+		STOP_PROCESSING(SSfastprocess, src)
 
 /obj/item/pinpointer/proc/scandisk()
 	if(!the_disk)
@@ -134,10 +135,12 @@
 		if(mode == 2)
 			point_at(target)
 		to_chat(usr, "<span class='notice'>You activate the pinpointer.</span>")
+		START_PROCESSING(SSfastprocess, src)
 	else
 		active = 0
 		icon_state = icon_off
 		to_chat(usr, "<span class='notice'>You deactivate the pinpointer.</span>")
+		STOP_PROCESSING(SSfastprocess, src)
 
 /obj/item/pinpointer/advpinpointer/process()
 	if(active == 1)
@@ -244,6 +247,8 @@
 	syndicate = TRUE
 
 /obj/item/pinpointer/nukeop/attack_self(mob/user as mob)
+	if(active == 0) // We want to SSfastprocess when the pinpointer goes on, BUT, we have 2 modes that can turn it on, thus the turn SSfastprocess must be put here.
+		START_PROCESSING(SSfastprocess, src)
 	if(active == 0 && !mode)
 		active = 1
 		workdisk()
@@ -260,6 +265,7 @@
 		active = 0
 		icon_state = icon_off
 		to_chat(user, "<span class='notice'>You deactivate the pinpointer.</span>")
+		STOP_PROCESSING(SSfastprocess, src)
 
 /obj/item/pinpointer/nukeop/process()
 	if(active)
@@ -341,10 +347,12 @@
 		active = 1
 		workop()
 		to_chat(usr, "<span class='notice'>You activate the pinpointer.</span>")
+		START_PROCESSING(SSfastprocess, src)
 	else
 		active = 0
 		icon_state = icon_off
 		to_chat(usr, "<span class='notice'>You deactivate the pinpointer.</span>")
+		STOP_PROCESSING(SSfastprocess, src)
 
 /obj/item/pinpointer/operative/process()
 	if(active)
@@ -380,7 +388,6 @@
 	name = "crew pinpointer"
 	desc = "A handheld tracking device that points to crew suit sensors."
 	shows_nuke_timer = FALSE
-	var/target = null //for targeting in processing
 	icon_state = "pinoff_crew"
 	icon_off = "pinoff_crew"
 	icon_null = "pinonnull_crew"
@@ -388,6 +395,7 @@
 	icon_close = "pinonclose_crew"
 	icon_medium = "pinonmedium_crew"
 	icon_far = "pinonfar_crew"
+	var/target = null //for targeting in processing
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
@@ -408,6 +416,7 @@
 		active = 0
 		icon_state = icon_off
 		user.visible_message("<span class='notice'>[user] deactivates [user.p_their()] pinpointer.</span>", "<span class='notice'>You deactivate your pinpointer.</span>")
+		STOP_PROCESSING(SSfastprocess, src)
 		return
 
 	var/list/name_counts = list()
@@ -442,6 +451,7 @@
 	active = 1
 	user.visible_message("<span class='notice'>[user] activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You activate your pinpointer.</span>")
 	point_at(target)
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/item/pinpointer/crew/process()
 	if(active)

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -46,13 +46,13 @@
 /obj/item/pinpointer/attack_self()
 	if(active == 0)
 		active = 1
-		mode = FALSE
+		mode = 0
 		workdisk()
 		to_chat(usr, "<span class='notice'>Authentication Disk Locator active.</span>")
 		START_PROCESSING(SSfastprocess, src)
 	else if(active == 1 && shows_nuke_timer)
 		active = 2
-		mode = TRUE
+		mode = 1
 		workbomb()
 		to_chat(usr, "<span class='notice'>Nuclear Device Locator active.</span>")
 	else
@@ -155,7 +155,7 @@
 
 
 /obj/item/pinpointer/advpinpointer/workdisk()
-	if(mode == FALSE)
+	if(mode == 0)
 		scandisk()
 		point_at(the_disk)
 
@@ -249,11 +249,12 @@
 /obj/item/pinpointer/nukeop/attack_self(mob/user as mob)
 	if(active == 0) // We want to SSfastprocess when the pinpointer goes on, BUT, we have 2 modes that can turn it on, thus the turn SSfastprocess must be put here.
 		START_PROCESSING(SSfastprocess, src)
-	if(active == 0 && !mode)
-		active = 1
-		workdisk()
-		to_chat(user, "<span class='notice'>Authentication Disk Locator active.</span>")
-	else if(active == 1 && !mode)
+		if(!mode)
+			active = 1
+			workdisk()
+			to_chat(user, "<span class='notice'>Authentication Disk Locator active.</span>")
+			return
+	if(active == 1 && !mode)
 		active = 2
 		workbomb()
 		to_chat(user, "<span class='notice'>Nuclear Device Locator active.</span>")
@@ -285,7 +286,7 @@
 		worklocation()
 		return
 	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
-		mode = TRUE	//Ensures worklocation() continues to work
+		mode = 1	//Ensures worklocation() continues to work
 		worklocation()
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
 		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
@@ -301,7 +302,7 @@
 		worklocation()
 		return
 	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
-		mode = TRUE	//Ensures worklocation() continues to work
+		mode = 1	//Ensures worklocation() continues to work
 		worklocation()
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
 		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
@@ -318,7 +319,7 @@
 		workdisk()
 		return
 	if(!GLOB.bomb_set)
-		mode = FALSE
+		mode = 0
 		workdisk()
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)
 		visible_message("<span class='notice'>Authentication Disk Locator mode actived.</span>")

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -245,7 +245,7 @@
 	var/obj/docking_port/mobile/home = null
 	slot_flags = SLOT_BELT | SLOT_PDA
 	syndicate = TRUE
-	modes = list(MODE_NUKE, MODE_DISK)
+	modes = list(MODE_DISK, MODE_NUKE)
 
 /obj/item/pinpointer/nukeop/process()
 	if(mode == MODE_DISK)
@@ -299,13 +299,13 @@
 	modes = list(MODE_OPERATIVE)
 
 /obj/item/pinpointer/operative/process()
-	if(MODE_OPERATIVE)
+	if(mode == MODE_OPERATIVE)
 		workop()
 	else
 		icon_state = icon_off
 
 /obj/item/pinpointer/operative/proc/scan_for_ops()
-	if(MODE_OPERATIVE)
+	if(mode == MODE_OPERATIVE)
 		nearest_op = null //Resets nearest_op every time it scans
 		var/closest_distance = 1000
 		for(var/mob/living/carbon/M in GLOB.mob_list)
@@ -341,6 +341,7 @@
 	icon_far = "pinonfar_crew"
 	modes = list(MODE_CREW)
 	var/target = null //for targeting in processing
+	var/target_set = FALSE //have we set a target at any point?
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
@@ -357,7 +358,7 @@
 	return FALSE
 
 /obj/item/pinpointer/crew/process()
-	if(mode == MODE_CREW)
+	if(mode == MODE_CREW && target_set)
 		point_at(target)
 
 /obj/item/pinpointer/crew/point_at(atom/target)
@@ -401,6 +402,7 @@
 
 	target = names[A]
 	mode = MODE_CREW
+	target_set = TRUE
 	user.visible_message("<span class='notice'>[user] activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You activate your pinpointer.</span>")
 	point_at(target)
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -5,6 +5,9 @@
 #define MODE_SHIP 4
 #define MODE_OPERATIVE 5
 #define MODE_CREW 6
+#define SETTING_DISK 0
+#define SETTING_LOCATION 1
+#define SETTING_OBJECT 2
 
 /obj/item/pinpointer
 	name = "pinpointer"
@@ -148,11 +151,11 @@
 	var/setting = 0
 
 /obj/item/pinpointer/advpinpointer/process()
-	if(setting == 0)
+	if(setting == SETTING_DISK)
 		workdisk()
-	if(setting == 1)
+	if(setting == SETTING_LOCATION)
 		point_at(location)
-	if(setting == 2)
+	if(setting == SETTING_OBJECT)
 		point_at(target)
 
 /obj/item/pinpointer/advpinpointer/workdisk() //since mode works diffrently for advpinpointer
@@ -178,7 +181,7 @@
 
 	switch(alert("Please select the mode you want to put the pinpointer in.", "Pinpointer Mode Select", "Location", "Disk Recovery", "Other Signature"))
 		if("Location")
-			setting = 1
+			setting = SETTING_LOCATION
 
 			var/locationx = input(usr, "Please input the x coordinate to search for.", "Location?" , "") as num
 			if(!locationx || !(usr in view(1,src)))
@@ -197,11 +200,11 @@
 			return attack_self()
 
 		if("Disk Recovery")
-			setting = 0
+			setting = SETTING_DISK
 			return attack_self()
 
 		if("Other Signature")
-			setting = 2
+			setting = SETTING_OBJECT
 			switch(alert("Search for item signature or DNA fragment?" , "Signature Mode Select" , "Item" , "DNA"))
 				if("Item")
 					var/list/item_names[0]
@@ -259,7 +262,7 @@
 /obj/item/pinpointer/nukeop/workdisk()
 	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
 		mode = MODE_SHIP	//Ensures worklocation() continues to work
-		worklocation()
+		modes = list(MODE_SHIP)
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
 		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
 		return		//Get outta here
@@ -269,7 +272,7 @@
 /obj/item/pinpointer/nukeop/workbomb()
 	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
 		mode = MODE_SHIP	//Ensures worklocation() continues to work
-		worklocation()
+		modes = list(MODE_SHIP)
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
 		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
 		return		//Get outta here
@@ -279,7 +282,7 @@
 /obj/item/pinpointer/nukeop/proc/worklocation()
 	if(!GLOB.bomb_set)
 		mode = MODE_DISK
-		workdisk()
+		modes = list(MODE_DISK, MODE_NUKE)
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)
 		visible_message("<span class='notice'>Authentication Disk Locator mode actived.</span>")
 		return
@@ -363,9 +366,6 @@
 		point_at(target)
 
 /obj/item/pinpointer/crew/point_at(atom/target)
-	if(mode == MODE_OFF)
-		return
-
 	if(!trackable(target) || !target)
 		icon_state = icon_null
 		return
@@ -402,10 +402,8 @@
 		return
 
 	target = names[A]
-	mode = MODE_CREW
 	target_set = TRUE
 	user.visible_message("<span class='notice'>[user] activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You activate your pinpointer.</span>")
-	point_at(target)
 
 /obj/item/pinpointer/crew/centcom
 	name = "centcom pinpointer"
@@ -423,3 +421,6 @@
 #undef MODE_SHIP
 #undef MODE_OPERATIVE
 #undef MODE_CREW
+#undef SETTING_DISK
+#undef SETTING_LOCATION
+#undef SETTING_OBJECT

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -151,12 +151,13 @@
 	var/setting = 0
 
 /obj/item/pinpointer/advpinpointer/process()
-	if(setting == SETTING_DISK)
-		workdisk()
-	if(setting == SETTING_LOCATION)
-		point_at(location)
-	if(setting == SETTING_OBJECT)
-		point_at(target)
+	switch(setting)
+		if(SETTING_DISK)
+			workdisk()
+		if(SETTING_LOCATION)
+			point_at(location)
+		if(SETTING_OBJECT)
+			point_at(target)
 
 /obj/item/pinpointer/advpinpointer/workdisk() //since mode works diffrently for advpinpointer
 	scandisk()

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -248,12 +248,13 @@
 	modes = list(MODE_DISK, MODE_NUKE)
 
 /obj/item/pinpointer/nukeop/process()
-	if(mode == MODE_DISK)
-		workdisk()
-	else if(mode == MODE_NUKE)
-		workbomb()
-	else if(mode == MODE_SHIP)
-		worklocation()
+	switch(mode)
+		if(MODE_DISK)
+			workdisk()
+		if(MODE_NUKE)
+			workbomb()
+		if(MODE_SHIP)
+			worklocation()
 
 /obj/item/pinpointer/nukeop/workdisk()
 	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3382,8 +3382,8 @@
 	hunter_mob.equipOutfit(O, FALSE)
 	var/obj/item/pinpointer/advpinpointer/N = new /obj/item/pinpointer/advpinpointer(hunter_mob)
 	hunter_mob.equip_to_slot_or_del(N, slot_in_backpack)
-	N.active = 1
-	N.mode = 2
+	N.mode = 3
+	N.setting = 2
 	N.target = H
 	N.point_at(N.target)
 	N.modelocked = TRUE

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3382,8 +3382,8 @@
 	hunter_mob.equipOutfit(O, FALSE)
 	var/obj/item/pinpointer/advpinpointer/N = new /obj/item/pinpointer/advpinpointer(hunter_mob)
 	hunter_mob.equip_to_slot_or_del(N, slot_in_backpack)
-	N.mode = 3
-	N.setting = 2
+	N.mode = MODE_ADV
+	N.setting = SETTING_OBJECT
 	N.target = H
 	N.point_at(N.target)
 	N.modelocked = TRUE

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3382,8 +3382,8 @@
 	hunter_mob.equipOutfit(O, FALSE)
 	var/obj/item/pinpointer/advpinpointer/N = new /obj/item/pinpointer/advpinpointer(hunter_mob)
 	hunter_mob.equip_to_slot_or_del(N, slot_in_backpack)
-	N.mode = MODE_ADV
-	N.setting = SETTING_OBJECT
+	N.mode = 3 //MODE_ADV, not defined here
+	N.setting = 2 //SETTING_OBJECT, not defined here
 	N.target = H
 	N.point_at(N.target)
 	N.modelocked = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR allows nuclear operative and crew pinpointers to point to their respective nuke, and changes most ones and zeros to TRUE / FALSE

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It's great to know where the NAD is, but if crew steals your nuke, or command has lost the nuke when the DS gets on station, or just when the greytide has got into the vault and moved the nuke, it may help to have a mode to point to the nuke, to arm it.

## Changelog
:cl:
tweak: Pinpointers can now point at the nuclear device, instead of just the NAD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
