### PR TITLE
Makes JMP usable by people other than admins if they are already a ghost

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1806,14 +1806,16 @@
 		log_admin("Admin [key_name_admin(usr)] has unlocked the Cult's ability to summon Nar'Sie.")
 
 	else if(href_list["adminplayerobservecoodjump"])
-		if(!check_rights(R_ADMIN))	return
+		var/client/C = usr.client
+		if(!isobserver(usr))
+			if(!check_rights(R_ADMIN)) // Need to be admin to aghost
+				return
+			C.admin_ghost()
 
 		var/x = text2num(href_list["X"])
 		var/y = text2num(href_list["Y"])
 		var/z = text2num(href_list["Z"])
 
-		var/client/C = usr.client
-		if(!isobserver(usr))	C.admin_ghost()
 		sleep(2)
 		C.jumptocoord(x,y,z)
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -75,7 +75,7 @@
 	set category = "Admin"
 	set name = "Jump to Coordinate"
 
-	if(!check_rights(R_ADMIN))
+	if(!isobserver(usr) && !check_rights(R_ADMIN)) // Only admins can jump without being a ghost
 		return
 
 	var/turf/T = locate(tx, ty, tz)


### PR DESCRIPTION
## What Does This PR Do
Makes the admin jump (JMP) usable by other staff members if they are already a ghost/observer.
If they are not ghosted then they still need the ADMIN permission to use it.

## Why It's Good For The Game
It can be a bit annoying to not be able to use the JMP while you're already a ghost. All the while you can already do it 99/100 times using the ghost verbs which take more time

## Changelog
:cl:
tweak: The admin JMP href is now usable by all staff members who are ghosted. If they are not ghosted they will still require the admin permission.
/:cl: