### PR TITLE
Fixes closed multi-tile poddoors in ruins being transparent

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -79,7 +79,7 @@
 	layer = CLOSED_DOOR_LAYER
 	closingLayer = CLOSED_DOOR_LAYER
 
-/obj/machinery/door/poddoor/multi_tile/New()
+/obj/machinery/door/poddoor/multi_tile/Initialize(mapload)
 	. = ..()
 	apply_opacity_to_my_turfs(opacity)
 


### PR DESCRIPTION
## What Does This PR Do
Currently, multi-tile spacepod doors which are loaded into ruins or otherwise maploaded in, don't initialize properly, which leads to them not having their opacity applied, resulting in you being able to see through them even if they're closed.
This PR fixes that,  by making them use Initialize(mapload) instead of New() to set their opacity.

## Changelog
:cl: Kyep
fix: fixed spacepod doors in ruins being see-through even when closed.
/:cl: