### PR TITLE
Fixes runtime in organs_internal.dm when removing an egg via surgery

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -291,11 +291,11 @@
 			add_attack_logs(user, target, "Surgically removed [I.name]. INTENT: [uppertext(user.a_intent)]")
 			spread_germs_to_organ(I, user, tool)
 			var/obj/item/thing = I.remove(target)
-			if(!istype(thing))
-				thing.forceMove(get_turf(target))
-			else
-				user.put_in_hands(thing)
-
+			if(thing) // some "organs", like egg infections, can have I.remove(target) return null, and so we can't use "thing" in that case
+				if(istype(thing))
+					user.put_in_hands(thing)
+				else
+					thing.forceMove(get_turf(target))
 			target.update_icons()
 		else
 			user.visible_message("<span class='notice'>[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!</span>",


### PR DESCRIPTION
## What Does This PR Do
Fixes this runtime: 
[2020-12-22T16:57:42] Runtime in organs_internal.dm,295: Cannot execute null.forceMove().
   proc name: end step (/datum/surgery_step/internal/manipulate_organs/end_step)
   usr: Kikeri (gangelwaefre) (/mob/living/carbon/human)
   usr.loc: The floor (146,107,1) (/turf/simulated/floor/plasteel)
   src: manipulate organs (/datum/surgery_step/internal/manipulate_organs)
   call stack:
   manipulate organs (/datum/surgery_step/internal/manipulate_organs): end step(Kikeri (/mob/living/carbon/human), Michael Bovine (/mob/living/carbon/human), "chest", the hemostat 
   
This is caused by manipulate_organs/end_step attempting to forcemove whatever is removed from something during organ removal surgery, but in the case of some organs (spider/terror eggs, possibly others) remove() doesn't return an organ... so of course it runtimes. This fixes that.

## Changelog
:cl: Kyep
fix: fixed a runtime error when removing eggs (spider, terror, possibly others) from a human via organ manipulation surgery
/:cl: