### PR TITLE
Stops explosions causing millions of runtimes

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -122,13 +122,13 @@
 							affecting_level = S.is_shielded() ? 2 : (S.intact ? 2 : 1)
 						for(var/atom in S.contents)	//bypass type checking since only atom can be contained by turfs anyway
 							var/atom/AM = atom
-							if(AM && AM.simulated)
+							if(!QDELETED(AM) && AM.simulated)
 								if(AM.level >= affecting_level)
 									AM.ex_act(dist)
 					else
 						for(var/atom in T.contents)	//see above
 							var/atom/AM = atom
-							if(AM && AM.simulated)
+							if(!QDELETED(AM) && AM.simulated)
 								AM.ex_act(dist)
 							CHECK_TICK
 					if(breach)


### PR DESCRIPTION
## What Does This PR Do
Stops explosions affecting GCed objects.
Objects that were destroyed while the explosion was in it's CHECK_TICK phase (AKA sleep on high load) were still considered when looping through them.
This PR checks if an atom is `QDELETED`. If so. Skip it

Test case:
Make about 5 breaches using the explosion on turf tool admins have in VV.
Spawn about 300 monkeys.
Run SDQL: CALL flicker() ON /obj/machinery/light

Make two bombs explode close to one another

## Why It's Good For The Game
Fixes a ton of runtimes related to explosions. Most notably the atmos pipenet one. `parent == null`

## Changelog
:cl:
fix: Deleted atoms are no longer affected by explosions
/:cl: