### PR TITLE
Adds nanopaste to IPC medkit

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -181,6 +181,7 @@
 	new /obj/item/stack/cable_coil(src)
 	new /obj/item/stack/cable_coil(src)
 	new /obj/item/robotanalyzer(src)
+	new /obj/item/stack/nanopaste(src)
 
 /obj/item/storage/firstaid/machine/empty
 	empty = TRUE


### PR DESCRIPTION
## What Does This PR Do
Adds nanopaste to IPC medkits

## Why It's Good For The Game
Nanopaste is handy to have to fix up IPCs as well as robotic limbs and organs. Sometimes RnD or robotics can't be bothered to make any so it'd be nice to have some on hand via cargo orders.

## Changelog
:cl:
tweak: added nanopaste to IPC medkits
/:cl: