### PR TITLE
Nuka cola speed buff nerf

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -37,6 +37,7 @@
 #define GOTTAGOFAST	32
 #define IGNORESLOWDOWN	128
 #define IGNORE_SPEED_CHANGES	256
+#define GOTTAGONOTSOFAST 512 //This is used for nukacola, mormal meth is a "1" speed up, nuka is 0.5 and they don't stack, feel free to use this one somewhere else
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define XENO_HOST	16384	//Tracks whether we're gonna be a baby alien's mummy.

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -228,6 +228,8 @@
 	if(has_gravity(H))
 		if(H.status_flags & GOTTAGOFAST)
 			. -= 1
+		else if(H.status_flags & GOTTAGONOTSOFAST)
+			. -= 0.5
 
 		var/ignoreslow = FALSE
 		if((H.status_flags & IGNORESLOWDOWN) || (RUN in H.mutations))

--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -74,7 +74,7 @@
 	M.AdjustDizzy(5)
 	M.SetDrowsy(0)
 	M.status_flags |= GOTTAGOFAST
-	M.apply_effect(2, IRRADIATE, negate_armor = 1)
+	M.apply_effect(2, IRRADIATE, negate_armor = TRUE)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/cold/nuka_cola/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -74,6 +74,7 @@
 	M.AdjustDizzy(5)
 	M.SetDrowsy(0)
 	M.status_flags |= GOTTAGOFAST
+	M.apply_effect(2, IRRADIATE, negate_armor = 1)
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/cold/nuka_cola/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -73,12 +73,11 @@
 	update_flags |= M.Druggy(30, FALSE)
 	M.AdjustDizzy(5)
 	M.SetDrowsy(0)
-	M.status_flags |= GOTTAGOFAST
-	M.apply_effect(2, IRRADIATE, negate_armor = TRUE)
+	M.status_flags |= GOTTAGONOTSOFAST
 	return ..() | update_flags
 
 /datum/reagent/consumable/drink/cold/nuka_cola/on_mob_delete(mob/living/M)
-	M.status_flags &= ~GOTTAGOFAST
+	M.status_flags &= ~GOTTAGONOTSOFAST
 	..()
 
 /datum/reagent/consumable/drink/cold/spacemountainwind


### PR DESCRIPTION
## What Does This PR Do
Nuka cola speed nerfed, it's now a budged version of meth speed.

## Why It's Good For The Game
Nuka Cola speed is too easy to get and speed is king in this game, this PR change how much you speed up when you drink it.
Normal Speed 2.5
Nuka Speed 2
Meth Speed 1.5

## Changelog
:cl:
tweak: Nuka Cola speed nerfed from 1 to 0.5.
/:cl: