### PR TITLE
Fixes revanents not respawning properly

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -355,7 +355,7 @@
 	addtimer(CALLBACK(src, .proc/attempt_revive), 1 MINUTES)
 
 /obj/item/ectoplasm/revenant/proc/attempt_revive()
-	if(src && reforming)
+	if(reforming)
 		reform()
 	else
 		inert = TRUE

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -212,6 +212,7 @@
 	var/reforming_essence = essence_regen_cap //retain the gained essence capacity
 	R.essence = max(reforming_essence - 15 * perfectsouls, 75) //minus any perfect souls
 	R.client_to_revive = src.client //If the essence reforms, the old revenant is put back in the body
+	R.reforming = TRUE
 	ghostize()
 	qdel(src)
 
@@ -344,20 +345,21 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "revenantEctoplasm"
 	w_class = WEIGHT_CLASS_SMALL
-	var/reforming = 1
+	var/reforming = FALSE // so spawning this doesnt instantly make a rev out of nowhere.
 	var/essence = 75 //the maximum essence of the reforming revenant
-	var/inert = 0
+	var/inert = FALSE
 	var/client/client_to_revive
 
 /obj/item/ectoplasm/revenant/New()
 	..()
-	reforming = 0
-	spawn(600) //1 minutes
-		if(src && reforming)
-			reform()
-		else
-			inert = 1
-			visible_message("<span class='warning'>[src] settles down and seems lifeless.</span>")
+	addtimer(CALLBACK(src, .proc/attempt_revive), 1 MINUTES)
+
+/obj/item/ectoplasm/revenant/proc/attempt_revive()
+	if(src && reforming)
+		reform()
+	else
+		inert = TRUE
+		visible_message("<span class='warning'>[src] settles down and seems lifeless.</span>")
 
 /obj/item/ectoplasm/revenant/attack_self(mob/user)
 	if(!reforming || inert)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR updates revenant respawn code to use timer / procs instead of spawn, replaces some ones and zeros with TRUES and FALSE, and most importantly, makes revenant dust able to respawn revenants after a minute.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Right, this is a bug fix, but should maybe be considered balance, due to the implications of fixing it. If this PR is merged, revenants will be able to respawn after a minute, if their dust is not touched. This may seem like a large rev buff, but consider the following.

Revenants either die early, or build up a lot of essence and don't get close to dying. Rev players that do really well, are unaffected by these changes, as they will not die. This helps newer players, or revs that make a mistake early on, have a chance to be revived after the bug is fixed. It is also _not hard_  to stop the revival of a revenant. Picking it up and throwing it, picking it up and using it in hand, or picking it up and... eating it... will stop the revival. Anyone that kills a revenent will generally be between 
1 - 4 tiles from it, and will be able to pick up the dust. This only really will revive the rev if crew forgets, rev is killed by a simple mob, or is killed in space outside a window.

## Changelog
:cl:
fix: fixed revenants not respawning from their dust after a minute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
