### PR TITLE
Makes syndicate depot structures Initialize()

### DIFF
--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -23,9 +23,9 @@
 	var/has_alerted = FALSE
 
 
-/obj/machinery/computer/syndicate_depot/New()
+/obj/machinery/computer/syndicate_depot/Initialize(mapload)
 	. = ..()
-	depotarea = areaMaster
+	depotarea = get_area(src)
 
 /obj/machinery/computer/syndicate_depot/attack_ai(mob/user)
 	if(req_access.len && !("syndicate" in user.faction))
@@ -191,7 +191,7 @@
 	alerts_when_broken = TRUE
 	var/area/syndicate_depot/perimeter/perimeterarea
 
-/obj/machinery/computer/syndicate_depot/shieldcontrol/New()
+/obj/machinery/computer/syndicate_depot/shieldcontrol/Initialize(mapload)
 	. = ..()
 	perimeterarea = locate(/area/syndicate_depot/perimeter)
 
@@ -245,7 +245,7 @@
 	alerts_when_broken = TRUE
 	var/message_sent = FALSE
 
-/obj/machinery/computer/syndicate_depot/syndiecomms/New()
+/obj/machinery/computer/syndicate_depot/syndiecomms/Initialize(mapload)
 	. = ..()
 	if(depotarea)
 		depotarea.comms_computer = src
@@ -361,11 +361,13 @@
 	var/portal_enabled = FALSE
 	var/portaldir = WEST
 
-/obj/machinery/computer/syndicate_depot/teleporter/New()
-	. = ..()
-	spawn(10)
-		findbeacon()
-		update_portal()
+/obj/machinery/computer/syndicate_depot/teleporter/Initialize(mapload)
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/computer/syndicate_depot/teleporter/LateInitialize()
+	findbeacon()
+	update_portal()
 
 /obj/machinery/computer/syndicate_depot/teleporter/Destroy()
 	if(mybeacon)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -57,7 +57,7 @@
 	name = "sentry mine"
 
 /obj/effect/mine/depot/mineEffect(mob/living/victim)
-	var/area/syndicate_depot/core/depotarea = areaMaster
+	var/area/syndicate_depot/core/depotarea = get_area(src)
 	if(istype(depotarea))
 		if(depotarea.mine_triggered(victim))
 			explosion(loc, 1, 0, 0, 1) // devastate the tile you are on, but leave everything else untouched

--- a/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
@@ -29,7 +29,7 @@
 
 /obj/structure/closet/secure_closet/syndicate/depot/proc/loot_pickup()
 	if(!ignore_use)
-		var/area/syndicate_depot/core/depotarea = areaMaster
+		var/area/syndicate_depot/core/depotarea = get_area(src)
 		if(istype(depotarea))
 			depotarea.locker_looted()
 			if(is_armory)

--- a/code/game/objects/structures/depot.dm
+++ b/code/game/objects/structures/depot.dm
@@ -9,17 +9,16 @@
 	var/area/syndicate_depot/core/depotarea
 	var/has_overloaded = FALSE
 
-/obj/structure/fusionreactor/New()
+/obj/structure/fusionreactor/Initialize(mapload)
 	. = ..()
-	// Do not attempt to put the code below into Initialize() or even LateInitialize() with a "return INITIALIZE_HINT_LATELOAD". It won't work!
-	depotarea = areaMaster
+	depotarea = get_area(src)
 	if(istype(depotarea))
 		depotarea.reactor = src
 		for(var/obj/machinery/porta_turret/syndicate/T in range(50, loc))
 			if(!istype(T.depotarea))
 				T.depotarea = depotarea
 	else
-		log_debug("[src] at [x],[y],[z] failed depotarea istype check during New()! Either it was spawned outside the depot area (bad idea), or a bug is happening.")
+		log_debug("[src] at [x],[y],[z] failed depotarea istype check during Initialize()! Either it was spawned outside the depot area (bad idea), or a bug is happening.")
 
 /obj/structure/fusionreactor/Destroy()
 	if(istype(depotarea))
@@ -81,18 +80,17 @@
 	var/max_cycles = 10
 	var/area/syndicate_depot/core/depotarea
 
-/obj/effect/overload/New()
+/obj/effect/overload/Initialize(mapload)
 	. = ..()
-	// Do not attempt to put the code below into Initialize() or even LateInitialize() with a "return INITIALIZE_HINT_LATELOAD". It won't work!
 	START_PROCESSING(SSobj, src)
-	depotarea = areaMaster
+	depotarea = get_area(src)
 	if(istype(depotarea))
 		if(!depotarea.used_self_destruct)
 			depotarea.used_self_destruct = TRUE // Silences all further alerts from this point onwards.
 			depotarea.updateicon()
 		depotarea.shields_down()
 	else
-		log_debug("[src] at [x],[y],[z] failed depotarea istype check during New()! Either it was spawned outside the depot area (bad idea), or a bug is happening.")
+		log_debug("[src] at [x],[y],[z] failed depotarea istype check during Initialize()! Either it was spawned outside the depot area (bad idea), or a bug is happening.")
 
 /obj/effect/overload/process()
 	var/turf/T = get_turf(src)
@@ -103,7 +101,7 @@
 		return
 
 	if(!istype(depotarea))
-		depotarea = areaMaster
+		depotarea = get_area(src)
 	if(istype(depotarea))
 		depotarea.destroyed = TRUE
 		depotarea.updateicon()

--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -23,7 +23,7 @@
 	desc = "Red Operations, Depot General Emission Regulator"
 	icon_state = "ai-magma"
 
-/mob/living/silicon/decoy/syndicate/New()
+/mob/living/silicon/decoy/syndicate/Initialize(mapload)
 	. = ..()
 	icon_state = "ai-magma"
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -102,11 +102,10 @@
 	var/shield_key = FALSE
 	var/turf/spawn_turf
 
-/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/New()
-	..()
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/Initialize(mapload)
+	. = ..()
 	name = "[name] [pick(GLOB.last_names)]"
-	// Do not attempt to move this code to Initialize() or LateInitialize(). Doing so with other objects has caused bugs in the past, because assigning "depotarea" may not work there.
-	depotarea = areaMaster
+	depotarea = get_area(src)
 	spawn_turf = get_turf(src)
 
 


### PR DESCRIPTION
## What Does This PR Do
Refactors the syndicate depot to use `Initialize()` for its structures and other things, instead of `New()`. This is in its own PR because its quite finnicky and needs testing on live.

## Why It's Good For The Game
The death of `New()` is my new crusade. Things will adapt, ~~or perish~~

## Changelog
N/A, refactor