### PR TITLE
more stealthy fake walls 2.0. Stealth harder!

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -360,6 +360,14 @@
 	if(reagents)
 		reagents.temperature_reagents(exposed_temperature)
 
+
+/**
+  * Calls the right tool act.
+  *
+  * Call the appropriate tool act, such as screwdriver_act, crowbar_act and so on.
+  * Returns TRUE if a tool act was found/used.
+  * This means the tool shouldn't call its attack_by proc.
+  */
 /atom/proc/tool_act(mob/living/user, obj/item/I, tool_type)
 	switch(tool_type)
 		if(TOOL_CROWBAR)
@@ -377,27 +385,68 @@
 
 
 // Tool-specific behavior procs. To be overridden in subtypes.
+
+/**
+  * Tool-specific behaviour proc, to be overriden in subtype.
+  *
+  * Called by tool_act. Returns TRUE if an appropriate act was found and executed,
+  * which prevents the tool from calling the attack_by proc.
+  */
 /atom/proc/crowbar_act(mob/living/user, obj/item/I)
 	return
-
+/**
+  * Tool-specific behaviour proc, to be overriden in subtype.
+  *
+  * Called by tool_act. Returns TRUE if an appropriate act was found and executed,
+  * which prevents the tool from calling the attack_by proc.
+  */
 /atom/proc/multitool_act(mob/living/user, obj/item/I)
 	return
 
-//Check if the multitool has an item in its data buffer
+/**
+  * Tool-specific behaviour proc, to be overriden in subtype.
+  *
+  * Called by tool_act. Returns TRUE if an appropriate act was found and executed,
+  * which prevents the tool from calling the attack_by proc.
+  */
 /atom/proc/multitool_check_buffer(user, silent = FALSE)
 	if(!silent)
 		to_chat(user, "<span class='warning'>[src] has no data buffer!</span>")
 	return FALSE
 
+/**
+  * Tool-specific behaviour proc, to be overriden in subtype.
+  *
+  * Called by tool_act. Returns TRUE if an appropriate act was found and executed,
+  * which prevents the tool from calling the attack_by proc.
+  */
 /atom/proc/screwdriver_act(mob/living/user, obj/item/I)
 	return
 
+/**
+  * Tool-specific behaviour proc, to be overriden in subtype.
+  *
+  * Called by tool_act. Returns TRUE if an appropriate act was found and executed,
+  * which prevents the tool from calling the attack_by proc.
+  */
 /atom/proc/wrench_act(mob/living/user, obj/item/I)
 	return
 
+/**
+  * Tool-specific behaviour proc, to be overriden in subtype.
+  *
+  * Called by tool_act. Returns TRUE if an appropriate act was found and executed,
+  * which prevents the tool from calling the attack_by proc.
+  */
 /atom/proc/wirecutter_act(mob/living/user, obj/item/I)
 	return
 
+/**
+  * Tool-specific behaviour proc, to be overriden in subtype.
+  *
+  * Called by tool_act. Returns TRUE if an appropriate act was found and executed,
+  * which prevents the tool from calling the attack_by proc.
+  */
 /atom/proc/welder_act(mob/living/user, obj/item/I)
 	return
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -18,6 +18,8 @@
 	var/walltype = /turf/simulated/wall
 	var/girder_type = /obj/structure/girder/displaced
 	var/opening = FALSE
+	/// If the false wall is 'locked', it won't open when clicked
+	var/locked = FALSE
 
 	density = TRUE
 	opacity = TRUE
@@ -70,6 +72,11 @@
 
 /obj/structure/falsewall/proc/toggle(mob/user)
 	if(opening)
+		return
+	if(locked)
+		user.changeNext_move(CLICK_CD_MELEE)	//copied from wall code
+		to_chat(user, "<span class='notice'>You push the wall but nothing happens!</span>")	//sneak 100
+		playsound(src, 'sound/weapons/genhit.ogg', 25, 1)
 		return
 
 	opening = 1
@@ -126,11 +133,14 @@
 			to_chat(user, "<span class='warning'>[src] is blocked!</span>")
 			return
 		if(istype(W, /obj/item/screwdriver))
-			if(!istype(T, /turf/simulated/floor))
-				to_chat(user, "<span class='warning'>[src] bolts must be tightened on the floor!</span>")
-				return
-			user.visible_message("<span class='notice'>[user] tightens some bolts on the wall.</span>", "<span class='warning'>You tighten the bolts on the wall.</span>")
-			ChangeToWall()
+			user.visible_message("<span class='notice'>[user] begins messing with some bolts on the wall.</span>", "<span class='warning'>You begin to mess with the bolts on the wall.</span>")
+			if(do_after_once(user, 50, target = src))
+				if(!locked)
+					user.visible_message("<span class='notice'>[user] tightens some bolts on the wall.</span>", "<span class='warning'>You tighten the bolts on the wall.</span>")
+					locked = TRUE
+				else
+					user.visible_message("<span class='notice'>[user] loosens some bolts on the wall.</span>", "<span class='warning'>You loosen the bolts on the wall.</span>")
+					locked = FALSE
 	else
 		to_chat(user, "<span class='warning'>You can't reach, close it first!</span>")
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -115,12 +115,6 @@
 	else
 		icon_state = "fwall_open"
 
-/obj/structure/falsewall/proc/ChangeToWall(delete = TRUE)
-	var/turf/T = get_turf(src)
-	T.ChangeTurf(walltype)
-	if(delete)
-		qdel(src)
-	return T
 
 /obj/structure/falsewall/attackby(obj/item/W, mob/user, params)
 	if(opening)
@@ -134,11 +128,12 @@
 			return
 		if(istype(W, /obj/item/screwdriver))
 			user.visible_message("<span class='notice'>[user] begins messing with some bolts on the wall.</span>", "<span class='warning'>You begin to mess with the bolts on the wall.</span>")
-			if(do_after_once(user, 50, target = src))
-				if(!locked)
+			if(!locked)
+				if(do_after_once(user, 10, target = src))
 					user.visible_message("<span class='notice'>[user] tightens some bolts on the wall.</span>", "<span class='warning'>You tighten the bolts on the wall.</span>")
 					locked = TRUE
-				else
+			else
+				if(do_after_once(user, 50, target = src))
 					user.visible_message("<span class='notice'>[user] loosens some bolts on the wall.</span>", "<span class='warning'>You loosen the bolts on the wall.</span>")
 					locked = FALSE
 	else
@@ -184,13 +179,6 @@
 /obj/structure/falsewall/reinforced/examine_status(mob/user)
 	. = ..()
 	. += "<br><span class='notice'>The outer <b>grille</b> is fully intact.</span>"	//not going to fake other states of disassembly
-
-/obj/structure/falsewall/reinforced/ChangeToWall(delete = 1)
-	var/turf/T = get_turf(src)
-	T.ChangeTurf(/turf/simulated/wall/r_wall)
-	if(delete)
-		qdel(src)
-	return T
 
 /*
  * Uranium Falsewalls

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -37,6 +37,18 @@
 	..()
 	air_update_turf(1)
 
+/obj/structure/falsewall/examine_status(mob/user)
+	var/healthpercent = (obj_integrity/max_integrity) * 100
+	switch(healthpercent)
+		if(100)
+			return "<span class='notice'>It looks fully intact.</span>"
+		if(70 to 99)
+			return  "<span class='warning'>It looks slightly damaged.</span>"
+		if(40 to 70)
+			return  "<span class='warning'>It looks moderately damaged.</span>"
+		if(0 to 40)
+			return "<span class='danger'>It looks heavily damaged.</span>"
+
 /obj/structure/falsewall/ratvar_act()
 	new /obj/structure/falsewall/brass(loc)
 	qdel(src)
@@ -158,6 +170,10 @@
 	icon_state = "r_wall"
 	walltype = /turf/simulated/wall/r_wall
 	mineral = /obj/item/stack/sheet/plasteel
+
+/obj/structure/falsewall/reinforced/examine_status(mob/user)
+	. = ..()
+	. += "<br><span class='notice'>The outer <b>grille</b> is fully intact.</span>"	//not going to fake other states of disassembly
 
 /obj/structure/falsewall/reinforced/ChangeToWall(delete = 1)
 	var/turf/T = get_turf(src)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -323,6 +323,13 @@
 
 	return ..()
 
+/turf/simulated/wall/screwdriver_act(mob/living/user, obj/item/I)	//for false wall stealth
+	. = TRUE
+	user.visible_message("<span class='notice'>[user] begins messing with some bolts on the wall.</span>", "<span class='warning'>You begin to mess with the bolts on the wall.</span>")
+	if(do_after_once(user, 50, target = src))
+		user.visible_message("<span class='notice'>[user] tries to loosen some bolts on the wall, but they don't budge.</span>", "<span class='warning'>You try to loosen some bolts on the wall, but they don't budge.</span>")
+
+
 /turf/simulated/wall/welder_act(mob/user, obj/item/I)
 	. = TRUE
 	if(thermite && I.use_tool(src, user, volume = I.tool_volume))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -51,7 +51,7 @@
 	. = ..()
 
 //Appearance
-/turf/simulated/wall/examine(mob/user)
+/turf/simulated/wall/examine(mob/user)	//If you change this, consider changing the examine proc of false walls to match
 	. = ..()
 
 	if(!damage)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -51,7 +51,7 @@
 	. = ..()
 
 //Appearance
-/turf/simulated/wall/examine(mob/user)	//If you change this, consider changing the examine proc of false walls to match
+/turf/simulated/wall/examine(mob/user)	//If you change this, consider changing the examine_status proc of false walls to match
 	. = ..()
 
 	if(!damage)

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -147,9 +147,12 @@
 	update_icon()
 
 /turf/simulated/wall/r_wall/screwdriver_act(mob/user, obj/item/I)
-	if(d_state != RWALL_SUPPORT_LINES && d_state != RWALL_COVER)
-		return
 	. = TRUE
+	if(d_state != RWALL_SUPPORT_LINES && d_state != RWALL_COVER)
+		user.visible_message("<span class='notice'>[user] begins messing with some bolts on the wall.</span>", "<span class='warning'>You begin to mess with the bolts on the wall.</span>")
+		if(do_after_once(user, 50, target = src))
+			user.visible_message("<span class='notice'>[user] tries to loosen some bolts on the wall, but they don't budge.</span>", "<span class='warning'>You try to loosen some bolts on the wall, but they don't budge.</span>")
+			return
 	if(!I.tool_use_check(user, 0))
 		return
 	var/state_check = d_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is a more far-reaching version of #15130 that includes the changes in that other PR as well. To sum up:

- The examination text of false walls now matches that of the corresponding real wall, preventing you from detecting false walls just by examining them.
- False walls can now be 'locked' by using a screwdriver on them while they're closed. A locked false wall _acts like a real wall_ when clicked. IE, it cannot be opened by clicking it, it produces the same sound, etc. It needs to be unlocked by using a screwdriver to unlock it again.
- Unlocking a false wall takes 5 seconds. EDIT: Locking a false wall takes just 1 second. Real walls now also have 'fake' interaction with screwdrivers, taking you 5 seconds to try and unlock them, followed by failing. This means it now takes 5 seconds per wall to check if something is a (hidden) fake wall, rather than a drive-by click while walking past.
- If you don't want to lock a wall, you can leave them unlocked and they will keep acting as they do now, for a quick getaway.
- False walls can no longer be turned into real walls by using a screwdriver on them.
- I added some autodoc documentation to tools acts while I was it, since what their return value means was very non-obvious to me.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Our maintenance being too small for our pop has been brought up a lot. It makes it really hard for antags to build on-station bases without being found. Making false walls harder to locate helps with this. Trying to spam-check every single wall takes a lot longer now, but you can still easily check a wall you suspect of being false with a small individual time-investment.
Being able to tell a false wall from a real one because their examine text doesn't match is, as far as I am concerned, a bug to be fixed.

Being able to instantly turn a false wall into a real wall felt very cheesy to me. The primary advantage of a false wall should be that it's a hidden door, not that it's a door you can instantly close. Still, you can now lock the wall in 1 second while it takes pursuers 5 seconds to get it open again, preserving the same effect.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Fake walls can now be locked and unlocked with a screwdriver. Locked fake walls will not open when clicked
tweak: fake wall examine text now matches real wall examine text.
del: You can no longer instantly turn fake walls into real walls with a screwdriver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
