### PR TITLE
Colour coded CPU usage

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -617,3 +617,14 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		processing = config.base_mc_tick_rate
 	else if(client_count > config.high_pop_mc_mode_amount)
 		processing = config.high_pop_mc_tick_rate
+
+/datum/controller/master/proc/formatcpu()
+	switch(world.cpu)
+		if(0 to 80) // 0-80 = green
+			. = "<font color='#32a852'>[world.cpu]</font>"
+		if(80 to 90) // 80-90 = orange
+			. = "<font color='#fcba03'>[world.cpu]</font>"
+		if(90 to 100) // 90-100 = red
+			. = "<font color='#eb4034'>[world.cpu]</font>"
+		if(100 to INFINITY) // >100 = bold red
+			. = "<font color='#eb4034'><b>[world.cpu]</b></font>"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -976,7 +976,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		if(statpanel("MC")) //looking at that panel
 			var/turf/T = get_turf(client.eye)
 			stat("Location:", COORD(T))
-			stat("CPU:", "[world.cpu]")
+			stat("CPU:", "[Master.formatcpu()]")
 			stat("Instances:", "[num2text(world.contents.len, 10)]")
 			GLOB.stat_entry()
 			stat("Server Time:", time_stamp())


### PR DESCRIPTION
## What Does This PR Do
Adds colour coding for the CPU monitor in the MC panel
0-80% = green
![image](https://user-images.githubusercontent.com/25063394/97689135-0fa63e80-1a93-11eb-8baa-ac84c471201e.png)

80-90% = orange
![image](https://user-images.githubusercontent.com/25063394/97689153-159c1f80-1a93-11eb-9e4d-fa90f8860670.png)

90-100% = red
![image](https://user-images.githubusercontent.com/25063394/97689169-1a60d380-1a93-11eb-8a09-16b681ec0aac.png)

\>100% (yes byond does this) = bold red
![image](https://user-images.githubusercontent.com/25063394/97689199-2351a500-1a93-11eb-9425-a42f31e723a3.png)

## Why It's Good For The Game
Makes it easier to tell at a glance the state of the server

## Changelog
:cl: AffectedArc07
add: CPU status is now colour coded in the MC panel
/:cl:
