### PR TITLE
Ingame CentCom Ban DB Lookup Interface

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -265,6 +265,9 @@
 	/// (This does not mean all ahelps are pinged, only ahelps sent when staff are offline get the ping, regardless of this setting)
 	var/discord_forward_all_ahelps = FALSE
 
+	/// URL for the CentCom Ban DB API
+	var/centcom_ban_db_url = null
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -754,6 +757,8 @@
 				if("discord_forward_all_ahelps")
 					discord_forward_all_ahelps = TRUE
 				// End discord stuff
+				if("centcom_ban_db_url")
+					centcom_ban_db_url = value
 				else
 					log_config("Unknown setting in configuration: '[name]'")
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -91,7 +91,10 @@ GLOBAL_VAR_INIT(nologevent, 0)
 		else
 			body += "\[[M.client.holder ? M.client.holder.rank : "Player"]\] "
 		body += "\[<A href='?_src_=holder;getplaytimewindow=[M.UID()]'>" + M.client.get_exp_type(EXP_TYPE_CREW) + " as [EXP_TYPE_CREW]</a>\]"
-		body += "<br>BYOND account registration date: [M.client.byondacc_date || "ERROR"] [M.client.byondacc_age <= config.byond_account_age_threshold ? "<b>" : ""]([M.client.byondacc_age] days old)[M.client.byondacc_age <= config.byond_account_age_threshold ? "</b>" : ""]<br>"
+		body += "<br>BYOND account registration date: [M.client.byondacc_date || "ERROR"] [M.client.byondacc_age <= config.byond_account_age_threshold ? "<b>" : ""]([M.client.byondacc_age] days old)[M.client.byondacc_age <= config.byond_account_age_threshold ? "</b>" : ""]"
+		body += "<br>Global Ban DB Lookup: [config.centcom_ban_db_url ? "<a href='?_src_=holder;open_ccbdb=[M.client.ckey]'>Lookup</a>" : "<i>Disabled</i>"]"
+
+		body += "<br>"
 
 	if(isnewplayer(M))
 		body += " <B>Hasn't Entered Game</B> "

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -69,7 +69,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/client/proc/reset_all_tcs,			/*resets all telecomms scripts*/
 	/client/proc/toggle_mentor_chat,
 	/client/proc/toggle_advanced_interaction, /*toggle admin ability to interact with not only machines, but also atoms such as buttons and doors*/
-	/client/proc/list_ssds_afks
+	/client/proc/list_ssds_afks,
+	/client/proc/ccbdb_lookup_ckey
 ))
 GLOBAL_LIST_INIT(admin_verbs_ban, list(
 	/client/proc/ban_panel,

--- a/code/modules/admin/centcom_ban_db.dm
+++ b/code/modules/admin/centcom_ban_db.dm
@@ -13,8 +13,12 @@
   * * ckey - ckey to be looked up
   */
 /datum/admins/proc/create_ccbdb_lookup(ckey)
+	// Bail if disabled
 	if(!config.centcom_ban_db_url)
 		to_chat(usr, "<span class='warning'>The CentCom Ban DB lookup is disabled. Please inform a maintainer or server host.</span>")
+		return
+	// Bail if no ckey is supplied
+	if(!ckey)
 		return
 
 	var/datum/callback/cb = CALLBACK(src, /datum/admins/.proc/ccbdb_lookup_callback, usr, ckey)
@@ -37,12 +41,12 @@
 
 	// Bail if it errored
 	if(response.errored)
-		to_chat(usr, "<span class='warning'>Error connecting to CentCom Ban DB. Please inform a maintainer or server host.</span>")
+		to_chat(user, "<span class='warning'>Error connecting to CentCom Ban DB. Please inform a maintainer or server host.</span>")
 		return
 
 	// Bail if the code isnt 200
 	if(response.status_code != 200)
-		to_chat(usr, "<span class='warning'>Error performing CentCom Ban DB lookup (Code: [response.status_code])</span>")
+		to_chat(user, "<span class='warning'>Error performing CentCom Ban DB lookup (Code: [response.status_code])</span>")
 		return
 
 	var/list/popup_data = list()
@@ -94,7 +98,7 @@
 					popup_data += "<hr>"
 
 		catch
-			to_chat(usr, "<span class='warning'>Error parsing JSON data from CentCom Ban DB lookup. Please inform a maintainer.</span>")
+			to_chat(user, "<span class='warning'>Error parsing JSON data from CentCom Ban DB lookup. Please inform a maintainer.</span>")
 			return
 
 	var/datum/browser/popup = new(user, "ccbdblookup-[ckey]", "<div align='center'>CC Ban DB Lookup - [ckey]</div>", 700, 600)

--- a/code/modules/admin/centcom_ban_db.dm
+++ b/code/modules/admin/centcom_ban_db.dm
@@ -1,0 +1,113 @@
+// CCBDB = CentCom Ban DB
+// This file contains procs for handling all requests to the CCBDB API, hosted by Bobbahbrown
+// API Documentation: https://centcom.melonmesa.com/swagger/index.html
+// Please refer to said documentation before editing any of the stuff in here, otherwise it will likely break
+
+
+/**
+  * CCBDB Lookup Initiator
+  *
+  * Checks the configuration before invoking the request to the CCBDB server.
+  *
+  * Arguments:
+  * * ckey - ckey to be looked up
+  */
+/datum/admins/proc/create_ccbdb_lookup(ckey)
+	if(!config.centcom_ban_db_url)
+		to_chat(usr, "<span class='warning'>The CentCom Ban DB lookup is disabled. Please inform a maintainer or server host.</span>")
+		return
+
+	var/datum/callback/cb = CALLBACK(src, /datum/admins/.proc/ccbdb_lookup_callback, usr, ckey)
+	SShttp.create_async_request(RUSTG_HTTP_METHOD_GET, "[config.centcom_ban_db_url][ckey]", proc_callback=cb)
+
+/**
+  * CCBDB Lookup Callback
+  *
+  * Callback assigned in [/datum/admins/proc/create_ccbdb_lookup] for async operations without a sleep()
+  *
+  * Arguments:
+  * * user - Mob calling the lookup so the UI can be opened
+  * * ckey - Ckey being looked up
+  * * response - [/datum/http_response] passed through from [SShttp]
+  */
+/datum/admins/proc/ccbdb_lookup_callback(mob/user, ckey, datum/http_response/response)
+	// If the admin DC'd during the lookup, dont try and do things
+	if(!user)
+		return
+
+	// Bail if it errored
+	if(response.errored)
+		to_chat(usr, "<span class='warning'>Error connecting to CentCom Ban DB. Please inform a maintainer or server host.</span>")
+		return
+
+	// Bail if the code isnt 200
+	if(response.status_code != 200)
+		to_chat(usr, "<span class='warning'>Error performing CentCom Ban DB lookup (Code: [response.status_code])</span>")
+		return
+
+	var/list/popup_data = list()
+
+	// A body of "[]" means there were no bans on record for the user
+	if(response.body == "\[]")
+		popup_data += "<center><h3>0 bans detected for [ckey]</h3></center>"
+	else
+		var/list/bans = list()
+		// Wrap this in try/catch because JSON is a finnicky bastard
+		try
+			bans = json_decode(response.body)
+			// Yes I threw a ternary in because I am that obsessed over OCD
+			popup_data += "<center><h3>[length(bans)] ban[length(bans) == 1 ? "" : "s"] detected for [ckey]</h3></center>"
+			// These vars are also just for OCD (Adding a <hr> between each ban but the last)
+			var/total_bans = length(bans)
+			var/index = 0
+			for(var/list/ban in bans)
+				index++
+				// For anyone else who edits this. SANITIZE ALL THE DATA. OTHER SERVERS MAY HAVE BAD ACTORS WHO TRY AND XSS PEOPLE.
+				popup_data += "<b>Server:</b> [sanitize(ban["sourceName"])] ([sanitize(ban["sourceRoleplayLevel"])] RP)<br>"
+
+				var/ban_status
+				// If the ban is active, its, well, active
+				if(ban["active"] == TRUE) // The == TRUE is intentional here. Dont remove it.
+					ban_status = "<font color='red'>Ban Active</font>"
+				// If they have an entry of being unbanned by someone, its been appealed
+				else if(ban["unbannedBy"])
+					ban_status = "<font color='green'>Ban Appealed</font>"
+				else
+					ban_status = "<font color='cyan'>Ban Expired</font>"
+				popup_data += "<b>Status:</b> [ban_status]<br>"
+
+				// All the other stats
+				popup_data += "<b>Ban Type:</b> [sanitize(ban["type"])]<br>"
+				popup_data += "<b>Banning Admin:</b> [sanitize(ban["bannedBy"])]<br>"
+				popup_data += "<b>Ban Date:</b> [sanitize(ban["bannedOn"])]<br>"
+				var/expiration = ban["expires"]
+				popup_data += "<b>Expires:</b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
+				popup_data += "<b>Ban Reason:</b> [sanitize(ban["reason"])]<br>"
+
+				// If its a job ban, tell the admin the job list
+				if(ban["type"] == "Job")
+					var/list/jobs = ban["jobs"]
+					popup_data += "<b>Jobs: </b>[sanitize(english_list(jobs))]<br>"
+
+				// Add a newline between bans if its not the last one
+				if(index != total_bans)
+					popup_data += "<hr>"
+
+		catch
+			to_chat(usr, "<span class='warning'>Error parsing JSON data from CentCom Ban DB lookup. Please inform a maintainer.</span>")
+			return
+
+	var/datum/browser/popup = new(user, "ccbdblookup-[ckey]", "<div align='center'>CC Ban DB Lookup - [ckey]</div>", 700, 600)
+	popup.set_content(popup_data.Join())
+	popup.open(FALSE)
+
+// Just a simple verb so admins can do manual lookups
+/client/proc/ccbdb_lookup_ckey()
+	set name = "Global Ban DB Lookup"
+	set category = "Admin"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/input_ckey = input(usr, "Please enter a ckey to lookup", "Global Ban DB Lookup")
+	holder.create_ccbdb_lookup(input_ckey)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3349,21 +3349,6 @@
 		// Refresh the page
 		src.view_flagged_books()
 
-	// Force unlink a discord key
-	// TODO: Delete this
-	else if(href_list["force_discord_unlink"])
-		if(!check_rights(R_ADMIN))
-			return
-		var/target_ckey = href_list["force_discord_unlink"]
-		var/DBQuery/admin_unlink_discord_id = GLOB.dbcon.NewQuery("DELETE FROM [format_table_name("discord")] WHERE ckey = '[target_ckey]'")
-		if(!admin_unlink_discord_id.Execute())
-			var/err = admin_unlink_discord_id.ErrorMsg()
-			log_game("SQL ERROR while admin-unlinking discord account. Error : \[[err]\]\n")
-			return
-		to_chat(src, "<span class='notice'>Successfully forcefully unlinked discord account from [target_ckey]</span>")
-		message_admins("[key_name_admin(usr)] forcefully unlinked the discord account belonging to [target_ckey]")
-		log_admin("[key_name_admin(usr)] forcefully unlinked the discord account belonging to [target_ckey]")
-
 	else if(href_list["create_outfit_finalize"])
 		if(!check_rights(R_EVENT))
 			return
@@ -3386,6 +3371,11 @@
 			return
 		var/datum/outfit/O = locate(href_list["chosen_outfit"]) in GLOB.custom_outfits
 		save_outfit(usr,O)
+	else if(href_list["open_ccbdb"])
+		if(!check_rights(R_ADMIN))
+			return
+		create_ccbdb_lookup(href_list["open_ccbdb"])
+
 
 /client/proc/create_eventmob_for(var/mob/living/carbon/human/H, var/killthem = 0)
 	if(!check_rights(R_EVENT))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -465,3 +465,9 @@ BYOND_ACCOUNT_AGE_THRESHOLD 7
 #DISCORD_FORWARD_ALL_AHELPS
 
 ##### END DISCORD STUFF #####
+
+## URL For CentCom global ban DB
+## This is a config option should you want to disable this system, or if the primary URL changes
+## THE TRAILING SLASH ON THE END IS IMPORTANT SINCE IT JUST APPENDS THE CKEY TO THE END IN RAW
+## Add a hash before the line below to disable the system
+CENTCOM_BAN_DB_URL https://centcom.melonmesa.com/ban/search/

--- a/paradise.dme
+++ b/paradise.dme
@@ -1196,6 +1196,7 @@
 #include "code\modules\admin\admin_verbs.dm"
 #include "code\modules\admin\banappearance.dm"
 #include "code\modules\admin\banjob.dm"
+#include "code\modules\admin\centcom_ban_db.dm"
 #include "code\modules\admin\create_mob.dm"
 #include "code\modules\admin\create_object.dm"
 #include "code\modules\admin\create_poll.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds an ingame interface for the CC Global Ban DB. This allows admins to do lookups on players for bans on other servers easily without having to tab out and open an external website. 

![image](https://user-images.githubusercontent.com/25063394/99455713-22889200-2920-11eb-8574-eb2b95731242.png)
An option is available in player panel to lookup that ckey directly. A verb is also available for custom lookups.
![image](https://user-images.githubusercontent.com/25063394/99455749-303e1780-2920-11eb-9c8d-2c0d2c05d819.png)
![image](https://user-images.githubusercontent.com/25063394/99455767-3502cb80-2920-11eb-8a94-638b441164b8.png)

Example of a clean lookup:
![image](https://user-images.githubusercontent.com/25063394/99455809-45b34180-2920-11eb-8254-81bcfe5bc15b.png)

Example of a different lookup:
![image](https://user-images.githubusercontent.com/25063394/99455853-56fc4e00-2920-11eb-81b4-f5bddae0127d.png)

Bans which are appealed successfully show in green. Tempbans which expired will show up in blue. Any ban which is currently active will show up in red. 

## Why It's Good For The Game
Stops admins having to go to an external website to lookup external ban info

## Changelog
:cl: AffectedArc07
add: [Administration] Added a button inside PP to view the CC ban DB lookup for players. A verb has also been added for custom ckey lookups. 
/:cl:
