### PR TITLE
Fixes a runtime when creating food

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -320,12 +320,12 @@
 				if(O.reagents)
 					O.reagents.del_reagent("nutriment")
 					O.reagents.update_total()
-					O.reagents.trans_to(temp_reagents, O.reagents.total_volume)
+					O.reagents.trans_to(temp_reagents, O.reagents.total_volume, no_react = TRUE) // Don't react with the abstract holder please
 				qdel(O)
 			source.reagents.clear_reagents()
 			for(var/e=1 to efficiency)		//upgraded machine? make additional servings and split the ingredient reagents among each serving equally.
 				var/obj/cooked = new recipe.result()
-				temp_reagents.trans_to(cooked, temp_reagents.total_volume/efficiency)
+				temp_reagents.trans_to(cooked, temp_reagents.total_volume/efficiency, no_react = TRUE) // Don't react with the abstract holder please
 				cooked.forceMove(loc)
 			temp_reagents.clear_reagents()
 			var/obj/byproduct = recipe.get_byproduct()	//if the recipe has a byproduct, handle returning that (such as re-usable candy moulds)


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime when the game tries to handle reactions in an abstract reagent holder when cooking food

This fix won't change any functionality since if it should have reacted it didn't due to the runtime. And it should never react anyway here since the reagents would have reacted in the cooking device before hand.

Fixes:
```
Runtime in holder.dm,417: Cannot read null.type
   proc name: handle reactions (/datum/reagents/proc/handle_reactions)
   usr: Unknown (as Stinky Slimes) (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (149,137,1) (/turf/simulated/floor/plasteel)
   src: /datum/reagents (/datum/reagents)
   call stack:
   /datum/reagents (/datum/reagents): handle reactions()
   /datum/reagents (/datum/reagents): remove reagent("sugar", 1.25, null)
   /datum/reagents (/datum/reagents): trans to(the choc-chip pancake (/obj/item/reagent_containers/food/snacks/pancake/choc_chip_pancake), 2.5, 1, 1, 0)
   the grill (/obj/machinery/kitchen_machine/grill): make recipes(/list (/list))
   the grill (/obj/machinery/kitchen_machine/grill): cook()
   the grill (/obj/machinery/kitchen_machine/grill): Topic("src=\[0x2005b1c]_2136;action=c...", /list (/list))
   CKEY (/client): Topic("src=\[0x2005b1c]_2136;action=c...", /list (/list), the grill (/obj/machinery/kitchen_machine/grill))
```

## Why It's Good For The Game
Nerfs jade's cooking

## Changelog
No CL since it doesn't do anything functionally