### PR TITLE
Makes red inquisitor ERT use the proper hardsuit

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -415,7 +415,7 @@
 
 /datum/outfit/job/centcom/response_team/paranormal/red
 	name = "RT Paranormal (Red)"
-	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal
 	suit_store = /obj/item/gun/energy/gun
 	r_pocket = /obj/item/nullrod/ert
 	glasses = /obj/item/clothing/glasses/sunglasses


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Changes red ert inquisitor armor from /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor to /obj/item/clothing/suit/space/hardsuit/ert/paranormal

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Red inquisitor has been using the wrong hardsuit for a long time, which had no slowdown, and better armor than gamma ert armor. This makes the red inquisitor get the normal ert inquisitor hardsuit, which has normal ert armor and slowdown. Gamma is unaffected, as to be honest, on gamma, they need the speed to make up for the lack of other gear gamma inquisitor gets.

Calling this a tweak, although may be a fix

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Red inquisitor ERT now uses the default paranomal armor instead of inquisitor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
