### PR TITLE
Fixes IV bags not letting you change transfer rate while buckled.

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -19,7 +19,7 @@
 	set category = "Object"
 	set src in range(0)
 
-	if(usr.stat || !usr.canmove || usr.restrained())
+	if(usr.incapacitated())
 		return
 	var/default = null
 	if(amount_per_transfer_from_this in possible_transfer_amounts)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes not being able to change the transfer rate on IV's while buckled.
## Why It's Good For The Game
Not being able to change the transfer rate on an IV bag while standing on a chair makes no sense.
## Changelog
:cl:
fix: fixed not being able to change IV transfer rate while buckled to a chair.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
