### PR TITLE
AIs can now toggle whether they wish to announce oncoming station arrivals or not

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -20,7 +20,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	/mob/living/silicon/ai/proc/toggle_acceleration,
 	/mob/living/silicon/ai/proc/toggle_camera_light,
 	/mob/living/silicon/ai/proc/botcall,
-	/mob/living/silicon/ai/proc/change_arrival_message
+	/mob/living/silicon/ai/proc/change_arrival_message,
+	/mob/living/silicon/ai/proc/arrivals_announcement
 ))
 
 //Not sure why this is necessary...
@@ -103,6 +104,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	var/obj/structure/AIcore/deactivated/linked_core //For exosuit control
 
+	var/announce_arrivals = TRUE //If our AI doesn't want to be the arrivals announcer, this gets set to 0.
 	var/arrivalmsg = "$name, $rank, has arrived on the station."
 
 	var/multicam_allowed = FALSE
@@ -1133,6 +1135,13 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	set desc = "Augment visual feed with internal sensor overlays."
 	set category = "AI Commands"
 	toggle_sensor_mode()
+
+/mob/living/silicon/ai/proc/arrivals_announcement()
+	set name = "Toggle Arrivals Announcer"
+	set desc = "Change whether or not you wish to announce arrivals."
+	set category = "AI Commands"
+	announce_arrivals = !announce_arrivals
+	to_chat(usr, "Arrivals announcement system toggled.")
 
 /mob/living/silicon/ai/proc/change_arrival_message()
 	set name = "Set Arrival Message"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	var/obj/structure/AIcore/deactivated/linked_core //For exosuit control
 
-	///If our AI doesn't want to be the arrivals announcer, this gets set to FALSE.
+	/// If our AI doesn't want to be the arrivals announcer, this gets set to FALSE.
 	var/announce_arrivals = TRUE
 	var/arrivalmsg = "$name, $rank, has arrived on the station."
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1141,7 +1141,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	set desc = "Change whether or not you wish to announce arrivals."
 	set category = "AI Commands"
 	announce_arrivals = !announce_arrivals
-	to_chat(usr, "Arrivals announcement system toggled.")
+	to_chat(usr, "Arrivals announcement system [announce_arrivals ? "enabled" : "disabled"]")
 
 /mob/living/silicon/ai/proc/change_arrival_message()
 	set name = "Set Arrival Message"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	var/obj/structure/AIcore/deactivated/linked_core //For exosuit control
 
-	var/announce_arrivals = TRUE //If our AI doesn't want to be the arrivals announcer, this gets set to 0.
+	var/announce_arrivals = TRUE //If our AI doesn't want to be the arrivals announcer, this gets set to FALSE.
 	var/arrivalmsg = "$name, $rank, has arrived on the station."
 
 	var/multicam_allowed = FALSE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -104,7 +104,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	var/obj/structure/AIcore/deactivated/linked_core //For exosuit control
 
-	var/announce_arrivals = TRUE //If our AI doesn't want to be the arrivals announcer, this gets set to FALSE.
+	///If our AI doesn't want to be the arrivals announcer, this gets set to FALSE.
+	var/announce_arrivals = TRUE
 	var/arrivalmsg = "$name, $rank, has arrived on the station."
 
 	var/multicam_allowed = FALSE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -415,7 +415,7 @@
 	if(SSticker.current_state == GAME_STATE_PLAYING)
 		var/ailist[] = list()
 		for(var/mob/living/silicon/ai/A in GLOB.alive_mob_list)
-			if(A.announce_arrivals == TRUE)
+			if(A.announce_arrivals)
 				ailist += A
 		if(ailist.len)
 			var/mob/living/silicon/ai/announcer = pick(ailist)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -415,7 +415,8 @@
 	if(SSticker.current_state == GAME_STATE_PLAYING)
 		var/ailist[] = list()
 		for(var/mob/living/silicon/ai/A in GLOB.alive_mob_list)
-			ailist += A
+			if(A.announce_arrivals == TRUE)
+				ailist += A
 		if(ailist.len)
 			var/mob/living/silicon/ai/announcer = pick(ailist)
 			if(character.mind)


### PR DESCRIPTION
## What Does This PR Do
See title.

## Why It's Good For The Game
As an AI, I generally wish I could delegate the arrivals messages to the automatic announcement system. This allows AIs who want to personalize their announcement system do so, while allowing others to opt out.

## Changelog
:cl:
add: Added a new command for AIs: "Toggle Arrivals Announcer". This will allow AIs to opt into or out of announcing all oncoming crew arrivals.
/:cl:
