### PR TITLE
Make Nar'Sie summoner RED

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -118,6 +118,10 @@
 		if(!keyword)
 			return
 
+	// Check everything again, in case they moved
+	if(!can_scribe(user))
+		return
+
 	// Check if the rune is allowed
 	var/area/A = get_area(src)
 	var/turf/runeturf = get_turf(user)
@@ -127,40 +131,43 @@
 			to_chat(user, "<span class='cultitalic'>The veil is not weak enough here to summon a cultist, you must be on station!</span>")
 			return
 
+	var/old_color = user.color  // we'll temporarily redden the user for better feedback to fellow cultists. Store this to revert them back.
 	if(narsie_rune)
 		if(!narsie_rune_check(user, A))
 			return // don't do shit
-		else
-			var/list/summon_areas = gamemode.cult_objs.obj_summon.summon_spots
-			if(!(A in summon_areas))  // Check again to make sure they didn't move
-				to_chat(user, "<span class='cultlarge'>The ritual can only begin where the veil is weak - in [english_list(summon_areas)]!</span>")
-				return
-			GLOB.command_announcement.Announce("Figments from an eldritch god are being summoned into the [A.map_name] from an unknown dimension. Disrupt the ritual at all costs, before the station is destroyed! Space law and SOP are suspended. The entire crew must kill cultists on sight.", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
-			for(var/I in spiral_range_turfs(1, user, 1))
-				var/turf/T = I
-				var/obj/machinery/shield/cult/narsie/N = new(T)
-				shields |= N
-
-	// Check everything again, in case they moved
-	if(!can_scribe(user))
-		return
+		var/list/summon_areas = gamemode.cult_objs.obj_summon.summon_spots
+		if(!(A in summon_areas))  // Check again to make sure they didn't move
+			to_chat(user, "<span class='cultlarge'>The ritual can only begin where the veil is weak - in [english_list(summon_areas)]!</span>")
+			return
+		GLOB.command_announcement.Announce("Figments from an eldritch god are being summoned into the [A.map_name] from an unknown dimension. Disrupt the ritual at all costs, before the station is destroyed! Space law and SOP are suspended. The entire crew must kill cultists on sight.", "Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
+		for(var/I in spiral_range_turfs(1, user, 1))
+			var/turf/T = I
+			var/obj/machinery/shield/cult/narsie/N = new(T)
+			shields |= N
+		user.color = "red"
 
 	// Draw the rune
 	var/mob/living/carbon/human/H = user
-	H.cult_self_harm(initial(rune.scribe_damage), TRUE)
-	if(!do_after(user, initial(rune.scribe_delay) * scribe_multiplier, target = runeturf))
-		for(var/V in shields) // Only used for the 'Tear Veil' rune
-			var/obj/machinery/shield/S = V
-			if(S && !QDELETED(S))
-				qdel(S)
+	H.cult_self_harm(initial(rune.scribe_damage))
+	var/others_message
+	if(!narsie_rune)
+		others_message = "<span class='warning'>[user] cuts [user.p_their()] body and begins writing in [user.p_their()] own blood!</span>"
+	else
+		others_message = "<span class='biggerdanger'>[user] cuts [user.p_their()] body and begins writing something particularly ominous in [user.p_their()] own blood!</span>"
+	user.visible_message(others_message,
+		"<span class='cultitalic'>You slice open your body and begin drawing a sigil of [SSticker.cultdat.entity_title3].</span>")
+
+	var/scribe_successful = do_after(user, initial(rune.scribe_delay) * scribe_multiplier, target = runeturf)
+	for(var/V in shields) // Only used for the 'Tear Veil' rune
+		var/obj/machinery/shield/S = V
+		if(S && !QDELETED(S))
+			qdel(S)
+	user.color = old_color
+	if(!scribe_successful)
 		return
 
 	user.visible_message("<span class='warning'>[user] creates a strange circle in [user.p_their()] own blood.</span>",
 						 "<span class='cultitalic'>You finish drawing the arcane markings of [SSticker.cultdat.entity_title3].</span>")
-	for(var/V in shields) // Only for the 'Tear Veil' rune
-		var/obj/machinery/shield/S = V
-		if(S && !QDELETED(S))
-			qdel(S)
 
 	var/obj/effect/rune/R = new rune(runeturf, keyword)
 	if(narsie_rune)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -74,7 +74,7 @@
 		return TRUE
 
 //Called when drawing cult runes/using cult spells. Deal damage to a random arm/hand, or chest if not there.
-/mob/living/carbon/cult_self_harm(damage, rune_message = FALSE)
+/mob/living/carbon/cult_self_harm(damage)
 	var/dam_zone = pick("l_arm", "l_hand", "r_arm", "r_hand")
 	var/obj/item/organ/external/affecting = get_organ(dam_zone)
 	if(!affecting)
@@ -82,6 +82,3 @@
 	if(!affecting) //bruh where's your chest
 		return FALSE
 	apply_damage(damage, BRUTE, affecting)
-	if(rune_message)
-		visible_message("<span class='warning'>[src] cuts open [src.p_their()] [affecting.name] and begins writing in [src.p_their()] own blood!</span>",
-		"<span class='cultitalic'>You slice open your [affecting.name] and begin drawing a sigil of [SSticker.cultdat.entity_title3].</span>")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -358,5 +358,5 @@
 			M.do_attack_animation(src, ATTACK_EFFECT_DISARM)
 			return TRUE
 
-/mob/living/proc/cult_self_harm(damage, rune_message = FALSE)
+/mob/living/proc/cult_self_harm(damage)
 	return FALSE


### PR DESCRIPTION
## What Does This PR Do
The primary invoker of Nar'Sie rune is now distinctly red.

The chat message for the summoning rune is also louder. Although, to accommodate that the flavourful "you slice open your [hand/arm/leg]" messages had to go, now replaced with just "you slice your body".

## Why It's Good For The Game
Currently there is somewhat little feedback about who is doing the summoning, creating confusion. Fellow cultists assume that the summoner is doing nothing, so they decide to go in and shuffle them, thus interrupting the ritual.

## Images of changes
![20201115-090854-2jfwkuUa1d](https://user-images.githubusercontent.com/7831163/99180959-c278cc80-2722-11eb-9eff-6e7054f334c9.gif)


## Changelog
:cl:
tweak: Nar'Sie primary summoner is now RED
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
