### PR TITLE
Adds two extra chairs to the Wizard's Den

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -1926,7 +1926,7 @@
 /turf/unsimulated/beach/sand,
 /area/ninja/holding)
 "fJ" = (
-/obj/structure/chair,
+/obj/structure/chair/comfy/purp,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "wood"
@@ -1985,7 +1985,7 @@
 	},
 /area/wizard_station)
 "fR" = (
-/obj/structure/chair{
+/obj/structure/chair/comfy/purp{
 	dir = 4
 	},
 /turf/unsimulated/floor{
@@ -2223,13 +2223,6 @@
 	dir = 4
 	},
 /area/space)
-"gu" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows3";
-	tag = "icon-fakewindows (WEST)"
-	},
-/area/wizard_station)
 "gv" = (
 /obj/structure/table/reinforced,
 /obj/structure/kitchenspike,
@@ -2240,6 +2233,9 @@
 /area/wizard_station)
 "gw" = (
 /obj/structure/showcase,
+/obj/structure/window/reinforced/clockwork{
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "chapel"
@@ -2435,6 +2431,9 @@
 "gW" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife/ritual,
+/obj/structure/window/reinforced/clockwork{
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "chapel"
@@ -12568,6 +12567,15 @@
 	icon_state = "floor"
 	},
 /area/centcom/evac)
+"VO" = (
+/obj/structure/chair/comfy/purp{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "wood"
+	},
+/area/wizard_station)
 "VZ" = (
 /turf/simulated/floor/holofloor{
 	tag = "icon-asteroid7";
@@ -50519,7 +50527,7 @@ fo
 fJ
 fU
 fY
-fo
+VO
 fo
 fo
 fo
@@ -50776,11 +50784,11 @@ fB
 fJ
 fS
 fX
-ih
-gu
+VO
 fo
 fo
-gu
+fo
+fo
 ih
 aN
 nj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds two new chairs to the Wizard's Den table, and makes them all comfier.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Primarily to help with the roundstart observing tradition of sitting around the Wizard's table.
Also, looking at it now, I personally think it just looks better. Why would the Wizards Federation *not* supply their mages with only the finest of chairs?

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
### Old
![old](https://user-images.githubusercontent.com/57483089/100528043-2c3bb080-31d0-11eb-9f20-cc957efbbd99.png)

### New
![new](https://user-images.githubusercontent.com/57483089/100528045-2f36a100-31d0-11eb-82b0-6de959cd6d3f.png)


## Changelog
:cl:
tweak: The Wizard's Den table now has two extra chairs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
