### PR TITLE
Adds a new examination message for damage severity

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -258,28 +258,22 @@
 
 	if(damage)
 		var/brute_message = !ismachineperson(src) ? "bruising" : "denting"
-		if(damage < 30)
-			msg += "[p_they(TRUE)] [p_have()] minor [brute_message].\n"
-		else if(damage < 60)
-			msg += "[p_they(TRUE)] [p_have()] moderate [brute_message].\n"
+		if(damage < 60)
+			msg += "[p_they(TRUE)] [p_have()] [damage < 30 ? "minor" : "moderate"] [brute_message].\n"
 		else
 			msg += "<B>[p_they(TRUE)] [p_have()] severe [brute_message]!</B>\n"
 
 	damage = getFireLoss()
 	if(damage)
-		if(damage < 30)
-			msg += "[p_they(TRUE)] [p_have()] minor burns.\n"
-		else if(damage < 60)
-			msg += "[p_they(TRUE)] [p_have()] moderate burns.\n"
+		if(damage < 60)
+			msg += "[p_they(TRUE)] [p_have()] [damage < 30 ? "minor" : "moderate"] burns.\n"
 		else
 			msg += "<B>[p_they(TRUE)] [p_have()] severe burns!</B>\n"
 
 	damage = getCloneLoss()
 	if(damage)
-		if(damage < 30)
-			msg += "[p_they(TRUE)] [p_have()] minor cellular damage.\n"
-		else if(damage < 60)
-			msg += "[p_they(TRUE)] [p_have()] moderate cellular damage.\n"
+		if(damage < 60)
+			msg += "[p_they(TRUE)] [p_have()] [damage < 30 ? "minor" : "moderate"] cellular damage.\n"
 		else
 			msg += "<B>[p_they(TRUE)] [p_have()] severe cellular damage.</B>\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -254,26 +254,32 @@
 	if(wound_flavor_text["r_foot"]&& (is_destroyed["right foot"] || (!shoes  && !skipshoes)))
 		msg += wound_flavor_text["r_foot"]
 
-	var/temp = getBruteLoss() //no need to calculate each of these twice
+	var/damage = getBruteLoss() //no need to calculate each of these twice
 
-	if(temp)
+	if(damage)
 		var/brute_message = !ismachineperson(src) ? "bruising" : "denting"
-		if(temp < 30)
-			msg += "[p_they(TRUE)] [p_have()] minor [brute_message ].\n"
+		if(damage < 30)
+			msg += "[p_they(TRUE)] [p_have()] minor [brute_message].\n"
+		else if(damage < 60)
+			msg += "[p_they(TRUE)] [p_have()] moderate [brute_message].\n"
 		else
-			msg += "<B>[p_they(TRUE)] [p_have()] severe [brute_message ]!</B>\n"
+			msg += "<B>[p_they(TRUE)] [p_have()] severe [brute_message]!</B>\n"
 
-	temp = getFireLoss()
-	if(temp)
-		if(temp < 30)
+	damage = getFireLoss()
+	if(damage)
+		if(damage < 30)
 			msg += "[p_they(TRUE)] [p_have()] minor burns.\n"
+		else if(damage < 60)
+			msg += "[p_they(TRUE)] [p_have()] moderate burns.\n"
 		else
 			msg += "<B>[p_they(TRUE)] [p_have()] severe burns!</B>\n"
 
-	temp = getCloneLoss()
-	if(temp)
-		if(temp < 30)
+	damage = getCloneLoss()
+	if(damage)
+		if(damage < 30)
 			msg += "[p_they(TRUE)] [p_have()] minor cellular damage.\n"
+		else if(damage < 60)
+			msg += "[p_they(TRUE)] [p_have()] moderate cellular damage.\n"
 		else
 			msg += "<B>[p_they(TRUE)] [p_have()] severe cellular damage.</B>\n"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds new examination text for Brute, Burn and Clone damage between 30 and 60 of each type.
(Not 100% sure about the term 'Moderate')

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The threshold for 'Severe' damage always seemed far too low to me, considering it only takes three toolbox hits to get there.
While in real life I'm sure being hit over the head with a loaded toolbox three times *would* be pretty severe, that sort of thing is a common occurance aboard the NSS Cyberiad.

Personally I think this is a pretty good compromise between leaving it as-is and just upping the 'severe' threshold. Right now it just jumps from 'Minor damage' to 'Severe damage' if you throw a screwdriver at someone.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
All three in action:
![hi](https://user-images.githubusercontent.com/57483089/99457719-52856480-2923-11eb-9c48-bbc7d59c98fb.PNG)


## Changelog
:cl:
add: Examining someone with between 30 and 60 damage now shows 'Moderate' damage rather than 'Severe'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
