### PR TITLE
[WIP] Guardian rework

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -66,7 +66,7 @@
 			holder.icon_state = "hudhealthy"
 
 /mob/living/simple_animal/hostile/guardian/Life(seconds, times_fired)
-	..()
+	. = ..()
 	if(summoner)
 		if(summoner.stat == DEAD || (!summoner.check_death_method() && summoner.health <= HEALTH_THRESHOLD_DEAD))
 			summoner.remove_guardian_actions()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
**Reworks or rebalances most Guardians.**
- **Standard**: TODO
- **Assassin**: TODO
- **Chaos**: TODO
- **Charger**: TODO
- **Ranged**:
  - **Adds an overheating mechanic. Too many successive attacks will cause the Guardian to run out of energy, preventing it from further attacking until the overheat counter reaches 0 again.**
  - Reduces armor penetration to `50%` (from `100%`).
  - Increases damage transfer to `1.2` (from `0.9`).
- **Explosive**: TODO
- **Lightning**: TODO
- **Protector**: TODO
- **Support**: TODO

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- **Standard**: TODO
- **Assassin**: TODO
- **Chaos**: TODO
- **Charger**: TODO
- **Ranged**:
  - Overheating prevents infinite spamming for no cost whatsoever and promotes taking careful shots rather than just indiscriminately clicking.
  - The projectiles bypassing armor completely was stupidly broken and resulted in instant fractures and/or IBs.
  - Ranged units are traditionally squishy. A ranged unit that can suppress without feeling much of a punishment for being hit is unfair for the opposition.
- **Explosive**: TODO
- **Lightning**: TODO
- **Protector**: TODO
- **Support**: TODO

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![3JXhNhi9eR](https://user-images.githubusercontent.com/1496804/100778183-f9c7c880-3406-11eb-9171-c347f2b9f06e.gif)
*Ranged*

## Changelog
:cl:
tweak: Ranged Guardian: Add an overheating mechanic. Too many successive attacks will cause the Guardian to run out of energy, preventing it from attacking for a while
tweak: Ranged Guardian: Reduce armor penetration to 50% (from 100%)
tweak: Ranged Guardian: Increase damage transfer to 1.2 (from 0.9)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
