### PR TITLE
Ticket-Machine enable/disable ability.

### DIFF
--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -104,7 +104,8 @@
 
 /obj/machinery/ticket_machine/proc/handle_maptext()
 	if(disabled)
-		maptext = ""
+		maptext_x = 13
+		maptext = "X"
 	else
 		switch(ticket_number) //This is here to handle maptext offsets so that the numbers align.
 			if(0 to 9)

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -106,7 +106,7 @@
 /obj/machinery/ticket_machine/proc/handle_maptext()
 	if(!dispense_enabled)
 		maptext_x = 6
-		maptext = "<font face='Small Fonts' color='#0f0f0f'>OFF</font>"
+		maptext = "<font face='Small Fonts' color='#4D535E'>OFF</font>"
 		return
 	switch(ticket_number) //This is here to handle maptext offsets so that the numbers align.
 		if(0 to 9)

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -21,7 +21,7 @@
 	var/list/ticket_holders = list()
 	var/list/tickets = list()
 	var/id = 1
-	var/disabled = FALSE //used to ID card disable/enable ticket dispensing
+	var/isDisabled = FALSE //used to ID card disable/enable ticket dispensing
 
 /obj/machinery/ticket_machine/Destroy()
 	for(var/obj/item/ticket_machine_ticket/ticket in tickets)
@@ -103,9 +103,9 @@
 	handle_maptext()
 
 /obj/machinery/ticket_machine/proc/handle_maptext()
-	if(disabled)
+	if(isDisabled)
 		maptext_x = 13
-		maptext = "X"
+		maptext = "<font face='Verdana'>X</font>"
 	else
 		switch(ticket_number) //This is here to handle maptext offsets so that the numbers align.
 			if(0 to 9)
@@ -138,8 +138,8 @@
 	else if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/heldID = I
 		if(ACCESS_HOP in heldID.access)
-			disabled = !disabled
-			to_chat(user, "<span class='notice'>You [disabled ? "disable" : "enable"] the ticket machine, it will [disabled ? "no longer" : "now"] dispense tickets!</span>")
+			isDisabled = !isDisabled
+			to_chat(user, "<span class='notice'>You [isDisabled ? "disable" : "enable"] the ticket machine, it will [isDisabled ? "no longer" : "now"] dispense tickets!</span>")
 			handle_maptext()
 			return
 		else
@@ -155,8 +155,8 @@
 	if(!ready)
 		to_chat(user,"<span class='warning'>You press the button, but nothing happens...</span>")
 		return
-	if(disabled)
-		to_chat(user, "<span class='warning'>The ticket machine has been disabled.</span>")
+	if(isDisabled)
+		to_chat(user, "<span class='warning'>The ticket machine is isDisabled.</span>")
 		return
 	if(ticket_number >= max_number)
 		to_chat(user,"<span class='warning'>Ticket supply depleted, please refill this unit with a hand labeller refill cartridge!</span>")
@@ -191,7 +191,7 @@
 
 /obj/machinery/ticket_machine/examine(mob/user)
 	. = ..()
-	. += "<span class='info'>Use an ID card with HOP access on this machine to [disabled ? "enable":"disable"] ticket dispensing.</span>"
+	. += "<span class='info'>Use an ID card with HOP access on this machine to [isDisabled ? "enable":"disable"] ticket dispensing.</span>"
 
 /obj/item/ticket_machine_ticket
 	name = "Ticket"

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -106,7 +106,7 @@
 /obj/machinery/ticket_machine/proc/handle_maptext()
 	if(!dispense_enabled)
 		maptext_x = 6
-		maptext = "<font face='Small Fonts' color='#4D535E'>OFF</font>"
+		maptext = "<font face='Small Fonts' color='#960b0b'>OFF</font>"
 		return
 	switch(ticket_number) //This is here to handle maptext offsets so that the numbers align.
 		if(0 to 9)

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -21,7 +21,8 @@
 	var/list/ticket_holders = list()
 	var/list/tickets = list()
 	var/id = 1
-	var/dispense_enabled = TRUE //used to ID card disable/enable ticket dispensing
+	/// If FALSE, the ticket machine will not dispense tickets. Toggled by swiping  aHoP ID
+	var/dispense_enabled = TRUE
 
 /obj/machinery/ticket_machine/Destroy()
 	for(var/obj/item/ticket_machine_ticket/ticket in tickets)
@@ -104,17 +105,17 @@
 
 /obj/machinery/ticket_machine/proc/handle_maptext()
 	if(!dispense_enabled)
-		maptext_x = 13
-		maptext = "<font face='Verdana'>X</font>"
-	else
-		switch(ticket_number) //This is here to handle maptext offsets so that the numbers align.
-			if(0 to 9)
-				maptext_x = 13
-			if(10 to 99)
-				maptext_x = 10
-			if(100)
-				maptext_x = 8
-		maptext = "<font face='Small Fonts'>[ticket_number]</font>"
+		maptext_x = 6
+		maptext = "<font face='Small Fonts' color='#0f0f0f'>OFF</font>"
+		return
+	switch(ticket_number) //This is here to handle maptext offsets so that the numbers align.
+		if(0 to 9)
+			maptext_x = 13
+		if(10 to 99)
+			maptext_x = 10
+		if(100)
+			maptext_x = 8
+	maptext = "<font face='Small Fonts'>[ticket_number]</font>"
 
 /obj/machinery/ticket_machine/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/hand_labeler_refill))
@@ -139,13 +140,12 @@
 		var/obj/item/card/id/heldID = I
 		if(ACCESS_HOP in heldID.access)
 			dispense_enabled = !dispense_enabled
-			to_chat(user, "<span class='notice'>You [dispense_enabled ? "enable" : "disable"] the ticket machine, it will [dispense_enabled ? "now" : "no longer"] dispense tickets!</span>")
+			to_chat(user, "<span class='notice'>You [dispense_enabled ? "enable" : "disable"] [src], it will [dispense_enabled ? "now" : "no longer"] dispense tickets!</span>")
 			handle_maptext()
 			return
-		else
-			to_chat(user, "<span class='warning'>You do not have the required access to [dispense_enabled ? "disable" : "enable"] the ticket machine.</span>")
-	else
-		return ..()
+		to_chat(user, "<span class='warning'>You do not have the required access to [dispense_enabled ? "disable" : "enable"] the ticket machine.</span>")
+		return
+	return ..()
 
 /obj/machinery/ticket_machine/proc/reset_cooldown()
 	ready = TRUE
@@ -156,7 +156,7 @@
 		to_chat(user,"<span class='warning'>You press the button, but nothing happens...</span>")
 		return
 	if(!dispense_enabled)
-		to_chat(user, "<span class='warning'>The ticket machine is disabled.</span>")
+		to_chat(user, "<span class='warning'>[src] is disabled.</span>")
 		return
 	if(ticket_number >= max_number)
 		to_chat(user,"<span class='warning'>Ticket supply depleted, please refill this unit with a hand labeller refill cartridge!</span>")
@@ -191,7 +191,7 @@
 
 /obj/machinery/ticket_machine/examine(mob/user)
 	. = ..()
-	. += "<span class='info'>Use an ID card with HOP access on this machine to [dispense_enabled ? "disable" : "enable"] ticket dispensing.</span>"
+	. += "<span class='info'>Use an ID card with <b>Head of Personnel</b> access on this machine to [dispense_enabled ? "disable" : "enable"] ticket dispensing.</span>"
 
 /obj/item/ticket_machine_ticket
 	name = "Ticket"

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -21,7 +21,7 @@
 	var/list/ticket_holders = list()
 	var/list/tickets = list()
 	var/id = 1
-	var/isDisabled = FALSE //used to ID card disable/enable ticket dispensing
+	var/dispense_enabled = TRUE //used to ID card disable/enable ticket dispensing
 
 /obj/machinery/ticket_machine/Destroy()
 	for(var/obj/item/ticket_machine_ticket/ticket in tickets)
@@ -103,7 +103,7 @@
 	handle_maptext()
 
 /obj/machinery/ticket_machine/proc/handle_maptext()
-	if(isDisabled)
+	if(!dispense_enabled)
 		maptext_x = 13
 		maptext = "<font face='Verdana'>X</font>"
 	else
@@ -138,12 +138,12 @@
 	else if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/heldID = I
 		if(ACCESS_HOP in heldID.access)
-			isDisabled = !isDisabled
-			to_chat(user, "<span class='notice'>You [isDisabled ? "disable" : "enable"] the ticket machine, it will [isDisabled ? "no longer" : "now"] dispense tickets!</span>")
+			dispense_enabled = !dispense_enabled
+			to_chat(user, "<span class='notice'>You [dispense_enabled ? "enable" : "disable"] the ticket machine, it will [dispense_enabled ? "now" : "no longer"] dispense tickets!</span>")
 			handle_maptext()
 			return
 		else
-			to_chat(user, "<span class='warning'>You do not have the required access to disable the ticket machine.</span>")
+			to_chat(user, "<span class='warning'>You do not have the required access to [dispense_enabled ? "disable" : "enable"] the ticket machine.</span>")
 	else
 		return ..()
 
@@ -155,8 +155,8 @@
 	if(!ready)
 		to_chat(user,"<span class='warning'>You press the button, but nothing happens...</span>")
 		return
-	if(isDisabled)
-		to_chat(user, "<span class='warning'>The ticket machine is isDisabled.</span>")
+	if(!dispense_enabled)
+		to_chat(user, "<span class='warning'>The ticket machine is disabled.</span>")
 		return
 	if(ticket_number >= max_number)
 		to_chat(user,"<span class='warning'>Ticket supply depleted, please refill this unit with a hand labeller refill cartridge!</span>")
@@ -191,7 +191,7 @@
 
 /obj/machinery/ticket_machine/examine(mob/user)
 	. = ..()
-	. += "<span class='info'>Use an ID card with HOP access on this machine to [isDisabled ? "enable":"disable"] ticket dispensing.</span>"
+	. += "<span class='info'>Use an ID card with HOP access on this machine to [dispense_enabled ? "disable" : "enable"] ticket dispensing.</span>"
 
 /obj/item/ticket_machine_ticket
 	name = "Ticket"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds the ability to disable/enable the ticket-machine, swipe an ID with HOP access through it to enable/disable its ticket dispensing ability. When disabled the machine will no longer dispense any new tickets, and display a "X".

Already dispensed tickets will still function normally, the button's functionality is not changed.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some HOP players do not wish for people to use the machine, and dont want to have to deal with them bringing tickets to their desks. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![SkzbdG4Tzj](https://user-images.githubusercontent.com/16618648/98432439-dcac0e00-2083-11eb-827b-8fab1539b702.gif)

![dreamseeker_MRAVHmQhd6](https://user-images.githubusercontent.com/16618648/98432442-e2095880-2083-11eb-9a03-f9542b8de02d.png)

_here is what it looks like when disable_
![dreamseeker_sqPg5mz7yb](https://user-images.githubusercontent.com/16618648/98448714-c8075e80-20f3-11eb-8964-f89f0b702c72.png)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Adds ability to disable the ticket machine when you swipe HOP access ID!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
