### PR TITLE
Adds the Synth to Loadout.

### DIFF
--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -138,6 +138,10 @@
 	path = /obj/item/cartridge/mob_hunt_game
 	cost = 2
 
+/datum/gear/piano_synth
+	display_name ="synthesizer"
+	path = /obj/item/instrument/piano_synth
+	cost = 2
 //////////////////////
 //		Mugs		//
 //////////////////////


### PR DESCRIPTION
## What Does This PR Do
Simply put this adds the Piano Synthesizer to the loadout screen, allowing players to select it for 2 loadout points. A sizeable chunk of your load-out points in exchange for a nice fluff item that's actually fairly fun to use. I contemplated adding the banjo, but it's technically a pretty decent weapon so I didn't want this to incur any sort of balance discussions or whatever.

## Why It's Good For The Game
Not every round are you able to afford a synthesizer, and rounds you aren't are often times rounds you just want to chill and play some good music. I have this happen frequently enough to myself that I assume it's a problem for others. The option to buy it is still there, but this way people will be able to choose between a fashion choice or the thing they wanted to spend all round doing. Less of an impact on Donors, but a decent decision to be made for non-donors.

## Changelog
:cl:
tweak: Added the Synthesizer to the Loadout section of character creation for 2 points.
/:cl:
