### PR TITLE
Adds functionality to the medical cyborg gripper

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -23,7 +23,7 @@
 	if(lying && surgeries.len)
 		if(user != src && user.a_intent == INTENT_HELP)
 			for(var/datum/surgery/S in surgeries)
-				if(S.next_step(user, src))
+				if(S.next_step(user, src, I))
 					return 1
 	return ..()
 
@@ -44,7 +44,7 @@
 	if(lying && surgeries.len)
 		if(user.a_intent == INTENT_HELP)
 			for(var/datum/surgery/S in surgeries)
-				if(S.next_step(user, src))
+				if(S.next_step(user, src, user.get_active_hand()))
 					return 1
 	return 0
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -41,7 +41,8 @@
 	desc = "A grasping tool used to give medication, assist with surgery, and help patients up once surgery is complete."
 	can_hold = list(/obj/item/implant,
 				/obj/item/organ,
-				/obj/item/reagent_containers/food/pill/
+				/obj/item/reagent_containers/food/pill/,
+				/obj/item/reagent_containers/applicator
 	)
 
 /obj/item/gripper/medical/afterattack(atom/target, mob/living/user, proximity, params)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -39,8 +39,7 @@
 /obj/item/gripper/medical
 	name = "medical gripper"
 	desc = "A grasping tool used to give medication, assist with surgery, and help patients up once surgery is complete."
-	can_hold = list(/obj/item/implant,
-				/obj/item/organ,
+	can_hold = list(/obj/item/organ,
 				/obj/item/reagent_containers/food/pill/,
 				/obj/item/reagent_containers/applicator
 	)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -38,9 +38,10 @@
 
 /obj/item/gripper/medical
 	name = "medical gripper"
-	desc = "A grasping tool used to assist with surgery and help patients up once surgery is complete."
+	desc = "A grasping tool used to give medication, assist with surgery, and help patients up once surgery is complete."
 	can_hold = list(/obj/item/implant,
-				/obj/item/organ
+				/obj/item/organ,
+				/obj/item/reagent_containers/food/pill/
 	)
 
 /obj/item/gripper/medical/afterattack(atom/target, mob/living/user, proximity, params)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -38,11 +38,10 @@
 
 /obj/item/gripper/medical
 	name = "medical gripper"
-	desc = "A grasping tool used to help patients up once surgery is complete."
-	can_hold = list()
-
-/obj/item/gripper/medical/attack_self(mob/user)
-	return
+	desc = "A grasping tool used to assist with surgery and help patients up once surgery is complete."
+	can_hold = list(/obj/item/implant,
+				/obj/item/organ
+	)
 
 /obj/item/gripper/medical/afterattack(atom/target, mob/living/user, proximity, params)
 	var/mob/living/carbon/human/H
@@ -60,6 +59,9 @@
 				"<span class='notice'>[user] shakes [H] trying to wake [H.p_them()] up!</span>",\
 				"<span class='notice'>You shake [H] trying to wake [H.p_them()] up!</span>",\
 				)
+			return
+	..()
+
 
 /obj/item/gripper/New()
 	..()
@@ -125,7 +127,7 @@
 	else if(istype(target,/obj/machinery/power/apc))
 		var/obj/machinery/power/apc/A = target
 		if(A.opened)
-			if(A.cell)
+			if(A.cell && is_type_in_typecache(A.cell, can_hold))
 
 				gripped_item = A.cell
 

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -337,7 +337,7 @@
 		if(stat == DEAD && surgeries.len)
 			if(M.a_intent == INTENT_HELP || M.a_intent == INTENT_DISARM)
 				for(var/datum/surgery/S in surgeries)
-					if(S.next_step(M, src))
+					if(S.next_step(M, src, M.get_active_hand()))
 						return 1
 		if(..()) //successful attack
 			attacked += 10
@@ -352,7 +352,7 @@
 	if(stat == DEAD && surgeries.len)
 		if(user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM)
 			for(var/datum/surgery/S in surgeries)
-				if(S.next_step(user, src))
+				if(S.next_step(user, src, user.get_active_hand()))
 					return 1
 	if(istype(I, /obj/item/stack/sheet/mineral/plasma) && !stat) //Let's you feed slimes plasma.
 		if(user in Friends)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -54,7 +54,7 @@
 							procedure.location = selected_zone
 							M.surgeries += procedure
 							procedure.organ_ref = affecting
-							procedure.next_step(user, M)
+							procedure.next_step(user, M, user.get_active_hand())
 
 				else
 					var/P = input("Begin which procedure?", "Surgery", null, null) as null|anything in available_surgeries

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -27,12 +27,12 @@
 	return 1
 
 
-/datum/surgery/proc/next_step(mob/user, mob/living/carbon/target)
+/datum/surgery/proc/next_step(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(step_in_progress)	return
 
 	var/datum/surgery_step/S = get_surgery_step()
 	if(S)
-		if(S.try_op(user, target, user.zone_selected, user.get_active_hand(), src))
+		if(S.try_op(user, target, user.zone_selected, tool, src))
 			return 1
 	return 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently, all you can do with the medical cyborg gripper is shake patients who are lying down to stand up. This PR lets you pick up, hold, and do surgery with implants, limbs, and organs using the medical cyborg's gripper. It also lets you pick up and administer pills, patches, and auto-menders. 

## Why It's Good For The Game
Currently, there is no way for a medical borg to reattach a limb, put in an implant, or give a cybernetic replacement limb.

Additionally with new crit, a medical borg is really bad at stopping someone from crashing as they are unable to deal with the ramping levels of brain damage that the cardiac arrest causes.  Once someone needs mannitol or they will start going into cardiac again, a medical borg has little ability to save the person. Also, medical borgs are bad at treating large quantities of damage besides just shoving someone into a sleeper, this should mitigate that issue somewhat, but they are still going to be far clumsier and slower at giving someone medicine that someone with hands.

People may say this just makes them doctor++. Medical cyborgs are still unable to do any surgery that requires hands, specifically removing or placing items in a cavity. Additionally, there are lots of nonsurgical tasks that doctors can do better, like minding the cloners or cyro tubes. As I said above, they are far clumsier with medicines than a doctor. Consider the following, a mid-round doctor has 5-10 fo a dozen different meds in their backpack and pockets. The medical cyborg gets what is in their hypospray (5 drugs) and then they can walk to a vending machine (no freezers for borgs), dispense one pill. Pick it up. Walk to the patient. Give them the drug.

If the medicines are controversial it would be very easily removed, but I don't think it will "invalidate doctors" personally. This PR was made to rectify their inability to reattach limbs and replace organs. The ability to hold pills, patches, and auto-menders is secondary and I am open to remove any or all of those things.

## Changelog
:cl:
add: Added the ability for medical cyborgs to pick up limbs, organs, implants, pills, patches, and auto-menders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
