### PR TITLE
Adds a config setting to enable observers before server initializations

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -241,6 +241,9 @@
 	//Start now warning
 	var/start_now_confirmation = 0
 
+	// Allow observers before initialization
+	var/observer_initialize = 0
+
 	// Lavaland
 	var/lavaland_budget = 60
 
@@ -727,6 +730,9 @@
 
 				if("start_now_confirmation")
 					config.start_now_confirmation = 1
+
+				if("observer_initialize")
+					config.observer_initialize = 1
 
 				if("tick_limit_mc_init")
 					config.tick_limit_mc_init = text2num(value)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -77,7 +77,7 @@
 		else	output += "<p><a href='byond://?src=[UID()];skip_antag=2'>Global Antag Candidacy</A>"
 		output += "<br /><small>You are <b>[client.skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
 
-	if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
+	if(!config.observer_initialize && (!SSticker || SSticker.current_state == GAME_STATE_STARTUP))
 		output += "<p>Observe (Please wait...)</p>"
 	else
 		output += "<p><a href='byond://?src=[UID()];observe=1'>Observe</A></p>"
@@ -188,7 +188,7 @@
 			to_chat(usr, "<span class='warning'>You must consent to the terms of service before you can join!</span>")
 			return FALSE
 
-		if(!SSticker || SSticker.current_state == GAME_STATE_STARTUP)
+		if(!config.observer_initialize && (!SSticker || SSticker.current_state == GAME_STATE_STARTUP))
 			to_chat(usr, "<span class='warning'>You must wait for the server to finish starting before you can join!</span>")
 			return FALSE
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -455,6 +455,9 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ## Uncomment to give a confirmation before hitting start now
 #START_NOW_CONFIRMATION
 
+## Uncomment to allow observers before initializations are complete (WARNING: May cause runtimes and errors)
+#OBSERVER_INITIALIZE
+
 ## If uncommented, all gamemodes will respect the number of required players. Defaults to no.
 #ENABLE_GAMEMODE_PLAYER_LIMIT
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a developer config setting to allow observers before server initializations are completed.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
While the checks added in #14462 are undoubtedly very useful on a live server, sometimes when testing something locally you want to be able to enter the game without waiting ~40 seconds for the server to load.
This *will* cause runtimes if enabled, but those aren't very important if you just want to check the colour of a sprite or something.

## Changelog
:cl:
add: Added a server config setting to allow observers before initializations are complete
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
