### PR TITLE
Adds contractor baton to rep uplink, change desc

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/contractor_hub.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/contractor_hub.dm
@@ -26,6 +26,7 @@
 	var/list/datum/rep_purchase/purchases = list(
 		/datum/rep_purchase/reroll,
 		/datum/rep_purchase/item/pinpointer,
+		/datum/rep_purchase/item/baton,
 		/datum/rep_purchase/item/fulton,
 		/datum/rep_purchase/blackout,
 		/datum/rep_purchase/item/zippo,

--- a/code/modules/antagonists/traitor/contractor/datums/rep_purchases/baton.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/rep_purchases/baton.dm
@@ -1,0 +1,9 @@
+/**
+  * # Rep Purchase - Contractor Baton
+  */
+/datum/rep_purchase/item/baton
+	name = "Replacement Contractor Baton"
+	description = "A compact, specialised baton issued to Syndicate contractors. Applies light electrical shocks to targets. Never know when you will get disarmed."
+	cost = 2
+	stock = 2
+	item_type = /obj/item/melee/classic_baton/telescopic/contractor

--- a/code/modules/antagonists/traitor/contractor/datums/rep_purchases/fulton.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/rep_purchases/fulton.dm
@@ -3,7 +3,7 @@
   */
 /datum/rep_purchase/item/fulton
 	name = "Fulton Extraction Kit"
-	description = "A balloon that can be used to extract equipment or personnel to a Fulton Recovery Beacon. Anything not bolted down can be moved. Link the pack to a beacon by using the pack in hand."
+	description = "A balloon that can be used to extract equipment or personnel to a Fulton Recovery Beacon. Anything not bolted down can be moved. Link the pack to a beacon by using the pack in hand. Beacon can be placed inside the station, but the Fulton will not work inside the station."
 	cost = 1
 	stock = 1
 	item_type = /obj/item/storage/box/contractor/fulton_kit

--- a/paradise.dme
+++ b/paradise.dme
@@ -1278,6 +1278,7 @@
 #include "code\modules\antagonists\traitor\contractor\datums\syndicate_contract.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\rep_purchases\_base.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\rep_purchases\balloon.dm"
+#include "code\modules\antagonists\traitor\contractor\datums\rep_purchases\baton.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\rep_purchases\blackout.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\rep_purchases\fulton.dm"
 #include "code\modules\antagonists\traitor\contractor\datums\rep_purchases\pinpointer.dm"


### PR DESCRIPTION
…t work on station

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR adds spare contractor batons to uplink for 2 rep (one kidnap to get a replacement) And changes the buy desc for fultons to warn you about how they don't work in station.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Replacement batons are nice if you get disarmed, and to be honest, sure they do stamina damage, but considering the VERY SHORT stun_time of 1 the baton has, with a 2.5 second cooldown, they are not too strong to have multiple of, or to give to other traitors, a stun prod is arguably better. Was inspired by abductors being able to buy their baton back.

Fulton description change, is so traitors don't buy it, try to use it to get out of a situation, and realize it does not work.

## Changelog
:cl:
add: Adds contractor batons to the contractor reputation uplink for 2 rep points.
tweak: tweaked the description of the fulton purchase to mention it doesn't work inside the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
