### PR TITLE
Snowballs from snow tiles

### DIFF
--- a/code/game/objects/effects/snowcloud.dm
+++ b/code/game/objects/effects/snowcloud.dm
@@ -125,7 +125,6 @@
 /obj/item/snowball
 	name = "snowball"
 	desc = "Get ready for a snowball fight!"
-	force = 0
 	throwforce = 10
 	icon_state = "snowball"
 	damtype = STAMINA

--- a/code/game/objects/structures/snow.dm
+++ b/code/game/objects/structures/snow.dm
@@ -8,9 +8,18 @@
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snow"
 	max_integrity = 15
+	var/cooldown = 0 // very cool down
 
 /obj/structure/snow/AltClick(mob/user)
 	. = ..()
+	if(cooldown > world.time)
+		return
 	if(ishuman(user) && Adjacent(user))
 		var/mob/living/carbon/human/H = user
-		H.put_in_hands(new /obj/item/snowball)
+		var/obj/item/snowball/S = new
+		cooldown = world.time + 3 SECONDS
+
+		if(H.put_in_hands(S))
+			playsound(src, 'sound/weapons/slashmiss.ogg', 15) // crunchy snow sound
+		else if(!QDELETED(S))
+			qdel(S) // Spawn in hands only

--- a/code/game/objects/structures/snow.dm
+++ b/code/game/objects/structures/snow.dm
@@ -21,5 +21,5 @@
 
 		if(H.put_in_hands(S))
 			playsound(src, 'sound/weapons/slashmiss.ogg', 15) // crunchy snow sound
-		else if(!QDELETED(S))
+		else
 			qdel(S) // Spawn in hands only

--- a/code/game/objects/structures/snow.dm
+++ b/code/game/objects/structures/snow.dm
@@ -1,11 +1,16 @@
 /obj/structure/snow
-    gender = PLURAL
-    name = "snow"
-    desc = "A crunchy layer of freshly fallen snow."
-    anchored = TRUE
-    density = FALSE
-    layer = TURF_LAYER
-    plane = FLOOR_PLANE
-    icon = 'icons/turf/snow.dmi'
-    icon_state = "snow"
-    max_integrity = 15
+	name = "snow"
+	desc = "A crunchy layer of freshly fallen snow."
+	anchored = TRUE
+	density = FALSE
+	layer = TURF_LAYER
+	plane = FLOOR_PLANE
+	icon = 'icons/turf/snow.dmi'
+	icon_state = "snow"
+	max_integrity = 15
+
+/obj/structure/snow/AltClick(mob/user)
+	. = ..()
+	if(ishuman(user) && Adjacent(user))
+		var/mob/living/carbon/human/H = user
+		H.put_in_hands(new /obj/item/snowball)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Allows players to make snowballs by alt-clicking on a snow covered tile.
Also changed spaces into tabs in `snow.dm`.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Snowball fights!

## Changelog
:cl:
tweak: You can now alt-click on a snow tile to make a snowball!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
