### PR TITLE
Refactors renaming things with a pen.

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -237,12 +237,7 @@ Thus, the two variables affect pump operation are set in New():
 
 /obj/machinery/atmospherics/binary/pump/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/pen))
-		var/t = copytext(stripped_input(user, "Enter the name for the pump.", "Rename", name), 1, MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		name = t
+		rename_interactive(user, W)
 		return
 	else if(!istype(W, /obj/item/wrench))
 		return ..()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -234,12 +234,7 @@ Thus, the two variables affect pump operation are set in New():
 
 /obj/machinery/atmospherics/binary/volume_pump/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/pen))
-		var/t = copytext(stripped_input(user, "Enter the name for the volume pump.", "Rename", name), 1, MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		name = t
+		rename_interactive(user, W)
 		return
 	else if(!istype(W, /obj/item/wrench))
 		return ..()

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -255,12 +255,7 @@
 
 /obj/machinery/atmospherics/trinary/filter/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/pen))
-		var/t = copytext(stripped_input(user, "Enter the name for the filter.", "Rename", name), 1, MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		name = t
+		rename_interactive(user, W)
 		return
 	else
 		return ..()

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -222,12 +222,7 @@
 
 /obj/machinery/atmospherics/trinary/mixer/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/pen))
-		var/t = copytext(stripped_input(user, "Enter the name for the mixer.", "Rename", name), 1, MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		name = t
+		rename_interactive(user, W)
 		return
 	else
 		return ..()

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -36,27 +36,27 @@
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(attempt_harvest(I, user))
-		return 1
+		return TRUE
 	return I.attack(src, user)
 
 /obj/item/proc/attack(mob/living/M, mob/living/user, def_zone)
 	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user)
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, user)
 	if(flags & (NOBLUDGEON))
-		return 0
+		return FALSE
 	if(can_operate(M))  //Checks if mob is lying down on table for surgery
 		if(istype(src,/obj/item/robot_parts))//popup override for direct attach
 			if(!attempt_initiate_surgery(src, M, user,1))
-				return 0
+				return FALSE
 			else
-				return 1
+				return TRUE
 		if(istype(src,/obj/item/organ/external))
 			var/obj/item/organ/external/E = src
 			if(E.is_robotic()) // Robot limbs are less messy to attach
 				if(!attempt_initiate_surgery(src, M, user,1))
-					return 0
+					return FALSE
 				else
-					return 1
+					return TRUE
 		var/obj/item/organ/external/O = M.get_organ(user.zone_selected)
 		if((is_sharp(src) || (isscrewdriver(src) && O?.is_robotic())) && user.a_intent == INTENT_HELP)
 			if(!attempt_initiate_surgery(src, M, user))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1000,6 +1000,9 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		prompt = "What would you like the label on [src] to be?"
 
 	var/t = input(user, prompt, "Renaming [src]", default_value)  as text | null
+	if(isnull(t))
+		// user pressed Cancel
+		return null
 
 	// Things could have changed between when `input` is called and when it returns.
 	if(!user)
@@ -1014,9 +1017,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		to_chat(user, "<span class='warning'>You cannot rename [src] in your current state.</span>")
 		return null
 
-	if(isnull(t))
-		// user pressed Cancel
-		return null
+
 	t = sanitize(copytext(t, 1, MAX_NAME_LEN))
 	if(actually_rename)
 		if(t == "")

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -27,16 +27,17 @@
 
 /obj/structure/closet/body_bag/attackby(W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/pen))
-		rename_interactive(user, W)
-		if(name == initial(name))
-			src.overlays.Cut()
-		else
-			src.overlays += image(src.icon, "bodybag_label")
+		var/t = rename_interactive(user, W)
+		if(isnull(t))
+			return
+		cut_overlays()
+		if(t)
+			add_overlay(image(icon, "bodybag_label"))
 		return
 	if(istype(W, /obj/item/wirecutters))
 		to_chat(user, "You cut the tag off the bodybag")
-		src.name = "body bag"
-		src.overlays.Cut()
+		name = "body bag"
+		cut_overlays()
 		return
 	return ..()
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -27,18 +27,11 @@
 
 /obj/structure/closet/body_bag/attackby(W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
-		if(user.get_active_hand() != W)
-			return
-		if(!in_range(src, user) && src.loc != user)
-			return
-		t = sanitize(copytext(t,1,MAX_MESSAGE_LEN))
-		if(t)
-			src.name = "body bag - "
-			src.name += t
-			src.overlays += image(src.icon, "bodybag_label")
+		rename_interactive(user, W)
+		if(name == initial(name))
+			src.overlays.Cut()
 		else
-			src.name = "body bag"
+			src.overlays += image(src.icon, "bodybag_label")
 		return
 	if(istype(W, /obj/item/wirecutters))
 		to_chat(user, "You cut the tag off the bodybag")

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -309,12 +309,7 @@
 			to_chat(user, "<span class='notice'>You wound the tape back in!</span>")
 			fix()
 	else if(istype(I, /obj/item/pen))
-		var/title = stripped_input(usr,"What do you want to name the tape?", "Tape Renaming", name, MAX_NAME_LEN)
-		if(!title || !length(title))
-			name = initial(name)
-			return
-		name = "tape - [title]"
-
+		rename_interactive(user, I)
 
 //Random colour tapes
 /obj/item/tape/random/New()

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -29,15 +29,7 @@
 /obj/item/implantcase/attackby(obj/item/W, mob/user, params)
 	..()
 	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "What would you like the label to be?", name, null)
-		if(user.get_active_hand() != W)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		if(t)
-			name = "implant case - '[t]'"
-		else
-			name = "implant case"
+		rename_interactive(user, W)
 	else if(istype(W, /obj/item/implanter))
 		var/obj/item/implanter/I = W
 		if(I.imp)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -43,15 +43,7 @@
 /obj/item/implanter/attackby(obj/item/W, mob/user, params)
 	..()
 	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "What would you like the label to be?", name, null)
-		if(user.get_active_hand() != W)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		if(t)
-			name = "implanter ([t])"
-		else
-			name = "implanter"
+		rename_interactive(user, W)
 
 /obj/item/implanter/New()
 	..()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -318,21 +318,9 @@
 
 /obj/item/storage/pill_bottle/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/pen) || istype(I, /obj/item/flashlight/pen))
-		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
-		if(length(tmp_label) > MAX_NAME_LEN)
-			to_chat(user, "<span class='warning'>The label can be at most [MAX_NAME_LEN] characters long.</span>")
-		else
-			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
-			label_text = tmp_label
-			update_name_label()
+		rename_interactive(user, I)
 	else
 		return ..()
-
-/obj/item/storage/pill_bottle/proc/update_name_label()
-	if(label_text == "")
-		name = base_name
-	else
-		name = "[base_name] ([label_text])"
 
 /obj/item/storage/pill_bottle/patch_pack
 	name = "Patch Pack"

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -55,12 +55,11 @@
 
 /obj/structure/door_assembly/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/pen))
-		var/t = copytext(stripped_input(user, "Enter the name for the door.", name, created_name),1,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		created_name = t
+		// The door assembly gets renamed to "Assembly - Foobar",
+		// but the `t` returned from the proc is just "Foobar" without the prefix.
+		var/t = rename_interactive(user, W, freeform = FALSE)
+		if(!isnull(t))
+			created_name = t
 		return
 
 	else if(iscoil(W) && state == AIRLOCK_ASSEMBLY_NEEDS_WIRES && anchored)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -57,7 +57,7 @@
 	if(istype(W, /obj/item/pen))
 		// The door assembly gets renamed to "Assembly - Foobar",
 		// but the `t` returned from the proc is just "Foobar" without the prefix.
-		var/t = rename_interactive(user, W, freeform = FALSE)
+		var/t = rename_interactive(user, W)
 		if(!isnull(t))
 			created_name = t
 		return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -125,17 +125,10 @@
 
 /obj/structure/morgue/attackby(P as obj, mob/user as mob, params)
 	if(istype(P, /obj/item/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", name), null)  as text
-		if(user.get_active_hand() != P)
-			return
-		if((!in_range(src, usr) && loc != user))
-			return
-		t = sanitize(copytext(t,1,MAX_MESSAGE_LEN))
-		if(t)
-			name = text("Morgue- '[]'", t)
+		rename_interactive(user, P)
+		if(name != initial(name))
 			overlays += image(icon, "morgue_label")
 		else
-			name = "Morgue"
 			overlays.Cut()
 		add_fingerprint(user)
 		return
@@ -325,16 +318,7 @@
 
 /obj/structure/crematorium/attackby(P as obj, mob/user as mob, params)
 	if(istype(P, /obj/item/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", name), null)  as text
-		if(user.get_active_hand() != P)
-			return
-		if((!in_range(src, usr) > 1 && loc != user))
-			return
-		t = sanitize(copytext(t,1,MAX_MESSAGE_LEN))
-		if(t)
-			name = text("Crematorium- '[]'", t)
-		else
-			name = "Crematorium"
+		rename_interactive(user, P)
 		add_fingerprint(user)
 		return
 	return ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -125,11 +125,12 @@
 
 /obj/structure/morgue/attackby(P as obj, mob/user as mob, params)
 	if(istype(P, /obj/item/pen))
-		rename_interactive(user, P)
-		if(name != initial(name))
-			overlays += image(icon, "morgue_label")
-		else
-			overlays.Cut()
+		var/t = rename_interactive(user, P)
+		if(isnull(t))
+			return
+		cut_overlays()
+		if(t)
+			add_overlay(image(icon, "morgue_label"))
 		add_fingerprint(user)
 		return
 	return ..()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -148,12 +148,9 @@
 					W.forceMove(loc)
 
 			else if(istype(W, /obj/item/pen))
-				var/t = stripped_input(user, "Enter the name for the door.", name, created_name,MAX_NAME_LEN)
-				if(!t)
-					return
-				if(!in_range(src, usr) && loc != usr)
-					return
-				created_name = t
+				var/t = rename_interactive(user, W)
+				if(!isnull(t))
+					created_name = t
 				return
 			else
 				return ..()

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -83,9 +83,7 @@
 
 /obj/item/reagent_containers/food/snacks/attackby(obj/item/W, mob/user, params)
 	if(istype(W,/obj/item/pen))
-		var/n_name = sanitize(copytext(input(usr, "What would you like to name this dish?", "Food Renaming", null)  as text, 1, MAX_NAME_LEN))
-		if((loc == usr && usr.stat == 0))
-			name = "[n_name]"
+		rename_interactive(user, W, freeform = TRUE, prompt = "What would you like to name this dish?")
 		return
 	if(istype(W,/obj/item/storage))
 		..() // -> item/attackby(, params)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -83,7 +83,7 @@
 
 /obj/item/reagent_containers/food/snacks/attackby(obj/item/W, mob/user, params)
 	if(istype(W,/obj/item/pen))
-		rename_interactive(user, W, freeform = TRUE, prompt = "What would you like to name this dish?")
+		rename_interactive(user, W, use_prefix = FALSE, prompt = "What would you like to name this dish?")
 		return
 	if(istype(W,/obj/item/storage))
 		..() // -> item/attackby(, params)

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -283,10 +283,9 @@
 		if(P.name != "Blank Card")
 			to_chat(user,"<span class='notice'>You cannot write on that card.</span>")
 			return
-		var/cardtext = sanitize(input(user, "What do you wish to write on the card?", "Card Editing") as text|null, MAX_PAPER_MESSAGE_LEN)
-		if(!cardtext)
-			return
-		P.name = cardtext
+		var/t = rename_interactive(user, P, freeform = TRUE, actually_rename = FALSE)
+		if(t && P.name == "Blank Card")
+			P.name = t
 		// SNOWFLAKE FOR CAG, REMOVE IF OTHER CARDS ARE ADDED THAT USE THIS.
 		P.card_icon = "cag_white_card"
 		update_icon()

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -283,7 +283,7 @@
 		if(P.name != "Blank Card")
 			to_chat(user,"<span class='notice'>You cannot write on that card.</span>")
 			return
-		var/t = rename_interactive(user, P, freeform = TRUE, actually_rename = FALSE)
+		var/t = rename_interactive(user, P, use_prefix = FALSE, actually_rename = FALSE)
 		if(t && P.name == "Blank Card")
 			P.name = t
 		// SNOWFLAKE FOR CAG, REMOVE IF OTHER CARDS ARE ADDED THAT USE THIS.

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -458,15 +458,7 @@
 /obj/item/disk/plantgene/attackby(obj/item/W, mob/user, params)
 	..()
 	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "What would you like the label to be?", name, null)
-		if(user.get_active_hand() != W)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		if(t)
-			name = "plant data disk - '[t]'"
-		else
-			name = "plant data disk"
+		rename_interactive(user, W)
 
 /obj/item/disk/plantgene/proc/update_name()
 	if(gene)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -33,13 +33,13 @@
 
 /obj/structure/bookcase/attackby(obj/item/O as obj, mob/user as mob, params)
 	if(busy) //So that you can't mess with it while deconstructing
-		return 1
+		return TRUE
 	if(is_type_in_list(O, allowed_books))
 		if(!user.drop_item())
 			return
 		O.forceMove(src)
 		update_icon()
-		return 1
+		return TRUE
 	else if(istype(O, /obj/item/storage/bag/books))
 		var/obj/item/storage/bag/books/B = O
 		for(var/obj/item/T in B.contents)
@@ -47,28 +47,26 @@
 				B.remove_from_storage(T, src)
 		to_chat(user, "<span class='notice'>You empty [O] into [src].</span>")
 		update_icon()
-		return 1
+		return TRUE
 	else if(istype(O, /obj/item/wrench))
 		user.visible_message("<span class='warning'>[user] starts disassembling \the [src].</span>", \
 		"<span class='notice'>You start disassembling \the [src].</span>")
 		playsound(get_turf(src), O.usesound, 50, 1)
-		busy = 1
+		busy = TRUE
 
 		if(do_after(user, 50 * O.toolspeed, target = src))
 			playsound(get_turf(src), O.usesound, 75, 1)
 			user.visible_message("<span class='warning'>[user] disassembles \the [src].</span>", \
 			"<span class='notice'>You disassemble \the [src].</span>")
-			busy = 0
+			busy = FALSE
 			density = 0
 			deconstruct(TRUE)
 		else
-			busy = 0
-		return 1
+			busy = FALSE
+		return TRUE
 	else if(istype(O, /obj/item/pen))
-		var/newname = stripped_input(user, "What would you like to title this [name]?")
-		if(newname)
-			name = ("bookcase ([sanitize(newname)])")
-		return 1
+		rename_interactive(user, O)
+		return TRUE
 	else
 		return ..()
 

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -29,13 +29,10 @@
 		qdel(src)
 
 	else if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		created_name = t
-		log_game("[key_name(user)] has renamed a robot to [t]")
+		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
+		if(!isnull(t))
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
 
 //Edbot Assembly
 
@@ -53,13 +50,10 @@
 	..()
 
 	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		created_name = t
-		log_game("[key_name(user)] has renamed a robot to [t]")
+		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
+		if(!isnull(t))
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
 		return
 
 	switch(build_step)
@@ -277,14 +271,10 @@
 		qdel(src)
 
 	else if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-
-		created_name = t
-		log_game("[key_name(user)] has renamed a robot to [t]")
+		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
+		if(!isnull(t))
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
 
 /obj/item/toolbox_tiles/sensor/attackby(obj/item/W, mob/user, params)
 	..()
@@ -297,14 +287,10 @@
 		user.unEquip(src, 1)
 		qdel(src)
 	else if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-
-		created_name = t
-		log_game("[key_name(user)] has renamed a robot to [t]")
+		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
+		if(!isnull(t))
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
 
 //Medbot Assembly
 /obj/item/storage/firstaid/attackby(obj/item/I, mob/user, params)
@@ -369,13 +355,10 @@
 /obj/item/firstaid_arm_assembly/attackby(obj/item/I, mob/user, params)
 	..()
 	if(istype(I, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name, MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		created_name = t
-		log_game("[key_name(user)] has renamed a robot to [t]")
+		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
+		if(!isnull(t))
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
 	else
 		switch(build_step)
 			if(0)
@@ -481,13 +464,10 @@
 		qdel(src)
 
 	else if(istype(I, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		created_name = t
-		log_game("[key_name(user)] has renamed a robot to [t]")
+		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
+		if(!isnull(t))
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
 
 	else if(istype(I, /obj/item/screwdriver))
 		if(!build_step)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -42,13 +42,7 @@
 		to_chat(user, "<span class='notice'>You put the [W] into \the [src].</span>")
 		update_icon()
 	else if(istype(W, /obj/item/pen))
-		var/n_name = clean_input("What would you like to label the folder?", "Folder Labelling", null)
-		if(!n_name)
-			return
-		n_name = sanitize(copytext(n_name, 1, MAX_NAME_LEN))
-
-		if((loc == usr || Adjacent(usr)) && usr.stat == 0)
-			name = "folder[(n_name ? text("- '[n_name]'") : null)]"
+		rename_interactive(user, W)
 	else
 		return ..()
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -103,11 +103,13 @@
 	if(!usr.is_literate())
 		to_chat(usr, "<span class='notice'>You don't know how to read.</span>")
 		return
-	var/n_name = sanitize(copytext(input(usr, "What would you like to label the paper?", "Paper Labelling", name) as text, 1, MAX_MESSAGE_LEN))
-	if((loc == usr && usr.stat == 0))
-		name = "[(n_name ? text("[n_name]") : initial(name))]"
-	if(name != "paper")
+	var/n_name = rename_interactive(usr)
+	if(isnull(n_name))
+		return
+	if(n_name != "")
 		desc = "This is a paper titled '" + name + "'."
+	else
+		desc = initial(desc)
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -64,7 +64,7 @@
 	var/pen_color_iconstate = "pencolor"
 	var/pen_color_shift = 3
 
-/obj/item/pen/multi/New()
+/obj/item/pen/multi/Initialize(mapload)
 	..()
 	update_icon()
 
@@ -104,21 +104,6 @@
 	icon_state = "fountainpen"
 	pen_color_shift = 0
 
-/obj/item/pen/attack(mob/living/M, mob/user)
-	if(!istype(M))
-		return
-
-	if(!force)
-		if(M.can_inject(user, TRUE))
-			to_chat(user, "<span class='warning'>You stab [M] with the pen.</span>")
-//			to_chat(M, "<span class='danger'>You feel a tiny prick!</span>")
-			. = 1
-
-		add_attack_logs(user, M, "Stabbed with [src]")
-
-	else
-		. = ..()
-
 /*
  * Sleepypens
  */
@@ -128,15 +113,24 @@
 
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
-	if(!istype(M))	return
+	if(!istype(M))
+		return
 
-	if(..())
-		if(reagents.total_volume)
-			if(M.reagents)
-				reagents.trans_to(M, 50)
+	if(!..())
+		return
+
+	if(!M.can_inject(user, TRUE))
+		return
+	var/transfered = 0
+	if(reagents.total_volume && M.reagents)
+		transfered = reagents.trans_to(M, 50)
+	to_chat(user, "<span class='warning'>You sneakily stab [M] with the pen.</span>")
+	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered.")
+	return TRUE
 
 
-/obj/item/pen/sleepy/New()
+
+/obj/item/pen/sleepy/Initialize(mapload)
 	create_reagents(100)
 	reagents.add_reagent("ketamine", 100)
 	..()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -129,11 +129,10 @@
 	return TRUE
 
 
-
 /obj/item/pen/sleepy/Initialize(mapload)
+	return ..()
 	create_reagents(100)
 	reagents.add_reagent("ketamine", 100)
-	..()
 
 
 /*

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -130,7 +130,7 @@
 
 
 /obj/item/pen/sleepy/Initialize(mapload)
-	return ..()
+	. = ..()
 	create_reagents(100)
 	reagents.add_reagent("ketamine", 100)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -318,9 +318,9 @@
 
 	if(unique_rename)
 		if(istype(I, /obj/item/pen))
-			var/t = rename_interactive(user, I, freeform = TRUE)
+			var/t = rename_interactive(user, I, use_prefix = FALSE)
 			if(!isnull(t))
-				to_chat(user, "You name the gun [name]. Say hello to your new friend.")
+				to_chat(user, "<span class='notice'>You name the gun [name]. Say hello to your new friend.</span>")
 	if(istype(I, /obj/item/kitchen/knife))
 		var/obj/item/kitchen/knife/K = I
 		if(!can_bayonet || !K.bayonet || bayonet) //ensure the gun has an attachment point available, and that the knife is compatible with it.

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -39,8 +39,8 @@
 	var/spread = 0
 	var/randomspread = 1
 
-	var/unique_rename = 0 //allows renaming with a pen
-	var/unique_reskin = 0 //allows one-time reskinning
+	var/unique_rename = TRUE //allows renaming with a pen
+	var/unique_reskin = TRUE //allows one-time reskinning
 	var/current_skin = null //the skin choice if we had a reskin
 	var/list/options = list()
 
@@ -318,7 +318,9 @@
 
 	if(unique_rename)
 		if(istype(I, /obj/item/pen))
-			rename_gun(user)
+			var/t = rename_interactive(user, I, freeform = TRUE)
+			if(!isnull(t))
+				to_chat(user, "You name the gun [name]. Say hello to your new friend.")
 	if(istype(I, /obj/item/kitchen/knife))
 		var/obj/item/kitchen/knife/K = I
 		if(!can_bayonet || !K.bayonet || bayonet) //ensure the gun has an attachment point available, and that the knife is compatible with it.
@@ -426,13 +428,6 @@
 		current_skin = options[choice]
 		to_chat(M, "Your gun is now skinned as [choice]. Say hello to your new friend.")
 		update_icon()
-
-/obj/item/gun/proc/rename_gun(mob/M)
-	var/input = stripped_input(M,"What do you want to name the gun?", ,"", MAX_NAME_LEN)
-	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
-		name = input
-		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
-		return
 
 /obj/item/gun/proc/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params)
 	if(!ishuman(user) || !ishuman(target))

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -89,7 +89,7 @@
 
 /obj/item/gun/projectile/revolver/detective
 	desc = "A cheap Martian knock-off of a classic law enforcement firearm. Uses .38-special rounds."
-	name = "\improper .38 Mars Special"
+	name = ".38 Mars Special"
 	icon_state = "detective"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	unique_rename = 1

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -107,21 +107,11 @@
 
 /obj/item/reagent_containers/glass/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/pen) || istype(I, /obj/item/flashlight/pen))
-		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
-		if(length(tmp_label) > MAX_NAME_LEN)
-			to_chat(user, "<span class='warning'>The label can be at most [MAX_NAME_LEN] characters long.</span>")
-		else
-			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
-			label_text = tmp_label
-			update_name_label()
+		var/t = rename_interactive(user, I)
+		if(!isnull(t))
+			label_text = t
 	else
 		return ..()
-
-/obj/item/reagent_containers/glass/proc/update_name_label()
-	if(label_text == "")
-		name = base_name
-	else
-		name = "[base_name] ([label_text])"
 
 /obj/item/reagent_containers/glass/beaker
 	name = "beaker"

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -159,7 +159,7 @@
 	list_reagents = list("salglu_solution" = 200)
 
 /obj/item/reagent_containers/iv_bag/salglu/Initialize(mapload)
-	..()
+	. = ..()
 	name = "[initial(name)] - Saline Glucose"
 
 /obj/item/reagent_containers/iv_bag/blood // Don't use this - just an abstract type to allow blood bags to have a common blood_type var for ease of creation.
@@ -167,7 +167,7 @@
 	amount_per_transfer_from_this = 5 // Bloodbags are set to transfer 5 units by default.
 
 /obj/item/reagent_containers/iv_bag/blood/Initialize(mapload)
-	..()
+	. = ..()
 	if(blood_type != null)
 		name = "[initial(name)] - [blood_type]"
 		reagents.add_reagent("blood", 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
@@ -176,7 +176,7 @@
 
 /obj/item/reagent_containers/iv_bag/blood/random/Initialize()
 	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-")
-	..()
+	return ..()
 
 /obj/item/reagent_containers/iv_bag/blood/APlus
 	blood_type = "A+"
@@ -200,5 +200,5 @@
 	list_reagents = list("slimejelly" = 200)
 
 /obj/item/reagent_containers/iv_bag/salglu/Initialize(mapload)
-	..()
+	. = ..()
 	name = "[initial(name)] - Slime Jelly"

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -199,6 +199,6 @@
 /obj/item/reagent_containers/iv_bag/slime
 	list_reagents = list("slimejelly" = 200)
 
-/obj/item/reagent_containers/iv_bag/salglu/Initialize(mapload)
+/obj/item/reagent_containers/iv_bag/slime/Initialize(mapload)
 	. = ..()
 	name = "[initial(name)] - Slime Jelly"

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -149,37 +149,32 @@
 			if(IV_INJECT)
 				overlays += "inject"
 
-/obj/item/reagent_containers/iv_bag/proc/set_label(new_label)
-	name = "[initial(name)] ([new_label])"
-
 /obj/item/reagent_containers/iv_bag/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/pen) || istype(I, /obj/item/flashlight/pen))
-		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
-		if(length(tmp_label) > MAX_NAME_LEN)
-			to_chat(user, "<span class='warning'>The label can be at most [MAX_NAME_LEN] characters long.</span>")
-		else
-			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
-			set_label(tmp_label)
+		rename_interactive(user, I)
 
 // PRE-FILLED IV BAGS BELOW
 
 /obj/item/reagent_containers/iv_bag/salglu
-	name = "\improper IV Bag (Saline Glucose)"
 	list_reagents = list("salglu_solution" = 200)
+
+/obj/item/reagent_containers/iv_bag/salglu/Initialize(mapload)
+	..()
+	name = "[initial(name)] - Saline Glucose"
 
 /obj/item/reagent_containers/iv_bag/blood // Don't use this - just an abstract type to allow blood bags to have a common blood_type var for ease of creation.
 	var/blood_type
 	amount_per_transfer_from_this = 5 // Bloodbags are set to transfer 5 units by default.
 
-/obj/item/reagent_containers/iv_bag/blood/New()
+/obj/item/reagent_containers/iv_bag/blood/Initialize(mapload)
 	..()
 	if(blood_type != null)
-		set_label(blood_type)
+		name = "[initial(name)] - [blood_type]"
 		reagents.add_reagent("blood", 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
 		update_icon()
 
 
-/obj/item/reagent_containers/iv_bag/blood/random/New()
+/obj/item/reagent_containers/iv_bag/blood/random/Initialize()
 	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-")
 	..()
 
@@ -202,5 +197,8 @@
 	blood_type = "O-"
 
 /obj/item/reagent_containers/iv_bag/slime
-	name = "\improper IV Bag (Slime Jelly)"
 	list_reagents = list("slimejelly" = 200)
+
+/obj/item/reagent_containers/iv_bag/salglu/Initialize(mapload)
+	..()
+	name = "[initial(name)] - Slime Jelly"

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -56,12 +56,7 @@
 			playsound(loc, 'sound/items/poster_ripped.ogg', 50, 1)
 
 	else if(istype(W, /obj/item/pen))
-		var/str = copytext(sanitize(input(user,"Label text?","Set label","")),1,MAX_NAME_LEN)
-		if(!str || !length(str))
-			to_chat(user, "<span class='notice'>Invalid text.</span>")
-			return
-		user.visible_message("<span class='notice'>[user] labels [src] as [str].</span>")
-		name = "[name] ([str])"
+		rename_interactive(user, W)
 
 	else if(istype(W, /obj/item/stack/wrapping_paper) && !giftwrapped)
 		var/obj/item/stack/wrapping_paper/WP = W
@@ -132,12 +127,7 @@
 			playsound(loc, 'sound/items/poster_ripped.ogg', 50, 1)
 
 	else if(istype(W, /obj/item/pen))
-		var/str = copytext(sanitize(input(user,"Label text?","Set label","")),1,MAX_NAME_LEN)
-		if(!str || !length(str))
-			to_chat(user, "<span class='notice'>Invalid text.</span>")
-			return
-		user.visible_message("<span class='notice'>[user] labels [src] as [str].</span>")
-		name = "[name] ([str])"
+		rename_interactive(user, W)
 
 	else if(istype(W, /obj/item/stack/wrapping_paper) && !giftwrapped)
 		var/obj/item/stack/wrapping_paper/WP = W


### PR DESCRIPTION
## What Does This PR Do
Unifies all the places that rename a thing with a pen to use common proc.
Now when renaming things you get a consistent format of "thing - user-provided label", so, e.g. "body bag - John Doe". (Unless overriden of course).
You also now consistently have an option to realize "oh, wait, no, i don't actually want to rename this" and bail out, without ruining the existing label.

The only concern I have is about the format. Some things currently use a "thing - label", while others go "thing (label)", and I don't have a strong enough opinion to meaningfully choose one of the two.

Also (almost unrelated) changes the pen attack handling, so it no longer gives "you stab a guy with a pen" messages that only you (but not your victim!) and admins(!) can see.

## Why It's Good For The Game
QoL

## Changelog
:cl:
tweak: renaming things should be a bit more consistent now.
fix: fix misleading messages when stabbing people with a pen.
/:cl:
