### PR TITLE
Optable no longer tracks health remotely.

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -57,19 +57,20 @@
 		return
 	take_patient(O, user)
 
-/obj/machinery/optable/proc/check_patient()
+/// Updates the `patient` var to be the mob occupying the table
+/// Returns whether the patient is present at all.
+/obj/machinery/optable/proc/update_patient()
 	var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, loc)
-	if(!M)
-		return FALSE
-	if(M.lying)
+	if(M && M.lying)
 		patient = M
-		if(!no_icon_updates)
-			icon_state = M.pulse ? "table2-active" : "table2-idle"
-		return TRUE
-	patient = null
+	else
+		patient = null
 	if(!no_icon_updates)
-		icon_state = "table2-idle"
-	return FALSE
+		if(patient && patient.pulse)
+			icon_state = "table2-active"
+		else
+			icon_state = "table2-idle"
+	return patient != null
 
 /obj/machinery/optable/Crossed(atom/movable/AM, oldloc)
 	. = ..()
@@ -77,36 +78,27 @@
 		to_chat(AM, "<span class='danger'>You feel a series of tiny pricks!</span>")
 
 /obj/machinery/optable/process()
-	check_patient()
+	update_patient()
 	if(LAZYLEN(injected_reagents))
 		for(var/mob/living/carbon/C in get_turf(src))
 			var/datum/reagents/R = C.reagents
 			for(var/chemical in injected_reagents)
 				R.check_and_add(chemical,reagent_target_amount,inject_amount)
 
-/obj/machinery/optable/proc/take_patient(mob/living/carbon/C, mob/living/carbon/user)
-	if(C == user)
+/obj/machinery/optable/proc/take_patient(mob/living/carbon/new_patient, mob/living/carbon/user)
+	if(new_patient == user)
 		user.visible_message("[user] climbs on the operating table.","You climb on the operating table.")
 	else
-		visible_message("<span class='alert'>[C] has been laid on the operating table by [user].</span>")
-	C.resting = TRUE
-	C.update_canmove()
-	C.forceMove(loc)
-	if(user.pulling == C)
+		visible_message("<span class='alert'>[new_patient] has been laid on the operating table by [user].</span>")
+	new_patient.resting = TRUE
+	new_patient.update_canmove()
+	new_patient.forceMove(loc)
+	if(user.pulling == new_patient)
 		user.stop_pulling()
-	if(C.s_active) //Close the container opened
-		C.s_active.close(C)
-	for(var/obj/O in src)
-		O.loc = src.loc
+	if(new_patient.s_active) //Close the container opened
+		new_patient.s_active.close(new_patient)
 	add_fingerprint(user)
-	if(ishuman(C))
-		var/mob/living/carbon/human/H = C
-		patient = H
-		if(!no_icon_updates)
-			icon_state = H.pulse ? "table2-active" : "table2-idle"
-	else
-		if(!no_icon_updates)
-			icon_state = "table2-idle"
+	update_patient()
 
 /obj/machinery/optable/verb/climb_on()
 	set name = "Climb On Table"
@@ -135,7 +127,7 @@
 		qdel(src)
 
 /obj/machinery/optable/proc/check_table()
-	if(check_patient() && patient.lying)
+	if(update_patient())
 		to_chat(usr, "<span class='notice'>The table is already occupied!</span>")
 		return FALSE
 	else

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -57,8 +57,9 @@
 		return
 	take_patient(O, user)
 
-/// Updates the `patient` var to be the mob occupying the table
-/// Returns whether the patient is present at all.
+/**
+  * Updates the `patient` var to be the mob occupying the table
+  */
 /obj/machinery/optable/proc/update_patient()
 	var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, loc)
 	if(M && M.lying)
@@ -70,7 +71,6 @@
 			icon_state = "table2-active"
 		else
 			icon_state = "table2-idle"
-	return patient != null
 
 /obj/machinery/optable/Crossed(atom/movable/AM, oldloc)
 	. = ..()
@@ -127,7 +127,8 @@
 		qdel(src)
 
 /obj/machinery/optable/proc/check_table()
-	if(update_patient())
+	update_patient()
+	if(patient != null)
 		to_chat(usr, "<span class='notice'>The table is already occupied!</span>")
 		return FALSE
 	else

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -7,8 +7,8 @@
 	icon_keyboard = "med_key"
 	icon_screen = "crew"
 	circuit = /obj/item/circuitboard/operating
-	var/obj/machinery/optable/table
 	light_color = LIGHT_COLOR_PURE_BLUE
+	var/obj/machinery/optable/table
 	var/verbose = TRUE //general speaker toggle
 	var/oxyAlarm = 30 //oxy damage at which the computer will beep
 	var/choice = FALSE //just for going into and out of the options menu
@@ -17,7 +17,10 @@
 	var/nextTick = OP_COMPUTER_COOLDOWN
 	var/healthAlarm = 50
 	var/oxy = TRUE //oxygen beeping toggle
-	var/mob/living/carbon/currentPatient //Who is on the Operating Table connected to the respective Operating Computer?
+	/// Who is on the Operating Table connected to the respective Operating Computer?
+	/// Only used to see if it changed from the previous occupant. If you want any actual information
+	/// about the mob - use `table.patient` instead.
+	var/mob/living/carbon/currentPatient
 	var/patientStatusHolder //Hold the last instance of table.patient.status. When table.patient.status no longer matches this variable, the computer should tell the doctor
 
 /obj/machinery/computer/operating/New()
@@ -176,7 +179,7 @@
 		return
 	if(!verbose) //Are the speakers on?
 		return
-	if(!table.check_patient()) //Is there a patient on the table?
+	if(!table.patient) //Is there a patient on the table?
 		currentPatient = null
 		return
 	var/patientStatus // Tell the computer what to say based on the status of the patient on the table.


### PR DESCRIPTION
## What Does This PR Do
Prevents operating table from showing vitals of people who have long left it, and are now dying to goliaths on lavaland.

Also streamlines the code a tiny bit.

## Why It's Good For The Game
Bugfix.

## Images of changes
![20201109-031846-7NV2DDoRlT](https://user-images.githubusercontent.com/7831163/98496896-93ea8580-223a-11eb-8f1a-c92128065c5c.gif)


## Changelog
:cl:
fix: Operating table/computer no longer tracks vitals of people not on the table.
/:cl:
