### PR TITLE
Fixes bad area pathing on all the lava ruins

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -8,21 +8,21 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "c" = (
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/wall/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "f" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/engine/cult{
@@ -30,11 +30,11 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/wall/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "i" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -43,7 +43,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /obj/effect/decal/remains/human,
 /obj/item/melee/cultblade,
@@ -52,7 +52,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "l" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/cult,
@@ -62,7 +62,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/engine/cult{
@@ -70,7 +70,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "o" = (
 /obj/effect/rune/narsie{
 	color = "#ff0000";
@@ -94,7 +94,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "q" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/cult,
@@ -105,10 +105,10 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "s" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -10,7 +10,7 @@
 /area/lavaland/surface/outdoors)
 "d" = (
 /turf/simulated/wall/rust,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -22,7 +22,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/clothing/head/human_head,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "f" = (
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -31,7 +31,7 @@
 	broken = 1
 	},
 /turf/simulated/floor/plating/burnt,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/mirror{
@@ -41,18 +41,18 @@
 	broken = 1
 	},
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "i" = (
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "j" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -62,7 +62,7 @@
 	},
 /obj/item/kitchen/knife/envy,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "l" = (
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -71,7 +71,7 @@
 	broken = 1
 	},
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -80,10 +80,10 @@
 	broken = 1
 	},
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "n" = (
 /turf/simulated/floor/plating/damaged,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "o" = (
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
@@ -92,16 +92,16 @@
 	broken = 1
 	},
 /turf/simulated/floor/plating/damaged,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "p" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "q" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "A" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_fountain_hall.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_fountain_hall.dmm
@@ -4,34 +4,34 @@
 /area/template_noop)
 "b" = (
 /turf/simulated/wall/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "c" = (
 /obj/structure/healingfountain,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /obj/structure/fluff/divine/conduit,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /obj/structure/sacrificealtar,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "f" = (
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /mob/living/simple_animal/butterfly,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "i" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -11,7 +11,7 @@
 /area/lavaland/surface/outdoors)
 "d" = (
 /turf/simulated/wall,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
@@ -19,7 +19,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "f" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/cups,
@@ -28,7 +28,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/structure/reagent_dispensers/water_cooler/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
@@ -37,7 +37,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
@@ -45,7 +45,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "i" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54,7 +54,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "j" = (
 /obj/item/reagent_containers/food/snacks/mushroompizzaslice,
 /obj/effect/decal/cleanable/dirt,
@@ -63,7 +63,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/pizzaparty,
@@ -73,7 +73,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "l" = (
 /obj/machinery/light{
 	dir = 4
@@ -87,7 +87,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
@@ -96,7 +96,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "n" = (
 /obj/structure/glowshroom/single,
 /obj/effect/decal/cleanable/dirt,
@@ -105,7 +105,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "o" = (
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/dirt,
@@ -114,7 +114,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "p" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -123,7 +123,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "q" = (
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
@@ -132,7 +132,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "r" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/decal/remains/human,
@@ -145,14 +145,14 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "s" = (
 /turf/simulated/floor/wood{
 	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "t" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/decal/remains/human,
@@ -161,7 +161,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "u" = (
 /obj/structure/glowshroom/single,
 /turf/simulated/floor/wood{
@@ -169,7 +169,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "v" = (
 /obj/structure/lattice,
 /obj/item/chair/wood/wings,
@@ -183,7 +183,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "x" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/pizzaparty,
@@ -192,7 +192,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "y" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -201,7 +201,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "z" = (
 /obj/structure/table/wood,
 /obj/structure/glowshroom/single,
@@ -211,7 +211,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "A" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
@@ -221,7 +221,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "B" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/wood{
@@ -229,7 +229,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "C" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -240,7 +240,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "D" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/margheritaslice,
@@ -250,7 +250,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "E" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meatpizzaslice,
@@ -259,7 +259,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "F" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/sliceable/birthdaycake,
@@ -268,7 +268,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "G" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood{
@@ -276,7 +276,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "H" = (
 /obj/item/chair/wood/wings,
 /turf/simulated/floor/wood{
@@ -284,7 +284,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "I" = (
 /obj/item/kitchen/utensil/fork,
 /obj/effect/decal/cleanable/dirt,
@@ -293,7 +293,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "J" = (
 /obj/structure/glowshroom/single,
 /obj/effect/decal/cleanable/dirt,
@@ -302,7 +302,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "K" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -314,7 +314,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "L" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -323,7 +323,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "M" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/a_gift,
@@ -332,7 +332,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "N" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -346,7 +346,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "P" = (
 /obj/machinery/light{
 	dir = 4
@@ -357,14 +357,14 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "Q" = (
 /turf/simulated/floor/plating{
 	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -1,23 +1,23 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "b" = (
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "c" = (
 /obj/item/paper/fluff/stations/lavaland/sloth/note,
 /turf/simulated/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /obj/machinery/door/airlock/wood,
 /obj/structure/fans/tiny/invisible,
@@ -25,7 +25,7 @@
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "f" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
@@ -33,7 +33,7 @@
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -41,14 +41,14 @@
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
@@ -7,20 +7,20 @@
 /area/template_noop)
 "c" = (
 /turf/simulated/wall/mineral/plastitanium,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/floor/mineral/plastitanium/red{
 	oxygen = 14;
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "f" = (
 /mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon,
 /turf/simulated/floor/mineral/plastitanium/red{
@@ -28,7 +28,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/mineral/plastitanium/red{
@@ -36,7 +36,7 @@
 	nitrogen = 23;
 	temperature = 300
 	},
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
@@ -8,66 +8,66 @@
 "c" = (
 /obj/machinery/abductor/experiment,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/wall/mineral/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "e" = (
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/machinery/abductor/pad,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/item/hemostat/alien,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "i" = (
 /obj/effect/mob_spawn/human/abductor,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "j" = (
 /obj/structure/closet/abductor,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "l" = (
 /obj/machinery/optable/abductor,
 /obj/item/cautery/alien,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/structure/table/abductor,
 /obj/item/storage/box/alienhandcuffs,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "n" = (
 /obj/item/scalpel/alien,
 /obj/item/surgical_drapes,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "o" = (
 /obj/item/retractor/alien,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "p" = (
 /obj/machinery/abductor/gland_dispenser,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "q" = (
 /obj/structure/table/abductor,
 /obj/item/surgicaldrill/alien,
 /obj/item/circular_saw/alien,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 "r" = (
 /obj/structure/bed/abductor,
 /turf/unsimulated/floor/abductor,
-/area/ruin/unpowered)
+/area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"
 a

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -90,3 +90,6 @@
 //ash walker nest
 /area/ruin/unpowered/ash_walkers
 	icon_state = "red"
+
+// This area exists so that lavaland ruins dont overwrite the baseturfs on regular space ruins
+/area/ruin/unpowered/misc_lavaruin


### PR DESCRIPTION
## What Does This PR Do
Fixes space ruins having lava as their turf baseturfs. Currently, if any of the affected lava ruins spawn in a round, it will modify all the turfs in `/area/ruin/unpowered` to give them the lava baseturf. Which makes sense on lavaland, but not the other Z-levels. Currently, spaceruins will randomly get lava baseturfs, which isnt right
 
## Why It's Good For The Game
Bugs bad

## Images of changes
Nothing noticable, but if you want to see 2 images which are the exact same, mapdiffbot exists

## Changelog
:cl: AffectedArc07
fix: Space ruins will no longer have random lava baseturfs. Dont ask. 
/:cl:
