### PR TITLE
Fixes oauth tokens / forum account linking

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -633,8 +633,9 @@
 		qdel(query_find_token)
 		return
 	if(query_find_token.NextRow())
+		var/tkn = query_find_token.item[1]
 		qdel(query_find_token)
-		return query_find_token.item[1]
+		return tkn
 	qdel(query_find_token)
 
 	var/tokenstr = md5("[rand(0,9999)][world.time][rand(0,9999)][ckey][rand(0,9999)][address][rand(0,9999)][computer_id][rand(0,9999)]")


### PR DESCRIPTION
## What Does This PR Do
Fixes a bug introduced in https://github.com/ParadiseSS13/Paradise/pull/15007 which caused forum oauth tokens to be unable to be created, and thus caused players to be unable to link their ingame/forum accounts.
Specifically qdel(query_find_token) was being called before query_find_token.item[1] is read, which meant that the value we want was being deleted right before we tried to read it, which resulted in runtime errors and oauth tokens not working.

## Changelog
:cl: Kyep
fix: fixed forum oauth tokens (ie: ingame/forum account linking) not working correctly.
/:cl: