### PR TITLE
Changes fleshmend description to be accurate

### DIFF
--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/fleshmend
 	name = "Fleshmend"
 	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Costs 20 chemicals."
-	helptext = "If we are on fire, the healing effect will not function. Does not regrow limbs or restore lost blood. Functions while unconscious."
+	helptext = "Does not regrow limbs. Functions while unconscious."
 	button_icon_state = "fleshmend"
 	chemical_cost = 20
 	dna_cost = 2

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/fleshmend
 	name = "Fleshmend"
 	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Costs 20 chemicals."
-	helptext = "Does not regrow limbs. Functions while unconscious."
+	helptext = "Does not regrow limbs. Partially recovers our blood. Functions while unconscious."
 	button_icon_state = "fleshmend"
 	chemical_cost = 20
 	dna_cost = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes fleshmend description to actually be accurate, so instead of
`"If we are on fire, the healing effect will not function. Does not regrow limbs or restore lost blood. Functions while unconscious."`

it's now

`"Does not regrow limbs. Partially recovers our blood. Functions while unconscious."`

fixes: #14819
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Description should match the mutation.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fleshmend description now accurate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
