### PR TITLE
Fix roundstart Robots having null-named brainmobs

### DIFF
--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -90,10 +90,13 @@
 
 /obj/item/mmi/robotic_brain/transfer_identity(mob/living/carbon/H)
 	name = "[src] ([H])"
-	if(isnull(brainmob.dna))
-		brainmob.dna = H.dna.Clone()
-	brainmob.name = brainmob.dna.real_name
-	brainmob.real_name = brainmob.name
+
+	brainmob.dna = H.dna.Clone()
+	// I'm not sure we can remove species override. There might be some loophole
+	// that would allow posibrains to be cloned without this.
+	brainmob.dna.species = new /datum/species/machine()
+	brainmob.real_name = brainmob.dna.real_name
+	brainmob.name = brainmob.real_name
 	brainmob.timeofhostdeath = H.timeofdeath
 	brainmob.stat = CONSCIOUS
 	if(brainmob.mind)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -91,13 +91,21 @@
 	O.job = "Cyborg"
 
 	if(O.mind && O.mind.assigned_role == "Cyborg")
-		if(O.mind.role_alt_title == "Robot")
-			O.mmi = new /obj/item/mmi/robotic_brain(O)
-			if(O.mmi.brainmob)
-				O.mmi.brainmob.name = O.name
-		else
-			O.mmi = new /obj/item/mmi(O)
-		O.mmi.transfer_identity(src) //Does not transfer key/client.
+		var/obj/item/mmi/new_mmi
+		switch(O.mind.role_alt_title)
+			if("Robot")
+				new_mmi = new /obj/item/mmi/robotic_brain(O)
+				if(new_mmi.brainmob)
+					new_mmi.brainmob.name = O.name
+			if("Cyborg")
+				new_mmi = new /obj/item/mmi(O)
+			else
+				// This should never happen, but oh well
+				new_mmi = new /obj/item/mmi(O)
+		new_mmi.transfer_identity(src) //Does not transfer key/client.
+		// Replace the MMI.
+		QDEL_NULL(O.mmi)
+		O.mmi = new_mmi
 
 	O.update_pipe_vision()
 


### PR DESCRIPTION
## What Does This PR Do
Very slightly fixes robotization process, so that old mmis are properly cleaned up.
The brainmobs in the new posibrains now get the name of a human being robotized, and not a `null`.
Side-effect: roundstart Robots' brainmob is now called their human name (rather than HIU-123), so said human name appears in the orbit menu (under NPCs) and orbiting that orbits the borg (does that make sense?). This should have next to no effect on gameplay, or break immersion, since the MMI already had the human name on it anyway.

Honestly this entire MMI affair looks rather gnarly, but i'm not confident enough in robotics to fix it "properly"

Fixes #14841 

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Roundstart Robots no longer have two MMIs; and the brain inside the MMI no longer has null name
/:cl: