### PR TITLE
Drops twohanded items that failed to wield instead of the user's active hand

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -163,7 +163,7 @@
 	if(slot == slot_l_hand || slot == slot_r_hand)
 		wield(user)
 		if(!wielded) // Drop immediately if we couldn't wield
-			user.drop_item()
+			user.unEquip(src)
 			to_chat(user, "<span class='notice'>[src] is too cumbersome to carry in one hand!</span>")
 	else
 		unwield(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Follow-up to #14993 after `/obj/item/twohanded/required` would drop the wrong item if wielding on pickup failed. It will now always drop the twohanded item instead of the active item.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfix to bugfix

## Changelog
:cl:
fix: Picking up a twohanded weapon and failing to wield it will now drop that item properly instead of sometimes dropping whatever is in the other hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
