### PR TITLE
Fixes #15065 - green terrors laying eggs while in vents

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -137,6 +137,9 @@
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/Web()
 	if(!web_type)
 		return
+	if(!isturf(loc))
+		to_chat(src, "<span class='danger'>Webs can only be spun while standing on a floor.</span>")
+		return
 	var/turf/mylocation = loc
 	visible_message("<span class='notice'>[src] begins to secrete a sticky substance.</span>")
 	if(do_after(src, delay_web, target = loc))

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/green.dm
@@ -50,6 +50,10 @@
 		if(!(eggtype in eggtypes))
 			to_chat(src, "<span class='danger'>Unrecognized egg type.</span>")
 			return 0
+	if(!isturf(loc))
+		// This has to be checked after we ask the user what egg type. Otherwise they could trigger prompt THEN move into a vent.
+		to_chat(src, "<span class='danger'>Eggs can only be laid while standing on a floor.</span>")
+		return
 	if(fed < feedings_to_lay)
 		// We have to check this again after the popup, to account for people spam-clicking the button, then doing all the popups at once.
 		to_chat(src, "<span class='warning'>You must wrap more humanoid prey before you can do this!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -72,6 +72,9 @@
 	if(regen_points < jelly_cost)
 		to_chat(src, "<span class='danger'>You only have [regen_points] of the [jelly_cost] regeneration points you need to do this.</span>")
 		return
+	if(!isturf(loc))
+		to_chat(src, "<span class='danger'>This can only be done while standing on a floor.</span>")
+		return
 	var/turf/mylocation = get_turf(src)
 	if(isspaceturf(mylocation))
 		to_chat(src, "<span class='danger'>Cannot secrete jelly in space.</span>")

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -73,7 +73,7 @@
 		to_chat(src, "<span class='danger'>You only have [regen_points] of the [jelly_cost] regeneration points you need to do this.</span>")
 		return
 	if(!isturf(loc))
-		to_chat(src, "<span class='danger'>This can only be done while standing on a floor.</span>")
+		to_chat(src, "<span class='danger'>You can only secrete jelly while standing on a floor.</span>")
 		return
 	var/turf/mylocation = get_turf(src)
 	if(isspaceturf(mylocation))

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -279,6 +279,9 @@
 	if(eggtype == null || numlings == null)
 		to_chat(src, "<span class='danger'>Cancelled.</span>")
 		return
+	if(!isturf(loc))
+		to_chat(src, "<span class='danger'>Eggs can only be laid while standing on a floor.</span>")
+		return
 	// Actually lay the eggs.
 	if(canlay < numlings)
 		// We have to check this again after the popups, to account for people spam-clicking the button, then doing all the popups at once.


### PR DESCRIPTION
## What Does This PR Do
Fixes #15065 
Adds some additional safety checks to a few terror spider functions (egglaying, web creation, royal jelly creation) to prevent people doing them while inside a pipe.

## Changelog
:cl: Kyep
fix: fixed terrors being able to lay eggs (and some other things) while inside a vent.
/:cl: