### PR TITLE
Terror event spawns now pick players randomly

### DIFF
--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -16,7 +16,6 @@
 		log_and_message_admins("Warning: Could not spawn any mobs for event Terror Spiders")
 
 /datum/event/spider_terror/start()
-	var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE)
 	var/spider_type
 	var/infestation_type
 	if((length(GLOB.clients)) < TS_HIGHPOP_TRIGGER)
@@ -44,11 +43,19 @@
 			// Strongest, only used during highpop.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen
 			spawncount = 1
-	while(spawncount && length(vents))
-		var/obj/vent = pick_n_take(vents)
-		new spider_type(vent.loc)
-		spawncount--
-		successSpawn = TRUE
+	spawn() // Just like in xeno and demon events, this spawn() is necessary. Do not remove.
+		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a terror spider?", null, TRUE, source = spider_type)
+		if(length(candidates) < spawncount)
+			message_admins("Warning: not enough players volunteered to be terrors. Could only spawn [length(candidates)] out of [spawncount]!")
+		var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE)
+		while(spawncount && length(vents) && length(candidates))
+			var/obj/vent = pick_n_take(vents)
+			var/mob/living/simple_animal/hostile/poison/terror_spider/S = new spider_type(vent.loc)
+			var/mob/M = pick_n_take(candidates)
+			S.key = M.key
+			S.spider_choose_player_randomly = TRUE
+			spawncount--
+			successSpawn = TRUE
 
 #undef TS_HIGHPOP_TRIGGER
 

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -53,7 +53,6 @@
 			var/mob/living/simple_animal/hostile/poison/terror_spider/S = new spider_type(vent.loc)
 			var/mob/M = pick_n_take(candidates)
 			S.key = M.key
-			S.spider_choose_player_randomly = TRUE
 			spawncount--
 			successSpawn = TRUE
 

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -16,6 +16,10 @@
 		log_and_message_admins("Warning: Could not spawn any mobs for event Terror Spiders")
 
 /datum/event/spider_terror/start()
+	// It is necessary to wrap this to avoid the event triggering repeatedly.
+	INVOKE_ASYNC(src, .proc/wrappedstart)
+
+/datum/event/spider_terror/proc/wrappedstart()
 	var/spider_type
 	var/infestation_type
 	if((length(GLOB.clients)) < TS_HIGHPOP_TRIGGER)
@@ -43,18 +47,17 @@
 			// Strongest, only used during highpop.
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen
 			spawncount = 1
-	spawn() // Just like in xeno and demon events, this spawn() is necessary. Do not remove.
-		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a terror spider?", null, TRUE, source = spider_type)
-		if(length(candidates) < spawncount)
-			message_admins("Warning: not enough players volunteered to be terrors. Could only spawn [length(candidates)] out of [spawncount]!")
-		var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE)
-		while(spawncount && length(vents) && length(candidates))
-			var/obj/vent = pick_n_take(vents)
-			var/mob/living/simple_animal/hostile/poison/terror_spider/S = new spider_type(vent.loc)
-			var/mob/M = pick_n_take(candidates)
-			S.key = M.key
-			spawncount--
-			successSpawn = TRUE
+	var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a terror spider?", null, TRUE, source = spider_type)
+	if(length(candidates) < spawncount)
+		message_admins("Warning: not enough players volunteered to be terrors. Could only spawn [length(candidates)] out of [spawncount]!")
+	var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE, exclude_visible_by_mobs = TRUE)
+	while(spawncount && length(vents) && length(candidates))
+		var/obj/vent = pick_n_take(vents)
+		var/mob/living/simple_animal/hostile/poison/terror_spider/S = new spider_type(vent.loc)
+		var/mob/M = pick_n_take(candidates)
+		S.key = M.key
+		spawncount--
+		successSpawn = TRUE
 
 #undef TS_HIGHPOP_TRIGGER
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -143,7 +143,6 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	var/chasecycles = 0
 	var/web_infects = 0
 	var/spider_creation_time = 0
-	var/spider_choose_player_randomly = FALSE
 
 	var/datum/action/innate/terrorspider/web/web_action
 	var/web_type = /obj/structure/spider/terrorweb
@@ -284,8 +283,6 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/announcetoghosts()
 	if(spider_awaymission)
-		return
-	if(spider_choose_player_randomly)
 		return
 	if(stat == DEAD)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -143,6 +143,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	var/chasecycles = 0
 	var/web_infects = 0
 	var/spider_creation_time = 0
+	var/spider_choose_player_randomly = FALSE
 
 	var/datum/action/innate/terrorspider/web/web_action
 	var/web_type = /obj/structure/spider/terrorweb
@@ -283,6 +284,8 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/announcetoghosts()
 	if(spider_awaymission)
+		return
+	if(spider_choose_player_randomly)
 		return
 	if(stat == DEAD)
 		return


### PR DESCRIPTION
## What Does This PR Do
Previously, the terror spiders major event spawned its spiders, then offered each to ghosts individually, with the first player to click a spider or its prompt getting control of that spider.
Now, the terror spiders event polls eligible ghosts for 30 seconds, then assigns spiders randomly to eligible opted-in players. Only after its picked who will be what spider, does it actually spawn any spiders.
This means players who accept quickly no longer have advantage on becoming initially spawned terror spiders.
It also means that if not enough people sign up to play terrors during an event, admins are warned and fewer than normal spiders are spawned.

## Why It's Good For The Game
Normally, if terrors are being spawned there's generally enough of them for them to be handled on a first-come, first-serve basis.
However, it is possible for the terror spider spawn event to choose to spawn, say, only a single prince of terror.
When that happens, its probably best for selection there to be entirely random, as its likely to be the only terror in the round at all.

## Note
Due to multiplayer issues, this will require a TM to fully test.
This only applies to the initial 1-5 spiders directly spawned by the event. It does NOT apply to any terror who grows up from a spiderling. Don't ask me to apply it there too. I may or may not do that in future, but I want to see how this goes before I even consider that.

## Changelog
:cl: Kyep
tweak: terror spiders spawned directly by event now get offered to all eligible ghosts for 30 seconds, and pick players randomly from that pool.
/:cl: