### PR TITLE
Fixes the singulo going through the containment when it shouldn't be able to

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -268,7 +268,8 @@
 					X.singularity_pull(src, current_size)
 				else
 					consume(X)
-			CHECK_TICK
+			if(TICK_CHECK)
+				return // You've eaten enough. Prevents weirdness like the singulo eating the containment on stage 2
 
 
 /obj/singularity/proc/consume(atom/A)


### PR DESCRIPTION
## What Does This PR Do
Makes the singulo not eat the containment when it shouldn't. Or noclip through it due to weirdness

Issue was with the sleep in the `CHECK_TICK`. This could cause the singulo to have multiple `process` calls open which could move it while it was still eating or worse. Make it grow. Making it's eat distance bigger causing it to eat things that it shouldn't eat.

Now it just stops eating when it has taken enough of the current ticks time. Ensuring no sleep occurs and thus only one process call ever exists

fixes: #14766 and other related singulo accidents on highpop

## Why It's Good For The Game
Dear god why

## Changelog
:cl:
fix: The singulo now can't go through containment when it shouldn't be able to
/:cl: