### PR TITLE
A couple of small ERT loadout tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1055,6 +1055,7 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/emergency_oxygen/engi/full(src)
 	new /obj/item/flashlight/flare(src)
+	new /obj/item/crowbar/red(src)
 	new /obj/item/kitchen/knife/combat(src)
 	new /obj/item/radio/centcom(src)
 	new /obj/item/reagent_containers/food/pill/patch/synthflesh(src)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -75,6 +75,7 @@
 	safety_hypo = TRUE
 
 /obj/item/reagent_containers/hypospray/safety/ert
+	name = "medical hypospray (Omnizine)"
 	list_reagents = list("omnizine" = 30)
 
 /obj/item/reagent_containers/hypospray/CMO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
1. Adds a crowbar to the ERT emergency box to stop them getting trapped by an unpowered door.
2. Adds a label to the Amber and Red ERT medic hyposprays. (`medical hypospray` to `medical hypospray (Omnizine)`)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. In theory, a gamma ERT could be trapped inside their shuttle if arrivals is depowered. This is obviously not very good for an ERT.
2. ERT medics have no way of knowing what's actually inside their hypospray without testing it out on someone.

## Changelog
:cl:
tweak: ERT emergency boxes now contain a crowbar
tweak: Added a label to the Amber and Red ERT medic hypospray, so you can actually tell what's inside it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
