### PR TITLE
ERT Timelock Increase

### DIFF
--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(role_playtime_requirements, list(
 	ROLE_PAI = 0,
 	ROLE_POSIBRAIN = 5, // Same as cyborg job.
 	ROLE_SENTIENT = 5,
-	ROLE_ERT = 10, // High, because they're team-based, and we want ERT to be robust
+	ROLE_ERT = 40, // High, because they're team-based, and we want ERT to be robust
 	ROLE_DEATHSQUAD = 10,
 	ROLE_TRADER = 20, // Very high, because they're an admin-spawned event with powerful items
 	ROLE_DRONE = 10, // High, because they're like mini engineering cyborgs that can ignore the AI, ventcrawl, and respawn themselves


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR significantly increases the ERT timelock from 10 hours to 40
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ERT is an incredibly difficult role that also has access to equipment that is incredibly powerful if used correctly, currently 10 hours is far too short for one to effectively understand the duties and skills required of an ERT member, likely resulting in more harm to the station than they help. Many people have said this but it's infinitely better to have no ERT than a bald ERT, since bald ERT will wander off alone, die, get looted, and make an already dangerous threat even more so than it was before. While increasing the timelock won't entirely solve this issue it's a step in the right direction by helping filter out the very newbies as 10 hours is barely enough to have a solid grasp on the game (that's only 5 full rounds by the way), 40 should at least hopefully give the player time to have a more solid grasp on the game and make it evident that the ERT is not a role to be taken lightly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: ERT timelock increased to 40 hours from 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
