### PR TITLE
Removes more PR mistakes

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -1,9 +1,6 @@
 #define ALL ~0 //For convenience.
 #define NONE 0
 
-// for /datum/var/datum_flags
-#define DF_USE_TAG		(1<<0)
-
 //FLAGS BITMASK
 #define STOPSPRESSUREDMAGE 		1		//This flag is used on the flags variable for SUIT and HEAD items which stop pressure damage. Note that the flag 1 was previous used as ONBACK, so it is possible for some code to use (flags & 1) when checking if something can be put on your back. Replace this code with (inv_flags & SLOT_BACK) if you see it anywhere To successfully stop you taking all pressure damage you must have both a suit and head item with this flag.
 #define NODROP					2		// This flag makes it so that an item literally cannot be removed at all, or at least that's how it should be. Only deleted.

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -7,7 +7,6 @@
 	var/list/comp_lookup
 	var/list/list/datum/callback/signal_procs
 	var/signal_enabled = FALSE
-	var/datum_flags = NONE
 	var/var_edited = FALSE //Warranty void if seal is broken
 	var/tmp/unique_datum_id = null
 


### PR DESCRIPTION
## What Does This PR Do
This was added in the diagonal movement PR seemingly by mistake or blind copypaste. Its being nuked. Its awful. 

## Why It's Good For The Game
We are literally wasting memory on a var which has 0 edits or reads in the entire gamecode, yet is applied to every single datum in the world

## Changelog
:cl: AffectedArc07
del: Deleted useless things added by mistake
/:cl:
