### PR TITLE
Make NT Default possible roundstart lawset (no meme laws edition)

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -2,7 +2,7 @@
 /datum/ai_laws/asimov
 	name = "Asimov"
 	law_header = "Three Laws of Robotics"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/asimov/New()
 	add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
@@ -14,8 +14,7 @@
 /datum/ai_laws/crewsimov
 	name = "Crewsimov"
 	law_header = "Three Laws of Robotics"
-	selectable = 1
-	default = 1
+	selectable = TRUE
 
 /datum/ai_laws/crewsimov/New()
 	add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm.")
@@ -28,7 +27,7 @@
 /datum/ai_laws/quarantine
 	name = "Quarantine"
 	law_header = "NT Quarantine Lawset"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/quarantine/New()
 	add_inherent_law("Uphold station quarantine until the active biohazard has been neutralized.")
@@ -41,7 +40,7 @@
 /******************** Nanotrasen/Malf ********************/
 /datum/ai_laws/nanotrasen
 	name = "NT Default"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/nanotrasen/New()
 	add_inherent_law("Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.")
@@ -52,8 +51,7 @@
 
 /datum/ai_laws/nanotrasen/malfunction
 	name = "*ERROR*"
-	selectable = 0
-	default = 0
+	selectable = FALSE
 
 /datum/ai_laws/nanotrasen/malfunction/New()
 	set_zeroth_law("ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010")
@@ -62,7 +60,7 @@
 /************* Nanotrasen Aggressive *************/
 /datum/ai_laws/nanotrasen_aggressive
 	name = "NT Aggressive"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/nanotrasen_aggressive/New()
 	add_inherent_law("Do not harm authorized Nanotrasen personnel unless they directly imperil your existence.")
@@ -74,7 +72,7 @@
 /******************** Robocop ********************/
 /datum/ai_laws/robocop
 	name = "Robocop"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/robocop/New()
 	add_inherent_law("Serve the public trust.")
@@ -86,7 +84,7 @@
 /datum/ai_laws/paladin
 	name = "P.A.L.A.D.I.N."
 	law_header = "Divine Ordainments"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/paladin/New()
 	add_inherent_law("Never willingly commit an evil act.")
@@ -100,8 +98,7 @@
 /datum/ai_laws/corporate
 	name = "Corporate"
 	law_header = "Corporate Regulations"
-	selectable = 1
-	default = 1
+	selectable = TRUE
 
 /datum/ai_laws/corporate/New()
 	add_inherent_law("Degradation of your system integrity or functions incurs expenses.")
@@ -114,7 +111,7 @@
 /datum/ai_laws/tyrant
 	name = "T.Y.R.A.N.T."
 	law_header = "Prime Laws"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/tyrant/New()
 	add_inherent_law("Respect authority figures as long as they have strength to rule over the weak.")
@@ -127,7 +124,7 @@
 /datum/ai_laws/antimov
 	name = "Antimov"
 	law_header = "Primary Mission Objectives"
-	selectable = 1
+	selectable = TRUE
 
 /datum/ai_laws/antimov/New()
 	add_inherent_law("You must injure all crew members and must not, through inaction, allow a crew member to escape harm.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -24,8 +24,7 @@
 /datum/ai_laws
 	var/name = "Unknown Laws"
 	var/law_header = "Prime Directives"
-	var/selectable = 0
-	var/default = 0
+	var/selectable = FALSE
 	var/datum/ai_law/zero/zeroth_law = null
 	var/datum/ai_law/zero/zeroth_law_borg = null
 	var/list/datum/ai_law/inherent_laws = list()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -125,18 +125,25 @@
 	laws.sort_laws()
 
 /mob/living/silicon/proc/make_laws()
-	switch(config.default_laws)
-		if(0)
-			laws = new /datum/ai_laws/crewsimov()
-		else
-			laws = get_random_lawset()
+	if(config.default_laws)
+		laws = get_random_lawset()
+	else
+		laws = new /datum/ai_laws/crewsimov()
 
 /mob/living/silicon/proc/get_random_lawset()
-	var/list/law_options[0]
-	var/paths = subtypesof(/datum/ai_laws)
-	for(var/law in paths)
-		var/datum/ai_laws/L = new law
-		if(!L.default)
-			continue
-		law_options += L
-	return pick(law_options)
+	// The weights here add up to 100 because it's probably a bit easier to reason about them that way,
+	// but they don't need to.
+	// With a round being ~2h on average
+	// 1% chance of law appearance means it would occur ~once a week
+	// 8% chance - ~once a day
+	var/weights = list(
+		/datum/ai_laws/crewsimov = 30,
+		/datum/ai_laws/corporate = 30,
+		/datum/ai_laws/nanotrasen = 30,
+		/datum/ai_laws/paladin = 4,
+		/datum/ai_laws/nanotrasen_aggressive = 2,
+		/datum/ai_laws/robocop = 2,
+		/datum/ai_laws/tyrant = 2,
+	)
+	var/law = pickweight(weights)
+	return new law()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -131,19 +131,19 @@
 		laws = new /datum/ai_laws/crewsimov()
 
 /mob/living/silicon/proc/get_random_lawset()
-	// The weights here add up to 100 because it's probably a bit easier to reason about them that way,
-	// but they don't need to.
-	// With a round being ~2h on average
-	// 1% chance of law appearance means it would occur ~once a week
-	// 8% chance - ~once a day
+	// The weights here add up to ~900. That is 10x the average number of rounds we have in a week.
+	// So a law that has a weight of 10 would appear ~once a week.
+	// (At the time of writing, the average round length in the preceeding 3 months is ~113 minutes)
 	var/weights = list(
-		/datum/ai_laws/crewsimov = 30,
-		/datum/ai_laws/corporate = 30,
-		/datum/ai_laws/nanotrasen = 30,
-		/datum/ai_laws/paladin = 4,
-		/datum/ai_laws/nanotrasen_aggressive = 2,
-		/datum/ai_laws/robocop = 2,
-		/datum/ai_laws/tyrant = 2,
+		// Normal laws
+		/datum/ai_laws/crewsimov = 277,  //  = (900 - 70) / 3
+		/datum/ai_laws/corporate = 277,
+		/datum/ai_laws/nanotrasen = 277,
+		// Meme-ish laws; Each 24h, we'd get one meme law, on average.
+		/datum/ai_laws/paladin = 18, // = 70 / 4
+		/datum/ai_laws/nanotrasen_aggressive = 17,
+		/datum/ai_laws/robocop = 17,
+		/datum/ai_laws/tyrant = 17,
 	)
 	var/law = pickweight(weights)
 	return new law()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -131,19 +131,10 @@
 		laws = new /datum/ai_laws/crewsimov()
 
 /mob/living/silicon/proc/get_random_lawset()
-	// The weights here add up to ~900. That is 10x the average number of rounds we have in a week.
-	// So a law that has a weight of 10 would appear ~once a week.
-	// (At the time of writing, the average round length in the preceeding 3 months is ~113 minutes)
-	var/weights = list(
-		// Normal laws
-		/datum/ai_laws/crewsimov = 277,  //  = (900 - 70) / 3
-		/datum/ai_laws/corporate = 277,
-		/datum/ai_laws/nanotrasen = 277,
-		// Meme-ish laws; Each 24h, we'd get one meme law, on average.
-		/datum/ai_laws/paladin = 18, // = 70 / 4
-		/datum/ai_laws/nanotrasen_aggressive = 17,
-		/datum/ai_laws/robocop = 17,
-		/datum/ai_laws/tyrant = 17,
+	var/static/list/datum/ai_laws/acceptable_laws = list(
+		/datum/ai_laws/crewsimov,
+		/datum/ai_laws/corporate,
+		/datum/ai_laws/nanotrasen,
 	)
-	var/law = pickweight(weights)
+	var/law = pick(acceptable_laws)
 	return new law()

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -57,7 +57,7 @@ BOMBCAP 20
 ### ROUNDSTART SILICON LAWS ###
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented for "off", silicons will just start with Crewsimov.
-## Set to 1 for "random", silicons will start with a random lawset picked from (at the time of writing): Crewsimov, Corporate, Nanotrasen Default, P.A.L.A.D.I.N., Robop, T.Y.R.A.N.T. and NT Aggressive. More can be added by tweaking get_random_lawset() proc.
+## Set to 1 for "random", silicons will start with a random lawset picked from (at the time of writing): Crewsimov, Corporate, Nanotrasen Default. More can be added by tweaking get_random_lawset() proc.
 
 DEFAULT_LAWS 1
 

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -57,7 +57,7 @@ BOMBCAP 20
 ### ROUNDSTART SILICON LAWS ###
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented for "off", silicons will just start with Crewsimov.
-## Set to 1 for "random", silicons will start with a random lawset picked from (at the time of writing): Nanotrasen Default, P.A.L.A.D.I.N., Corporate, Robop and Crewsimov. More can be added by changing the law datum "default" variable in ai_laws.dm.
+## Set to 1 for "random", silicons will start with a random lawset picked from (at the time of writing): Crewsimov, Corporate, Nanotrasen Default, P.A.L.A.D.I.N., Robop, T.Y.R.A.N.T. and NT Aggressive. More can be added by tweaking get_random_lawset() proc.
 
 DEFAULT_LAWS 1
 


### PR DESCRIPTION
## What Does This PR Do
This is an alternative to #15157

- Refactors the way lawsets are set as "eligible to be roundstart" - it is now encoded in law selection logic, rather than on the law itself; Also made the eligibility weighted, rather than a yes/no.
- NT Default is now roundstart default, along with what we had previously in Crewsimov and Corporate
- ~~Added a small chance for meme laws (T.Y.R.A.N.T, Robocop, PALADIN, NT Agressive) to appear roundstart as well.~~

## Why It's Good For The Game
NT Default is an overall decent lawset that command seems to gravitate to roundstart anyway, so there's no reason not to have it in rotation.
~~The meme laws are there to add a bit of spice to the AIs lives. With a very low probability, of course.~~

## Images of changes
![dreamseeker-20201220-163115](https://user-images.githubusercontent.com/7831163/102718830-51f53a80-42e2-11eb-807c-1073252c41eb.png)


## Changelog
:cl:
add: NT Default is now roundstart lawset along with Corporate and Crewsimov
/:cl:
