### PR TITLE
Makes brig cells have an unknown job title for the AI instead of /list

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -86,7 +86,7 @@
 	var/timetext = seconds_to_time(timetoset / 10)
 	var/announcetext = "Detainee [occupant] ([prisoner_drank]) has been incarcerated for [timetext] for the crime of: '[crimes]'. \
 	Arresting Officer: [usr.name].[R ? "" : " Detainee record not found, manual record update required."]"
-	Radio.autosay(announcetext, name, "Security", list(z))
+	Radio.autosay(announcetext, name, "Security")
 
 	// Notify the actual criminal being brigged. This is a QOL thing to ensure they always know the charges against them.
 	// Announcing it on radio isn't enough, as they're unlikely to have sec radio.


### PR DESCRIPTION
## What Does This PR Do
Fixes:
![image](https://user-images.githubusercontent.com/15887760/103276691-83979100-49c7-11eb-94c0-3c74c88d7d4c.png)


## Why It's Good For The Game
Bug b gone

## Changelog
:cl:
fix: Brig cells now show an unknown job to the AI instead of /list
/:cl: