### PR TITLE
Implements force_eject_occupant for disposal units. Allowing disposaled SSDs to be cryod

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -502,6 +502,9 @@
 	if(user.stat == DEAD || !(user.sight & (SEEOBJS|SEEMOBS)))
 		user.overlay_fullscreen("remote_view", /obj/screen/fullscreen/impaired, 2)
 
+/obj/machinery/disposal/force_eject_occupant(mob/target)
+	target.forceMove(get_turf(src))
+
 // virtual disposal object
 // travels through pipes in lieu of actual items
 // contents will be items flushed by the disposal


### PR DESCRIPTION
## What Does This PR Do
Does as the title says

Fixes:
```
Runtime in objs.dm,359: Proc force_eject_occupant() is not overriden on a machine containing a mob.
   proc name: force eject occupant (/obj/proc/force_eject_occupant)
   src: the disposal unit (/obj/machinery/disposal)
   src.loc: the floor (108,156,1) (/turf/simulated/floor/plasteel)
   call stack:
   the disposal unit (/obj/machinery/disposal): force eject occupant(NAME (/mob/living/carbon/human))
   cryo ssd(NAME (/mob/living/carbon/human))
   NAME (/mob/living/carbon/human): handle ssd()
   NAME (/mob/living/carbon/human): Life(2, 651)
   Mobs (/datum/controller/subsystem/mobs): fire(0)
   Mobs (/datum/controller/subsystem/mobs): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game
No place is safe for the sleepy boiis

## Changelog
:cl:
fix: SSDs can be auto cryod now when they are in a disposal unit
/:cl: