### PR TITLE
Makes terrors less strong when pulling depending on their tier/class

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/brown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/brown.dm
@@ -23,6 +23,7 @@
 	spider_opens_doors = 2 // Breach specialist.
 	environment_smash = ENVIRONMENT_SMASH_RWALLS // Breaks anything.
 	spider_tier = TS_TIER_2
+	pull_force = PULL_FORCE_DEFAULT
 	ai_ventbreaker = 1
 	freq_ventcrawl_combat = 600 // Ventcrawls very frequently, breaking open vents as it goes.
 	freq_ventcrawl_idle =  1800

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
@@ -21,6 +21,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 25
 	spider_tier = TS_TIER_2
+	pull_force = PULL_FORCE_DEFAULT
 	move_to_delay = 5 // at 20ticks/sec, this is 4 tile/sec movespeed, same as a human. Faster than a normal spider, so it can intercept attacks on queen.
 	speed = 0 // '0' (also the default for human mobs) converts to 2.5 total delay, or 4 tiles/sec.
 	spider_opens_doors = 2

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -296,6 +296,16 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	U.add_hud_to(src)
 	spider_creation_time = world.time
 
+/mob/living/simple_animal/hostile/poison/terror_spider/Initialize(mapload)
+	if(!pull_force)
+		switch(spider_tier)
+			if(TS_TIER_3, TS_TIER_4)
+				pull_force = MOVE_FORCE_DEFAULT
+			else
+				pull_force = MOVE_FORCE_WEAK
+	return ..()
+
+
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/announcetoghosts()
 	if(spider_awaymission)
 		return
@@ -366,6 +376,11 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 			F.open()
 			return 1
 	. = ..()
+
+/mob/living/simple_animal/hostile/poison/terror_spider/start_pulling(atom/movable/AM, state, force = pull_force, show_message = FALSE)
+	if(isliving(AM))
+		force = max(PULL_FORCE_DEFAULT, force) // Primal force engage
+	return ..()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/msg_terrorspiders(msgtext)
 	for(var/thing in GLOB.ts_spiderlist)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 /mob/living/simple_animal/hostile/poison/terror_spider/Initialize(mapload)
 	if(!pull_force)
 		switch(spider_tier)
-			if(TS_TIER_3, TS_TIER_4)
+			if(TS_TIER_3 to INFINITY)
 				pull_force = MOVE_FORCE_DEFAULT
 			else
 				pull_force = MOVE_FORCE_WEAK


### PR DESCRIPTION
## What Does This PR Do
Makes lesser terror spiders unable to pull big objects behind them. Any machine or structure that can be moved is usually considered a bigger object in this case. Items of size bulky or bigger are also considered to big. They can still pull mobs without an issue

Tier 3 and higher spiders can drag things like they normally could since they are stronger and bigger. The brown and purple spiders can also do this even though they are tier 2 spiders.

## Why It's Good For The Game
Reduces the cheese terrors use. Dragging either undestroyable/hard to destroy objects behind them to block laser shots or dragging fuel/water tanks behind them to instantly kill people.

## Changelog
:cl:
balance: Terror spiders of tier 2 and lower now can't drag bigger objects behind them. They can still drag mobs just fine. Exceptions are the brown and purple spiders.
/:cl: