### PR TITLE
Makes blobbernauts and blob spores able to catch on fire

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -16,6 +16,8 @@
 	universal_speak = 1 //So mobs can understand them when a blob uses Blob Broadcast
 	sentience_type = SENTIENCE_OTHER
 	gold_core_spawnable = NO_SPAWN
+	can_be_on_fire = TRUE
+	fire_damage = 3
 	var/mob/camera/blob/overmind = null
 
 /mob/living/simple_animal/hostile/blob/proc/adjustcolors(var/a_color)
@@ -56,11 +58,6 @@
 	var/list/human_overlays = list()
 	var/mob/living/carbon/human/oldguy
 	var/is_zombie = FALSE
-
-/mob/living/simple_animal/hostile/blob/blobspore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
-	..()
-	adjustBruteLoss(clamp(0.01 * exposed_temperature, 1, 5))
-
 
 /mob/living/simple_animal/hostile/blob/blobspore/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover, /obj/structure/blob))
@@ -189,6 +186,8 @@
 		if(locate(/obj/structure/blob) in get_turf(src))
 			adjustBruteLoss(-0.25)
 			adjustFireLoss(-0.25)
+			if(on_fire)
+				adjust_fire_stacks(-1)	// Slowly extinguish the flames
 		else
 			adjustBruteLoss(0.2) // If you are at full health, you won't lose health. You'll need it. However the moment anybody sneezes on you, the decaying will begin.
 			adjustFireLoss(0.2)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -183,20 +183,21 @@
 	if(fire_stacks < 0) //If we've doused ourselves in water to avoid fire, dry off slowly
 		fire_stacks = min(0, fire_stacks + 1)//So we dry ourselves back to default, nonflammable.
 	if(!on_fire)
-		return 1
+		return FALSE
 	if(fire_stacks > 0)
 		adjust_fire_stacks(-0.1) //the fire is slowly consumed
 		for(var/obj/item/clothing/C in contents)
 			C.catch_fire()
 	else
 		ExtinguishMob()
-		return
+		return FALSE
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.oxygen < 1)
 		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire
-		return
+		return FALSE
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(700, 50, 1)
+	return TRUE
 
 /mob/living/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -36,8 +36,14 @@
 	//Temperature effect
 	var/minbodytemp = 250
 	var/maxbodytemp = 350
-	var/heat_damage_per_tick = 2	//amount of damage applied if animal's body temperature is higher than maxbodytemp
-	var/cold_damage_per_tick = 2	//same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
+	/// Amount of damage applied if animal's body temperature is higher than maxbodytemp
+	var/heat_damage_per_tick = 2
+	/// Same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
+	var/cold_damage_per_tick = 2
+	/// If the mob can catch fire
+	var/can_be_on_fire = FALSE
+	/// Damage the mob will take if it is on fire
+	var/fire_damage = 2
 
 	//Healable by medical stacks? Defaults to yes.
 	var/healable = 1
@@ -394,13 +400,30 @@
 	return TRUE
 
 /mob/living/simple_animal/handle_fire()
-	return TRUE
+	if(!can_be_on_fire)
+		return TRUE
+	. = ..()
+	if(!.)
+		return
+	adjustFireLoss(fire_damage) // Slowly start dying from being on fire
 
 /mob/living/simple_animal/IgniteMob()
-	return FALSE
+	if(!can_be_on_fire)
+		return FALSE
+	return ..()
 
 /mob/living/simple_animal/ExtinguishMob()
-	return
+	if(!can_be_on_fire)
+		return
+	return ..()
+
+
+/mob/living/simple_animal/update_fire()
+	if(!can_be_on_fire)
+		return
+	overlays -= image("icon"='icons/mob/OnFire.dmi', "icon_state"="Generic_mob_burning")
+	if(on_fire)
+		overlays += image("icon"='icons/mob/OnFire.dmi', "icon_state"="Generic_mob_burning")
 
 /mob/living/simple_animal/revive()
 	..()


### PR DESCRIPTION
## What Does This PR Do
Makes blob spores and blobbernauts able to be lit aflame.
They take 3 damage per tick while on fire. They will slowly extinguish themselves over time and standing on a blob structure will speed this process up a lot.

Metrics:
Blob suicide fuel tank bomb without healing died in about 1 minute and 23 seconds on it's own
Blob fuel tank bomb who went onto a blob structure: Put out it's fires in about 6-8 seconds

The system also allows for other simple mobs to catch fire but I've kept it to blobbernauts and blob spores for now.

Some code is removed which did not do anything for blob spores. Simple mobs never had their fire_act called (from what I've seen while testing) so the code did nothing before.

## Why It's Good For The Game
Makes fire dangerous to blob mobs. Fuel tank bombings are now dangerous to the blobbernauts as well instead of them taking about 30-40 damage and killing an entire team of heavily armed officers due to the sleep.


## Changelog
:cl:
balance: Blob spores and blobbernauts can now catch fire. Getting on a blob structure will extinguish the flames faster
/:cl: