### PR TITLE
Fixes snowballs damaging structures

### DIFF
--- a/code/game/objects/effects/snowcloud.dm
+++ b/code/game/objects/effects/snowcloud.dm
@@ -125,12 +125,15 @@
 /obj/item/snowball
 	name = "snowball"
 	desc = "Get ready for a snowball fight!"
-	throwforce = 10
 	icon_state = "snowball"
-	damtype = STAMINA
+	/// The amount of stamina damage to do on hit.
+	var/stamina_damage = 10
 
 /obj/item/snowball/throw_impact(atom/target)
 	..()
+	if(istype(target, /mob/living))
+		var/mob/living/M = target
+		M.adjustStaminaLoss(stamina_damage)
 	qdel(src)
 
 /obj/item/snowball/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)

--- a/code/game/objects/effects/snowcloud.dm
+++ b/code/game/objects/effects/snowcloud.dm
@@ -130,8 +130,8 @@
 	var/stamina_damage = 10
 
 /obj/item/snowball/throw_impact(atom/target)
-	..()
-	if(istype(target, /mob/living))
+	. = ..()
+	if(!. && isliving(target))
 		var/mob/living/M = target
 		M.adjustStaminaLoss(stamina_damage)
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Fixes #15110 by moving the stamina damage application to `throw_impact`. Issue root cause was that all thrown objects deal brute damage regardless of `damtype`, which is likely intended

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Snowballs can no longer break things

## Changelog
:cl:
fix: Fix snowballs being able to damage and break structures (e.g. windows, mechs)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
