### PR TITLE
Makes spoopy ghost boo's on open airlocks not break the airlock sprite

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -127,7 +127,7 @@ About the new airlock wires panel:
  * reimp, imitate an access denied event.
  */
 /obj/machinery/door/airlock/flicker()
-	if(arePowerSystemsOn())
+	if(density && !operating && arePowerSystemsOn())
 		do_animate("deny")
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## What Does This PR Do
Makes it so that boo's on an open airlock won't do anything since it relies on closed doors faking a rejected access attempt.

## Why It's Good For The Game
Less bugs more hugs

## Changelog
:cl:
fix: Ghosts can't break open airlock sprites anymore using boo
/:cl: