### PR TITLE
Orbit menu no longer bundles dead players with dead butterflies.

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -58,12 +58,14 @@
 
 		var/mob/M = poi
 		if(istype(M))
+			if(isnewplayer(M))  // People in the lobby screen; only have their ckey as a name.
+				continue
 			if(isobserver(M))
 				ghosts += list(serialized)
-			else if(M.stat == DEAD)
-				dead += list(serialized)
 			else if(M.mind == null)
 				npcs += list(serialized)
+			else if(M.stat == DEAD)
+				dead += list(serialized)
 			else
 				alive += list(serialized)
 


### PR DESCRIPTION
## What Does This PR Do
Before the PR, on current live the sections on the orbit menu went:
- antags
- alive players
- ghosts
- non-alive mobs (players, npcs, and people on the lobby screen)
- npcs
- misc

With this PR in place the sections go:
- antags
- alive players
- ghosts
- dead players (not people in the lobby)
- npcs (alive and dead)
- misc

## Why It's Good For The Game
Easier to navigate. You often don't care about dead monkeys, but DO care about dead John Doe. It's nice when the information you care about is separated from that that you don't.

## Changelog
:cl:
tweak: orbit menu grouping is a tiny bit easier to navigate.
/:cl: