### PR TITLE
Fixes issues/runtimes with the brand intelligence event

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -18,32 +18,30 @@
 
 /datum/event/brand_intelligence/start()
 	for(var/obj/machinery/vending/V in GLOB.machines)
-		if(!is_station_level(V.z))	continue
+		if(!is_station_level(V.z))
+			continue
+		RegisterSignal(V, COMSIG_PARENT_QDELETING, .proc/vendor_destroyed)
 		vendingMachines.Add(V)
 
-	if(!vendingMachines.len)
+	if(!length(vendingMachines))
 		kill()
 		return
 
 	originMachine = pick(vendingMachines)
 	vendingMachines.Remove(originMachine)
-	originMachine.shut_up = 0
-	originMachine.shoot_inventory = 1
+	originMachine.shut_up = FALSE
+	originMachine.shoot_inventory = TRUE
 	log_debug("Original brand intelligence machine: [originMachine] ([ADMIN_VV(originMachine,"VV")]) [ADMIN_JMP(originMachine)]")
 
 /datum/event/brand_intelligence/tick()
-	if(!originMachine || QDELETED(originMachine) || originMachine.shut_up || originMachine.wires.is_all_cut())	//if the original vending machine is missing or has it's voice switch flipped
-		for(var/obj/machinery/vending/saved in infectedMachines)
-			saved.shoot_inventory = 0
-		if(originMachine)
-			originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
-			originMachine.visible_message("[originMachine] beeps and seems lifeless.")
-		kill()
+	if(originMachine.shut_up || originMachine.wires.is_all_cut())	//if the original vending machine is missing or has it's voice switch flipped
+		origin_machine_defeated()
 		return
 
-	if(!vendingMachines.len)	//if every machine is infected
-		for(var/obj/machinery/vending/upriser in infectedMachines)
-			if(prob(70) && !QDELETED(upriser))
+	if(!length(vendingMachines))	//if every machine is infected
+		for(var/thing in infectedMachines)
+			var/obj/machinery/vending/upriser = thing
+			if(prob(70))
 				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
 				M.faction = list("profit")
 				M.speak = rampant_speeches.Copy()
@@ -59,8 +57,31 @@
 		var/obj/machinery/vending/rebel = pick(vendingMachines)
 		vendingMachines.Remove(rebel)
 		infectedMachines.Add(rebel)
-		rebel.shut_up = 0
-		rebel.shoot_inventory = 1
+		rebel.shut_up = FALSE
+		rebel.shoot_inventory = TRUE
 
 		if(ISMULTIPLE(activeFor, 8))
 			originMachine.speak(pick(rampant_speeches))
+
+/datum/event/brand_intelligence/proc/origin_machine_defeated()
+	for(var/thing in infectedMachines)
+		var/obj/machinery/vending/saved = thing
+		saved.shoot_inventory = FALSE
+	if(originMachine)
+		originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
+		originMachine.visible_message("[originMachine] beeps and seems lifeless.")
+	kill()
+
+/datum/event/brand_intelligence/kill()
+	for(var/V in infectedMachines + vendingMachines)
+		UnregisterSignal(V, COMSIG_PARENT_QDELETING)
+	infectedMachines.Cut()
+	vendingMachines.Cut()
+	. = ..()
+
+
+/datum/event/brand_intelligence/proc/vendor_destroyed(obj/machinery/vending/V, force)
+	infectedMachines -= V
+	vendingMachines -= V
+	if(V == originMachine)
+		origin_machine_defeated()


### PR DESCRIPTION
## What Does This PR Do
Refactors the brand intelligence event to remove the qdeleted entries of the list using signals.
Fixes a couple of runtimes and the ability to never have the event finalize due to you destroying one non infected vendor


Fixes:
```
Runtime in brand_intelligence.dm,62: Cannot modify null.shut_up.
   proc name: tick (/datum/event/brand_intelligence/tick)
   src: /datum/event/brand_intelligenc... (/datum/event/brand_intelligence)
   call stack:
   /datum/event/brand_intelligenc... (/datum/event/brand_intelligence): tick()
   /datum/event/brand_intelligenc... (/datum/event/brand_intelligence): process()
   Events (/datum/controller/subsystem/events): fire(0)
   Events (/datum/controller/subsystem/events): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game
Bug fix b gut

## Changelog
:cl:
fix: Destroying vendors now won't break the rampant brand intelligence event
/:cl: