### PR TITLE
Stop giving dead people as objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		return TARGET_INVALID_IS_TARGET
 	if(!ishuman(possible_target.current))
 		return TARGET_INVALID_NOT_HUMAN
-	if(!possible_target.current.stat == DEAD)
+	if(possible_target.current.stat == DEAD)
 		return TARGET_INVALID_DEAD
 	if(!possible_target.key)
 		return TARGET_INVALID_NOCKEY


### PR DESCRIPTION
## What Does This PR Do
Prevents dead people from being given as new random objectives.
At least, per @SteelSlayer, full credit to them.

## Why It's Good For The Game
Bugfix. Or typo-fix, I guess.

## Changelog
:cl:
fix: Dead people should no longer be assigned as new random objectives.
/:cl:
