### PR TITLE
Adds the ability to pat out fires on burning people

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -251,12 +251,17 @@
 
 			else if(on_fire)
 				var/self_message = "<span class='warning'>You try to extinguish [src]!</span>"
-				if(prob(30)) // 30% chance of burning your hands
-					var/obj/item/organ/external/active_hand = M.get_organ("[M.hand ? "l" : "r"]_hand")
-					if(active_hand) // Wouldn't really work without a hand
+				if(prob(30) && ishuman(M)) // 30% chance of burning your hands
+					var/mob/living/carbon/human/H = M
+					var/protected = FALSE // Protected from the fire
+					if((H.gloves?.max_heat_protection_temperature > 360) || (HEATRES in H.mutations))
+						protected = TRUE
+
+					var/obj/item/organ/external/active_hand = H.get_organ("[H.hand ? "l" : "r"]_hand")
+					if(active_hand && !protected) // Wouldn't really work without a hand
 						active_hand.receive_damage(0, 5)
 						self_message = "<span class='danger'>You burn your hand trying to extinguish [src]!</span>"
-						M.update_icons()
+						H.update_icons()
 
 				M.visible_message("<span class='warning'>[M] tries to extinguish [src]!</span>", self_message)
 				playsound(get_turf(src), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -248,6 +248,20 @@
 						"<span class='notice'>[M] shakes [src] trying to wake [p_them()] up!</span>",\
 						"<span class='notice'>You shake [src] trying to wake [p_them()] up!</span>",\
 						)
+
+			else if(on_fire)
+				var/self_message = "<span class='warning'>You try to extinguish [src]!</span>"
+				if(prob(30)) // 30% chance of burning your hands
+					var/obj/item/organ/external/active_hand = M.get_organ("[M.hand ? "l" : "r"]_hand")
+					if(active_hand) // Wouldn't really work without a hand
+						active_hand.receive_damage(0, 5)
+						self_message = "<span class='danger'>You burn your hand trying to extinguish [src]!</span>"
+						M.update_icons()
+
+				M.visible_message("<span class='warning'>[M] tries to extinguish [src]!</span>", self_message)
+				playsound(get_turf(src), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				adjust_fire_stacks(-0.5)
+
 			// BEGIN HUGCODE - N3X
 			else
 				playsound(get_turf(src), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds the ability to put out fires on another player by clicking on them with help intent.
While doing this there's a 30% chance that you'll burn your hand, and take some damage.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's always a bit awkward to just stand around staring at someone burning to death if there's no fire extinguishers.
This way people can at least do something proactive.

## Changelog
:cl:
add: Using help intent on someone who is on fire will now help put the fire out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
