### PR TITLE
Fixes the running while bola'd exploit

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -110,24 +110,7 @@
 	screen_loc = ui_acti
 
 /obj/screen/mov_intent/Click()
-	if(iscarbon(usr))
-		var/mob/living/carbon/C = usr
-		if(C.legcuffed)
-			to_chat(C, "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>")
-			C.m_intent = MOVE_INTENT_WALK	//Just incase
-			C.hud_used.move_intent.icon_state = "walking"
-			return 1
-		switch(usr.m_intent)
-			if(MOVE_INTENT_RUN)
-				usr.m_intent = MOVE_INTENT_WALK
-				usr.hud_used.move_intent.icon_state = "walking"
-			if(MOVE_INTENT_WALK)
-				usr.m_intent = MOVE_INTENT_RUN
-				usr.hud_used.move_intent.icon_state = "running"
-		if(istype(usr,/mob/living/carbon/alien/humanoid))
-			usr.update_icons()
-
-
+	usr.toggle_move_intent()
 
 /obj/screen/pull
 	name = "stop pulling"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -482,13 +482,26 @@
 	set hidden = TRUE
 	set instant = TRUE
 	if(mob)
-		mob.toggle_move_intent(usr)
+		mob.toggle_move_intent()
 
-/mob/proc/toggle_move_intent(mob/user)
+/mob/proc/toggle_move_intent()
+	if(iscarbon(src))
+		var/mob/living/carbon/C = src
+		if(C.legcuffed)
+			to_chat(C, "<span class='notice'>You are legcuffed! You cannot run until you get [C.legcuffed] removed!</span>")
+			C.m_intent = MOVE_INTENT_WALK	//Just incase
+			C.hud_used.move_intent.icon_state = "walking"
+			return
+
+	var/icon_toggle
 	if(m_intent == MOVE_INTENT_RUN)
 		m_intent = MOVE_INTENT_WALK
+		icon_toggle = "walking"
 	else
 		m_intent = MOVE_INTENT_RUN
-	if(hud_used && hud_used.static_inventory)
+		icon_toggle = "running"
+
+	if(hud_used && hud_used.move_intent && hud_used.static_inventory)
+		hud_used.move_intent.icon_state = icon_toggle
 		for(var/obj/screen/mov_intent/selector in hud_used.static_inventory)
 			selector.update_icon(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes: #14820 
Also makes it so that holding 'Alt' to change your move intent also changes the button icon. (If applicable)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's a pretty bad exploit.

## Changelog
:cl:
tweak: Holding 'Alt' to change your move intent now also changes the button icon
fix: Fixed being able to run while bola'd by holding 'Alt'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
