### PR TITLE
CI Fixes and tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 on:
+  push:
+    branches:
+    - master
   pull_request:
     branches:
     - master
+
 jobs:
   run_linters:
     name: Run Linters
@@ -48,6 +52,7 @@ jobs:
           source $HOME/BYOND/byond/bin/byondsetup
           tools/ci/generate_maplist.sh
           tools/ci/dm.sh -Mci_map_testing paradise.dme
+
   unit_tests_and_sql:
     name: Unit Tests + SQL Validation
     runs-on: ubuntu-18.04
@@ -80,7 +85,6 @@ jobs:
       - name: Compile & Run Unit Tests
         run: |
           tools/ci/install_byond.sh
-          tools/ci/install_rustg.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/ci/dm.sh -DCIBUILDING paradise.dme
           tools/ci/run_server.sh


### PR DESCRIPTION
## What Does This PR Do
- CI now builds master branch, which is required for caching
- CI now caches the BYOND install, saving download times each CI run
- CI now doesnt try to install RUSTG twice in the unit tests run (saving about 30 seconds)

## Why It's Good For The Game
Faster + better functioning CI

## Changelog
N/A