### PR TITLE
Bar sign maint/dismantle bug fix.

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -44,10 +44,6 @@
 	if(!broken && !(flags & NODECONSTRUCT))
 		broken = TRUE
 
-/obj/structure/sign/barsign/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/metal(drop_location(), 2)
-	new /obj/item/stack/cable_coil(drop_location(), 2)
-	qdel(src)
 
 /obj/structure/sign/barsign/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -59,6 +55,9 @@
 /obj/structure/sign/barsign/attack_ai(mob/user as mob)
 	return src.attack_hand(user)
 
+// Added to prevent people from unscrewing the barsign, making go invisible in the process
+obj/structure/sign/barsign/screwdriver_act()
+    return
 
 
 /obj/structure/sign/barsign/attack_hand(mob/user as mob)
@@ -69,42 +68,6 @@
 		to_chat(user, "<span class ='danger'>The controls seem unresponsive.</span>")
 		return
 	pick_sign()
-
-
-
-
-/obj/structure/sign/barsign/attackby(var/obj/item/I, var/mob/user)
-	if( istype(I, /obj/item/screwdriver))
-		if(!panel_open)
-			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-			set_sign(new /datum/barsign/hiddensigns/signoff)
-			panel_open = 1
-		else
-			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
-			if(!broken && !emagged)
-				set_sign(pick(barsigns))
-			else if(emagged)
-				set_sign(new /datum/barsign/hiddensigns/syndibarsign)
-			else
-				set_sign(new /datum/barsign/hiddensigns/empbarsign)
-			panel_open = 0
-
-	if(istype(I, /obj/item/stack/cable_coil) && panel_open)
-		var/obj/item/stack/cable_coil/C = I
-		if(emagged) //Emagged, not broken by EMP
-			to_chat(user, "<span class='warning'>Sign has been damaged beyond repair!</span>")
-			return
-		else if(!broken)
-			to_chat(user, "<span class='warning'>This sign is functioning properly!</span>")
-			return
-
-		if(C.use(2))
-			to_chat(user, "<span class='notice'>You replace the burnt wiring.</span>")
-			broken = 0
-		else
-			to_chat(user, "<span class='warning'>You need at least two lengths of cable!</span>")
-	else
-		return ..()
 
 
 

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -44,6 +44,10 @@
 	if(!broken && !(flags & NODECONSTRUCT))
 		broken = TRUE
 
+/obj/structure/sign/barsign/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/metal(drop_location(), 2)
+	new /obj/item/stack/cable_coil(drop_location(), 2)
+	qdel(src)
 
 /obj/structure/sign/barsign/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -55,9 +59,40 @@
 /obj/structure/sign/barsign/attack_ai(mob/user as mob)
 	return src.attack_hand(user)
 
+/obj/structure/sign/barsign/attackby(var/obj/item/I, var/mob/user)
+		if(istype(I, /obj/item/stack/cable_coil) && panel_open)
+		var/obj/item/stack/cable_coil/C = I
+		if(emagged) //Emagged, not broken by EMP
+			to_chat(user, "<span class='warning'>Sign has been damaged beyond repair!</span>")
+			return
+		else if(!broken)
+			to_chat(user, "<span class='warning'>This sign is functioning properly!</span>")
+			return
+
+		if(C.use(2))
+			to_chat(user, "<span class='notice'>You replace the burnt wiring.</span>")
+			broken = 0
+		else
+			to_chat(user, "<span class='warning'>You need at least two lengths of cable!</span>")
+	else
+		return ..()
+
 // Added to prevent people from unscrewing the barsign, making go invisible in the process
 /obj/structure/sign/barsign/screwdriver_act()
-    return
+    if( istype(I, /obj/item/screwdriver))
+		if(!panel_open)
+			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
+			set_sign(new /datum/barsign/hiddensigns/signoff)
+			panel_open = 1
+		else
+			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
+			if(!broken && !emagged)
+				set_sign(pick(barsigns))
+			else if(emagged)
+				set_sign(new /datum/barsign/hiddensigns/syndibarsign)
+			else
+				set_sign(new /datum/barsign/hiddensigns/empbarsign)
+			panel_open = 0
 
 
 /obj/structure/sign/barsign/attack_hand(mob/user as mob)

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -56,7 +56,7 @@
 	return src.attack_hand(user)
 
 // Added to prevent people from unscrewing the barsign, making go invisible in the process
-obj/structure/sign/barsign/screwdriver_act()
+/obj/structure/sign/barsign/screwdriver_act()
     return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removed the ability to unscrew and dismantle
the bar sign, as it caused the bar sign to
disappear, without a way to make it visible again.
This was done, as there were no sprites for either of these functions.
fixes #14884
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As stated in the [issue report](https://github.com/ParadiseSS13/Paradise/issues/14884), invisible objects aren't really a good addition to the game. Yes, its a cosmetic one, but it can be a bit distracting.
## Changelog
:cl: Windbomb
fix: you can no longer break the bar sign by trying to disassemble it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
