### PR TITLE
Methamphaldehyde - Memechem Nerf/Change

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_INIT(standard_chemicals, list("slimejelly","blood","water","lube","c
 								"plasma","teporone","lexorin","silver_sulfadiazine","salbutamol",
 								"perfluorodecalin","omnizine","synaptizine","haloperidol","potass_iodide",
 								"pen_acid","mannitol","oculine","styptic_powder","methamphetamine",
-								"cryoxadone","spaceacillin","carpotoxin","lsd","fluorosurfactant",
+								"methamphaldehyde","cryoxadone","spaceacillin","carpotoxin","lsd","fluorosurfactant",
 								"fluorosurfactant","ethanol","ammonia","diethylamine","antihol","pancuronium",
 								"lipolicide","condensedcapsaicin","frostoil","amanitin","psilocybin",
 								"enzyme","nothing","salglu_solution","antifreeze","neurotoxin", "jestosterone"))

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -360,17 +360,39 @@
 	return list(effect, update_flags)
 
 /datum/reagent/methamphaldehyde
-	name = "methamphaldehyde"
+	name = "Methamphaldehyde"
 	id = "methamphaldehyde"
-	description = ""
+	description = "A diluted mix of methamphetamine and mannitol. Its effects are weaker leading to no chance at brain damage or addiction, but it reacts poorly to one's immune system."
 	reagent_state = LIQUID
-	color = "#60A584" // rgb: 96, 165, 132
+	color = "#97d1b5" // rgb: 59, 82, 71
 	overdose_threshold = 0
 	addiction_chance = 0
 	addiction_threshold = 0
 	metabolization_rate = 0.6
 	heart_rate_increase = 1
 	taste_description = "speed"
+
+/datum/reagent/methamphaldehyde/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
+	if(prob(5))
+		M.emote(pick("twitch_s","blink_r","shiver"))
+	if(current_cycle >= 25)
+		M.AdjustJitter(5)
+	M.AdjustDrowsy(-10)
+	update_flags |= M.AdjustParalysis(-1.5, FALSE)
+	update_flags |= M.AdjustStunned(-1.5, FALSE)
+	update_flags |= M.AdjustWeakened(-1.5, FALSE)
+	update_flags |= M.adjustStaminaLoss(-1, FALSE)
+	update_flags |= M.SetSleeping(0, FALSE)
+	M.status_flags |= GOTTAGOFAST
+	if(prob(10))
+		var/mob/living/carbon/human/C = M
+		C.vomit()
+	return ..() | update_flags
+
+/datum/reagent/methamphaldehyde/on_mob_delete(mob/living/M)
+	M.status_flags &= ~GOTTAGOFAST
+	..()
 
 /datum/reagent/bath_salts
 	name = "Bath Salts"

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -381,8 +381,7 @@
 			var/datum/reagent/R = I
 			if(stimulant_list.Find(R.id))
 				has_stimulant = TRUE
-				if(R.id == "methamphetamine")
-					M.reagents.remove_reagent(R.id, 5)
+				M.reagents.remove_reagent(R.id, 5)
 			else
 				has_stimulant = FALSE
 	if(has_stimulant == TRUE)

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -382,24 +382,23 @@
 			if(stimulant_list.Find(R.id))
 				has_stimulant = TRUE
 				M.reagents.remove_reagent(R.id, 5)
-			else
-				has_stimulant = FALSE
 	if(has_stimulant == TRUE)
 		if(prob(10))
 			if(iscarbon(M))
 				var/mob/living/carbon/human/C = M
 				C.vomit()
-				update_flags |= M.Weaken(15, FALSE)
+				update_flags |= M.Weaken(5, FALSE)
+	else
+		M.AdjustDrowsy(-10)
+		update_flags |= M.AdjustParalysis(-2, FALSE)
+		update_flags |= M.AdjustStunned(-2, FALSE)
+		update_flags |= M.AdjustWeakened(-2, FALSE)
+		update_flags |= M.adjustStaminaLoss(-1.5, FALSE)
+		update_flags |= M.SetSleeping(0, FALSE)
 	if(prob(5))
 		M.emote(pick("twitch_s","blink_r","shiver"))
 	if(current_cycle >= 25)
 		M.AdjustJitter(5)
-	M.AdjustDrowsy(-10)
-	update_flags |= M.AdjustParalysis(-2, FALSE)
-	update_flags |= M.AdjustStunned(-2, FALSE)
-	update_flags |= M.AdjustWeakened(-2, FALSE)
-	update_flags |= M.adjustStaminaLoss(-1.5, FALSE)
-	update_flags |= M.SetSleeping(0, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/methamphaldehyde/overdose_process(mob/living/M, severity)

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -362,7 +362,7 @@
 /datum/reagent/methamphaldehyde
 	name = "Methamphaldehyde"
 	id = "methamphaldehyde"
-	description = "A diluted mix of methamphetamine and mannitol. Its effects are weaker leading to no chance at brain damage or addiction, but it reacts poorly to one's immune system."
+	description = "A diluted mix of methamphetamine and mannitol. Its effects are weaker leading to no chance at brain damage or addiction, but it reacts VERY poorly with other stimulants, causing severe stomach aches and vomiting."
 	reagent_state = LIQUID
 	color = "#97d1b5" // rgb: 59, 82, 71
 	overdose_threshold = 20
@@ -371,9 +371,26 @@
 	metabolization_rate = 0.6
 	heart_rate_increase = 1
 	taste_description = "quick"
+	var/list/stimulant_list = list("methamphetamine", "crank", "bath_salts", "stimulative_agent", "stimulants")
 
 /datum/reagent/methamphaldehyde/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	var/has_stimulant = FALSE
+	if(M.reagents.reagent_list)
+		for(var/I in M.reagents.reagent_list)
+			var/datum/reagent/R = I
+			if(stimulant_list.Find(R.id))
+				has_stimulant = TRUE
+				if(R.id == "methamphetamine")
+					M.reagents.remove_reagent(R.id, 5)
+			else
+				has_stimulant = FALSE
+	if(has_stimulant == TRUE)
+		if(prob(10))
+			if(iscarbon(M))
+				var/mob/living/carbon/human/C = M
+				C.vomit()
+				update_flags |= M.Weaken(15, FALSE)
 	if(prob(5))
 		M.emote(pick("twitch_s","blink_r","shiver"))
 	if(current_cycle >= 25)

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -382,12 +382,12 @@
 	update_flags |= M.AdjustParalysis(-1.5, FALSE)
 	update_flags |= M.AdjustStunned(-1.5, FALSE)
 	update_flags |= M.AdjustWeakened(-1.5, FALSE)
-	update_flags |= M.adjustStaminaLoss(-1, FALSE)
 	update_flags |= M.SetSleeping(0, FALSE)
 	M.status_flags |= GOTTAGOFAST
-	if(prob(10))
-		var/mob/living/carbon/human/C = M
-		C.vomit()
+	if(prob(5))
+		if(iscarbon(M))
+			var/mob/living/carbon/human/C = M
+			C.vomit()
 	return ..() | update_flags
 
 /datum/reagent/methamphaldehyde/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -359,6 +359,19 @@
 			M.emote("laugh")
 	return list(effect, update_flags)
 
+/datum/reagent/methamphaldehyde
+	name = "methamphaldehyde"
+	id = "methamphaldehyde"
+	description = ""
+	reagent_state = LIQUID
+	color = "#60A584" // rgb: 96, 165, 132
+	overdose_threshold = 0
+	addiction_chance = 0
+	addiction_threshold = 0
+	metabolization_rate = 0.6
+	heart_rate_increase = 1
+	taste_description = "speed"
+
 /datum/reagent/bath_salts
 	name = "Bath Salts"
 	id = "bath_salts"

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -50,6 +50,13 @@
 			C.reagents.add_reagent("toxin", 10)
 			C.reagents.add_reagent("neurotoxin2", 20)
 
+/datum/chemical_reaction/methamphaldehyde
+	name = "methamphaldehyde"
+	id = "methamphaldehyde"
+	result = "methamphaldehyde"
+	required_reagents = list("methamphetamine" = 1, "mannitol" = 1)
+	result_amount = 2
+
 /datum/chemical_reaction/bath_salts
 	name = "bath_salts"
 	id = "bath_salts"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new chemical, methamphaldehyde, to act as a sort of "buffer chemical" to prevent the mixing of Meth and Mannitol in one of the most common memechem combos. It acts as a "safer" meth-like chemical by not applying brain damage, but it doesnt mix well with other stimulants and will cause complications if done so.

**Paralysis Adjust**: -1.5 -> -2
**Stun Adjust**: -1.5 -> -2
**Weakened Adjust**: -1.5 -> -2
**Stamina Adjust**: removed -> -1.5
**Vomit Chance**: 10% -> removed
**Speed Increase**: removed

If mixed with other stimulants, it will now cause vomiting, a knockdown much like when overdosing, and will purge the offending stimulant from your system. This prevents it from being mixed with other stimulants for MASSIVELY increased anti-stun.


The discussions around other possible changes for what the effects can be are found at: https://www.paradisestation.org/forum/topic/19884-possible-memechem-nerfs-meth-mannitol/
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Memechems are one of the dumbest ways for antags to get dunked on by the Crew. I haven't seen a single Nukies round where there aren't 10 people packed into Sci/MedChem making 1000u+ of Meth+Mann+Hydro. When your only answer to it is "blow them up with explosives", that's poor balance. With this PR, it addresses the issue that people can use Meth safely with zero downsides by simply adding mannitol to the mix. 

Originally, I was going to leave it at that, but Qwerty and a few others in #coding_chat mentioned how you would just add this chemical to a meth+methamphaldehyde mix and literally be an unstunnable god. So, to counter this case, I've made it so that you have to choose between the safer-yet-slower methamphaldehyde or the faster-but-dangerous methamphetamine. This allows for antags to still have a potent anti-stun in a game where the combat only revolves around stuns for the most part, but prevents them from zipping around at Mach 7 at the same time with zero downsides.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: adds methamphaldehyde, a 1:1 ratio mixture of methamphetamine and mannitol
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
