### PR TITLE
Traitor uplink changes: Remove don't improve

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -287,6 +287,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	job = list("Psychiatrist")//why? Becuase its funny that a person in charge of your mental wellbeing has a cat granade..
 
+//Virology
+
+/datum/uplink_item/jobspecific/viral_injector
+	name = "Viral Injector"
+	desc = "A modified hypospray disguised as a functional pipette. The pipette can infect victims with viruses upon injection."
+	reference = "VI"
+	item = /obj/item/reagent_containers/dropper/precision/viral_injector
+	cost = 2
+	job = list("Virologist")
+
 //Assistant
 
 /datum/uplink_item/jobspecific/pickpocketgloves
@@ -1447,11 +1457,21 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/implants/microbomb
 	name = "Microbomb Implant"
-	desc = "An implant injected into the body, and later activated either manually or automatically upon death. The more implants inside of you, the higher the explosive power. \
-	This will permanently destroy your body, however."
+	desc = "An implant injected into the body, and later activated either manually or automatically upon death. \
+	Limited stock of one per uplink."
 	reference = "MBI"
 	item = /obj/item/implanter/explosive
 	cost = 2
+	limited_stock = 1
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/implants/microbomb/nukies
+	desc = "An implant injected into the body, and later activated either manually or automatically upon death. The more implants inside of you, the higher the explosive power. \
+	This will permanently destroy your body, however."
+	reference = "NMBI"
+	item = /obj/item/implanter/explosive
+	limited_stock = -1
+	excludefrom = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 
 // Cybernetics

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1453,6 +1453,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "MBI"
 	item = /obj/item/implanter/explosive
 	cost = 2
+	gamemodes = list(/datum/game_mode/nuclear)
 
 // Cybernetics
 /datum/uplink_item/cyber_implants

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -826,7 +826,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CQC"
 	item = /obj/item/CQC_manual
 	cost = 13
-	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/cameraflash
 	name = "Camera Flash"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -205,6 +205,17 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 5 //you need two for full damage, so total of 10 for maximum damage
 	job = list("Shaft Miner")
 
+//Janitor
+
+/datum/uplink_item/jobspecific/cautionsign
+	name = "Proximity Mine"
+	desc = "An Anti-Personnel proximity mine cleverly disguised as a wet floor caution sign that is triggered by running past it, activate it to start the 15 second timer and activate again to disarm."
+	reference = "PM"
+	item = /obj/item/caution/proximity_sign
+	cost = 4
+	job = list("Janitor")
+	surplus = 0
+
 //Chef
 /datum/uplink_item/jobspecific/specialsauce
 	name = "Chef Excellence's Special Sauce"
@@ -921,7 +932,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "X4"
 	item = /obj/item/grenade/plastic/x4
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/x4bag
 	name = "Bag of X-4 explosives"
@@ -930,9 +940,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			For when you want a controlled explosion that leaves a wider, deeper, hole."
 	reference = "X4B"
 	item = /obj/item/storage/backpack/duffel/syndie/x4
-	cost = 4
+	cost = 5
 	cant_discount = TRUE
-	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -173,14 +173,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 5
 	job = list("Clown")
 
-/datum/uplink_item/jobspecific/clownmagboots
-	name = "Clown Magboots"
-	desc = "A pair of modified clown shoes fitted with an advanced magnetic traction system. Look and sound exactly like regular clown shoes unless closely inspected."
-	reference = "CM"
-	item = /obj/item/clothing/shoes/magboots/clown
-	cost = 3
-	job = list("Clown")
-
 /datum/uplink_item/jobspecific/trick_revolver
 	name = "Trick Revolver"
 	desc = "A revolver that will fire backwards and kill whoever attempts to use it. Perfect for those pesky vigilante or just a good laugh."
@@ -219,7 +211,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A custom sauce made from the highly poisonous fly amanita mushrooms. Anyone who ingests it will take variable toxin damage depending on how long it has been in their system, with a higher dosage taking longer to metabolize."
 	reference = "CESS"
 	item = /obj/item/reagent_containers/food/condiment/syndisauce
-	cost = 2
+	cost = 1
 	job = list("Chef")
 
 /datum/uplink_item/jobspecific/meatcleaver
@@ -266,17 +258,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0 //No lucky chances from the crate; if you get this, this is ALL you're getting
 	hijack_only = TRUE //This is a murderbone weapon, as such, it should only be available in those scenarios.
 
-//Janitor
-
-/datum/uplink_item/jobspecific/cautionsign
-	name = "Proximity Mine"
-	desc = "An Anti-Personnel proximity mine cleverly disguised as a wet floor caution sign that is triggered by running past it, activate it to start the 15 second timer and activate again to disarm."
-	reference = "PM"
-	item = /obj/item/caution/proximity_sign
-	cost = 4
-	job = list("Janitor")
-	surplus = 0
-
 //Medical
 
 /datum/uplink_item/jobspecific/rad_laser
@@ -284,18 +265,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A radiation laser concealed inside of a Health Analyzer. After a moderate delay, causes temporary collapse and radiation. Has adjustable controls, but will not function as a regular health analyzer, only appears like one. May not function correctly on radiation resistant humanoids!"
 	reference = "RL"
 	item = /obj/item/rad_laser
-	cost = 5
-	job = list("Chief Medical Officer", "Medical Doctor", "Geneticist", "Psychiatrist",	"Chemist", "Paramedic", "Coroner", "Virologist")
-
-//Virology
-
-/datum/uplink_item/jobspecific/viral_injector
-	name = "Viral Injector"
-	desc = "A modified hypospray disguised as a functional pipette. The pipette can infect victims with viruses upon injection."
-	reference = "VI"
-	item = /obj/item/reagent_containers/dropper/precision/viral_injector
 	cost = 3
-	job = list("Virologist")
+	job = list("Chief Medical Officer", "Medical Doctor", "Geneticist", "Psychiatrist",	"Chemist", "Paramedic", "Coroner", "Virologist")
 
 /datum/uplink_item/jobspecific/cat_grenade
 	name = "Feral Cat Delivery Grenade"
@@ -365,16 +336,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 12
 	job = list("Research Director")
 
-//Roboticist
-/datum/uplink_item/jobspecific/syndiemmi
-	name = "Syndicate MMI"
-	desc = "A syndicate developed man-machine-interface which will make any cyborg it is inserted into follow the standard syndicate lawset."
-	reference = "SMMI"
-	item = /obj/item/mmi/syndie
-	cost = 2
-	job = list("Roboticist")
-	surplus = 0
-
 //Librarian
 /datum/uplink_item/jobspecific/etwenty
 	name = "The E20"
@@ -383,6 +344,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/dice/d20/e20
 	cost = 3
 	job = list("Librarian")
+	surplus = 0 //hijack only so no surplus
+	hijack_only = TRUE // a fun item, but not a good idea to not have it be hijack-only considering you'll get banned if your RNG is too good
 
 //Botanist
 /datum/uplink_item/jobspecific/ambrosiacruciatus
@@ -407,7 +370,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fire axe with a massive energy charge built into it. Upon striking someone while charged it will throw them backwards while stunning them briefly, but will take some time to charge up again. It is also much sharper than a regular axe and can pierce light armor."
 	reference = "EFA"
 	item = /obj/item/twohanded/fireaxe/energized
-	cost = 10
+	cost = 8
 	job = list("Life Support Specialist")
 
 //Stimulants
@@ -429,18 +392,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/reagent_containers/glass/bottle/traitor
 	cost = 2
 	job = list("Research Director", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Chemist", "Paramedic", "Virologist", "Bartender", "Chef")
-
-// Paper contact poison pen
-
-/datum/uplink_item/jobspecific/poison_pen
-	name = "Poison Pen"
-	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with delayed contact poison."
-	reference = "PP"
-	item = /obj/item/pen/poison
-	cost = 2
-	excludefrom = list(/datum/game_mode/nuclear)
-	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian")
-
 
 // DANGEROUS WEAPONS
 
@@ -672,21 +623,21 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds that are less effective at injuring the target but penetrate protective gear."
 	reference = "10MMAP"
 	item = /obj/item/ammo_box/magazine/m10mm/ap
-	cost = 2
+	cost = 1
 
 /datum/uplink_item/ammo/pistolfire
 	name = "Stechkin - 10mm Incendiary Magazine"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with incendiary rounds which ignite the target."
 	reference = "10MMFIRE"
 	item = /obj/item/ammo_box/magazine/m10mm/fire
-	cost = 2
+	cost = 1
 
 /datum/uplink_item/ammo/pistolhp
 	name = "Stechkin - 10mm Hollow Point Magazine"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds which are more damaging but ineffective against armour."
 	reference = "10MMHP"
 	item = /obj/item/ammo_box/magazine/m10mm/hp
-	cost = 3
+	cost = 1
 
 /datum/uplink_item/ammo/bullslug
 	name = "Bulldog - 12g Slug Magazine"
@@ -831,7 +782,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A speed loader that contains seven additional .357 Magnum rounds for the syndicate revolver. For when you really need a lot of things dead."
 	reference = "357"
 	item = /obj/item/ammo_box/a357
-	cost = 3
+	cost = 1
 
 // STEALTHY WEAPONS
 
@@ -864,6 +815,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CQC"
 	item = /obj/item/CQC_manual
 	cost = 13
+	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/cameraflash
 	name = "Camera Flash"
@@ -950,36 +902,19 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Just add water to make your very own hostile to everything space carp. It looks just like a plushie. The first person to squeeze it will be registered as its owner, who it will not attack. If no owner is registered, it'll just attack everyone."
 	reference = "DSC"
 	item = /obj/item/toy/carpplushie/dehy_carp
-	cost = 2
+	cost = 1
 
 // GRENADES AND EXPLOSIVES
 
 /datum/uplink_item/explosives
 	category = "Grenades and Explosives"
 
-/datum/uplink_item/explosives/plastic_explosives
-	name = "Composition C-4"
-	desc = "C-4 is plastic explosive of the common variety Composition C. You can use it to breach walls or connect an assembly to its wiring to make it remotely detonable. It has a modifiable timer with a minimum setting of 10 seconds."
-	reference = "C4"
-	item = /obj/item/grenade/plastic/c4
-	cost = 1
-
 /datum/uplink_item/explosives/plastic_explosives_pack
 	name = "Pack of 5 C-4 Explosives"
 	desc = "A package containing 5 C-4 Explosives at a discounted price. For when you need that little bit extra for your sabotaging needs."
 	reference = "C4P"
 	item = /obj/item/storage/box/syndie_kit/c4
-	cost = 4
-
-/datum/uplink_item/explosives/c4bag
-	name = "Bag of C-4 explosives"
-	desc = "Because sometimes quantity is quality. Contains 10 C-4 plastic explosives."
-	reference = "C4B"
-	item = /obj/item/storage/backpack/duffel/syndie/c4
-	cost = 8 //20% discount!
-	cant_discount = TRUE
-	gamemodes = list(/datum/game_mode/nuclear)
-
+	cost = 3
 /datum/uplink_item/explosives/breaching_charge
 	name = "Composition X-4"
 	desc = "X-4 is a shaped charge designed to be safe to the user while causing maximum damage to the occupants of the room beach breached. It has a modifiable timer with a minimum setting of 10 seconds."
@@ -1008,6 +943,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 11
 	surplus = 0
 	cant_discount = TRUE
+	hijack_only = TRUE
 
 /datum/uplink_item/explosives/emp_bomb
 	name = "EMP bomb"
@@ -1094,14 +1030,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	it can also be used in a washing machine to forge clothing."
 	reference = "CHST"
 	item = /obj/item/stamp/chameleon
-	cost = 1
-	surplus = 35
-
-/datum/uplink_item/stealthy_tools/chameleonflag
-	name = "Chameleon Flag"
-	desc = "A flag that can be disguised as any other known flag. There is a hidden spot in the pole to boobytrap the flag with a grenade or minibomb, which will detonate some time after the flag is set on fire."
-	reference = "CHFLAG"
-	item = /obj/item/flag/chameleon
 	cost = 1
 	surplus = 35
 
@@ -1228,15 +1156,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	excludefrom = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/stealthy_tools/cutouts
-	name = "Adaptive Cardboard Cutouts"
-	desc = "These cardboard cutouts are coated with a thin material that prevents discoloration and makes the images on them appear more lifelike. This pack contains three as well as a \
-	spraycan for changing their appearances."
-	reference = "ADCC"
-	item = /obj/item/storage/box/syndie_kit/cutouts
-	cost = 1
-	surplus = 20
-
 /datum/uplink_item/stealthy_tools/safecracking
 	name = "Safe-cracking Kit"
 	desc = "Everything you need to quietly open a mechanical combination safe."
@@ -1292,7 +1211,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Stolen prototype bone repair nanites. Contains one nanocalcium autoinjector and guide."
 	reference = "NCAI"
 	item = /obj/item/storage/box/syndie_kit/bonerepair
-	cost = 4
+	cost = 3
 
 /datum/uplink_item/device_tools/thermal_drill
 	name = "Thermal Safe Drill"
@@ -1410,19 +1329,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/powersink
 	cost = 10
 
-/datum/uplink_item/device_tools/singularity_beacon
-	name = "Power Beacon"
-	desc = "When screwed to wiring attached to an electric grid and activated, this large device pulls any \
-			active gravitational singularities or tesla balls towards it. This will not work when the engine is still \
-			in containment. Because of its size, it cannot be carried. Ordering this \
-			sends you a small beacon that will teleport the larger beacon to your location upon activation."
-	reference = "SNGB"
-	item = /obj/item/radio/beacon/syndicate
-	cost = 10
-	surplus = 0
-	hijack_only = TRUE //This is an item only useful for a hijack traitor, as such, it should only be available in those scenarios.
-	cant_discount = TRUE
-
 /datum/uplink_item/device_tools/syndicate_detonator
 	name = "Syndicate Detonator"
 	desc = "The Syndicate Detonator is a companion device to the Syndicate Bomb. Simply press the included button and an encrypted radio frequency will instruct all live syndicate bombs to detonate. \
@@ -1451,7 +1357,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This device will disrupt any nearby outgoing radio communication when activated."
 	reference = "RJ"
 	item = /obj/item/jammer
-	cost = 5
+	cost = 2
 
 /datum/uplink_item/device_tools/teleporter
 	name = "Teleporter Circuit Board"
@@ -1506,7 +1412,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An implant injected into the body, and later activated manually to open an uplink with 10 telecrystals. The ability for an agent to open an uplink after their possessions have been stripped from them makes this implant excellent for escaping confinement."
 	reference = "UI"
 	item = /obj/item/implanter/uplink
-	cost = 14
+	cost = 12
 	surplus = 0
 	cant_discount = TRUE
 
@@ -1538,7 +1444,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "MBI"
 	item = /obj/item/implanter/explosive
 	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
 
 // Cybernetics
 /datum/uplink_item/cyber_implants

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -877,13 +877,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 	surplus = 10
 
-/datum/uplink_item/stealthy_weapons/false_briefcase
-	name = "False Bottomed Briefcase"
-	desc = "A modified briefcase capable of storing and firing a gun under a false bottom. Use a screwdriver to pry away the false bottom and make modifications. Distinguishable upon close examination due to the added weight."
-	reference = "FBBC"
-	item = /obj/item/storage/briefcase/false_bottomed
-	cost = 3
-
 /datum/uplink_item/stealthy_weapons/soap
 	name = "Syndicate Soap"
 	desc = "A sinister-looking surfactant used to clean blood stains to hide murders and prevent DNA analysis. You can also drop it underfoot to slip people."
@@ -954,14 +947,24 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
-	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 90 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
+	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 30 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	reference = "SB"
-	item = /obj/item/radio/beacon/syndicate/bomb
+	item = /obj/item/radio/beacon/syndicate/bomb/hijack
 	cost = 11
 	surplus = 0
 	cant_discount = TRUE
 	hijack_only = TRUE
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/explosives/syndicate_bomb/nukies
+	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 90 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
+	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
+	reference = "NSB"
+	item = /obj/item/radio/beacon/syndicate/bomb
+	cost = 11
+	excludefrom = list()
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/explosives/emp_bomb
 	name = "EMP bomb"
@@ -1231,21 +1234,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/bonerepair
 	cost = 3
 
-/datum/uplink_item/device_tools/thermal_drill
-	name = "Thermal Safe Drill"
-	desc = "A tungsten carbide thermal drill with magnetic clamps for the purpose of drilling hardened objects. Guaranteed 100% jam proof."
-	reference = "DRL"
-	item = /obj/item/thermal_drill
-	cost = 3
-	excludefrom = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/device_tools/diamond_drill
 	name = "Diamond Tipped Thermal Safe Drill"
 	desc = "A diamond tipped thermal drill with magnetic clamps for the purpose of quickly drilling hardened objects. Guaranteed 100% jam proof."
 	reference = "DDRL"
 	item = /obj/item/thermal_drill/diamond_drill
 	cost = 1
-	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/medkit
 	name = "Syndicate Combat Medic Kit"

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -273,6 +273,10 @@
 	desc = "A salvaged syndicate device gutted of its explosives to be used as a training aid for aspiring bomb defusers."
 	payload = /obj/item/bombcore/training
 
+/obj/machinery/syndicatebomb/hijack
+	minimum_timer = 30
+	timer_set = 30
+
 /obj/machinery/syndicatebomb/emp
 	name = "emp bomb"
 	icon_state = "emp-bomb"

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -86,6 +86,9 @@
 		user.drop_item()
 		qdel(src)
 
+/obj/item/radio/beacon/syndicate/bomb/hijack
+	bomb = /obj/machinery/syndicatebomb/hijack
+
 /obj/item/radio/beacon/syndicate/bomb/emp
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance EMP explosive to your location</i>."
 	bomb = /obj/machinery/syndicatebomb/emp

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 	if(!UI)
 		return
 	if(UI.limited_stock == 0)
-		to_chat(usr, "<span class='warning'>You have redeemed this discount already.</span>")
+		to_chat(usr, "<span class='warning'>You have redeemed this purchase already.</span>")
 		return
 	UI.buy(src,usr)
 	if(UI.limited_stock > 0) // only decrement it if it's actually limited

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -28,11 +28,11 @@
 			new /obj/item/encryptionkey/syndicate(src) // 2TC
 			return
 
-		if("bond") // 33TC + three 0TC
+		if("bond") // 30TC + three 0TC
 			new /obj/item/gun/projectile/automatic/pistol(src) // 4TC
 			new /obj/item/suppressor(src) // 1TC
-			new /obj/item/ammo_box/magazine/m10mm/hp(src)  // 3TC
-			new /obj/item/ammo_box/magazine/m10mm/ap(src) // 2TC
+			new /obj/item/ammo_box/magazine/m10mm/hp(src)  // 1TC
+			new /obj/item/ammo_box/magazine/m10mm/ap(src) // 1TC
 			new /obj/item/clothing/under/suit_jacket/really_black(src) // 0TC
 			new /obj/item/card/id/syndicate(src) // 2TC
 			new /obj/item/clothing/suit/storage/lawyer/blackjacket/armored(src) // 0TC
@@ -58,12 +58,12 @@
 			new /obj/item/encryptionkey/syndicate(src) // 2TC
 			return
 
-		if("payday") // 35TC + four 0TC
+		if("payday") // 28TC + four 0TC
 			new /obj/item/gun/projectile/revolver(src) // 13TC
-			new /obj/item/ammo_box/a357(src) // 3TC
-			new /obj/item/ammo_box/a357(src) // 3TC
+			new /obj/item/ammo_box/a357(src) // 1TC
+			new /obj/item/ammo_box/a357(src) // 1TC
 			new /obj/item/card/emag(src) // 6TC
-			new /obj/item/jammer(src) // 5TC
+			new /obj/item/jammer(src) // 2TC
 			new /obj/item/card/id/syndicate(src) // 2TC
 			new /obj/item/clothing/under/suit_jacket/really_black(src) //0TC
 			new /obj/item/clothing/suit/storage/lawyer/blackjacket/armored(src) //0TC
@@ -73,9 +73,9 @@
 			new /obj/item/encryptionkey/syndicate(src) // 2TC
 			return
 
-		if("implant") // 39TC + ten free TC
+		if("implant") // 37TC + ten free TC
 			new /obj/item/implanter/freedom(src) // 5TC
-			new /obj/item/implanter/uplink(src) // 14TC (ten free TC)
+			new /obj/item/implanter/uplink(src) // 12TC (ten free TC)
 			new /obj/item/implanter/emp(src) // 0TC
 			new /obj/item/implanter/adrenalin(src) // 8TC
 			new /obj/item/implanter/explosive(src) // 2TC

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -152,6 +152,9 @@
 	damage = 27
 	armour_penetration = 40
 
+/obj/item/projectile/bullet/midbullet3/fire
+	damage = 25
+
 /obj/item/projectile/bullet/midbullet3/fire/on_hit(atom/target, blocked = 0)
 	if(..(target, blocked))
 		var/mob/living/M = target


### PR DESCRIPTION
warning: wall of text

## What Does This PR Do

Removes the following items from the traitor uplink:
- False Bottomed Briefcase
- Clown Magboots
- Roboticist Syndicate MMI
- Poison Pen
- Power Beacon
- Single C4
- Bag of 10 C4s from nukies
- Chameleon Flag
- Adaptive Cardboard Cutouts

Reduces the cost of the following items:
- Chef Poison ( 2 -> 1) (considering just letting them buy poison bottles and removing this)
- Doctor Radiation Laser (5 -> 3)
- Virologist Viral Injector (3 -> 2)
- Dehydrated Carp (2 -> 1)
- Energized Fire-axe (10 -> 8)
- Nanocalcium Injector (4 -> 3) (considering reducing to 2)
- Radio Jammer (5 -> 2)
- 5 C4 kit (4 -> 3)
- Uplink Implant (14 -> 12)
- All Stechkin Ammo and .357 ammo(2 or 3 -> 1)

Makes the following items hijack-only:
- Librarian E20 (you can also no longer get it from surplus)
- Macrobomb

And whatever else:
- Allows traitors to buy X4 and microbomb implants, the latter being restricted to one for each uplink
- Replaces 3TC traitor drill with 1TC nukie diamond drill
- Incendiary ammo for the stechkin deals 25 damage instead of 30
- Hijack Syndicate bombs have a 30 second timer instead of a 90 seconds one (nukies still have the 90 seconds)

## Why It's Good For The Game

   All items I've removed I consider bloat to the uplink, given that they're unfixable in their current state. This is due to them either fulfilling a purpose that isn't that needed (clown magboots, poison pen, chameleon flag, cardboard cutouts, briefcase), are outclassed by something else (Syndicate MMI by the emag, C4 to X4), bear in mind you can still buy the kit of 5 C4s for specialized tactics with ninja stars and payloads, i just removed the excessive or barebones quantities or in the special case of the power beacon, it encourages hijackers to try the second most boring hijack tactic there is, next to e-magging bolted doors.

   The items i've reduced the price from have their uses, and can be salvaged from their shitty pricing, explanation for the reduction being:
- They have a good effect, but their price is just too high to be considered a good deal, this is the case with the nanocalcium injector, radio jammer, uplink implant, the different ammo for the stechkin and .357.
-  They're a subpar item with a bad effect for it's price, this is my way of seeing if they're actually worth anything before removing them or giving them a full rework, this is the case with chef sauce, radiation laser, energized fireaxe, dehydrated carp and viral injector.

Macrobomb was made hijack-only given that this will get you banned by using it outside of the hijack objective, same to the E20, given that rolling too high will get you in trouble. The timer was reduced from the macrobomb given that it's also a bad item as is, so now the chances of it being disarmed or thrown into space before explosion are much slimmer.

Microbomb implants were added as a tool for traitors to both get rid of soon-to-be-corpses or to get the final laugh on security. The implant has a limited stock of one per uplink, so you cannot stack it in the same way nuclear operatives can.

X4s are actually useful C4s, consider them a replacement of C4s (in the breaching aspect) after this PR , as they'll fulfill the purpose of breaching into places consistently without having to pop five of them.

I reduced the damage from incendiary ammo to give it a downside from normal ammo, to make it a side-grade like the other ammo types, whether it's dealing less damage to armored people or less damage in general, for the upside of armor penetration

## Changelog
:cl:
add: Added X4 and diamond vault drills to the traitor uplink.
add: Added Microbomb implants to the traitor uplink, they have a limited stock of one.
del: Removed clown magboots, syndicate MMI, viral injector, poison pen, power beacon, 1 C4 and 10 C4s, false bottomed briefcase, 3TC drill, chameleon flag and adaptive cardboard cutouts from the uplink.
tweak: Chef Poison costs 1TC instead of 2 in the uplink
tweak: Radiation laser costs 3TC instead of 5 in the uplink.
tweak: Dehydrated Carp cost 1TC instead of 2 in the uplink.
tweak: Energized Fire-axe costs 8TC instead of 10 in the uplink.
tweak: Nanocalcium injector costs 3TC instead of 4 in the uplink.
tweak: Radio Jammer costs 2TC instead of 5 in the uplink.
tweak: Uplink implant costs 12TC instead of 14 in the uplink.
tweak: All stechkin ammo and .357 ammo costs 1TC in the uplink.
tweak: the 5 C4 kit costs 3TC instead of 4 in the uplink.
tweak: Stechkin incendiary ammo deals 25 damage instead of 30.
tweak: Syndicate bomb and E20 are now hijack-only purchases from the uplink.
tweak: Syndicate bombs bought from the hijack uplink have a 30 second timer instead of a 90 seconds one.
/:cl: