### PR TITLE
Removes meteor shot from crafting menu

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -151,17 +151,6 @@
 	subcategory = CAT_WEAPON
 	alert_admins_on_craft = TRUE
 
-/datum/crafting_recipe/meteorshot
-	name = "Meteorshot Shell"
-	result = /obj/item/ammo_casing/shotgun/meteorshot
-	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
-				/obj/item/rcd_ammo = 1,
-				/obj/item/stock_parts/manipulator = 2)
-	tools = list(TOOL_SCREWDRIVER)
-	time = 5
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-
 /datum/crafting_recipe/pulseslug
 	name = "Pulse Slug Shell"
 	result = /obj/item/ammo_casing/shotgun/pulseslug


### PR DESCRIPTION
## What Does This PR Do
As the name says, it removes meteor shot from the crafting menu. Do note that the shell itself still exists but crew can no longer normally get it.

Edit: an alternative PR has been made if people still want to keep the shells, however it would respect anchored objects now #14941

## Why It's Good For The Game
Meteor shot is able to move things that you _really_ shouldn't be moving or shouldn't be movable at all. Examples include, the gateway the grav gen, the vault door, the safe within, Lava land tendrils, shutter walls, and other things.

## Changelog
:cl:
del: Removed meteor shot from the crafting menu
/:cl: