### PR TITLE
Jani ERT implant rebalancing

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -471,6 +471,9 @@
 
 	r_hand = /obj/item/gun/energy/disabler
 
+	cybernetic_implants = list(
+		/obj/item/organ/internal/cyberimp/arm/advmop)
+
 /datum/outfit/job/centcom/response_team/janitorial/red
 	name = "RT Janitor (Red)"
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/janitor
@@ -480,7 +483,7 @@
 	l_pocket = /obj/item/gun/energy/gun/mini
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/arm/advmop,
+		/obj/item/organ/internal/cyberimp/arm/janitorial,
 		/obj/item/organ/internal/cyberimp/chest/nutriment
 	)
 


### PR DESCRIPTION
## What Does This PR Do
Gives Red alert jani ERTthe improved jani arm implant from https://github.com/ParadiseSS13/Paradise/pull/14348
Moves the mop implant to to the amber jani ERT

This may or may not need a Balance tag.

## Why It's Good For The Game
It's neat, useful, and a good QoL improvement for the rare clean up crew,

## Changelog
:cl:
tweak: Give red alert janitor ERT the improved janitor implant. Moves the mop implant to amber level ones
/:cl: