### PR TITLE
Firelocks can be opened by hand in reasonable time

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -14,21 +14,26 @@
 	damage_deflection = 10
 	var/closingLayer = CLOSED_DOOR_LAYER
 	var/visible = 1
+	/// Is it currently in the process of opening or closing.
 	var/operating = FALSE
 	var/autoclose = 0
-	var/safe = TRUE //whether the door detects things and mobs in its way and reopen or crushes them.
-	var/locked = FALSE //whether the door is bolted or not.
+	/// Whether the door detects things and mobs in its way and reopen or crushes them.
+	var/safe = TRUE
+	// Whether the door is bolted or not.
+	var/locked = FALSE
 	var/glass = FALSE
 	var/welded = FALSE
 	var/normalspeed = TRUE
 	var/auto_close_time = 150
 	var/auto_close_time_dangerous = 15
-	var/assemblytype //the type of door frame to drop during deconstruction
+	/// The type of door frame to drop during deconstruction
+	var/assemblytype
 	var/datum/effect_system/spark_spread/spark_system
 	var/real_explosion_block	//ignore this, just use explosion_block
 	var/heat_proof = FALSE // For rglass-windowed airlocks and firedoors
 	var/emergency = FALSE
-	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
+	/// Unrestricted sides. A bitflag for which direction (if any) can open the door with no access.
+	var/unres_sides = 0
 	//Multi-tile doors
 	var/width = 1
 
@@ -300,7 +305,7 @@
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)
-	operating = 0
+	operating = FALSE
 	air_update_turf(1)
 	update_freelook_sight()
 	if(safe)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -19,11 +19,11 @@
 	safe = FALSE
 	layer = BELOW_OPEN_DOOR_LAYER
 	closingLayer = CLOSED_FIREDOOR_LAYER
-	auto_close_time = 50
+	auto_close_time = 5 SECONDS
 	assemblytype = /obj/structure/firelock_frame
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 70)
 	/// How long does opening by hand take, in deciseconds.
-	var/manual_open_time = 50
+	var/manual_open_time = 5 SECONDS
 	var/can_crush = TRUE
 	var/nextstate = null
 	/// Whether the "bolts" are "screwed". Used for deconstruction sequence. Has nothing to do with airlock bolting.
@@ -98,13 +98,13 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	user.visible_message(
-		"<span class='notice'>[user] tries to open \the [src] manually.</span>",
-		"<span class='notice'>You operate the manual lever on \the [src].</span>")
+		"<span class='notice'>[user] tries to open [src] manually.</span>",
+		"<span class='notice'>You operate the manual lever on [src].</span>")
 
 	if(do_after(user, manual_open_time, target = src))
 		user.visible_message(
-			"<span class='notice'>[user] opens \the [src].</span>",
-			"<span class='notice'>You open \the [src].</span>")
+			"<span class='notice'>[user] opens [src].</span>",
+			"<span class='notice'>You open [src].</span>")
 		open(auto_close = FALSE)
 
 /obj/machinery/door/firedoor/attackby(obj/item/C, mob/user, params)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -6,7 +6,7 @@
 
 /obj/machinery/door/firedoor
 	name = "firelock"
-	desc = "Apply crowbar."
+	desc = "A convenable firelock. Equipped with a manual lever for operating in case of emergency."
 	icon = 'icons/obj/doors/doorfireglass.dmi'
 	icon_state = "door_open"
 	opacity = 0
@@ -22,12 +22,11 @@
 	auto_close_time = 50
 	assemblytype = /obj/structure/firelock_frame
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 70)
-	/// Whether can be opened by hand, when on non-help intent
-	var/can_force = TRUE
 	/// How long does opening by hand take, in deciseconds.
-	var/force_open_time = 50
+	var/manual_open_time = 50
 	var/can_crush = TRUE
 	var/nextstate = null
+	/// Whether the "bolts" are "screwed". Used for deconstruction sequence. Has nothing to do with airlock bolting.
 	var/boltslocked = TRUE
 	var/active_alarm = FALSE
 	var/list/affecting_areas
@@ -91,20 +90,22 @@
 	if(operating || !density)
 		return
 
+	if(welded)
+		to_chat(user, "<span class='warning'>[src] is welded shut!</span>")
+		return
+
 	add_fingerprint(user)
 	user.changeNext_move(CLICK_CD_MELEE)
 
-	if(can_force && (!glass || user.a_intent != INTENT_HELP))
-		user.visible_message("<span class='notice'>[user] begins forcing \the [src].</span>", \
-							 "<span class='notice'>You begin forcing \the [src].</span>")
-		if(do_after(user, force_open_time, target = src))
-			user.visible_message("<span class='notice'>[user] forces \the [src].</span>", \
-								 "<span class='notice'>You force \the [src].</span>")
-			open()
-	else if(glass)
-		user.visible_message("<span class='warning'>[user] bangs on \the [src].</span>",
-							 "<span class='warning'>You bang on \the [src].</span>")
-		playsound(get_turf(src), 'sound/effects/glassknock.ogg', 10, 1)
+	user.visible_message(
+		"<span class='notice'>[user] tries to open \the [src] manually.</span>",
+		"<span class='notice'>You operate the manual lever on \the [src].</span>")
+
+	if(do_after(user, manual_open_time, target = src))
+		user.visible_message(
+			"<span class='notice'>[user] opens \the [src].</span>",
+			"<span class='notice'>You open \the [src].</span>")
+		open(auto_close = FALSE)
 
 /obj/machinery/door/firedoor/attackby(obj/item/C, mob/user, params)
 	add_fingerprint(user)
@@ -300,7 +301,6 @@
 	opacity = 1
 	explosion_block = 2
 	assemblytype = /obj/structure/firelock_frame/heavy
-	can_force = FALSE
 	max_integrity = 550
 
 /obj/item/firelock_electronics

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -22,8 +22,10 @@
 	auto_close_time = 50
 	assemblytype = /obj/structure/firelock_frame
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 70)
+	/// Whether can be opened by hand, when on non-help intent
 	var/can_force = TRUE
-	var/force_open_time = 300
+	/// How long does opening by hand take, in deciseconds.
+	var/force_open_time = 50
 	var/can_crush = TRUE
 	var/nextstate = null
 	var/boltslocked = TRUE


### PR DESCRIPTION
## What Does This PR Do
Reduces the time it takes to open firelock by hand (without a crowbar) from 30 seconds down to 5.

## Why It's Good For The Game
Atmos breaches are fairly regular on the station. Whenever one happens, firelocks, naturally, engage. However they often cut you off from the fire panel, so you effectively need a crowbar to get yourself to where you want to be (and often, to safety).
However, needing to carry a crowbar on you at all times exactly for the reason of "what if i get bombed?" is.. unexciting, especially if you play a role that shouldn't *need* to carry a crowbar IC'ly.

Now, turns out, that it *is* possible to open firelocks by hand, but it takes an excuriating 30 seconds, which is just waaay too long. Lowering that time to something - still long, but reasonable, like 5 seconds (or maybe 10 even) would eliminate the need to carry crowbar "just in case", and (arguably!) higher the RP standards a tiniest bit.

Please note that 5 seconds is still way way longer than the "instant" that you get when applying the crowbar, so crowbar absolutely does not become useless item.

## Images of changes
![20201108-025530-IhHankIt98](https://user-images.githubusercontent.com/7831163/98455848-f1fd6700-216d-11eb-9158-d919e93758cd.gif)


## Changelog
:cl:
tweak: Firelocks can be opened by hand in 5 seconds, down from 30
/:cl: