### PR TITLE
Fixes Captain being contractor target, contractor batons not stunning silicons

### DIFF
--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -98,6 +98,7 @@
   */
 /obj/item/melee/classic_baton/proc/on_silicon_stun(mob/living/silicon/target, mob/living/user)
 	target.flash_eyes(affect_silicon = TRUE)
+	target.Weaken(stun_time_silicon)
 
 /**
   * Called when a non-silicon has been stunned.

--- a/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
@@ -7,7 +7,7 @@
 	// Settings
 	/// Jobs that cannot be the kidnapping target.
 	var/static/list/forbidden_jobs = list(
-		/datum/job/captain,
+		"Captain",
 	)
 	/// Static whitelist of area names that can be used as an extraction zone, structured by difficulty.
 	/// An area's difficulty should be measured in how crowded it generally is, how out of the way it is and so on.
@@ -185,7 +185,7 @@
 	return ..()
 
 /datum/objective/contract/is_invalid_target(datum/mind/possible_target)
-	if((possible_target.assigned_job in forbidden_jobs) || (target_blacklist && (possible_target in target_blacklist)))
+	if((possible_target.assigned_role in forbidden_jobs) || (target_blacklist && (possible_target in target_blacklist)))
 		return TARGET_INVALID_BLACKLISTED
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Fixes Captain being a potential contractor target
- Fixes classic baton sub-classes (e.g. contractor baton) not stunning silicons if `affect_silicon` is set

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fix

## Changelog
:cl:
fix: Fix Captains being a potential Contractor target
fix: Fix Contractor Batons not stunning cyborgs as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
