### PR TITLE
Fixes cyborgs using hotkeys while dead

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -17,6 +17,8 @@
 
 	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
 		return
+	if(stat == DEAD)
+		return
 
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])


### PR DESCRIPTION
## What Does This PR Do
Fixes #15047 - cyborgs being able to use hotkeys like ctrl/shift click to control airlocks while dead.

## Changelog
:cl: Kyep
fix: cyborgs can no longer use hotkeys to control doors/etc while dead.
/:cl:
