### PR TITLE
removes magic wall safe exploit

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -24,8 +24,9 @@
 		) //For Armalis anything but this and the nitrogen tank will use the default backpack icon.
 
 /obj/item/storage/backpack/attackby(obj/item/W as obj, mob/user as mob, params)
-	playsound(src.loc, "rustle", 50, 1, -5)
-	return ..()
+	if(!in_range(user, src))
+		playsound(src.loc, "rustle", 50, 1, -5)
+		return ..()
 
 /obj/item/storage/backpack/examine(mob/user)
 	var/space_used = 0

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -24,7 +24,7 @@
 		) //For Armalis anything but this and the nitrogen tank will use the default backpack icon.
 
 /obj/item/storage/backpack/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(!in_range(user, src))
+	if(in_range(user, src))
 		playsound(src.loc, "rustle", 50, 1, -5)
 		return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Resolves #7916 and #9897 - forces backpacks to check that you're actually holding/beside them. Literally just adds `if(in_range(user, src))` to backpack code.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents an exploit where players could put items inside of their bags from across the station if the bag was inside of a secure wall safe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: thatdanguy23
fix: fixed being able to teleport items into a bag inside of a secure wall safe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
