### PR TITLE
In-code server revision info

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -12,7 +12,7 @@
 
 #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 
-// Git related operations // - AA TODO: Add in in-code revision parsing
+// Git related operations //
 #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
 #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
 

--- a/code/datums/revision.dm
+++ b/code/datums/revision.dm
@@ -1,0 +1,56 @@
+GLOBAL_DATUM_INIT(revision_info, /datum/code_revision, new)
+GLOBAL_PROTECT(revision_info) // Dont mess with this
+
+/**
+  * Code Revision Datum
+  *
+  * Allows the server code to be aware of the Git environment it is running in, and lets commit hash be viewed
+  */
+/datum/code_revision
+	/// Current commit hash the server is running
+	var/commit_hash
+	/// Date that this commit was made
+	var/commit_date
+
+/datum/code_revision/New()
+	commit_hash = rustg_git_revparse("HEAD")
+	if(commit_hash)
+		commit_date = rustg_git_commit_date(commit_hash)
+
+/**
+  * Code Revision Logging Helper
+  *
+  * Small proc to simplify logging all this stuff
+  */
+/datum/code_revision/proc/log_info()
+	// Put revision info in the world log
+	var/logmsg
+	if(commit_hash && commit_date)
+		logmsg = "Running ParaCode commit: [GLOB.revision_info.commit_hash] (Date: [GLOB.revision_info.commit_date])"
+	else
+		logmsg = "Unable to determine revision info! Code may not be running in a git repository."
+
+	// Log it in all these
+	log_world(logmsg)
+	log_runtime_txt(logmsg)
+	log_runtime_summary(logmsg)
+
+/client/verb/get_revision_info()
+	set name = "Get Revision Info"
+	set category = "OOC"
+	set desc = "Retrieve technical information about the server"
+
+	var/list/msg = list()
+	msg += "<span class='notice'><b>Server Revision Info</b></span>"
+	// Commit info first
+	if(GLOB.revision_info.commit_hash && GLOB.revision_info.commit_date)
+		msg += "<b>Server Commit:</b> <a href='[config.githuburl]/commit/[GLOB.revision_info.commit_hash]'>[GLOB.revision_info.commit_hash]</a> (Date: [GLOB.revision_info.commit_date])"
+	else
+		msg += "<b>Server Commit:</b> <i>Unable to determine</i>"
+
+	// Show server BYOND version
+	msg += "<b>Server BYOND Version:</b> [world.byond_version].[world.byond_build]"
+	// And the clients for good measure
+	msg += "<b>Client (your) BYOND Version:</b> [byond_version].[byond_build]"
+
+	to_chat(usr, msg.Join("<br>"))

--- a/code/datums/revision.dm
+++ b/code/datums/revision.dm
@@ -26,7 +26,7 @@ GLOBAL_PROTECT(revision_info) // Dont mess with this
 	// Put revision info in the world log
 	var/logmsg
 	if(commit_hash && commit_date)
-		logmsg = "Running ParaCode commit: [GLOB.revision_info.commit_hash] (Date: [GLOB.revision_info.commit_date])"
+		logmsg = "Running ParaCode commit: [commit_hash] (Date: [commit_date])"
 	else
 		logmsg = "Unable to determine revision info! Code may not be running in a git repository."
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED) // creates a new TGS object
 	log_world("World loaded at [time_stamp()]")
 	log_world("[GLOB.vars.len - GLOB.gvars_datum_in_built_vars.len] global variables")
+	GLOB.revision_info.log_info()
 	connectDB() // This NEEDS TO HAPPEN EARLY. I CANNOT STRESS THIS ENOUGH!!!!!!! -aa
 	load_admins() // Same here
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -296,6 +296,7 @@
 #include "code\datums\progressbar.dm"
 #include "code\datums\radio.dm"
 #include "code\datums\recipe.dm"
+#include "code\datums\revision.dm"
 #include "code\datums\ruins.dm"
 #include "code\datums\shuttles.dm"
 #include "code\datums\soullink.dm"


### PR DESCRIPTION
## What Does This PR Do
Gives the server code the ability to be aware of the commit hash the server is running on, as well as providing players a link to said hash if they want to try a specific build from a specific round locally. Pressing `Get Revision Info` in the OOC tab will provide you with this
![image](https://user-images.githubusercontent.com/25063394/98447695-e33b9380-211e-11eb-90d0-dba61ca49a8f.png)
*more info may be added here if it seems fit*

It also stamps into the loglines of `game.log`, `runtime.log` and `runtime_summary.log`
![image](https://user-images.githubusercontent.com/25063394/98447710-f9495400-211e-11eb-9702-f84ffc2abec7.png)

![image](https://user-images.githubusercontent.com/25063394/98447716-ff3f3500-211e-11eb-9428-554f4cd39c96.png)

![image](https://user-images.githubusercontent.com/25063394/98447727-08c89d00-211f-11eb-9b56-a6ddf3403dcb.png)

And yes the server still works outside a git environment
![image](https://user-images.githubusercontent.com/25063394/99181936-8f860700-2729-11eb-843d-1af2158cfeed.png)
![image](https://user-images.githubusercontent.com/25063394/99181943-990f6f00-2729-11eb-9695-ee9484350f3f.png)
![image](https://user-images.githubusercontent.com/25063394/99181949-a0367d00-2729-11eb-881e-7b5a5c72e9bf.png)
![image](https://user-images.githubusercontent.com/25063394/99181952-a593c780-2729-11eb-9f90-efa0b158d922.png)


## Why It's Good For The Game
The server being aware of its commit hash and date is a very valuable tool for debugging testmerges, round-isolated incidents, amongst other things

## Changelog
:cl: AffectedArc07
add: The code now knows what commit its running at. Use "Get Revision Info" in the OOC tab to view the server code revision
add: [Administration] game.log and runtime.log now mark commit hash at the start  of the log to aid debugging
/:cl:
