### PR TITLE
Starvation No Longer Impacts SSDs

### DIFF
--- a/code/datums/diseases/critical.dm
+++ b/code/datums/diseases/critical.dm
@@ -165,6 +165,8 @@
 
 /datum/disease/critical/hypoglycemia/stage_act()
 	if(..())
+		if(isLivingSSD(affected_mob)) // We don't want AFK people dying from this.
+			return
 		if(affected_mob.nutrition > NUTRITION_LEVEL_HYPOGLYCEMIA)
 			to_chat(affected_mob, "<span class='notice'>You feel a lot better!</span>")
 			cure()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -625,7 +625,7 @@
 				else
 					overeatduration -= 2
 
-		if(!ismachineperson(src) && nutrition < NUTRITION_LEVEL_HYPOGLYCEMIA) //Gosh damn snowflakey IPCs
+		if(!ismachineperson(src) && !isLivingSSD(src) && nutrition < NUTRITION_LEVEL_HYPOGLYCEMIA) //Gosh damn snowflakey IPCs
 			var/datum/disease/D = new /datum/disease/critical/hypoglycemia
 			ForceContractDisease(D)
 


### PR DESCRIPTION
I've seen way too many people dying in cryo because they've been SSD forever.


Starvation is meant to be a mechanic to punish not eating, during a shift, when you're active.

This won't prevent people who are AFK from starving (we can have a discussion on that one if needed), but it will prevent people who are SSD from doing so, which is, IMO, for the better.

:cl: Fox McCloud
tweak: SSD individuals will no longer die from starvation
/:cl: