### PR TITLE
Allows nanopaste to repair machinery

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -480,24 +480,27 @@ Class Procs:
 
 /obj/machinery/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/stack/nanopaste))
-		if(stat && BROKEN)
-			to_chat(user, "<span class='notice'>\The [src] is too damaged to be fixed with nanopaste!</span>")
+		if(stat & BROKEN)
+			to_chat(user, "<span class='notice'>[src] is too damaged to be fixed with nanopaste!</span>")
 			return
 		if(obj_integrity == max_integrity)
-			to_chat(user, "<span class='notice'>\The [src] is fully intact.</span>")
+			to_chat(user, "<span class='notice'>[src] is fully intact.</span>")
 			return
 		if(!being_repaired)
-			to_chat(user, "<span class='notice'>You start applying the [O] to the [src].</span>")
+			to_chat(user, "<span class='notice'>You start applying [O] to [src].</span>")
 			being_repaired = TRUE
 			var/result = do_after(user, 3 SECONDS, target = src)
 			being_repaired = FALSE
 			if(result)
 				var/obj/item/stack/nanopaste/N = O
 				obj_integrity = clamp((obj_integrity + 50), obj_integrity, max_integrity)
-				N.use(1)
+				if(!N.use(1))
+					to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
+					return
 				user.visible_message("<span class='notice'>[user.name] applied some [O] at [src]'s damaged areas.</span>",\
 					"<span class='notice'>You apply some [O] at [name]'s damaged areas.</span>")
-
+	else
+		return ..()
 /obj/machinery/proc/exchange_parts(mob/user, obj/item/storage/part_replacer/W)
 	var/shouldplaysound = 0
 	if((flags & NODECONSTRUCT))

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -495,11 +495,11 @@ Class Procs:
 		if(!result)
 			return
 		var/obj/item/stack/nanopaste/N = O
-		obj_integrity = clamp((obj_integrity + 50), obj_integrity, max_integrity)
+		obj_integrity = min(obj_integrity + 50, max_integrity)
 		if(!N.use(1))
 			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
 			return
-		user.visible_message("<span class='notice'>[user.name] applied some [O] at [src]'s damaged areas.</span>",\
+		user.visible_message("<span class='notice'>[user] applied some [O] at [src]'s damaged areas.</span>",\
 			"<span class='notice'>You apply some [O] at [src]'s damaged areas.</span>")
 	else
 		return ..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -480,6 +480,7 @@ Class Procs:
 
 /obj/machinery/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/stack/nanopaste))
+		var/obj/item/stack/nanopaste/N = O
 		if(stat & BROKEN)
 			to_chat(user, "<span class='notice'>[src] is too damaged to be fixed with nanopaste!</span>")
 			return
@@ -488,20 +489,19 @@ Class Procs:
 			return
 		if(being_repaired)
 			return
+		if(N.get_amount() < 1)
+			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
+			return
 		to_chat(user, "<span class='notice'>You start applying [O] to [src].</span>")
 		being_repaired = TRUE
 		var/result = do_after(user, 3 SECONDS, target = src)
 		being_repaired = FALSE
 		if(!result)
 			return
-		var/obj/item/stack/nanopaste/N = O
-		obj_integrity = min(obj_integrity + 50, max_integrity)
-		if(N.get_amount() < 1)
-			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
-			return
 		if(!N.use(1))
-			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
+			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>") // this is here, as we don't want to use nanopaste until you finish applying
 			return
+		obj_integrity = min(obj_integrity + 50, max_integrity)
 		user.visible_message("<span class='notice'>[user] applied some [O] at [src]'s damaged areas.</span>",\
 			"<span class='notice'>You apply some [O] at [src]'s damaged areas.</span>")
 	else

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -496,6 +496,9 @@ Class Procs:
 			return
 		var/obj/item/stack/nanopaste/N = O
 		obj_integrity = min(obj_integrity + 50, max_integrity)
+		if(N.get_amount() < 1)
+			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
+			return
 		if(!N.use(1))
 			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
 			return

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -126,6 +126,8 @@ Class Procs:
 	var/frequency = NONE
 	/// A reference to a `datum/radio_frequency`. Gives the machine the ability to interact with things using radio signals.
 	var/datum/radio_frequency/radio_connection
+	/// This is if the machinery is being repaired
+	var/being_repaired = FALSE
 
 /*
  * reimp, attempts to flicker this machinery if the behavior is supported.
@@ -475,6 +477,26 @@ Class Procs:
 	. = ..()
 	if(.)
 		power_change()
+
+/obj/machinery/attackby(obj/item/O, mob/user, params)
+	if(istype(O, /obj/item/stack/nanopaste))
+		if(stat && BROKEN)
+			to_chat(user, "<span class='notice'>\The [src] is too damaged to be fixed with nanopaste!</span>")
+			return
+		if(obj_integrity == max_integrity)
+			to_chat(user, "<span class='notice'>\The [src] is fully intact.</span>")
+			return
+		if(!being_repaired)
+			to_chat(user, "<span class='notice'>You start applying the [O] to the [src].</span>")
+			being_repaired = TRUE
+			var/result = do_after(user, 3 SECONDS, target = src)
+			being_repaired = FALSE
+			if(result)
+				var/obj/item/stack/nanopaste/N = O
+				obj_integrity = clamp((obj_integrity + 50), obj_integrity, max_integrity)
+				N.use(1)
+				user.visible_message("<span class='notice'>[user.name] applied some [O] at [src]'s damaged areas.</span>",\
+					"<span class='notice'>You apply some [O] at [name]'s damaged areas.</span>")
 
 /obj/machinery/proc/exchange_parts(mob/user, obj/item/storage/part_replacer/W)
 	var/shouldplaysound = 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -486,19 +486,21 @@ Class Procs:
 		if(obj_integrity == max_integrity)
 			to_chat(user, "<span class='notice'>[src] is fully intact.</span>")
 			return
-		if(!being_repaired)
-			to_chat(user, "<span class='notice'>You start applying [O] to [src].</span>")
-			being_repaired = TRUE
-			var/result = do_after(user, 3 SECONDS, target = src)
-			being_repaired = FALSE
-			if(result)
-				var/obj/item/stack/nanopaste/N = O
-				obj_integrity = clamp((obj_integrity + 50), obj_integrity, max_integrity)
-				if(!N.use(1))
-					to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
-					return
-				user.visible_message("<span class='notice'>[user.name] applied some [O] at [src]'s damaged areas.</span>",\
-					"<span class='notice'>You apply some [O] at [name]'s damaged areas.</span>")
+		if(being_repaired)
+			return
+		to_chat(user, "<span class='notice'>You start applying [O] to [src].</span>")
+		being_repaired = TRUE
+		var/result = do_after(user, 3 SECONDS, target = src)
+		being_repaired = FALSE
+		if(!result)
+			return
+		var/obj/item/stack/nanopaste/N = O
+		obj_integrity = clamp((obj_integrity + 50), obj_integrity, max_integrity)
+		if(!N.use(1))
+			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
+			return
+		user.visible_message("<span class='notice'>[user.name] applied some [O] at [src]'s damaged areas.</span>",\
+			"<span class='notice'>You apply some [O] at [src]'s damaged areas.</span>")
 	else
 		return ..()
 /obj/machinery/proc/exchange_parts(mob/user, obj/item/storage/part_replacer/W)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR lets nanopaste be used on subtypes of obj/machinery to repair 50 object damage each use, at the cost of one nanopaste, so long as the object is not broken. Takes 3 seconds.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

When something is damaged in game currently... it's just damaged. You can't fix it unless you deconstruct the item or in certain cases, preform an action (IE fixing wires on a camera). This is very annoying on things like the RND servers, apcs, or protolathe, where deconstruction risks levels, require re-linking, disables an area for a long period of time, or destroys resources inside. By the addition of allowing nanopaste to be used on machinery, this allows people to repair important structures without disabling an area, or loosing resources. 3 second cooldown prevents spamming on structures to fast repair.

## Changelog
:cl:
add: Nanopaste can now be used on machinery to heal 50 object damage per use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
