### PR TITLE
Pinpointer runtime fixes

### DIFF
--- a/code/datums/cache/crew.dm
+++ b/code/datums/cache/crew.dm
@@ -34,7 +34,7 @@ GLOBAL_DATUM_INIT(crew_repository, /datum/repository/crew, new())
 		if(!C || C.sensor_mode == SUIT_SENSOR_OFF || !C.has_sensor)
 			continue
 		var/turf/pos = get_turf(C)
-		if(!T || pos.z != T.z)
+		if(!istype(pos) || !T || pos.z != T.z)
 			continue
 		var/list/crewmemberData = list("dead"=0, "oxy"=-1, "tox"=-1, "fire"=-1, "brute"=-1, "area"="", "x"=-1, "y"=-1, "ref" = "\ref[H]")
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -349,17 +349,14 @@
 	var/target_set = FALSE //have we set a target at any point?
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
-	var/turf/here = get_turf(src)
-	if(istype(H.w_uniform, /obj/item/clothing/under))
+	if(H && istype(H.w_uniform, /obj/item/clothing/under))
+		var/turf/here = get_turf(src)
 		var/obj/item/clothing/under/U = H.w_uniform
-
 		// Suit sensors must be on maximum.
 		if(!U.has_sensor || U.sensor_mode < 3)
 			return FALSE
-
 		var/turf/there = get_turf(U)
-		return there && there.z == here.z
-
+		return istype(there) && there.z == here.z
 	return FALSE
 
 /obj/item/pinpointer/crew/process()

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -364,7 +364,7 @@
 		point_at(target)
 
 /obj/item/pinpointer/crew/point_at(atom/target)
-	if(!trackable(target) || !target)
+	if(!target || !trackable(target))
 		icon_state = icon_null
 		return
 
@@ -410,7 +410,7 @@
 /obj/item/pinpointer/crew/centcom/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
 	var/turf/there = get_turf(H)
-	return there && there.z == here.z
+	return istype(there) && istype(here) && there.z == here.z
 
 #undef MODE_OFF
 #undef MODE_DISK


### PR DESCRIPTION
## What Does This PR Do
Fixes a couple of runtime errors in pinpointer.dm:
![pinpointer-runtimes](https://user-images.githubusercontent.com/16434066/102723777-84169480-4302-11eb-926e-a73c90fbe71d.png)
Runtime causes:
- checking H.w_uniform without checking first that H even exists
- checking there.z without even checking that there is a valid turf
- checking trackable(target) without first checking that there even is a target

Fixes this runtime:
[2020-12-20T19:21:02] Runtime in crew.dm,37: Cannot read null.z
   proc name: health data (/datum/repository/crew/proc/health_data)

## Changelog
:cl: Kyep
fix: fixed some runtime errors that can happen in pinpointer.dm and crew.dm
/:cl: