### PR TITLE
Clarifies CC announcements during cult ascension

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -226,7 +226,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 			SEND_SOUND(M.current, 'sound/hallucinations/im_here1.ogg')
 			to_chat(M.current, "<span class='cultlarge'>Your cult is ascendant and the red harvest approaches - you cannot hide your true nature for much longer!")
 			addtimer(CALLBACK(src, .proc/ascend, M.current), 20 SECONDS)
-		GLOB.command_announcement.Announce("Picking up extradimensional activity related to the Cult of [SSticker.cultdat ? SSticker.cultdat.entity_name : "Nar'Sie"] from your station. Data suggests that about [ascend_percent * 100]% of the station has been converted. Security staff is authorised lethal force on confirmed cultists to contain the threat. Ensure dead crewmembers are revived and deconverted once the situation is under control.", "Central Command Higher Dimensional Affairs", 'sound/AI/commandreport.ogg')
+		GLOB.command_announcement.Announce("Picking up extradimensional activity related to the Cult of [SSticker.cultdat ? SSticker.cultdat.entity_name : "Nar'Sie"] from your station. Data suggests that about [ascend_percent * 100]% of the station has been converted. Security staff are authorized to use lethal force freely against cultists. Non-security staff should be prepared to defend themselves and their work areas from hostile cultists. Self defense permits non-security staff to use lethal force as a last resort, but non-security staff should be defending their work areas, not hunting down cultists. Dead crewmembers must be revived and deconverted once the situation is under control.", "Central Command Higher Dimensional Affairs", 'sound/AI/commandreport.ogg')
 
 
 /datum/game_mode/proc/rise(cultist)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -135,7 +135,7 @@
 			if(!(A in summon_areas))  // Check again to make sure they didn't move
 				to_chat(user, "<span class='cultlarge'>The ritual can only begin where the veil is weak - in [english_list(summon_areas)]!</span>")
 				return
-			GLOB.command_announcement.Announce("Figments from an eldritch god are being summoned into the [A.map_name] from an unknown dimension. Disrupt the ritual at all costs!", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
+			GLOB.command_announcement.Announce("Figments from an eldritch god are being summoned into the [A.map_name] from an unknown dimension. Disrupt the ritual at all costs, before the station is destroyed! Space law and SOP are suspended. The entire crew must kill cultists on sight.", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
 			for(var/I in spiral_range_turfs(1, user, 1))
 				var/turf/T = I
 				var/obj/machinery/shield/cult/narsie/N = new(T)


### PR DESCRIPTION
## What Does This PR Do
Changes the CC messages sent when cult gets halos, and when they ascend, to make a few things clearer:
- When cult gets halos, sec can lethal them as needed. Non-sec can also lethal them as a last resort (self-defense, defense of their workplace, etc). But even when cult has halos, non-sec crew should NOT be trying to hunt them down (partly as its validhunting, partly as there's no way your average civilian will win against a big group of armed cultists).
- When cult goes for the summon-your-god rune, EVERYONE on station is obliged to kill them on sight. Space Law and SOP are suspended until the crisis is dealt with. 

## Why It's Good For The Game
We've been getting some confusion, even among admins, about exactly how far sec and non-sec can go hunting cultists in the various stages of cult.

## Changelog
:cl: Kyep
tweak: Tweaked the CC messages sent when cult is growing in power, to make it clearer when lethal force is or is not authorized.
/:cl:
