### PR TITLE
Rapier Sheath quick-equip and sound effects

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -38,7 +38,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	block_chance = 50
 	armour_penetration = 75
-	sharp = 1
+	sharp = TRUE
 	origin_tech = "combat=5"
 	attack_verb = list("lunged at", "stabbed")
 	hitsound = 'sound/weapons/rapierhit.ogg'

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -607,16 +607,14 @@
 	new /obj/item/melee/rapier(src)
 	update_icon()
 
-/obj/item/storage/belt/rapier/examine(mob/user)
-	. = ..()
-	if(length(contents))
-		. += "<span class='notice'>Alt-click it to quickly draw the blade.</span>"
+/obj/item/storage/belt/rapier/attack_hand(mob/user)
+	if(loc != user)
+		return ..()
 
-/obj/item/storage/belt/rapier/AltClick(mob/user)
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user
-	if((loc != H) || H.incapacitated())
+	if(H.incapacitated())
 		return
 
 	if(length(contents))

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -602,21 +602,51 @@
 	max_w_class = WEIGHT_CLASS_BULKY
 	can_hold = list(/obj/item/melee/rapier)
 
-/obj/item/storage/belt/rapier/update_icon()
-	icon_state = "[initial(icon_state)]"
-	item_state = "[initial(item_state)]"
-	if(contents.len)
-		icon_state = "[initial(icon_state)]-rapier"
-		item_state = "[initial(item_state)]-rapier"
-	if(isliving(loc))
-		var/mob/living/L = loc
-		L.update_inv_belt()
-	..()
-
 /obj/item/storage/belt/rapier/New()
 	..()
 	new /obj/item/melee/rapier(src)
 	update_icon()
+
+/obj/item/storage/belt/rapier/examine(mob/user)
+	. = ..()
+	if(length(contents))
+		. += "<span class='notice'>Alt-click it to quickly draw the blade.</span>"
+
+/obj/item/storage/belt/rapier/AltClick(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if((loc != H) || H.incapacitated())
+		return
+
+	if(length(contents))
+		var/obj/item/I = contents[1]
+		H.visible_message("<span class='notice'>[H] takes [I] out of [src].</span>", "<span class='notice'>You take [I] out of [src].</span>")
+		H.put_in_hands(I)
+		update_icon()
+	else
+		to_chat(user, "<span class='warning'>[src] is empty!</span>")
+
+/obj/item/storage/belt/rapier/handle_item_insertion(obj/item/W, prevent_warning)
+	if(!..())
+		return
+	playsound(src, 'sound/weapons/blade_sheath.ogg', 20)
+
+/obj/item/storage/belt/rapier/remove_from_storage(obj/item/W, atom/new_location)
+	if(!..())
+		return
+	playsound(src, 'sound/weapons/blade_unsheath.ogg', 20)
+
+/obj/item/storage/belt/rapier/update_icon()
+	. = ..()
+	icon_state = initial(icon_state)
+	item_state = initial(item_state)
+	if(length(contents))
+		icon_state = "[icon_state]-rapier"
+		item_state = "[item_state]-rapier"
+	if(isliving(loc))
+		var/mob/living/L = loc
+		L.update_inv_belt()
 
 // -------------------------------------
 //     Bluespace Belt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Makes clicking on the Captain's rapier sheath equip the rapier, rather than having to open the inventory to get it out.
Also adds sound effects for sheathing and unsheathing it.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. QOL improvement.
2. We already have these sound effects in the game files, why not use them.
3. It feels pretty cool to use.

## Changelog
:cl:
add: Clicking on the Captain's rapier sheath will now quickly equip the rapier (Alt-clicking still opens the inventory)
tweak: Sheathing and Unsheathing the Captain's rapier now has sound effects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

*(pretty much taken 1:1 from TG)*
