### PR TITLE
Makes morgue tray respect unrevivable mobs

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -49,12 +49,16 @@
 			if(M)
 				var/mob/dead/observer/G = M.get_ghost()
 
-				if(M.client && M.mind && M.mind.is_revivable() && !M.mind.suicided)
-					icon_state = "morgue3"
-					desc = initial(desc) + "\n[status_descriptors[4]]"
-				else if(G && G.client && M.mind && M.mind.is_revivable() && !M.mind.suicided) //There is a ghost and it is connected to the server
-					icon_state = "morgue5"
-					desc = initial(desc) + "\n[status_descriptors[6]]"
+				if(M.mind && M.mind.is_revivable() && !M.mind.suicided)
+					if(M.client)
+						icon_state = "morgue3"
+						desc = initial(desc) + "\n[status_descriptors[4]]"
+					else if(G && G.client) //There is a ghost and it is connected to the server
+						icon_state = "morgue5"
+						desc = initial(desc) + "\n[status_descriptors[6]]"
+					else
+						icon_state = "morgue2"
+						desc = initial(desc) + "\n[status_descriptors[3]]"
 				else
 					icon_state = "morgue2"
 					desc = initial(desc) + "\n[status_descriptors[3]]"

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -49,10 +49,10 @@
 			if(M)
 				var/mob/dead/observer/G = M.get_ghost()
 
-				if(M.client && M.mind && M.mind.is_revivable() && !M.mind.suicided && M.mind.current.stat != DEAD)
+				if(M.client && M.mind && M.mind.is_revivable() && !M.mind.suicided)
 					icon_state = "morgue3"
 					desc = initial(desc) + "\n[status_descriptors[4]]"
-				else if(G && G.client && M.mind && M.mind.is_revivable() && !M.mind.suicided && M.mind.current.stat != DEAD) //There is a ghost and it is connected to the server
+				else if(G && G.client && M.mind && M.mind.is_revivable() && !M.mind.suicided) //There is a ghost and it is connected to the server
 					icon_state = "morgue5"
 					desc = initial(desc) + "\n[status_descriptors[6]]"
 				else

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -49,10 +49,10 @@
 			if(M)
 				var/mob/dead/observer/G = M.get_ghost()
 
-				if(M.client)
+				if(M.client && M.mind && M.mind.is_revivable() && !M.mind.suicided && M.mind.current.stat != DEAD)
 					icon_state = "morgue3"
 					desc = initial(desc) + "\n[status_descriptors[4]]"
-				else if(G && G.client) //There is a ghost and it is connected to the server
+				else if(G && G.client && M.mind && M.mind.is_revivable() && !M.mind.suicided && M.mind.current.stat != DEAD) //There is a ghost and it is connected to the server
 					icon_state = "morgue5"
 					desc = initial(desc) + "\n[status_descriptors[6]]"
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds logic from cloner to morgue trays, so suicided or otherwise unrevivable mobs don't show up as green or purple.

## Why It's Good For The Game
It's confusing when someone who committed suicide shows up as green in the morgue.

## Changelog
:cl:
fix: Morgue trays now respect unrevivable mobs for their lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
