### PR TITLE
Swarmer Beacon EMP damage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -57,10 +57,14 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	layer = BELOW_MOB_LAYER
 	AIStatus = AI_OFF
 	del_on_death = TRUE
+	/// Current spawn cooldown remaining
 	var/swarmer_spawn_cooldown = 0
-	var/swarmer_spawn_cooldown_amt = 15 SECONDS //Seconds between the swarmers we spawn
+	/// Current help cooldown remaining
 	var/call_help_cooldown = 0
-	var/call_help_cooldown_amt = 15 SECONDS //Seconds between calling swarmers to help us when attacked
+	/// Time between the swarmers we spawn
+	var/swarmer_spawn_cooldown_amt = 15 SECONDS
+	/// Time between calling swarmers to help us when attacked
+	var/call_help_cooldown_amt = 15 SECONDS
 	var/static/list/swarmer_caps
 
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -56,10 +56,11 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	wander = FALSE
 	layer = BELOW_MOB_LAYER
 	AIStatus = AI_OFF
+	del_on_death = TRUE
 	var/swarmer_spawn_cooldown = 0
-	var/swarmer_spawn_cooldown_amt = 150 //Deciseconds between the swarmers we spawn
+	var/swarmer_spawn_cooldown_amt = 15 SECONDS //Seconds between the swarmers we spawn
 	var/call_help_cooldown = 0
-	var/call_help_cooldown_amt = 150 //Deciseconds between calling swarmers to help us when attacked
+	var/call_help_cooldown_amt = 15 SECONDS //Seconds between calling swarmers to help us when attacked
 	var/static/list/swarmer_caps
 
 
@@ -87,6 +88,8 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 		call_help_cooldown = world.time + call_help_cooldown_amt
 		summon_backup(25) //long range, only called max once per 15 seconds, so it's not deathlag
 
+/mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/emp_act(severity)
+	adjustHealth(50)
 
 /obj/item/gps/internal/swarmer_beacon
 	icon_state = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Changes swarmer beacons (The lavaland kind) to take 50 damage from EMP pulses and Ion rifles.
This is one and a half ion rifles of ammo to kill it, assuming you never miss or have to target a swarmer instead.

Also added `del_on_death` to swarmer beacons, since currently they're just kinda sitting there with no sprite.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's a bit counter intuitive that the best way to kill a Swarmer is to use an EMP, but the actual spawner itself is completely immune to them.

## Changelog
:cl:
tweak: Swarmer beacons now take damage from EMP pulses
fix: Swarmer beacons now actually get deleted on death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
