### PR TITLE
Tweaks adminwho discord message

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -126,6 +126,6 @@
 				modmsg += "\t[C] is a [C.holder.rank]\n"
 				num_mods_online++
 
-	var/noadmins_info = "\n<span class='notice'>If no admins or mentors are online, make a ticket anyways. Adminhelps and mentorhelps will be relayed to discord, and staff will still be informed.</span>"
+	var/noadmins_info = "\n<span class='notice'><small>If no admins or mentors are online, make a ticket anyways. Adminhelps and mentorhelps will be relayed to discord, and staff will still be informed.<small></span>"
 	msg = "<b>Current Admins ([num_admins_online]):</b>\n" + msg + "\n<b>Current Mentors ([num_mods_online]):</b>\n" + modmsg + noadmins_info
 	to_chat(src, msg)


### PR DESCRIPTION
## What Does This PR Do
Tweaks the adminwho discord message to make it fit all on one line with default chat size at 1080p (What most people use, I assume)

## Why It's Good For The Game
Just looks nicer in my opinion

## Images of changes
Before:
![image](https://user-images.githubusercontent.com/25063394/99155899-1dbfa600-26b4-11eb-84de-7480c7687602.png)

After:
![image](https://user-images.githubusercontent.com/25063394/99155902-244e1d80-26b4-11eb-87b8-be2709c9d6f9.png)

## Changelog
:cl: AffectedArc07
tweak: Made discord ticket info in adminwho slightly smaller
/:cl:
