### PR TITLE
Allows doctors to eject cloning pods, activates the radio cloners have.

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -220,28 +220,28 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 //Start growing a human clone in the pod!
 /obj/machinery/clonepod/proc/growclone(datum/dna2/record/R)
 	if(mess || attempting || panel_open || stat & (NOPOWER|BROKEN))
-		return FALSE
+		return 0
 	clonemind = locate(R.mind)
 	if(!istype(clonemind))	//not a mind
-		return FALSE
+		return 0
 	if(clonemind.current && clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
-		return FALSE
+		return 0
 	if(clonemind.damnation_type)
 		spooky_devil_flavor()
-		return FALSE
+		return 0
 	if(!clonemind.is_revivable()) //Other reasons for being unrevivable
-		return FALSE
+		return 0
 	if(clonemind.active)	//somebody is using that mind
 		if(ckey(clonemind.key) != R.ckey )
-			return FALSE
+			return 0
 		if(clonemind.suicided) // and stay out!
 			malfunction(go_easy = 0)
-			return FALSE// Flush the record
+			return -1 // Flush the record
 	else
 		// get_ghost() will fail if they're unable to reenter their body
 		var/mob/dead/observer/G = clonemind.get_ghost()
 		if(!G)
-			return FALSE
+			return 0
 
 /*
 	if(clonemind.damnation_type) //Can't clone the damned.
@@ -253,7 +253,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	if(biomass >= CLONE_BIOMASS)
 		biomass -= CLONE_BIOMASS
 	else
-		return FALSE
+		return 0
 
 	attempting = TRUE //One at a time!!
 	countdown.start()
@@ -313,7 +313,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 
 	H.suiciding = FALSE
 	attempting = FALSE
-	return TRUE
+	return 1
 
 //Grow clones to maturity then kick them out. FREELOADERS
 /obj/machinery/clonepod/process()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -22,19 +22,19 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 #define BRAIN_INITIAL_DAMAGE 90 // our minds are too feeble for 190
 
 /obj/machinery/clonepod
-	anchored = 1
+	anchored = TRUE
 	name = "cloning pod"
 	desc = "An electronically-lockable pod for growing organic tissue."
-	density = 1
+	density = TRUE
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "pod_idle"
-	req_access = list(ACCESS_GENETICS) //For premature unlocking.
+	req_access = list(ACCESS_MEDICAL) //For premature unlocking.
 
 	var/mob/living/carbon/human/occupant
 	var/heal_level //The clone is released once its health reaches this level.
 	var/obj/machinery/computer/cloning/connected = null //So we remember the connected clone machine.
-	var/mess = 0 //Need to clean out it if it's full of exploded clone.
-	var/attempting = 0 //One clone attempt at a time thanks
+	var/mess = FALSE //Need to clean out it if it's full of exploded clone.
+	var/attempting = FALSE //One clone attempt at a time thanks
 	var/biomass = 0
 	var/speed_coeff
 	var/efficiency
@@ -43,7 +43,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	var/grab_ghost_when = CLONER_MATURE_CLONE
 
 	var/obj/item/radio/Radio
-	var/radio_announce = 0
+	var/radio_announce = TRUE
 
 	var/obj/effect/countdown/clonepod/countdown
 
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	name = "Cloning Data Disk"
 	icon_state = "datadisk0" //Gosh I hope syndies don't mistake them for the nuke disk.
 	var/datum/dna2/record/buf = null
-	var/read_only = 0 //Well,it's still a floppy disk
+	var/read_only = FALSE //Well,it's still a floppy disk
 
 /obj/item/disk/data/proc/initialize()
 	buf = new
@@ -136,7 +136,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 
 /obj/item/disk/data/demo
 	name = "data disk - 'God Emperor of Mankind'"
-	read_only = 1
+	read_only = TRUE
 
 /obj/item/disk/data/demo/New()
 	..()
@@ -213,35 +213,35 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 
 /obj/machinery/clonepod/proc/spooky_devil_flavor()
 	playsound(loc, pick('sound/goonstation/voice/male_scream.ogg', 'sound/goonstation/voice/female_scream.ogg'), 100, 1)
-	mess = 1
+	mess = TRUE
 	update_icon()
 	connected_message("<font face=\"REBUFFED\" color=#600A0A>If you keep trying to steal from me, you'll end up with me.</font>")
 
 //Start growing a human clone in the pod!
 /obj/machinery/clonepod/proc/growclone(datum/dna2/record/R)
 	if(mess || attempting || panel_open || stat & (NOPOWER|BROKEN))
-		return 0
+		return FALSE
 	clonemind = locate(R.mind)
 	if(!istype(clonemind))	//not a mind
-		return 0
+		return FALSE
 	if(clonemind.current && clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
-		return 0
+		return FALSE
 	if(clonemind.damnation_type)
 		spooky_devil_flavor()
-		return 0
+		return FALSE
 	if(!clonemind.is_revivable()) //Other reasons for being unrevivable
-		return 0
+		return FALSE
 	if(clonemind.active)	//somebody is using that mind
 		if(ckey(clonemind.key) != R.ckey )
-			return 0
+			return FALSE
 		if(clonemind.suicided) // and stay out!
 			malfunction(go_easy = 0)
-			return -1 // Flush the record
+			return FALSE// Flush the record
 	else
 		// get_ghost() will fail if they're unable to reenter their body
 		var/mob/dead/observer/G = clonemind.get_ghost()
 		if(!G)
-			return 0
+			return FALSE
 
 /*
 	if(clonemind.damnation_type) //Can't clone the damned.
@@ -253,9 +253,9 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	if(biomass >= CLONE_BIOMASS)
 		biomass -= CLONE_BIOMASS
 	else
-		return 0
+		return FALSE
 
-	attempting = 1 //One at a time!!
+	attempting = TRUE //One at a time!!
 	countdown.start()
 
 	if(!R.dna)
@@ -311,9 +311,9 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 
 	update_icon()
 
-	H.suiciding = 0
-	attempting = 0
-	return 1
+	H.suiciding = FALSE
+	attempting = FALSE
+	return TRUE
 
 //Grow clones to maturity then kick them out. FREELOADERS
 /obj/machinery/clonepod/process()
@@ -469,13 +469,13 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 //Put messages in the connected computer's temp var for display.
 /obj/machinery/clonepod/proc/connected_message(message)
 	if((isnull(connected)) || (!istype(connected, /obj/machinery/computer/cloning)))
-		return 0
+		return FALSE
 	if(!message)
-		return 0
+		return FALSE
 
 	connected.temp = "[name] : [message]"
 	connected.updateUsrDialog()
-	return 1
+	return TRUE
 
 /obj/machinery/clonepod/proc/go_out()
 	countdown.stop()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Updates most of cloner code to TRUE / FALSE, changes the access requirement to stop a clone to medical instead of genetics, enables the radio cloners have

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Stopping the cloner from cloning, or clearing out the bloody mess inside, is not ment to be a hard thing to do. It is supposed to be CMO, or geneticists, that clean out the cloner. However, with genetics often never running the cloner, only really the CMO ever does this, who is often busy. By making it medical, it just makes cleaning the cloner easier, and stops medical from having to ask borgs to turn off the APC to stop a clone early.

Having the radio for the cloner enabled is nice, tells when the cloner gets jammed, or when someone finishes cloning. No real downside to having it on.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
Radio messages:
![image](https://user-images.githubusercontent.com/52090703/99150790-03aaa700-2665-11eb-97ac-2f7331aa73b7.png)
![image](https://user-images.githubusercontent.com/52090703/99150807-18873a80-2665-11eb-966b-94b2fc2eb311.png)
![image](https://user-images.githubusercontent.com/52090703/99150827-36549f80-2665-11eb-89c4-de8e07564b88.png)
![image](https://user-images.githubusercontent.com/52090703/99150831-3ce31700-2665-11eb-9f33-dfaec9b7ddef.png)


## Changelog
:cl:
tweak: Cloner now requires medical access instead of genetics to eject a cloning pod.
tweak: The radio inside of cloners is now enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
