### PR TITLE
Cardiac arrest now also shows as crit on medHUD

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -71,11 +71,19 @@
 //HELPERS
 
 /// Whether the carbon mob is currently in crit.
+// Even though "crit" does not realistically happen for non-humans..
 /mob/living/carbon/proc/is_in_crit()
 	for(var/thing in viruses)
 		var/datum/disease/D = thing
 		if(istype(D, /datum/disease/critical))
 			return TRUE
+	return FALSE
+
+/mob/living/carbon/human/is_in_crit()
+	if(..())
+		return TRUE
+	if(undergoing_cardiac_arrest())
+		return TRUE
 	return FALSE
 
 /// Whether a virus worthy displaying on the HUD is present.


### PR DESCRIPTION
## What Does This PR Do
Quick followup to #14900 - stopped heart with no other crit "diseases" now also shows on medHUD as being a bad thing.

I *think* this is not a regression from #14900, and has been present since forever, but I also didn't investigate and may be mistaken.

## Why It's Good For The Game
Bugfix.

## Changelog
N/A. Let's pretend it happend in previous PR
