### PR TITLE
Removes areamaster

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -29,11 +29,6 @@
 
 	var/moving_diagonally = 0 //0: not doing a diagonal move. 1 and 2: doing the first/second step of the diagonal move
 	var/list/client_mobs_in_contents
-	var/area/areaMaster
-
-/atom/movable/New()
-	. = ..()
-	areaMaster = get_area(src)
 
 /atom/movable/attempt_init(loc, ...)
 	var/turf/T = get_turf(src)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -244,7 +244,7 @@
 	if(!alarm_area)
 		alarm_area = get_area(src)
 	if(!alarm_area)
-		log_runtime(EXCEPTION("Air alarm /obj/machinery/alarm lacks alarm_area and areaMaster vars during proc/master_is_operating()"), src)
+		log_runtime(EXCEPTION("Air alarm /obj/machinery/alarm lacks alarm_area vars during proc/master_is_operating()"), src)
 		return FALSE
 	return alarm_area.master_air_alarm && !(alarm_area.master_air_alarm.stat & (NOPOWER|BROKEN))
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -263,7 +263,7 @@
 	find_control_computer()
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent=0)
-	for(var/obj/machinery/computer/cryopod/C in areaMaster.contents) //locate() is shit, this actually works, and there's a decent chance it's faster than locate()
+	for(var/obj/machinery/computer/cryopod/C in get_area(src).contents)
 		control_computer = C
 		break
 

--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -34,7 +34,7 @@
 
 /mob/living/silicon/decoy/syndicate/depot/proc/raise_alert()
 	raised_alert = TRUE
-	var/area/syndicate_depot/core/depotarea = get_area(src) // Cannot use myArea or areaMaster as neither will be defined for this mob type
+	var/area/syndicate_depot/core/depotarea = get_area(src) // Cannot use myArea as it wont be defined for this mob type
 	if(istype(depotarea))
 		depotarea.increase_alert("AI Unit Offline")
 	else


### PR DESCRIPTION
## What Does This PR Do
Removes `areamaster` var on all atoms. Its used in 1 place which can easily be converted, and has drawbacks (explained in why its good)

## Why It's Good For The Game
- Lowers RAM usage (Were no longer tracking an area on every single **atom** in the world)
- Lowers worldload time (No longer having to set a var in every single atom/New()). Its a marginal improvement but still an improvement

## Changelog
N/A