### PR TITLE
Fixes reflector chat spam

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -22,7 +22,6 @@
 		new_dir = 0
 		return ..() //Hits as normal, explodes or emps or whatever
 
-	visible_message("<span class='notice'>[P] bounces off of [src]</span>")
 	reflect_turf = get_step(loc,new_dir)
 
 	P.original = reflect_turf


### PR DESCRIPTION
# Changelog
:cl: Kyep
del: Removed the chat message when an emitter beam bounces off a reflector.
/:cl:

# Why
Because of SM setups that include 16+ emitters and crash the chat of anyone who watches them due to obscene amounts of chat messages created by 16 emitters' beams being constantly reflected.