### PR TITLE
Removes the Lesser Drake form from dragons blood

### DIFF
--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -119,22 +119,17 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/random = rand(1,3)
+	var/random = rand(1, 2)
 
 	switch(random)
 		if(1)
 			to_chat(user, "<span class='danger'>Your flesh begins to melt! Miraculously, you seem fine otherwise.</span>")
 			H.set_species(/datum/species/skeleton)
 		if(2)
-			to_chat(user, "<span class='danger'>Power courses through you! You can now shift your form at will.")
-			if(user.mind)
-				var/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/D = new
-				user.mind.AddSpell(D)
-		if(3)
 			to_chat(user, "<span class='danger'>You feel like you could walk straight through lava now.</span>")
 			H.weather_immunities |= "lava"
 
-	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
+	playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)
 	qdel(src)
 
 /datum/disease/transformation/dragon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes the chance for miners to get the ability to transform into a lesser ash drake by drinking dragons blood.

## Why It's Good For The Game
Lesser Ash drake form is extremely powerful, outside of shotguns, you cannot combat it as sec. it has a powerful ranged attack dealing a large amount of burn damage, igniting and it can hit multiple targets. It has a lot of melee damage that is armour piercing. It is slow, however it has a swoop attack which deals a MASSIVE amount of brute damage and making lava tiles underneath it, dealing even more damage and closing the distance for melee attacks. Then, if the target of a swoop or melee attack, is dead/asleep it will gib them, and if a swoop gibbed them the lava will likely burn their brain, removing them from the round permanently. Also, it makes miners practically unstunnable because as soon as they go down and sec comes over to cuff them, they will morph into a giant dragon and eat them. Finally, lesser drakes can cause a lot of confusion on station, "ASH DRAKE ON STATION", "SOMEONE GET CLOSE TO IT TO FIND OUT IF IT IS A MINER"


## Changelog
:cl:
del: Removed lesser ash drake form from mining loot
tweak: also cleaned up the code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
