### PR TITLE
Makes Lavaland "Hostile" to Vampires

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -439,6 +439,14 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		check_sun()
 	if(istype(owner.loc.loc, /area/chapel) && !get_ability(/datum/vampire_passive/full))
 		vamp_burn(7)
+	if(istype(owner.loc.loc, /area/lavaland) && !get_ability(/datum/vampire_passive/full)) 
+		if(bloodtotal >= 160) //bloodtotal 160 allows for Cloak but NOT Rejuv+, which means you can get your stealth without getting antistun for the station prowling
+			to_chat(owner, "<span class='warning'>You feel your skin burning! You can feel the the presence of the Legion bearing down on you!</span>")
+			vamp_burn(7)
+		if(bloodtotal >= 100) //warning and hint that you shouldnt be out in lavaland hunting miners
+			to_chat(owner, "<span class='warning'>You feel your skin starting to grow warmer! Perhaps it is best that you take your hunting elsewhere...</span>")
+		else
+			to_chat(owner, "<span class='warning'>You feel a vibration on your skin, the gods of this place do no appreciate competitors...</span>")
 	nullified = max(0, nullified - 1)
 
 /datum/vampire/proc/handle_vampire_cloak()

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -442,10 +442,10 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	if(istype(get_area(owner), /area/lavaland)) 
 		if(bloodtotal >= 160) //bloodtotal 160 allows for Cloak but NOT Rejuv+, which means you can get your stealth without getting antistun for the station prowling
 			to_chat(owner, "<span class='warning'>You feel your skin burning! You can feel the the presence of the Necropolis bearing down on you!</span>")
-			vamp_burn(9)
+			vamp_lavaland(50)
 		else if(bloodtotal >= 100) //warning and hint that you shouldnt be out in lavaland hunting miners
 			to_chat(owner, "<span class='warning'>You feel your skin starting to grow warmer! Perhaps it is best that you take your hunting elsewhere...</span>")
-			vamp_burn(3)
+			vamp_lavaland(10)
 		else
 			to_chat(owner, "<span class='warning'>You feel a vibration on your skin, the gods of this place do no appreciate competitors...</span>")
 	nullified = max(0, nullified - 1)
@@ -469,6 +469,25 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		return 1
 	else
 		owner.alpha = round((255 * 0.80))
+
+/datum/vampire/proc/vamp_lavaland(burn_chance)
+	if(prob(burn_chance) && owner.health >= 50)
+		switch(owner.health)
+			if(75 to 100)
+				to_chat(owner, "<span class='warning'>Your skin flakes away...</span>")
+			if(50 to 75)
+				to_chat(owner, "<span class='warning'>Your skin sizzles!</span>")
+		owner.adjustFireLoss(3)
+	else if(owner.health < 50)
+		if(!owner.on_fire)
+			to_chat(owner, "<span class='danger'>Your skin catches fire!</span>")
+			owner.emote("scream")
+		else
+			to_chat(owner, "<span class='danger'>You continue to burn!</span>")
+		owner.adjustFireLoss(5)
+		owner.adjust_fire_stacks(5)
+		owner.IgniteMob()
+	return
 
 /datum/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.health >= 50)

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -439,12 +439,13 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		check_sun()
 	if(istype(owner.loc.loc, /area/chapel) && !get_ability(/datum/vampire_passive/full))
 		vamp_burn(7)
-	if(istype(owner.loc.loc, /area/lavaland) && !get_ability(/datum/vampire_passive/full)) 
+	if(istype(get_area(owner), /area/lavaland)) 
 		if(bloodtotal >= 160) //bloodtotal 160 allows for Cloak but NOT Rejuv+, which means you can get your stealth without getting antistun for the station prowling
-			to_chat(owner, "<span class='warning'>You feel your skin burning! You can feel the the presence of the Legion bearing down on you!</span>")
-			vamp_burn(7)
-		if(bloodtotal >= 100) //warning and hint that you shouldnt be out in lavaland hunting miners
+			to_chat(owner, "<span class='warning'>You feel your skin burning! You can feel the the presence of the Necropolis bearing down on you!</span>")
+			vamp_burn(9)
+		else if(bloodtotal >= 100) //warning and hint that you shouldnt be out in lavaland hunting miners
 			to_chat(owner, "<span class='warning'>You feel your skin starting to grow warmer! Perhaps it is best that you take your hunting elsewhere...</span>")
+			vamp_burn(3)
 		else
 			to_chat(owner, "<span class='warning'>You feel a vibration on your skin, the gods of this place do no appreciate competitors...</span>")
 	nullified = max(0, nullified - 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This change makes it so that Vampires with a certain bloodtotal cannot just farm miners for full power. I've made it so that there are 3 "tiers" of warnings for Vampires on Lavaland, so that you cant meta the job-change miner whos trying to avoid these effects. This effect ONLY procs while being on Lavaland proper, so the mining base/gulag are still safe.

0-99 Bloodtotal: You feel a vibration on your skin, the gods of this place do no appreciate competitors...
100-159 Bloodtotal: You feel your skin starting to grow warmer! Perhaps it is best that you take your hunting elsewhere...
10% burn chance on proc (its 3 burn per, not too harmful, but annoying enough)
160+ Bloodtotal: You feel your skin burning! You can feel the the presence of the Legion bearing down on you!
50% burn chance on proc (aka GTFO of Lavaland)
This last tier also practically acts as the Chapel, having a chance to burn you for ever proc you stand outside in Lavaland. ICly, I justify it as the Legion not liking other demonic-style entities feeding on its territory.

The "tiers" have somewhat of a justification. A miner Vamp SHOULD still be able to hunt maybe one of their coworkers, but making it so that if they full drain a fellow miner (~200 useable blood) while on Lavaland, theyll have to GTFO. They can still drain to 150+ which allows for them to get Cloak + Vision, which will help upon going back on station to prey on the Crew.

## Why It's Good For The Game
Miners getting farmed for blood is unfun and nobody likes it. Lavaland already kills you in some nasty and permanent ways, theres no reason that you should have to deal with someone walking up to you, glaring you, giving you the succ, then chasm-ing or tossing you deep into lava.

## Changelog
:cl:
add: adds warnings and a chapel-esque burn effect to vampires on Lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
