### PR TITLE
Makes EMP actually useful on reactive armor

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -260,7 +260,8 @@
 /obj/item/clothing/suit/armor/reactive
 	name = "reactive armor"
 	desc = "Doesn't seem to do much for some reason."
-	var/active = 0
+	var/active = FALSE
+	var/emp_d = FALSE
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	blood_overlay_type = "armor"
@@ -271,6 +272,9 @@
 
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
 	active = !(active)
+	if(emp_d)
+		to_chat(user, "<span class='warning'>[src] is disabled from an electromagnetic pulse!</span>")
+		return
 	if(active)
 		to_chat(user, "<span class='notice'>[src] is now active.</span>")
 		icon_state = "reactive"
@@ -286,13 +290,18 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/suit/armor/reactive/emp_act(severity)
-	active = 0
+	active = FALSE
+	emp_d = TRUE
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	if(istype(loc, /mob/living/carbon/human))
 		var/mob/living/carbon/human/C = loc
 		C.update_inv_wear_suit()
+		addtimer(CALLBACK(src, .proc/reboot), 100 / severity)
 	..()
+
+/obj/item/clothing/suit/armor/reactive/proc/reboot()
+	emp_d = FALSE
 
 //When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive/teleport


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR changes reactive teleport armor to be disabled for 5-10 seconds based on the severity of EMP when it is hit by an EMP, instead of just being turned off.

Armor does not automatically turn on when timer runs out.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Reactive teleport armor is quite strong, with any attack on the person having a 50% chance to trigger it. It is supposed to have a counter of EMPS disabling it, but unless the person is stunned, they can instantly turn the armor right back on. By adding a 5-10 second disable, this allows security to use an ion carbine or rifle to disable the armor, before using a taser or lethals. Vice versa with traitors, allowing them to emp the RD before stunprodding them / blasting them with 357, without the RD instantly turning it back on.

## Changelog
:cl:
tweak: Reactive armors are now disabled for 5-10 seconds by emp, based on EMP strength.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
