### PR TITLE
Reverts 'Sling thralling now respects mindshields'

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -236,9 +236,6 @@
 	if(!(ling.mind in SSticker.mode.shadows))
 		return
 	var/mob/living/carbon/human/target = targets[1]
-	if(ismindshielded(target))
-		to_chat(user, "<span class='danger'>This target has a mindshield, blocking your powers! You cannot thrall it!</span>")
-		return
 	enthralling = TRUE
 	to_chat(user, "<span class='danger'>This target is valid. You begin the enthralling.</span>")
 	to_chat(target, "<span class='userdanger'>[user] stares at you. You feel your head begin to pulse.</span>")
@@ -253,11 +250,23 @@
 				user.visible_message("<span class='warning'>[user]'s palms flare a bright red against [target]'s temples!</span>")
 				to_chat(target, "<span class='danger'>A terrible red light floods your mind. You collapse as conscious thought is wiped away.</span>")
 				target.Weaken(12)
+				sleep(20)
+				if(ismindshielded(target))
+					to_chat(user, "<span class='notice'>They have a mindshield implant. You begin to deactivate it - this will take some time.</span>")
+					user.visible_message("<span class='warning'>[user] pauses, then dips [user.p_their()] head in concentration!</span>")
+					to_chat(target, "<span class='boldannounce'>Your mindshield implant becomes hot as it comes under attack!</span>")
+					sleep(100) //10 seconds - not spawn() so the enthralling takes longer
+					to_chat(user, "<span class='notice'>The nanobots composing the mindshield implant have been rendered inert. Now to continue.</span>")
+					user.visible_message("<span class='warning'>[user] relaxes again.</span>")
+					for(var/obj/item/implant/mindshield/L in target)
+						if(L && L.implanted)
+							qdel(L)
+					to_chat(target, "<span class='boldannounce'>Your mental protection implant unexpectedly falters, dims, dies.</span>")
 			if(3)
 				to_chat(user, "<span class='notice'>You begin planting the tumor that will control the new thrall...</span>")
 				user.visible_message("<span class='warning'>A strange energy passes from [user]'s hands into [target]'s head!</span>")
 				to_chat(target, "<span class='boldannounce'>You feel your memories twisting, morphing. A sense of horror dominates your mind.</span>")
-		if(!do_mob(user, target, 7.7 SECONDS)) //around 23 seconds total for enthralling
+		if(!do_mob(user, target, 70)) //around 21 seconds total for enthralling, 31 for someone with a mindshield implant
 			to_chat(user, "<span class='warning'>The enthralling has been interrupted - your target's mind returns to its previous state.</span>")
 			to_chat(target, "<span class='userdanger'>You wrest yourself away from [user]'s hands and compose yourself</span>")
 			enthralling = FALSE


### PR DESCRIPTION
## What Does This PR Do
Reverts everything in #14521

## Why It's Good For The Game
I hate shadowlings with a passion, I believe they're the second-worst gamemode after roundstart blobs, but this change made them horrible.
Shadowlings have a lot of problems, but the biggest one being that it's a snowball gamemode, where if one side has the upperhand, it's unlikely the other side will ever recover. You could usually see this when most shadowlings died, they would almost never catch up, this also happened when security were the first ones getting thralled.
This change, however, almost never win, as the shadowlings now couldn't convert the department that is actually expected to step into maintenance in the gamemode, making this even more TDM.
I am not happy with thralling security either, but this change works for now, without needing to make a full rework of shadowlings on the entirety.

## Changelog
:cl:
tweak: Shadowlings can thrall mindshielded personnel again.
/:cl: