### PR TITLE
Adds slowdown to borgs when enough damage is taken

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -91,12 +91,16 @@
 /obj/item/borg/upgrade/vtec/action(var/mob/living/silicon/robot/R)
 	if(..())
 		return
-	if(R.speed < 0)
+	if(R.health != 100)
+		to_chat(R, "<span class='notice'>System damaged, unable to install upgrade!</span>")
+		to_chat(usr, "<span class='notice'>VTEC is unable to be engaged when robot is damaged, repair it first!</span>")
+	if(R.has_vtec)
 		to_chat(R, "<span class='notice'>A VTEC unit is already installed!</span>")
 		to_chat(usr, "<span class='notice'>There's no room for another VTEC unit!</span>")
 		return
 
 	R.speed = -1 // Gotta go fast.
+	R.has_vtec = TRUE
 
 	return TRUE
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -91,7 +91,7 @@
 /obj/item/borg/upgrade/vtec/action(var/mob/living/silicon/robot/R)
 	if(..())
 		return
-	if(R.health != 100)
+	if(R.health != R.maxHealth)
 		to_chat(R, "<span class='notice'>System damaged, unable to install upgrade!</span>")
 		to_chat(usr, "<span class='notice'>VTEC is unable to be engaged when robot is damaged, repair it first!</span>")
 	if(R.has_vtec)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1472,6 +1472,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	default_cell_type = /obj/item/stock_parts/cell/super
 	var/eprefix = "Amber"
 	see_reagents = TRUE
+	can_slowdown = FALSE
 
 
 /mob/living/silicon/robot/ert/init(alien = FALSE, connect_to_AI = TRUE, mob/living/silicon/ai/ai_to_sync_to = null)
@@ -1507,7 +1508,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	damage_protection = 5 // Reduce all incoming damage by this number
 	eprefix = "Gamma"
 	magpulse = 1
-	slowdown_damage_increase = 25
 
 
 /mob/living/silicon/robot/destroyer

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -14,7 +14,7 @@
 	damage_protection = 5
 	brute_mod = 0.7 //30% less damage
 	burn_mod = 0.7
-	slowdown_damage_increase = 25
+	can_slowdown = FALSE
 	can_lock_cover = TRUE
 	lawchannel = "State"
 	var/playstyle_string = "<span class='userdanger'>You are a Syndicate assault cyborg!</span><br>\

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -14,6 +14,7 @@
 	damage_protection = 5
 	brute_mod = 0.7 //30% less damage
 	burn_mod = 0.7
+	slowdown_damage_increase = 25
 	can_lock_cover = TRUE
 	lawchannel = "State"
 	var/playstyle_string = "<span class='userdanger'>You are a Syndicate assault cyborg!</span><br>\


### PR DESCRIPTION
As this is another fun controversial PR, please read over the details before commenting. This slowdown is less harsh on borgs than it is on carbon mobs.
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Borgs now have damage slowdown. If they take 100 or more damage by default, they are slowed down, and are slowed down further at 150 total damage. If a borg has vtec, they are slowed down to normal non vtec borg speed at 50 damage by default. This means vtechonly works in good health, and doesnt hurt borgs too much for not having it.

(For context, humans start to slowdown at 40 hp, and max at 100.)

Vtec can only be applied to a borg at full HP, to avoid issues

Adds a variable to prevent borg slowdown, DS and destroyer borgs have this.

Adds a variable to increase the thresholds for borg slowdowns, set to 25 on syndicate and gamma borgs. This changes the damage to slow to 75 (with vtech). 125 to slower than normal borg speed, and 175 for even slower.

Gives borgs a have vtec variable, instead of checking for speed when vtec is implanted.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Borgs, specifically security, are always a hot topic. One of the complaints about them, has always been, they don't slow down from damage. This means antags can't slow down a borg by shooting behind them like an officer, and terrors can't bite a borg to slow them down to actually kill them, like they would a person.

This pr adds a slowdown to borgs, in a way that is less severe than the slowdown to humans. Even with vtech, they start slowing down 10 damage after the point where normal carbon mobs get slowdown. After that, they don't slow down again, till they take 100 damage, are down 2 modules, and where a normal human would be in crit and randomly getting stunned. This is still making borgs stronger than people, while meaning they can't full tilt charge to you with a baton while you are lasering / shooting / floor tilling them, like an officer, they will be slowed as this happens.

Special borgs are also not impacted as hard with this, with gamma and syndicate borgs taking more damage to slow down, and destroyer / DS borgs are fully immune to damage from slowdown like before.

## Changelog
:cl:
tweak: Borgs now slowdown while they take damage, with gamma ert and syndicate borgs being less weak to this, and admin / DS borgs being immune.
tweak: Vtec can now only be applied when a borg is fully intact.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
