### PR TITLE
Gives Zealot's Blindfolds the ability to see concealed cult runes and structures

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -6,6 +6,10 @@
 
 #define SEE_INVISIBLE_LIVING 25
 
+// Hidden cult runes
+#define INVISIBILITY_HIDDEN_RUNES  30
+#define SEE_INVISIBLE_HIDDEN_RUNES 30
+
 #define SEE_INVISIBLE_LEVEL_ONE 35	//Used by some stuff in code. It's really poorly organized.
 
 #define SEE_INVISIBLE_LEVEL_TWO 45	//Used by some other stuff in code. It's really poorly organized.

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -247,6 +247,7 @@
 	icon_state = "blindfold"
 	item_state = "blindfold"
 	see_in_dark = 8
+	invis_override = SEE_INVISIBLE_HIDDEN_RUNES
 	flash_protect = TRUE
 	prescription = TRUE
 	origin_tech = null

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -71,6 +71,9 @@
 	if(!iscultist(user))
 		to_chat(user, "[heathen_message]")
 		return
+	if(invisibility)
+		to_chat(user, "<span class='cultitalic'>The magic in [src] is being channeled into Redspace, reveal the structure first!</span>")
+		return
 	if(HULK in user.mutations)
 		to_chat(user, "<span class='danger'>You cannot seem to manipulate this structure with your bulky hands!</span>")
 		return
@@ -108,7 +111,7 @@
 /obj/structure/cult/functional/cult_conceal()
 	density = FALSE
 	visible_message("<span class='danger'>[src] fades away.</span>")
-	invisibility = INVISIBILITY_OBSERVER
+	invisibility = INVISIBILITY_HIDDEN_RUNES
 	alpha = 100 //To help ghosts distinguish hidden objs
 	light_range = 0
 	light_power = 0

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -122,7 +122,7 @@ To draw a rune, use a ritual dagger.
 
 /obj/effect/rune/cult_conceal() //for concealing spell
 	visible_message("<span class='danger'>[src] fades away.</span>")
-	invisibility = INVISIBILITY_OBSERVER
+	invisibility = INVISIBILITY_HIDDEN_RUNES
 	alpha = 100 //To help ghosts distinguish hidden runes
 
 /obj/effect/rune/cult_reveal() //for revealing spell
@@ -142,7 +142,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	//This proc determines if the rune can be invoked at the time. If there are multiple required cultists, it will find all nearby cultists.
 	var/list/invokers = list() //people eligible to invoke the rune
 	var/list/chanters = list() //people who will actually chant the rune when passed to invoke()
-	if(invisibility == INVISIBILITY_OBSERVER)//hidden rune
+	if(invisibility == INVISIBILITY_HIDDEN_RUNES)//hidden rune
 		return
 	// Get the user
 	if(user)
@@ -211,7 +211,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 /obj/effect/rune/proc/fail_invoke()
 	//This proc contains the effects of a rune if it is not invoked correctly, through either invalid wording or not enough cultists. By default, it's just a basic fizzle.
-	visible_message("<span class='warning'>The markings pulse with a small flash of red light, then fall dark.</span>")
+	if(!invisibility) // No visible messages if not visible
+		visible_message("<span class='warning'>The markings pulse with a small flash of red light, then fall dark.</span>")
 	animate(src, color = rgb(255, 0, 0), time = 0)
 	animate(src, color = rune_blood_color, time = 5)
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -9,19 +9,19 @@
 	icon_dead = "shade_dead"
 	speed = 0
 	a_intent = INTENT_HARM
-	stop_automated_movement = 1
-	status_flags = CANPUSH
+	stop_automated_movement = TRUE
 	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_HIDDEN_RUNES
 	attack_sound = 'sound/weapons/punch1.ogg'
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	faction = list("cult")
 	flying = TRUE
 	pressure_resistance = 100
-	universal_speak = 1
+	universal_speak = TRUE
 	AIStatus = AI_OFF //normal constructs don't have AI
 	loot = list(/obj/item/reagent_containers/food/snacks/ectoplasm)
-	del_on_death = 1
+	del_on_death = TRUE
 	deathmessage = "collapses in a shattered heap."
 	var/construct_type = "shade"
 	var/list/construct_spells = list()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -23,6 +23,7 @@
 	stop_automated_movement = TRUE
 	status_flags = 0
 	pull_force = 0
+	see_invisible = SEE_INVISIBLE_HIDDEN_RUNES
 	universal_speak = TRUE
 	faction = list("cult")
 	status_flags = CANPUSH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Allows cultists to wear the 'Zealot's Blindfold' item in order to see hidden runes or structures.
Also adds this to Constructs and Shades by default.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hopefully encourages the use of small, hidden cult bases as well as the use of the 'Conceal Presence' spell in general.
Also it's pretty fitting for the theme of a magic blindfold, letting you see stuff in other dimensions.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![0oUUviQuMK](https://user-images.githubusercontent.com/57483089/101693909-32e8e400-3a6a-11eb-971a-ab38005392b2.gif)

## Changelog
:cl:
add: Wearing a 'Zealot's Blindfold' will now show any Cult runes and structures hidden by the 'Conceal' spell. Constructs and Shades also get this ability built-in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
