### PR TITLE
Changes some world init order stuff around

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -13,6 +13,9 @@ GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 	// Setup all log paths and stamp them with startups, including round IDs
 	SetupLogs()
 
+	// This needs to happen early, otherwise people can get a null species, nuking their character
+	makeDatumRefLists()
+
 	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED) // creates a new TGS object
 	log_world("World loaded at [time_stamp()]")
 	log_world("[GLOB.vars.len - GLOB.gvars_datum_in_built_vars.len] global variables")
@@ -58,7 +61,6 @@ GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 	load_motd() // Loads up the MOTD (Welcome message players see when joining the server)
 	load_mode() // Loads up the gamemode
 	investigate_reset() // This is part of the admin investigate system. PLEASE DONT SS THIS EITHER
-	makeDatumRefLists() // Setups up lists of datums and their subtypes
 
 /// List of all world topic spam prevention handlers. See code/modules/world_topic/_spam_prevention_handler.dm
 GLOBAL_LIST_EMPTY(world_topic_spam_prevention_handlers)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,6 +1,10 @@
 GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 
 /world/New()
+	// IMPORTANT
+	// If you do any SQL operations inside this proc, they must ***NOT*** be ran async. Otherwise players can join mid query
+	// This is BAD.
+
 	//temporary file used to record errors with loading config and the database, moved to log directory once logging is set up
 	GLOB.config_error_log = GLOB.world_game_log = GLOB.world_runtime_log = GLOB.sql_log = "data/logs/config_error.log"
 	load_configuration()
@@ -20,7 +24,7 @@ GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 	log_world("World loaded at [time_stamp()]")
 	log_world("[GLOB.vars.len - GLOB.gvars_datum_in_built_vars.len] global variables")
 	GLOB.revision_info.log_info()
-	load_admins() // Same here
+	load_admins(run_async=FALSE) // This better happen early on.
 
 	#ifdef UNIT_TESTS
 	log_world("Unit Tests Are Enabled!")

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -56,7 +56,7 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 	testing(msg)
 	#endif
 
-/proc/load_admins()
+/proc/load_admins(run_async = FALSE)
 	if(IsAdminAdvancedProcCall())
 		to_chat(usr, "<span class='boldannounce'>Admin reload blocked: Advanced ProcCall detected.</span>")
 		message_admins("[key_name(usr)] attempted to reload admins via advanced proc-call")
@@ -118,7 +118,7 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 			return
 
 		var/datum/db_query/query = SSdbcore.NewQuery("SELECT ckey, rank, level, flags FROM [format_table_name("admin")]")
-		if(!query.warn_execute())
+		if(!query.warn_execute(async=run_async))
 			qdel(query)
 			return
 

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -68,7 +68,7 @@ GLOBAL_DATUM_INIT(jobban_regex, /regex, regex("(\[\\S]+) - (\[^#]+\[^# ])(?: ## 
 		//Job permabans
 		var/datum/db_query/permabans = SSdbcore.NewQuery("SELECT ckey, job FROM [format_table_name("ban")] WHERE bantype = 'JOB_PERMABAN' AND isnull(unbanned)")
 
-		if(!permabans.warn_execute())
+		if(!permabans.warn_execute(async=FALSE))
 			qdel(permabans)
 			return FALSE
 
@@ -83,7 +83,7 @@ GLOBAL_DATUM_INIT(jobban_regex, /regex, regex("(\[\\S]+) - (\[^#]+\[^# ])(?: ## 
 		// Job tempbans
 		var/datum/db_query/tempbans = SSdbcore.NewQuery("SELECT ckey, job FROM [format_table_name("ban")] WHERE bantype = 'JOB_TEMPBAN' AND isnull(unbanned) AND expiration_time > Now()")
 
-		if(!tempbans.warn_execute())
+		if(!tempbans.warn_execute(async=FALSE))
 			qdel(tempbans)
 			return FALSE
 

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -116,7 +116,7 @@
 	message_admins("[key_name_admin(usr)] has manually reloaded admins")
 	log_admin("[key_name(usr)] has manually reloaded admins")
 
-	load_admins()
+	load_admins(run_async=TRUE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Reload Admins") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 


### PR DESCRIPTION
## What Does This PR Do
Currently, people can join the world in the split second before early inits are done (Specifically SQL queries), and end up attempting to reference a species which doesnt exist because `GLOB.all_species` hasnt been loaded yet. This fixes that.

Note that this is not the confirmed reason people are losing characters, but it adds up with code flow and with runtimes
```
[2020-12-26T17:55:38] Runtime in preferences_setup.dm,10: Cannot read null.bodyflags
   proc name: random character (/datum/preferences/proc/random_character)
   src: /datum/preferences (/datum/preferences)
   call stack:
   /datum/preferences (/datum/preferences): random character(null)
   /datum/preferences (/datum/preferences): New([redacted] (/client))
   [redacted] (/client): New(null)
```
`null.bodyflags` is meant to be a reference to `species.bodyflags`, which is looked up in `GLOB.species`

## Why It's Good For The Game
People losing characters is bad

## Changelog
:cl: AffectedArc07
fix: Moved some world init stuff round.
/:cl: