### PR TITLE
Optimises SSchangelog

### DIFF
--- a/code/controllers/subsystem/changelog.dm
+++ b/code/controllers/subsystem/changelog.dm
@@ -163,6 +163,7 @@ SUBSYSTEM_DEF(changelog)
 
 // This proc is the star of the show
 /datum/controller/subsystem/changelog/proc/GenerateChangelogHTML()
+	. = FALSE
 	// Modify the code below to modify the header of the changelog
 	var/changelog_header = {"
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" rel="stylesheet">
@@ -188,51 +189,63 @@ SUBSYSTEM_DEF(changelog)
 	// Load in the header
 	changelogHTML += changelog_header
 
-	// Make blocks for all the PRs
+	// We put all these queries into a list so we can batch-execute them to avoid excess delays
+	// We index these based on PR numbers. MAKE SURE YOU USE STRING INDICIES IN THIS IF YOU EVER TWEAK IT -aa
+	var/list/datum/db_query/meta_queries = list()
+	var/list/datum/db_query/entry_queries = list()
+
+	// Create some queries for each PR
+	for(var/pr_number in prs_to_process)
+		var/datum/db_query/pr_meta = SSdbcore.NewQuery(
+			"SELECT author, DATE_FORMAT(date_merged, '%Y-%m-%d at %T') AS date FROM changelog WHERE pr_number = :prnum LIMIT 1",
+			list("prnum" = pr_number)
+		)
+
+		// MAKE SURE YOU CAST TO STRINGS HERE!
+		meta_queries["[pr_number]"] = pr_meta
+
+		var/datum/db_query/pr_cl_entries = SSdbcore.NewQuery(
+			"SELECT cl_type, cl_entry FROM changelog WHERE pr_number = :prnum",
+			list("prnum" = pr_number)
+		)
+
+		// And here
+		entry_queries["[pr_number]"] = pr_cl_entries
+
+	ASSERT(length(meta_queries) == length(entry_queries)) // If these dont add up, something went very wrong
+
+	// Explanation for parameters:
+	// TRUE: We want warnings if these fail
+	// FALSE: Do NOT qdel() queries here, otherwise they wont be read. At all.
+	// TRUE: This is an assoc list, so it needs to prepare for that
+	SSdbcore.MassExecute(meta_queries, TRUE, FALSE, TRUE)
+	SSdbcore.MassExecute(entry_queries, TRUE, FALSE, TRUE)
+
 	for(var/pr_number in prs_to_process)
 		// Initial declarations
 		var/pr_block = "" // HTML for the changelog section
 		var/author = "" // Author of the PR
 		var/merge_date = "" // Timestamp of when the PR was merged
 
-		// Now we gather the data from the DB
-		var/datum/db_query/pr_meta = SSdbcore.NewQuery(
-			"SELECT author, DATE_FORMAT(date_merged, '%Y-%m-%d at %T') AS date FROM changelog WHERE pr_number = :prnum LIMIT 1",
-			list("prnum" = pr_number)
-		)
-
-		if(!pr_meta.warn_execute())
-			qdel(pr_meta)
-			return FALSE
-
-		while(pr_meta.NextRow())
-			author = pr_meta.item[1]
-			merge_date = pr_meta.item[2]
-
-		qdel(pr_meta)
+		// Assemble metadata
+		while(meta_queries["[pr_number]"].NextRow())
+			author = meta_queries["[pr_number]"].item[1]
+			merge_date = meta_queries["[pr_number]"].item[2]
 
 		// Now for each actual entry
-		var/datum/db_query/pr_cl_entries = SSdbcore.NewQuery(
-			"SELECT cl_type, cl_entry FROM changelog WHERE pr_number = :prnum",
-			list("prnum" = pr_number)
-		)
-
-		if(!pr_cl_entries.warn_execute())
-			qdel(pr_cl_entries)
-			return FALSE
-
-		// Now we make a changelog block
 		pr_block += "<div class='statusDisplay'>"
-		// If the github URL in the config has a trailing slash, it doesnt matter here, thankfully github accepts having a double slash: https://github.com/org/repo//pull/1
 		pr_block += "<p class='white'><a href='?src=[UID()];openPR=[pr_number]'>#[pr_number]</a> by <b>[author]</b> (Merged on [merge_date])</span>"
 
-		while(pr_cl_entries.NextRow())
-			pr_block += "<p>[Text2Icon(pr_cl_entries.item[1])] [pr_cl_entries.item[2]]</p>"
+		while(entry_queries["[pr_number]"].NextRow())
+			pr_block += "<p>[Text2Icon(entry_queries["[pr_number]"].item[1])] [entry_queries["[pr_number]"].item[2]]</p>"
 
-		qdel(pr_cl_entries)
 		pr_block += "</div><br>"
 
 		changelogHTML += pr_block
+
+	// Cleanup queries
+	QDEL_LIST_ASSOC_VAL(meta_queries)
+	QDEL_LIST_ASSOC_VAL(entry_queries)
 
 	// Make sure we return TRUE so we know it worked
 	return TRUE
@@ -263,6 +276,7 @@ SUBSYSTEM_DEF(changelog)
 		if(config.githuburl)
 			if(alert("This will open PR #[href_list["openPR"]] in your browser. Are you sure?",,"Yes","No")=="No")
 				return
+			// If the github URL in the config has a trailing slash, it doesnt matter here, thankfully github accepts having a double slash: https://github.com/org/repo//pull/1
 			var/url = "[config.githuburl]/pull/[href_list["openPR"]]"
 			usr << link(url)
 		else

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -264,26 +264,39 @@ SUBSYSTEM_DEF(dbcore)
   * * querys - List of queries to execute
   * * warn - Boolean to warn on query failure
   * * qdel - Boolean to enable auto qdel of queries
+  * * assoc - Boolean to enable support for an associative list of queries
   */
-/datum/controller/subsystem/dbcore/proc/MassExecute(list/querys, warn = FALSE, qdel = FALSE)
+/datum/controller/subsystem/dbcore/proc/MassExecute(list/querys, warn = FALSE, qdel = FALSE, assoc = FALSE)
 	if(!islist(querys))
 		if(!istype(querys, /datum/db_query))
 			CRASH("Invalid query passed to MassExecute: [querys]")
 		querys = list(querys)
 
+	var/start_time = start_watch()
+	log_debug("Mass executing [length(querys)] queries...")
+
 	for(var/thing in querys)
-		var/datum/db_query/query = thing
+		var/datum/db_query/query
+		if(assoc)
+			query = querys[thing]
+		else
+			query = thing
 		if(warn)
 			INVOKE_ASYNC(query, /datum/db_query.proc/warn_execute)
 		else
 			INVOKE_ASYNC(query, /datum/db_query.proc/Execute)
 
 	for(var/thing in querys)
-		var/datum/db_query/query = thing
+		var/datum/db_query/query
+		if(assoc)
+			query = querys[thing]
+		else
+			query = thing
 		UNTIL(!query.in_progress)
 		if(qdel)
 			qdel(query)
 
+	log_debug("Executed [length(querys)] queries in [stop_watch(start_time)]s")
 
 /**
   * # db_query


### PR DESCRIPTION
## What Does This PR Do
Fixes the wait on the list of queries used by `SSchangelog` by adding them to a batch to be executed. I saw this and just instantly cried "I need to fix this good lord"
![image](https://user-images.githubusercontent.com/25063394/103174224-4bbe0b80-4858-11eb-8ba2-1e19d2a0612e.png)

## Why It's Good For The Game
Performance good. Useless sleeps bad.

## Changelog
:cl: AffectedArc07
fix: SSchangelog no longer takes 15 full seconds to query data
/:cl:
