### PR TITLE
Autolathe disable wire actually disables autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -79,7 +79,6 @@
 
 	if(panel_open)
 		wires.Interact(user)
-
 	else if(!disabled)
 		tgui_interact(user)
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -451,7 +451,7 @@
 		else
 			return
 	while(D)
-		if(stat & (NOPOWER|BROKEN))
+		if(stat & (NOPOWER|BROKEN|disabled))
 			being_built = new /list()
 			return 0
 		if(!can_build(D, multiplier))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -451,7 +451,7 @@
 		else
 			return
 	while(D)
-		if(stat & (NOPOWER|BROKEN|disabled))
+		if((stat & (NOPOWER|BROKEN)) || disabled)
 			being_built = new /list()
 			return 0
 		if(!can_build(D, multiplier))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -204,7 +204,7 @@
 				busy = FALSE
 
 /obj/machinery/autolathe/tgui_status(mob/user, datum/tgui_state/state)
-	. = disabled ? STATUS_CLOSE : STATUS_INTERACTIVE
+	. = disabled ? STATUS_DISABLED : STATUS_INTERACTIVE
 
 	return min(..(), .)
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -79,7 +79,8 @@
 
 	if(panel_open)
 		wires.Interact(user)
-	else
+
+	else if(!disabled)
 		tgui_interact(user)
 
 /obj/machinery/autolathe/tgui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = TRUE, datum/tgui/master_ui = null, datum/tgui_state/state = GLOB.tgui_default_state)
@@ -201,6 +202,11 @@
 				busy = TRUE
 				process_queue()
 				busy = FALSE
+
+/obj/machinery/autolathe/tgui_status(mob/user, datum/tgui_state/state)
+	. = disabled ? STATUS_CLOSE : STATUS_INTERACTIVE
+
+	return min(..(), .)
 
 /obj/machinery/autolathe/proc/design_cost_data(datum/design/D)
 	var/list/data = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Autolathe disable wire now actually disables the autolathe, making it impossible to open new autolathe windows and disabling any currently open autolathe windows.

fixes: #14894 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously the disable wire didn't actually... Disable the autolathe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Autolathe disable wire now actually disables autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
