### PR TITLE
Fix: allow AIs to restore safties on hacked bots

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -879,7 +879,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	update_controls()
 
 /mob/living/simple_animal/bot/proc/canhack(mob/M)
-	return ((issilicon(M) && !emagged) || M.can_admin_interact())
+	return ((issilicon(M) && (!emagged || hacked)) || M.can_admin_interact())
 
 /mob/living/simple_animal/bot/proc/handle_hacking(mob/M) // refactored out of Topic/ to allow re-use by TGUIs
 	if(!canhack(M))


### PR DESCRIPTION
## What Does This PR Do
Fixes an oversight where the TGUI bots PR made it so that while AIs can hack their bots, they could not unhack said bots.
Now, if they hack a bot, they can also unhack that bot.
Note: this does NOT allow AIs to unhack emagged bots. Only hacked bots.

## Changelog
:cl: Kyep
fix: fixed AIs being unable to restore safeties / unhack bots they'd previously hacked.
/:cl: