### PR TITLE
Better "please update byond" prompts

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -335,14 +335,13 @@
 		alert(src, "You are using a byond build which is not supported by this server. Please use a build version of atleast [config.minimum_client_build].", "Incorrect build", "OK")
 		qdel(src)
 		return
+
 	var/show_update_prompt = FALSE
 	if(byond_version < SUGGESTED_CLIENT_VERSION) // Update is suggested, but not required.
 		show_update_prompt = TRUE
 	else if(byond_version == SUGGESTED_CLIENT_VERSION && byond_build < SUGGESTED_CLIENT_BUILD)
 		show_update_prompt = TRUE
-	if(show_update_prompt)
-		to_chat(src,"<span class='userdanger'>Your BYOND client (v: [byond_version].[byond_build]) is out of date. This can cause glitches. We highly suggest you download the latest client from http://www.byond.com/ before playing. </span>")
-
+	// Actually sent to client much later, so it appears after MOTD.
 
 	to_chat(src, "<span class='warning'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</span>")
 
@@ -423,6 +422,9 @@
 
 	generate_clickcatcher()
 	apply_clickcatcher()
+
+	if(show_update_prompt)
+		to_chat(src,"<span class='userdanger'>Your BYOND client (v: [byond_version].[byond_build]) is out of date. This can cause glitches. We highly suggest you download the latest client from <a href='https://www.byond.com/download/'>Byond.com</a> before playing.</span>")
 
 	check_forum_link()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -8,7 +8,9 @@
 #define UPLOAD_LIMIT		10485760	//Restricts client uploads to the server to 10MB //Boosted this thing. What's the worst that can happen?
 #define MIN_CLIENT_VERSION	0		//Just an ambiguously low version for now, I don't want to suddenly stop people playing.
 									//I would just like the code ready should it ever need to be used.
-#define SUGGESTED_CLIENT_VERSION	511		// only integers (e.g: 510, 511) useful here. Does not properly handle minor versions (e.g: 510.58, 511.848)
+#define SUGGESTED_CLIENT_VERSION	513		// only integers (e.g: 513, 514) are useful here. This is the part BEFORE the ".", IE 513 out of 513.1536
+#define SUGGESTED_CLIENT_BUILD	1536		// only integers (e.g: 1536, 1539) are useful here. This is the part AFTER the ".", IE 1536 out of 513.1536
+
 #define SSD_WARNING_TIMER 30 // cycles, not seconds, so 30=60s
 
 #define LIMITER_SIZE	5
@@ -333,8 +335,14 @@
 		alert(src, "You are using a byond build which is not supported by this server. Please use a build version of atleast [config.minimum_client_build].", "Incorrect build", "OK")
 		qdel(src)
 		return
+	var/show_update_prompt = FALSE
 	if(byond_version < SUGGESTED_CLIENT_VERSION) // Update is suggested, but not required.
-		to_chat(src,"<span class='userdanger'>Your BYOND client (v: [byond_version]) is out of date. This can cause glitches. We highly suggest you download the latest client from http://www.byond.com/ before playing. </span>")
+		show_update_prompt = TRUE
+	else if(byond_version == SUGGESTED_CLIENT_VERSION && byond_build < SUGGESTED_CLIENT_BUILD)
+		show_update_prompt = TRUE
+	if(show_update_prompt)
+		to_chat(src,"<span class='userdanger'>Your BYOND client (v: [byond_version].[byond_build]) is out of date. This can cause glitches. We highly suggest you download the latest client from http://www.byond.com/ before playing. </span>")
+
 
 	to_chat(src, "<span class='warning'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</span>")
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -424,7 +424,7 @@
 	apply_clickcatcher()
 
 	if(show_update_prompt)
-		to_chat(src,"<span class='userdanger'>Your BYOND client (v: [byond_version].[byond_build]) is out of date. This can cause glitches. We highly suggest you download the latest client from <a href='https://www.byond.com/download/'>Byond.com</a> before playing.</span>")
+		to_chat(src, "<span class='userdanger'>Your BYOND client (v: [byond_version].[byond_build]) is out of date. This can cause glitches. We highly suggest you download the latest client from <a href='https://www.byond.com/download/'>Byond.com</a> before playing.</span>")
 
 	check_forum_link()
 


### PR DESCRIPTION
## What Does This PR Do
Alters the "please update byond" prompt that people with out-of-date byond versions get.
Before, it would only alert them if they were on major version *510* or lower. That version is _ancient_.
Now, it will alert them if they're on any version less than (as of writing) the current standard version: 513.1536.
It will consider both major version (e.g: 512, 513) and build number when making this determination.

## Why it is good for the game
There are lots of bugs (like the %22 URL bug) caused by out-of-date versions of byond.
This encourages people using those versions to update. It doesn't require they upgrade. It just reminds them to do so.

## Changelog
:cl: Kyep
add: Players now get asked to update their Byond if they connect using an out-of-date version.
/:cl: