### PR TITLE
Barricade creation fixes. Atmos runtimes and wood creation exploit fix

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -77,14 +77,16 @@
 /obj/structure/barricade/wooden/attackby(obj/item/I, mob/user)
 	if(istype(I,/obj/item/stack/sheet/wood))
 		var/obj/item/stack/sheet/wood/W = I
-		if(W.amount < 5)
+		if(W.get_amount() < 5)
 			to_chat(user, "<span class='warning'>You need at least five wooden planks to make a wall!</span>")
 			return
 		else
 			to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
 			if(do_after(user, 50, target = src))
-				W.use(5)
-				new /turf/simulated/wall/mineral/wood/nonmetal(get_turf(src))
+				if(!W.use(5))
+					return
+				var/turf/T = get_turf(src)
+				T.ChangeTurf(/turf/simulated/wall/mineral/wood/nonmetal)
 				qdel(src)
 				return
 	return ..()


### PR DESCRIPTION
## What Does This PR Do
Fixes #14925
Fixes an exploit where you could create unlimited wood by making wooden walls from barricades while you shouldn't have been able to.

## Why It's Good For The Game
Runtimes and exploits be gone

## Changelog
:cl:
fix: Creating a wooden wall from a barricade now won't break lighting and atmos
fix: Creating a wooden wall from a barricade now won't work if you don't have enough wood
/:cl: