### PR TITLE
Radial Menus for the Bible and Null Rod

### DIFF
--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -5,7 +5,7 @@
 	department_flag = JOBCAT_SUPPORT
 	total_positions = 1
 	spawn_positions = 1
-	is_service = 1
+	is_service = TRUE
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -36,134 +36,51 @@
 	if(H.mind)
 		H.mind.isholy = TRUE
 
-	spawn()
+	INVOKE_ASYNC(src, .proc/religion_pick, H)
 
-		var/obj/item/storage/bible/B = new /obj/item/storage/bible(H)
-		H.equip_to_slot_or_del(B, slot_l_hand)
+/datum/outfit/job/chaplain/proc/religion_pick(mob/living/carbon/human/user)
+	var/obj/item/storage/bible/B = new /obj/item/storage/bible(get_turf(user))
+	B.customisable = TRUE // Only the initial bible is customisable
+	user.put_in_l_hand(B)
 
-		var/religion_name = "Christianity"
-		var/new_religion = sanitize(copytext(input(H, "You are the Chaplain. What name do you give your beliefs? Default is Christianity.", "Name change", religion_name),1,MAX_NAME_LEN))
+	var/religion_name = "Christianity"
+	var/new_religion = sanitize(copytext(input(user, "You are the Chaplain. What name do you give your beliefs? Default is Christianity.", "Name change", religion_name), 1, MAX_NAME_LEN))
 
-		if(!new_religion)
-			new_religion = religion_name
+	if(!new_religion)
+		new_religion = religion_name
 
-		switch(lowertext(new_religion))
-			if("christianity")
-				B.name = pick("The Holy Bible")
-			if("satanism")
-				B.name = "The Unholy Bible"
-			if("cthulu")
-				B.name = "The Necronomicon"
-			if("islam")
-				B.name = "Quran"
-			if("scientology")
-				B.name = pick("The Biography of L. Ron Hubbard","Dianetics")
-			if("chaos")
-				B.name = "The Book of Lorgar"
-			if("imperium")
-				B.name = "Uplifting Primer"
-			if("toolboxia")
-				B.name = "Toolbox Manifesto Robusto"
-			if("science")
-				B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
-			else
-				B.name = "The Holy Book of [new_religion]"
-		feedback_set_details("religion_name","[new_religion]")
+	switch(lowertext(new_religion))
+		if("christianity")
+			B.name = pick("The Holy Bible")
+		if("satanism")
+			B.name = "The Unholy Bible"
+		if("cthulu")
+			B.name = "The Necronomicon"
+		if("islam")
+			B.name = "Quran"
+		if("scientology")
+			B.name = pick("The Biography of L. Ron Hubbard", "Dianetics")
+		if("chaos")
+			B.name = "The Book of Lorgar"
+		if("imperium")
+			B.name = "Uplifting Primer"
+		if("toolboxia")
+			B.name = "Toolbox Manifesto Robusto"
+		if("science")
+			B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
+		else
+			B.name = "The Holy Book of [new_religion]"
+	feedback_set_details("religion_name", "[new_religion]")
 
-		var/deity_name = "Space Jesus"
-		var/new_deity = sanitize(copytext(input(H, "Who or what do you worship? Default is Space Jesus.", "Name change", deity_name), 1, MAX_NAME_LEN))
+	var/deity_name = "Space Jesus"
+	var/new_deity = sanitize(copytext(input(user, "Who or what do you worship? Default is Space Jesus.", "Name change", deity_name), 1, MAX_NAME_LEN))
 
-		if((length(new_deity) == 0) || (new_deity == "Space Jesus") )
-			new_deity = deity_name
-		B.deity_name = new_deity
+	if(!length(new_deity) || (new_deity == "Space Jesus"))
+		new_deity = deity_name
+	B.deity_name = new_deity
+	feedback_set_details("religion_deity", "[new_deity]")
 
-		H.AddSpell(new /obj/effect/proc_holder/spell/targeted/click/chaplain_bless(null))
+	user.AddSpell(new /obj/effect/proc_holder/spell/targeted/click/chaplain_bless(null))
 
-		var/accepted = 0
-		var/outoftime = 0
-		spawn(200) // 20 seconds to choose
-			outoftime = 1
-		var/new_book_style = "Bible"
-
-		while(!accepted)
-			if(!B || !H.client)
-				break // prevents possible runtime errors
-			new_book_style = input(H, "Which bible style would you like?") in list("Bible", "Koran", "Scrapbook", "Creeper", "White Bible", "Holy Light", "PlainRed", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "the bible melts", "Necronomicon", "Greentext")
-			switch(new_book_style)
-				if("Koran")
-					B.icon_state = "koran"
-					B.item_state = "koran"
-					for(var/area/chapel/main/A in world)
-						for(var/turf/T in A.contents)
-							if(T.icon_state == "carpetsymbol")
-								T.dir = 4
-				if("Scrapbook")
-					B.icon_state = "scrapbook"
-					B.item_state = "scrapbook"
-				if("Creeper")
-					B.icon_state = "creeper"
-					B.item_state = "syringe_kit"
-				if("White Bible")
-					B.icon_state = "white"
-					B.item_state = "syringe_kit"
-				if("Holy Light")
-					B.icon_state = "holylight"
-					B.item_state = "syringe_kit"
-				if("PlainRed")
-					B.icon_state = "athiest"
-					B.item_state = "syringe_kit"
-				if("Tome")
-					B.icon_state = "tome"
-					B.item_state = "syringe_kit"
-				if("The King in Yellow")
-					B.icon_state = "kingyellow"
-					B.item_state = "kingyellow"
-				if("Ithaqua")
-					B.icon_state = "ithaqua"
-					B.item_state = "ithaqua"
-				if("Scientology")
-					B.icon_state = "scientology"
-					B.item_state = "scientology"
-					for(var/area/chapel/main/A in world)
-						for(var/turf/T in A.contents)
-							if(T.icon_state == "carpetsymbol")
-								T.dir = 8
-				if("the bible melts")
-					B.icon_state = "melted"
-					B.item_state = "melted"
-				if("Necronomicon")
-					B.icon_state = "necronomicon"
-					B.item_state = "necronomicon"
-				if("Greentext")
-					B.icon_state = "greentext"
-					B.item_state = "greentext"
-				else
-					// if christian bible, revert to default
-					B.icon_state = "bible"
-					B.item_state = "bible"
-					for(var/area/chapel/main/A in world)
-						for(var/turf/T in A.contents)
-							if(T.icon_state == "carpetsymbol")
-								T.dir = 2
-
-			H.update_inv_l_hand() // so that it updates the bible's item_state in his hand
-
-			if(!B || !H.client)
-				break // prevents possible runtime errors
-			switch(input(H, "Look at your bible - is this what you want?") in list("Yes", "No"))
-				if("Yes")
-					accepted = 1
-				if("No")
-					if(outoftime)
-						to_chat(H, "Welp, out of time, buddy. You're stuck. Next time choose faster.")
-						accepted = 1
-
-		if(SSticker)
-			SSticker.Bible_icon_state = B.icon_state
-			SSticker.Bible_item_state = B.item_state
-			SSticker.Bible_name = B.name
-			SSticker.Bible_deity_name = B.deity_name
-		feedback_set_details("religion_deity", "[new_deity]")
-		feedback_set_details("religion_book", "[new_book_style]")
-
-
+	if(SSticker)
+		SSticker.Bible_deity_name = B.deity_name

--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -44,14 +44,14 @@
 	user.put_in_l_hand(B)
 
 	var/religion_name = "Christianity"
-	var/new_religion = sanitize(copytext(input(user, "You are the Chaplain. What name do you give your beliefs? Default is Christianity.", "Name change", religion_name), 1, MAX_NAME_LEN))
+	var/new_religion = copytext(clean_input("You are the Chaplain. What name do you give your beliefs? Default is Christianity.", "Name change", religion_name, user), 1, MAX_NAME_LEN)
 
 	if(!new_religion)
 		new_religion = religion_name
 
 	switch(lowertext(new_religion))
 		if("christianity")
-			B.name = pick("The Holy Bible")
+			B.name = "The Holy Bible"
 		if("satanism")
 			B.name = "The Unholy Bible"
 		if("cthulu")
@@ -73,7 +73,7 @@
 	feedback_set_details("religion_name", "[new_religion]")
 
 	var/deity_name = "Space Jesus"
-	var/new_deity = sanitize(copytext(input(user, "Who or what do you worship? Default is Space Jesus.", "Name change", deity_name), 1, MAX_NAME_LEN))
+	var/new_deity = copytext(clean_input("Who or what do you worship? Default is Space Jesus.", "Name change", deity_name, user), 1, MAX_NAME_LEN)
 
 	if(!length(new_deity) || (new_deity == "Space Jesus"))
 		new_deity = deity_name

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -1,6 +1,6 @@
 /obj/item/nullrod
 	name = "null rod"
-	desc = "A rod of pure obsidian, its very presence disrupts and dampens the powers of Nar'Sie's followers."
+	desc = "A rod of pure obsidian, its very presence disrupts and dampens the powers of dark magic."
 	icon_state = "nullrod"
 	item_state = "nullrod"
 	force = 15
@@ -8,10 +8,27 @@
 	throw_range = 4
 	throwforce = 10
 	w_class = WEIGHT_CLASS_TINY
+	/// Null rod variant names, used for the radial menu
+	var/static/list/variant_names = list()
+	/// Null rod variant icons, used for the radial menu
+	var/static/list/variant_icons = list()
+	/// Has the null rod been reskinned yet
 	var/reskinned = FALSE
-	var/reskin_selectable = TRUE			//set to FALSE if a subtype is meant to not normally be available as a reskin option (fluff ones will get re-added through their list)
-	var/list/fluff_transformations = list() //does it have any special transformations only accessible to it? Should only be subtypes of /obj/item/nullrod
+	/// Is this variant selectable through the reskin menu (Set to FALSE for fluff items)
+	var/reskin_selectable = TRUE
+	/// Does this null rod have fluff variants available
+	var/list/fluff_transformations = list()
+	/// Extra 'Holy' burn damage for ERT null rods
 	var/sanctify_force = 0
+
+/obj/item/nullrod/Initialize(mapload)
+	. = ..()
+	if(!length(variant_names))
+		for(var/I in typesof(/obj/item/nullrod))
+			var/obj/item/nullrod/rod = I
+			if(initial(rod.reskin_selectable))
+				variant_names[initial(rod.name)] = rod
+				variant_icons += list(initial(rod.name) = image(icon = initial(rod.icon), icon_state = initial(rod.icon_state)))
 
 /obj/item/nullrod/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is killing [user.p_them()]self with \the [src.name]! It looks like [user.p_theyre()] trying to get closer to god!</span>")
@@ -19,12 +36,10 @@
 
 /obj/item/nullrod/attack(mob/M, mob/living/carbon/user)
 	..()
-	if(M.mind)
-		if(M.mind.vampire)
-			if(ishuman(M))
-				if(!M.mind.vampire.get_ability(/datum/vampire_passive/full))
-					to_chat(M, "<span class='warning'>The nullrod's power interferes with your own!</span>")
-					M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
+	if(ishuman(M) && M.mind?.vampire)
+		if(!M.mind.vampire.get_ability(/datum/vampire_passive/full))
+			to_chat(M, "<span class='warning'>The nullrod's power interferes with your own!</span>")
+			M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
 
 /obj/item/nullrod/pickup(mob/living/user)
 	. = ..()
@@ -41,7 +56,7 @@
 
 
 /obj/item/nullrod/attack_self(mob/user)
-	if(user.mind && (user.mind.isholy) && !reskinned)
+	if(user.mind?.isholy && !reskinned)
 		reskin_holy_weapon(user)
 
 /obj/item/nullrod/examine(mob/living/user)
@@ -49,39 +64,35 @@
 	if(sanctify_force)
 		. += "<span class='notice'>It bears the inscription: 'Sanctified weapon of the inquisitors. Only the worthy may wield. Nobody shall expect us.'</span>"
 
-/obj/item/nullrod/proc/reskin_holy_weapon(mob/M)
-	var/list/holy_weapons_list = typesof(/obj/item/nullrod)
-	for(var/entry in holy_weapons_list)
-		var/obj/item/nullrod/variant = entry
-		if(!initial(variant.reskin_selectable))
-			holy_weapons_list -= variant
-	if(fluff_transformations.len)
-		for(var/thing in fluff_transformations)
-			holy_weapons_list += thing
-	var/list/display_names = list()
-	for(var/V in holy_weapons_list)
-		var/atom/A = V
-		display_names += initial(A.name)
-
-	var/choice = input(M,"What theme would you like for your holy weapon?","Holy Weapon Theme") as null|anything in display_names
-	if(!src || !choice || !in_range(M, src) || M.incapacitated() || reskinned)
+/obj/item/nullrod/proc/reskin_holy_weapon(mob/user)
+	if(!ishuman(user))
+		return
+	for(var/I in fluff_transformations) // If it's a fluffy null rod
+		var/obj/item/nullrod/rod = I
+		variant_names[initial(rod.name)] = rod
+		variant_icons += list(initial(rod.name) = image(icon = initial(rod.icon), icon_state = initial(rod.icon_state)))
+	var/mob/living/carbon/human/H = user
+	var/choice = show_radial_menu(H, src, variant_icons, null, 42, CALLBACK(src, .proc/radial_check, H), TRUE)
+	if(!choice || !radial_check(H))
 		return
 
-	var/index = display_names.Find(choice)
-	var/A = holy_weapons_list[index]
+	var/picked_type = variant_names[choice]
+	var/obj/item/nullrod/new_rod = new picked_type(get_turf(user))
 
-	var/obj/item/nullrod/holy_weapon = new A
+	feedback_set_details("chaplain_weapon", "[picked_type]")
 
-	feedback_set_details("chaplain_weapon","[choice]")
-
-	if(holy_weapon)
-		holy_weapon.reskinned = TRUE
-		M.unEquip(src)
-		M.put_in_active_hand(holy_weapon)
-		if(sanctify_force)
-			holy_weapon.sanctify_force = sanctify_force
-			holy_weapon.name = "sanctified " + holy_weapon.name
+	if(new_rod)
+		new_rod.reskinned = TRUE
 		qdel(src)
+		user.put_in_active_hand(new_rod)
+		if(sanctify_force)
+			new_rod.sanctify_force = sanctify_force
+			new_rod.name = "sanctified " + new_rod.name
+
+/obj/item/nullrod/proc/radial_check(mob/living/carbon/human/user)
+	if(!src || !user.is_in_hands(src) || user.incapacitated() || reskinned)
+		return FALSE
+	return TRUE
 
 /obj/item/nullrod/afterattack(atom/movable/AM, mob/user, proximity)
 	. = ..()
@@ -133,7 +144,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK|SLOT_BELT
 	block_chance = 30
-	sharp = 1
+	sharp = TRUE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
@@ -219,7 +230,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	armour_penetration = 35
 	slot_flags = SLOT_BACK
-	sharp = 1
+	sharp = TRUE
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
@@ -258,13 +269,13 @@
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the spirit of [user.real_name]'s blade?", ROLE_PAI, FALSE, 10 SECONDS, source = src)
 	var/mob/dead/observer/theghost = null
 
-	if(candidates.len)
+	if(length(candidates))
 		theghost = pick(candidates)
 		var/mob/living/simple_animal/shade/sword/S = new(src)
 		S.real_name = name
 		S.name = name
 		S.ckey = theghost.ckey
-		var/input = stripped_input(S,"What are you named?", ,"", MAX_NAME_LEN)
+		var/input = stripped_input(S, "What are you named?", null, "", MAX_NAME_LEN)
 
 		if(src && input)
 			name = input
@@ -297,7 +308,7 @@
 	item_state = "mounted_chainsaw"
 	w_class = WEIGHT_CLASS_HUGE
 	flags = NODROP | ABSTRACT
-	sharp = 1
+	sharp = TRUE
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsaw.ogg'
 
@@ -308,7 +319,7 @@
 	item_state = "gold_horn"
 	desc = "Used for absolutely hilarious sacrifices."
 	hitsound = 'sound/items/bikehorn.ogg'
-	sharp = 1
+	sharp = TRUE
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "honked")
 
 /obj/item/nullrod/whip
@@ -353,7 +364,7 @@
 	item_state = "arm_blade"
 	flags = ABSTRACT | NODROP
 	w_class = WEIGHT_CLASS_HUGE
-	sharp = 1
+	sharp = TRUE
 
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"
@@ -382,7 +393,7 @@
 	force = 13
 	block_chance = 40
 	slot_flags = SLOT_BACK
-	sharp = 0
+	sharp = FALSE
 	hitsound = "swing_hit"
 	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
 	icon_state = "bostaff0"
@@ -394,7 +405,7 @@
 	item_state = "crysknife"
 	w_class = WEIGHT_CLASS_HUGE
 	desc = "They say fear is the true mind killer, but stabbing them in the head works too. Honour compels you to not sheathe it once drawn."
-	sharp = 1
+	sharp = TRUE
 	slot_flags = null
 	flags = HANDSLOW
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -419,7 +430,7 @@
 	desc = "Holding this makes you look absolutely devilish."
 	attack_verb = list("poked", "impaled", "pierced", "jabbed")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	sharp = 1
+	sharp = TRUE
 
 /obj/item/nullrod/rosary
 	name = "prayer beads"
@@ -428,7 +439,7 @@
 	desc = "A set of prayer beads used by many of the more traditional religions in space.<br>Vampires and other unholy abominations have learned to fear these."
 	force = 0
 	throwforce = 0
-	var/praying = 0
+	var/praying = FALSE
 
 /obj/item/nullrod/rosary/New()
 	..()
@@ -438,7 +449,7 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/nullrod/rosary/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/nullrod/rosary/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!iscarbon(M))
 		return ..()
 
@@ -450,24 +461,24 @@
 		to_chat(user, "<span class='notice'>You are already using [src].</span>")
 		return
 
-	user.visible_message("<span class='info'>[user] kneels[M == user ? null : " next to [M]"] and begins to utter a prayer to [SSticker.Bible_deity_name].</span>", \
+	user.visible_message("<span class='info'>[user] kneels[M == user ? null : " next to [M]"] and begins to utter a prayer to [SSticker.Bible_deity_name].</span>",
 		"<span class='info'>You kneel[M == user ? null : " next to [M]"] and begin a prayer to [SSticker.Bible_deity_name].</span>")
 
-	praying = 1
-	if(do_after(user, 150, target = M))
+	praying = TRUE
+	if(do_after(user, 15 SECONDS, target = M))
 		if(ishuman(M))
 			var/mob/living/carbon/human/target = M
 
 			if(target.mind)
 				if(iscultist(target))
 					SSticker.mode.remove_cultist(target.mind) // This proc will handle message generation.
-					praying = 0
+					praying = FALSE
 					return
 
 				if(target.mind.vampire && !target.mind.vampire.get_ability(/datum/vampire_passive/full)) // Getting a full prayer off on a vampire will interrupt their powers for a large duration.
 					target.mind.vampire.nullified = max(120, target.mind.vampire.nullified + 120)
 					to_chat(target, "<span class='userdanger'>[user]'s prayer to [SSticker.Bible_deity_name] has interfered with your power!</span>")
-					praying = 0
+					praying = FALSE
 					return
 
 			if(prob(25))
@@ -477,16 +488,16 @@
 				target.adjustBruteLoss(-5)
 				target.adjustFireLoss(-5)
 
-			praying = 0
+			praying = FALSE
 
 	else
 		to_chat(user, "<span class='notice'>Your prayer to [SSticker.Bible_deity_name] was interrupted.</span>")
-		praying = 0
+		praying = FALSE
 
 /obj/item/nullrod/rosary/process()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/holder = loc
-		if(src == holder.l_hand || src == holder.r_hand) // Holding this in your hand will
+		if(holder.l_hand == src || holder.r_hand == src) // Holding this in your hand will
 			for(var/mob/living/carbon/human/H in range(5, loc))
 				if(H.mind && H.mind.vampire && !H.mind.vampire.get_ability(/datum/vampire_passive/full))
 					H.mind.vampire.nullified = max(5, H.mind.vampire.nullified + 2)
@@ -510,8 +521,8 @@
 		return
 
 	if(!(ghostcall_CD > world.time))
-		ghostcall_CD = world.time + 3000 //deciseconds..5 minutes
-		user.visible_message("<span class='info'>[user] kneels and begins to utter a prayer to [SSticker.Bible_deity_name] while drawing a circle with salt!</span>", \
+		ghostcall_CD = world.time + 5 MINUTES
+		user.visible_message("<span class='info'>[user] kneels and begins to utter a prayer to [SSticker.Bible_deity_name] while drawing a circle with salt!</span>",
 		"<span class='info'>You kneel and begin a prayer to [SSticker.Bible_deity_name] while drawing a circle!</span>")
 		notify_ghosts("The Chaplain is calling ghosts to [get_area(src)] with [name]!", source = src)
 	else
@@ -570,23 +581,23 @@
 
 /obj/item/nullrod/missionary_staff/attack_self(mob/user)
 	if(robes)	//as long as it is linked, sec can't try to meta by stealing your staff and seeing if they get the link error message
-		return 0
+		return FALSE
 	if(!ishuman(user))		//prevents the horror (runtimes) of missionary xenos and other non-human mobs that might be able to activate the item
-		return 0
+		return FALSE
 	var/mob/living/carbon/human/missionary = user
 	if(missionary.wear_suit && istype(missionary.wear_suit, /obj/item/clothing/suit/hooded/chaplain_hoodie/missionary_robe))
 		var/obj/item/clothing/suit/hooded/chaplain_hoodie/missionary_robe/robe_to_link = missionary.wear_suit
 		if(robe_to_link.linked_staff)
 			to_chat(missionary, "<span class='warning'>These robes are already linked with a staff and cannot support another. Connection refused.</span>")
-			return 0
+			return FALSE
 		robes = robe_to_link
 		robes.linked_staff = src
 		to_chat(missionary, "<span class='notice'>Link established. Faith generators initialized. Go spread the word.</span>")
 		faith = 100		//full charge when a fresh link is made (can't be delinked without destroying the robes so this shouldn't be an exploitable thing)
-		return 1
+		return TRUE
 	else
 		to_chat(missionary, "<span class='warning'>You must be wearing the missionary robes you wish to link with this staff.</span>")
-		return 0
+		return FALSE
 
 /obj/item/nullrod/missionary_staff/afterattack(mob/living/carbon/human/target, mob/living/carbon/human/missionary, flag, params)
 	if(!ishuman(target) || !ishuman(missionary)) //ishuman checks
@@ -619,7 +630,7 @@
 		to_chat(missionary, "<span class='warning'>Your concentration was broken!</span>")
 
 /obj/item/nullrod/missionary_staff/proc/do_convert(mob/living/carbon/human/target, mob/living/carbon/human/missionary)
-	var/convert_duration = 6000		//10 min
+	var/convert_duration = 10 MINUTES
 
 	if(!target || !ishuman(target) || !missionary || !ishuman(missionary))
 		return

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -72,7 +72,7 @@
 		variant_names[initial(rod.name)] = rod
 		variant_icons += list(initial(rod.name) = image(icon = initial(rod.icon), icon_state = initial(rod.icon_state)))
 	var/mob/living/carbon/human/H = user
-	var/choice = show_radial_menu(H, src, variant_icons, null, 42, CALLBACK(src, .proc/radial_check, H), TRUE)
+	var/choice = show_radial_menu(H, src, variant_icons, null, 40, CALLBACK(src, .proc/radial_check, H), TRUE)
 	if(!choice || !radial_check(H))
 		return
 

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -11,16 +11,26 @@
 	/// Is the sprite of this bible customisable
 	var/customisable = FALSE
 
-	// ALL OF THESE MUST BE THE SAME LENGTH
-	/// List of bible variant names, used for the radial menu
-	var/static/list/bible_names = list("Bible", "Koran", "Scrapbook", "Creeper", "White Bible", "Holy Light", "PlainRed", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "the bible melts", "Necronomicon", "Greentext")
-	/// List of bible variant icon states, used for the radial menu
-	var/static/list/bible_states = list("bible", "koran", "scrapbook", "creeper", "white", "holylight", "athiest", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon", "greentext")
-	/// List of bible variant inhand states, used for the radial menu
-	var/static/list/bible_inhand = list("bible", "koran", "scrapbook", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon", "greentext")
+	/// Associative list of accociative lists of bible variants, used for the radial menu
+	var/static/list/bible_variants = list(
+		"Bible" =			   list("state" = "bible",		  "inhand" = "bible"),
+		"Koran" =			   list("state" = "koran",		  "inhand" = "koran"),
+		"Scrapbook" =		   list("state" = "scrapbook",	  "inhand" = "scrapbook"),
+		"Creeper" =			   list("state" = "creeper",	  "inhand" = "syringe_kit"),
+		"White Bible" =		   list("state" = "white",		  "inhand" = "syringe_kit"),
+		"Holy Light" =		   list("state" = "holylight",	  "inhand" = "syringe_kit"),
+		"PlainRed" =		   list("state" = "athiest",	  "inhand" = "syringe_kit"),
+		"Tome" =			   list("state" = "tome",		  "inhand" = "syringe_kit"),
+		"The King in Yellow" = list("state" = "kingyellow",	  "inhand" = "kingyellow"),
+		"Ithaqua" =			   list("state" = "ithaqua",	  "inhand" = "ithaqua"),
+		"Scientology" =		   list("state" = "scientology",  "inhand" = "scientology"),
+		"the bible melts" =	   list("state" = "melted",		  "inhand" = "melted"),
+		"Necronomicon" =	   list("state" = "necronomicon", "inhand" = "necronomicon"),
+		"Greentext" =		   list("state" = "greentext",	  "inhand" = "greentext"),
+	)
 
 /obj/item/storage/bible/suicide_act(mob/user)
-	to_chat(viewers(user), "<span class='boldwarning'>[user] stares into [name] and attempts to transcend understanding of the universe!</span>")
+	user.visible_message("<span class='suicide'>[user] stares into [name] and attempts to transcend understanding of the universe!</span>")
 	user.dust()
 	return OBLITERATION
 
@@ -130,18 +140,18 @@
 		return
 
 	var/list/skins = list()
-	for(var/I in 1 to length(bible_states))
-		var/image/bible_image = image('icons/obj/storage.dmi', icon_state = bible_states[I])
-		skins += list(bible_names[I] = bible_image)
+	for(var/I in bible_variants)
+		var/icons = bible_variants[I] // Get the accociated list
+		var/image/bible_image = image('icons/obj/storage.dmi', icon_state = icons["state"])
+		skins[I] = bible_image
 
 	var/choice = show_radial_menu(user, src, skins, null, 42, CALLBACK(src, .proc/radial_check, user), TRUE)
 	if(!choice || !radial_check(user))
 		return
-	var/index = bible_names.Find(choice)
-	if(!index)
-		return
-	icon_state = bible_states[index]
-	item_state = bible_inhand[index]
+	var/choice_icons = bible_variants[choice]
+
+	icon_state = choice_icons["state"]
+	item_state = choice_icons["inhand"]
 	customisable = FALSE
 
 	// Carpet symbol icons are currently broken, so commented out until it's fixed

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -145,7 +145,7 @@
 		var/image/bible_image = image('icons/obj/storage.dmi', icon_state = icons["state"])
 		skins[I] = bible_image
 
-	var/choice = show_radial_menu(user, src, skins, null, 42, CALLBACK(src, .proc/radial_check, user), TRUE)
+	var/choice = show_radial_menu(user, src, skins, null, 40, CALLBACK(src, .proc/radial_check, user), TRUE)
 	if(!choice || !radial_check(user))
 		return
 	var/choice_icons = bible_variants[choice]

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -8,9 +8,19 @@
 	resistance_flags = FIRE_PROOF
 	var/mob/affecting = null
 	var/deity_name = "Christ"
+	/// Is the sprite of this bible customisable
+	var/customisable = FALSE
+
+	// ALL OF THESE MUST BE THE SAME LENGTH
+	/// List of bible variant names, used for the radial menu
+	var/static/list/bible_names = list("Bible", "Koran", "Scrapbook", "Creeper", "White Bible", "Holy Light", "PlainRed", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "the bible melts", "Necronomicon", "Greentext")
+	/// List of bible variant icon states, used for the radial menu
+	var/static/list/bible_states = list("bible", "koran", "scrapbook", "creeper", "white", "holylight", "athiest", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon", "greentext")
+	/// List of bible variant inhand states, used for the radial menu
+	var/static/list/bible_inhand = list("bible", "koran", "scrapbook", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon", "greentext")
 
 /obj/item/storage/bible/suicide_act(mob/user)
-	to_chat(viewers(user), "<span class='warning'><b>[user] stares into [src.name] and attempts to transcend understanding of the universe!</b></span>")
+	to_chat(viewers(user), "<span class='boldwarning'>[user] stares into [name] and attempts to transcend understanding of the universe!</span>")
 	user.dust()
 	return OBLITERATION
 
@@ -38,7 +48,7 @@
 	new /obj/item/stack/spacecash(src)
 //BS12 EDIT
  // All cult functionality moved to Null Rod
-/obj/item/storage/bible/proc/bless(mob/living/carbon/M as mob)
+/obj/item/storage/bible/proc/bless(mob/living/carbon/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/heal_amt = 10
@@ -47,19 +57,19 @@
 				H.UpdateDamageIcon()
 	return
 
-/obj/item/storage/bible/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/storage/bible/attack(mob/living/M, mob/living/user)
 	add_attack_logs(user, M, "Hit with [src]")
 	if(!iscarbon(user))
 		M.LAssailant = null
 	else
 		M.LAssailant = user
 
-	if(!(istype(user, /mob/living/carbon/human) || SSticker) && SSticker.mode.name != "monkey")
+	if(!(ishuman(user) || SSticker) && SSticker.mode.name != "monkey")
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
-	if(!user.mind || !user.mind.isholy)
+	if(!user.mind?.isholy)
 		to_chat(user, "<span class='warning'>The book sizzles in your hands.</span>")
-		user.take_organ_damage(0,10)
+		user.take_organ_damage(0, 10)
 		return
 
 	if((CLUMSY in user.mutations) && prob(50))
@@ -68,51 +78,98 @@
 		user.Paralyse(20)
 		return
 
-	if(M.stat !=2)
-		if((istype(M, /mob/living/carbon/human) && prob(60)))
-			bless(M)
-			for(var/mob/O in viewers(M, null))
-				O.show_message(text("<span class='danger'>[] heals [] with the power of [src.deity_name]!</span>", user, M), 1)
-			to_chat(M, "<span class='warning'>May the power of [src.deity_name] compel you to be healed!</span>")
-			playsound(src.loc, "punch", 25, 1, -1)
+	if(M.stat != DEAD && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(prob(60))
+			bless(H)
+			H.visible_message("<span class='danger>[user] heals [H == user ? "[user.p_them()]self" : "[H]"] with the power of [deity_name]!</span>",
+				"<span class='danger'>May the power of [deity_name] compel you to be healed!</span>")
+			playsound(loc, "punch", 25, 1, -1)
 		else
-			if(ishuman(M) && !istype(M:head, /obj/item/clothing/head/helmet))
+			if(!istype(H.head, /obj/item/clothing/head/helmet))
 				M.adjustBrainLoss(10)
 				to_chat(M, "<span class='warning'>You feel dumber.</span>")
-			for(var/mob/O in viewers(M, null))
-				O.show_message(text("<span class='danger'>[] beats [] over the head with []!</span>", user, M, src), 1)
+			H.visible_message("<span class='danger'>[user] beats [H == user ? "[user.p_them()]self" : "[H]"] over the head with [src]!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)
-	else if(M.stat == 2)
-		for(var/mob/O in viewers(M, null))
-			O.show_message(text("<span class='danger'>[] smacks []'s lifeless corpse with [].</span>", user, M, src), 1)
+	else
+		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")
 		playsound(src.loc, "punch", 25, 1, -1)
-	return
 
-/obj/item/storage/bible/afterattack(atom/A, mob/user as mob, proximity)
+
+/obj/item/storage/bible/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)
 		return
-	if(istype(A, /turf/simulated/floor))
-		to_chat(user, "<span class='notice'>You hit the floor with the bible.</span>")
-		if(user.mind && user.mind.isholy)
-			for(var/obj/O in A)
-				O.cult_reveal()
-	if(istype(A, /obj/machinery/door/airlock))
-		to_chat(user, "<span class='notice'>You hit the airlock with the bible.</span>")
-		if(user.mind && user.mind.isholy)
-			var/obj/airlock = A
-			airlock.cult_reveal()
-	if(user.mind && (user.mind.isholy))
-		if(A.reagents && A.reagents.has_reagent("water")) //blesses all the water in the holder
-			to_chat(user, "<span class='notice'>You bless [A].</span>")
-			var/water2holy = A.reagents.get_reagent_amount("water")
-			A.reagents.del_reagent("water")
-			A.reagents.add_reagent("holywater",water2holy)
-		if(A.reagents && A.reagents.has_reagent("unholywater")) //yeah yeah, copy pasted code - sue me
-			to_chat(user, "<span class='notice'>You purify [A].</span>")
-			var/unholy2clean = A.reagents.get_reagent_amount("unholywater")
-			A.reagents.del_reagent("unholywater")
-			A.reagents.add_reagent("holywater",unholy2clean)
 
-/obj/item/storage/bible/attackby(obj/item/W as obj, mob/user as mob, params)
-	playsound(src.loc, "rustle", 50, 1, -5)
-	..()
+	if(isfloorturf(target))
+		to_chat(user, "<span class='notice'>You hit the floor with the bible.</span>")
+		if(user.mind?.isholy)
+			for(var/obj/O in target)
+				O.cult_reveal()
+	if(istype(target, /obj/machinery/door/airlock))
+		to_chat(user, "<span class='notice'>You hit the airlock with the bible.</span>")
+		if(user.mind?.isholy)
+			var/obj/airlock = target
+			airlock.cult_reveal()
+
+	if(user.mind?.isholy && target.reagents)
+		if(target.reagents.has_reagent("water")) //blesses all the water in the holder
+			to_chat(user, "<span class='notice'>You bless [target].</span>")
+			var/water2holy = target.reagents.get_reagent_amount("water")
+			target.reagents.del_reagent("water")
+			target.reagents.add_reagent("holywater", water2holy)
+
+		if(target.reagents.has_reagent("unholywater")) //yeah yeah, copy pasted code - sue me
+			to_chat(user, "<span class='notice'>You purify [target].</span>")
+			var/unholy2clean = target.reagents.get_reagent_amount("unholywater")
+			target.reagents.del_reagent("unholywater")
+			target.reagents.add_reagent("holywater", unholy2clean)
+
+/obj/item/storage/bible/attack_self(mob/user)
+	. = ..()
+	if(!customisable || !user.mind?.isholy)
+		return
+
+	var/list/skins = list()
+	for(var/I in 1 to length(bible_states))
+		var/image/bible_image = image('icons/obj/storage.dmi', icon_state = bible_states[I])
+		skins += list(bible_names[I] = bible_image)
+
+	var/choice = show_radial_menu(user, src, skins, null, 42, CALLBACK(src, .proc/radial_check, user), TRUE)
+	if(!choice || !radial_check(user))
+		return
+	var/index = bible_names.Find(choice)
+	if(!index)
+		return
+	icon_state = bible_states[index]
+	item_state = bible_inhand[index]
+	customisable = FALSE
+
+	// Carpet symbol icons are currently broken, so commented out until it's fixed
+	/*var/carpet_dir
+	switch(choice)
+		if("Bible")
+			carpet_dir = 2
+		if("Koran")
+			carpet_dir = 4
+		if("Scientology")
+			carpet_dir = 8
+	if(carpet_dir)
+		for(var/area/chapel/main/A in world)
+			for(var/turf/T in A.contents)
+				if(T.icon_state == "carpetsymbol")
+					T.dir = carpet_dir*/
+
+	feedback_set_details("religion_book", "[choice]")
+
+	if(SSticker)
+		SSticker.Bible_name = name
+		SSticker.Bible_icon_state = icon_state
+		SSticker.Bible_item_state = item_state
+
+/obj/item/storage/bible/proc/radial_check(mob/user)
+	if(!user?.mind.isholy || !ishuman(user))
+		return FALSE
+	var/mob/living/carbon/human/H = user
+	if(!src || !H.is_in_hands(src) || H.incapacitated())
+		return FALSE
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Converts the Chaplain's Bible and Null Rod to use Radial Menus rather than a text list.
Because of this the Bible menu only opens if you activate the Bible in your hand as opposed to opening when you spawn in.
I've also removed the 20 second time limit on choosing a Bible type, since I didn't see any good reason for it to be there.

Choosing a Null Rod though is unchanged, except for the visual differences.

Also commented out the Chapel's carpet symbols changing, since it didn't actually work properly.
Also also cleaned up and documented some of the code and variables.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. It looks better.
2. You don't need to tab out to the wiki if you want to try out a new Null Rod.
3. Choosing a bible sprite is far more flexible, and admins can also re-enable the `customisable` variable if they want to change it.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
*All options have highlighting and tooltips, so contrast with the background tiles shouldn't ever be an issue.*
### Bible Radial Menu
![NSS Cyberiad 2020-12-12 213641](https://user-images.githubusercontent.com/57483089/101995618-1c899500-3cc3-11eb-962b-b2ce10006c56.png)![NSS Cyberiad 2020-12-12 213646](https://user-images.githubusercontent.com/57483089/101995619-1e535880-3cc3-11eb-8a12-def17873357d.png)

### Null Rod Radial Menu
![NSS Cyberiad 2020-12-12 213702](https://user-images.githubusercontent.com/57483089/101995625-2f03ce80-3cc3-11eb-8352-510c002cfd72.png)![NSS Cyberiad 2020-12-12 213705](https://user-images.githubusercontent.com/57483089/101995626-32975580-3cc3-11eb-81e3-90ff1c7cd334.png)
![NSS Cyberiad 2020-12-12 213708](https://user-images.githubusercontent.com/57483089/101995627-34611900-3cc3-11eb-84c7-84af3ef382ac.png)![NSS Cyberiad 2020-12-12 213711](https://user-images.githubusercontent.com/57483089/101995629-35924600-3cc3-11eb-910d-6e5a93cc93b7.png)
![NSS Cyberiad 2020-12-12 213714](https://user-images.githubusercontent.com/57483089/101995630-375c0980-3cc3-11eb-9473-22d5ec88d313.png)


## Changelog
:cl:
add: Added a fancy new Radial Menu for Bibles and Null Rods!
tweak: Picking a Bible variation is now done by activating it in your hand, rather than when you spawn in
tweak: Removed the 20 second time limit when choosing a Bible
tweak: Stopped the Chapel's carpet from changing based on the Bible sprite, since the implimentation was bugged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
