### PR TITLE
Makes grass, flowers, and bushes easily destroyable

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -50,6 +50,7 @@
 	name = "grass"
 	icon = 'icons/obj/flora/snowflora.dmi'
 	anchored = 1
+	max_integrity = 15
 
 /obj/structure/flora/grass/brown
 	icon_state = "snowgrass1bb"
@@ -80,6 +81,7 @@
 	icon = 'icons/obj/flora/snowflora.dmi'
 	icon_state = "snowbush1"
 	anchored = 1
+	max_integrity = 15
 
 /obj/structure/flora/bush/New()
 	..()
@@ -92,6 +94,7 @@
 	icon = 'icons/obj/flora/ausflora.dmi'
 	icon_state = "firstbush_1"
 	anchored = 1
+	max_integrity = 15
 
 /obj/structure/flora/ausbushes/New()
 	..()


### PR DESCRIPTION
## What Does This PR Do
Reduces the object health of bushes, flowers, and grass to make it easier to destroy them.

## Why It's Good For The Game
The escape garden area is great for doing wire art however the grass and bushes there get in the way and take a _long_ time to destroy.

## Changelog
:cl:
tweak: reduced object health of grass, flowers, and bushes
/:cl: