### PR TITLE
PDA messsages are logged using the new logging system

### DIFF
--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -459,6 +459,15 @@
 
 							recipient_messenger.notify("<b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='?src=[recipient_messenger.UID()];choice=Message;target=\ref[PDARec]'>Reply</a>)")
 							log_pda("(PDA: [PDARec.owner]) sent \"[custommessage]\" to [customrecepient.owner]", usr)
+						var/log_message = "sent PDA message \"[custommessage]\" using [src] as [customsender] ([customjob])"
+						var/receiver
+						if(ishuman(customrecepient.loc))
+							receiver = customrecepient.loc
+							log_message = "[log_message] to [customrecepient]"
+						else
+							receiver = customrecepient
+							log_message = "[log_message] (no holder)"
+						usr.create_log(MISC_LOG, log_message, receiver)
 						//Finally..
 						ResetMessage()
 

--- a/code/modules/pda/messenger.dm
+++ b/code/modules/pda/messenger.dm
@@ -188,7 +188,16 @@
 
 		SStgui.update_uis(src)
 		PM.notify("<b>Message from [pda.owner] ([pda.ownjob]), </b>\"[t]\" (<a href='?src=[PM.UID()];choice=Message;target=[pda.UID()]'>Reply</a>)")
-		log_pda("(PDA: [src.name]) sent \"[t]\" to [P.name]", usr)
+		log_pda("(PDA: [src.name]) sent \"[t]\" to [P.name]", U)
+		var/log_message = "sent PDA message \"[t]\" using [pda]"
+		var/receiver
+		if(ishuman(P.loc))
+			receiver = P.loc
+			log_message = "[log_message] to [P]"
+		else
+			receiver = P
+			log_message = "[log_message] (no holder)"
+		U.create_log(MISC_LOG, log_message, receiver)
 	else
 		to_chat(U, "<span class='notice'>ERROR: Messaging server is not responding.</span>")
 


### PR DESCRIPTION
## What Does This PR Do
Adds PDA messages to the logging viewer system.

One quirk. The target will not be properly set to the holder if the PDA is not in the PDA slot or a pocket. Though in 99% of the cases this will not be an issue

## Why It's Good For The Game
Easier for admins to see who messaged what to who

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/102767660-3a6c8f00-4380-11eb-897c-43d4bdc65d71.png)


## Changelog
:cl:
add: PDA messages are now logged in the new logging system
/:cl: