### PR TITLE
Gives red and gamma ERT (just gamma for janitor) death alarms

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -89,6 +89,9 @@
 		/obj/item/storage/lockbox/mindshield = 1
 	)
 
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
+	)
 /datum/outfit/job/centcom/response_team/commander/gamma
 	name = "RT Commander (Gamma)"
 	shoes = /obj/item/clothing/shoes/magboots/advance
@@ -112,6 +115,10 @@
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/arm/flash
+	)
+
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
 	)
 
 //////////////////// SECURITY ///////////////////
@@ -169,6 +176,10 @@
 		/obj/item/ammo_box/magazine/laser = 2
 	)
 
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
+	)
+
 /datum/outfit/job/centcom/response_team/security/gamma
 	name = "RT Security (Gamma)"
 	shoes = /obj/item/clothing/shoes/magboots/advance
@@ -198,6 +209,9 @@
 		/obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	)
 
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
+	)
 
 //////////////////// ENGINEER ///////////////////
 
@@ -253,6 +267,10 @@
 		/obj/item/gun/energy/gun = 1
 	)
 
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
+	)
+
 /datum/outfit/job/centcom/response_team/engineer/gamma
 	name = "RT Engineer (Gamma)"
 	shoes = /obj/item/clothing/shoes/magboots/advance
@@ -277,6 +295,10 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/shield,
 		/obj/item/organ/internal/cyberimp/arm/toolset
+	)
+
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
 	)
 
 //////////////////// MEDIC ///////////////////
@@ -349,6 +371,10 @@
 		/obj/item/handheld_defibrillator = 1
 	)
 
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
+	)
+
 /datum/outfit/job/centcom/response_team/medic/gamma
 	name = "RT Medic (Gamma)"
 	shoes = /obj/item/clothing/shoes/magboots/advance
@@ -378,6 +404,10 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+	)
+
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
 	)
 
 //////////////////// PARANORMAL ///////////////////
@@ -425,6 +455,10 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment
 	)
 
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
+	)
+
 /datum/outfit/job/centcom/response_team/paranormal/gamma
 	name = "RT Paranormal (Gamma)"
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
@@ -438,6 +472,10 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/eyes/hud/security,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+	)
+
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
 	)
 
 //////////////////// JANITORIAL ///////////////////
@@ -504,4 +542,8 @@
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/arm/advmop,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened
+	)
+
+	implants = list(/obj/item/implant/mindshield,
+		/obj/item/implant/death_alarm
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Gives all gamma and red ERT (bar janitor for red) Death alarm implants.
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ert sadly often wordlessly die. Command gets death alarm implants. ERT is kinda like command. Therefore, they should probably get death alarm implants, so ert / crew knows when the ERT is loosing badly, be it verse a blob, or kidnapped by a vampire in medmaints.

## Changelog
:cl:
tweak: All gamma ERT, and all red ERT (bar janitor) now have death alarm implants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
