### PR TITLE
Suit storage unit wires now be accessible when electrocuted and hacked UV radiation properly destroys contents

### DIFF
--- a/code/datums/wires/suitstorage.dm
+++ b/code/datums/wires/suitstorage.dm
@@ -19,8 +19,6 @@
 
 /datum/wires/suitstorage/interactable(mob/user)
 	var/obj/machinery/suit_storage_unit/A = holder
-	if(iscarbon(user) && A.Adjacent(user) && A.shocked)
-		return A.shock(user, 100)
 	if(A.panel_open)
 		return TRUE
 	return FALSE

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -292,18 +292,15 @@
 	if(shocked)
 		if(shock(user, 100))
 			return
-
 	if(!is_operational())
 		if(panel_open)
 			to_chat(usr, "<span class='warning'>Close the maintenance panel first.</span>")
 		else
 			to_chat(usr, "<span class='warning'>The unit is not operational.</span>")
 		return
-
 	if(panel_open)
 		wires.Interact(user)
 		return
-
 	if(state_open)
 		if(store_item(I, user))
 			update_icon()
@@ -536,11 +533,9 @@
 		return
 	if(panel_open) //The maintenance panel is open. Time for some shady stuff
 		wires.Interact(user)
-
 	if(uv) //The thing is running its cauterisation cycle. You have to wait.
 		dat += "<HEAD><TITLE>Suit storage unit</TITLE></HEAD>"
 		dat+= "<font color ='red'><B>Unit is cauterising contents with selected UV ray intensity. Please wait.</font></B><BR>"
-
 	else
 		if(!broken)
 			dat+= "<B>Welcome to the Unit control panel.</B><HR>"

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -26,7 +26,7 @@
 	var/secure = FALSE	//set to true to enable ID locking
 	var/shocked = FALSE//is it shocking anyone that touches it?
 	req_access = list(ACCESS_EVA)	//the ID needed if ID lock is enabled
-	var/datum/wires/suitstorage/wires
+	var/datum/wires/suitstorage/wires = null
 
 	var/uv = FALSE
 	var/uv_super = FALSE
@@ -288,10 +288,11 @@
 	else if(occupant)
 		add_overlay("human")
 
-/obj/machinery/suit_storage_unit/attackby(obj/item/I as obj, mob/user as mob, params)
+/obj/machinery/suit_storage_unit/attackby(obj/item/I as obj, mob/user, params)
 	if(shocked)
 		if(shock(user, 100))
 			return
+
 	if(!is_operational())
 		if(panel_open)
 			to_chat(usr, "<span class='warning'>Close the maintenance panel first.</span>")
@@ -301,7 +302,6 @@
 
 	if(panel_open)
 		wires.Interact(user)
-		return
 
 	if(state_open)
 		if(store_item(I, user))
@@ -314,22 +314,14 @@
 	return ..()
 
 /obj/machinery/suit_storage_unit/screwdriver_act(mob/user, obj/item/I)
-	. = TRUE
-	if(shocked && shock(user, 100))
-		return
-	if(!is_operational())
-		if(panel_open)
-			to_chat(user, "<span class='warning'>Close the maintenance panel first.</span>")
-		else
-			to_chat(user, "<span class='warning'>The unit is not operational.</span>")
-		return
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-
-	panel_open = !panel_open
-	to_chat(user, text("<span class='notice'>You [panel_open ? "open up" : "close"] the unit's maintenance panel.</span>"))
-	updateUsrDialog()
-	return
+	. = TRUE
+	if(shocked && !(stat & NOPOWER))
+		if(shock(user, 100))
+			return
+	if(default_deconstruction_screwdriver(user, "panel", "close", I))
+		I.play_tool_sound(user, I.tool_volume)
 
 /obj/machinery/suit_storage_unit/proc/store_item(obj/item/I, mob/user)
 	. = FALSE
@@ -426,16 +418,17 @@
 		if(uv_super)
 			visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A cloud of foul black smoke escapes from its chamber.</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 50, 1)
-			helmet = null
 			qdel(helmet)
-			suit = null
-			qdel(suit) // Delete everything but the occupant.
-			mask = null
 			qdel(mask)
-			magboots = null
 			qdel(magboots)
-			storage = null
 			qdel(storage)
+			qdel(suit) 
+			helmet = null
+			suit = null
+			mask = null
+			magboots = null
+			storage = null
+
 		else
 			if(!occupant)
 				visible_message("<span class='notice'>[src]'s door slides open. The glowing yellow lights dim to a gentle green.</span>")
@@ -445,14 +438,6 @@
 		open_machine(FALSE)
 		if(occupant)
 			dump_contents()
-
-/obj/machinery/suit_storage_unit/shock(mob/user, prb)
-	if(prob(prb))	//why was this inverted before?!?
-		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
-		if(electrocute_mob(user, src, src, 1, TRUE))
-			return TRUE
 
 /obj/machinery/suit_storage_unit/relaymove(mob/user)
 	if(locked)
@@ -539,19 +524,15 @@
 
 ////////
 
-/obj/machinery/suit_storage_unit/attack_hand(mob/user as mob)
+/obj/machinery/suit_storage_unit/attack_hand(mob/user)
 	var/dat
-	if(shocked)
-		if(shock(usr, 100))
+	if(shocked && !(stat & NOPOWER))
+		if(shock(user, 100))
 			return
-	if(..())
-		return
-	if(stat & NOPOWER)
-		return
-	if(!user.IsAdvancedToolUser())
-		return FALSE
+	
 	if(panel_open) //The maintenance panel is open. Time for some shady stuff
 		wires.Interact(user)
+
 	if(uv) //The thing is running its cauterisation cycle. You have to wait.
 		dat += "<HEAD><TITLE>Suit storage unit</TITLE></HEAD>"
 		dat+= "<font color ='red'><B>Unit is cauterising contents with selected UV ray intensity. Please wait.</font></B><BR>"
@@ -606,7 +587,7 @@
 /obj/machinery/suit_storage_unit/Topic(href, href_list)
 	if(..())
 		return 1
-	if(shocked)
+	if(shocked && !(stat & NOPOWER))
 		if(shock(usr, 100))
 			return
 	if((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon/ai)))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -288,7 +288,7 @@
 	else if(occupant)
 		add_overlay("human")
 
-/obj/machinery/suit_storage_unit/attackby(obj/item/I as obj, mob/user, params)
+/obj/machinery/suit_storage_unit/attackby(obj/item/I, mob/user, params)
 	if(shocked)
 		if(shock(user, 100))
 			return
@@ -302,6 +302,7 @@
 
 	if(panel_open)
 		wires.Interact(user)
+		return
 
 	if(state_open)
 		if(store_item(I, user))
@@ -529,7 +530,10 @@
 	if(shocked && !(stat & NOPOWER))
 		if(shock(user, 100))
 			return
-	
+	if(stat & NOPOWER)
+		return
+	if(..())
+		return
 	if(panel_open) //The maintenance panel is open. Time for some shady stuff
 		wires.Interact(user)
 
@@ -644,8 +648,7 @@
 	return
 
 
-/obj/machinery/suit_storage_unit/proc/toggleUV(mob/user as mob)
-
+/obj/machinery/suit_storage_unit/proc/toggleUV(mob/user)
 	if(!panel_open)
 		return
 	else
@@ -656,7 +659,7 @@
 			to_chat(user, "<span class='notice'>You crank the dial all the way up to \"15nm\".</span>")
 			uv_super = TRUE
 
-/obj/machinery/suit_storage_unit/proc/togglesafeties(mob/user as mob)
+/obj/machinery/suit_storage_unit/proc/togglesafeties(mob/user)
 	if(!panel_open)
 		return
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes: #14909

Do note that the suit storage unit is **still** capable of permanently deleting high value items, I assumed this to be intended behaviour, but if I am wrong in this, please do let me know.

Also slightly cleans up the code
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs are bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Suit storage unit will now actually electrocute when electrocute wire is cut/pulsed
fix: Suit storage unit wires can now still be accessed if the electrocute wire is cut/pulsed
fix: Suit storage unit UV radiation at 15 nm now will permanently delete the unit's contents, rather than allowing it to be conjured back into existence
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
