### PR TITLE
Fixes SQL Error 1048 when connecting via VSCode

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -531,9 +531,12 @@
 			return
 
 	if(sql_id)
+		var/client_address = address
+		if(!client_address) // Localhost can sometimes have no address set
+			client_address = "127.0.0.1"
 		//Player already identified previously, we need to just update the 'lastseen', 'ip' and 'computer_id' variables
 		var/datum/db_query/query_update = SSdbcore.NewQuery("UPDATE [format_table_name("player")] SET lastseen = Now(), ip=:sql_ip, computerid=:sql_cid, lastadminrank=:sql_ar WHERE id=:sql_id", list(
-			"sql_ip" = address,
+			"sql_ip" = client_address,
 			"sql_cid" = computer_id,
 			"sql_ar" = admin_rank,
 			"sql_id" = sql_id


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes this:
`MySqlError { ERROR 1048 (23000): Column 'ip' cannot be null }`
By temporarily sending the DB `127.0.0.1` as the clients IP address if it doesn't have one set.

As far as I can tell this will only happen when connecting to the server via VSCode, and probably other programs via the local computer.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
While it doesn't seem to have any in-game effects other than an admin message, having an error log be generated every time you log in clearly isn't a good thing.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
This is the error:
![image](https://user-images.githubusercontent.com/57483089/102959582-d52bb180-44d7-11eb-8192-f9975e9dda99.png)


## Changelog
:cl:
fix: Fixed SQL Error 1048 when connecting as localhost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
