### PR TITLE
Mechs must now have maint protocols active to be repaired.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -840,7 +840,7 @@
 	if(repairing)
 		to_chat(user, "<span class='notice'>[src] is currently being repaired!</span>")
 		return
-	if(state == 0)
+	if(state == 0) // If maint protocols are not active, the state is zero
 		to_chat(user, "<span class='warning'>[src] can not be repaired without maintenance protocols active!</span>")
 		return
 	WELDER_ATTEMPT_REPAIR_MESSAGE

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -840,6 +840,9 @@
 	if(repairing)
 		to_chat(user, "<span class='notice'>[src] is currently being repaired!</span>")
 		return
+	if(state < 1)
+		to_chat(user, "<span class='notice'>[src] can not be repaired without maintenance protocols active!</span>")
+		return
 	WELDER_ATTEMPT_REPAIR_MESSAGE
 	repairing = TRUE
 	if(I.use_tool(src, user, 15, volume = I.tool_volume))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -841,7 +841,7 @@
 		to_chat(user, "<span class='notice'>[src] is currently being repaired!</span>")
 		return
 	if(state == 0)
-		to_chat(user, "<span class='notice'>[src] can not be repaired without maintenance protocols active!</span>")
+		to_chat(user, "<span class='warning'>[src] can not be repaired without maintenance protocols active!</span>")
 		return
 	WELDER_ATTEMPT_REPAIR_MESSAGE
 	repairing = TRUE

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -840,7 +840,7 @@
 	if(repairing)
 		to_chat(user, "<span class='notice'>[src] is currently being repaired!</span>")
 		return
-	if(state < 1)
+	if(state == 0)
 		to_chat(user, "<span class='notice'>[src] can not be repaired without maintenance protocols active!</span>")
 		return
 	WELDER_ATTEMPT_REPAIR_MESSAGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR adds a check to welder_act on mech code, requiring maintenance protocols to be active in order for a mech to be repaired via welder.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Mechs are strong, perhaps too strong, and could use some nerfs. This is a simple change, that forces a mech to be vulnerable, and unable to move or fire, when getting welder repaired. This prevents crew from fighting blob with a mech and constantly welding it, making it effectively an un-killable infinitely firing turret. Instead, the mech must retreat a distance to be fixed and stop firing, or be repaired on the front lines and vulnerable.

## Changelog
:cl:
tweak: Mechs must now have maintenance protocols active in order to be repaired with a welder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
