### PR TITLE
Xray Cameras is now malf only

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -128,18 +128,7 @@
 	var/msg = "<span class='notice'>You attach [I] into the assembly inner circuits.</span>"
 	var/msg2 = "<span class='notice'>The camera already has that upgrade!</span>"
 
-	if(istype(I, /obj/item/analyzer) && panel_open) //XRay
-		if(!user.drop_item())
-			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
-			return
-		if(!isXRay())
-			upgradeXRay()
-			qdel(I)
-			to_chat(user, "[msg]")
-		else
-			to_chat(user, "[msg2]")
-
-	else if(istype(I, /obj/item/stack/sheet/mineral/plasma) && panel_open)
+	if(istype(I, /obj/item/stack/sheet/mineral/plasma) && panel_open)
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
 			return


### PR DESCRIPTION
## What Does This PR Do
Make cameras no longer able to be upgraded with just an analyzer to make them Xray, so we no longer have engineers, cargo techs, civilians or whatever that can get easy access to analyzer (plus they can be mass produced inside an autolathe) the power to just go around and making not only all cameras super powerful but also filling maints with xray cameras so AI can watch your every move.
Also, xray is busted, we all know this, it's not fun to try and play antag while Robocop is just screaming about your every location and calls for security to murder you on crewsimov.

## Why It's Good For The Game
Antags often get fucked by power hungry AIs and/or players who just spamcameras in maints and upgrade them to Xray just to make antags life hell, even on green alert.

## Images of changes

Poor CE can no longer upgrade the cameras

![xray 2](https://user-images.githubusercontent.com/26222480/98030402-b3734f80-1def-11eb-9ea7-0448cf9ed964.png)
![xray cam 1](https://user-images.githubusercontent.com/26222480/98030403-b4a47c80-1def-11eb-940d-a0e70ae9f54a.png)


Malf AI can still do that
![xray4](https://user-images.githubusercontent.com/26222480/98030460-c7b74c80-1def-11eb-9442-6fc493c6be8e.png)
![xray5](https://user-images.githubusercontent.com/26222480/98030463-c9811000-1def-11eb-8be6-a5ab227dda3c.png)

## KNOWN ISSUE
Malf AI camera upgrade don't make the cameras get Night vision like they should, i did not figure out how to fix that without breaking everything.

## Changelog
:cl:
del: You can no longer upgrade cameras to xray with just an Analyzer, Malf AIs still have the power to upgrade them and watch your every move.
/:cl: