### PR TITLE
Fixes ticker roundstart being slow

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -271,6 +271,8 @@ SUBSYSTEM_DEF(jobs)
 *  This proc must not have any side effect besides of modifying "assigned_role".
 **/
 /datum/controller/subsystem/jobs/proc/DivideOccupations()
+	// Lets roughly time this
+	var/watch = start_watch()
 	//Setup new player list and get the jobs list
 	Debug("Running DO")
 	SetupOccupations()
@@ -404,6 +406,7 @@ SUBSYSTEM_DEF(jobs)
 			player.ready = 0
 			unassigned -= player
 
+	log_debug("Dividing Occupations took [stop_watch(watch)]s")
 	return 1
 
 /datum/controller/subsystem/jobs/proc/AssignRank(var/mob/living/carbon/human/H, var/rank, var/joined_late = 0)

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(whitelist)
 				list("ckey" = M.ckey)
 			)
 
-			if(!job_read.warn_execute())
+			if(!job_read.warn_execute(async = FALSE)) // Dont async this. Youll make roundstart slow.
 				qdel(job_read)
 				return FALSE
 
@@ -87,7 +87,7 @@ GLOBAL_LIST_EMPTY(alien_whitelist)
 			list("ckey" = M.ckey)
 		)
 
-		if(!species_read.warn_execute())
+		if(!species_read.warn_execute(async = FALSE)) // Dont async this one. It makes roundstart take 10 years.
 			qdel(species_read)
 			return FALSE
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -572,7 +572,7 @@
 	// Log player connections to DB
 	var/datum/db_query/query_accesslog = SSdbcore.NewQuery("INSERT INTO `[format_table_name("connection_log")]`(`datetime`,`ckey`,`ip`,`computerid`) VALUES(Now(), :ckey, :ip, :cid)", list(
 		"ckey" = ckey,
-		"ip" = address,
+		"ip" = "[address ? address : ""]", // This is important. NULL is not the same as "", and if you directly open the `.dmb` file, you get a NULL IP.
 		"cid" = computer_id
 	))
 	// We do nothing with output here, or anything else after, so we dont need to if() wrap it

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -129,7 +129,7 @@
 			"slot" = slot,
 			"ckey" = C.ckey
 		))
-		if(!firstquery.warn_execute())
+		if(!firstquery.warn_execute(async = FALSE)) // Dont make this async. It makes roundstart slow.
 			qdel(firstquery)
 			return
 		qdel(firstquery)
@@ -192,7 +192,7 @@
 						 "ckey" = C.ckey,
 						 "slot" = slot
 					 ))
-	if(!query.warn_execute())
+	if(!query.warn_execute(async = FALSE)) // Dont make this async. It makes roundstart slow.
 		qdel(query)
 		return
 
@@ -481,7 +481,7 @@
 			qdel(firstquery)
 			qdel(query)
 			return 1
-	
+
 	qdel(firstquery)
 
 	var/datum/db_query/query = SSdbcore.NewQuery({"
@@ -612,7 +612,7 @@
 	))
 	var/list/saves = list()
 
-	if(!query.warn_execute())
+	if(!query.warn_execute(async = FALSE)) // Dont async this. Youll make roundstart slow.
 		qdel(query)
 		return
 
@@ -633,7 +633,7 @@
 		"ckey" = C.ckey,
 		"slot" = default_slot
 	))
-	
+
 	if(!query.warn_execute())
 		qdel(query)
 		return

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -9,7 +9,7 @@
 			"ckey" = M.ckey,
 			"realname" = M.real_name
 		))
-	if(!query.warn_execute())
+	if(!query.warn_execute(async = FALSE)) // Dont make this async. Youll make roundstart slow. Trust me.
 		qdel(query)
 		return
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -42,7 +42,7 @@
 		qdel(query)
 		// If our query failed, just assume yes
 		tos_consent = TRUE
-		return TRUE 
+		return TRUE
 
 	while(query.NextRow())
 		qdel(query)


### PR DESCRIPTION
## What Does This PR Do
This *hopefully* fixes the issue where the ticker takes 10 years to start the round. While Async SQL is very good for queries to run in the background instead of blocking DD, the tradeoff is it taking a while for mass queries which return data since it sleeps for atleast 1 tick each query. Now throw in checking every player for job bans and species bans at roundstart and you see where the delay comes from. These queries have been made blocking now. While this does mean DD will freeze at roundstart (like it always has), its only for about 5 seconds, instead of 30 seconds of limbo where you can still chat, but nothing happens.

At some point I may refactor these so it loads into a GLOB list to avoid the massive DB lookups, but this will do for now

## Why It's Good For The Game
Roundstart shouldnt take an eternity.

## Changelog
:cl: AffectedArc07
fix: Roundstart setup no longer takes an eternity
/:cl:
