### PR TITLE
Fixes TGUI ghost orbit menu runtime

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -54,7 +54,8 @@
 	R.name = heldname
 	R.custom_name = heldname
 	R.real_name = heldname
-
+	if(R.mmi && R.mmi.brainmob)
+		R.mmi.brainmob.name = R.name
 	return TRUE
 
 /obj/item/borg/upgrade/restart

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -47,10 +47,10 @@
 
 	var/list/pois = getpois(mobs_only = FALSE, skip_mindless = FALSE)
 	for(var/name in pois)
-		var/poi = pois[name]
+		var/mob/M = pois[name]
 		if(name == null)
-			if(pois[name] && pois[name].type)
-				stack_trace("getpois returned something under a null name. Type: [poi.type]")
+			if(pois[name] && M.type)
+				stack_trace("getpois returned something under a null name. Type: [M.type]")
 			else
 				stack_trace("getpois returned a null value")
 			continue
@@ -58,12 +58,11 @@
 		var/list/serialized = list()
 		serialized["name"] = "[name]" // stringify it; If it's null or something - we'd like to know it and fix getpois()
 		if(serialized["name"] != name)
-			stack_trace("getpois returned something under a non-string name [name] - [pois[name]] - [poi.type]")
+			stack_trace("getpois returned something under a non-string name [name] - [pois[name]] - [M.type]")
 			continue
 
-		serialized["ref"] = "\ref[poi]"
+		serialized["ref"] = "\ref[M]"
 
-		var/mob/M = poi
 		if(istype(M))
 			if(isnewplayer(M))  // People in the lobby screen; only have their ckey as a name.
 				continue

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -47,18 +47,19 @@
 
 	var/list/pois = getpois(mobs_only = FALSE, skip_mindless = FALSE)
 	for(var/name in pois)
+		var/poi = pois[name]
 		if(name == null)
 			if(pois[name] && pois[name].type)
-				stack_trace("getpois returned something under a null name. Type: [pois[name].type]")
+				stack_trace("getpois returned something under a null name. Type: [poi.type]")
 			else
 				stack_trace("getpois returned a null value")
 			continue
+
 		var/list/serialized = list()
 		serialized["name"] = "[name]" // stringify it; If it's null or something - we'd like to know it and fix getpois()
 		if(serialized["name"] != name)
-			stack_trace("getpois returned something under a non-string name [name] - [pois[name]] - [pois[name].type]")
+			stack_trace("getpois returned something under a non-string name [name] - [pois[name]] - [poi.type]")
 			continue
-		var/poi = pois[name]
 
 		serialized["ref"] = "\ref[poi]"
 

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -47,11 +47,17 @@
 
 	var/list/pois = getpois(mobs_only = FALSE, skip_mindless = FALSE)
 	for(var/name in pois)
+		if(name == null)
+			if(pois[name] && pois[name].type)
+				stack_trace("getpois returned something under a null name. Type: [pois[name].type]")
+			else
+				stack_trace("getpois returned a null value")
+			continue
 		var/list/serialized = list()
 		serialized["name"] = "[name]" // stringify it; If it's null or something - we'd like to know it and fix getpois()
-		if(name == null || serialized["name"] != name)
-			stack_trace("getpois returned something under a non-string name [name] - [pois[name]]")
-
+		if(serialized["name"] != name)
+			stack_trace("getpois returned something under a non-string name [name] - [pois[name]] - [pois[name].type]")
+			continue
 		var/poi = pois[name]
 
 		serialized["ref"] = "\ref[poi]"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -230,6 +230,9 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 				if(Entry[2] == ckey)	//They're in the list? Custom sprite time, var and icon change required
 					custom_sprite = 1
 
+	if(mmi && mmi.brainmob)
+		mmi.brainmob.name = newname
+
 	return 1
 
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -93,6 +93,8 @@
 	if(O.mind && O.mind.assigned_role == "Cyborg")
 		if(O.mind.role_alt_title == "Robot")
 			O.mmi = new /obj/item/mmi/robotic_brain(O)
+			if(O.mmi.brainmob)
+				O.mmi.brainmob.name = O.name
 		else
 			O.mmi = new /obj/item/mmi(O)
 		O.mmi.transfer_identity(src) //Does not transfer key/client.


### PR DESCRIPTION
## What Does This PR Do
1) Fixes this runtime:
[2020-11-29T03:53:21] Runtime in unsorted.dm,1986: getpois returned something under a non-string name - 
   proc name: stack trace (/datum/proc/stack_trace)
   usr: XXXXXXXXXXXXXXXXXX
   usr.loc: The floor (50,145,1) (/turf/simulated/floor/plasteel)
   src: /datum/orbit_menu (/datum/orbit_menu)
   call stack:
   /datum/orbit_menu (/datum/orbit_menu): stack trace("getpois returned something und...")
   /datum/orbit_menu (/datum/orbit_menu): ui static data(XXXXXXXXXXXX (/mob/dead/observer))
   /datum/tgui (/datum/tgui): open()
   /datum/orbit_menu (/datum/orbit_menu): ui interact(XXXXXXXXXX (/mob/dead/observer), "main", /datum/tgui (/datum/tgui), 0, null, /datum/ui_state/observer_state (/datum/ui_state/observer_state))
   XXXXXXXXXXX (/mob/dead/observer): Orbit()
   Orbit (/obj/screen/ghost/orbit): Click(null, "mapwindow.map", "icon-x=20;icon-y=10;left=1;scr...")

The problem was caused by cyborg.mmi.brainmob /mob/living/carbon/brain not having a name defined, which led to runtimes in TGUI.

2) Adds better logging (runtimes now show the path of the object) so if more errors like this come up in future, it will be easier to find which mob is causing them.

## Changelog
:cl: Kyep
fix: fixed TGUI ghost orbit menu generating a runtime error.
/:cl: