### PR TITLE
Makes starting funds amount spread a bit tighter.

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -585,7 +585,7 @@ SUBSYSTEM_DEF(jobs)
 
 
 /datum/controller/subsystem/jobs/proc/CreateMoneyAccount(mob/living/H, rank, datum/job/job)
-	var/datum/money_account/M = create_account(H.real_name, rand(50,500)*10, null)
+	var/datum/money_account/M = create_account(H.real_name, rand(250,500)*10, null)
 	var/remembered_info = ""
 
 	remembered_info += "<b>Your account number is:</b> #[M.account_number]<br>"


### PR DESCRIPTION
## What Does This PR Do
~Increase minimum starting funds from 500 to 2500.~
Reduces the starting funds rng from 500-5000 to 2500-5000

## Why It's Good For The Game
With ~#14982~ #14953 being merged, there is now no way to make money.
While we wait for "real economy"  to arrive, let's temporarily increase the starting funds so that people can afford to buy a synth.

## Changelog
:cl:
tweak: You are now guaranteed to start the round with at least 2500cr balance
/:cl: