### PR TITLE
Stops crew from pushing massive spiders

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -24,7 +24,7 @@
 	projectiletype = /obj/item/projectile/terrorqueenspit/empress
 	icon = 'icons/mob/terrorspider64.dmi'
 	pixel_x = -16
-	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
+	move_resist = MOVE_FORCE_STRONG // no more pushing a several hundred if not thousand pound spider
 	mob_size = MOB_SIZE_LARGE
 	icon_state = "terror_empress"
 	icon_living = "terror_empress"

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -24,6 +24,7 @@
 	projectiletype = /obj/item/projectile/terrorqueenspit/empress
 	icon = 'icons/mob/terrorspider64.dmi'
 	pixel_x = -16
+	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
 	mob_size = MOB_SIZE_LARGE
 	icon_state = "terror_empress"
 	icon_living = "terror_empress"

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -30,7 +30,7 @@
 	web_type = /obj/structure/spider/terrorweb/purple
 	ai_spins_webs = FALSE
 	gender = MALE
-	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
+	move_resist = MOVE_FORCE_STRONG // no more pushing a several hundred if not thousand pound spider
 
 /mob/living/simple_animal/hostile/poison/terror_spider/prince/death(gibbed)
 	if(can_die() && !hasdied && spider_uo71)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -30,6 +30,7 @@
 	web_type = /obj/structure/spider/terrorweb/purple
 	ai_spins_webs = FALSE
 	gender = MALE
+	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
 
 /mob/living/simple_animal/hostile/poison/terror_spider/prince/death(gibbed)
 	if(can_die() && !hasdied && spider_uo71)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
@@ -19,6 +19,7 @@
 	maxHealth = 150
 	health = 150
 	spider_tier = TS_TIER_3
+	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
 
 	// Unlike queens, no ranged attack.
 	ranged = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
@@ -19,7 +19,7 @@
 	maxHealth = 150
 	health = 150
 	spider_tier = TS_TIER_3
-	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
+	move_resist = MOVE_FORCE_STRONG // no more pushing a several hundred if not thousand pound spider
 
 	// Unlike queens, no ranged attack.
 	ranged = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
@@ -25,6 +25,7 @@
 	speed = 0 // '0' (also the default for human mobs) converts to 2.5 total delay, or 4 tiles/sec.
 	spider_opens_doors = 2
 	ventcrawler = 0
+	move_resist = MOVE_FORCE_STRONG // no more pushing a several hundred if not thousand pound spider
 	ai_ventcrawls = FALSE
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	idle_ventcrawl_chance = 0 // stick to the queen!

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -26,6 +26,7 @@
 	ai_spins_webs = FALSE
 	ai_ventcrawls = FALSE
 	idle_ventcrawl_chance = 0
+	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
 	force_threshold = 18 // outright immune to anything of force under 18, this means welders can't hurt it, only guns can
 	ranged = 1
 	retreat_distance = 5

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -26,7 +26,7 @@
 	ai_spins_webs = FALSE
 	ai_ventcrawls = FALSE
 	idle_ventcrawl_chance = 0
-	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
+	move_resist = MOVE_FORCE_STRONG // no more pushing a several hundred if not thousand pound spider
 	force_threshold = 18 // outright immune to anything of force under 18, this means welders can't hurt it, only guns can
 	ranged = 1
 	retreat_distance = 5

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/red.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/red.dm
@@ -24,6 +24,7 @@
 	move_to_delay = 10 // at 20ticks/sec, this is 2 tile/sec movespeed
 	speed = 2 // movement_delay() gives 4.5, or 0.45s between steps, which = about 2.2 tiles/second. Player is slightly faster than AI, but cannot move on diagonals.
 	spider_opens_doors = 2
+	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
 	web_type = /obj/structure/spider/terrorweb/red
 	var/enrage = 0
 	var/melee_damage_lower_rage0 = 15

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/red.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/red.dm
@@ -24,7 +24,7 @@
 	move_to_delay = 10 // at 20ticks/sec, this is 2 tile/sec movespeed
 	speed = 2 // movement_delay() gives 4.5, or 0.45s between steps, which = about 2.2 tiles/second. Player is slightly faster than AI, but cannot move on diagonals.
 	spider_opens_doors = 2
-	move_resist = STRONG // no more pushing a several hundred if not thousand pound spider
+	move_resist = MOVE_FORCE_STRONG // no more pushing a several hundred if not thousand pound spider
 	web_type = /obj/structure/spider/terrorweb/red
 	var/enrage = 0
 	var/melee_damage_lower_rage0 = 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sets the move_resist of the following terror spiders to "STRONG" (2000) making it so the crew cannot push/pull them. I may do the same with brown terrors but that will make them capable of literally walking in a line and deleting everything they touch.
The fucking EMPRESS.
Prince of Terror.
Queen of Terror.
Princess of Terror.
Purple Terror Spider.
Red Terror Spider.
## Why It's Good For The Game
Being able to push a several hundred, if not thousand pound spider isn't realistic, it also makes it near impossible to escape a lot of scenarios.

## Changelog
:cl:
tweak: Makes larger terror spiders un-push/pull able.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
