### PR TITLE
Fixes Flagellant's Robes speed boost stacking

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -183,7 +183,6 @@
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list("melee" = -50, "bullet" = -50, "laser" = -50,"energy" = -50, "bomb" = -50, "bio" = -50, "rad" = -50, "fire" = 0, "acid" = 0)
-	slowdown = -1
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi',
 		"Drask" = 'icons/mob/species/drask/suit.dmi',
@@ -200,6 +199,13 @@
 		user.unEquip(src, 1)
 		user.Confused(10)
 		user.Weaken(5)
+	else if(slot == slot_wear_suit)
+		user.status_flags |= GOTTAGOFAST
+
+/obj/item/clothing/suit/hooded/cultrobes/flagellant_robe/dropped(mob/user)
+	. = ..()
+	if(user)
+		user.status_flags &= ~GOTTAGOFAST
 
 /obj/item/clothing/head/hooded/flagellant_hood
 	name = "flagellant's robes"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Stops the Flagellant's Robes stacking their speed boost on top of any others affecting the player.
This doesn't change the actual speed boost value of the robes, just the way it's applied.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Cultists crossing the station in ten seconds isn't really balanced, you know?

## Changelog
:cl:
fix: Fixed the Flagellant's Robe speed boost stacking with other speedy stuff (Meth, nuka cola, etc)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

*(Credit to @hal9000pr for letting me know about this.) ~~please stop bullying me~~*