### PR TITLE
Make fluff items cheaper

### DIFF
--- a/code/modules/arcade/claw_game.dm
+++ b/code/modules/arcade/claw_game.dm
@@ -5,7 +5,7 @@ GLOBAL_VAR(claw_game_html)
 	desc = "One of the most infuriating ways to win a toy."
 	icon = 'icons/obj/arcade.dmi'
 	icon_state = "clawmachine_1_on"
-	token_price = 15
+	token_price = 5
 	window_name = "Claw Game"
 	var/machine_image = "_1"
 	var/bonus_prize_chance = 5		//chance to dispense a SECOND prize if you win, increased by matter bin rating

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -43,178 +43,178 @@
 	name = "Snap-Pops"
 	desc = "Ten-thousand-year-old chinese fireworks: IN SPACE"
 	typepath = /obj/item/storage/box/snappops
-	cost = 200
+	cost = 100
 
 /datum/storeitem/dnd
 	name = "Dungeons & Dragons Set"
 	desc = "A box containing minifigures suitable for a good game of D&D."
 	typepath = /obj/item/storage/box/characters
-	cost = 200
+	cost = 100
 
 /datum/storeitem/dice
 	name = "Dice Set"
 	desc = "A box containing multiple different types of die."
 	typepath = /obj/item/storage/box/dice
-	cost = 200
+	cost = 100
 
 /datum/storeitem/candle
 	name = "Candles"
 	desc = "A box of candles. Use them to fool others into thinking you're out for a romantic dinner...or something."
 	typepath = /obj/item/storage/fancy/candle_box/full
-	cost = 200
+	cost = 100
 
 /datum/storeitem/nanomob_booster
 	name = "Nano-Mob Hunter Trading Card Booster Pack"
 	desc = "Contains 6 random Nano-Mob Hunter Trading Cards. May contain a holographic card!"
 	typepath = /obj/item/storage/box/nanomob_booster_pack
-	cost = 250
+	cost = 125
 
 /datum/storeitem/crayons
 	name = "Crayons"
 	desc = "Let security know how they're doing by scrawling love notes all over their hallways."
 	typepath = /obj/item/storage/fancy/crayons
-	cost = 350
+	cost = 175
 
 /datum/storeitem/pipe
 	name = "Smoking Pipe"
 	desc = "A pipe, for smoking. Probably made of meerschaum or something."
 	typepath = /obj/item/clothing/mask/cigarette/pipe
-	cost = 350
+	cost = 175
 
 /datum/storeitem/minigibber
 	name = "Miniature Gibber"
 	desc = "A miniature recreation of Nanotrasen's famous meat grinder."
 	typepath = /obj/item/toy/minigibber
-	cost = 400
+	cost = 200
 
 /datum/storeitem/katana
 	name = "Replica Katana"
 	desc = "Woefully underpowered in D20."
 	typepath = /obj/item/toy/katana
-	cost = 500
+	cost = 250
 
 /datum/storeitem/violin
 	name = "Space Violin"
 	desc = "A wooden musical instrument with four strings and a bow. \"The devil went down to space, he was looking for an assistant to grief.\""
 	typepath = /obj/item/instrument/violin
-	cost = 500
+	cost = 250
 
 /datum/storeitem/guitar
 	name = "Guitar"
 	desc = "It's made of wood and has bronze strings."
 	typepath = /obj/item/instrument/guitar
-	cost = 500
+	cost = 250
 
 /datum/storeitem/eguitar
 	name = "Electric Guitar"
 	desc = "Makes all your shredding needs possible."
 	typepath = /obj/item/instrument/eguitar
-	cost = 500
+	cost = 250
 
 /datum/storeitem/banjo
 	name = "Banjo"
 	desc = "It's pretty much just a drum with a neck and strings."
 	typepath = /obj/item/instrument/banjo
-	cost = 500
+	cost = 250
 
 /datum/storeitem/piano_synth
 	name = "Piano Synthesizer"
 	desc = "An advanced electronic synthesizer that can emulate various instruments."
 	typepath = /obj/item/instrument/piano_synth
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/baby
 	name = "Toddler"
 	desc = "This baby looks almost real. Wait, did it just burp?"
 	typepath = /obj/item/toddler
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_slime
 	name = "Slime People Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Slime People."
 	typepath = /obj/item/flag/species/slime
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_skrell
 	name = "Skrell Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Skrell."
 	typepath = /obj/item/flag/species/skrell
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_vox
 	name = "Vox Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Vox."
 	typepath = /obj/item/flag/species/vox
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_machine
 	name = "Synthetics Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Synthetics."
 	typepath = /obj/item/flag/species/machine
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_diona
 	name = "Diona Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Dionae."
 	typepath = /obj/item/flag/species/diona
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_human
 	name = "Human Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Humans."
 	typepath = /obj/item/flag/species/human
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_greys
 	name = "Greys Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Greys."
 	typepath = /obj/item/flag/species/greys
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_kidan
 	name = "Kidan Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Kidan."
 	typepath = /obj/item/flag/species/kidan
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_taj
 	name = "Tajaran Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Tajara."
 	typepath = /obj/item/flag/species/taj
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_unathi
 	name = "Unathi Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Unathi."
 	typepath = /obj/item/flag/species/unathi
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_vulp
 	name = "Vulpkanin Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Vulpkanin."
 	typepath = /obj/item/flag/species/vulp
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_drask
 	name = "Drask Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Drask."
 	typepath = /obj/item/flag/species/drask
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_plasma
 	name = "Plasmaman Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Plasmamen."
 	typepath = /obj/item/flag/species/plasma
-	cost = 1000
+	cost = 500
 
 /datum/storeitem/flag_ian
 	name = "Ian Flag"
 	desc = "The banner of Ian, because SQUEEEEE."
 	typepath = /obj/item/flag/ian
-	cost = 1500
+	cost = 750
 
 /datum/storeitem/banhammer
 	name = "Banhammer"
 	desc = "A Banhammer."
 	typepath = /obj/item/banhammer
-	cost = 2000
+	cost = 1000


### PR DESCRIPTION
## What Does This PR Do
Fluff items are now 2x cheaper, claw game now costs 5cr.
This puts banjo at 250cr (slightly cheaper than a PDA) and synth at 500cr (slightly more expensive than a PDA)
This is a - hopefully - less controversial alternative to #14989 
This is NOT changing starting account balance in any way, since that seems to be a very touchy subject

## Why It's Good For The Game
The prices in the cargo shop are mostly arbitrary, since nobody particularly cared how much an item costs if you can spend 15 minutes spinning slots and get infinite money.
Now that #14953 is merged and infinite money is a thing of the past, being able to obtain a synth is no longer a given, and people are upset that they cannot play music and have fun.
This calls to re-evaluate the pricing (which, again, was set more or less arbitrarily in the first place).
Being able to buy a synth the moment you enter the station (even, potentially, having to spend ALL your money doing so) is a good thing

## Changelog
:cl:
tweak: Cargo shop fluff items are twice as cheap now.
tweak: Claw game is now cheaper to play.
/:cl: