### PR TITLE
Makes changeling and stable mutagen transforms update your sec HUD

### DIFF
--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -94,12 +94,4 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	if(!D)
 		return
 
-	H.set_species(D.species.type, retain_damage = TRUE)
-	H.dna = D.Clone()
-	H.real_name = D.real_name
-	domutcheck(H, null, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
-	H.flavor_text = ""
-	H.dna.UpdateSE()
-	H.dna.UpdateUI()
-	H.sync_organ_dna(1)
-	H.UpdateAppearance()
+	H.change_dna(D, TRUE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1225,6 +1225,22 @@
 	else
 		to_chat(usr, "<span class='notice'>[self ? "Your" : "[src]'s"] pulse is [src.get_pulse(GETPULSE_HAND)].</span>")
 
+
+/mob/living/carbon/human/proc/change_dna(datum/dna/new_dna, include_species_change = FALSE, keep_flavor_text = FALSE)
+	if(include_species_change)
+		set_species(new_dna.species.type, retain_damage = TRUE)
+	dna = new_dna.Clone()
+	real_name = new_dna.real_name
+	domutcheck(src, null, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
+	if(!keep_flavor_text)
+		flavor_text = ""
+	dna.UpdateSE()
+	dna.UpdateUI()
+	sync_organ_dna(TRUE)
+	UpdateAppearance()
+	sec_hud_set_ID()
+
+
 /mob/living/carbon/human/proc/set_species(datum/species/new_species, default_colour, delay_icon_update = FALSE, skip_same_check = FALSE, retain_damage = FALSE)
 	if(!skip_same_check)
 		if(dna.species.name == initial(new_species.name))

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -221,14 +221,7 @@
 			var/mob/living/carbon/human/H = M
 			var/datum/dna/D = data["dna"]
 			if(!D.species.is_small)
-				H.set_species(D.species.type, retain_damage = TRUE)
-				H.dna = D.Clone()
-				H.real_name = D.real_name
-				domutcheck(H, null, MUTCHK_FORCED)
-				H.dna.UpdateSE()
-				H.dna.UpdateUI()
-				H.sync_organ_dna(TRUE)
-				H.UpdateAppearance()
+				H.change_dna(D, TRUE, TRUE)
 
 	return ..()
 


### PR DESCRIPTION
## What Does This PR Do
fixes #15059

I kept the workings of smutagen and the cling transform the same. So smutagen won't remove flavor text but cling transforms do

## Why It's Good For The Game
Bug fix good fix

## Images of changes
![L4L2y7LFvb](https://user-images.githubusercontent.com/15887760/101935562-96485280-3bdf-11eb-9f24-b72284cf2829.gif)


## Changelog
:cl:
fix: changeling and stable mutagen transforms now updates your sec HUD status
/:cl: