### PR TITLE
Adds a notification in dchat when a player dies

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -49,10 +49,11 @@
 #define PREFTOGGLE_2_ANONDCHAT		16
 #define PREFTOGGLE_2_AFKWATCH		32
 #define PREFTOGGLE_2_RUNECHAT		64
+#define PREFTOGGLE_2_DEATHMESSAGE	128
 
-#define TOGGLES_2_TOTAL 			127 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
+#define TOGGLES_2_TOTAL 			255 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 
-#define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT)
+#define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_2_DEATHMESSAGE)
 
 // Sanity checks
 #if TOGGLES_TOTAL > 16777215

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -293,7 +293,7 @@
 /client/verb/toggle_ghost_pda()
 	set name = "Show/Hide GhostPDA"
 	set category = "Preferences"
-	set desc = ".Toggle seeing PDA messages as an observer."
+	set desc = "Toggle seeing PDA messages as an observer."
 	prefs.toggles ^= PREFTOGGLE_CHAT_GHOSTPDA
 	to_chat(src, "As a ghost, you will now [(prefs.toggles & PREFTOGGLE_CHAT_GHOSTPDA) ? "see all PDA messages" : "no longer see PDA messages"].")
 	prefs.save_preferences(src)
@@ -314,3 +314,11 @@
 	prefs.toggles2 ^= PREFTOGGLE_2_RUNECHAT
 	prefs.save_preferences(src)
 	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) ? "now see" : "no longer see"] floating chat messages.")
+
+/client/verb/toggle_death_messages()
+	set name = "Show/Hide Death Notifications"
+	set category = "Preferences"
+	set desc = "Toggle player death notifications"
+	prefs.toggles2 ^= PREFTOGGLE_2_DEATHMESSAGE
+	prefs.save_preferences(src)
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_DEATHMESSAGE) ? "now" : "no longer"] see a notification in deadchat when a player dies.")

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -93,10 +93,11 @@
 	if(mind)
 		if(mind.name && !isbrain(src)) // !isbrain() is to stop it from being called twice
 			var/turf/T = get_turf(src)
+			var/area_name = get_area_name(T)
 			for(var/P in GLOB.player_list)
 				var/mob/M = P
 				if((isobserver(M) || M.stat == DEAD) && (M.client.prefs.toggles2 & PREFTOGGLE_2_DEATHMESSAGE))
-					to_chat(M, "<span class='deadsay'><b>[mind.name]</b> has died at <b>[get_area_name(T)]</b>. (<a href='?src=[M.UID()];jump=\ref[src]'>JMP</a>)</span>")
+					to_chat(M, "<span class='deadsay'><b>[mind.name]</b> has died at <b>[area_name]</b>. (<a href='?src=[M.UID()];jump=\ref[src]'>JMP</a>)</span>")
 
 		mind.store_memory("Time of death: [station_time_timestamp("hh:mm:ss", timeofdeath)]", 0)
 		GLOB.respawnable_list += src

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -91,6 +91,13 @@
 	GLOB.alive_mob_list -= src
 	GLOB.dead_mob_list += src
 	if(mind)
+		if(mind.name && !isbrain(src)) // !isbrain() is to stop it from being called twice
+			var/turf/T = get_turf(src)
+			for(var/P in GLOB.player_list)
+				var/mob/M = P
+				if(isobserver(M) || M.stat == DEAD)
+					to_chat(M, "<span class='deadsay'><b>[mind.name]</b> has died at <b>[get_area_name(T)]</b>. (<a href='?src=[M.UID()];jump=\ref[src]'>JMP</a>)</span>")
+
 		mind.store_memory("Time of death: [station_time_timestamp("hh:mm:ss", timeofdeath)]", 0)
 		GLOB.respawnable_list += src
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -91,16 +91,16 @@
 	GLOB.alive_mob_list -= src
 	GLOB.dead_mob_list += src
 	if(mind)
+		mind.store_memory("Time of death: [station_time_timestamp("hh:mm:ss", timeofdeath)]", 0)
+		GLOB.respawnable_list += src
+
 		if(mind.name && !isbrain(src)) // !isbrain() is to stop it from being called twice
 			var/turf/T = get_turf(src)
 			var/area_name = get_area_name(T)
-			for(var/P in GLOB.player_list)
+			for(var/P in GLOB.dead_mob_list)
 				var/mob/M = P
-				if((isobserver(M) || M.stat == DEAD) && (M.client.prefs.toggles2 & PREFTOGGLE_2_DEATHMESSAGE))
+				if((M.client?.prefs.toggles2 & PREFTOGGLE_2_DEATHMESSAGE) && (isobserver(M) || M.stat == DEAD))
 					to_chat(M, "<span class='deadsay'><b>[mind.name]</b> has died at <b>[area_name]</b>. (<a href='?src=[M.UID()];jump=\ref[src]'>JMP</a>)</span>")
-
-		mind.store_memory("Time of death: [station_time_timestamp("hh:mm:ss", timeofdeath)]", 0)
-		GLOB.respawnable_list += src
 
 	if(SSticker && SSticker.mode)
 		SSticker.mode.check_win()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -95,7 +95,7 @@
 			var/turf/T = get_turf(src)
 			for(var/P in GLOB.player_list)
 				var/mob/M = P
-				if(isobserver(M) || M.stat == DEAD)
+				if((isobserver(M) || M.stat == DEAD) && (M.client.prefs.toggles2 & PREFTOGGLE_2_DEATHMESSAGE))
 					to_chat(M, "<span class='deadsay'><b>[mind.name]</b> has died at <b>[get_area_name(T)]</b>. (<a href='?src=[M.UID()];jump=\ref[src]'>JMP</a>)</span>")
 
 		mind.store_memory("Time of death: [station_time_timestamp("hh:mm:ss", timeofdeath)]", 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Shows a message to observers whenever someone dies, showing their name and location as well as a `(JMP)` jump button.
This is enabled by default, but can be disabled with the `Show/Hide Death Notifications` setting in the Preferences tab.

Also fixed a small typo in the `Show/Hide GhostPDA` setting.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Provides a more interesting experience for observers.
*(Probably more when I'm not so tired)*

If someone doesn't want the messages for any reason, then there's a preferences toggle to disable it.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![death message](https://user-images.githubusercontent.com/57483089/99733998-f6a11400-2ab9-11eb-994b-3bfef485bfb1.PNG)

## Changelog
:cl:
add: A player dying will now display a message in dchat with their name and location. (Enabled by default, this can be disabled with 'Show/Hide Death Notifications')
spellcheck: Removed a '.' in the 'Ghost PDA' setting toggle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
