### PR TITLE
Cult barrier rune chaining

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -634,7 +634,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 //Rite of the Corporeal Shield: When invoked, becomes solid and cannot be passed. Invoke again to undo.
 /obj/effect/rune/wall
 	cultist_name = "Barrier"
-	cultist_desc = "when invoked, makes a temporary invisible wall to block passage. Can be destroyed by brute force. Can be invoked again to reverse this."
+	cultist_desc = "when invoked makes a temporary wall to block passage. Can be destroyed by brute force. Can be invoked again to reverse this."
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "barrier"
 	///The barrier summoned by the rune when invoked. Tracked as a variable to prevent refreshing the barrier's integrity. shieldgen.dm
@@ -643,6 +643,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/wall/Initialize(mapload)
 	. = ..()
 	GLOB.wall_runes += src
+	B = new /obj/machinery/shield/cult/barrier(loc)
+	B.parent_rune = src
 
 /obj/effect/rune/wall/Destroy()
 	GLOB.wall_runes -= src
@@ -653,10 +655,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/wall/invoke(list/invokers)
 	var/mob/living/user = invokers[1]
 	..()
-	if(!B)
-		B = new /obj/machinery/shield/cult/barrier(loc)
-		B.parent_rune = src
-	B.Toggle()
+	if(B.Toggle()) // Toggling on
+		for(var/obj/effect/rune/wall/rune in orange(1, src)) // Chaining barriers
+			if(!rune.B.density) // Barrier is invisible
+				rune.B.Toggle()
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.cult_self_harm(2)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -655,13 +655,16 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/wall/invoke(list/invokers)
 	var/mob/living/user = invokers[1]
 	..()
+	var/amount = 1
 	if(B.Toggle()) // Toggling on
 		for(var/obj/effect/rune/wall/rune in orange(1, src)) // Chaining barriers
-			if(!rune.B.density) // Barrier is invisible
+			if(!rune.B.density) // Barrier is currently invisible
+				amount++ // Count the invoke damage for each rune
+				rune.do_invoke_glow()
 				rune.B.Toggle()
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
-		C.cult_self_harm(2)
+		C.cult_self_harm(2 * amount)
 
 //Rite of Joined Souls: Summons a single cultist.
 /obj/effect/rune/summon

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -81,9 +81,18 @@
 	layer = ABOVE_MOB_LAYER
 
 /obj/machinery/shield/cult/barrier
-	density = FALSE //toggled on right away by the parent rune
+	density = FALSE
 	/// The rune that created the shield itself. Used to delete the rune when the shield is destroyed.
 	var/obj/effect/rune/parent_rune
+
+/obj/machinery/shield/cult/barrier/Initialize()
+	. = ..()
+	invisibility = INVISIBILITY_MAXIMUM
+
+/obj/machinery/shield/cult/barrier/Destroy()
+	if(parent_rune && !QDELETED(parent_rune))
+		QDEL_NULL(parent_rune)
+	return ..()
 
 /obj/machinery/shield/cult/barrier/attack_hand(mob/living/user)
 	parent_rune.attack_hand(user)
@@ -94,11 +103,6 @@
 	else
 		..()
 
-/obj/machinery/shield/cult/barrier/Destroy()
-	if(parent_rune && !QDELETED(parent_rune))
-		QDEL_NULL(parent_rune)
-	return ..()
-
 /**
 * Turns the shield on and off.
 *
@@ -107,13 +111,18 @@
 * The barrier itself is not intended to interact with the conceal runes cult spell for balance purposes.
 */
 /obj/machinery/shield/cult/barrier/proc/Toggle()
+	var/visible
 	if(!density) // Currently invisible
 		density = TRUE // Turn visible
 		invisibility = initial(invisibility)
+		visible = TRUE
 	else // Currently visible
 		density = FALSE // Turn invisible
 		invisibility = INVISIBILITY_MAXIMUM
+		visible = FALSE
+
 	air_update_turf(1)
+	return visible
 
 /obj/machinery/shieldgen
 	name = "Emergency shield projector"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a chaining effect to Cult barrier runes, so that activating one will also activate any adjacent runes.
This doesn't work for deactivating though, so they still need to be individually turned off.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
QOL improvement for Cultists.
*(Could maybe be considered a buff, but I'd say it's a very small one.)*

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
### Before:
![XuoRET8ENl](https://user-images.githubusercontent.com/57483089/101645080-dc5db480-3a2d-11eb-9927-60af3e208891.gif)
### After:
![cgDXMwC83P](https://user-images.githubusercontent.com/57483089/101645086-df58a500-3a2d-11eb-8bbb-791bafc96e5c.gif)

## Changelog
:cl:
tweak: When activating a Cult barrier rune, any adjacent barrier runes will also be enabled (This still includes the invoke damage for each activated rune)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
