### PR TITLE
Actually prevents swarmers from eating high-value targets

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -194,7 +194,7 @@
 
 /obj/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	if(resistance_flags & INDESTRUCTIBLE)
-		to_chat(S, "<span class='warning'>A hidden hostile subroutine prevents you from consuming [src]. Aborting.</span>")
+		to_chat(S, "<span class='warning'>High value materials detected, consuming [src] would waste them. Aborting.</span>")
 		return FALSE
 	for(var/mob/living/L in contents)
 		if(!issilicon(L) && !isbrain(L))

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -194,6 +194,7 @@
 
 /obj/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	if(resistance_flags & INDESTRUCTIBLE)
+		to_chat(S, "<span class='warning'>A hidden hostile subroutine prevents you from consuming [src]. Aborting.</span>")
 		return FALSE
 	for(var/mob/living/L in contents)
 		if(!issilicon(L) && !isbrain(L))
@@ -202,7 +203,9 @@
 	return ..()
 
 /obj/item/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
-	return S.Integrate(src)
+	if(..())
+		return S.Integrate(src)
+	return FALSE
 
 /atom/movable/proc/IntegrateAmount()
 	return 0

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -43,6 +43,7 @@
 	attack_verb = list("lunged at", "stabbed")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF // Theft targets should be hard to destroy
 
 /obj/item/melee/rapier/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Swarmers already had a check for preventing them from eating high-value items or other items flagged as indestructible, however, the parent call was missing. Also, this gives the captain's rapier the same resistance flags as all other high-value items.

Also adds an IC reason that swarmers can't eat high-value targets, eg: "High value materials detected, consuming captain's rapier would waste them. Aborting."

## Why It's Good For The Game
This is just a bug fix and bringing an item to parity with other high-value targets.

## Changelog
:cl:
fix: Fixes bug that allowed swarmers to eat high-value targets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
