### PR TITLE
Makes admin jobs bolded over radio channels

### DIFF
--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -15,7 +15,7 @@
 /datum/nttc_configuration
 	var/regex/word_blacklist = new("(<iframe|<embed|<script|<svg|<canvas|<video|<audio|onload)", "i") // Blacklist of naughties
 	// ALL OF THE JOB CRAP
-	// Dict of all jobs and their department color classes
+	/// Associative list of all jobs and their department color classes
 	var/all_jobs = list(
 		// AI
 		"AI" = "airadio",
@@ -43,12 +43,14 @@
 		"Maintenance Technician" = "engradio",
 		"Mechanic" = "engradio",
 		"Station Engineer" = "engradio",
-		// ERT
+		// Central Command
 		"Emergency Response Team Engineer" = "dsquadradio", // I know this says deathsquad but the class for responseteam is neon green. No.
 		"Emergency Response Team Leader" = "dsquadradio",
 		"Emergency Response Team Medic" = "dsquadradio",
 		"Emergency Response Team Member" = "dsquadradio",
 		"Emergency Response Team Officer" = "dsquadradio",
+		"Nanotrasen Navy Officer" = "dsquadradio",
+		"Special Operations Officer" = "dsquadradio",
 		// Medical
 		"Chemist" = "medradio",
 		"Chief Medical Officer" = "medradio",
@@ -112,10 +114,12 @@
 		"Librarian" = "srvradio",
 		"Mime" = "srvradio",
 	)
-	// Just command members
-	var/heads = list("Captain", "Head of Personnel", "Nanotrasen Representative", "Blueshield", "Chief Engineer", "Chief Medical Officer", "Research Director", "Head of Security", "Magistrate", "AI")
-	// Just ERT
-	var/ert_jobs = list("Emergency Response Team Officer", "Emergency Response Team Engineer", "Emergency Response Team Medic", "Emergency Response Team Leader", "Emergency Response Team Member")
+	/// List of Command jobs
+	var/list/heads = list("Captain", "Head of Personnel", "Nanotrasen Representative", "Blueshield", "Chief Engineer", "Chief Medical Officer", "Research Director", "Head of Security", "Magistrate", "AI")
+	/// List of ERT jobs
+	var/list/ert_jobs = list("Emergency Response Team Officer", "Emergency Response Team Engineer", "Emergency Response Team Medic", "Emergency Response Team Leader", "Emergency Response Team Member")
+	/// List of CentComm jobs
+	var/list/cc_jobs = list("Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer")
 	// Defined so code compiles and incase someone has a non-standard job
 	var/job_class = "radio"
 	// NOW FOR ACTUAL TOGGLES
@@ -274,7 +278,7 @@
 	// Makes heads of staff bold
 	if(toggle_command_bold)
 		var/job = tcm.sender_job
-		if((job in ert_jobs) || (job in heads))
+		if((job in ert_jobs) || (job in heads) || (job in cc_jobs))
 			for(var/datum/multilingual_say_piece/S in message_pieces)
 				if(S.message)
 					S.message = "<b>[capitalize(S.message)]</b>" // This only capitalizes the first word


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Makes the Nanotrasen Navy Officer, Special Operations Officer and Syndicate Officer show as bolded on radio channels when 'Command Amplification' is enabled in telecomms.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Stops admins from getting drowned out by command members arguing over comms.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![soo](https://user-images.githubusercontent.com/57483089/101952966-6dc95400-3bf1-11eb-84f7-791ad1482197.PNG)
![nno](https://user-images.githubusercontent.com/57483089/101952974-6efa8100-3bf1-11eb-845d-1d19d7e3f00b.PNG)
![so](https://user-images.githubusercontent.com/57483089/101952976-702bae00-3bf1-11eb-9549-ecaf6f34ad2e.PNG)

## Changelog
:cl:
tweak: Admin roles (Navy Officer, Special Operations Officer, Syndicate Officer) are now bolded over the radio when 'Command Amplification' is enabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
