### PR TITLE
Revert the workaround for byond version 1537. Bump min version for travis

### DIFF
--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -6,6 +6,6 @@ export NODE_VERSION=12
 # Byond Major
 export BYOND_MAJOR=513
 # Byond Minor
-export BYOND_MINOR=1526
+export BYOND_MINOR=1528
 # For the RUSTG library. Not actually installed by CI but kept as a reference
 export RUSTG_VERSION=2.1-P

--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -6,6 +6,6 @@ export NODE_VERSION=12
 # Byond Major
 export BYOND_MAJOR=513
 # Byond Minor
-export BYOND_MINOR=1537
+export BYOND_MINOR=1526
 # For the RUSTG library. Not actually installed by CI but kept as a reference
 export RUSTG_VERSION=2.1-P

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1248,8 +1248,7 @@
 				if(has_antag_datum(/datum/antagonist/traitor/contractor))
 					return
 				var/datum/antagonist/traitor/T = has_antag_datum(/datum/antagonist/traitor)
-				var/memory
-				memory = T?.antag_memory // Need to preserve the codewords and such
+				var/memory = T?.antag_memory // Need to preserve the codewords and such
 				// Replace the traitor datum by a contractor one
 				remove_antag_datum(/datum/antagonist/traitor)
 				C = new()

--- a/code/modules/antagonists/traitor/contractor/datums/contractor_hub_ui.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/contractor_hub_ui.dm
@@ -15,8 +15,7 @@
 					return
 				page = newpage
 			if("extract")
-				var/error_message
-				error_message = current_contract?.start_extraction_process(ui_host(), usr)
+				var/error_message = current_contract?.start_extraction_process(ui_host(), usr)
 				if(length(error_message))
 					to_chat(usr, "<span class='warning'>[error_message]</span>")
 			if("claim")

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -368,8 +368,7 @@
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/Kill(mob/living/carbon/human/H)
 	playsound(H, 'sound/spookoween/scary_horn2.ogg', 100, 0)
-	var/old_color
-	old_color = H.client?.color
+	var/old_color = H.client?.color
 	client_kill_animation(H)
 
 	for(var/turf/T in orange(H, 4))

--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -365,8 +365,7 @@
 					playsound(loc, 'sound/machines/terminal_insert_disc.ogg', 30, TRUE)
 			else if(issilicon(usr))
 				var/mob/living/silicon/M = usr
-				var/datum/picture/selection
-				selection = M.aiCamera?.selectpicture()
+				var/datum/picture/selection = M.aiCamera?.selectpicture()
 				if(!selection)
 					return
 				var/obj/item/photo/P = new


### PR DESCRIPTION
## What Does This PR Do
Removes the workaround for the previous byond version with the `?.` stuff

## Why It's Good For The Game
It's an ugly workaround that was needed but no more

## Changelog
Not needed