### PR TITLE
Gets rid of <br> on science request console 

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -160,7 +160,7 @@
 		return
 	message_sent = TRUE
 	var/area/A = get_area(src)
-	var/msg = "Now available in [A]:<br>"
+	var/msg = "Now available in [A]:\n"
 
 	var/has_minerals = FALSE
 	var/mineral_name = null
@@ -171,7 +171,7 @@
 		mineral_name = capitalize(M.name)
 		if(mineral_amount)
 			has_minerals = TRUE
-		msg += "[mineral_name]: [mineral_amount] sheets<br>"
+		msg += "[mineral_name]: [mineral_amount] sheets\n"
 
 	if(!has_minerals)
 		return

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -160,7 +160,7 @@
 		return
 	message_sent = TRUE
 	var/area/A = get_area(src)
-	var/msg = "Now available in [A]:\n"
+	var/msg = "Now available in [A]:"
 
 	var/has_minerals = FALSE
 	var/mineral_name = null
@@ -171,7 +171,7 @@
 		mineral_name = capitalize(M.name)
 		if(mineral_amount)
 			has_minerals = TRUE
-		msg += "[mineral_name]: [mineral_amount] sheets\n"
+		msg += "[mineral_name]: [mineral_amount] sheets"
 
 	if(!has_minerals)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #14949 by changing the <br> with \n. It looks less horrible more readable. 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Science players are already using their brains for stuff, this stops their brain from dying when looking at request console.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
(Original Picture from the issue)
https://user-images.githubusercontent.com/44008012/99836259-d1e98280-2b33-11eb-9854-fca34e56fcde.png

My Temporary fix
https://i.imgur.com/1VF4mzZ.png
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Changed "break" to \n for messages that ORM sends to science request consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
Note: Unable to type the actual break as it makes a line break in the request itself. I lack to knowledge to alter the formatting lets say and thanks to those on discord for help. Just wanted to help with this annoying problem that popped up.