### PR TITLE
Re adds ticket conversion via the chat link. Minor tweak to formatting

### DIFF
--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -119,8 +119,8 @@ SUBSYSTEM_DEF(tickets)
 	L += "([ADMIN_QUE(C.mob,"?")]) ([ADMIN_PP(C.mob,"PP")]) ([ADMIN_VV(C.mob,"VV")]) ([ADMIN_TP(C.mob,"TP")]) ([ADMIN_SM(C.mob,"SM")]) "
 	L += "([admin_jump_link(C.mob)]) (<a href='?_src_=holder;openticket=[ticketNum][anchor_link_extra]'>TICKET</a>) "
 	L += "[isAI(C.mob) ? "(<a href='?_src_=holder;adminchecklaws=[C.mob.UID()]'>CL</a>)" : ""] (<a href='?_src_=holder;take_question=[ticketNum][anchor_link_extra]'>TAKE</a>) "
-	L += "(<a href='?_src_=holder;resolve=[ticketNum][anchor_link_extra]'>RESOLVE</a>) <a href='?_src_=holder;autorespond=[ticketNum][anchor_link_extra]'>(AUTO)</a> "
-	L += "<a href='?_src_=holder;convert_ticket=[ticketNum][anchor_link_extra]'>(CONVERT)</a> :</span> <span class='[ticket_help_span]'>[msg]</span>"
+	L += "(<a href='?_src_=holder;resolve=[ticketNum][anchor_link_extra]'>RESOLVE</a>) (<a href='?_src_=holder;autorespond=[ticketNum][anchor_link_extra]'>AUTO</a>) "
+	L += "(<a href='?_src_=holder;convert_ticket=[ticketNum][anchor_link_extra]'>CONVERT</a>) :</span> <span class='[ticket_help_span]'>[msg]</span>"
 	return L.Join()
 
 //Open a new ticket and populate details then add to the list of open tickets

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1676,6 +1676,13 @@
 			return
 		SStickets.autoRespond(index)
 
+	if(href_list["convert_ticket"])
+		var/indexNum = text2num(href_list["convert_ticket"])
+		if(href_list["is_mhelp"])
+			SSmentor_tickets.convert_to_other_ticket(indexNum)
+		else
+			SStickets.convert_to_other_ticket(indexNum)
+
 	else if(href_list["cult_mindspeak"])
 		var/input = stripped_input(usr, "Communicate to all the cultists with the voice of [SSticker.cultdat.entity_name]", "Voice of [SSticker.cultdat.entity_name]")
 		if(!input)


### PR DESCRIPTION
## What Does This PR Do
Re adds ticket converting using the chatbox text message. Which got accidently removed in https://github.com/ParadiseSS13/Paradise/pull/14516/files#diff-8b4e3b713fad0f9d94341e1681075020b85302d04ab3e23c5913770fc86b2842L1679

Fixes the formatting of the (AUTO) and (CONVERT) to only have the text be an anchor.

## Why It's Good For The Game
Well yeah duh

## Changelog
:cl:
fix: Re adds the conversion of tickets.
tweak: Makes only the text of AUTO and CONVERT be anchors
/:cl: