### PR TITLE
Beach Biodome Remap part 2

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -3,12 +3,16 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/simulated/floor/beach/sand,
+/obj/effect/turf_decal/sand,
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/turf/simulated/floor/pod/dark,
 /area/ruin/powered/beach)
 "ac" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/simulated/floor/beach/sand,
+/obj/effect/turf_decal/sand,
+/obj/structure/table,
+/obj/item/storage/box/beakers,
+/turf/simulated/floor/pod/dark,
 /area/ruin/powered/beach)
 "ad" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -19,57 +23,56 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil,
 /obj/item/storage/box/lights/mixed,
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/simulated/floor/pod/dark,
 /area/ruin/powered/beach)
 "af" = (
-/obj/structure/table,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/sunglasses/big,
-/obj/item/clothing/glasses/sunglasses/big,
-/obj/item/clothing/glasses/sunglasses/big,
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/sand,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/pod/dark,
 /area/ruin/powered/beach)
 "ag" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "ah" = (
-/obj/effect/mob_spawn/human/bartender/alive,
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/obj/machinery/light,
+/turf/simulated/floor/pod/dark,
 /area/ruin/powered/beach)
 "ai" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "aj" = (
 /turf/simulated/wall/mineral/sandstone,
 /area/ruin/powered/beach)
 "ak" = (
-/obj/structure/toilet,
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/plating,
-/area/ruin/powered/beach)
-"al" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/machinery/door/airlock/sandstone{
+	name = "Bar Storage"
 	},
+/obj/effect/turf_decal/sand,
 /turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "am" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "an" = (
-/obj/item/flashlight/lantern,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand,
 /turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "ao" = (
@@ -96,37 +99,47 @@
 /turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "as" = (
-/turf/simulated/floor/plating,
+/obj/machinery/chem_dispenser/beer,
+/obj/structure/table,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "at" = (
-/obj/item/tank/oxygen,
-/turf/simulated/floor/plating,
+/obj/structure/chair/wood,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "au" = (
-/obj/structure/lattice,
-/turf/simulated/floor/pod/light,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "av" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Lavatory"
+/obj/structure/table/wood,
+/obj/machinery/door/window/westright{
+	req_one_access_txt = "25"
 	},
-/turf/simulated/floor/plating,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "aw" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Bar Storage"
+/obj/machinery/chem_dispenser/soda,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "ax" = (
-/obj/structure/extinguisher_cabinet,
-/turf/simulated/wall/mineral/sandstone,
+/obj/machinery/disco/immobile,
+/turf/simulated/floor/light/colour_cycle,
 /area/ruin/powered/beach)
 "ay" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Restroom"
 	},
-/turf/simulated/floor/beach/sand,
+/obj/effect/turf_decal/sand,
+/turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "az" = (
 /obj/item/clothing/accessory/necklace/dope,
@@ -141,57 +154,35 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/sand,
 /turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
 "aC" = (
 /turf/simulated/floor/wood,
 /area/ruin/powered/beach)
-"aD" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser/soda,
-/turf/simulated/floor/wood,
-/area/ruin/powered/beach)
 "aE" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/simulated/floor/wood,
-/area/ruin/powered/beach)
-"aF" = (
-/obj/machinery/vending/boozeomat{
-	emagged = 1;
-	req_access_txt = "0"
+/obj/structure/table/wood,
+/obj/machinery/door/window/westleft{
+	req_one_access_txt = "25"
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "aG" = (
 /obj/effect/turf_decal/sand,
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"aH" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/wood,
+/obj/effect/turf_decal/sand,
+/obj/item/flashlight/lantern,
+/turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "aI" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "aJ" = (
 /obj/structure/closet/crate,
 /obj/item/tank/emergency_oxygen,
 /obj/item/trash/candy,
-/obj/item/toy/owl,
 /obj/effect/turf_decal/sand,
-/turf/simulated/floor/plasteel,
+/obj/item/toy/figure/bartender,
+/turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
 "aK" = (
 /obj/effect/turf_decal/sand,
@@ -200,44 +191,23 @@
 "aL" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/cigarette/beach,
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"aM" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
 "aN" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/cola/free,
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"aO" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"aP" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
 "aQ" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "aR" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/tequila,
-/turf/simulated/floor/wood,
-/area/ruin/powered/beach)
-"aS" = (
-/obj/machinery/processor,
-/turf/simulated/floor/wood,
-/area/ruin/powered/beach)
-"aT" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Bar"
+	},
 /obj/effect/turf_decal/sand,
-/obj/machinery/vending/snack/free,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/ruin/powered/beach)
 "aU" = (
 /obj/effect/overlay/palmtree_l,
@@ -247,74 +217,9 @@
 /obj/effect/mob_spawn/human/beach/alive,
 /turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
-"aW" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/caution{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"aX" = (
-/obj/structure/closet/secure_closet/freezer/meat/open,
-/turf/simulated/floor/wood,
-/area/ruin/powered/beach)
-"aY" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/caution{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
 "aZ" = (
 /obj/effect/overlay/coconut,
 /turf/simulated/floor/beach/sand,
-/area/ruin/powered/beach)
-"ba" = (
-/obj/machinery/disco{
-	anchored = 1
-	},
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/light/colour_cycle,
-/area/ruin/powered/beach)
-"bb" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"bc" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Bar Access"
-	},
-/turf/simulated/floor/wood,
-/area/ruin/powered/beach)
-"bd" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/turf/simulated/floor/wood,
-/area/ruin/powered/beach)
-"be" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/caution,
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"bf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/plasteel,
-/area/ruin/powered/beach)
-"bg" = (
-/obj/structure/sign/barsign,
-/turf/simulated/wall/mineral/sandstone,
-/area/ruin/powered/beach)
-"bh" = (
-/obj/item/reagent_containers/spray/spraytan,
-/obj/effect/turf_decal/sand,
-/turf/simulated/floor/plasteel,
 /area/ruin/powered/beach)
 "bi" = (
 /obj/structure/closet/athletic_mixed,
@@ -362,8 +267,8 @@
 /area/ruin/powered/beach)
 "bp" = (
 /obj/machinery/light/small{
-	light_power = 3;
-	dir = 8
+	dir = 8;
+	light_power = 3
 	},
 /obj/effect/turf_decal/sand,
 /turf/simulated/floor/pod,
@@ -492,6 +397,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/beach/water,
 /area/ruin/powered/beach)
+"cP" = (
+/obj/structure/flora/tree/palm{
+	pixel_x = -7;
+	pixel_y = 18
+	},
+/turf/simulated/floor/beach/sand,
+/area/ruin/powered/beach)
 "cR" = (
 /obj/structure/table/wood,
 /obj/item/tank/oxygen,
@@ -500,27 +412,18 @@
 /turf/simulated/floor/pod,
 /area/ruin/powered/beach)
 "gg" = (
-/obj/structure/table,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/donkpockets,
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/sand,
+/turf/simulated/floor/pod/dark,
 /area/ruin/powered/beach)
-"hY" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/beer,
-/turf/simulated/floor/wood,
+"lh" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
 "lF" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/pod{
-	oxygen = 14;
-	nitrogen = 23;
-	temperature = 300
-	},
+/turf/simulated/floor/pod/light,
 /area/ruin/powered/beach)
 "lM" = (
 /obj/structure/dresser,
@@ -549,6 +452,31 @@
 	},
 /turf/simulated/floor/pod/light,
 /area/ruin/powered/beach)
+"sp" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ruin/powered/beach)
+"uA" = (
+/obj/item/radio/beacon,
+/turf/simulated/floor/beach/sand,
+/area/ruin/powered/beach)
+"uP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/flora/rock,
+/turf/simulated/floor/beach/sand,
+/area/ruin/powered/beach)
+"wb" = (
+/obj/effect/mob_spawn/human/bartender/alive,
+/turf/simulated/floor/wood,
+/area/ruin/powered/beach)
+"yc" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/simulated/floor/beach/sand,
+/area/ruin/powered/beach)
 "zw" = (
 /obj/structure/closet/athletic_mixed,
 /turf/simulated/floor/pod,
@@ -559,6 +487,10 @@
 	},
 /turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
+"Ds" = (
+/obj/structure/sign/barsign,
+/turf/simulated/wall/mineral/sandstone,
+/area/ruin/powered/beach)
 "Ec" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Beach Access"
@@ -566,12 +498,11 @@
 /turf/simulated/floor/pod,
 /area/ruin/powered/beach)
 "Ei" = (
-/obj/effect/turf_decal/sand,
-/obj/machinery/light/small{
-	light_power = 3;
-	dir = 8
+/obj/machinery/door/airlock/sandstone{
+	name = "Bar Kitchen";
+	req_one_access_txt = "25"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "Gc" = (
 /turf/simulated/floor/pod/light,
@@ -582,29 +513,48 @@
 /obj/item/clothing/shoes/sandal,
 /turf/simulated/floor/pod,
 /area/ruin/powered/beach)
+"JF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/wood,
+/area/ruin/powered/beach)
+"Pl" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/simulated/floor/beach/sand,
+/area/ruin/powered/beach)
+"QM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ruin/powered/beach)
 "QS" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
+"TD" = (
+/turf/template_noop,
+/area/ruin/powered/beach)
 "TP" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/pod{
-	oxygen = 14;
-	nitrogen = 23;
-	temperature = 300
-	},
+/turf/simulated/floor/pod/light,
+/area/ruin/powered/beach)
+"TW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/kitchen_machine/microwave,
+/turf/simulated/floor/wood,
 /area/ruin/powered/beach)
 "VO" = (
 /turf/simulated/floor/pod,
 /area/ruin/powered/beach)
 "Xp" = (
 /obj/machinery/light/small{
-	light_power = 3;
-	dir = 8
+	dir = 8;
+	light_power = 3
 	},
 /turf/simulated/floor/pod,
 /area/ruin/powered/beach)
@@ -620,7 +570,7 @@ aa
 aa
 aa
 lF
-aa
+TD
 bW
 bW
 bW
@@ -630,7 +580,7 @@ pI
 bW
 bW
 bW
-aa
+TD
 lF
 aa
 aa
@@ -745,11 +695,11 @@ bW
 ad
 bE
 bE
-ab
 bE
-ac
 bE
-Bl
+bE
+bE
+uP
 bE
 bE
 bm
@@ -778,7 +728,6 @@ bE
 bE
 bE
 bE
-aV
 bE
 bE
 bE
@@ -786,7 +735,8 @@ bE
 bE
 bE
 bE
-bE
+aK
+Pl
 bz
 bE
 bJ
@@ -805,19 +755,19 @@ aa
 aa
 bW
 bW
-bE
-ap
+aj
+aj
 az
+lh
 bE
-ab
+yc
 bE
-ac
 bE
 bE
 bE
 aU
 aZ
-bE
+aK
 bE
 bE
 bE
@@ -836,20 +786,20 @@ aa
 (8,1,1) = {"
 aa
 bW
-ad
+ab
+af
+aj
+bE
+bE
+aV
 bE
 bE
 bE
 bE
 bE
 bE
-bE
-bE
-bE
-bE
-bE
-bE
-bE
+aK
+Pl
 bE
 bE
 bE
@@ -868,20 +818,20 @@ aa
 (9,1,1) = {"
 aa
 bW
-bW
-bW
-bW
+ac
+ah
+aj
 aB
-aK
-aK
-aK
-aK
-aK
-aK
-aK
-aK
+lh
+bE
+yc
 bE
 bE
+bE
+bE
+aK
+aK
+aK
 bE
 ap
 bE
@@ -902,17 +852,17 @@ aa
 bW
 ae
 gg
-bW
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-bh
-aK
+aj
 bE
+bE
+bE
+bE
+bE
+bE
+bE
+aA
+Pl
+aK
 bE
 ap
 bx
@@ -932,19 +882,19 @@ aa
 (11,1,1) = {"
 aa
 bW
-af
-as
+aj
+ak
 aj
 aj
 aj
 aj
-aG
-aG
-aG
-aG
-aG
-aK
 bE
+bE
+bE
+bE
+bE
+aK
+Pl
 bE
 bE
 bE
@@ -965,16 +915,16 @@ aa
 aa
 bW
 ag
-as
-aw
 aC
 aC
-aP
-aO
-aG
-aY
-aG
-aG
+aC
+aC
+aR
+aK
+Pl
+bE
+bE
+aK
 aK
 bE
 bE
@@ -996,18 +946,18 @@ aa
 (13,1,1) = {"
 aa
 bW
-ah
-as
-aj
-aD
 aC
+at
 aQ
-aO
-aW
-ba
-be
-aG
+sp
+aC
+mh
+Pl
+Pl
 aK
+Pl
+aK
+Pl
 bE
 bx
 bE
@@ -1030,17 +980,17 @@ aa
 bW
 ai
 at
-ax
-hY
+aQ
+sp
 aC
-aP
-aO
-aG
-bb
-aG
-aG
+mh
+Pl
 aK
-bE
+Pl
+aK
+ax
+Pl
+uA
 ap
 bE
 bE
@@ -1060,18 +1010,18 @@ aa
 (15,1,1) = {"
 aa
 bW
-aj
-aj
-aj
-aF
+QM
+aC
+aC
+aC
 aC
 aR
-aO
-aG
-aG
-aG
-aG
 aK
+bE
+bE
+Pl
+aK
+Pl
 br
 bE
 bE
@@ -1092,19 +1042,19 @@ aa
 (16,1,1) = {"
 aa
 bW
-ak
+aj
 Ei
-aj
+av
 aE
-aC
 aj
 aj
-bc
-aj
-bf
-aG
-aK
+aB
 bE
+ap
+bE
+bE
+aK
+Pl
 bE
 bE
 bE
@@ -1124,19 +1074,19 @@ aa
 (17,1,1) = {"
 aa
 bW
-aj
-av
-aj
-aH
+au
 aC
 aC
-aC
-aC
-bg
-aG
-aG
-aK
+wb
+JF
+Ds
 bE
+bE
+bE
+bE
+bE
+Pl
+Pl
 bE
 aU
 bE
@@ -1156,19 +1106,19 @@ aa
 (18,1,1) = {"
 aa
 bW
-al
+am
 as
-aj
+aw
 aI
-aM
-aS
-aX
-bd
+TW
 aj
-aG
-aG
-aK
 bE
+bE
+bE
+bE
+bE
+bE
+aK
 aZ
 bE
 bE
@@ -1188,20 +1138,20 @@ aa
 (19,1,1) = {"
 aa
 bW
-am
-as
 aj
 aj
 aj
 aj
 aj
 aj
-aj
-bf
-aG
+bE
+bE
+bE
+bE
+bE
 aK
-bE
-bE
+aK
+Pl
 bE
 bE
 QS
@@ -1221,23 +1171,23 @@ aa
 aa
 bW
 an
-ar
+aG
 aj
 aJ
 aL
 aN
-aT
-aG
-aG
-aG
-aG
+bE
+bE
+bE
+bE
+bx
+Pl
 aK
-bE
-bE
+Pl
 bE
 bA
 bG
-au
+Gc
 bE
 bR
 bT
@@ -1255,17 +1205,17 @@ bW
 ao
 ar
 ay
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
+bE
+bE
+bE
+bE
+bE
+bE
+bE
+bE
 aK
-bE
-bE
+Pl
+aK
 bE
 bB
 bH
@@ -1284,19 +1234,19 @@ aa
 (22,1,1) = {"
 aa
 bW
-bW
-bW
-bW
+aj
+aj
+aj
 aB
-aK
-aK
-aK
-aK
-aK
-aK
-aK
-aK
+ap
 bE
+bE
+bE
+ap
+bE
+bE
+bE
+aK
 bE
 bE
 bE
@@ -1327,9 +1277,9 @@ bE
 bE
 bE
 bE
-bE
-bE
-bE
+cP
+aK
+ap
 bE
 bE
 bE
@@ -1360,9 +1310,9 @@ bE
 bz
 bE
 bE
-bE
-bE
-bE
+aK
+Pl
+aK
 aZ
 bE
 bE
@@ -1393,8 +1343,8 @@ bE
 bE
 bE
 bE
-bE
-bE
+aK
+Pl
 bE
 bE
 bE
@@ -1428,7 +1378,7 @@ bn
 aK
 bn
 bE
-bE
+bx
 cs
 bE
 bR
@@ -1548,7 +1498,7 @@ aa
 aa
 aa
 TP
-aa
+TD
 bW
 bW
 bW
@@ -1558,7 +1508,7 @@ pI
 bW
 bW
 bW
-aa
+TD
 TP
 aa
 aa

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -1,6 +1,7 @@
 //Lavaland Ruins
 
 /area/ruin/powered/beach
+	name = "Beach Bar"
 	icon_state = "dk_yellow"
 
 /area/ruin/powered/clownplanet

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -483,3 +483,13 @@
 		playsound(src,'sound/machines/terminal_off.ogg',50,1)
 		icon_state = "disco0"
 		stop = world.time + 100
+
+
+
+/obj/machinery/disco/immobile
+	name = "radiant dance machine mark V"
+	desc = "The mark V is nigh-immovable, thanks to its bluespace-plastitanium anchor. The technology required to stop visitors from stealing this thing is astounding."
+	anchored = TRUE
+
+/obj/machinery/disco/immobile/wrench_act()
+	return FALSE


### PR DESCRIPTION
What Does This PR Do
Remaps the beach biodome lavaland ruin, same as #14072, but since i'm so bad at everything github, I had to close and make a fresh PR. Oops...
The diff should be the same, since I had a map backup. Tested it all again and seems to work fine! 

![beachmap](https://user-images.githubusercontent.com/67055922/98333637-2a9d2380-203c-11eb-8f26-0328f18655d7.PNG)

## Changelog
:cl:
add: Remaps the beach biodome ruin.
/:cl: