### PR TITLE
Donut box folding

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -25,42 +25,15 @@
 	icon_state = "box"
 	item_state = "syringe_kit"
 	resistance_flags = FLAMMABLE
-	var/foldable = /obj/item/stack/sheet/cardboard
-	var/amt = 1
-
-/obj/item/storage/box/attack_self(mob/user)
-	..()
-
-	if(!foldable)
-		return
-	if(contents.len)
-		to_chat(user, "<span class='warning'>You can't fold this box with items still inside!</span>")
-		return
-	if(!ispath(foldable))
-		return
-
-	// Close any open UI windows first
-	var/found = 0
-	for(var/mob/M in range(1))
-		if(M.s_active == src)
-			close(M)
-		if(M == user)
-			found = 1
-	if(!found)	// User is too far away
-		return
-
-	to_chat(user, "<span class='notice'>You fold [src] flat.</span>")
-	var/obj/item/stack/I = new foldable(get_turf(src), amt)
-	user.put_in_hands(I)
-	qdel(src)
+	foldable = /obj/item/stack/sheet/cardboard
+	foldable_amt = 1
 
 /obj/item/storage/box/large
 	name = "large box"
 	desc = "You could build a fort with this."
 	icon_state = "largebox"
 	w_class = 4 // Big, bulky.
-	foldable = /obj/item/stack/sheet/cardboard
-	amt = 4
+	foldable_amt = 4
 	storage_slots = 21
 	max_combined_w_class = 42 // 21*2
 
@@ -897,7 +870,6 @@
 	icon_state = "light"
 	desc = "This box is shaped on the inside so that only light tubes and bulbs fit."
 	item_state = "syringe_kit"
-	foldable = /obj/item/stack/sheet/cardboard
 	storage_slots=21
 	can_hold = list(/obj/item/light/tube, /obj/item/light/bulb)
 	max_combined_w_class = 21

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -46,6 +46,8 @@
 	storage_slots = 6
 	can_hold = list(/obj/item/reagent_containers/food/snacks/donut)
 	icon_type = "donut"
+	foldable = /obj/item/stack/sheet/cardboard
+	foldable_amt = 1
 
 /obj/item/storage/fancy/donut_box/update_icon()
 	overlays.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Moves the box folding code into its own proc on `/obj/item/storage`, and makes the donut box foldable.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Less empy donut boxes clogging up the tables at Security, and the ability for more items in the future to also use this proc.

## Changelog
:cl:
add: Empty donut boxes can now be folded into cardboard
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
