### PR TITLE
Notes can be removed from airlocks with wirecutters, even if the airlock maintenance panel is closed

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -719,7 +719,7 @@ About the new airlock wires panel:
 		return
 
 	if(headbutt_airlock(user))
-		return//Smack that head against that airlock
+		return // Smack that head against that airlock
 	if(remove_airlock_note(user, FALSE))
 		return
 
@@ -1004,8 +1004,13 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/wirecutter_act(mob/user, obj/item/I)
 	if(!headbutt_shock_check(user))
 		return
-	if(!panel_open || user.a_intent == INTENT_HARM)
-		return
+
+	if(!panel_open)
+		if(note && user.a_intent == INTENT_HARM)
+			return remove_airlock_note(user, TRUE)
+		// Can't do much else with the panel closed.
+		return FALSE
+
 	. = TRUE
 	if(!I.tool_start_check(src, user, 0))
 		return
@@ -1020,10 +1025,7 @@ About the new airlock wires panel:
 								"<span class='notice'>You cut through \the [src]'s outer grille.</span>")
 			security_level = AIRLOCK_SECURITY_PLASTEEL_O
 		return
-	if(note)
-		remove_airlock_note(user, TRUE)
-	else
-		interact_with_panel(user)
+	interact_with_panel(user)
 
 /obj/machinery/door/airlock/multitool_act(mob/user, obj/item/I)
 	if(!headbutt_shock_check(user))
@@ -1413,23 +1415,24 @@ About the new airlock wires panel:
 
 //Removes the current note on the door if any. Returns if a note is removed
 /obj/machinery/door/airlock/proc/remove_airlock_note(mob/user, wirecutters_used = TRUE)
-	if(note)
-		if(!wirecutters_used)
-			if (ishuman(user) && user.a_intent == INTENT_GRAB)//grab that note
-				user.visible_message("<span class='notice'>[user] removes [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
-				playsound(src, 'sound/items/poster_ripped.ogg', 50, 1)
-			else
-				return FALSE
+	if(!note)
+		return FALSE
+
+	if(!wirecutters_used)
+		if (ishuman(user) && (user.a_intent == INTENT_GRAB || user.a_intent == INTENT_HARM)) //grab that note
+			user.visible_message("<span class='notice'>[user] removes [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
+			playsound(src, 'sound/items/poster_ripped.ogg', 50, 1)
 		else
-			user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
-			playsound(src, 'sound/items/wirecutter.ogg', 50, 1)
-		note.add_fingerprint(user)
-		user.create_log(MISC_LOG, "removed [note] from", src)
-		user.put_in_hands(note)
-		note = null
-		update_icon()
-		return TRUE
-	return FALSE
+			return FALSE
+	else
+		user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
+		playsound(src, 'sound/items/wirecutter.ogg', 50, 1)
+	note.add_fingerprint(user)
+	user.create_log(MISC_LOG, "removed [note] from", src)
+	user.put_in_hands(note)
+	note = null
+	update_icon()
+	return TRUE
 
 /obj/machinery/door/airlock/narsie_act(weak = FALSE)
 	var/turf/T = get_turf(src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1006,7 +1006,7 @@ About the new airlock wires panel:
 		return
 
 	if(!panel_open)
-		if(note && user.a_intent == INTENT_HARM)
+		if(note)
 			return remove_airlock_note(user, TRUE)
 		// Can't do much else with the panel closed.
 		return FALSE
@@ -1419,7 +1419,7 @@ About the new airlock wires panel:
 		return FALSE
 
 	if(!wirecutters_used)
-		if (ishuman(user) && (user.a_intent == INTENT_GRAB || user.a_intent == INTENT_HARM)) //grab that note
+		if (ishuman(user) && (user.a_intent == INTENT_GRAB)) //grab that note
 			user.visible_message("<span class='notice'>[user] removes [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
 			playsound(src, 'sound/items/poster_ripped.ogg', 50, 1)
 		else


### PR DESCRIPTION
## What Does This PR Do
Notes can be removed from airlocks with wirecutters, even if the airlock maintenance panel is closed.

## Why It's Good For The Game
This is a salt-induced PR. I couldn't figure out how to remove the note without diving into the code.
After diving I realized that
1) i should have used grab intent, not harm, when trying by hand (although, admittedly, examine text should tell me what to do very clearly) and
2) to cut it with wirecutters one needs to open the panel first, which is unintuitive and must be an oversight.

This PR fixes the latter.

## Images of changes
![20201115-231617-GZR34kRlKZ](https://user-images.githubusercontent.com/7831163/99199660-9ef06900-2798-11eb-94d2-3a2e389cfc0e.gif)


## Changelog
:cl:
fix: No longer need to open airlock panel to wirecutter the note out of it.
/:cl:
