### PR TITLE
More New() -> Initialize() for /obj/structure

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -140,7 +140,7 @@
 	choosable_items = list("Eldritch Whetstone" = /obj/item/whetstone/cult, "Flask of Unholy Water" = /obj/item/reagent_containers/food/drinks/bottle/unholywater,
 							"Construct Shell" = /obj/structure/constructshell)
 
-/obj/structure/cult/functional/altar/New()
+/obj/structure/cult/functional/altar/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.altar_icon_state
 
@@ -160,7 +160,7 @@
 	choosable_items = list("Shielded Robe" = /obj/item/clothing/suit/hooded/cultrobes/cult_shield, "Flagellant's Robe" = /obj/item/clothing/suit/hooded/cultrobes/flagellant_robe,
 							"Mirror Shield" = /obj/item/shield/mirror)
 
-/obj/structure/cult/functional/forge/New()
+/obj/structure/cult/functional/forge/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.forge_icon_state
 
@@ -217,16 +217,13 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 	var/corrupt_delay = 50
 	var/last_corrupt = 0
 
-/obj/structure/cult/functional/pylon/New()
+/obj/structure/cult/functional/pylon/Initialize(mapload)
 	. = ..()
+	START_PROCESSING(SSobj, src)
 	icon_state = SSticker.cultdat?.pylon_icon_state
 
 /obj/structure/cult/functional/pylon/attack_hand(mob/living/user)//override as it should not create anything
 	return
-
-/obj/structure/cult/functional/pylon/New()
-	START_PROCESSING(SSobj, src)
-	..()
 
 /obj/structure/cult/functional/pylon/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -307,7 +304,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 	choosable_items = list("Shuttle Curse" = /obj/item/shuttle_curse, "Zealot's Blindfold" = /obj/item/clothing/glasses/hud/health/night/cultblind,
 							"Veil Shifter" = /obj/item/cult_shift) //Add void torch to veil shifter spawn
 
-/obj/structure/cult/functional/archives/New()
+/obj/structure/cult/functional/archives/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.archives_icon_state
 

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -242,8 +242,8 @@
 	anchored = TRUE
 	state = AI_READY_CORE
 
-/obj/structure/AIcore/deactivated/New()
-	..()
+/obj/structure/AIcore/deactivated/Initialize(mapload)
+	. = ..()
 	circuit = new(src)
 
 /obj/structure/AIcore/deactivated/Destroy()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -179,13 +179,12 @@
 	orient_right = 1
 	icon_state = "cryo_rear-r"
 
-/obj/structure/cryofeed/New()
-
+/obj/structure/cryofeed/Initialize(mapload)
+	. = ..()
 	if(orient_right)
 		icon_state = "cryo_rear-r"
 	else
 		icon_state = "cryo_rear"
-	..()
 
 //Cryopods themselves.
 /obj/machinery/cryopod

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -132,8 +132,8 @@
 	var/deploy_time = 40
 	var/deploy_message = TRUE
 
-/obj/structure/barricade/security/New()
-	..()
+/obj/structure/barricade/security/Initialize(mapload)
+	. = ..()
 	addtimer(CALLBACK(src, .proc/deploy), deploy_time)
 
 /obj/structure/barricade/security/proc/deploy()

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -12,8 +12,8 @@
 	var/poster_type
 	var/obj/structure/sign/poster/poster_structure
 
-/obj/item/poster/New(loc, obj/structure/sign/poster/new_poster_structure)
-	..()
+/obj/item/poster/Initialize(mapload, obj/structure/sign/poster/new_poster_structure)
+	. = ..()
 	poster_structure = new_poster_structure
 	if(!new_poster_structure && poster_type)
 		poster_structure = new poster_type(src)
@@ -61,8 +61,8 @@
 	var/poster_item_desc = "This hypothetical poster item should not exist, let's be honest here."
 	var/poster_item_icon_state = "rolled_poster"
 
-/obj/structure/sign/poster/New()
-	..()
+/obj/structure/sign/poster/Initialize(mapload)
+	. = ..()
 	if(random_basetype)
 		randomise(random_basetype)
 	if(!ruined)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -34,8 +34,8 @@
 /obj/structure/spider/stickyweb
 	icon_state = "stickyweb1"
 
-/obj/structure/spider/stickyweb/New()
-	..()
+/obj/structure/spider/stickyweb/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		icon_state = "stickyweb2"
 
@@ -60,8 +60,8 @@
 	var/player_spiders = 0
 	var/list/faction = list("spiders")
 
-/obj/structure/spider/eggcluster/New()
-	..()
+/obj/structure/spider/eggcluster/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(3,-3)
 	pixel_y = rand(3,-3)
 	START_PROCESSING(SSobj, src)
@@ -93,8 +93,8 @@
 	var/list/faction = list("spiders")
 	var/selecting_player = 0
 
-/obj/structure/spider/spiderling/New()
-	..()
+/obj/structure/spider/spiderling/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(6,-6)
 	pixel_y = rand(6,-6)
 	START_PROCESSING(SSobj, src)
@@ -213,8 +213,8 @@
 	icon_state = "cocoon1"
 	max_integrity = 60
 
-/obj/structure/spider/cocoon/New()
-	..()
+/obj/structure/spider/cocoon/Initialize(mapload)
+	. = ..()
 	icon_state = pick("cocoon1","cocoon2","cocoon3")
 
 /obj/structure/spider/cocoon/Destroy()

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -14,21 +14,17 @@
 	var/prev_sign = ""
 	var/panel_open = 0
 
-/obj/structure/sign/barsign/New()
-	..()
+/obj/structure/sign/barsign/Initialize(mapload)
+	. = ..()
 
-
-//filling the barsigns list
+	//filling the barsigns list
 	for(var/bartype in subtypesof(/datum/barsign))
 		var/datum/barsign/signinfo = new bartype
 		if(!signinfo.hidden)
 			barsigns += signinfo
 
-
-//randomly assigning a sign
+	//randomly assigning a sign
 	set_sign(pick(barsigns))
-
-
 
 /obj/structure/sign/barsign/proc/set_sign(var/datum/barsign/sign)
 	if(!istype(sign))

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -6,8 +6,8 @@
 	density = 1
 	var/obj/item/paper/manifest/manifest
 
-/obj/structure/largecrate/New()
-	..()
+/obj/structure/largecrate/Initialize(mapload)
+	. = ..()
 	update_icon()
 
 /obj/structure/largecrate/update_icon()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -20,10 +20,10 @@
 	var/material_type = /obj/item/stack/sheet/metal
 	var/material_amt = 4
 
-/obj/structure/door_assembly/New()
+/obj/structure/door_assembly/Initialize(mapload)
+	. = ..()
 	update_icon()
 	update_name()
-	..()
 
 /obj/structure/door_assembly/Destroy()
 	QDEL_NULL(electronics)

--- a/code/game/objects/structures/door_assembly_types.dm
+++ b/code/game/objects/structures/door_assembly_types.dm
@@ -143,14 +143,14 @@
 	glass_type = /obj/machinery/door/airlock/multi_tile/glass
 	material_amt = 8
 
-/obj/structure/door_assembly/multi_tile/New()
+/obj/structure/door_assembly/multi_tile/Initialize(mapload)
+	. = ..()
 	if(dir in list(EAST, WEST))
 		bound_width = width * world.icon_size
 		bound_height = world.icon_size
 	else
 		bound_width = world.icon_size
 		bound_height = width * world.icon_size
-	..()
 
 /obj/structure/door_assembly/multi_tile/Move()
 	. = ..()
@@ -169,7 +169,7 @@
 	airlock_type = /obj/machinery/door/airlock/cult
 	glass_type = /obj/machinery/door/airlock/cult/glass
 
-/obj/structure/door_assembly/door_assembly_cult/New()
+/obj/structure/door_assembly/door_assembly_cult/Initialize(mapload)
 	. = ..()
 	icon = SSticker.cultdat?.airlock_runed_icon_file
 	overlays_file = SSticker.cultdat?.airlock_runed_overlays_file
@@ -181,7 +181,7 @@
 	airlock_type = /obj/machinery/door/airlock/cult/unruned
 	glass_type = /obj/machinery/door/airlock/cult/unruned/glass
 
-/obj/structure/door_assembly/door_assembly_cult/unruned/New()
+/obj/structure/door_assembly/door_assembly_cult/unruned/Initialize(mapload)
 	. = ..()
 	icon = SSticker.cultdat?.airlock_unruned_icon_file
 	overlays_file = SSticker.cultdat?.airlock_unruned_overlays_file

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -7,19 +7,19 @@
 	var/last_time = 1.0
 	var/delay_time = 50
 
-/obj/structure/chair/e_chair/New()
-	..()
+/obj/structure/chair/e_chair/Initialize(mapload)
+	. = ..()
 	overlays += image('icons/obj/chairs.dmi', src, "echair_over", MOB_LAYER + 1, dir)
-	spawn(2)
-		if(isnull(part)) //This e-chair was not custom built
-			part = new(src)
-			var/obj/item/clothing/head/helmet/part1 = new(part)
-			var/obj/item/radio/electropack/part2 = new(part)
-			part2.frequency = 1445
-			part2.code = 6
-			part2.master = part
-			part.part1 = part1
-			part.part2 = part2
+
+	if(isnull(part)) //This e-chair was not custom built
+		part = new(src)
+		var/obj/item/clothing/head/helmet/part1 = new(part)
+		var/obj/item/radio/electropack/part2 = new(part)
+		part2.frequency = 1445
+		part2.code = 6
+		part2.master = part
+		part.part1 = part1
+		part.part2 = part2
 
 /obj/structure/chair/e_chair/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/wrench))

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -7,15 +7,18 @@
 	var/last_time = 1.0
 	var/delay_time = 50
 
-/obj/structure/chair/e_chair/Initialize(mapload)
+/obj/structure/chair/e_chair/Initialize(mapload, obj/item/assembly/shock_kit/sk)
 	. = ..()
 	overlays += image('icons/obj/chairs.dmi', src, "echair_over", MOB_LAYER + 1, dir)
+
+	if(sk)
+		part = sk
 
 	if(isnull(part)) //This e-chair was not custom built
 		part = new(src)
 		var/obj/item/clothing/head/helmet/part1 = new(part)
 		var/obj/item/radio/electropack/part2 = new(part)
-		part2.frequency = 1445
+		part2.set_frequency(1445)
 		part2.code = 6
 		part2.master = part
 		part.part1 = part1

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -17,8 +17,8 @@
 	var/opened = 0
 	var/material_drop = /obj/item/stack/sheet/metal
 
-/obj/structure/extinguisher_cabinet/New(turf/loc, direction = null)
-	..()
+/obj/structure/extinguisher_cabinet/Initialize(mapload, direction = null)
+	. = ..()
 	if(direction)
 		setDir(direction)
 		set_pixel_offsets_from_dir(28, -28, 30, -30)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -33,8 +33,8 @@
 	/turf/simulated/wall/r_wall/rust)
 	smooth = SMOOTH_TRUE
 
-/obj/structure/falsewall/New(loc)
-	..()
+/obj/structure/falsewall/Initialize(mapload)
+	. = ..()
 	air_update_turf(1)
 
 /obj/structure/falsewall/ratvar_act()
@@ -349,8 +349,8 @@
 	walltype = /turf/simulated/wall/clockwork
 	mineral = /obj/item/stack/tile/brass
 
-/obj/structure/falsewall/brass/New(loc)
-	..()
+/obj/structure/falsewall/brass/Initialize(mapload)
+	. = ..()
 	var/turf/T = get_turf(src)
 	new /obj/effect/temp_visual/ratvar/wall/false(T)
 	new /obj/effect/temp_visual/ratvar/beam/falsewall(T)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -15,8 +15,8 @@
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_1"
 
-/obj/structure/flora/tree/pine/New()
-	..()
+/obj/structure/flora/tree/pine/Initialize(mapload)
+	. = ..()
 	icon_state = "pine_[rand(1, 3)]"
 
 /obj/structure/flora/tree/pine/xmas
@@ -24,24 +24,20 @@
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_c"
 
-/obj/structure/flora/tree/pine/xmas/New()
-	..()
-	icon_state = "pine_c"
-
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/flora/deadtrees.dmi'
 	icon_state = "tree_1"
 
-/obj/structure/flora/tree/dead/New()
-	..()
+/obj/structure/flora/tree/dead/Initialize(mapload)
+	. = ..()
 	icon_state = "tree_[rand(1, 6)]"
 
 /obj/structure/flora/tree/palm
 	icon = 'icons/misc/beach2.dmi'
 	icon_state = "palm1"
 
-/obj/structure/flora/tree/palm/New()
-	..()
+/obj/structure/flora/tree/palm/Initialize(mapload)
+	. = ..()
 	icon_state = pick("palm1","palm2")
 	pixel_x = 0
 
@@ -55,23 +51,23 @@
 /obj/structure/flora/grass/brown
 	icon_state = "snowgrass1bb"
 
-/obj/structure/flora/grass/brown/New()
-	..()
+/obj/structure/flora/grass/brown/Initialize(mapload)
+	. = ..()
 	icon_state = "snowgrass[rand(1, 3)]bb"
 
 
 /obj/structure/flora/grass/green
 	icon_state = "snowgrass1gb"
 
-/obj/structure/flora/grass/green/New()
-	..()
+/obj/structure/flora/grass/green/Initialize(mapload)
+	. = ..()
 	icon_state = "snowgrass[rand(1, 3)]gb"
 
 /obj/structure/flora/grass/both
 	icon_state = "snowgrassall1"
 
-/obj/structure/flora/grass/both/New()
-	..()
+/obj/structure/flora/grass/both/Initialize(mapload)
+	. = ..()
 	icon_state = "snowgrassall[rand(1, 3)]"
 
 
@@ -83,8 +79,8 @@
 	anchored = 1
 	max_integrity = 15
 
-/obj/structure/flora/bush/New()
-	..()
+/obj/structure/flora/bush/Initialize(mapload)
+	. = ..()
 	icon_state = "snowbush[rand(1, 6)]"
 
 //newbushes
@@ -96,113 +92,113 @@
 	anchored = 1
 	max_integrity = 15
 
-/obj/structure/flora/ausbushes/New()
-	..()
+/obj/structure/flora/ausbushes/Initialize(mapload)
+	. = ..()
 	icon_state = "firstbush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/reedbush
 	icon_state = "reedbush_1"
 
-/obj/structure/flora/ausbushes/reedbush/New()
-	..()
+/obj/structure/flora/ausbushes/reedbush/Initialize(mapload)
+	. = ..()
 	icon_state = "reedbush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/leafybush
 	icon_state = "leafybush_1"
 
-/obj/structure/flora/ausbushes/leafybush/New()
-	..()
+/obj/structure/flora/ausbushes/leafybush/Initialize(mapload)
+	. = ..()
 	icon_state = "leafybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/palebush
 	icon_state = "palebush_1"
 
-/obj/structure/flora/ausbushes/palebush/New()
-	..()
+/obj/structure/flora/ausbushes/palebush/Initialize(mapload)
+	. = ..()
 	icon_state = "palebush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/stalkybush
 	icon_state = "stalkybush_1"
 
-/obj/structure/flora/ausbushes/stalkybush/New()
-	..()
+/obj/structure/flora/ausbushes/stalkybush/Initialize(mapload)
+	. = ..()
 	icon_state = "stalkybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/grassybush
 	icon_state = "grassybush_1"
 
-/obj/structure/flora/ausbushes/grassybush/New()
-	..()
+/obj/structure/flora/ausbushes/grassybush/Initialize(mapload)
+	. = ..()
 	icon_state = "grassybush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/fernybush
 	icon_state = "fernybush_1"
 
-/obj/structure/flora/ausbushes/fernybush/New()
-	..()
+/obj/structure/flora/ausbushes/fernybush/Initialize(mapload)
+	. = ..()
 	icon_state = "fernybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/sunnybush
 	icon_state = "sunnybush_1"
 
-/obj/structure/flora/ausbushes/sunnybush/New()
-	..()
+/obj/structure/flora/ausbushes/sunnybush/Initialize(mapload)
+	. = ..()
 	icon_state = "sunnybush_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/genericbush
 	icon_state = "genericbush_1"
 
-/obj/structure/flora/ausbushes/genericbush/New()
-	..()
+/obj/structure/flora/ausbushes/genericbush/Initialize(mapload)
+	. = ..()
 	icon_state = "genericbush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/pointybush
 	icon_state = "pointybush_1"
 
-/obj/structure/flora/ausbushes/pointybush/New()
-	..()
+/obj/structure/flora/ausbushes/pointybush/Initialize(mapload)
+	. = ..()
 	icon_state = "pointybush_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/lavendergrass
 	icon_state = "lavendergrass_1"
 
-/obj/structure/flora/ausbushes/lavendergrass/New()
-	..()
+/obj/structure/flora/ausbushes/lavendergrass/Initialize(mapload)
+	. = ..()
 	icon_state = "lavendergrass_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/ywflowers
 	icon_state = "ywflowers_1"
 
-/obj/structure/flora/ausbushes/ywflowers/New()
-	..()
+/obj/structure/flora/ausbushes/ywflowers/Initialize(mapload)
+	. = ..()
 	icon_state = "ywflowers_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/brflowers
 	icon_state = "brflowers_1"
 
-/obj/structure/flora/ausbushes/brflowers/New()
-	..()
+/obj/structure/flora/ausbushes/brflowers/Initialize(mapload)
+	. = ..()
 	icon_state = "brflowers_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/ppflowers
 	icon_state = "ppflowers_1"
 
-/obj/structure/flora/ausbushes/ppflowers/New()
-	..()
+/obj/structure/flora/ausbushes/ppflowers/Initialize(mapload)
+	. = ..()
 	icon_state = "ppflowers_[rand(1, 4)]"
 
 /obj/structure/flora/ausbushes/sparsegrass
 	icon_state = "sparsegrass_1"
 
-/obj/structure/flora/ausbushes/sparsegrass/New()
-	..()
+/obj/structure/flora/ausbushes/sparsegrass/Initialize(mapload)
+	. = ..()
 	icon_state = "sparsegrass_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/fullgrass
 	icon_state = "fullgrass_1"
 
-/obj/structure/flora/ausbushes/fullgrass/New()
-	..()
+/obj/structure/flora/ausbushes/fullgrass/Initialize(mapload)
+	. = ..()
 	icon_state = "fullgrass_[rand(1, 3)]"
 
 
@@ -250,8 +246,8 @@
 	resistance_flags = FIRE_PROOF
 	anchored = 1
 
-/obj/structure/flora/rock/New()
-	..()
+/obj/structure/flora/rock/Initialize(mapload)
+	. = ..()
 	icon_state = "rock[rand(1,5)]"
 
 /obj/structure/flora/rock/pile
@@ -259,8 +255,8 @@
 	desc = "some rocks"
 	icon_state = "rockpile1"
 
-/obj/structure/flora/rock/pile/New()
-	..()
+/obj/structure/flora/rock/pile/Initialize(mapload)
+	. = ..()
 	icon_state = "rockpile[rand(1,5)]"
 
 /obj/structure/flora/rock/icy
@@ -308,7 +304,7 @@
 	var/indestructable = 0
 	var/stump = 0
 
-/obj/structure/bush/New()
+/obj/structure/bush/Initialize(mapload)
 	. = ..()
 	if(prob(20))
 		opacity = 1

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -412,7 +412,7 @@
 	metalUsed = 1
 	metal_type = /obj/item/stack/sheet/runed_metal
 
-/obj/structure/girder/cult/New()
+/obj/structure/girder/cult/Initialize(mapload)
 	. = ..()
 	icon_state = SSticker.cultdat?.cult_girder_icon_state
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -20,10 +20,10 @@
 	var/shockcooldown = 0
 	var/my_shockcooldown = 1 SECONDS
 
-/obj/structure/grille/fence/
+/obj/structure/grille/fence
 	var/width = 3
 
-/obj/structure/grille/fence/New()
+/obj/structure/grille/fence/Initialize(mapload)
 	. = ..()
 	if(width > 1)
 		if(dir in list(EAST, WEST))
@@ -290,8 +290,8 @@
 	desc = "A strangely-shaped grille."
 	broken_type = /obj/structure/grille/ratvar/broken
 
-/obj/structure/grille/ratvar/New()
-	..()
+/obj/structure/grille/ratvar/Initialize(mapload)
+	. = ..()
 	if(broken)
 		new /obj/effect/temp_visual/ratvar/grille/broken(get_turf(src))
 	else

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -9,11 +9,11 @@
 	armor = list("melee" = 0, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 20)
 	var/obj/item/holosign_creator/projector
 
-/obj/structure/holosign/New(loc, source_projector)
+/obj/structure/holosign/Initialize(mapload, source_projector)
+	. = ..()
 	if(source_projector)
 		projector = source_projector
 		projector.signs += src
-	..()
 
 /obj/structure/holosign/Destroy()
 	if(projector)
@@ -73,8 +73,8 @@
 	layer = ABOVE_MOB_LAYER
 	alpha = 150
 
-/obj/structure/holosign/barrier/atmos/New()
-	..()
+/obj/structure/holosign/barrier/atmos/Initialize(mapload)
+	. = ..()
 	air_update_turf(TRUE)
 
 /obj/structure/holosign/barrier/atmos/CanAtmosPass(turf/T)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -18,8 +18,8 @@
 	var/const/max_signs = 4
 
 
-/obj/structure/janitorialcart/New()
-	..()
+/obj/structure/janitorialcart/Initialize(mapload)
+	. = ..()
 	create_reagents(100)
 	GLOB.janitorial_equipment += src
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -21,12 +21,9 @@
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/damageSound = null
 
-/obj/structure/mineral_door/New(location)
-	..()
-	initial_state = icon_state
-
 /obj/structure/mineral_door/Initialize()
-	..()
+	. = ..()
+	initial_state = icon_state
 	air_update_turf(1)
 
 /obj/structure/mineral_door/Destroy()

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -10,8 +10,8 @@
 	integrity_failure = 100
 	var/list/ui_users = list()
 
-/obj/structure/mirror/New(turf/T, newdir = SOUTH, building = FALSE)
-	..()
+/obj/structure/mirror/Initialize(mapload, newdir = SOUTH, building = FALSE)
+	. = ..()
 	if(building)
 		switch(newdir)
 			if(NORTH)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -7,13 +7,13 @@
 	container_type = OPENCONTAINER
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 
-/obj/structure/mopbucket/New()
-	..()
+/obj/structure/mopbucket/Initialize(mapload)
+	. = ..()
 	create_reagents(100)
 	GLOB.janitorial_equipment += src
 
-/obj/structure/mopbucket/full/New()
-	..()
+/obj/structure/mopbucket/full/Initialize(mapload)
+	. = ..()
 	reagents.add_reagent("water", 100)
 
 /obj/structure/mopbucket/Destroy()

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -10,9 +10,9 @@
 	comfort = 0
 	flags = NODECONSTRUCT
 
-/obj/structure/bed/nest/New()
+/obj/structure/bed/nest/Initialize(mapload)
+	. = ..()
 	nest_overlay = image('icons/mob/alien.dmi', "nestoverlay", layer=MOB_LAYER - 0.2)
-	return ..()
 
 /obj/structure/bed/nest/user_unbuckle_mob(mob/living/user)
 	if(has_buckled_mobs())

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -18,12 +18,6 @@
 	var/propelled = FALSE // Check for fire-extinguisher-driven chairs
 	var/comfort = 0
 
-/obj/structure/chair/New()
-	..()
-	spawn(3)	//sorry. i don't think there's a better way to do this.
-		handle_rotation()
-	return
-
 /obj/structure/chair/narsie_act()
 	if(prob(20))
 		var/obj/structure/chair/wood/W = new/obj/structure/chair/wood(get_turf(src))

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -40,10 +40,9 @@
 			to_chat(user, "<span class='notice'>[SK] is not ready to be attached!</span>")
 			return
 		user.drop_item()
-		var/obj/structure/chair/e_chair/E = new /obj/structure/chair/e_chair(src.loc)
+		var/obj/structure/chair/e_chair/E = new /obj/structure/chair/e_chair(get_turf(src), SK)
 		playsound(src.loc, W.usesound, 50, 1)
 		E.dir = dir
-		E.part = SK
 		SK.loc = E
 		SK.master = E
 		qdel(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -35,8 +35,8 @@
 	var/deconstruction_ready = TRUE
 	var/flipped = 0
 
-/obj/structure/table/New()
-	..()
+/obj/structure/table/Initialize(mapload)
+	. = ..()
 	if(flipped)
 		update_icon()
 
@@ -70,11 +70,11 @@
 		if(istype(src, /obj/structure/table/reinforced))
 			base = "rtable"
 		if(istype(src, /obj/structure/table/wood/poker))
-			base = "poker"	
+			base = "poker"
 		if(istype(src, /obj/structure/table/wood/fancy))
-			base = "fancy"	
+			base = "fancy"
 		if(istype(src, /obj/structure/table/wood/fancy/black))
-			base = "fancyblack"	
+			base = "fancyblack"
 
 		icon_state = "[base]flip[type][type == 1 ? subtype : ""]"
 
@@ -394,7 +394,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 100)
 	var/list/debris = list()
 
-/obj/structure/table/glass/New()
+/obj/structure/table/glass/Initialize(mapload)
 	. = ..()
 	debris += new frame
 	debris += new /obj/item/shard
@@ -503,16 +503,16 @@
 	buildstack = /obj/item/stack/tile/carpet
 	canSmoothWith = list(/obj/structure/table/wood/fancy, /obj/structure/table/wood/fancy/black)
 
-/obj/structure/table/wood/fancy/New()
+/obj/structure/table/wood/fancy/Initialize(mapload)
+	. = ..()
 	icon = 'icons/obj/smooth_structures/fancy_table.dmi' //so that the tables place correctly in the map editor
-	..()
 
 /obj/structure/table/wood/fancy/black
 	icon_state = "fancy_table_black"
 	buildstack = /obj/item/stack/tile/carpet/black
 
-/obj/structure/table/wood/fancy/black/New()
-	..()
+/obj/structure/table/wood/fancy/black/Initialize(mapload)
+	. = ..()
 	icon = 'icons/obj/smooth_structures/fancy_table_black.dmi' //so that the tables place correctly in the map editor
 
 /*

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -18,8 +18,8 @@
 /obj/structure/dispenser/plasma
 	starting_oxygen_tanks = 0
 
-/obj/structure/dispenser/New()
-	..()
+/obj/structure/dispenser/Initialize(mapload)
+	. = ..()
 	initialize_tanks()
 	update_icon()
 

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -19,8 +19,8 @@
 
 	var/list/disallowed_mobs = list(/mob/living/silicon/ai)
 
-/obj/structure/transit_tube/station/New()
-	..()
+/obj/structure/transit_tube/station/Initialize(mapload)
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/transit_tube/station/Destroy()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -13,8 +13,8 @@
 	var/mob/living/swirlie = null	//the mob being given a swirlie
 
 
-/obj/structure/toilet/New()
-	..()
+/obj/structure/toilet/Initialize(mapload)
+	. = ..()
 	open = round(rand(0, 1))
 	update_icon()
 
@@ -181,7 +181,7 @@
 /obj/structure/toilet/secret
 	var/secret_type = null
 
-/obj/structure/toilet/secret/New()
+/obj/structure/toilet/secret/Initialize(mapload)
 	. = ..()
 	if(secret_type)
 		var/obj/item/secret = new secret_type(src)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -31,8 +31,8 @@
 	. = ..()
 	. += "<span class='notice'>Alt-click to rotate it clockwise.</span>"
 
-/obj/structure/windoor_assembly/New(loc, set_dir)
-	..()
+/obj/structure/windoor_assembly/Initialize(mapload, set_dir)
+	. = ..()
 	if(set_dir)
 		dir = set_dir
 	ini_dir = dir

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -69,8 +69,9 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	if(!anchored && !fulltile)
 		. += "<span class='notice'>Alt-click to rotate it.</span>"
 
-/obj/structure/window/New(Loc, direct)
-	..()
+/obj/structure/window/Initialize(mapload, direct)
+	. = ..()
+
 	if(direct)
 		setDir(direct)
 	if(reinf && anchored)
@@ -106,9 +107,7 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
 
-/obj/structure/window/Initialize()
-	air_update_turf(1)
-	return ..()
+	air_update_turf(TRUE)
 
 /obj/structure/window/narsie_act()
 	color = NARSIE_WINDOW_COLOUR
@@ -729,10 +728,10 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 	cancolor = FALSE
 	var/made_glow = FALSE
 
-/obj/structure/window/reinforced/clockwork/New(loc, direct)
+/obj/structure/window/reinforced/clockwork/Initialize(mapload, direct)
+	. = ..()
 	if(fulltile)
 		made_glow = TRUE
-	..()
 	QDEL_LIST(debris)
 	if(fulltile)
 		new /obj/effect/temp_visual/ratvar/window(get_turf(src))

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -418,8 +418,8 @@
 	var/obj/structure/spacevine_controller/master = null
 	var/list/mutations = list()
 
-/obj/structure/spacevine/New()
-	..()
+/obj/structure/spacevine/Initialize(mapload)
+	. = ..()
 	color = "#ffffff"
 
 /obj/structure/spacevine/examine(mob/user)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -99,8 +99,8 @@
 /obj/structure/bookcase/manuals/medical
 	name = "Medical Manuals bookcase"
 
-/obj/structure/bookcase/manuals/medical/New()
-	..()
+/obj/structure/bookcase/manuals/medical/Initialize()
+	. = ..()
 	new /obj/item/book/manual/medical_cloning(src)
 	update_icon()
 
@@ -108,8 +108,8 @@
 /obj/structure/bookcase/manuals/engineering
 	name = "Engineering Manuals bookcase"
 
-/obj/structure/bookcase/manuals/engineering/New()
-	..()
+/obj/structure/bookcase/manuals/engineering/Initialize()
+	. = ..()
 	new /obj/item/book/manual/engineering_construction(src)
 	new /obj/item/book/manual/engineering_particle_accelerator(src)
 	new /obj/item/book/manual/engineering_hacking(src)
@@ -121,8 +121,8 @@
 /obj/structure/bookcase/manuals/research_and_development
 	name = "R&D Manuals bookcase"
 
-/obj/structure/bookcase/manuals/research_and_development/New()
-	..()
+/obj/structure/bookcase/manuals/research_and_development/Initialize()
+	. = ..()
 	new /obj/item/book/manual/research_and_development(src)
 	update_icon()
 

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -27,7 +27,7 @@
 	icon_state = "random_bookcase"
 	anchored = TRUE
 
-/obj/structure/bookcase/random/New()
+/obj/structure/bookcase/random/Initialize()
 	. = ..()
 	if(!book_count || !isnum(book_count))
 		update_icon()
@@ -54,7 +54,7 @@
 	if(category)
 		c = " AND category=:category"
 		sql_params["category"] = category
-	
+
 	sql_params["amount"] = amount
 	var/datum/db_query/query_get_random_books = SSdbcore.NewQuery("SELECT author, title, content FROM [format_table_name("library")] WHERE (isnull(flagged) OR flagged = 0)[c] GROUP BY title ORDER BY rand() LIMIT :amount", sql_params)
 	if(!query_get_random_books.warn_execute())

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -162,8 +162,8 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	density = FALSE
 	var/beacon_network = "station"
 
-/obj/structure/extraction_point/New()
-	..()
+/obj/structure/extraction_point/Initialize(mapload)
+	. = ..()
 	name += " ([rand(100,999)]) ([get_location_name(src)])"
 	GLOB.total_extraction_beacons += src
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -165,8 +165,8 @@
 	icon_state = "stickyweb1"
 	var/creator_ckey = null
 
-/obj/structure/spider/terrorweb/New()
-	..()
+/obj/structure/spider/terrorweb/Initialize(mapload)
+	. = ..()
 	if(prob(50))
 		icon_state = "stickyweb2"
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -367,7 +367,7 @@
 	desc = "This multi-layered web seems to be able to resist air pressure."
 
 
-/obj/structure/spider/terrorweb/queen/New()
+/obj/structure/spider/terrorweb/queen/Initialize(mapload)
 	. = ..()
 	air_update_turf(TRUE)
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -186,9 +186,7 @@
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/DoLayTerrorEggs(lay_type, lay_number)
 	stop_automated_movement = 1
-	var/obj/structure/spider/eggcluster/terror_eggcluster/C = new /obj/structure/spider/eggcluster/terror_eggcluster(get_turf(src))
-	C.spiderling_type = lay_type
-	C.update_name() // Sets the name after setting the egg type on the line above
+	var/obj/structure/spider/eggcluster/terror_eggcluster/C = new /obj/structure/spider/eggcluster/terror_eggcluster(get_turf(src), lay_type)
 	C.spiderling_number = lay_number
 	C.spider_myqueen = spider_myqueen
 	C.spider_mymother = src
@@ -210,11 +208,11 @@
 	var/spiderling_number = 1
 	var/list/enemies = list()
 
-/obj/structure/spider/eggcluster/terror_eggcluster/Initialize(mapload)
+/obj/structure/spider/eggcluster/terror_eggcluster/Initialize(mapload, lay_type)
 	. = ..()
 	GLOB.ts_egg_list += src
+	spiderling_type = lay_type
 
-/obj/structure/spider/eggcluster/terror_eggcluster/proc/update_name()
 	switch(spiderling_type)
 		if(/mob/living/simple_animal/hostile/poison/terror_spider/red)
 			name = "red terror eggs"

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -188,6 +188,7 @@
 	stop_automated_movement = 1
 	var/obj/structure/spider/eggcluster/terror_eggcluster/C = new /obj/structure/spider/eggcluster/terror_eggcluster(get_turf(src))
 	C.spiderling_type = lay_type
+	C.update_name() // Sets the name after setting the egg type on the line above
 	C.spiderling_number = lay_number
 	C.spider_myqueen = spider_myqueen
 	C.spider_mymother = src
@@ -213,24 +214,26 @@
 	. = ..()
 	GLOB.ts_egg_list += src
 
-	if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/red)
-		name = "red terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/gray)
-		name = "gray terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/green)
-		name = "green terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/black)
-		name = "black terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/purple)
-		name = "purple terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/white)
-		name = "white terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/mother)
-		name = "mother of terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/prince)
-		name = "prince of terror eggs"
-	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/queen)
-		name = "queen of terror eggs"
+/obj/structure/spider/eggcluster/terror_eggcluster/proc/update_name()
+	switch(spiderling_type)
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/red)
+			name = "red terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/gray)
+			name = "gray terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/green)
+			name = "green terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/black)
+			name = "black terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/purple)
+			name = "purple terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/white)
+			name = "white terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/mother)
+			name = "mother of terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/prince)
+			name = "prince of terror eggs"
+		if(/mob/living/simple_animal/hostile/poison/terror_spider/queen)
+			name = "queen of terror eggs"
 
 /obj/structure/spider/eggcluster/terror_eggcluster/Destroy()
 	GLOB.ts_egg_list -= src

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -22,8 +22,8 @@
 	var/debug_ai_choices = FALSE
 	var/movement_disabled = FALSE
 
-/obj/structure/spider/spiderling/terror_spiderling/New()
-	..()
+/obj/structure/spider/spiderling/terror_spiderling/Initialize(mapload)
+	. = ..()
 	GLOB.ts_spiderling_list += src
 	if(is_away_level(z))
 		spider_awaymission = TRUE
@@ -209,28 +209,28 @@
 	var/spiderling_number = 1
 	var/list/enemies = list()
 
-/obj/structure/spider/eggcluster/terror_eggcluster/New()
-	..()
+/obj/structure/spider/eggcluster/terror_eggcluster/Initialize(mapload)
+	. = ..()
 	GLOB.ts_egg_list += src
-	spawn(50)
-		if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/red)
-			name = "red terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/gray)
-			name = "gray terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/green)
-			name = "green terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/black)
-			name = "black terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/purple)
-			name = "purple terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/white)
-			name = "white terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/mother)
-			name = "mother of terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/prince)
-			name = "prince of terror eggs"
-		else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/queen)
-			name = "queen of terror eggs"
+
+	if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/red)
+		name = "red terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/gray)
+		name = "gray terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/green)
+		name = "green terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/black)
+		name = "black terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/purple)
+		name = "purple terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/white)
+		name = "white terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/mother)
+		name = "mother of terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/prince)
+		name = "prince of terror eggs"
+	else if(spiderling_type == /mob/living/simple_animal/hostile/poison/terror_spider/queen)
+		name = "queen of terror eggs"
 
 /obj/structure/spider/eggcluster/terror_eggcluster/Destroy()
 	GLOB.ts_egg_list -= src

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -187,9 +187,9 @@ GLOBAL_LIST_EMPTY(employmentCabinets)
 	icon_state = "employmentcabinet"
 	var/populated = FALSE
 
-/obj/structure/filingcabinet/employment/New()
+/obj/structure/filingcabinet/employment/Initialize(mapload)
+	. = ..()
 	GLOB.employmentCabinets += src
-	return ..()
 
 /obj/structure/filingcabinet/employment/Destroy()
 	GLOB.employmentCabinets -= src

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -23,10 +23,10 @@
 		return FALSE //so we can refill them via their afterattack.
 	return ..()
 
-/obj/structure/reagent_dispensers/New()
+/obj/structure/reagent_dispensers/Initialize(mapload)
+	. = ..()
 	create_reagents(tank_volume)
 	reagents.add_reagent(reagent_id, tank_volume)
-	..()
 
 /obj/structure/reagent_dispensers/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -16,8 +16,8 @@
 	var/base_state
 	var/dpdir = 0	// directions as disposalpipe
 
-/obj/structure/disposalconstruct/New(loc, pipe_type, direction)
-	..()
+/obj/structure/disposalconstruct/Initialize(mapload, pipe_type, direction)
+	. = ..()
 	if(pipe_type)
 		ptype = pipe_type
 	if(dir)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -693,8 +693,8 @@
 	var/base_icon_state	// initial icon state on map
 
 	// new pipe, set the icon_state as on map
-/obj/structure/disposalpipe/New()
-	..()
+/obj/structure/disposalpipe/Initialize(mapload)
+	. = ..()
 	base_icon_state = icon_state
 
 
@@ -754,8 +754,8 @@
 
 // update the icon_state to reflect hidden status
 /obj/structure/disposalpipe/proc/update()
-	var/turf/T = src.loc
-	hide(T.intact && !istype(T,/turf/space))	// space never hides pipes
+	var/turf/T = get_turf(src)
+	hide(T.intact && !istype(T, /turf/space))	// space never hides pipes
 	update_icon()
 
 // hide called by levelupdate if turf intact status changes
@@ -935,13 +935,12 @@
 /obj/structure/disposalpipe/segment
 	icon_state = "pipe-s"
 
-/obj/structure/disposalpipe/segment/New()
-	..()
+/obj/structure/disposalpipe/segment/Initialize(mapload)
+	. = ..()
 	if(icon_state == "pipe-s")
 		dpdir = dir | turn(dir, 180)
 	else
 		dpdir = dir | turn(dir, -90)
-
 	update()
 
 
@@ -950,8 +949,8 @@
 /obj/structure/disposalpipe/junction
 	icon_state = "pipe-j1"
 
-/obj/structure/disposalpipe/junction/New()
-	..()
+/obj/structure/disposalpipe/junction/Initialize(mapload)
+	. = ..()
 	if(icon_state == "pipe-j1")
 		dpdir = dir | turn(dir, -90) | turn(dir,180)
 	else if(icon_state == "pipe-j2")
@@ -1016,8 +1015,8 @@
 
 	dpdir = sortdir | posdir | negdir
 
-/obj/structure/disposalpipe/sortjunction/New()
-	..()
+/obj/structure/disposalpipe/sortjunction/Initialize(mapload)
+	. = ..()
 	updatedir()
 	updatedesc()
 	update()
@@ -1083,8 +1082,8 @@
 	var/negdir = 0
 	var/sortdir = 0
 
-/obj/structure/disposalpipe/wrapsortjunction/New()
-	..()
+/obj/structure/disposalpipe/wrapsortjunction/Initialize(mapload)
+	. = ..()
 	posdir = dir
 	if(icon_state == "pipe-j1s")
 		sortdir = turn(posdir, -90)
@@ -1138,11 +1137,10 @@
 	icon_state = "pipe-t"
 	var/obj/linked 	// the linked obj/machinery/disposal or obj/disposaloutlet
 
-/obj/structure/disposalpipe/trunk/New()
-	..()
+/obj/structure/disposalpipe/trunk/Initialize(mapload)
+	. = ..()
 	dpdir = dir
-	spawn(1)
-		getlinked()
+	addtimer(CALLBACK(src, .proc/getlinked), 0) // This has a delay of 0, but wont actually start until the MC is done
 
 	update()
 	return
@@ -1244,8 +1242,8 @@
 					// i.e. will be treated as an empty turf
 	desc = "A broken piece of disposal pipe."
 
-/obj/structure/disposalpipe/broken/New()
-	..()
+/obj/structure/disposalpipe/broken/Initialize(mapload)
+	. = ..()
 	update()
 	return
 
@@ -1270,13 +1268,16 @@
 	var/obj/structure/disposalpipe/trunk/linkedtrunk
 	var/mode = 0
 
-/obj/structure/disposaloutlet/New()
-	..()
-	spawn(1)
-		target = get_ranged_target_turf(src, dir, 10)
-		var/obj/structure/disposalpipe/trunk/T = locate() in loc
-		if(T)
-			T.nicely_link_to_other_stuff(src)
+/obj/structure/disposaloutlet/Initialize(mapload)
+	. = ..()
+	addtimer(CALLBACK(src, .proc/setup), 0) // Wait of 0, but this wont actually do anything until the MC is firing
+
+
+/obj/structure/disposaloutlet/proc/setup()
+	target = get_ranged_target_turf(src, dir, 10)
+	var/obj/structure/disposalpipe/trunk/T = locate() in get_turf(src)
+	if(T)
+		T.nicely_link_to_other_stuff(src)
 
 /obj/structure/disposaloutlet/Destroy()
 	if(linkedtrunk)

--- a/code/modules/spacepods/construction.dm
+++ b/code/modules/spacepods/construction.dm
@@ -10,8 +10,8 @@
 
 	var/datum/construction/construct
 
-/obj/structure/spacepod_frame/New()
-	..()
+/obj/structure/spacepod_frame/Initialize(mapload)
+	. = ..()
 	bound_width = 64
 	bound_height = 64
 


### PR DESCRIPTION
## What Does This PR Do
Converts more structures to `Initialize()`. A few of them still remain on `/New()` since they require fleshing out and testing in their own PR due to their specifics (IE: Blob stuff).

A lot of the changes here are simple ones which only did stuff like setting icon states, or adding to global lists. Some tweaks have been commented on below in the review.

Remaining conversions for `/obj/structure` are below
![image](https://user-images.githubusercontent.com/25063394/102717768-5ae30d80-42dc-11eb-81b9-1f201b8ebdd9.png)

## Why It's Good For The Game
`New()` bad

## Changelog
:cl: AffectedArc07
add: [Backend] Most /obj/structure types now spawn with the SSatoms instead of /New()
/:cl:
