### PR TITLE
Make "undeleted query" & byond acc creation logs for admins respect "see debug logs" setting

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(dbcore)
 	for(var/I in active_queries)
 		var/datum/db_query/Q = I
 		if(world.time - Q.last_activity_time > 5 MINUTES)
-			message_admins("Found undeleted query, please check the server logs and notify coders.")
+			log_debug("Found undeleted query, please check the server logs and notify coders.")
 			log_sql("Undeleted query: \"[Q.sql]\" LA: [Q.last_activity] LAT: [Q.last_activity_time]")
 			qdel(Q)
 		if(MC_TICK_CHECK)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1026,13 +1026,13 @@
 				// Main return is here
 				return parsed_data
 			catch
-				message_admins("Error parsing byond.com data for [ckey]. Please inform maintainers.")
+				log_debug("Error parsing byond.com data for [ckey]. Please inform maintainers.")
 				return null
 		else
-			message_admins("Error retrieving data from byond.com for [ckey]. Invalid status code (Expected: 200 | Got: [status]).")
+			log_debug("Error retrieving data from byond.com for [ckey]. Invalid status code (Expected: 200 | Got: [status]).")
 			return null
 	else
-		message_admins("Failed to retrieve data from byond.com for [ckey]. Connection failed.")
+		log_debug("Failed to retrieve data from byond.com for [ckey]. Connection failed.")
 		return null
 
 
@@ -1067,7 +1067,7 @@
 	// They dont have a date, lets grab one
 	var/list/byond_data = retrieve_byondacc_data()
 	if(isnull(byond_data) || !(byond_data["general"]["joined"]))
-		message_admins("Failed to retrieve an account creation date for [ckey].")
+		log_debug("Failed to retrieve an account creation date for [ckey].")
 		return
 
 	byondacc_date = byond_data["general"]["joined"]


### PR DESCRIPTION
## What Does This PR Do
- Changes the handling of the "found undeleted query, please check the server logs and notify coders" error, and the various errors related to attempting to get a user's byond account creation date from byond.com.
- Instead of sending these errors to all online admins, now only sends them to people with R_DEBUG permissions and the "debug logs" setting enabled.

## Why It's Good For The Game
- These logs are intended to help developers debug code issues. They are debug logs. As such, they should not be sent to admins who have turned off their "see debug logs" setting.
- Bugging admins less about these logs should reduce the hassle that admins give maints/coders/heads about them. This is a good because some of our tech staff were getting annoyed about the number of people pinging them about logs. For example, one of our maints was annoyed at repeated pings about undeleted query logs, and I got a ping today about "unable to reach byond.com" logs despite the fact this is normal (byond.com sometimes has downtime, it is NOT worth pinging all online admins over).

## Changelog
:cl: Kyep
tweak: admins with "debug logs" disabled no longer see error messages about undeleted DB queries or being unable to download nice-to-have but non-essential info from byond.com.
/:cl: