### PR TITLE
Further increases the speed of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,11 @@ jobs:
           sudo systemctl start mysql
           python3 tools/ci/generate_sql_scripts.py
           tools/ci/validate_sql.sh
-      - name: Install RUST_G
+      - name: Install RUST_G Deps
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
           sudo apt install libssl1.1:i386
-          bash tools/ci/install_rustg.sh
       - name: Compile & Run Unit Tests
         run: |
           tools/ci/install_byond.sh

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ stddef.dm
 
 # ignore midi2piano build cache
 /tools/midi2piano/midi2piano/obj/*
-
-# ignore RUSTG linux binary, since linux dependencies vary with pretty much every single install
-librust_g.so

--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -7,5 +7,5 @@ export NODE_VERSION=12
 export BYOND_MAJOR=513
 # Byond Minor
 export BYOND_MINOR=1526
-# For the RUSTG library
+# For the RUSTG library. Not actually installed by CI but kept as a reference
 export RUSTG_VERSION=2.1-P

--- a/tools/ci/install_rustg.sh
+++ b/tools/ci/install_rustg.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This script is not actually used by CI, but kept as a reference incase we refactor CI again
+
 source _build_dependencies.sh
 
 mkdir -p ~/.byond/bin


### PR DESCRIPTION
## What Does This PR Do
Further increases the speed of the CI chain. We spend 20 seconds downloading RUSTG, even though it never changes inside the repo, so we may as well keep it there

## Why It's Good For The Repository
Even faster CI

## Changelog
N/A