### PR TITLE
Rework of chav text replacement

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -84,13 +84,7 @@
 	activation_message = "Ye feel like a rite prat like, innit?"
 	deactivation_message = "You no longer feel like being rude and sassy."
 	mutation = CHAV
-
-/datum/dna/gene/disability/speech/chav/New()
-	..()
-	block = GLOB.chavblock
-	
-//Normal word first, chav word second
-/var/static/list/chavlinks = list(
+	/var/static/list/chavlinks = list(
 	"arrest" = "nick",
 	"arrested" = "nicked",
 	"ass" = "arse",
@@ -151,7 +145,14 @@
 	"yikes" = "blimey",
 	"you" = "u",
 	"your" = "ur"
-)
+	)
+
+/datum/dna/gene/disability/speech/chav/New()
+	..()
+	block = GLOB.chavblock
+	
+//Normal word first, chav word second
+
 /datum/dna/gene/disability/speech/chav/OnSay(mob/M, message)
 	var/static/regex/R = regex("\\b([chavlinks.Join("|")])\\b", "g")
 	message = R.Replace(message, /proc/rep_test)

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -81,41 +81,85 @@
 /datum/dna/gene/disability/speech/chav
 	name = "Chav"
 	desc = "Forces the language center of the subject's brain to construct sentences in a more rudimentary manner."
-	activation_message = "Ye feel like a reet prat like, innit?"
+	activation_message = "Ye feel like a rite prat like, innit?"
 	deactivation_message = "You no longer feel like being rude and sassy."
 	mutation = CHAV
 
 /datum/dna/gene/disability/speech/chav/New()
 	..()
 	block = GLOB.chavblock
-
+	
+//Normal word first, chav word second
+var/global/chavlinks = list(
+	"arrest" = "nick",
+	"arrested" = "nicked",
+	"ass" = "arse",
+	"bad" = "pants",
+	"bar" = "spoons",
+	"brain" = "noggin",
+	"break" = "smash",
+	"broken" = "gone kaput",
+	"comdom" = "knob'ed",
+	"cool" = "ace",
+	"crazy" = "well mad",
+	"cup of tea" = "cuppa",
+	"destroyed" = "rekt",
+	"dick" = "prat",
+	"disappointed" = "gutted",
+	"disgusting" = "minging",
+	"disposals" = "bins",
+	"drink" = "bevvy",
+	"engineer" = "sparky",
+	"excited" = "jacked",
+	"fight" = "scuffle",
+	"food" = "nosh",
+	"friend" = "blud",
+	"get" = "giz",
+	"girl" = "bird",
+	"go away" = "jog on",
+	"good" = "mint",
+	"great" = "bangin'",
+	"great" = "crackin'",
+	"happy" = "chuffed",
+	"hello" = "orite",
+	"hi" = "sup",
+	"idiot" = "twit",
+	"isn't it" = "innit",
+	"kill" = "bang",
+	"man" = "bloke",
+	"mess" = "shambles",
+	"mistake" = "cock-up",
+	"murder" = "hench",
+	"murdered" = "henched",
+	"no" = "naw",
+	"really" = "propa",
+	"robust" = "'ard",
+	"run" = "leg it",
+	"sec" = "cops",
+	"security" = "coppers",
+	"silly" = "daft",
+	"steal" = "nick",
+	"stole" = "nicked",
+	"surprised" = "gobsmacked",
+	"suspicious" = "dodgy",
+	"tired" = "knackered",
+	"wet" = "moist",
+	"what" = "wot",
+	"window" = "windy",
+	"windows" = "windies",
+	"yes" = "ye",
+	"yikes" = "blimey",
+	"you" = "u",
+	"your" = "ur"
+)
 /datum/dna/gene/disability/speech/chav/OnSay(mob/M, message)
-	// THIS ENTIRE THING BEGS FOR REGEX
-	message = replacetext(message,"dick","prat")
-	message = replacetext(message,"comdom","knob'ead")
-	message = replacetext(message,"looking at","gawpin' at")
-	message = replacetext(message,"great","bangin'")
-	message = replacetext(message,"man","mate")
-	message = replacetext(message,"friend",pick("mate","bruv","bledrin"))
-	message = replacetext(message,"what","wot")
-	message = replacetext(message,"drink","wet")
-	message = replacetext(message,"get","giz")
-	message = replacetext(message,"what","wot")
-	message = replacetext(message,"no thanks","wuddent fukken do one")
-	message = replacetext(message,"i don't know","wot mate")
-	message = replacetext(message,"no","naw")
-	message = replacetext(message,"robust","chin")
-	message = replacetext(message," hi ","how what how")
-	message = replacetext(message,"hello","sup bruv")
-	message = replacetext(message,"kill","bang")
-	message = replacetext(message,"murder","bang")
-	message = replacetext(message,"windows","windies")
-	message = replacetext(message,"window","windy")
-	message = replacetext(message,"break","do")
-	message = replacetext(message,"your","yer")
-	message = replacetext(message,"security","coppers")
+	var/static/chavjoined = jointext(chavlinks, "|")
+	var/static/regex/R = regex("\\b[chavjoined]\\b", "g")
+	message = R.Replace(message, /proc/rep_test)
 	return message
-
+/proc/rep_test(matched)
+	return chavlinks[matched]
+	
 // WAS: /datum/bioEffect/swedish
 /datum/dna/gene/disability/speech/swedish
 	name = "Swedish"

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -154,9 +154,9 @@
 	
 /datum/dna/gene/disability/speech/chav/OnSay(mob/M, message)
 	var/static/regex/R = regex("\\b([chavlinks.Join("|")])\\b", "g")
-	message = R.Replace(message, /datum/dna/gene/disability/speech/chav/proc/rep_test)
+	message = R.Replace(message, /datum/dna/gene/disability/speech/chav/proc/replace_speech)
 	return message
-/datum/dna/gene/disability/speech/chav/proc/rep_test(matched)
+/datum/dna/gene/disability/speech/chav/proc/replace_speech(matched)
 	return chavlinks[matched]
 	
 // WAS: /datum/bioEffect/swedish

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -84,7 +84,7 @@
 	activation_message = "Ye feel like a rite prat like, innit?"
 	deactivation_message = "You no longer feel like being rude and sassy."
 	mutation = CHAV
-	/var/static/list/chavlinks = list(
+	var/static/list/chavlinks = list(
 	"arrest" = "nick",
 	"arrested" = "nicked",
 	"ass" = "arse",
@@ -155,9 +155,9 @@
 
 /datum/dna/gene/disability/speech/chav/OnSay(mob/M, message)
 	var/static/regex/R = regex("\\b([chavlinks.Join("|")])\\b", "g")
-	message = R.Replace(message, /proc/rep_test)
+	message = R.Replace(message, /datum/dna/gene/disability/speech/chav/proc/rep_test)
 	return message
-/proc/rep_test(matched)
+/datum/dna/gene/disability/speech/chav/proc/rep_test(matched)
 	return chavlinks[matched]
 	
 // WAS: /datum/bioEffect/swedish

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -93,6 +93,7 @@
 	"bar" = "spoons",
 	"brain" = "noggin",
 	"break" = "smash",
+	"broke" = "smashed",
 	"broken" = "gone kaput",
 	"comdom" = "knob'ed",
 	"cool" = "ace",
@@ -109,18 +110,19 @@
 	"fight" = "scuffle",
 	"food" = "nosh",
 	"friend" = "blud",
+	"fuck" = "fook",
 	"get" = "giz",
 	"girl" = "bird",
 	"go away" = "jog on",
 	"good" = "mint",
 	"great" = "bangin'",
-	"great" = "crackin'",
 	"happy" = "chuffed",
 	"hello" = "orite",
 	"hi" = "sup",
 	"idiot" = "twit",
 	"isn't it" = "innit",
 	"kill" = "bang",
+	"killed" = "banged",
 	"man" = "bloke",
 	"mess" = "shambles",
 	"mistake" = "cock-up",
@@ -144,8 +146,7 @@
 	"windows" = "windies",
 	"yes" = "ye",
 	"yikes" = "blimey",
-	"you" = "u",
-	"your" = "ur"
+	"your" = "yur"
 	)
 
 /datum/dna/gene/disability/speech/chav/New()

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -90,7 +90,7 @@
 	block = GLOB.chavblock
 	
 //Normal word first, chav word second
-var/global/chavlinks = list(
+/var/static/list/chavlinks = list(
 	"arrest" = "nick",
 	"arrested" = "nicked",
 	"ass" = "arse",
@@ -153,8 +153,7 @@ var/global/chavlinks = list(
 	"your" = "ur"
 )
 /datum/dna/gene/disability/speech/chav/OnSay(mob/M, message)
-	var/static/chavjoined = jointext(chavlinks, "|")
-	var/static/regex/R = regex("\\b[chavjoined]\\b", "g")
+	var/static/regex/R = regex("\\b([chavlinks.Join("|")])\\b", "g")
 	message = R.Replace(message, /proc/rep_test)
 	return message
 /proc/rep_test(matched)

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -84,6 +84,7 @@
 	activation_message = "Ye feel like a rite prat like, innit?"
 	deactivation_message = "You no longer feel like being rude and sassy."
 	mutation = CHAV
+	//List of swappable words. Normal word first, chav word second.
 	var/static/list/chavlinks = list(
 	"arrest" = "nick",
 	"arrested" = "nicked",
@@ -151,8 +152,6 @@
 	..()
 	block = GLOB.chavblock
 	
-//Normal word first, chav word second
-
 /datum/dna/gene/disability/speech/chav/OnSay(mob/M, message)
 	var/static/regex/R = regex("\\b([chavlinks.Join("|")])\\b", "g")
 	message = R.Replace(message, /datum/dna/gene/disability/speech/chav/proc/rep_test)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
**Updates the chav disability:**
Replaces individual replacetext() calls with one regex function and a list of words to check against.
Adds more chav terms, removes or updates disused terms.
Stops replacetext() calls changing matches found in the middle of other words, now only changes whole words.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Little things like this add immersion and variety, so having a few extra changes at minimal performance cost seems like a positive change.

Matches found in the middle of words no longer get replaced, so you don't end up looking like a tool by saying "com**mate**d" every time you try and say "com**man**d".

Multiple replacetext() calls weren't the most efficient way to code this originally, one list with a single regex check is easier to maintain.

Also, who doesn't want more chavs infesting space in the far future?
![image](https://user-images.githubusercontent.com/12197162/101279232-c1363f00-37b8-11eb-9a98-65229edb6630.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more chav words, innit.
del: Removed some old words.
tweak: Replaced many replacetext() calls with a single regex function that only changes whole words.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->