### PR TITLE
Maint drones now can't be chosen as agent by autotraitor

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -52,7 +52,7 @@
 		if(!traitor || !istype(traitor))
 			pre_traitors.Remove(traitor)
 			continue
-		if(istype(traitor)) 
+		if(istype(traitor))
 			traitor.special_role = SPECIAL_ROLE_TRAITOR
 			traitor.restricted_roles = restricted_jobs
 
@@ -83,7 +83,7 @@
 				if(player.mind.special_role)
 					traitorcount += 1
 					continue
-				if(ishuman(player) || isrobot(player) || isAI(player))
+				if(ishuman(player) || isAI(player))
 					if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
 						possible_traitors += player.mind
 		for(var/datum/mind/player in possible_traitors)


### PR DESCRIPTION
## What Does This PR Do
Makes it so that maint drones can't be picked as agent by autotraitor.

## Why It's Good For The Game
How ever funny it is it's a bug

## Changelog
:cl:
fix: Maint drones can't be made agent anymore due to the autotraitor gamemode
/:cl: