### PR TITLE
Skills HUD now shows job icon, and other minor HUD improvements

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -61,3 +61,11 @@
 #define NOTIFY_JUMP "jump"
 #define NOTIFY_ATTACK "attack"
 #define NOTIFY_FOLLOW "orbit"
+
+
+// The kind of things granted by HUD items in game, that do not manifest as
+// on-screen icons, but rather go to examine text.
+#define EXAMINE_HUD_SECURITY_READ "security_read"
+#define EXAMINE_HUD_SECURITY_WRITE "security_write"
+#define EXAMINE_HUD_MEDICAL "medical"
+#define EXAMINE_HUD_SKILLS "skills"

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -111,3 +111,4 @@ GLOBAL_LIST_INIT(huds, list( \
 
 /mob/new_player/add_click_catcher()
 	return
+

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -111,4 +111,3 @@ GLOBAL_LIST_INIT(huds, list( \
 
 /mob/new_player/add_click_catcher()
 	return
-

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -446,3 +446,37 @@
 		holder.icon_state = ""
 		return
 	holder.icon_state = "hudweed[RoundPlantBar(weedlevel/10)]"
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	I'll just put this somewhere near the end...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+/// Helper function to add a "comment" to a data record. Used for medical or security records.
+/mob/living/carbon/human/proc/add_comment(mob/commenter, comment_kind, comment_text)
+	var/perpname = get_visible_name(TRUE) //gets the name of the perp, works if they have an id or if their face is uncovered
+	if(!perpname)
+		return
+	var/datum/data/record/R
+	switch(comment_kind)
+		if("security")
+			R = find_record("name", perpname, GLOB.data_core.security)
+		if("medical")
+			R = find_record("name", perpname, GLOB.data_core.medical)
+	if(!R)
+		return
+
+	var/commenter_display = "Somebody(???)"
+	if(ishuman(commenter))
+		var/mob/living/carbon/human/U = commenter
+		commenter_display = "[U.get_authentification_name()] ([U.get_assignment()])"
+	else if(isrobot(commenter))
+		var/mob/living/silicon/robot/U = commenter
+		commenter_display = "[U.name] ([U.modtype] [U.braintype])"
+	else if(isAI(commenter))
+		var/mob/living/silicon/ai/U = commenter
+		commenter_display = "[U.name] (artificial intelligence)"
+	comment_text = "Made by [commenter_display] on [GLOB.current_date_string] [station_time_timestamp()]:<br>[comment_text]"
+
+	if(!R.fields["comments"])
+		R.fields["comments"] = list()
+	R.fields["comments"] += list(comment_text)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -465,7 +465,7 @@
 	if(!R)
 		return
 
-	var/commenter_display = "Somebody(???)"
+	var/commenter_display = "Something(???)"
 	if(ishuman(commenter))
 		var/mob/living/carbon/human/U = commenter
 		commenter_display = "[U.get_authentification_name()] ([U.get_assignment()])"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -3,9 +3,11 @@
 	desc = "A heads-up display that provides important info in (almost) real time."
 	flags = null //doesn't protect eyes because it's a monocle, duh
 	origin_tech = "magnets=3;biotech=2"
-	var/HUDType = null //Hudtype is defined on glasses.dm
 	prescription_upgradable = 1
-	var/list/icon/current = list() //the current hud icons
+	/// The visual icons granted by wearing these glasses.
+	var/HUDType = null
+	/// List of things added to examine text, like security or medical records.
+	var/list/examine_extensions = null
 
 
 /obj/item/clothing/glasses/hud/equipped(mob/living/carbon/human/user, slot)
@@ -31,6 +33,7 @@
 	icon_state = "healthhud"
 	origin_tech = "magnets=3;biotech=2"
 	HUDType = DATA_HUD_MEDICAL_ADVANCED
+	examine_extensions = list(EXAMINE_HUD_MEDICAL)
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
@@ -94,7 +97,7 @@
 	origin_tech = "magnets=3;combat=2"
 	var/global/list/jobs[0]
 	HUDType = DATA_HUD_SECURITY_ADVANCED
-	var/read_only = FALSE
+	examine_extensions = list(EXAMINE_HUD_SECURITY_READ, EXAMINE_HUD_SECURITY_WRITE)
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
@@ -121,7 +124,7 @@
 	prescription_upgradable = 0
 
 /obj/item/clothing/glasses/hud/security/sunglasses/read_only
-	read_only = TRUE
+	examine_extensions = list(EXAMINE_HUD_SECURITY_READ)
 
 /obj/item/clothing/glasses/hud/security/sunglasses
 	name = "HUDSunglasses"
@@ -202,6 +205,8 @@
 	desc = "A heads-up display capable of showing the employment history records of NT crew members."
 	icon_state = "skill"
 	item_state = "glasses"
+	HUDType = DATA_HUD_SECURITY_BASIC
+	examine_extensions = list(EXAMINE_HUD_SKILLS)
 	sprite_sheets = list(
 		"Drask" = 'icons/mob/species/drask/eyes.dmi',
 		"Grey"  = 'icons/mob/species/grey/eyes.dmi',

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -34,7 +34,7 @@
 		return ..()
 
 /mob/living/carbon/human/get_description_fluff()
-	return print_flavor_text(0)
+	return print_flavor_text()
 
 /* The examine panel itself */
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -621,8 +621,6 @@
 	dna.species.spec_electrocute_act(src, shock_damage, source, siemens_coeff, safety, override, tesla_shock, illusion, stun)
 	. = ..(shock_damage, source, siemens_coeff, safety, override, tesla_shock, illusion, stun)
 
-
-
 /mob/living/carbon/human/Topic(href, href_list)
 	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))
 		var/thief_mode = 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -621,6 +621,8 @@
 	dna.species.spec_electrocute_act(src, shock_damage, source, siemens_coeff, safety, override, tesla_shock, illusion, stun)
 	. = ..(shock_damage, source, siemens_coeff, safety, override, tesla_shock, illusion, stun)
 
+
+
 /mob/living/carbon/human/Topic(href, href_list)
 	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))
 		var/thief_mode = 0
@@ -730,7 +732,7 @@
 						update_inv_w_uniform()
 
 	if(href_list["criminal"])
-		if(hasHUD(usr,"security"))
+		if(hasHUD(usr, EXAMINE_HUD_SECURITY_WRITE))
 			if(usr.incapacitated())
 				return
 			var/found_record = 0
@@ -747,7 +749,7 @@
 								if(!t1)
 									t1 = "(none)"
 
-								if(hasHUD(usr, "security") && setcriminal != "Cancel")
+								if(hasHUD(usr, EXAMINE_HUD_SECURITY_WRITE) && setcriminal != "Cancel")
 									found_record = 1
 									if(R.fields["criminal"] == SEC_RECORD_STATUS_EXECUTE)
 										to_chat(usr, "<span class='warning'>Unable to modify the sec status of a person with an active Execution order. Use a security computer instead.</span>")
@@ -770,7 +772,7 @@
 				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 
 	if(href_list["secrecord"])
-		if(hasHUD(usr,"security"))
+		if(hasHUD(usr, EXAMINE_HUD_SECURITY_READ))
 			if(usr.incapacitated())
 				return
 			var/perpname = get_visible_name(TRUE)
@@ -780,7 +782,7 @@
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in GLOB.data_core.security)
 						if(R.fields["id"] == E.fields["id"])
-							if(hasHUD(usr,"security"))
+							if(hasHUD(usr, EXAMINE_HUD_SECURITY_READ))
 								to_chat(usr, "<b>Name:</b> [R.fields["name"]]	<b>Criminal Status:</b> [R.fields["criminal"]]")
 								to_chat(usr, "<b>Minor Crimes:</b> [R.fields["mi_crim"]]")
 								to_chat(usr, "<b>Details:</b> [R.fields["mi_crim_d"]]")
@@ -794,7 +796,7 @@
 				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 
 	if(href_list["secrecordComment"])
-		if(hasHUD(usr,"security"))
+		if(hasHUD(usr, EXAMINE_HUD_SECURITY_READ))
 			if(usr.incapacitated() && !isobserver(usr)) //give the ghosts access to "View Comment Log" while they can't manipulate it
 				return
 			var/perpname = get_visible_name(TRUE)
@@ -804,44 +806,30 @@
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in GLOB.data_core.security)
 						if(R.fields["id"] == E.fields["id"])
-							if(hasHUD(usr,"security"))
+							if(hasHUD(usr, EXAMINE_HUD_SECURITY_READ))
 								read = 1
 								if(LAZYLEN(R.fields["comments"]))
 									for(var/c in R.fields["comments"])
 										to_chat(usr, c)
 								else
 									to_chat(usr, "<span class='warning'>No comments found</span>")
-								to_chat(usr, "<a href='?src=[UID()];secrecordadd=`'>\[Add comment\]</a>")
+								if(hasHUD(usr, EXAMINE_HUD_SECURITY_WRITE))
+									to_chat(usr, "<a href='?src=[UID()];secrecordadd=`'>\[Add comment\]</a>")
 
 			if(!read)
 				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 
 	if(href_list["secrecordadd"])
-		if(hasHUD(usr,"security"))
-			if(usr.incapacitated())
-				return
-			var/perpname = get_visible_name(TRUE)
-
-			for(var/datum/data/record/E in GLOB.data_core.general)
-				if(E.fields["name"] == perpname)
-					for(var/datum/data/record/R in GLOB.data_core.security)
-						if(R.fields["id"] == E.fields["id"])
-							if(hasHUD(usr,"security"))
-								var/t1 = copytext(trim(sanitize(input("Add Comment:", "Sec. records", null, null) as message)), 1, MAX_MESSAGE_LEN)
-								if(!t1 || usr.stat || usr.restrained() || !hasHUD(usr, "security"))
-									return
-								if(ishuman(usr))
-									var/mob/living/carbon/human/U = usr
-									R.fields["comments"] += "Made by [U.get_authentification_name()] ([U.get_assignment()]) on [GLOB.current_date_string] [station_time_timestamp()]<BR>[t1]"
-								if(isrobot(usr))
-									var/mob/living/silicon/robot/U = usr
-									R.fields["comments"] += "Made by [U.name] ([U.modtype] [U.braintype]) on [GLOB.current_date_string] [station_time_timestamp()]<BR>[t1]"
-								if(isAI(usr))
-									var/mob/living/silicon/ai/U = usr
-									R.fields["comments"] += "Made by [U.name] (artificial intelligence) on [GLOB.current_date_string] [station_time_timestamp()]<BR>[t1]"
+		if(usr.incapacitated() || !hasHUD(usr, EXAMINE_HUD_SECURITY_WRITE))
+			return
+		var/raw_input = input("Add Comment:", "Security records", null, null) as message
+		var/sanitized = copytext(trim(sanitize(raw_input)), 1, MAX_MESSAGE_LEN)
+		if(!sanitized || usr.stat || usr.restrained() || !hasHUD(usr,  EXAMINE_HUD_SECURITY_WRITE))
+			return
+		add_comment(usr, "security", sanitized)
 
 	if(href_list["medical"])
-		if(hasHUD(usr,"medical"))
+		if(hasHUD(usr, EXAMINE_HUD_MEDICAL))
 			if(usr.incapacitated())
 				return
 			var/modified = 0
@@ -853,7 +841,7 @@
 						if(R.fields["id"] == E.fields["id"])
 							var/setmedical = input(usr, "Specify a new medical status for this person.", "Medical HUD", R.fields["p_stat"]) in list("*SSD*", "*Deceased*", "Physically Unfit", "Active", "Disabled", "Cancel")
 
-							if(hasHUD(usr,"medical"))
+							if(hasHUD(usr, EXAMINE_HUD_MEDICAL))
 								if(setmedical != "Cancel")
 									R.fields["p_stat"] = setmedical
 									modified = 1
@@ -867,7 +855,7 @@
 				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 
 	if(href_list["medrecord"])
-		if(hasHUD(usr,"medical"))
+		if(hasHUD(usr, EXAMINE_HUD_MEDICAL))
 			if(usr.incapacitated())
 				return
 			var/read = 0
@@ -877,7 +865,7 @@
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in GLOB.data_core.medical)
 						if(R.fields["id"] == E.fields["id"])
-							if(hasHUD(usr,"medical"))
+							if(hasHUD(usr, EXAMINE_HUD_MEDICAL))
 								to_chat(usr, "<b>Name:</b> [R.fields["name"]]	<b>Blood Type:</b> [R.fields["b_type"]]")
 								to_chat(usr, "<b>DNA:</b> [R.fields["b_dna"]]")
 								to_chat(usr, "<b>Minor Disabilities:</b> [R.fields["mi_dis"]]")
@@ -892,18 +880,18 @@
 				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 
 	if(href_list["medrecordComment"])
-		if(hasHUD(usr,"medical"))
+		if(hasHUD(usr, EXAMINE_HUD_MEDICAL))
 			if(usr.incapacitated())
 				return
 			var/perpname = get_visible_name(TRUE)
-			var/read = 0
+			var/read = FALSE
 
 			for(var/datum/data/record/E in GLOB.data_core.general)
 				if(E.fields["name"] == perpname)
 					for(var/datum/data/record/R in GLOB.data_core.medical)
 						if(R.fields["id"] == E.fields["id"])
-							if(hasHUD(usr,"medical"))
-								read = 1
+							if(hasHUD(usr, EXAMINE_HUD_MEDICAL))
+								read = TRUE
 								if(LAZYLEN(R.fields["comments"]))
 									for(var/c in R.fields["comments"])
 										to_chat(usr, c)
@@ -915,27 +903,28 @@
 				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 
 	if(href_list["medrecordadd"])
-		if(hasHUD(usr,"medical"))
+		if(usr.incapacitated() || !hasHUD(usr, EXAMINE_HUD_MEDICAL))
+			return
+		var/raw_input = input("Add Comment:", "Medical records", null, null) as message
+		var/sanitized = copytext(trim(sanitize(raw_input)), 1, MAX_MESSAGE_LEN)
+		if(!sanitized || usr.stat || usr.restrained() || !hasHUD(usr,  EXAMINE_HUD_MEDICAL))
+			return
+		add_comment(usr, "medical", sanitized)
+
+	if(href_list["employment_more"])
+		if(hasHUD(usr, EXAMINE_HUD_SKILLS))
 			if(usr.incapacitated())
 				return
+
+			var/skills
 			var/perpname = get_visible_name(TRUE)
-			for(var/datum/data/record/E in GLOB.data_core.general)
-				if(E.fields["name"] == perpname)
-					for(var/datum/data/record/R in GLOB.data_core.medical)
-						if(R.fields["id"] == E.fields["id"])
-							if(hasHUD(usr,"medical"))
-								var/t1 = copytext(trim(sanitize(input("Add Comment:", "Med. records", null, null) as message)), 1, MAX_MESSAGE_LEN)
-								if(!t1 || usr.stat || usr.restrained() || !hasHUD(usr, "medical"))
-									return
-								if(ishuman(usr))
-									var/mob/living/carbon/human/U = usr
-									R.fields["comments"] += "Made by [U.get_authentification_name()] ([U.get_assignment()]) on [GLOB.current_date_string] [station_time_timestamp()]<BR>[t1]"
-								if(isrobot(usr))
-									var/mob/living/silicon/robot/U = usr
-									R.fields["comments"] += "Made by [U.name] ([U.modtype] [U.braintype]) on [GLOB.current_date_string] [station_time_timestamp()]<BR>[t1]"
-								if(isAI(usr))
-									var/mob/living/silicon/ai/U = usr
-									R.fields["comments"] += "Made by [U.name] (artificial intelligence) on [GLOB.current_date_string] [station_time_timestamp()]<BR>[t1]"
+			if(perpname)
+				for(var/datum/data/record/E in GLOB.data_core.general)
+					if(E.fields["name"] == perpname)
+						skills = E.fields["notes"]
+						break
+				if(skills)
+					to_chat(usr, "<span class='deptradio'>Employment records: [skills]</span>\n")
 
 	if(href_list["lookitem"])
 		var/obj/item/I = locate(href_list["lookitem"])

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -441,11 +441,15 @@
 
 	switch(stat)
 		if(CONSCIOUS)
-			if(!client)	msg += "\nIt appears to be in stand-by mode." //afk
-		if(UNCONSCIOUS)		msg += "\n<span class='warning'>It doesn't seem to be responding.</span>"
-		if(DEAD)			msg += "\n<span class='deadsay'>It looks completely unsalvageable.</span>"
+			if(!client)
+				msg += "\nIt appears to be in stand-by mode." //afk
+		if(UNCONSCIOUS)
+			msg += "\n<span class='warning'>It doesn't seem to be responding.</span>"
+		if(DEAD)
+			msg += "\n<span class='deadsay'>It looks completely unsalvageable.</span>"
 
-	if(print_flavor_text()) msg += "\n[print_flavor_text()]"
+	if(print_flavor_text())
+		msg += "\n[print_flavor_text()]"
 
 	if(pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -47,7 +47,8 @@
 				msg += "<span class='warning'>It looks like its system is corrupted beyond repair. There is no hope of recovery.</span>\n"
 	msg += "*---------*</span>"
 
-	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"
+	if(print_flavor_text())
+		msg += "\n[print_flavor_text()]\n"
 
 	if(pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -732,7 +732,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 		flavor_text = msg
 
-/mob/proc/print_flavor_text(var/shrink = 1)
+/mob/proc/print_flavor_text(var/shrink = TRUE)
 	if(flavor_text && flavor_text != "")
 		var/msg = replacetext(flavor_text, "\n", " ")
 		if(length(msg) <= 40 || !shrink)

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -84,6 +84,8 @@
 	desc = "These cybernetic eyes will display a HUD over everything you see. Maybe."
 	slot = "eye_hud"
 	var/HUD_type = 0
+	/// A list of extension kinds added to the examine text. Things like medical or security records.
+	var/list/examine_extensions = null
 
 /obj/item/organ/internal/cyberimp/eyes/hud/insert(var/mob/living/carbon/M, var/special = 0)
 	..()
@@ -107,6 +109,7 @@
 	origin_tech = "materials=4;programming=4;biotech=4"
 	aug_message = "You suddenly see health bars floating above people's heads..."
 	HUD_type = DATA_HUD_MEDICAL_ADVANCED
+	examine_extensions = list(EXAMINE_HUD_MEDICAL)
 
 /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic
 	name = "Diagnostic HUD implant"
@@ -125,6 +128,7 @@
 	origin_tech = "materials=4;programming=4;biotech=3;combat=3"
 	aug_message = "Job indicator icons pop up in your vision. That is not a certified surgeon..."
 	HUD_type = DATA_HUD_SECURITY_ADVANCED
+	examine_extensions = list(EXAMINE_HUD_SECURITY_READ, EXAMINE_HUD_SECURITY_WRITE)
 
 // Welding shield implant
 /obj/item/organ/internal/cyberimp/eyes/shield


### PR DESCRIPTION
## What Does This PR Do
- skills HUD now shows assigned job
- adding security/medical comments from the examine panel actually works now
- (arrest/demotion/etc all also still work)
- employment records no longer span five screens, and are trimmed instead.

## Why It's Good For The Game
Captain and HoP need to know at a glance current job assignments, since that's more or less their job. It's weird that skills HUD shows past employment records, but not current ones.
The other changes are good because they make for better code.

## Images of changes
![20201109-062640-i0Ch9aoXNz](https://user-images.githubusercontent.com/7831163/98508064-b68a9780-2256-11eb-8d46-974fa98a1163.gif)


## Changelog
:cl:
tweak: Skills HUDglasses now show job assignment icon
fix: Adding security/medical comments now works
/:cl: