### PR TITLE
Adds Brute / burn mod to borgs (only syndicate for now) and gives syndicate borgs 5 damage reduction

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -59,8 +59,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/ear_protection = 0
 	var/damage_protection = 0
 	var/emp_protection = FALSE
-	var/brute_mod = 1
-	var/burn_mod = 1
+	var/brute_mod = 1 // Value incoming brute damage to borgs is mutiplied by
+	var/burn_mod = 1 // Value incoming burn damage to borgs is multiplied by
 
 	var/list/force_modules = list()
 	var/allow_rename = TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -59,6 +59,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/ear_protection = 0
 	var/damage_protection = 0
 	var/emp_protection = FALSE
+	var/brute_mod = 1
+	var/burn_mod = 1
 
 	var/list/force_modules = list()
 	var/allow_rename = TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -59,8 +59,10 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	var/ear_protection = 0
 	var/damage_protection = 0
 	var/emp_protection = FALSE
-	var/brute_mod = 1 // Value incoming brute damage to borgs is mutiplied by
-	var/burn_mod = 1 // Value incoming burn damage to borgs is multiplied by
+ 	/// Value incoming brute damage to borgs is mutiplied by.
+	var/brute_mod = 1
+	/// Value incoming burn damage to borgs is multiplied by.
+	var/burn_mod = 1
 
 	var/list/force_modules = list()
 	var/allow_rename = TRUE

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -107,9 +107,9 @@
 	if(status_flags & GODMODE)
 		return
 
-	if(damage_protection)
-		brute = clamp(brute - damage_protection, 0, brute)
-		burn = clamp(burn - damage_protection, 0, burn)
+	if(damage_protection || burn_mod != 1 || brute_mod != 1)
+		brute = clamp((brute - damage_protection)*brute_mod, 0, brute)
+		burn = clamp((burn - damage_protection)*burn_mod, 0, burn)
 
 	var/list/datum/robot_component/parts = get_damageable_components()
 

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -107,7 +107,7 @@
 	if(status_flags & GODMODE)
 		return
 
-	brute = clamp((brute - damage_protection)*brute_mod, 0, brute)
+	brute = clamp((brute - damage_protection) * brute_mod, 0, brute)
 	burn = clamp((burn - damage_protection)*burn_mod, 0, burn)
 
 	var/list/datum/robot_component/parts = get_damageable_components()

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -108,7 +108,7 @@
 		return
 
 	brute = clamp((brute - damage_protection) * brute_mod, 0, brute)
-	burn = clamp((burn - damage_protection)*burn_mod, 0, burn)
+	burn = clamp((burn - damage_protection) * burn_mod, 0, burn)
 
 	var/list/datum/robot_component/parts = get_damageable_components()
 

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -107,9 +107,8 @@
 	if(status_flags & GODMODE)
 		return
 
-	if(damage_protection || burn_mod != 1 || brute_mod != 1)
-		brute = clamp((brute - damage_protection)*brute_mod, 0, brute)
-		burn = clamp((burn - damage_protection)*burn_mod, 0, burn)
+	brute = clamp((brute - damage_protection)*brute_mod, 0, brute)
+	burn = clamp((burn - damage_protection)*burn_mod, 0, burn)
 
 	var/list/datum/robot_component/parts = get_damageable_components()
 

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -107,8 +107,8 @@
 	if(status_flags & GODMODE)
 		return
 
-	brute = clamp((brute - damage_protection) * brute_mod, 0, brute)
-	burn = clamp((burn - damage_protection) * burn_mod, 0, burn)
+	brute = max((brute - damage_protection) * brute_mod, 0)
+	burn = max((burn - damage_protection) * burn_mod, 0)
 
 	var/list/datum/robot_component/parts = get_damageable_components()
 

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -11,6 +11,9 @@
 	modtype = "Syndicate"
 	req_access = list(ACCESS_SYNDICATE)
 	ionpulse = 1
+	damage_protection = 5
+	brute_mod = 0.7
+	burn_mod = 0.7
 	can_lock_cover = TRUE
 	lawchannel = "State"
 	var/playstyle_string = "<span class='userdanger'>You are a Syndicate assault cyborg!</span><br>\
@@ -41,6 +44,8 @@
 	icon_state = "syndi-medi"
 	modtype = "Syndicate Medical"
 	designation = "Syndicate Medical"
+	brute_mod = 0.8
+	burn_mod = 0.8
 	playstyle_string = "<span class='userdanger'>You are a Syndicate medical cyborg!</span><br>\
 						<b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
 						Your hypospray will produce Restorative Nanites, a wonder-drug that will heal most types of bodily damages, including clone and brain damage. It also produces morphine for offense. \
@@ -57,6 +62,8 @@
 	icon_state = "syndi-engi"
 	modtype = "Syndicate Saboteur"
 	designation = "Syndicate Saboteur"
+	brute_mod = 0.8
+	burn_mod = 0.8
 	var/mail_destination = 0
 	var/obj/item/borg_chameleon/cham_proj = null
 	playstyle_string = "<span class='userdanger'>You are a Syndicate saboteur cyborg!</span><br>\

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -44,7 +44,7 @@
 	icon_state = "syndi-medi"
 	modtype = "Syndicate Medical"
 	designation = "Syndicate Medical"
-	brute_mod = 0.8 //20%
+	brute_mod = 0.8 //20% less damage
 	burn_mod = 0.8
 	playstyle_string = "<span class='userdanger'>You are a Syndicate medical cyborg!</span><br>\
 						<b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -12,7 +12,7 @@
 	req_access = list(ACCESS_SYNDICATE)
 	ionpulse = 1
 	damage_protection = 5
-	brute_mod = 0.7
+	brute_mod = 0.7 //30% less damage
 	burn_mod = 0.7
 	can_lock_cover = TRUE
 	lawchannel = "State"
@@ -44,7 +44,7 @@
 	icon_state = "syndi-medi"
 	modtype = "Syndicate Medical"
 	designation = "Syndicate Medical"
-	brute_mod = 0.8
+	brute_mod = 0.8 //20%
 	burn_mod = 0.8
 	playstyle_string = "<span class='userdanger'>You are a Syndicate medical cyborg!</span><br>\
 						<b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Adds a brute and burn damage modifier variable to borgs, which multiplies incoming damage to the borg by that modifier after damage reduction comes in, grants it to syndicate borgs, giving combat a multiplier of 0.7 and medical / saboteur 0.8. Also grants all syndicate borgs 5 damage reduction.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Syndicate borgs are nice. There is one main catch to them. Unlike all the other operatives, they have no armor, and with the exception of engineering borg, no self repair, vs adrenerals and donkpockets of nukies. While ERT and gamma borgs get by fine with slight damage reduction, to make blob spores and blobernaughts barely hurt them, it does not solve the problem of what happens to most nukie borgs, shotguns. 2 slugs take out armor, preventing welding above 0 HP, and disable 2 modules. A 3rd slug will disable the last modual, and a single laser after that does it in. In comparison, a nukie with a basic syndicate hardsuit takes 90 damage from 3 slugs, not even in crit. Buckshot is also stronger on borgs than on nukies, due to the negative armor pen, that does not matter as the borgs do not have armor. In general, the borgs just die too easily, vs the high damage weapons the crew has. 

## Comparing borgs to reinforcements.

Lets compare a reinforcement borg to a reinforcement operative. We will try to match the operative in stats to the borg as much as possible, or perhaps even improve on it.

Assault borg: 65 tc.
(vtech, optional, 6, total 71)

Reinforcement: 25 tc
m90-gl: Has the most similar gun to the assault borg, although it has burst fire as well 35 damage per bullet, 3 round burst, mounted grenade launcher. 18 tc
Box of grenades, bringing up to 5 shells instead of 1: 4 tc
Ammo for gun, 2 tc per mag, go for 4 mags total including gun, 120 shots, 6 tc.
Access tuner for door bolting / unbolting like borg? 6
Emag for emaging like borg? 6
(adrenerals for healing and speed, which the borg does not have: 8, optional)
Syndicate red suit on ship: Free, nukies often take shielded or elite instead of the free suits. 50 bullet armor off the bat.
Free donk on ship for speed and healing? Free.
Flashbangs on ship for flashing like borg? Free.

Price of reinforcement: 65
(with adrenerals, 8, total 73)

The reinforcement costs the same, with adrenerals only 2 more than borg with vtech, and gets the bonuses of meth speed, armor, healing, and hands, which the borg will not have. The downside would be the lack of an esword, but the assault borg almost never uses it as it attacks at range, and one less grenade than the assault borg, that is harder to reload.

## How to fix this?

Originally, I just was going to give borgs armor, but only carbon mobs and objects had armor, and that seemed overly complex for what borgs are. Flat damage reduction is not the way to go, as cutting slugs enough in damage to make them not 2 shot the first 100 HP of a borg, would be giving it 11 damage reduction, which sounds nice, but would mean welders do only 4 damage to it, lasers 9, and buckshot could not hurt it. Not exactly fun to fight without a shotgun. By combining slight damage reduction with the incoming damage modifier, buckshot is still good but not insane, slugs do not do too much damage, and lasers and welders are about half as effective, which is a larger change, but once you flash a borg, it is over anyway. Stats of some attacks below on assault and medical borgs.

## Assault damage value on left, medical on right:

**Slug:** 38.5, 44
Hits to 100 3, 3
Hits to kill 6, 5

**Point blank buckshot:** 31.5, 36.
HT100: 4, 3
HTK: 7, 6

**Laser:** 10.5, 12
HT100: 10, 9
HTK: 20, 17

**Welder:** 7, 8
HT100: 15, 13
HTK: 29, 25

Welder is the largest change, but again, borgs killed in melee with welder are being chain flashed, and probably already toast.
Lasers are more or less half as effective, but, burn is much harder for nuke ops to heal on a borg than brute, as they have to open up the borg, or use nanopaste on it from a medborg.

## Changelog
:cl:
add: Adds a variable to borgs, that allow incoming brute and burn damage to the borg to be multiplied by that value.
tweak: Syndicate borgs get 20% incoming damage resist after taking 5 less damage, with the assault borg getting 30% instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
