### PR TITLE
Makes crypods also check for user adjacency

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -572,7 +572,7 @@
 		willing = 1
 
 	if(willing)
-		if(!Adjacent(L))
+		if(!Adjacent(L) && !Adjacent(user))
 			to_chat(user, "<span class='boldnotice'>You're not close enough to [src].</span>")
 			return
 		if(L == user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes cryopods check for user adjacency as well as the target, so you don't need to have the body directly next to the pod.
The gifs explain it better so see below.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Small QOL improvement.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
**Before:**
![cryo 1](https://user-images.githubusercontent.com/57483089/99891721-f729de00-2c64-11eb-9d91-50c395b1d162.png)
![SxNgAgnBmv](https://user-images.githubusercontent.com/57483089/99891723-f85b0b00-2c64-11eb-9fa6-fecc7237e526.gif)

**After:**
![cryo 2](https://user-images.githubusercontent.com/57483089/99891729-06a92700-2c65-11eb-9443-52733117e82b.png)
![beD44m36TR](https://user-images.githubusercontent.com/57483089/99891730-0741bd80-2c65-11eb-8c72-644057270b5c.gif)


## Changelog
:cl:
tweak: Cryopods now check for user adjacency too, so the SSD person doesn't need to be directly next to it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
