### PR TITLE
Removes ability to put collars on jumpsuits

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -668,12 +668,16 @@ BLIND     // can't see anything
 	var/list/accessories = list()
 
 	/// List of blacklisted accessory types
-	var/list/blacklisted_accessory_typecache = list(
-		/obj/item/clothing/accessory/petcollar // No collars on jumpsuits
-	)
+	var/list/blacklisted_accessory_typecache
 	var/displays_id = 1
 	var/rolled_down = 0
 	var/basecolor
+
+/obj/item/clothing/under/Initialize(mapload)
+	. = ..()
+	blacklisted_accessory_typecache = typecacheof(list(
+		/obj/item/clothing/accessory/petcollar // No collars on jumpsuits
+	))
 
 /obj/item/clothing/under/rank/New()
 	if(random_sensor)
@@ -690,7 +694,7 @@ BLIND     // can't see anything
 	else
 		return FALSE
 
-	if(A.type in blacklisted_accessory_typecache)
+	if(is_type_in_typecache(A, blacklisted_accessory_typecache))
 		to_chat(usr, "<span class='notice'>[A] doesn't fit on [src].</span>")
 		return FALSE
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -666,6 +666,11 @@ BLIND     // can't see anything
 		3 = Report location
 		*/
 	var/list/accessories = list()
+
+	/// List of blacklisted accessory types
+	var/list/blacklisted_accessory_typecache = list(
+		/obj/item/clothing/accessory/petcollar // No collars on jumpsuits
+	)
 	var/displays_id = 1
 	var/rolled_down = 0
 	var/basecolor
@@ -685,11 +690,17 @@ BLIND     // can't see anything
 	else
 		return FALSE
 
+	if(A.type in blacklisted_accessory_typecache)
+		to_chat(usr, "<span class='notice'>[A] doesn't fit on [src].</span>")
+		return FALSE
+
 	if(accessories.len)
 		for(var/obj/item/clothing/accessory/AC in accessories)
 			if((A.slot in list(ACCESSORY_SLOT_UTILITY, ACCESSORY_SLOT_ARMBAND)) && AC.slot == A.slot)
+				to_chat(usr, "<span class='notice'>[A] doesn't fit on [src].</span>")
 				return FALSE
 			if(!A.allow_duplicates && AC.type == A.type)
+				to_chat(usr, "<span class='notice'>You cannot attach more accessories of this type to [src].</span>")
 				return FALSE
 
 /obj/item/clothing/under/attackby(obj/item/I, mob/user, params)
@@ -716,8 +727,6 @@ BLIND     // can't see anything
 			H.update_inv_w_uniform()
 
 		return TRUE
-	else
-		to_chat(user, "<span class='notice'>You cannot attach more accessories of this type to [src].</span>")
 
 	return FALSE
 


### PR DESCRIPTION
# Preliminary Note
This has already been discussed internally between admins and heads, and we have decided we want this. Please do not reeeee in the comments.

## What Does This PR Do
Removes the ability to put collars on jumpsuits.

## Why It's Good For The Game
People only ever add collars to jumpsuits for weird petplay fetish things, which we dont want here. Its time to stop this.

## Changelog
:cl: AffectedArc07
del: You can no longer put pet collars on jumpsuits
/:cl:
