### PR TITLE
Only show PDA messages to awake or dead owners

### DIFF
--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -33,7 +33,7 @@
 		else
 			L = get(pda, /mob/living/silicon)
 
-		if(L)
+		if(L && L.stat == CONSCIOUS)
 			to_chat(L, "[bicon(pda)] [message]")
 			SStgui.update_user_uis(L, pda) // Update the receiving user's PDA UI so that they can see the new message
 

--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -33,7 +33,7 @@
 		else
 			L = get(pda, /mob/living/silicon)
 
-		if(L && L.stat == CONSCIOUS)
+		if(L && L.stat != UNCONSCIOUS) // Awake or dead people can see their messages
 			to_chat(L, "[bicon(pda)] [message]")
 			SStgui.update_user_uis(L, pda) // Update the receiving user's PDA UI so that they can see the new message
 


### PR DESCRIPTION
## What Does This PR Do
Does as the title says
fixes #15114

## Why It's Good For The Game
Technology is far but the PDA is still a separate object from your brain.

## Changelog
:cl:
fix: PDA messages now won't be shown to unconcious people
/:cl: