### PR TITLE
Changes vent, scrubber, and passive vent plane back to FLOOR_PLANE

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -1,7 +1,7 @@
 /obj/machinery/atmospherics/unary/passive_vent
 	icon = 'icons/atmos/vent_pump.dmi'
 	icon_state = "map_vent"
-
+	plane = FLOOR_PLANE
 	name = "passive vent"
 	desc = "A large air vent"
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -9,7 +9,7 @@
 	name = "air vent"
 	desc = "Has a valve and pump attached to it"
 	use_power = IDLE_POWER_USE
-
+	plane = FLOOR_PLANE
 	layer = GAS_SCRUBBER_LAYER
 
 	can_unwrench = 1
@@ -79,7 +79,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/update_icon(safety = 0)
 	..()
 
-	plane = GAME_PLANE
+	plane = FLOOR_PLANE
 
 	if(!check_icon_cache())
 		return

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -7,7 +7,7 @@
 	name = "air scrubber"
 	desc = "Has a valve and pump attached to it"
 	layer = GAS_SCRUBBER_LAYER
-
+	plane = FLOOR_PLANE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
 	active_power_usage = 60
@@ -95,7 +95,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/update_icon(var/safety = 0)
 	..()
 
-	plane = GAME_PLANE
+	plane = FLOOR_PLANE
 
 	if(!check_icon_cache())
 		return


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes vents, scrubbers and passive vents to use `FLOOR_PLANE` instead of `GAME_PLANE`, partially reverting what was done in #14975. All other atmospherics machines still use the `GAME_PLANE`. The only thing that's changed is vents, scrubbers and passive vents.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Vents/scrubbers having a shadow under them looks odd.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Left: before, Right: after
![unknown](https://user-images.githubusercontent.com/42044220/102702081-2744ac80-4224-11eb-8245-6c42283853eb.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Changed vent, scrubber and passive vent plane, removing the odd shadow that was appearing under them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
