### PR TITLE
Adds a message to the level 7 biohazard event: tells ghosts who got infected and with what disease

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,6 +1,9 @@
 /datum/event/disease_outbreak
 	announceWhen = 15
+	/// The type of disease that patient zero will be infected with.
 	var/datum/disease/D
+	/// The initial target of the disease.
+	var/mob/living/carbon/human/patient_zero
 
 /datum/event/disease_outbreak/setup()
 	announceWhen = rand(15, 30)
@@ -18,6 +21,10 @@
 
 /datum/event/disease_outbreak/announce()
 	GLOB.event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+	for(var/p in GLOB.dead_mob_list)
+		var/mob/M = p
+		if(isobserver(M) || M.stat == DEAD)
+			to_chat(M, "<span class='deadsay'><b>[patient_zero]</b> has been infected with <b>[D.name]</b> ([ghost_follow_link(patient_zero, M)])</span>")
 
 /datum/event/disease_outbreak/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.alive_mob_list))
@@ -33,4 +40,5 @@
 
 		if(!H.ForceContractDisease(D))
 			continue
+		patient_zero = H
 		break

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -23,8 +23,7 @@
 	GLOB.event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 	for(var/p in GLOB.dead_mob_list)
 		var/mob/M = p
-		if(isobserver(M) || M.stat == DEAD)
-			to_chat(M, "<span class='deadsay'><b>[patient_zero]</b> has been infected with <b>[D.name]</b> ([ghost_follow_link(patient_zero, M)])</span>")
+		to_chat(M, "<span class='deadsay'><b>[patient_zero]</b> has been infected with <b>[D.name]</b> ([ghost_follow_link(patient_zero, M)])</span>")
 
 /datum/event/disease_outbreak/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.alive_mob_list))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a message to the level 7 biohazard event that tells ghosts who got infected and with what disease. Someone mentioned this in deadchat a few days ago, and I thought it would be a neat idea to have.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think it's a nice QoL thing for ghosts. Instead of having to track down patient zero, they can jump to them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
I got some randomly-generated disease name here which is why you've never heard of it.

![u2KdpSl](https://user-images.githubusercontent.com/42044220/101291316-7b37a600-37cd-11eb-950e-a1c66d26fa10.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Adds a message to the level 7 biohazard event that tells ghosts who got infected and with what disease
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
