### PR TITLE
Auto-highlight code words, add "View code words" secret

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1176,6 +1176,7 @@
 				if(has_antag_datum(/datum/antagonist/traitor))
 					to_chat(current, "<span class='warning'><FONT size = 3><B>You have been brainwashed! You are no longer a traitor!</B></FONT></span>")
 					remove_antag_datum(/datum/antagonist/traitor)
+					current.client.chatOutput?.clear_syndicate_codes()
 					log_admin("[key_name(usr)] has de-traitored [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has de-traitored [key_name_admin(current)]")
 

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -109,7 +109,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 /datum/announcement/proc/Format_Message(message, message_title, message_announcer, from)
 	var/formatted_message
 	formatted_message += "<h2 class='alert'>[message_title]</h2>"
-	formatted_message += "<br><span class='alert'>[message]</span>"
+	formatted_message += "<br><span class='alert body'>[message]</span>"
 	if(message_announcer)
 		formatted_message += "<br><span class='alert'> -[message_announcer]</span>"
 
@@ -125,7 +125,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 /datum/announcement/priority/Format_Message(message, message_title, message_announcer, from)
 	var/formatted_message
 	formatted_message += "<h1 class='alert'>[message_title]</h1>"
-	formatted_message += "<br><span class='alert'>[message]</span>"
+	formatted_message += "<br><span class='alert body'>[message]</span>"
 	if(message_announcer)
 		formatted_message += "<br><span class='alert'> -[message_announcer]</span>"
 	formatted_message += "<br>"
@@ -136,7 +136,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 	var/formatted_message
 	formatted_message += "<h1 class='alert'>[from]</h1>"
 	if(message_title)
-		formatted_message += "<br><h2 class='alert'>[message_title]</h2>"
+		formatted_message += "<br><h2 class='alert body'>[message_title]</h2>"
 	formatted_message += "<br><span class='alert'>[message]</span><br>"
 	formatted_message += "<br>"
 

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -23,6 +23,7 @@
 						<A href='?src=[UID()];secretsadmin=showgm'>Show Game Mode</A>&nbsp;&nbsp;
 						<A href='?src=[UID()];secretsadmin=manifest'>Show Crew Manifest</A><br>
 						<A href='?src=[UID()];secretsadmin=check_antagonist'>Show current traitors and objectives</A><BR>
+						<A href='?src=[UID()];secretsadmin=view_codewords'>Show code phrases and responses</A><BR>
 						<a href='?src=[UID()];secretsadmin=night_shift_set'>Set Night Shift Mode</a><br>
 						<B>Bombs</b><br>
 						[check_rights(R_SERVER, 0) ? "&nbsp;&nbsp;<A href='?src=[UID()];secretsfun=togglebombcap'>Toggle bomb cap</A><br>" : "<br>"]

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3141,6 +3141,9 @@
 				usr << browse(dat, "window=manifest;size=440x410")
 			if("check_antagonist")
 				check_antagonists()
+			if("view_codewords")
+				to_chat(usr, "<b>Code Phrases:</b> <span class='codephrases'>[GLOB.syndicate_code_phrase]</span>")
+				to_chat(usr, "<b>Code Responses:</b> <span class='coderesponses'>[GLOB.syndicate_code_response]</span>")
 			if("DNA")
 				var/dat = "<b>Showing DNA from blood.</b><hr>"
 				dat += "<table cellspacing=5><tr><th>Name</th><th>DNA</th><th>Blood Type</th></tr>"

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -288,8 +288,8 @@
 	var/responses = jointext(GLOB.syndicate_code_response, ", ")
 
 	to_chat(traitor_mob, "<U><B>The Syndicate have provided you with the following codewords to identify fellow agents:</B></U>")
-	to_chat(traitor_mob, "<B>Code Phrase: <span class='codephrases'>[phrases]</span></B>")
-	to_chat(traitor_mob, "<B>Code Response: <span class='coderesponses'>[responses]</span></B>")
+	to_chat(traitor_mob, "<span class='bold body'>Code Phrase: <span class='codephrases'>[phrases]</span></span>")
+	to_chat(traitor_mob, "<span class='bold body'>Code Response: <span class='coderesponses'>[responses]</span></span>")
 
 	antag_memory += "<b>Code Phrase</b>: <span class='red'>[phrases]</span><br>"
 	antag_memory += "<b>Code Response</b>: <span class='red'>[responses]</span><br>"

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -288,14 +288,16 @@
 	var/responses = jointext(GLOB.syndicate_code_response, ", ")
 
 	to_chat(traitor_mob, "<U><B>The Syndicate have provided you with the following codewords to identify fellow agents:</B></U>")
-	to_chat(traitor_mob, "<B>Code Phrase: <span class='danger'>[phrases]</span></B>")
-	to_chat(traitor_mob, "<B>Code Response: <span class='danger'>[responses]</span></B>")
+	to_chat(traitor_mob, "<B>Code Phrase: <span class='codephrases'>[phrases]</span></B>")
+	to_chat(traitor_mob, "<B>Code Response: <span class='coderesponses'>[responses]</span></B>")
 
 	antag_memory += "<b>Code Phrase</b>: <span class='red'>[phrases]</span><br>"
 	antag_memory += "<b>Code Response</b>: <span class='red'>[responses]</span><br>"
 
 	to_chat(traitor_mob, "Use the codewords during regular conversation to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
+	to_chat(traitor_mob, "<b><font color=red>You memorize the codewords, allowing you to recognize them when heard.</font></b>")
 
+	traitor_mob.client.chatOutput?.notify_syndicate_codes()
 
 /datum/antagonist/traitor/proc/add_law_zero()
 	var/mob/living/silicon/ai/killer = owner.current

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -424,5 +424,5 @@ h1.alert, h2.alert			{color: #FFF;}
 .adminticketalt {color: #ccb847; font-weight: bold}
 
 /* Syndicate codewords */
-.codephrases {color: #5555FF;}
-.coderesponses {color: #FF3333;}
+span.body > .codephrases {color: #5555FF;}
+span.body > .coderesponses {color: #FF3333;}

--- a/goon/browserassets/css/browserOutput-dark.css
+++ b/goon/browserassets/css/browserOutput-dark.css
@@ -422,3 +422,7 @@ h1.alert, h2.alert			{color: #FFF;}
 .adminticket {color: #3daf21; font-weight: bold}
 
 .adminticketalt {color: #ccb847; font-weight: bold}
+
+/* Syndicate codewords */
+.codephrases {color: #5555FF;}
+.coderesponses {color: #FF3333;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -421,3 +421,7 @@ h1.alert, h2.alert			{color: #000000;}
 .adminticket {color: #3e7336; font-weight: bold}
 
 .adminticketalt {color: #014c8a; font-weight: bold}
+
+/* Syndicate codewords */
+.codephrases {color: #0000FF;}
+.coderesponses {color: #FF0000;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -423,5 +423,5 @@ h1.alert, h2.alert			{color: #000000;}
 .adminticketalt {color: #014c8a; font-weight: bold}
 
 /* Syndicate codewords */
-.codephrases {color: #0000FF;}
-.coderesponses {color: #FF0000;}
+span.body > .codephrases {color: #0000FF;}
+span.body > .coderesponses {color: #FF0000;}

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -72,7 +72,11 @@ var opts = {
 	'enableEmoji': true,
 
 	// Reboot message stuff
-	'rebootIntervalHandler': null
+	'rebootIntervalHandler': null,
+
+	// Syndicate codewords
+	'codePhrases': [],
+	'codeResponses': []
 };
 
 var regexHasError = false; //variable to check if regex has excepted
@@ -186,11 +190,18 @@ function highlightTerms(el) {
 
 	if (regexHasError) return; //just stop right there ig the regex is gonna except
 
-	function highlightRecursor(element, term){ //recursor function to do the highlighting proper
+	function highlightRecursor(element, term, className){ //recursor function to do the highlighting proper
 		var regex = new RegExp(term, "gi");
 
-		function replace(str) {
-			return str.replace(regex, '<span class="highlight" style="background-color:'+opts.highlightColor+'">$&</span>');
+		var replace;
+		if (className) {
+			replace = function(str) {
+				return str.replace(regex, '<span class="' + className + '">$&</span>');
+			};
+		} else {
+			replace = function(str) {
+				return str.replace(regex, '<span class="highlight" style="background-color:'+opts.highlightColor+'">$&</span>');
+			};
 		}
 
 		var s = '';
@@ -243,6 +254,14 @@ function highlightTerms(el) {
 				highlightRecursor(el, opts.highlightTerms[i]);
 			}
 		}
+	}
+
+	// Code phrases
+	for (var i = 0; i < opts.codePhrases.length; i++) {
+		highlightRecursor(el, escapeRegexCharacters(opts.codePhrases[i]), "codephrases");
+	}
+	for (var i = 0; i < opts.codeResponses.length; i++) {
+		highlightRecursor(el, escapeRegexCharacters(opts.codeResponses[i]), "coderesponses");
 	}
 }
 
@@ -602,6 +621,22 @@ function rebootFinished() {
 	}
 	$("<span> Reconnected automatically!</span>").insertBefore("#reconnectTimer");
 	$("#reconnectTimer").remove();
+}
+
+function codewords(phrases, responses) {
+	function cleanCodewords(words) {
+		var arr = [];
+		for (var i in words) {
+			var trimmed = words[i].trim();
+			if (trimmed.length > 0) {
+				arr.push(trimmed);
+			}
+		}
+		return arr;
+	}
+
+	opts.codePhrases = cleanCodewords(phrases.split(","));
+	opts.codeResponses = cleanCodewords(responses.split(","));
 }
 
 /*****************************************

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -112,6 +112,10 @@ var/list/chatResources = list(
 	owner << output(null, "browseroutput:rebootFinished")
 	if(owner.holder)
 		loadAdmin()
+	if(owner.mob?.mind?.has_antag_datum(/datum/antagonist/traitor))
+		notify_syndicate_codes() // Send them the current round's codewords
+	else
+		clear_syndicate_codes() // Flush any codewords they may have in chat
 	for(var/message in messageQueue)
 		to_chat(owner, message)
 
@@ -209,6 +213,12 @@ var/list/chatResources = list(
 	var/urlphrases = url_encode(copytext(phrases, 1, length(phrases)))
 	var/urlresponses = url_encode(copytext(responses, 1, length(responses)))
 	owner << output("[urlphrases]&[urlresponses]", "browseroutput:codewords")
+
+/**
+  * Clears any locally stored code phrases to highlight
+  */
+/datum/chatOutput/proc/clear_syndicate_codes()
+	notify_syndicate_codes("", "")
 
 /client/verb/debug_chat()
 	set hidden = 1

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -198,6 +198,18 @@ var/list/chatResources = list(
 	error = "\[[time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")]\] Client : [owner.key ? owner.key : owner] triggered JS error: [error]"
 	chatDebug << error
 
+/**
+  * Sends the lists of code phrases and responses to Goonchat for clientside highlighting
+  *
+  * Arguments:
+  * * phrases - List of code phrases
+  * * responses - List of code responses
+  */
+/datum/chatOutput/proc/notify_syndicate_codes(phrases = GLOB.syndicate_code_phrase, responses = GLOB.syndicate_code_response)
+	var/urlphrases = url_encode(copytext(phrases, 1, length(phrases)))
+	var/urlresponses = url_encode(copytext(responses, 1, length(responses)))
+	owner << output("[urlphrases]&[urlresponses]", "browseroutput:codewords")
+
 /client/verb/debug_chat()
 	set hidden = 1
 	chatOutput.ehjax_send(data = list("firebug" = 1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- **Adds auto-highlighting of code phrases and responses in the chat. Code phrases are highlighted in blue while code responses in red.**
- Add a secret to view code phrases and responses for admins (requested by @Qwertytoforty)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Code words are not very often used because they require the player to manually configure their chat highlights to be used effectively. Even then, they may end up being mixed with regular highlight words, which shouldn't happen. With this feature, memorizing and noticing code words becomes less of a hassle, hopefully increasing their use and encouraging team play.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![dreamseeker_2l6UPSs7EU](https://user-images.githubusercontent.com/1496804/97920643-08fd1d00-1d5a-11eb-80b7-8b22a45fd7ab.png)

![dreamseeker_QDIrEnQbB2](https://user-images.githubusercontent.com/1496804/97920639-07335980-1d5a-11eb-9270-f78b0fbb514c.png)

## Changelog
:cl:
add: Syndicate code words are now automatically highlighted in chat for traitors
add: Add "View Code Words" secret for administrators
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
