### PR TITLE
Makes it so only engineer, heads, and other command staff can open station goal crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1790,7 +1790,8 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	cost = 10
 	special = TRUE
 	containername = "empty station goal crate"
-	containertype = /obj/structure/closet/crate/engineering
+	containertype = /obj/structure/closet/crate/secure/engineering
+	access = ACCESS_CONSTRUCTION
 
 /datum/supply_packs/misc/station_goal/bsa
 	name = "Bluespace Artillery Parts"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As the title states, this PR locks the station goal crates to everyone with access to engineering: engineering, CE, atmos, heads, IAA, BS, Magistrate, and captain

## Why It's Good For The Game
Particularly with the shield sats, it's really annoying for items that are in goal crates to not fit back into the crate. Also, station goal items should really be the domain of engineers and not go missing to random people. Finally, by making them secure crates they can no longer lose items, removing annoyance with missing goal items, particularly with newer crews who don't realize an item is missing.

## Changelog
:cl:
add: Added station goals to crates locked to engineering access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
