### PR TITLE
Makes purge/reset boards clear the 0th law of synched borgs when a non antag AI is purged/reset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -107,6 +107,8 @@
 			laws.set_zeroth_law(zeroth_law_borg.law)
 		else if(zeroth_law)
 			laws.set_zeroth_law(zeroth_law.law)
+		else
+			laws.clear_zeroth_laws()
 
 /mob/living/silicon/ai/sync_zeroth(var/datum/ai_law/zeroth_law, var/datum/ai_law/zeroth_law_borg)
 	if(zeroth_law)


### PR DESCRIPTION
## What Does This PR Do
Makes law syncs properly sync the zeroth law for borgs when the master AI gets it's zeroth law cleared by a purge/reset upload board.

Fixes #13439

## Why It's Good For The Game
Keeps AI and borg in sync

## Changelog
:cl:
fix: Resetting/purging a non antag AI with a 0th law now properly removes the law from the linked borgs as well
/:cl: