### PR TITLE
Fixes empty candle box in loadout 

### DIFF
--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -34,7 +34,7 @@
 /datum/gear/candlebox
 	display_name = "a box candles"
 	description = "For setting the mood or for occult rituals."
-	path = /obj/item/storage/fancy/candle_box
+	path = /obj/item/storage/fancy/candle_box/full
 
 /datum/gear/rock
 	display_name = "a pet rock"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces empty candle box with a full one.

Fixes [#14870](https://github.com/ParadiseSS13/Paradise/issues/14870)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nobody will spend their loadout points for cardboard.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


:cl:
fix: loadout candle box now spawns with candles inside it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
