### PR TITLE
Keeps CQC from benifitting from Gloves of the North Start

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -166,7 +166,10 @@
 	var/mob/living/M = loc
 
 	if(M.a_intent in accepted_intents)
-		M.changeNext_move(click_speed_modifier)
+		if(istype(M.mind.martial_art, /datum/martial_art/cqc))
+			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
+		else
+			M.changeNext_move(click_speed_modifier)
 	.= FALSE
 
 /obj/item/clothing/gloves/fingerless/rapid/admin


### PR DESCRIPTION
Prevents CQC from benefitting from the speed of glove of the northstar, simply by lowering the click speed back to regular. I may need to change it so it excludes the admin subtype.
The reasoning is that when someone gets it, and its honestly not too rare if someone knows how it can be pretty ridiculous 

Consideration: Restrict Sleeping carp in the same manner, I am torn on this as the feel of carp is to be a hand to hand master..and well gloves go brrr fits that bill. If people feel i need to add that restriction i can but i am on the fence.

## Changelog
:cl: Fethas
tweak: CQC is no longer super fast with gloves of the northstar.
/:cl:

