### PR TITLE
Removes X-ray from non AI controlled cameras

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -391,7 +391,7 @@
 		user.overlay_fullscreen("remote_view", /obj/screen/fullscreen/impaired, 2)
 
 /obj/machinery/camera/update_remote_sight(mob/living/user)
-	if(isXRay())
+	if(isXRay() && isAI(user))
 		user.sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		user.see_in_dark = max(user.see_in_dark, 8)
 		user.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -120,9 +120,7 @@
 			return TRUE
 
 		var/list/visible_turfs = list()
-		for(var/turf/T in (C.isXRay() \
-				? range(C.view_range, get_turf(C)) \
-				: view(C.view_range, get_turf(C))))
+		for(var/turf/T in (view(C.view_range, get_turf(C))))
 			visible_turfs += T
 
 		var/list/bbox = get_bbox_of_atoms(visible_turfs)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -120,7 +120,7 @@
 			return TRUE
 
 		var/list/visible_turfs = list()
-		for(var/turf/T in (view(C.view_range, get_turf(C))))
+		for(var/turf/T in view(C.view_range, get_turf(C)))
 			visible_turfs += T
 
 		var/list/bbox = get_bbox_of_atoms(visible_turfs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes X-ray effects from all non-AI camera viewing.

## Why It's Good For The Game
The previous PR that made it so only malf AI can make cameras X-ray means that ability would reveal them to anyone on a security camera console. This PR removes security's unintended ability to spot a malf AI via cameras from #14816

## Changelog
:cl:
del: Removed the ability to X-ray via cameras from non AI as it is now a malf only effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
