### PR TITLE
Swaps Gatfruit with Red Glowcaps @ Lavaland Terrarium

### DIFF
--- a/code/modules/ruins/lavalandruin_code/seed_vault.dm
+++ b/code/modules/ruins/lavalandruin_code/seed_vault.dm
@@ -2,7 +2,7 @@
 	name = "seed vault seeds"
 	lootcount = 1
 
-	loot = list(/obj/item/seeds/gatfruit = 10,
+	loot = list(/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap = 10,
 				/obj/item/seeds/cherry/bomb = 10,
 				/obj/item/seeds/berry/glow = 10,
 				/obj/item/seeds/sunflower/moonflower = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes Gatfruit from the loot table of the Terrarium and adds Red Glowcaps (a powerful RND component, allowing for Power 6/7) in its place.

## Why It's Good For The Game
Infinite .357s that you can shove into a plant bag are REALLY dumb, and frankly shouldnt be something a traitor can just find for free, ESPECIALLY as a miner who already has a TON of other dumb and overpowered items at their disposal anyway. Botany, frankly, doesnt need it either as they can commit chemical warfare anyway which is a whole can of beans i dont even want to complain about here. Swapping it with Red Glowcaps allows for Science on station to possibly benefit too in the event that botany is new/MIA.

## Changelog
:cl:
tweak: replaces gatfruit (free guns) with red glowcaps (RND research tech) at the Lavaland Terrarium
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->