### PR TITLE
Future proofs tcomms code

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -292,7 +292,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	if(loc && loc.z)
 		tcm.source_level = loc.z // For anyone that reads this: This used to pull from a LIST from the CONFIG DATUM. WHYYYYYYYYY!!!!!!!! -aa
 	else
-		tcm.source_level = 1 // Assume Z1 if we dont have an actual Z level available to us.
+		tcm.source_level = level_name_to_num(MAIN_STATION) // Assume station level if we dont have an actual Z level available to us.
 	tcm.freq = connection.frequency
 	tcm.follow_target = follow_target
 


### PR DESCRIPTION
## What Does This PR Do
Removes a hardcoded Z-level definition from tcomms code which will cause issues when I bring map rotation in. This PR ensures that it will work

## Why It's Good For The Game
Hardcoded z-level IDs bad

## Changelog
N/A