### PR TITLE
Cuts the price of summon guns in half, now only 2 points

### DIFF
--- a/code/datums/spells/infinite_guns.dm
+++ b/code/datums/spells/infinite_guns.dm
@@ -6,7 +6,7 @@
 	range = -1
 
 	school = "conjuration"
-	charge_max = 750
+	charge_max = 600
 	clothes_req = 1
 	cooldown_min = 10 //Gun wizard
 	action_icon_state = "bolt_action"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -171,7 +171,6 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/infinite_guns
 	log_name = "IG"
 	category = "Offensive"
-	cost = 4
 
 //Defensive
 /datum/spellbook_entry/disabletech


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Cuts the price of lesser summon guns in half, making it cost 2 wizard points instead of 4. Reduces cooldown by 15 seconds, now takes a minute to recharge.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Right. Lesser summon guns right now... is not good. 4 points, almost half of what you get. It summons around 20 guns for you to use, which sounds nice, but you need both hands to use it, so it can not be combined well with a taser or riot shield or wand, and the bullets only do 20 brute, less than even a stechkin. Most wizards would just rather a laser gun and charge, or an autorifile, or a shotgun the hos dropped. More importantly, it's 4 points for 20 shots using both hands, 400 total damage, with a cooldown of 75 seconds. In comparison, one could buy mutate, get eye lasers, 20 burn per shot, only one hand available needed, with the bonus of hulk for punches and stun immunity, active for 30 seconds and a cooldown of 40, so a downtime of *10 seconds*. In the current state, there is no point to buying lesser summon guns over mutate.

This PR makes the spell way more affordable, and a bit lower of a cooldown, but honestly, could potentially use a larger buff than this. 

## Changelog
:cl:
tweak: Lesser summon guns has a cooldown of 1 minute now, and costs 2 spellpoints instead of 4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
