### PR TITLE
Adds the door runtime event as an event, and to event rotation.

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -368,18 +368,8 @@
 	uses = 1
 
 /datum/action/innate/ai/lockdown/Activate()
-	for(var/obj/machinery/door/D in GLOB.airlocks)
-		if(!is_station_level(D.z))
-			continue
-		INVOKE_ASYNC(D, /obj/machinery/door.proc/hostile_lockdown, owner)
-		addtimer(CALLBACK(D, /obj/machinery/door.proc/disable_lockdown), 900)
-
-	post_status("alert", "lockdown")
-
-	GLOB.minor_announcement.Announce("Hostile runtime detected in door controllers. Isolation lockdown protocols are now in effect. Please remain calm.", "Network Alert")
 	to_chat(owner, "<span class='warning'>Lockdown Initiated. Network reset in 90 seconds.</span>")
-	spawn(900)
-		GLOB.minor_announcement.Announce("Automatic system reboot complete. Have a secure day.","Network reset:")
+	new /datum/event/door_runtime()
 
 //Destroy RCDs: Detonates all non-cyborg RCDs on the station.
 /datum/AI_Module/large/destroy_rcd

--- a/code/modules/events/door_runtime.dm
+++ b/code/modules/events/door_runtime.dm
@@ -1,0 +1,15 @@
+/datum/event/door_runtime
+
+/datum/event/door_runtime/announce()
+	GLOB.minor_announcement.Announce("Hostile runtime detected in door controllers. Isolation lockdown protocols are now in effect. Please remain calm.", "Network Alert")
+
+/datum/event/door_runtime/start()
+	for(var/obj/machinery/door/D in GLOB.airlocks)
+		if(!is_station_level(D.z))
+			continue
+		INVOKE_ASYNC(D, /obj/machinery/door.proc/hostile_lockdown)
+		addtimer(CALLBACK(D, /obj/machinery/door.proc/disable_lockdown), 900)
+
+	post_status("alert", "lockdown")
+	spawn(900)
+		GLOB.minor_announcement.Announce("Automatic system reboot complete. Have a secure day.","Network reset:")

--- a/code/modules/events/door_runtime.dm
+++ b/code/modules/events/door_runtime.dm
@@ -8,8 +8,9 @@
 		if(!is_station_level(D.z))
 			continue
 		INVOKE_ASYNC(D, /obj/machinery/door.proc/hostile_lockdown)
-		addtimer(CALLBACK(D, /obj/machinery/door.proc/disable_lockdown), 900)
+		addtimer(CALLBACK(D, /obj/machinery/door.proc/disable_lockdown), 90 SECONDS)
+	addtimer(CALLBACK(src, .proc/reboot), 90 SECONDS)
 
 	post_status("alert", "lockdown")
-	spawn(900)
-		GLOB.minor_announcement.Announce("Automatic system reboot complete. Have a secure day.","Network reset:")
+/datum/event/door_runtime/proc/reboot()
+	GLOB.minor_announcement.Announce("Automatic system reboot complete. Have a secure day.","Network reset:")

--- a/code/modules/events/door_runtime.dm
+++ b/code/modules/events/door_runtime.dm
@@ -10,7 +10,7 @@
 		INVOKE_ASYNC(D, /obj/machinery/door.proc/hostile_lockdown)
 		addtimer(CALLBACK(D, /obj/machinery/door.proc/disable_lockdown), 90 SECONDS)
 	addtimer(CALLBACK(src, .proc/reboot), 90 SECONDS)
-
 	post_status("alert", "lockdown")
+
 /datum/event/door_runtime/proc/reboot()
 	GLOB.minor_announcement.Announce("Automatic system reboot complete. Have a secure day.","Network reset:")

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -183,7 +183,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Swarmer Spawn", 			/datum/event/spawn_swarmer, 			150, is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn", 				/datum/event/spawn_morph, 				40,		list(ASSIGNMENT_SECURITY = 10), is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Disease Outbreak",			/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Headcrabs",				/datum/event/headcrabs, 				0,		list(ASSIGNMENT_SECURITY = 20))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Headcrabs",				/datum/event/headcrabs, 				0,		list(ASSIGNMENT_SECURITY = 20)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Door Runtime",				/datum/event/door_runtime,				50,		list(ASSIGNMENT_ENGINEER = 25, ASSIGNMENT_AI = 150), TRUE)
 	)
 
 /datum/event_container/major

--- a/paradise.dme
+++ b/paradise.dme
@@ -1478,6 +1478,7 @@
 #include "code\modules\events\carp_migration.dm"
 #include "code\modules\events\communications_blackout.dm"
 #include "code\modules\events\disease_outbreak.dm"
+#include "code\modules\events\door_runtime.dm"
 #include "code\modules\events\dust.dm"
 #include "code\modules\events\electrical_storm.dm"
 #include "code\modules\events\event.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Changes the every door bolt and shut malf AI ability into an event, and adds it to rotation. Can only happen once per round (unless AI forces it for 30 CPU)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More events are always nice, and an event that adds suspicion to the crew, that the AI could be malfunctioning, or that it could be a random event, is interesting, similar to communications blackout, or ion laws. Also gives traitors and other antagonists a quick moment to kill people, while security and most other people are trapped in rooms, and help will be unable to arrive for 90 seconds.

## Changelog
:cl:
tweak: Converts Malfunctioning AI door runtime ability into an event that ai can force.
add: Malfunctioning AI door runtime is now a medium event, and now in event rotation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
