### PR TITLE
Nukies can now buy VTEC so medical borgs will not cry in pain

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -612,6 +612,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refund_path = /obj/item/antag_spawner/nuke_ops/borg_tele/medical
 	cost = 35
 
+/datum/uplink_item/support/reinforcement/vtec
+	name = "Cyborg VTEC upgrade"
+	desc = "Used to kick in a robot's VTEC systems, increasing their speed"
+	reference = "CVU"
+	item = /obj/item/borg/upgrade/vtec
+	refund_path = /obj/item/borg/upgrade/vtec
+	cost = 6
+	refundable = TRUE
+
 /datum/uplink_item/support/reinforcement/saboteur_borg
 	name = "Syndicate Saboteur Cyborg"
 	desc = "A streamlined engineering cyborg, equipped with covert modules and engineering equipment. Also incapable of leaving the welder in the shuttle. \


### PR DESCRIPTION
## What Does This PR Do
Add VTEC for nukies to buy so medical borgs will not cry in pain because they can't keep up. Cost is **6 TC**

## Why It's Good For The Game
Nukies borg could use some love, they have a terrible battery and movement speed, this PR fix at least the movement speed part, mostly for medical borgs because they can't keep up with his team and suffer in silence while they beep their way into oblivion.

## Changelog
:cl:
add: Add VTEC for the nukie uplink
/:cl: