### PR TITLE
Ghosts now know what guardian type the user wants to spawn. User can cancel when selecting the guardian type

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -239,6 +239,8 @@
 	var/ling_failure = "The deck refuses to respond to a souless creature such as you."
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive", "Assassin", "Lightning", "Charger", "Protector")
 	var/random = FALSE
+	/// What type was picked the first activation
+	var/picked_random_type
 	var/color_list = list("Pink" = "#FFC0CB",
 		"Red" = "#FF0000",
 		"Orange" = "#FFA500",
@@ -264,12 +266,25 @@
 		used = FALSE
 		return
 	to_chat(user, "[use_message]")
-	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the [mob_name] of [user.real_name]?", ROLE_GUARDIAN, FALSE, 10 SECONDS, source = src)
+
+	var/guardian_type
+	if(random)
+		if(!picked_random_type) // Only pick the type once. No type fishing
+			picked_random_type = pick(possible_guardians)
+		guardian_type = picked_random_type
+	else
+		guardian_type = input(user, "Pick the type of [mob_name]", "[mob_name] Creation") as null|anything in possible_guardians
+		if(!guardian_type)
+			to_chat(user, "<span class='warning'>You decide against using the [name].</span>")
+			used = FALSE
+			return
+
+	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Do you want to play as the [mob_name] ([guardian_type]) of [user.real_name]?", ROLE_GUARDIAN, FALSE, 10 SECONDS, source = src, role_cleanname = "[mob_name] ([guardian_type])")
 	var/mob/dead/observer/theghost = null
 
 	if(candidates.len)
 		theghost = pick(candidates)
-		spawn_guardian(user, theghost.key)
+		spawn_guardian(user, theghost.key, guardian_type)
 	else
 		to_chat(user, "[failure_message]")
 		used = FALSE
@@ -279,12 +294,7 @@
 	if(used)
 		. += "<span class='notice'>[used_message]</span>"
 
-/obj/item/guardiancreator/proc/spawn_guardian(mob/living/user, key)
-	var/guardian_type = "Standard"
-	if(random)
-		guardian_type = pick(possible_guardians)
-	else
-		guardian_type = input(user, "Pick the type of [mob_name]", "[mob_name] Creation") as null|anything in possible_guardians
+/obj/item/guardiancreator/proc/spawn_guardian(mob/living/user, key, guardian_type)
 	var/pickedtype = /mob/living/simple_animal/hostile/guardian/punch
 	switch(guardian_type)
 


### PR DESCRIPTION
## What Does This PR Do
1. Makes it so that ghosts are notified about the choice of guardian the owner wants to spawn.
2. Also adds a cancel option when picking guardian types. Currently it picks the default type now if you press cancel when selecting guardians.

## Why It's Good For The Game
1. Ghosts can make a better choice this way.
2. Some usability for the owner

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/103036648-8844eb00-456a-11eb-879b-a840b5a8f4bf.png)


## Changelog
:cl:
tweak: Ghosts now know what guardian type the user wants to spawn
tweak: User can cancel when selecting the guardian type
/:cl: