### PR TITLE
Fixes akimbo crafted chainsaws (and any item requiring two hands)

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -162,6 +162,9 @@
 	..()
 	if(slot == slot_l_hand || slot == slot_r_hand)
 		wield(user)
+		if(!wielded) // Drop immediately if we couldn't wield
+			user.drop_item()
+			to_chat(user, "<span class='notice'>[src] is too cumbersome to carry in one hand!</span>")
 	else
 		unwield(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Makes any subclass of `/obj/item/twohanded/required` check whether it was wielded successfully on equip; if not, it will drop to the ground immediately.
  - Fixes #12551
  - Fixes #14480 (duplicate of the above)

**This is a bandaid fix and two-handed items should be refactored eventually.**

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Prevents players from holding two items that require both hands to even be picked up because bug.

## Changelog
:cl:
fix: Fix being able to hold an object that requires both hands in each hand (e.g. one crafted chainsaw in each hand)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
