### PR TITLE
Tcomm power fixes

### DIFF
--- a/code/game/machinery/tcomms/_base.dm
+++ b/code/game/machinery/tcomms/_base.dm
@@ -105,6 +105,10 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	tgui_interact(user)
 
 
+// If we do not override the default process(), the machine defaults to not processing, meaning it uses no power.
+/obj/machinery/tcomms/process()
+	return
+
 /**
   * Start of Ion Anomaly Event
   *

--- a/code/game/machinery/tcomms/core.dm
+++ b/code/game/machinery/tcomms/core.dm
@@ -156,7 +156,11 @@
 			continue
 		// If another core is active, return FALSE
 		if(C.active)
-			return FALSE
+			if(C.stat & NOPOWER)	// If another core has no power but is supposed to be on, we shut it down so we can continue.
+				C.active = FALSE	// Since only one active core is allowed per z level, give priority to the one actually working.
+				C.update_icon()
+			else
+				return FALSE
 	// If we got here there isnt an active core on this Z-level. So return true
 	return TRUE
 

--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -88,7 +88,11 @@
 			continue
 		// If another relay is active, return FALSE
 		if(R.active)
-			return FALSE
+			if(R.stat & NOPOWER)	// If another relay has no power but is supposed to be on, we shut it down so we can continue.
+				R.active = FALSE	// Since only one active relay is allowed per z level, give priority to the one that's actually working.
+				R.update_icon()
+			else
+				return FALSE
 	// If we got here there isnt an active relay on this Z-level. So return TRUE
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #14789
Fixes #14768
This PR does two things. First, tcomm machines now consume power as intended.

Secondly, if you try to turn on a tcomm core or relay and there is another core or relay on the z level that is unpowered, then your core or relay will take priority, turning the other core or relay off.
I did it this way instead of toggling active on depowering so that a simple loss of power doesn't need you to go manually toggle the core back on. 

Trying to do some logic where a core checks on regaining power for active cores and then doesn't power on would lead to basically the same outcome but with more steps, so I decided against that.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Destroying the tcomms APC now no longer prevents you from making a replacement core on station, which was very unintuitive.
Also, machines using the power they say they should is good, too. You can no longer infinitely power tcomms without a power source.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: tcomms machines now use power
fix: You can power on a replacement tcomms machine if the other machine on the z level is out of power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
