### PR TITLE
Changes atmospherics machinery plane from "FLOOR_PLANE" to "GAME_PLANE"

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -13,7 +13,7 @@ Pipelines + Other Objects -> Pipe network
 	layer = GAS_PIPE_HIDDEN_LAYER  //under wires
 	resistance_flags = FIRE_PROOF
 	max_integrity = 200
-	plane = FLOOR_PLANE
+	plane = GAME_PLANE
 	idle_power_usage = 0
 	active_power_usage = 0
 	power_channel = ENVIRON

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -79,7 +79,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/update_icon(safety = 0)
 	..()
 
-	plane = FLOOR_PLANE
+	plane = GAME_PLANE
 
 	if(!check_icon_cache())
 		return

--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -97,7 +97,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/update_icon(var/safety = 0)
 	..()
 
-	plane = FLOOR_PLANE
+	plane = GAME_PLANE
 
 	if(!check_icon_cache())
 		return


### PR DESCRIPTION
## What Does This PR Do
Changes the atmospherics' plane from -2 to -1

## Why It's Good For The Game
Allows mappers to *see the pipes*, as -2 is under the walls, resulting in:

## Images of changes
**VIEW FROM A MAPPING TOOL (Identical results with StrongDMM and Dreammaker)**
## **BEFORE:**
![StrongDMM_2020-11-23_18-29-59](https://user-images.githubusercontent.com/11361525/99988292-23a33e80-2dba-11eb-8d9f-2867b22fe7af.png)

## **AFTER:**
![StrongDMM_2020-11-23_18-24-25](https://user-images.githubusercontent.com/11361525/99988312-2a31b600-2dba-11eb-83ba-4fbc9d09cad1.png)

Was briefly tested, no ill effects were found in-game at a quick glance.

## Changelog
:cl:FreeStylaLT
tweak:Changed atmos machinery plane.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
