### PR TITLE
Adds radial menus to cult structures and constructs

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -256,8 +256,10 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	if(current_user)
 		current_user.images -= menu_holder
 
-/datum/radial_menu/proc/wait()
-	while (current_user && !finished && !selected_choice)
+/datum/radial_menu/proc/wait(mob/user, atom/anchor, require_near = FALSE)
+	while(current_user && !finished && !selected_choice)
+		if(require_near && !user.Adjacent(anchor))
+			return
 		if(custom_check_callback && next_check < world.time)
 			if(!custom_check_callback.Invoke())
 				return
@@ -275,7 +277,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
 */
-/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check)
+/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE)
 	if(!user || !anchor || !length(choices))
 		return
 	if(!uniqueid)
@@ -294,7 +296,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	menu.check_screen_border(user) //Do what's needed to make it look good near borders or on hud
 	menu.set_choices(choices)
 	menu.show_to(user)
-	menu.wait()
+	menu.wait(user, anchor, require_near)
 	var/answer = menu.selected_choice
 	qdel(menu)
 	GLOB.radial_menus -= uniqueid

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -80,12 +80,15 @@
 	if(cooldowntime > world.time)
 		to_chat(user, "<span class='cultitalic'>The magic in [src] is weak, it will be ready to use again in [get_ETA()].</span>")
 		return
-	var/choice = input(user, selection_prompt, selection_title) as null|anything in choosable_items
-	var/pickedtype = choosable_items[choice]
-	if(pickedtype && Adjacent(user) && src && !QDELETED(src) && !user.incapacitated() && cooldowntime <= world.time)
+
+	var/choice = show_radial_menu(user, src, choosable_items, require_near = TRUE)
+	var/picked_type = choosable_items[choice]
+	if(!QDELETED(src) && picked_type && Adjacent(user) && !user.incapacitated() && cooldowntime <= world.time)
 		cooldowntime = world.time + creation_delay
-		var/obj/item/N = new pickedtype(get_turf(src))
-		to_chat(user, replacetext("[creation_message]", "%ITEM%", "[N.name]"))
+		var/obj/O = new picked_type
+		if(istype(O, /obj/structure) || !user.put_in_hands(O))
+			O.forceMove(get_turf(src))
+		to_chat(user, replacetext("[creation_message]", "%ITEM%", "[O.name]"))
 
 /**
   * Returns the cooldown time in minutes and seconds

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -306,29 +306,32 @@
 		if("CONSTRUCT")
 			var/obj/structure/constructshell/shell = target
 			var/mob/living/simple_animal/shade/shade = locate() in src
+			var/list/construct_types = list("Juggernaut" = /mob/living/simple_animal/hostile/construct/armoured,
+											"Wraith" = /mob/living/simple_animal/hostile/construct/wraith,
+											"Artificer" = /mob/living/simple_animal/hostile/construct/builder)
+			/// Custom construct icons for different cults
+			var/list/construct_icons = list("Juggernaut" = image(icon = 'icons/mob/mob.dmi', icon_state = SSticker.cultdat.get_icon("juggernaut")),
+											"Wraith" = image(icon = 'icons/mob/mob.dmi', icon_state = SSticker.cultdat.get_icon("wraith")),
+											"Artificer" = image(icon = 'icons/mob/mob.dmi', icon_state = SSticker.cultdat.get_icon("builder")))
+
 			if(shade)
-				var/construct_class = alert(user, "Please choose which type of construct you wish to create.", null, "Juggernaut", "Wraith", "Artificer")
-				if(shell.active)
-					return // Don't want two people doing it at once
-				shell.active = TRUE
-				switch(construct_class)
-					if("Juggernaut")
-						var/mob/living/simple_animal/hostile/construct/armoured/C = new(shell.loc)
-						C.init_construct(shade, src, shell)
-						to_chat(C, "<B>You are a Juggernaut. Though slow, your shell can withstand extreme punishment, create shield walls and even deflect energy weapons, and rip apart enemies and walls alike.</B>")
-
-					if("Wraith")
-						var/mob/living/simple_animal/hostile/construct/wraith/C = new(shell.loc)
-						C.init_construct(shade, src, shell)
-						to_chat(C, "<B>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</B>")
-
-					if("Artificer")
-						var/mob/living/simple_animal/hostile/construct/builder/C = new(shell.loc)
-						C.init_construct(shade, src, shell)
-						to_chat(C, "<B>You are an Artificer. You are incredibly weak and fragile, but you are able to construct fortifications, use magic missile, repair allied constructs (by clicking on them), </B><I>and most important of all create new constructs</I><B> (Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>")
+				var/construct_choice = show_radial_menu(user, shell, construct_icons, custom_check = CALLBACK(src, .proc/radial_check, user), require_near = TRUE)
+				var/picked_class = construct_types[construct_choice]
+				if((picked_class && !QDELETED(shell) && !QDELETED(src)) && user.Adjacent(shell) && !user.incapacitated() && radial_check(user))
+					var/mob/living/simple_animal/hostile/construct/C = new picked_class(shell.loc)
+					C.init_construct(shade, src, shell)
+					to_chat(C, C.playstyle_string)
 			else
 				to_chat(user, "<span class='danger'>Creation failed!</span>: The soul stone is empty! Go kill someone!")
-	return
+
+/obj/item/soulstone/proc/radial_check(mob/user)
+	if(!ishuman(user)) // Should never happen, but just in case
+		return FALSE
+
+	var/mob/living/carbon/human/H = user
+	if(!H.is_in_hands(src)) // Not holding the soulstone
+		return FALSE
+	return TRUE
 
 /mob/living/simple_animal/hostile/construct/proc/init_construct(mob/living/simple_animal/shade/shade, obj/item/soulstone/SS, obj/structure/constructshell/shell)
 	if(shade.mind)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds Radial menus to cult structures (Altar, Archives, Forge) and the construct selection menu.

I was going to add one for the 'Blood Rites' menu too, but then if anyone wanted to add a new spell they would also need a sprite for the selection menu.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. It looks better.

2. It's a lot easier to tell what the item/construct is going to be.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
### Structures: (Before/After)
**Altar**
![Altar BA](https://user-images.githubusercontent.com/57483089/98489233-1405f080-2225-11eb-90c2-474a345e42f3.png)

**Archives**
![Archives BA](https://user-images.githubusercontent.com/57483089/98489266-2da73800-2225-11eb-8b89-e6eed6e8666b.png)

**Forge**
![Forge BA](https://user-images.githubusercontent.com/57483089/98489272-34ce4600-2225-11eb-8f2a-a209a38b0c88.png)

### Construct Selection: (Before/After)
![Construct BA](https://user-images.githubusercontent.com/57483089/98489295-444d8f00-2225-11eb-807c-eb748f96821f.png)


## Changelog
:cl:
add: Added fancy radial menus to cult structures (Altar, Archives, Forge) and constructs
tweak: Making an item at a cult structure now puts it directly into your hand when applicable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
