### PR TITLE
Prevents staff of change from being bought on raging rounds.

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -486,6 +486,7 @@
 	item_path = /obj/item/gun/magic/staff/change
 	log_name = "ST"
 	category = "Staves"
+	is_ragin_restricted = TRUE
 
 /datum/spellbook_entry/item/staffchaos
 	name = "Staff of Chaos"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This pr adds is_ragin_restricted = TRUE to the staff of change spellbook datum, preventing it from being bought on raging rounds.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This is an interesting staff. Anyone you shoot in one shot gets turned into a simple mob, another species, a xenomorph, or a borg, and deletes most of your stuff on you when you are hit by it. Perfectly fine on a normal wizard round. Problematic on raging rounds. On raging rounds, this happens. Wizard heads to station with staff of change, yeets a few crewmembers into xenos or slimes, then one of 3 things happens. A xenomorph disarms and kills the wizard, wizard gets shotguned, falls asleep dropping item and gibing, or finally, the wizard gets tased, drops the staff, and polymorphed. The problem is this. Crew now has a staff, with infinite ammo and high fire rate, that one shots any slaughter demon, statue, or wizard into a harmless simplemob or borg, and wizards have no counter. As we restrict things on raging rounds that screw over other wizards majorly (see, summon guns / magic), we should probably restrict staff of change as well.

Why not staff of chaos? As it has a chance to fire many projectiles, might heal the wizard, do nothing, do slight damage, or kill them, but it is not certain death 100% of the time, verse the certain defeat of any wizard or demon with polymorph.

Why not belt of wands? As that is more likely to be on the wizards belt when they gib and not stripped, and even if it is stripped, it has limited charges, especially if the wizard has used the wands.

## Changelog
:cl:
tweak: Staff of change can no longer be purchased on raging mages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
