### PR TITLE
Fixes 'Long-Distance Cloning Machine' ghosts being objectives

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -51,16 +51,17 @@
 	desc = "Top-of-the-line Nanotrasen technology allows for cloning of crew members from off-station upon bluespace request."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "borgcharger1(old)"
-	anchored = 1
-	density = 1
+	anchored = TRUE
+	density = TRUE
 
-/obj/structure/respawner/attack_ghost(mob/dead/observer/user as mob)
-	var/response = alert(user, "Are you sure you want to spawn like this?\n(If you do this, you won't be able to be cloned!)","Respawn?","Yes","No")
+/obj/structure/respawner/attack_ghost(mob/dead/observer/user)
+	var/response = alert(user, "Are you sure you want to spawn here?\n(If you do this, you won't be able to be cloned!)", "Respawn?", "Yes", "No")
 	if(response == "Yes")
 		user.forceMove(get_turf(src))
 		log_admin("[key_name(user)] was incarnated by a respawner machine.")
 		message_admins("[key_name_admin(user)] was incarnated by a respawner machine.")
-		user.incarnate_ghost()
+		var/mob/living/carbon/human/new_human = user.incarnate_ghost()
+		new_human.mind.offstation_role = TRUE // To prevent them being an antag objective
 
 /obj/structure/ghost_beacon
 	name = "ethereal beacon"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes #7310.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's been a bug for almost four years, and traitors shouldn't get an impossible objectve.

## Changelog
:cl:
fix: Ghosts who used the admin spawned 'Long-Distance Cloning Machine' will no longer be given as antag objectives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
