### PR TITLE
Re-add misc places of interest (such as nuke and NAD) to the orbit menu.

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -9,7 +9,7 @@
 /datum/orbit_menu/tgui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/tgui_state/state = GLOB.tgui_observer_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "Orbit", "Orbit", 800, 600, master_ui, state)
+		ui = new(user, src, ui_key, "Orbit", "Orbit", 700, 500, master_ui, state)
 		ui.open()
 
 /datum/orbit_menu/tgui_act(action, list/params, datum/tgui/ui)
@@ -45,7 +45,7 @@
 	var/list/misc = list()
 	var/list/npcs = list()
 
-	var/list/pois = getpois(mobs_only=TRUE)
+	var/list/pois = getpois(mobs_only = FALSE, skip_mindless = FALSE)
 	for(var/name in pois)
 		var/list/serialized = list()
 		serialized["name"] = name


### PR DESCRIPTION
## What Does This PR Do
Adds "miscellaneous" places of interest to the orbit menu (nuke, nad, mob spawners, megafauna, gps, ..)

Also makes the orbit window a liitttle bit smaller. I feel I overshot it a bit in the original PR. It's still resizable though, so can be adjusted by the user as needed.

Fixes #14831

## Why It's Good For The Game
These used to be selectable pre-#14810 but got accidentally removed.
They are back.
As a bonus: the old only had bots in the list of mindless mobs, now we have all the mobs here. I claim this is a good thing (despite a longer box), for this has already served me well to find terror spiders that have been long spawned, but who no ghosts took control of.

## Images of changes
![dreamseeker-20201105-204939](https://user-images.githubusercontent.com/7831163/98294789-6edee400-1fa8-11eb-96c6-9f574a9e3e09.png)


## Changelog
:cl:
fix: Re-added nuke/nad to the orbit menu
/:cl: