### PR TITLE
Emote *help species fix

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -932,41 +932,43 @@
 					return
 
 		if("help")
-			var/emotelist = "aflap(s), airguitar, blink(s), blink(s)_r, blush(es), bow(s)-(none)/mob, burp(s), choke(s), chuckle(s), clap(s), collapse(s), cough(s),cry, cries, custom, dance, dap(s)(none)/mob," \
-			+ " deathgasp(s), drool(s), eyebrow, fart(s), faint(s), flap(s), flip(s), frown(s), gasp(s), giggle(s), glare(s)-(none)/mob, grin(s), groan(s), grumble(s), grin(s)," \
-			+ " handshake-mob, hug(s)-(none)/mob, hem, highfive, johnny, jump, laugh(s), look(s)-(none)/mob, moan(s), mumble(s), nod(s), pale(s), point(s)-atom, quiver(s), raise(s), salute(s)-(none)/mob, scream(s), shake(s)," \
-			+ " shiver(s), shrug(s), sigh(s), signal(s)-#1-10,slap(s)-(none)/mob, smile(s),snap(s), sneeze(s), sniff(s), snore(s), stare(s)-(none)/mob, swag(s), tremble(s), twitch(es), twitch(es)_s," \
-			+ " wag(s), wave(s),  whimper(s), wink(s), yawn(s), quill(s)"
+			var/emotelist = "aflap(s), airguitar, blink(s), blink(s)_r, blush(es), bow(s)-none/mob, burp(s), choke(s), chuckle(s), clap(s), collapse(s), cough(s), cry, cries, custom, dance, dap(s)-none/mob," \
+			+ " deathgasp(s), drool(s), eyebrow, fart(s), faint(s), flap(s), flip(s), frown(s), gasp(s), giggle(s), glare(s)-none/mob, grin(s), groan(s), grumble(s), grin(s)," \
+			+ " handshake-mob, hug(s)-none/mob, hem, highfive, johnny, jump, laugh(s), look(s)-none/mob, moan(s), mumble(s), nod(s), pale(s), point(s)-atom, quiver(s), raise(s), salute(s)-none/mob, scream(s), shake(s)," \
+			+ " shiver(s), shrug(s), sigh(s), signal(s)-#1-10,slap(s)-none/mob, smile(s),snap(s), sneeze(s), sniff(s), snore(s), stare(s)-none/mob, tremble(s), twitch(es), twitch(es)_s," \
+			+ " wave(s), whimper(s), wink(s), yawn(s)"
 
 			switch(dna.species.name)
-				if("Drask")
-					emotelist += "\nDrask specific emotes :- drone(s)-(none)/mob, hum(s)-(none)/mob, rumble(s)-(none)/mob"
-				if("Kidan")
-					emotelist += "\nKidan specific emotes :- click(s), clack(s)"
-				if("Unathi")
-					emotelist += "\nUnathi specific emotes :- hiss(es)"
-				if("Vulpkanin")
-					emotelist += "\nVulpkanin specific emotes :- growl(s)-none/mob, howl(s)-none/mob"
-				if("Vox")
-					emotelist += "\nVox specific emotes :- quill(s)"
 				if("Diona")
-					emotelist += "\nDiona specific emotes :- creak(s)"
+					emotelist += "\n<u>Diona specific emotes</u> :- creak(s)"
+				if("Drask")
+					emotelist += "\n<u>Drask specific emotes</u> :- drone(s)-none/mob, hum(s)-none/mob, rumble(s)-none/mob"
+				if("Kidan")
+					emotelist += "\n<u>Kidan specific emotes</u> :- click(s), clack(s)"
 				if("Skrell")
-					emotelist += "\nSkrell specific emotes :- warble(s)"
+					emotelist += "\n<u>Skrell specific emotes</u> :- warble(s)"
+				if("Tajaran")
+					emotelist += "\n<u>Tajaran specifc emotes</u> :- wag(s), swag(s)"
+				if("Unathi")
+					emotelist += "\n<u>Unathi specific emotes</u> :- wag(s), swag(s), hiss(es)"
+				if("Vox")
+					emotelist += "\n<u>Vox specific emotes</u> :- wag(s), swag(s), quill(s)"
+				if("Vulpkanin")
+					emotelist += "\n<u>Vulpkanin specific emotes</u> :- wag(s), swag(s), growl(s)-none/mob, howl(s)-none/mob"
 
 			if(ismachineperson(src))
-				emotelist += "\nMachine specific emotes :- beep(s)-(none)/mob, buzz(es)-none/mob, no-(none)/mob, ping(s)-(none)/mob, yes-(none)/mob, buzz2-(none)/mob"
+				emotelist += "\n<u>Machine specific emotes</u> :- beep(s)-none/mob, buzz(es)-none/mob, no-none/mob, ping(s)-none/mob, yes-none/mob, buzz2-none/mob"
 			else
 				var/obj/item/organ/external/head/H = get_organ("head") // If you have a robotic head, you can make beep-boop noises
 				if(H && H.is_robotic())
-					emotelist += "\nRobotic head specific emotes :- beep(s)-(none)/mob, buzz(es)-none/mob, no-(none)/mob, ping(s)-(none)/mob, yes-(none)/mob, buzz2-(none)/mob"
+					emotelist += "\n<u>Robotic head specific emotes</u> :- beep(s)-none/mob, buzz(es)-none/mob, no-none/mob, ping(s)-none/mob, yes-none/mob, buzz2-none/mob"
 
 			if(isslimeperson(src))
-				emotelist += "\nSlime people specific emotes :- squish(es)-(none)/mob"
+				emotelist += "\n<u>Slime people specific emotes</u> :- squish(es)-none/mob"
 			else
 				for(var/obj/item/organ/external/L in bodyparts) // if your limbs are squishy you can squish too!
 					if(istype(L.dna.species, /datum/species/slime))
-						emotelist += "\nSlime people body part specific emotes :- squish(es)-(none)/mob"
+						emotelist += "\n<u>Slime people body part specific emotes</u> :- squish(es)-none/mob"
 						break
 
 			to_chat(src, emotelist)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Slightly reogranises the code for the `*help` menu for emotes, and moves `*wag` `*swag` and `*quill` to the species specific sections.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Only four species can `*wag`, and only one can `*quill`. Those emotes really shouldn't be in the global list.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![emotes](https://user-images.githubusercontent.com/57483089/100795904-b4f85d80-3417-11eb-9876-2088e19ead22.PNG)

## Changelog
:cl:
tweak: The 'Species specific emotes' section is now underlined to help it stand out more
fix: Fixed `*wag`, `*swag`, and `*quill` showing for species without the correct body parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
