### PR TITLE
Fix protolathe/autolathe mixup when exporting designs in R&D console

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -780,10 +780,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 /obj/machinery/computer/rdconsole/proc/can_copy_design(datum/design/D)
 	if(D)
-		if(D.build_type & AUTOLATHE)
+		if(D.build_type & PROTOLATHE)
 			return TRUE
 
-		if(D.build_type & PROTOLATHE)
+		if(D.build_type & AUTOLATHE)
 			for(var/M in D.materials)
 				if(M != MAT_METAL && M != MAT_GLASS)
 					return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Protolathe designs couldn't be exported if they required materials other than metal and glass, whereas Autolathe designs could always be exported. It's supposed to be the opposite. (Namely prevents exporting Alien Alloy for the ORM)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfix

## Changelog
:cl:
fix: Fix not being able to export most Protolathe designs to a disk
fix: Fix being able to export more designs than intended for the Autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
