### PR TITLE
Allows ghosts to see faxes when they are sent

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -341,8 +341,7 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 
 /obj/machinery/photocopier/faxmachine/Topic(href, href_list)
 	if(href_list["GhostFaxView"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost))
+		if(isobserver(usr))
 			var/obj/item/fax = locate(href_list["ghostfaxview"])
 			if(istype(fax, /obj/item/paper))
 				var/obj/item/paper/P = fax
@@ -365,13 +364,12 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 				to_chat(usr, "<span class='warning'>The faxed item is not viewable. This is probably a bug, and should be reported on the tracker: [fax.type]</span>")
 
 	else if(href_list["GhostFaxViewPage"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost))
+		if(isobserver(usr))
 			var/page = text2num(href_list["GhostFaxViewPage"])
 			var/obj/item/paper_bundle/bundle = locate(href_list["paper_bundle"])
 
 			if(!bundle)
-			    return
+				return
 
 			if(istype(bundle.contents[page], /obj/item/paper))
 				var/obj/item/paper/P = bundle.contents[page]
@@ -379,7 +377,6 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 			else if(istype(bundle.contents[page], /obj/item/photo))
 				var/obj/item/photo/H = bundle.contents[page]
 				H.show(usr)
-		return
 
 /obj/machinery/photocopier/faxmachine/proc/cooldown_seconds()
 	if(sendcooldown < world.time)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -346,7 +346,7 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 			var/obj/item/fax = locate(href_list["ghostfaxview"])
 			if(istype(fax, /obj/item/paper))
 				var/obj/item/paper/P = fax
-				P.show_content(usr,1)
+				P.show_content(usr, 1)
 			else if(istype(fax, /obj/item/photo))
 				var/obj/item/photo/H = fax
 				H.show(usr)
@@ -356,7 +356,7 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 				var/data = ""
 				var/obj/item/paper_bundle/B = fax
 
-				for(var/page = 1, page <= B.amount + 1, page++)
+				for(var/page in 1 to B.amount + 1)
 					var/obj/pageobj = B.contents[page]
 					data += "<A href='?src=[UID()];GhostFaxViewPage=[page];paper_bundle=\ref[B]'>Page [page] - [pageobj.name]</A><BR>"
 
@@ -370,7 +370,8 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 			var/page = text2num(href_list["GhostFaxViewPage"])
 			var/obj/item/paper_bundle/bundle = locate(href_list["paper_bundle"])
 
-			if(!bundle) return
+			if(!bundle)
+			    return
 
 			if(istype(bundle.contents[page], /obj/item/paper))
 				var/obj/item/paper/P = bundle.contents[page]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Notifies ghosts when someone sends a fax to CC / syndicate, and allows ghosts to view the message

##TODO

- [ ] actualy have the href work

- [ ] Allow ghosts to see responses to the fax from CC

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Allows ghosts to see what is going on in more detail, interesting stuff for them to see, perhaps learn the difference between a good and a bad fax.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Ghosts can now see faxes sent to the syndicate / CC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
