### PR TITLE
How the goat stole Christmas

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -46,10 +46,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 2;
+	tag = "icon-window5_mid";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_mid";
-	tag = "icon-window5_mid"
+	dir = 2
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -69,10 +69,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 2;
+	tag = "icon-window5_end";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end"
+	dir = 2
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -87,10 +87,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 1;
+	tag = "icon-window5_end (NORTH)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -214,9 +214,9 @@
 /area/shuttle/syndicate)
 "acf" = (
 /obj/machinery/light/spot{
-	dir = 4;
+	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -284,8 +284,8 @@
 /obj/effect/decal/warning_stripes/southwest,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/range)
 "acp" = (
@@ -321,23 +321,23 @@
 "act" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/range)
 "acu" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/range)
 "acv" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/range)
 "acw" = (
@@ -376,9 +376,9 @@
 /area/shuttle/syndicate)
 "acB" = (
 /obj/machinery/shower{
-	dir = 8;
+	tag = "icon-shower (WEST)";
 	icon_state = "shower";
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower/security,
 /turf/simulated/floor/plasteel{
@@ -392,9 +392,9 @@
 /obj/item/target,
 /obj/item/target,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -802,7 +802,6 @@
 	name = "Bathroom";
 	req_access_txt = "0"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -978,8 +977,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -1085,16 +1084,9 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "adN" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -1157,9 +1149,9 @@
 /area/security/range)
 "adS" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/suit_storage_unit/syndicate/secure,
 /turf/simulated/shuttle/floor{
@@ -1178,9 +1170,9 @@
 /area/shuttle/syndicate)
 "adU" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -1208,19 +1200,15 @@
 	},
 /area/shuttle/syndicate)
 "adX" = (
+/obj/structure/chair/stool,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/item/gift,
-/obj/item/clothing/head/cowboyhat/black,
-/obj/structure/snow,
-/obj/item/toy/figure/secofficer,
-/obj/item/gun/projectile/automatic/toy/pistol,
-/obj/item/clothing/head/helmet/justice,
-/obj/item/nanomob_card,
-/obj/item/ammo_box/magazine/toy/pistol,
+/obj/effect/landmark/start{
+	name = "Detective"
+	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "adY" = (
@@ -1230,7 +1218,6 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
@@ -1293,10 +1280,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
@@ -1384,12 +1367,9 @@
 	pixel_x = 0;
 	pixel_y = 30
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/main)
 "aek" = (
@@ -1462,9 +1442,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whiteblue (NORTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	dir = 9
 	},
 /area/security/medbay)
 "aeq" = (
@@ -1490,9 +1470,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/security/medbay)
 "aes" = (
@@ -1529,16 +1509,16 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/range)
 "aev" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/range)
 "aew" = (
@@ -1563,13 +1543,6 @@
 /area/shuttle/syndicate_sit)
 "aey" = (
 /obj/machinery/computer/brigcells,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -1629,9 +1602,6 @@
 /obj/structure/rack,
 /obj/item/tank/oxygen,
 /obj/item/tank/jetpack/oxygen,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/security/podbay)
 "aeF" = (
@@ -1680,9 +1650,9 @@
 /obj/item/reagent_containers/syringe/charcoal,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whiteblue (NORTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	dir = 9
 	},
 /area/security/medbay)
 "aeK" = (
@@ -1708,9 +1678,9 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/security/medbay)
 "aeM" = (
@@ -1829,9 +1799,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/security/medbay)
 "aeU" = (
@@ -1846,7 +1816,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -1982,9 +1951,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/security/medbay)
 "afe" = (
@@ -2062,7 +2031,6 @@
 	shock_proof = 0
 	},
 /obj/machinery/photocopier,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -2084,10 +2052,6 @@
 	pixel_y = -28;
 	req_access_txt = "2"
 	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2105,10 +2069,6 @@
 	},
 /obj/effect/landmark/start{
 	name = "Brig Physician"
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -2185,16 +2145,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/security/medbay)
 "afv" = (
 /obj/structure/closet/secure_closet/brigdoc,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue";
@@ -2321,17 +2278,11 @@
 /obj/effect/landmark/start{
 	name = "Security Officer"
 	},
-/obj/structure/chair/stool,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "afK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -2386,9 +2337,9 @@
 	req_access_txt = "150"
 	},
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -2400,9 +2351,9 @@
 	req_access_txt = "150"
 	},
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -2494,9 +2445,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/security/medbay)
 "afZ" = (
@@ -2578,9 +2529,9 @@
 /area/shuttle/vox)
 "agf" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2783,9 +2734,9 @@
 	req_access_txt = "152"
 	},
 /obj/machinery/light/spot{
-	dir = 4;
+	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2808,10 +2759,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 2;
+	tag = "icon-window5_end";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end"
+	dir = 2
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2826,10 +2777,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 1;
+	tag = "icon-window5_end (NORTH)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2844,10 +2795,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 2;
+	tag = "icon-window5_mid";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_mid";
-	tag = "icon-window5_mid"
+	dir = 2
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2859,19 +2810,15 @@
 	req_access_txt = "152"
 	},
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "agD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2969,10 +2916,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2986,10 +2929,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3096,9 +3035,9 @@
 /area/security/securearmoury)
 "agT" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3156,10 +3095,6 @@
 "agX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
@@ -3233,12 +3168,9 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/main)
 "ahg" = (
@@ -3324,10 +3256,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 8;
+	tag = "icon-window5_end (WEST)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3354,10 +3286,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 8;
+	tag = "icon-window5_end (WEST)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3470,10 +3402,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -3513,8 +3441,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/armoury)
 "ahI" = (
@@ -3536,10 +3464,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 4;
+	tag = "icon-window5_end (EAST)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3565,17 +3493,17 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 4;
+	tag = "icon-window5_end (EAST)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "ahN" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l"
+	tag = "icon-propulsion_l";
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -3585,8 +3513,8 @@
 /area/shuttle/syndicate)
 "ahP" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r"
+	tag = "icon-propulsion_r";
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -3613,8 +3541,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 5
 	},
 /area/security/armoury)
 "ahS" = (
@@ -3626,8 +3554,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 5
 	},
 /area/security/armoury)
 "ahT" = (
@@ -3639,8 +3567,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/armoury)
 "ahU" = (
@@ -3785,8 +3713,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/security/armoury)
 "aig" = (
@@ -3855,8 +3783,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/security/armoury)
 "aio" = (
@@ -3866,8 +3794,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -4010,8 +3938,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/armoury)
 "aix" = (
@@ -4049,8 +3977,8 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/armoury)
 "aiA" = (
@@ -4357,10 +4285,6 @@
 	pixel_y = -25
 	},
 /obj/machinery/light,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -4553,8 +4477,8 @@
 /obj/vehicle/secway,
 /obj/item/key/security,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/armoury)
 "ajl" = (
@@ -5050,9 +4974,9 @@
 /obj/item/harpoon,
 /obj/item/tank/nitrogen,
 /obj/machinery/light/spot{
-	dir = 4;
+	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -5279,8 +5203,8 @@
 /area/security/podbay)
 "akp" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l"
+	tag = "icon-propulsion_l";
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/vox)
@@ -5339,7 +5263,16 @@
 /area/security/securearmoury)
 "akv" = (
 /obj/structure/table,
-/obj/structure/snow,
+/obj/item/taperecorder{
+	pixel_y = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = -25
+	},
+/obj/item/radio/intercom/department/security{
+	pixel_x = 0;
+	pixel_y = 28
+	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "akw" = (
@@ -5429,25 +5362,14 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
-/obj/item/gift,
-/obj/item/clothing/head/cowboyhat/pink,
-/obj/structure/snow,
-/obj/item/toy/figure/hos,
-/obj/item/toy/prize/gygax,
-/obj/item/nanomob_card,
-/obj/item/gun/projectile/automatic/toy,
-/obj/item/ammo_box/magazine/toy/smg,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "akG" = (
 /obj/structure/chair/stool,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -5456,9 +5378,9 @@
 "akH" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
@@ -5541,10 +5463,10 @@
 "akP" = (
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 1;
+	tag = "icon-window5_end (NORTH)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -5565,18 +5487,18 @@
 "akR" = (
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 2;
+	tag = "icon-window5_end";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end"
+	dir = 2
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "akS" = (
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 5
 	},
 /area/security/permabrig)
 "akT" = (
@@ -5587,8 +5509,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/permabrig)
 "akU" = (
@@ -5756,9 +5678,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "ale" = (
@@ -5782,30 +5704,30 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/armoury)
 "alg" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/armoury)
 "alh" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/armoury)
 "ali" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/armoury)
 "alj" = (
@@ -5909,6 +5831,17 @@
 	},
 /area/security/brig)
 "alp" = (
+/obj/structure/table,
+/obj/item/ashtray/bronze{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -5917,11 +5850,6 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/flora/tree/pine/xmas,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "alq" = (
@@ -5931,7 +5859,6 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redcorner"
@@ -5979,7 +5906,6 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -6023,16 +5949,16 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "alD" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/power/tracker,
 /obj/structure/lattice/catwalk,
@@ -6042,6 +5968,15 @@
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
+"alF" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/turf/simulated/floor/plasteel,
+/area/security/main)
 "alG" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/status_display{
@@ -6050,7 +5985,6 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "alH" = (
@@ -6234,7 +6168,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6326,12 +6259,9 @@
 	dir = 1;
 	on = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/main)
 "amd" = (
@@ -6339,12 +6269,9 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/main)
 "ame" = (
@@ -6372,12 +6299,9 @@
 	name = "station intercom (General)";
 	pixel_y = 25
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 5
 	},
 /area/security/main)
 "amg" = (
@@ -6437,26 +6361,19 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/security/main)
 "amn" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_y = 3
+	},
+/obj/item/book/manual/sop_legal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/structure/table/reinforced,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -6494,18 +6411,19 @@
 "amq" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
 "amr" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start{
-	name = "Detective"
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/obj/structure/snow,
+/obj/effect/landmark/start{
+	name = "Head of Security"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redfull";
@@ -6610,9 +6528,6 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -6637,9 +6552,6 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -6648,22 +6560,14 @@
 "amD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
 "amE" = (
 /obj/machinery/computer/prisoner,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -6678,8 +6582,8 @@
 "amG" = (
 /obj/machinery/vending/security,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/seceqstorage)
 "amH" = (
@@ -6701,8 +6605,8 @@
 	},
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/seceqstorage)
 "amI" = (
@@ -6723,8 +6627,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/seceqstorage)
 "amK" = (
@@ -6737,18 +6641,17 @@
 /area/maintenance/fsmaint)
 "amL" = (
 /obj/machinery/shower{
-	dir = 8;
+	tag = "icon-shower (WEST)";
 	icon_state = "shower";
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "amM" = (
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/security/main)
 "amN" = (
@@ -6772,17 +6675,12 @@
 	},
 /area/security/main)
 "amO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/reinforced,
-/obj/item/ashtray/bronze{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/item/folder/red{
+	pixel_y = 3
 	},
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
+/obj/item/book/manual/security_space_law,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "amP" = (
@@ -6804,8 +6702,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 8
 	},
 /area/security/main)
 "amQ" = (
@@ -6829,10 +6727,6 @@
 	c_tag = "Brig Pod Pilot's Office";
 	dir = 8;
 	network = list("SS13")
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6866,8 +6760,8 @@
 /area/security/hos)
 "amU" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/power/tracker,
 /obj/structure/lattice/catwalk,
@@ -6953,6 +6847,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
+"anf" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
+/area/security/permabrig)
 "ang" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7030,8 +6929,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/security/permabrig)
 "anp" = (
@@ -7107,9 +7006,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7163,10 +7059,6 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7178,10 +7070,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7201,10 +7089,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7249,7 +7133,6 @@
 	name = "Warden's Desk";
 	req_access_txt = "3"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/warden)
 "anE" = (
@@ -7259,7 +7142,6 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -7341,9 +7223,6 @@
 /area/security/main)
 "anM" = (
 /obj/structure/chair/stool,
-/obj/effect/landmark/start{
-	name = "Head of Security"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redfull";
@@ -7399,7 +7278,6 @@
 	dir = 4;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "anR" = (
@@ -7418,10 +7296,6 @@
 	dir = 4;
 	level = 1
 	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "anS" = (
@@ -7429,10 +7303,9 @@
 	dir = 4;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 5
 	},
 /area/security/main)
 "anT" = (
@@ -7449,22 +7322,17 @@
 	},
 /area/security/permabrig)
 "anU" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_y = 3
+	},
+/obj/item/book/manual/sop_security,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
 	initialize_directions = 11;
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/reinforced,
-/obj/item/book/manual/sop_legal,
-/obj/item/book/manual/security_space_law,
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "anV" = (
@@ -7514,9 +7382,9 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aoa" = (
@@ -7534,13 +7402,10 @@
 	dir = 1;
 	in_use = 1
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aob" = (
@@ -7549,9 +7414,9 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aoc" = (
@@ -7581,9 +7446,9 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aof" = (
@@ -7635,9 +7500,9 @@
 "aoj" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -7652,8 +7517,8 @@
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/security/lobby)
 "aol" = (
@@ -7693,8 +7558,8 @@
 /area/security/lobby)
 "aoo" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -7720,15 +7585,15 @@
 	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 8
 	},
 /area/security/lobby)
 "aoq" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -7752,7 +7617,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7768,7 +7632,6 @@
 /obj/effect/landmark/start{
 	name = "Warden"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7789,7 +7652,6 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7801,9 +7663,6 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/structure/snow{
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7812,10 +7671,6 @@
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start{
 	name = "Warden"
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7828,17 +7683,12 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "aox" = (
 /obj/machinery/computer/secure_data,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -7864,8 +7714,8 @@
 /obj/item/crowbar,
 /obj/item/radio,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 8
 	},
 /area/security/seceqstorage)
 "aoA" = (
@@ -7962,9 +7812,17 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
+/turf/simulated/floor/plasteel,
+/area/security/main)
+"aoI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -8012,7 +7870,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "aoM" = (
@@ -8025,10 +7882,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/main)
 "aoN" = (
@@ -8037,10 +7893,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/main)
 "aoO" = (
@@ -8080,15 +7935,9 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/main)
 "aoQ" = (
@@ -8099,11 +7948,6 @@
 "aoR" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
-/obj/item/book/manual/sop_security,
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "aoS" = (
@@ -8138,8 +7982,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "aoV" = (
@@ -8166,8 +8010,8 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "aoX" = (
@@ -8276,7 +8120,6 @@
 	pixel_x = -28;
 	pixel_y = -10
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -8288,7 +8131,6 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkred"
@@ -8299,15 +8141,12 @@
 /obj/item/book/manual/sop_legal,
 /obj/item/paper/armory,
 /obj/item/clipboard,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/warden)
 "aph" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkred"
@@ -8317,7 +8156,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/megaphone,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkred"
@@ -8325,7 +8163,6 @@
 /area/security/warden)
 "apj" = (
 /obj/structure/table/reinforced,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkred"
@@ -8335,11 +8172,6 @@
 /obj/machinery/computer/security{
 	network = list("SS13","Research Outpost","Mining Outpost")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkred"
@@ -8395,8 +8227,8 @@
 /area/space/nearstation)
 "app" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -8421,22 +8253,22 @@
 /area/solar/auxstarboard)
 "apr" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall12"
+	icon_state = "swall12";
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "aps" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f6";
 	icon_state = "swall_f6";
-	tag = "icon-swall_f6"
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "apt" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall14"
+	icon_state = "swall14";
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "apu" = (
@@ -8455,8 +8287,8 @@
 "apv" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "apw" = (
@@ -8466,8 +8298,8 @@
 /area/shuttle/trade/sol)
 "apx" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "apy" = (
@@ -8517,8 +8349,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/security/seceqstorage)
 "apB" = (
@@ -8582,9 +8414,9 @@
 /area/security/medbay)
 "apG" = (
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8594,9 +8426,6 @@
 /obj/structure/closet/secure_closet/security,
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -8617,9 +8446,6 @@
 /area/security/main)
 "apJ" = (
 /obj/structure/closet/secure_closet/security,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -8635,9 +8461,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -8647,14 +8470,6 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/light,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/toffee{
-	pixel_x = -10
-	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/toffee{
-	pixel_x = 9
-	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/toffee,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "apN" = (
@@ -8666,7 +8481,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "apO" = (
@@ -8676,7 +8490,6 @@
 /obj/effect/landmark/start{
 	name = "Security Pod Pilot"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "apP" = (
@@ -8708,9 +8521,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -8729,7 +8542,6 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "apU" = (
@@ -8808,9 +8620,9 @@
 "apY" = (
 /obj/structure/bed,
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -8857,9 +8669,9 @@
 /area/shuttle/trade/sol)
 "aqg" = (
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/effect/spawner/lootdrop/trade_sol/donksoft,
 /obj/structure/closet,
@@ -8880,9 +8692,9 @@
 /area/shuttle/trade/sol)
 "aqj" = (
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/trade/sol)
@@ -9052,9 +8864,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -9092,7 +8904,6 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "aqE" = (
@@ -9257,9 +9068,9 @@
 	},
 /obj/item/pen,
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -9323,23 +9134,39 @@
 /area/security/brig)
 "aqY" = (
 /obj/structure/chair/stool,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aqZ" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/auxstarboard)
+"ara" = (
+/obj/structure/table/reinforced,
+/obj/item/folder{
+	pixel_x = -4
+	},
+/obj/item/folder/red{
+	pixel_y = 3
+	},
+/obj/item/folder/blue{
+	pixel_x = 5
+	},
+/obj/item/folder/yellow{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stamp/law,
+/obj/item/pen/multi,
+/turf/simulated/floor/plasteel{
+	tag = "icon-cult";
+	icon_state = "cult";
+	dir = 2
+	},
+/area/lawoffice)
 "arb" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -9348,9 +9175,9 @@
 "arc" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9422,8 +9249,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/security/lobby)
 "ark" = (
@@ -9452,9 +9279,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -9485,8 +9312,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "aro" = (
@@ -9507,8 +9334,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 8
 	},
 /area/security/lobby)
 "arq" = (
@@ -9608,8 +9435,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -9619,10 +9446,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "arw" = (
@@ -9675,8 +9501,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "arz" = (
@@ -9689,10 +9515,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -9752,12 +9574,9 @@
 	pixel_x = 25;
 	pixel_y = -7
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "arF" = (
@@ -9767,12 +9586,9 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "arG" = (
@@ -9796,8 +9612,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/security/permabrig)
 "arI" = (
@@ -9837,8 +9653,8 @@
 	shock_proof = 0
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -9965,8 +9781,8 @@
 /area/maintenance/fsmaint)
 "arU" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -9986,8 +9802,8 @@
 /area/shuttle/trade/sol)
 "arX" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -10109,8 +9925,8 @@
 /obj/item/seeds/wheat/rice,
 /obj/item/seeds/wheat/rice,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 8
 	},
 /area/security/permabrig)
 "asj" = (
@@ -10133,6 +9949,10 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
+"asl" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel,
+/area/security/permabrig)
 "asm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -10224,10 +10044,6 @@
 /obj/item/radio/intercom/department/security{
 	pixel_x = -28
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "ast" = (
@@ -10265,10 +10081,6 @@
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -10308,10 +10120,6 @@
 	network = list("Prison");
 	pixel_x = 0;
 	pixel_y = 30
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -10535,9 +10343,6 @@
 	dir = 4;
 	level = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -10561,16 +10366,16 @@
 "asJ" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f5";
 	icon_state = "swall_f5";
-	tag = "icon-swall_f5"
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "asK" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "asL" = (
@@ -10613,7 +10418,6 @@
 /turf/space,
 /area/solar/auxport)
 "asN" = (
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "asO" = (
@@ -10621,38 +10425,26 @@
 	req_access = null;
 	req_access_txt = "2"
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "asP" = (
-/obj/structure/chair/comfy/green{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "asQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -10673,8 +10465,8 @@
 "asS" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f6"
+	icon_state = "swall_f6";
+	dir = 2
 	},
 /area/shuttle/siberia)
 "asT" = (
@@ -10695,9 +10487,9 @@
 "asV" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f10";
 	icon_state = "swall_f10";
-	tag = "icon-swall_f10"
+	dir = 2
 	},
 /area/shuttle/siberia)
 "asW" = (
@@ -10806,6 +10598,19 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
+"atd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner";
+	dir = 1
+	},
+/area/security/prison/cell_block/A)
 "ate" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
@@ -10823,10 +10628,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
@@ -10857,15 +10658,9 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/processing)
 "atj" = (
@@ -10899,10 +10694,6 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "atm" = (
@@ -10924,9 +10715,6 @@
 	d2 = 8;
 	icon_state = "2-8";
 	tag = ""
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -10951,9 +10739,6 @@
 	icon_state = "1-2";
 	pixel_y = 0;
 	tag = ""
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -11034,10 +10819,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "atw" = (
@@ -11107,8 +10888,8 @@
 /obj/item/seeds/corn,
 /obj/item/seeds/corn,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 8
 	},
 /area/security/permabrig)
 "atB" = (
@@ -11195,8 +10976,8 @@
 /area/maintenance/fsmaint)
 "atH" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/plant_analyzer,
@@ -11206,8 +10987,8 @@
 /area/security/permabrig)
 "atI" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/siberia)
 "atJ" = (
@@ -11236,11 +11017,19 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/siberia)
+"atM" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/prisonershuttle)
 "atN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -11262,8 +11051,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
@@ -11272,8 +11061,8 @@
 /obj/item/dice/d20,
 /obj/item/instrument/harmonica,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -11537,9 +11326,9 @@
 "aui" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/security/seceqstorage)
@@ -11633,10 +11422,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -11676,38 +11461,34 @@
 /area/maintenance/fsmaint)
 "auq" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall12";
 	icon_state = "swall12";
-	tag = "icon-swall12"
+	dir = 2
 	},
 /area/shuttle/pod_3)
 "aur" = (
 /obj/structure/filingcabinet/employment,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aus" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/pod_3)
 "aut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "auu" = (
@@ -11814,8 +11595,8 @@
 "auF" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/security/lobby)
 "auG" = (
@@ -11906,8 +11687,8 @@
 "auL" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 8
 	},
 /area/security/lobby)
 "auM" = (
@@ -11924,8 +11705,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/lobby)
 "auN" = (
@@ -12096,7 +11877,6 @@
 /obj/item/radio/intercom/department/security{
 	pixel_x = -28
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "auU" = (
@@ -12123,7 +11903,6 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "auX" = (
@@ -12136,7 +11915,6 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "auY" = (
@@ -12178,8 +11956,8 @@
 /area/maintenance/fsmaint)
 "avd" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/lobby)
 "ave" = (
@@ -12219,8 +11997,8 @@
 /obj/item/seeds/chili,
 /obj/item/seeds/chili,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 8
 	},
 /area/security/permabrig)
 "avh" = (
@@ -12273,9 +12051,6 @@
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -12417,8 +12192,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/security/permabrig)
 "avs" = (
@@ -12483,9 +12258,9 @@
 "avz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -12499,19 +12274,12 @@
 /area/security/processing)
 "avA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "avB" = (
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/processing)
 "avC" = (
@@ -12700,10 +12468,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "avO" = (
@@ -12748,11 +12512,10 @@
 	network = list("SS13")
 	},
 /obj/machinery/photocopier,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "avR" = (
@@ -12762,16 +12525,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "avS" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "avT" = (
@@ -12782,10 +12543,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -12812,13 +12569,24 @@
 	dir = 4;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
+"avX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/prison/cell_block/A)
 "avY" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -12875,8 +12643,8 @@
 	req_access_txt = "63"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	icon_state = "airlock_unres_helper";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12923,7 +12691,6 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "awf" = (
@@ -12939,10 +12706,9 @@
 	req_access = null;
 	req_access_txt = "63"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/processing)
 "awg" = (
@@ -12977,8 +12743,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/processing)
 "awi" = (
@@ -12989,10 +12755,9 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "awj" = (
@@ -13009,7 +12774,6 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "awk" = (
@@ -13023,9 +12787,9 @@
 	req_access_txt = "13"
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -13036,8 +12800,8 @@
 "awm" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/pod_3)
 "awn" = (
@@ -13059,7 +12823,6 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "awo" = (
@@ -13071,17 +12834,17 @@
 /area/shuttle/syndicate_elite)
 "awp" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
+	tag = "icon-propulsion (NORTH)";
 	icon_state = "propulsion";
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "awq" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
+	tag = "icon-propulsion_r (NORTH)";
 	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
@@ -13094,9 +12857,9 @@
 /area/shuttle/syndicate_elite)
 "aws" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
+	tag = "icon-propulsion_l (NORTH)";
 	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
@@ -13109,17 +12872,17 @@
 /area/shuttle/syndicate_sit)
 "awu" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
+	tag = "icon-propulsion (NORTH)";
 	icon_state = "propulsion";
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "awv" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
+	tag = "icon-propulsion_r (NORTH)";
 	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
@@ -13132,9 +12895,9 @@
 /area/shuttle/syndicate_sit)
 "awx" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
+	tag = "icon-propulsion_l (NORTH)";
 	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
@@ -13170,13 +12933,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "awB" = (
@@ -13214,10 +12973,9 @@
 	pixel_x = 0;
 	pixel_y = -22
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "awD" = (
@@ -13235,6 +12993,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
+"awG" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/detectives_office)
 "awH" = (
 /obj/structure/table,
 /obj/item/dice/d20,
@@ -13324,8 +13087,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	icon_state = "airlock_unres_helper";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -13420,8 +13183,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/permabrig)
 "axa" = (
@@ -13446,8 +13209,8 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/permabrig)
 "axb" = (
@@ -13543,9 +13306,9 @@
 "axj" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
+	tag = "icon-heater (NORTH)";
 	icon_state = "heater";
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
@@ -13558,9 +13321,9 @@
 "axl" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
+	tag = "icon-heater (NORTH)";
 	icon_state = "heater";
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
@@ -13609,13 +13372,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "axq" = (
@@ -13633,14 +13396,10 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "axs" = (
@@ -13749,8 +13508,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/lobby)
 "axC" = (
@@ -13779,9 +13538,9 @@
 /area/security/evidence)
 "axD" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j1 (EAST)";
 	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -13908,7 +13667,6 @@
 /area/security/prison/cell_block/A)
 "axK" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkredcorners"
@@ -13940,10 +13698,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -13957,7 +13711,6 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redcorner"
@@ -13970,7 +13723,6 @@
 	req_access = null;
 	req_access_txt = "63"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
@@ -13983,8 +13735,6 @@
 	pixel_x = 0;
 	pixel_y = -28
 	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redcorner"
@@ -13997,7 +13747,6 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redcorner"
@@ -14011,7 +13760,6 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
@@ -14026,7 +13774,6 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "axU" = (
@@ -14050,7 +13797,6 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "axV" = (
@@ -14090,8 +13836,8 @@
 /area/maintenance/fsmaint)
 "axZ" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/lobby)
 "aya" = (
@@ -14164,8 +13910,8 @@
 "ayj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/lobby)
 "ayk" = (
@@ -14212,18 +13958,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/processing)
 "ayq" = (
 /obj/structure/table,
 /obj/item/taperecorder{
 	pixel_y = 0
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -14374,7 +14116,6 @@
 	},
 /obj/item/pen/multi,
 /obj/item/reagent_containers/food/drinks/flask/detflask,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -14480,23 +14221,18 @@
 	pixel_y = 0
 	},
 /obj/machinery/vending/coffee/free,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "ayI" = (
-/obj/structure/chair/comfy/red,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
+/obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "ayJ" = (
@@ -14527,8 +14263,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/lobby)
 "ayL" = (
@@ -14735,8 +14471,6 @@
 	},
 /area/security/prison/cell_block/A)
 "ayV" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "ayW" = (
@@ -14744,10 +14478,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -14787,10 +14517,6 @@
 /area/security/processing)
 "ayZ" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonershuttle)
 "aza" = (
@@ -14837,16 +14563,15 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/interrogation)
 "aze" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -14857,9 +14582,9 @@
 /area/shuttle/syndicate_elite)
 "azf" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/shuttle{
@@ -14975,8 +14700,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 5
 	},
 /area/security/permabrig)
 "azu" = (
@@ -14988,8 +14713,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/permabrig)
 "azv" = (
@@ -15051,8 +14776,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "azy" = (
@@ -15104,11 +14829,10 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "azB" = (
@@ -15122,14 +14846,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "azC" = (
@@ -15138,14 +14858,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "azD" = (
@@ -15161,8 +14877,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/lobby)
 "azF" = (
@@ -15179,8 +14895,8 @@
 /area/magistrateoffice)
 "azG" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster/official/random{
@@ -15249,8 +14965,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "azL" = (
@@ -15280,8 +14996,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "azO" = (
@@ -15303,8 +15019,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/lobby)
 "azQ" = (
@@ -15329,8 +15045,8 @@
 "azR" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/lobby)
 "azS" = (
@@ -15419,10 +15135,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15462,8 +15174,8 @@
 "aAe" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f5"
+	icon_state = "swall_f5";
+	dir = 2
 	},
 /area/shuttle/siberia)
 "aAf" = (
@@ -15490,8 +15202,8 @@
 "aAj" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/siberia)
 "aAk" = (
@@ -15530,9 +15242,9 @@
 /area/security/permabrig)
 "aAo" = (
 /obj/machinery/shower{
-	dir = 4;
+	tag = "icon-shower (EAST)";
 	icon_state = "shower";
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -15545,6 +15257,11 @@
 "aAq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/patriot,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/security/permabrig)
+"aAr" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -15593,8 +15310,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/security/permabrig)
 "aAw" = (
@@ -15620,8 +15337,8 @@
 /area/security/execution)
 "aAz" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/security/lobby)
 "aAA" = (
@@ -15673,17 +15390,10 @@
 /area/security/interrogation)
 "aAD" = (
 /obj/structure/closet/lawcloset,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aAE" = (
@@ -15704,8 +15414,8 @@
 	pixel_y = -5
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/light_switch{
 	pixel_x = -25;
@@ -15716,15 +15426,12 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aAF" = (
-/obj/structure/snow{
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "aAG" = (
@@ -15734,14 +15441,10 @@
 /obj/effect/landmark/start{
 	name = "Internal Affairs Agent"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aAH" = (
@@ -15750,14 +15453,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aAI" = (
@@ -15770,9 +15469,9 @@
 	},
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aAJ" = (
@@ -15784,9 +15483,9 @@
 /area/maintenance/fsmaint)
 "aAK" = (
 /obj/machinery/atmospherics/binary/valve/open{
-	dir = 4;
+	tag = "icon-map_valve1 (EAST)";
 	icon_state = "map_valve1";
-	tag = "icon-map_valve1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -15827,9 +15526,6 @@
 	name = "station intercom (General)";
 	pixel_x = 28;
 	pixel_y = 5
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
@@ -16044,17 +15740,17 @@
 /area/maintenance/abandonedbar)
 "aBd" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
+	tag = "icon-wooden_chair_wings (EAST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/abandonedbar)
 "aBe" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -16063,9 +15759,9 @@
 /area/maintenance/abandonedbar)
 "aBf" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
+	tag = "icon-wooden_chair_wings (EAST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar)
@@ -16250,14 +15946,14 @@
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	tag_airpump = "solar_tool_pump";
+	tag_exterior_door = "solar_tool_outer";
 	frequency = 1379;
 	id_tag = "solar_tool_airlock";
+	tag_interior_door = "solar_tool_inner";
 	pixel_x = 25;
 	req_access_txt = "13";
-	tag_airpump = "solar_tool_pump";
-	tag_chamber_sensor = "solar_tool_sensor";
-	tag_exterior_door = "solar_tool_outer";
-	tag_interior_door = "solar_tool_inner"
+	tag_chamber_sensor = "solar_tool_sensor"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -16294,9 +15990,9 @@
 "aBH" = (
 /obj/item/soap,
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -16423,8 +16119,8 @@
 "aBY" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aBZ" = (
@@ -16436,8 +16132,8 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/hallway/primary/fore)
 "aCb" = (
@@ -16464,9 +16160,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aCd" = (
@@ -16479,9 +16175,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aCe" = (
@@ -16500,14 +16196,10 @@
 	pixel_x = -25;
 	pixel_y = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aCf" = (
@@ -16520,9 +16212,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aCh" = (
@@ -16533,17 +16225,12 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/security_space_law,
 /obj/item/pen/multi/gold,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aCj" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/magistrate,
 /obj/item/paper_bin/nanotrasen,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aCk" = (
@@ -16560,14 +16247,10 @@
 /area/magistrateoffice)
 "aCl" = (
 /obj/structure/closet/secure_closet/magistrate,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aCm" = (
@@ -16584,7 +16267,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aCn" = (
@@ -16594,7 +16276,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aCo" = (
@@ -16642,8 +16323,8 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/prison/cell_block/A)
 "aCs" = (
@@ -16686,11 +16367,6 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "green"
@@ -16706,8 +16382,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aCw" = (
@@ -16724,8 +16400,8 @@
 /area/security/prison/cell_block/A)
 "aCx" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/hallway/primary/fore)
 "aCy" = (
@@ -16943,9 +16619,9 @@
 /area/maintenance/abandonedbar)
 "aCT" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -16988,9 +16664,9 @@
 /area/shuttle/syndicate_elite)
 "aCY" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -16999,12 +16675,12 @@
 "aCZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aDa" = (
@@ -17097,33 +16773,23 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aDi" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aDj" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aDk" = (
@@ -17162,8 +16828,8 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aDn" = (
@@ -17251,12 +16917,8 @@
 	track = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -17343,9 +17005,9 @@
 "aDE" = (
 /obj/item/seeds/ambrosia,
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/structure/toilet{
 	dir = 4
@@ -17454,11 +17116,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aDS" = (
@@ -17485,13 +17146,10 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/snow{
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aDV" = (
@@ -17550,7 +17208,6 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aEe" = (
@@ -17570,11 +17227,10 @@
 /area/shuttle/syndicate_sit)
 "aEg" = (
 /obj/structure/filingcabinet,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aEh" = (
@@ -17611,7 +17267,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aEl" = (
@@ -17639,9 +17294,6 @@
 	name = "Detective Privacy Shutters Control";
 	pixel_x = 25;
 	pixel_y = 25
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -17806,9 +17458,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -18073,8 +17722,8 @@
 /area/shuttle/syndicate_elite)
 "aFh" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18089,8 +17738,8 @@
 /area/shuttle/syndicate_sit)
 "aFj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18126,11 +17775,10 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aFn" = (
@@ -18148,11 +17796,10 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aFp" = (
@@ -18166,11 +17813,10 @@
 	dir = 5;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aFq" = (
@@ -18182,11 +17828,10 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aFr" = (
@@ -18203,22 +17848,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aFs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aFt" = (
@@ -18227,17 +17870,16 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aFu" = (
@@ -18294,8 +17936,8 @@
 /area/hallway/primary/fore)
 "aFy" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aFz" = (
@@ -18327,7 +17969,6 @@
 /obj/structure/table/wood,
 /obj/item/book/manual/security_space_law,
 /obj/item/clothing/glasses/sunglasses,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aFC" = (
@@ -18340,10 +17981,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -18358,10 +17995,6 @@
 /obj/item/ashtray/bronze,
 /obj/item/radio/intercom/department/security{
 	pixel_x = 28
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -18447,8 +18080,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -18612,8 +18245,8 @@
 "aGl" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	tag = "icon-wood-broken";
+	icon_state = "wood-broken"
 	},
 /area/maintenance/fpmaint)
 "aGm" = (
@@ -18631,8 +18264,8 @@
 "aGp" = (
 /obj/machinery/vending/coffee/free,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	tag = "icon-wood-broken6";
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/fpmaint)
 "aGq" = (
@@ -18654,8 +18287,8 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/crew_quarters/courtroom)
 "aGs" = (
@@ -18664,9 +18297,17 @@
 	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 8
 	},
+/area/crew_quarters/courtroom)
+"aGt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aGu" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -18694,10 +18335,6 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aGz" = (
@@ -18717,7 +18354,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aGA" = (
@@ -18742,13 +18378,6 @@
 	d2 = 8;
 	icon_state = "4-8";
 	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -18781,20 +18410,12 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/security/detectives_office)
 "aGF" = (
 /obj/machinery/computer/secure_data,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -18817,9 +18438,9 @@
 /area/maintenance/fsmaint)
 "aGH" = (
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -18896,6 +18517,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aGP" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /obj/machinery/camera{
 	c_tag = "Arcade";
 	dir = 2;
@@ -18904,9 +18528,6 @@
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
-	},
-/obj/structure/chair/comfy/red{
-	dir = 4
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -18917,7 +18538,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aGR" = (
-/obj/structure/chair/comfy/green{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -18960,8 +18581,8 @@
 	track = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -18970,10 +18591,6 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -19036,9 +18653,9 @@
 "aHd" = (
 /obj/item/toy/crayon/white,
 /obj/machinery/light/small{
-	dir = 8;
+	tag = "icon-bulb1 (WEST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -19099,8 +18716,8 @@
 "aHm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	tag = "icon-wood-broken7";
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/fpmaint2)
 "aHn" = (
@@ -19115,7 +18732,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aHp" = (
@@ -19169,8 +18785,8 @@
 	req_access_txt = "2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/crew_quarters/courtroom)
 "aHx" = (
@@ -19183,8 +18799,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/crew_quarters/courtroom)
 "aHy" = (
@@ -19193,13 +18809,9 @@
 	pixel_x = 0
 	},
 /obj/structure/window/reinforced,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/crew_quarters/courtroom)
 "aHz" = (
@@ -19281,8 +18893,8 @@
 "aHH" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aHI" = (
@@ -19371,17 +18983,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "aHX" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -19547,6 +19154,7 @@
 /turf/simulated/wall,
 /area/lawoffice)
 "aIp" = (
+/obj/structure/chair/comfy/black,
 /obj/effect/landmark/start{
 	name = "Civilian"
 	},
@@ -19558,7 +19166,6 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/structure/chair/comfy/green,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aIq" = (
@@ -19635,8 +19242,8 @@
 /area/maintenance/fpmaint2)
 "aIy" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	tag = "icon-wood-broken7";
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/fpmaint2)
 "aIz" = (
@@ -19665,8 +19272,8 @@
 /area/maintenance/auxsolarstarboard)
 "aIB" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -19717,8 +19324,8 @@
 /area/maintenance/fpmaint2)
 "aIH" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	tag = "icon-wood-broken3";
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/fpmaint2)
 "aII" = (
@@ -19737,8 +19344,8 @@
 /area/maintenance/fpmaint2)
 "aIL" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	tag = "icon-wood-broken6";
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/fpmaint2)
 "aIM" = (
@@ -19748,9 +19355,9 @@
 	req_access_txt = "74"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aIN" = (
@@ -19769,8 +19376,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -19778,9 +19385,6 @@
 /area/hallway/primary/fore)
 "aIP" = (
 /obj/structure/closet/secure_closet/clown,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = -17
-	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aIQ" = (
@@ -19831,10 +19435,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aIY" = (
@@ -19850,7 +19450,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aJa" = (
@@ -19864,8 +19463,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/crew_quarters/courtroom)
 "aJc" = (
@@ -19873,8 +19472,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/crew_quarters/courtroom)
 "aJd" = (
@@ -19889,8 +19488,8 @@
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aJf" = (
@@ -19912,14 +19511,14 @@
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	tag_airpump = "arrivals_pump";
+	tag_exterior_door = "arrivals_outer";
 	frequency = 1379;
 	id_tag = "arrivals_airlock";
+	tag_interior_door = "arrivals_inner";
 	pixel_x = 25;
 	req_access_txt = "13";
-	tag_airpump = "arrivals_pump";
-	tag_chamber_sensor = "arrivals_sensor";
-	tag_exterior_door = "arrivals_outer";
-	tag_interior_door = "arrivals_inner"
+	tag_chamber_sensor = "arrivals_sensor"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -19941,7 +19540,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aJj" = (
@@ -19971,7 +19569,6 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -19981,7 +19578,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -19994,18 +19590,17 @@
 /obj/item/camera_film,
 /obj/item/camera_film,
 /obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "detectives camera";
-	pictures_left = 30;
+	desc = "A one use - polaroid camera. 30 photos left.";
 	pixel_x = 0;
-	pixel_y = 0
+	pixel_y = 0;
+	pictures_left = 30
 	},
 /obj/machinery/requests_console{
 	name = "Detective Requests Console";
 	pixel_x = 0;
 	pixel_y = -30
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -20016,11 +19611,6 @@
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
-/obj/structure/snow,
-/obj/item/gift,
-/obj/item/toy/figure/detective,
-/obj/item/gun/projectile/revolver/capgun,
-/obj/item/lighter/zippo/engraved,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -20251,22 +19841,22 @@
 "aJP" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f6"
+	icon_state = "swall_f6";
+	dir = 2
 	},
 /area/shuttle/pod_1)
 "aJQ" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/pod_1)
 "aJR" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f6"
+	icon_state = "swall_f6";
+	dir = 2
 	},
 /area/shuttle/pod_2)
 "aJS" = (
@@ -20277,8 +19867,8 @@
 "aJT" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/pod_2)
 "aJU" = (
@@ -20300,8 +19890,8 @@
 /area/shuttle/pod_2)
 "aJW" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	tag = "icon-wood-broken3";
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/fpmaint)
 "aJX" = (
@@ -20344,8 +19934,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -20399,21 +19989,15 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aKk" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/megaphone,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aKl" = (
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aKm" = (
@@ -20435,23 +20019,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aKr" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/crew_quarters/courtroom)
 "aKs" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aKt" = (
@@ -20488,14 +20068,10 @@
 /area/crew_quarters/courtroom)
 "aKw" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aKx" = (
@@ -20512,11 +20088,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/magistrateoffice)
 "aKy" = (
@@ -20554,9 +20129,6 @@
 /obj/structure/closet/secure_closet/detective,
 /obj/item/restraints/handcuffs,
 /obj/item/flash,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -20606,8 +20178,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -20634,7 +20206,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aKI" = (
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -20733,8 +20305,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -20774,8 +20346,8 @@
 /area/maintenance/fsmaint2)
 "aLa" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/pod_1)
 "aLb" = (
@@ -20804,8 +20376,8 @@
 /area/hallway/secondary/entry)
 "aLe" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/pod_2)
 "aLf" = (
@@ -20840,7 +20412,6 @@
 	req_access = null;
 	req_access_txt = "4"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -20918,8 +20489,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	tag = "icon-wood-broken3";
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/fpmaint2)
 "aLo" = (
@@ -21076,10 +20647,6 @@
 /area/maintenance/fpmaint)
 "aLE" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aLF" = (
@@ -21122,8 +20689,8 @@
 /area/maintenance/fpmaint)
 "aLL" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	tag = "icon-wood-broken7";
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/fpmaint)
 "aLM" = (
@@ -21137,22 +20704,20 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom ";
 	dir = 4;
 	network = list("SS13")
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aLO" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
 /obj/item/gavelhammer,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aLP" = (
@@ -21169,20 +20734,17 @@
 	pixel_y = 0;
 	req_one_access_txt = "74;3"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aLR" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aLS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aLT" = (
@@ -21293,8 +20855,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "aMa" = (
@@ -21653,9 +21215,9 @@
 /obj/item/pen,
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/lawoffice)
 "aMP" = (
@@ -21728,10 +21290,6 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aNb" = (
@@ -21742,7 +21300,6 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle{
 	pixel_x = 5
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aNc" = (
@@ -21767,7 +21324,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aNf" = (
@@ -21839,7 +21395,6 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aNm" = (
@@ -21865,20 +21420,16 @@
 "aNp" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aNq" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/bluegrid,
 /area/maintenance/electrical)
@@ -22076,15 +21627,15 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aNM" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -22119,8 +21670,8 @@
 "aNQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aNR" = (
@@ -22187,8 +21738,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "aNW" = (
@@ -22216,9 +21767,6 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -22414,6 +21962,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"aOu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/courtroom)
 "aOv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Courtroom Maintenance";
@@ -22442,10 +21999,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aOx" = (
@@ -22460,7 +22013,6 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aOy" = (
@@ -22468,10 +22020,6 @@
 /obj/item/folder/red,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -22597,10 +22145,6 @@
 	name = "Courtroom Privacy Shutters";
 	opacity = 0
 	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aOP" = (
@@ -22643,10 +22187,6 @@
 /area/maintenance/fpmaint2)
 "aOV" = (
 /obj/structure/computerframe,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aOW" = (
@@ -22791,8 +22331,8 @@
 "aPk" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aPm" = (
@@ -22801,8 +22341,8 @@
 "aPn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aPs" = (
@@ -22852,10 +22392,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aPz" = (
@@ -22865,7 +22401,6 @@
 	icon_state = "1-4";
 	tag = "90Curve"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aPA" = (
@@ -22892,8 +22427,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/crew_quarters/courtroom)
 "aPD" = (
@@ -23059,9 +22594,9 @@
 /area/hallway/secondary/entry)
 "aPS" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -23167,8 +22702,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
@@ -23204,8 +22739,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQl" = (
@@ -23223,8 +22758,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQn" = (
@@ -23238,8 +22773,8 @@
 	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQo" = (
@@ -23252,15 +22787,15 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQp" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQq" = (
@@ -23268,8 +22803,8 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQr" = (
@@ -23286,8 +22821,8 @@
 /obj/structure/table,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQs" = (
@@ -23313,8 +22848,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQu" = (
@@ -23326,15 +22861,15 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQv" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding1 (NORTH)";
 	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQw" = (
@@ -23354,8 +22889,8 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQy" = (
@@ -23366,17 +22901,17 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 5
 	},
 /area/hallway/secondary/entry)
 "aQz" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding1 (NORTH)";
 	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQA" = (
@@ -23386,9 +22921,9 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding1 (NORTH)";
 	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQB" = (
@@ -23401,9 +22936,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding1 (NORTH)";
 	icon_state = "bluered";
-	tag = "icon-siding1 (NORTH)"
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQC" = (
@@ -23442,8 +22977,8 @@
 	req_access_txt = "0"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQG" = (
@@ -23455,15 +22990,15 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aQI" = (
@@ -23784,8 +23319,8 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f5"
+	icon_state = "swall_f5";
+	dir = 2
 	},
 /area/shuttle/pod_1)
 "aRn" = (
@@ -23921,8 +23456,8 @@
 /area/ai_monitored/storage/eva)
 "aRx" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "aRy" = (
@@ -23935,8 +23470,8 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/pod_1)
 "aRA" = (
@@ -24027,10 +23562,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "aRI" = (
@@ -24071,17 +23606,17 @@
 /area/maintenance/fsmaint2)
 "aRL" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_x = 0;
 	pixel_y = 24
-	},
-/obj/structure/chair/comfy/red{
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -24101,7 +23636,7 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/structure/chair/comfy/green{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
@@ -24133,10 +23668,6 @@
 /area/crew_quarters/courtroom)
 "aRR" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aRS" = (
@@ -24164,14 +23695,14 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f5"
+	icon_state = "swall_f5";
+	dir = 2
 	},
 /area/shuttle/pod_2)
 "aRW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -24191,8 +23722,8 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/pod_2)
 "aRZ" = (
@@ -24285,8 +23816,8 @@
 "aSk" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aSl" = (
@@ -24364,16 +23895,16 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aSw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -24580,8 +24111,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aSS" = (
@@ -24614,7 +24145,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "aSW" = (
-/obj/structure/chair/comfy/green,
+/obj/structure/chair/comfy/beige,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -24642,8 +24173,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aTa" = (
@@ -24655,8 +24186,8 @@
 /area/hallway/primary/central/ne)
 "aTb" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aTc" = (
@@ -24666,8 +24197,8 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aTd" = (
@@ -24677,8 +24208,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aTe" = (
@@ -24719,23 +24250,23 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "aTj" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aTk" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -24749,8 +24280,8 @@
 /area/maintenance/electrical)
 "aTm" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -24788,10 +24319,10 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "aTr" = (
@@ -24834,8 +24365,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 1
 	},
 /area/gateway)
 "aTw" = (
@@ -24851,8 +24382,8 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 4
 	},
 /area/gateway)
 "aTy" = (
@@ -24860,8 +24391,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/gateway)
 "aTz" = (
@@ -24924,8 +24455,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aTE" = (
@@ -24946,8 +24477,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "aTG" = (
@@ -24991,24 +24522,24 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 6
 	},
 /area/security/nuke_storage)
 "aTL" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "aTM" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	dir = 4
 	},
 /area/medical/reception)
 "aTN" = (
@@ -25086,7 +24617,10 @@
 "aTS" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
-/obj/structure/snow,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whiteblue";
@@ -25094,22 +24628,22 @@
 	},
 /area/medical/reception)
 "aTT" = (
-/obj/structure/table,
-/obj/structure/snow,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whiteblue (NORTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/reception)
 "aTU" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/britcup,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTV" = (
@@ -25119,31 +24653,24 @@
 /obj/item/radio/intercom/department/medbay{
 	pixel_y = 25
 	},
-/obj/structure/table,
-/obj/item/storage/box/cups{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/structure/chair/comfy/teal{
+	dir = 4
 	},
-/obj/item/roller,
-/obj/structure/snow,
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTW" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 28;
-	req_access_txt = "0"
+/obj/structure/chair/comfy/teal{
+	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTX" = (
@@ -25155,19 +24682,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aTY" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
-/obj/structure/chair/comfy/green{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aTZ" = (
@@ -25222,8 +24745,8 @@
 /area/maintenance/electrical)
 "aUg" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/smes{
 	charge = 0
@@ -25232,8 +24755,8 @@
 /area/maintenance/electrical)
 "aUh" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -25364,8 +24887,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aUx" = (
@@ -25404,9 +24927,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
-	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aUB" = (
@@ -25429,8 +24949,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/gateway)
 "aUD" = (
@@ -25438,8 +24958,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/gateway)
 "aUE" = (
@@ -25501,9 +25021,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aUM" = (
@@ -25534,9 +25054,9 @@
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whiteblue (NORTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/reception)
 "aUP" = (
@@ -25551,13 +25071,9 @@
 	},
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "aUQ" = (
@@ -25579,12 +25095,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/assistant,
-/obj/item/toy/syndicateballoon,
-/obj/item/toy/sword,
-/obj/item/nanomob_card,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25596,8 +25106,8 @@
 /area/maintenance/fsmaint2)
 "aUV" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -25706,8 +25216,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/security/nuke_storage)
 "aVl" = (
@@ -25722,8 +25232,8 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 10
 	},
 /area/security/nuke_storage)
 "aVm" = (
@@ -25758,8 +25268,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/security/nuke_storage)
 "aVo" = (
@@ -25771,7 +25281,6 @@
 	},
 /obj/structure/table/wood,
 /obj/item/instrument/eguitar,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25780,7 +25289,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/snow,
+/obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25804,8 +25313,8 @@
 	name = "JoinLateGateway"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/gateway)
 "aVs" = (
@@ -25815,8 +25324,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
+/obj/structure/table/wood,
+/obj/item/instrument/piano_synth,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25857,8 +25366,8 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory East";
@@ -25866,8 +25375,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aVx" = (
@@ -25878,9 +25387,9 @@
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whiteblue (NORTHEAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	dir = 5
 	},
 /area/medical/reception)
 "aVy" = (
@@ -26017,7 +25526,6 @@
 /area/maintenance/fpmaint)
 "aVG" = (
 /obj/machinery/vending/coffee,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aVH" = (
@@ -26159,8 +25667,8 @@
 /area/ai_monitored/storage/eva)
 "aVS" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall12"
+	icon_state = "swall12";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aVT" = (
@@ -26185,17 +25693,17 @@
 "aVV" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f6";
 	icon_state = "swall_f6";
-	tag = "icon-swall_f6"
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aVW" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f10";
 	icon_state = "swall_f10";
-	tag = "icon-swall_f10"
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aVX" = (
@@ -26218,8 +25726,8 @@
 /area/shuttle/arrival/station)
 "aWa" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall14"
+	icon_state = "swall14";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aWb" = (
@@ -26243,8 +25751,8 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/checkpoint2)
 "aWd" = (
@@ -26257,8 +25765,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 9
 	},
 /area/security/checkpoint2)
 "aWe" = (
@@ -26284,13 +25792,9 @@
 /obj/machinery/computer/security{
 	network = list("SS13","Research Outpost","Mining Outpost")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/checkpoint2)
 "aWg" = (
@@ -26310,17 +25814,13 @@
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
 	department = "Security";
-	departmentType = 5;
 	name = "Security Requests Console";
+	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/checkpoint2)
 "aWi" = (
@@ -26433,8 +25933,8 @@
 /area/storage/primary)
 "aWs" = (
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 6
 	},
 /area/security/nuke_storage)
 "aWt" = (
@@ -26443,14 +25943,14 @@
 /area/storage/primary)
 "aWu" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 1
 	},
 /area/security/nuke_storage)
 "aWv" = (
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 10
 	},
 /area/security/nuke_storage)
 "aWw" = (
@@ -26464,14 +25964,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/security/nuke_storage)
 "aWx" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/nuke_storage)
 "aWy" = (
@@ -26532,8 +26032,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aWC" = (
@@ -26619,9 +26119,9 @@
 /area/crew_quarters/dorms)
 "aWN" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -26655,8 +26155,8 @@
 "aWP" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "aWQ" = (
@@ -26693,13 +26193,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
+"aWT" = (
+/turf/simulated/floor/plasteel{
+	tag = "icon-vault";
+	icon_state = "vault"
+	},
+/area/crew_quarters/dorms)
 "aWU" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26714,7 +26217,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26794,9 +26296,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aXd" = (
@@ -26811,9 +26313,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/maintenance/fsmaint2)
 "aXe" = (
@@ -26821,9 +26323,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aXf" = (
@@ -26844,9 +26346,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aXh" = (
@@ -26863,10 +26365,10 @@
 /area/chapel/main)
 "aXi" = (
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "aXj" = (
@@ -26880,9 +26382,9 @@
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aXk" = (
@@ -26890,9 +26392,9 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aXl" = (
@@ -26906,8 +26408,8 @@
 /area/chapel/main)
 "aXm" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall11"
+	icon_state = "swall11";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aXn" = (
@@ -26926,15 +26428,15 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aXp" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall7"
+	icon_state = "swall7";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aXq" = (
@@ -27024,8 +26526,8 @@
 /obj/item/crowbar,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 8
 	},
 /area/security/checkpoint2)
 "aXC" = (
@@ -27046,8 +26548,8 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/security/checkpoint2)
 "aXF" = (
@@ -27137,9 +26639,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "aXN" = (
@@ -27177,8 +26676,8 @@
 	},
 /obj/item/storage/belt/champion,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 1
 	},
 /area/security/nuke_storage)
 "aXP" = (
@@ -27220,8 +26719,8 @@
 	name = "Silver Crate"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/nuke_storage)
 "aXU" = (
@@ -27236,10 +26735,10 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "aXV" = (
@@ -27249,10 +26748,10 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "aXW" = (
@@ -27345,18 +26844,12 @@
 /area/crew_quarters/bar)
 "aYf" = (
 /obj/machinery/computer/card,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "green"
 	},
 /area/bridge)
 "aYg" = (
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "greencorner"
@@ -27392,9 +26885,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -27449,8 +26939,8 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/security/armoury)
 "aYn" = (
@@ -27460,9 +26950,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/office)
@@ -27502,9 +26989,6 @@
 /obj/structure/closet/wardrobe/coroner,
 /obj/item/reagent_containers/glass/bottle/reagent/formaldehyde,
 /obj/item/reagent_containers/dropper,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27609,9 +27093,9 @@
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/chapel/office)
 "aYy" = (
@@ -27632,15 +27116,15 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/chapel/main)
 "aYA" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/chapel/main)
 "aYB" = (
@@ -27661,8 +27145,8 @@
 "aYD" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f6"
+	icon_state = "swall_f6";
+	dir = 2
 	},
 /area/shuttle/escape)
 "aYE" = (
@@ -27750,14 +27234,14 @@
 "aYM" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aYN" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "aYO" = (
@@ -27800,8 +27284,8 @@
 /area/shuttle/escape)
 "aYV" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
+	icon_state = "heater";
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27883,8 +27367,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 6
 	},
 /area/security/checkpoint2)
 "aZc" = (
@@ -27914,8 +27398,8 @@
 "aZe" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/item/stack/cable_coil{
 	pixel_x = 2;
@@ -27960,8 +27444,8 @@
 "aZi" = (
 /mob/living/simple_animal/mouse/brown/Tom,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 6
 	},
 /area/security/nuke_storage)
 "aZj" = (
@@ -27981,8 +27465,8 @@
 "aZk" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 1
 	},
 /area/security/nuke_storage)
 "aZl" = (
@@ -27994,8 +27478,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/chapel/main)
 "aZm" = (
@@ -28018,8 +27502,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 10
 	},
 /area/security/nuke_storage)
 "aZp" = (
@@ -28052,8 +27536,8 @@
 	amount = 100000
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/nuke_storage)
 "aZr" = (
@@ -28066,8 +27550,8 @@
 /area/storage/primary)
 "aZs" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "aZt" = (
@@ -28075,9 +27559,6 @@
 /area/crew_quarters/dorms)
 "aZu" = (
 /obj/machinery/hologram/holopad,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/dorms)
 "aZv" = (
@@ -28119,9 +27600,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "arrival"
@@ -28135,10 +27613,6 @@
 /area/crew_quarters/dorms)
 "aZB" = (
 /obj/machinery/computer/card/minor/ce,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -28152,6 +27626,9 @@
 /area/crew_quarters/dorms)
 "aZD" = (
 /obj/effect/decal/warning_stripes/white,
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -28177,10 +27654,6 @@
 	},
 /area/chapel/main)
 "aZG" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -28199,8 +27672,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "aZJ" = (
@@ -28225,10 +27698,10 @@
 /obj/item/paper_bin,
 /obj/item/toy/crayon/mime,
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "aZM" = (
@@ -28237,10 +27710,10 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "aZN" = (
@@ -28308,6 +27781,10 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
+"aZV" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "aZW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -28341,8 +27818,8 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/security/checkpoint2)
 "aZZ" = (
@@ -28574,8 +28051,8 @@
 /area/library)
 "bay" = (
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/chapel/main)
 "baz" = (
@@ -28584,12 +28061,9 @@
 "baA" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/candle_box/full,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/chapel/main)
 "baB" = (
@@ -28886,9 +28360,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -28931,8 +28405,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/security/nuke_storage)
 "bbg" = (
@@ -28981,8 +28455,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "bbj" = (
@@ -29056,9 +28530,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j1 (EAST)";
 	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -29101,8 +28575,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bby" = (
@@ -29146,26 +28620,23 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "bbB" = (
 /obj/structure/closet/secure_closet/mime,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = 19
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "bbC" = (
@@ -29203,10 +28674,10 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "bbE" = (
@@ -29426,8 +28897,8 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "bca" = (
@@ -29439,8 +28910,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "bcb" = (
@@ -29526,9 +28997,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "bcj" = (
@@ -29599,9 +29067,6 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -29609,16 +29074,13 @@
 "bcr" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "bcs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -29701,6 +29163,11 @@
 	icon_state = "arrival"
 	},
 /area/crew_quarters/dorms)
+"bcz" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "bcA" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -29725,9 +29192,6 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -29736,9 +29200,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
 	pixel_y = 30
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -29770,8 +29231,8 @@
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/chapel/main)
 "bcG" = (
@@ -29867,8 +29328,8 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -29977,8 +29438,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/hallway/primary/port)
 "bda" = (
@@ -30086,8 +29547,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bdn" = (
@@ -30142,10 +29603,10 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "bdt" = (
@@ -30156,17 +29617,17 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "bdu" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 8
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -30179,9 +29640,9 @@
 /area/hallway/primary/central/north)
 "bdw" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/item/flag/nt,
 /obj/machinery/power/apc{
@@ -30202,12 +29663,12 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -30274,9 +29735,9 @@
 /area/hallway/primary/central/north)
 "bdE" = (
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/tank/emergency_oxygen,
@@ -30337,12 +29798,6 @@
 	pixel_y = 25
 	},
 /obj/structure/closet/chefcloset,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -30399,8 +29854,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bdO" = (
@@ -30448,8 +29903,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bdR" = (
@@ -30473,8 +29928,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bdT" = (
@@ -30511,9 +29966,9 @@
 "bdW" = (
 /obj/structure/table,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/reagentgrinder,
 /obj/machinery/power/apc{
@@ -30698,9 +30153,9 @@
 "beh" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f5";
 	icon_state = "swall_f5";
-	tag = "icon-swall_f5"
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "bei" = (
@@ -30713,8 +30168,8 @@
 /area/hydroponics)
 "bej" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall13"
+	icon_state = "swall13";
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "bek" = (
@@ -30783,9 +30238,6 @@
 	},
 /obj/effect/landmark/start{
 	name = "Chaplain"
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
@@ -30876,7 +30328,7 @@
 	},
 /area/crew_quarters/toilet)
 "beF" = (
-/obj/structure/chair/comfy/green{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -30975,8 +30427,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 5
 	},
 /area/hallway/primary/port)
 "beP" = (
@@ -31061,8 +30513,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "beX" = (
@@ -31091,21 +30543,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "beZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfa" = (
@@ -31115,10 +30567,10 @@
 	req_access_txt = "46"
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "tranquillite";
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_plating = "plating"
 	},
 /area/mimeoffice)
 "bfb" = (
@@ -31138,8 +30590,8 @@
 	srange = 7
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfc" = (
@@ -31164,8 +30616,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfe" = (
@@ -31220,8 +30672,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfj" = (
@@ -31240,15 +30692,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfk" = (
 /obj/machinery/requests_console{
 	department = "Bar";
-	departmentType = 2;
 	name = "Bar Requests Console";
+	departmentType = 2;
 	pixel_x = 0;
 	pixel_y = 30
 	},
@@ -31259,11 +30711,11 @@
 	},
 /area/crew_quarters/bar)
 "bfl" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/structure/chair/comfy/red{
-	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -31297,9 +30749,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j1 (EAST)";
 	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -31307,9 +30759,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -31330,8 +30782,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfr" = (
@@ -31354,8 +30806,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfs" = (
@@ -31403,8 +30855,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfw" = (
@@ -31437,8 +30889,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfy" = (
@@ -31454,8 +30906,8 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfz" = (
@@ -31471,8 +30923,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bfA" = (
@@ -31491,9 +30943,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
-	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "bfB" = (
@@ -31504,7 +30953,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -31520,9 +30968,6 @@
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -31545,9 +30990,6 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -31658,9 +31100,6 @@
 	icon_state = "1-8";
 	tag = ""
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -31761,10 +31200,6 @@
 	pixel_x = -24;
 	shock_proof = 0
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -31786,10 +31221,6 @@
 	pixel_y = 10
 	},
 /obj/item/eftpos,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bgb" = (
@@ -31821,9 +31252,9 @@
 "bge" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f9";
 	icon_state = "swall_f9";
-	tag = "icon-swall_f9"
+	dir = 2
 	},
 /area/shuttle/arrival/station)
 "bgf" = (
@@ -32053,8 +31484,8 @@
 /area/hallway/secondary/entry)
 "bgH" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 0;
@@ -32098,8 +31529,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 4
 	},
 /area/gateway)
 "bgL" = (
@@ -32113,8 +31544,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 1
 	},
 /area/gateway)
 "bgM" = (
@@ -32129,8 +31560,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 8
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -32244,8 +31675,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "bgY" = (
@@ -32264,8 +31695,8 @@
 "bgZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bha" = (
@@ -32294,27 +31725,27 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bhf" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "bhg" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/hallway/primary/central/ne)
 "bhh" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/hallway/primary/central/north)
 "bhi" = (
@@ -32443,11 +31874,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bhv" = (
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/beige{
 	dir = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -32501,15 +31929,10 @@
 /area/storage/office)
 "bhA" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/snow,
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bhB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bhC" = (
@@ -32540,8 +31963,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/hallway/secondary/entry)
 "bhF" = (
@@ -32756,10 +32179,6 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -32771,10 +32190,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -32807,9 +32222,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "bib" = (
@@ -32822,8 +32234,8 @@
 /area/hydroponics)
 "bic" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bid" = (
@@ -32859,9 +32271,6 @@
 	tag = ""
 	},
 /obj/structure/closet/secure_closet/hydroponics,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -32899,8 +32308,8 @@
 "bim" = (
 /obj/machinery/status_display,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall12"
+	icon_state = "swall12";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bin" = (
@@ -32926,10 +32335,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -32973,7 +32378,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -32998,7 +32402,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bis" = (
@@ -33008,10 +32411,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -33043,7 +32442,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -33052,7 +32450,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -33064,7 +32461,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -33081,8 +32477,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
+	icon_state = "neutral";
+	dir = 8
 	},
 /area/hallway/secondary/entry)
 "biB" = (
@@ -33236,8 +32632,8 @@
 	pixel_y = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
@@ -33314,8 +32710,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -33343,10 +32737,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -33361,8 +32751,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "biX" = (
@@ -33395,10 +32785,6 @@
 	initialize_directions = 10;
 	level = 1
 	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -33419,8 +32805,8 @@
 /area/crew_quarters/bar)
 "bja" = (
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -33467,8 +32853,8 @@
 /area/crew_quarters/bar)
 "bjd" = (
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -33489,9 +32875,6 @@
 /area/clownoffice)
 "bjf" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bjg" = (
@@ -33602,7 +32985,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -33678,8 +33060,8 @@
 /area/hydroponics)
 "bjC" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall12"
+	icon_state = "swall12";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bjD" = (
@@ -33698,8 +33080,8 @@
 /area/library)
 "bjG" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall13"
+	icon_state = "swall13";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bjI" = (
@@ -33941,9 +33323,9 @@
 /area/hallway/primary/port)
 "bkh" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -34006,9 +33388,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -34115,7 +33494,6 @@
 /area/hallway/primary/central/nw)
 "bkx" = (
 /obj/machinery/door/firedoor,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bky" = (
@@ -34299,9 +33677,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "bkM" = (
@@ -34417,9 +33792,9 @@
 	name = "Forbidden Knowledge"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/library)
 "bkY" = (
@@ -34444,9 +33819,9 @@
 /obj/item/stack/tape_roll,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/library)
 "bla" = (
@@ -34472,12 +33847,12 @@
 	},
 /area/hydroponics)
 "bld" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/structure/chair/comfy/green{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -34492,8 +33867,8 @@
 /area/hydroponics)
 "blf" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -34527,8 +33902,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
+	icon_state = "neutral";
+	dir = 8
 	},
 /area/hallway/secondary/entry)
 "bli" = (
@@ -34641,13 +34016,13 @@
 	},
 /area/shuttle/escape)
 "blw" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /obj/item/radio/intercom{
 	frequency = 1459;
 	name = "station intercom (General)";
 	pixel_x = -28
-	},
-/obj/structure/chair/comfy/red{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -34680,8 +34055,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
 "blB" = (
@@ -34871,8 +34246,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -34910,8 +34285,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -34936,8 +34311,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
@@ -34962,12 +34337,12 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
@@ -35092,11 +34467,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "bmo" = (
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/beige{
 	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -35212,9 +34584,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bmA" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -35255,9 +34624,9 @@
 "bmE" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/library)
 "bmF" = (
@@ -35266,9 +34635,9 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/library)
 "bmG" = (
@@ -35279,9 +34648,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/library)
 "bmH" = (
@@ -35289,6 +34658,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bmI" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -35298,9 +34670,6 @@
 	name = "west bump";
 	pixel_x = -24;
 	shock_proof = 0
-	},
-/obj/structure/chair/comfy/green{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -35344,6 +34713,12 @@
 	icon_state = "darkred"
 	},
 /area/hallway/secondary/exit)
+"bmM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "bmN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -35516,7 +34891,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/southeastcorner,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnh" = (
@@ -35718,22 +35092,14 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnB" = (
 /obj/machinery/vending/cola,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnC" = (
 /obj/machinery/vending/artvend,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnD" = (
@@ -35751,15 +35117,10 @@
 /area/civilian/pet_store)
 "bnF" = (
 /obj/machinery/vending/clothing,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnG" = (
 /obj/machinery/vending/autodrobe,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnH" = (
@@ -35831,11 +35192,6 @@
 /area/crew_quarters/bar)
 "bnR" = (
 /obj/machinery/computer/atmos_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "yellow"
@@ -35856,7 +35212,6 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/ids,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bnV" = (
@@ -35864,15 +35219,10 @@
 	name = "Bridge Power Monitoring Computer"
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "yellow"
@@ -35880,11 +35230,6 @@
 /area/bridge)
 "bnW" = (
 /obj/machinery/computer/station_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "yellow"
@@ -35892,11 +35237,6 @@
 /area/bridge)
 "bnX" = (
 /obj/machinery/computer/communications,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
@@ -35904,11 +35244,6 @@
 /area/bridge)
 "bnY" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "blue"
@@ -35927,11 +35262,6 @@
 /area/hallway/secondary/exit)
 "boa" = (
 /obj/machinery/computer/shuttle/mining,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "blue"
@@ -35996,7 +35326,6 @@
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
-/obj/item/reagent_containers/food/snacks/candy/candycane,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -36010,7 +35339,6 @@
 /obj/item/assembly/timer,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "boi" = (
@@ -36019,9 +35347,6 @@
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -36037,8 +35362,8 @@
 	},
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "bok" = (
@@ -36161,8 +35486,8 @@
 "bou" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -36183,15 +35508,14 @@
 "bow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hydroponics)
 "box" = (
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "boy" = (
@@ -36201,9 +35525,9 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/library)
 "boz" = (
@@ -36329,7 +35653,6 @@
 /area/crew_quarters/bar)
 "boN" = (
 /obj/machinery/gibber,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -36342,7 +35665,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -36367,7 +35689,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -36384,7 +35705,6 @@
 /area/hallway/secondary/entry)
 "boS" = (
 /obj/structure/closet/crate/freezer,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -36483,7 +35803,6 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bpe" = (
@@ -36503,11 +35822,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j1 (EAST)";
 	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bph" = (
@@ -36617,8 +35935,6 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
 "bpo" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -36647,7 +35963,6 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -36657,7 +35972,6 @@
 /obj/structure/table/reinforced,
 /obj/item/flash,
 /obj/item/flash,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bps" = (
@@ -36675,7 +35989,6 @@
 	pixel_x = 29;
 	pixel_y = 8
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bpt" = (
@@ -36689,10 +36002,9 @@
 /obj/item/book/manual/sop_command,
 /obj/item/aicard,
 /obj/item/multitool,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/bridge)
 "bpv" = (
@@ -36717,10 +36029,9 @@
 /area/hallway/primary/central/north)
 "bpw" = (
 /obj/structure/table/reinforced,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/bridge)
 "bpx" = (
@@ -36731,7 +36042,6 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "greencorner"
@@ -36777,7 +36087,6 @@
 "bpB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bpC" = (
@@ -36898,7 +36207,6 @@
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
-/obj/item/reagent_containers/food/snacks/candy/cotton/bad_rainbow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -36922,8 +36230,8 @@
 /area/chapel/main)
 "bpQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -36955,9 +36263,6 @@
 /area/crew_quarters/kitchen)
 "bpT" = (
 /obj/machinery/hologram/holopad,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "bpU" = (
@@ -37083,12 +36388,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bqi" = (
 /obj/structure/table/wood,
-/obj/item/clothing/head/cakehat,
+/obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bqj" = (
@@ -37102,12 +36406,9 @@
 /area/maintenance/fsmaint2)
 "bqk" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (WEST)"
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -37163,9 +36464,9 @@
 /area/shuttle/escape)
 "bqp" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall7";
 	icon_state = "swall7";
-	tag = "icon-swall7"
+	dir = 2
 	},
 /area/shuttle/escape)
 "bqq" = (
@@ -37208,15 +36509,26 @@
 /area/maintenance/fpmaint2)
 "bqu" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"bqv" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bqw" = (
-/obj/structure/snow,
-/obj/item/a_gift,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"bqx" = (
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bqy" = (
@@ -37265,10 +36577,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -37323,9 +36631,6 @@
 	},
 /area/hydroponics)
 "bqJ" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
 "bqK" = (
@@ -37361,10 +36666,6 @@
 	req_access = null;
 	req_access_txt = "2"
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -37375,11 +36676,6 @@
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -37394,14 +36690,6 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "red"
@@ -37412,7 +36700,9 @@
 /obj/machinery/recharger{
 	pixel_y = 0
 	},
-/obj/structure/snow,
+/turf/simulated/floor/plasteel,
+/area/bridge)
+"bqS" = (
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bqT" = (
@@ -37423,20 +36713,12 @@
 	},
 /area/chapel/main)
 "bqU" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluecorner"
 	},
 /area/bridge)
 "bqV" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -37456,22 +36738,15 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bqY" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bqZ" = (
 /obj/machinery/computer/shuttle/mining,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "brown"
@@ -37479,15 +36754,10 @@
 /area/bridge)
 "bra" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/computer/security/mining,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "brown"
@@ -37504,11 +36774,6 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "brown"
@@ -37541,8 +36806,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/hallway/secondary/entry)
 "brf" = (
@@ -37556,19 +36821,30 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/obj/machinery/gameboard,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brg" = (
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (WEST)";
+	icon_state = "wooden_chair_wings";
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Civilian"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brh" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/table/wood,
+/obj/item/taperecorder{
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"bri" = (
+/obj/structure/table/wood,
+/obj/item/dice/d20,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brj" = (
@@ -37595,8 +36871,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
+	icon_state = "neutral";
+	dir = 1
 	},
 /area/hallway/secondary/entry)
 "brl" = (
@@ -37607,8 +36883,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
+	icon_state = "neutral";
+	dir = 1
 	},
 /area/hallway/secondary/entry)
 "brm" = (
@@ -37634,8 +36910,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
+	icon_state = "neutral";
+	dir = 1
 	},
 /area/hallway/secondary/entry)
 "bro" = (
@@ -37655,8 +36931,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/hallway/secondary/entry)
 "brq" = (
@@ -37666,8 +36942,8 @@
 /area/hallway/primary/central/nw)
 "brr" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 8
 	},
 /area/hydroponics)
 "brs" = (
@@ -37687,8 +36963,8 @@
 /area/hydroponics)
 "bru" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hydroponics)
 "brv" = (
@@ -37698,7 +36974,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "brw" = (
@@ -37713,7 +36988,7 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bry" = (
-/obj/structure/chair/comfy/red,
+/obj/structure/chair/comfy/black,
 /turf/simulated/floor/wood,
 /area/library)
 "brz" = (
@@ -37792,6 +37067,7 @@
 /area/library)
 "brH" = (
 /obj/structure/table/wood,
+/obj/item/clothing/head/cakehat,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brI" = (
@@ -37851,15 +37127,15 @@
 /area/crew_quarters/locker)
 "brO" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall12"
+	icon_state = "swall12";
+	dir = 2
 	},
 /area/shuttle/transport)
 "brP" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/transport)
 "brQ" = (
@@ -37874,11 +37150,6 @@
 /area/shuttle/transport)
 "brS" = (
 /obj/machinery/computer/crew,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "green"
@@ -37935,8 +37206,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hydroponics)
 "bsa" = (
@@ -38001,8 +37272,11 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bsg" = (
-/obj/structure/flora/tree/pine/xmas,
-/obj/structure/snow,
+/obj/structure/table,
+/obj/item/clothing/head/soft/grey{
+	pixel_x = -2;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bsh" = (
@@ -38107,26 +37381,22 @@
 "bsu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
 "bsv" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 1
 	},
 /area/bridge)
 "bsw" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/bridge)
 "bsx" = (
@@ -38136,10 +37406,6 @@
 "bsy" = (
 /obj/effect/landmark{
 	name = "Marauder Entry"
-	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -38157,7 +37423,6 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bsA" = (
@@ -38170,15 +37435,10 @@
 /obj/effect/landmark{
 	name = "Marauder Entry"
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bsB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bsC" = (
@@ -38194,7 +37454,6 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bsD" = (
@@ -38207,7 +37466,6 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "browncorner";
@@ -38221,21 +37479,13 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bsG" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-browncorner (EAST)";
 	icon_state = "browncorner";
-	tag = "icon-browncorner (EAST)"
+	dir = 4
 	},
 /area/bridge)
 "bsH" = (
@@ -38247,10 +37497,6 @@
 	},
 /obj/structure/chair{
 	dir = 1
-	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -38349,8 +37595,8 @@
 	},
 /obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "bsT" = (
@@ -38378,8 +37624,8 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "bsV" = (
@@ -38392,8 +37638,8 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "bsW" = (
@@ -38412,8 +37658,8 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "bsY" = (
@@ -38483,21 +37729,35 @@
 /turf/simulated/wall,
 /area/hallway/primary/starboard/east)
 "btf" = (
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (EAST)";
+	icon_state = "wooden_chair_wings";
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/landmark/start{
+	name = "Civilian"
 	},
-/area/hallway/primary/fore)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"btg" = (
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "bth" = (
 /obj/structure/table/wood,
 /obj/item/paper,
 /turf/simulated/floor/wood,
 /area/library)
 "bti" = (
-/obj/structure/chair/comfy/green{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -38521,18 +37781,20 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/chair/wood/wings,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"btn" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood,
+/obj/item/dice,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bto" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/snow,
+/obj/structure/table/wood,
+/obj/item/deck/cards,
 /turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
+/area/crew_quarters/bar)
 "btp" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom";
@@ -38543,19 +37805,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "btr" = (
 /obj/structure/table/wood,
-/obj/item/kitchen/utensil/fork,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bts" = (
@@ -38570,30 +37831,31 @@
 "btt" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "btu" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "btv" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	icon_state = "swall_f9";
-	tag = "icon-swall_f9"
+	tag = "icon-swall_f9";
+	icon_state = "swall_f9"
 	},
 /area/shuttle/transport)
 "btw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "btx" = (
@@ -38601,16 +37863,19 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (EAST)";
+	icon_state = "wooden_chair_wings";
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/wood,
-/obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bty" = (
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -38619,9 +37884,9 @@
 /area/shuttle/transport)
 "btz" = (
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor,
@@ -38740,9 +38005,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -38777,9 +38039,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -38822,8 +38081,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hydroponics)
 "btV" = (
@@ -38921,14 +38180,17 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bug" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
-/obj/item/a_gift,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "buh" = (
@@ -38938,10 +38200,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -39002,26 +38260,19 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bup" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "buq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/stew{
-	pixel_x = 16
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (EAST)";
+	icon_state = "wooden_chair_wings";
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bur" = (
@@ -39037,8 +38288,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "but" = (
@@ -39060,8 +38311,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/cream,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "buv" = (
@@ -39082,12 +38333,12 @@
 "bux" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -39207,9 +38458,6 @@
 /obj/effect/landmark/start{
 	name = "Chef"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -39221,14 +38469,14 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/requests_console{
 	department = "Kitchen";
-	departmentType = 2;
 	name = "Kitchen Requests Console";
+	departmentType = 2;
 	pixel_x = 30;
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "buL" = (
@@ -39258,6 +38506,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
+"buN" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "buO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39281,6 +38534,23 @@
 	icon_state = "dark"
 	},
 /area/hydroponics)
+"buQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (NORTH)";
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"buR" = (
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (NORTH)";
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "buS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39313,8 +38583,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "buV" = (
@@ -39508,24 +38778,16 @@
 /area/security/vacantoffice)
 "bvo" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bvp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
-	},
-/obj/structure/table,
-/obj/item/clothing/head/soft/grey{
-	pixel_x = -2;
-	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -39543,29 +38805,27 @@
 "bvs" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
+"bvt" = (
+/obj/structure/table,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "bvu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
@@ -39628,10 +38888,6 @@
 /obj/item/radio/beacon,
 /obj/effect/landmark{
 	name = "Marauder Entry"
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -39724,16 +38980,15 @@
 	name = "Chapel Office";
 	req_access_txt = "22"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/chapel/office)
 "bvO" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -39765,7 +39020,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bvR" = (
@@ -39797,7 +39051,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvT" = (
@@ -39815,13 +39068,6 @@
 	dir = 8;
 	initialize_directions = 11;
 	level = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -39847,8 +39093,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 6
 	},
 /area/bridge)
 "bvW" = (
@@ -39866,8 +39112,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
-/obj/item/a_gift,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvX" = (
@@ -39875,13 +39119,9 @@
 /area/turret_protected/ai_upload)
 "bvY" = (
 /obj/structure/filingcabinet/filingcabinet,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/bridge)
 "bvZ" = (
@@ -39900,8 +39140,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
-/obj/item/a_gift,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwa" = (
@@ -39916,7 +39154,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwb" = (
@@ -39940,8 +39177,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
-/obj/item/a_gift,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwc" = (
@@ -39965,10 +39200,6 @@
 	initialize_directions = 10;
 	level = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwe" = (
@@ -39983,8 +39214,8 @@
 "bwf" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/hallway/primary/central/ne)
 "bwg" = (
@@ -40086,10 +39317,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwr" = (
@@ -40101,9 +39328,6 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -40189,22 +39413,22 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bwC" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "bwD" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/chocolate,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "bwE" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	icon_state = "swall_f10";
-	tag = "icon-swall_f10"
+	tag = "icon-swall_f10";
+	icon_state = "swall_f10"
 	},
 /area/shuttle/transport)
 "bwF" = (
@@ -40282,8 +39506,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/hallway/primary/central/nw)
 "bwO" = (
@@ -40411,12 +39635,12 @@
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -40592,10 +39816,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
@@ -40645,8 +39865,7 @@
 	},
 /area/bridge)
 "bxx" = (
-/obj/structure/flora/tree/pine/xmas,
-/obj/structure/snow,
+/obj/machinery/computer/arcade,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxy" = (
@@ -40664,15 +39883,15 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "bxz" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/h_chocolate,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "bxA" = (
 /obj/structure/closet/fireaxecabinet{
@@ -40707,10 +39926,6 @@
 	dir = 1;
 	initialize_directions = 11;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -40912,12 +40127,12 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bxR" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /obj/machinery/light/small,
 /obj/effect/landmark/start{
 	name = "Civilian"
-	},
-/obj/structure/chair/comfy/red{
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -40927,18 +40142,18 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bxT" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
 /obj/effect/landmark/start{
 	name = "Civilian"
-	},
-/obj/structure/chair/comfy/green{
-	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/library)
 "bxU" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/light,
 /obj/machinery/power/apc{
@@ -40953,17 +40168,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "blue"
 	},
 /area/bridge)
 "bxV" = (
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -41013,7 +40224,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "bluecorner"
@@ -41079,8 +40289,8 @@
 "byd" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/transport)
 "bye" = (
@@ -41230,8 +40440,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/hallway/primary/central/ne)
 "bys" = (
@@ -41344,6 +40554,14 @@
 	},
 /turf/simulated/wall,
 /area/quartermaster/office)
+"byD" = (
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (EAST)";
+	icon_state = "wooden_chair_wings";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "byE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -41360,11 +40578,10 @@
 	},
 /area/hallway/primary/central/west)
 "byG" = (
+/obj/machinery/photocopier,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/structure/table,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "byH" = (
@@ -41374,10 +40591,6 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/structure/snow,
-/obj/item/nanomob_card,
-/obj/item/a_gift,
-/obj/item/twohanded/dualsaber/toy,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "byI" = (
@@ -41387,8 +40600,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/photocopier,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "byJ" = (
@@ -41403,11 +40614,6 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "byK" = (
@@ -41421,16 +40627,12 @@
 /obj/machinery/light_switch{
 	pixel_y = 27
 	},
-/obj/structure/table,
-/obj/item/book/manual/sop_general,
-/obj/item/storage/fancy/donut_box,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "byL" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -41438,11 +40640,6 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/stack/packageWrap,
-/obj/item/assembly/timer,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "byM" = (
@@ -41454,8 +40651,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hydroponics)
 "byN" = (
@@ -41664,9 +40861,6 @@
 /turf/simulated/wall,
 /area/crew_quarters/bar)
 "bzf" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitecorner"
@@ -41727,22 +40921,30 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
+"bzm" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/exit)
 "bzn" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bzo" = (
 /obj/machinery/light,
 /obj/structure/chair/wood/wings{
-	dir = 4;
+	tag = "icon-wooden_chair_wings (EAST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bzp" = (
@@ -41900,10 +41102,6 @@
 /area/hallway/secondary/exit)
 "bzE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bzF" = (
@@ -41921,8 +41119,8 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	departmentType = 2;
 	name = "Cargo Requests Console";
+	departmentType = 2;
 	pixel_y = 30
 	},
 /obj/item/stack/tape_roll,
@@ -41935,8 +41133,8 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 1
 	},
 /area/quartermaster/office)
 "bzI" = (
@@ -41950,12 +41148,9 @@
 	name = "station intercom (General)";
 	pixel_y = 25
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 1
 	},
 /area/quartermaster/office)
 "bzJ" = (
@@ -41968,8 +41163,8 @@
 /obj/item/stack/packageWrap,
 /obj/item/rcs,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 5
 	},
 /area/quartermaster/office)
 "bzL" = (
@@ -41984,9 +41179,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
@@ -42003,11 +41195,10 @@
 	},
 /area/hallway/primary/central/west)
 "bzN" = (
-/obj/structure/flora/tree/pine/xmas,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/obj/structure/snow,
+/obj/structure/table,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bzO" = (
@@ -42017,9 +41208,6 @@
 "bzP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
 	},
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
@@ -42073,10 +41261,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bzV" = (
@@ -42084,10 +41268,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -42114,8 +41294,11 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
+"bzY" = (
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "bzZ" = (
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -42130,10 +41313,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bAc" = (
@@ -42141,14 +41320,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bAd" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
-	},
-/obj/structure/chair/comfy/green{
-	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -42183,8 +41362,8 @@
 /area/hallway/primary/starboard/west)
 "bAj" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -42291,6 +41470,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
+"bAv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/bar)
 "bAw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42336,8 +41522,8 @@
 "bAA" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 6
 	},
 /area/hallway/primary/central/nw)
 "bAB" = (
@@ -42430,18 +41616,20 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bAJ" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hallway/secondary/exit)
 "bAK" = (
 /obj/structure/sign/poster/official/random,
 /turf/simulated/wall,
+/area/hallway/secondary/exit)
+"bAL" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
 /area/hallway/secondary/exit)
 "bAM" = (
 /obj/structure/cable{
@@ -42478,9 +41666,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor{
@@ -42498,10 +41686,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -42670,13 +41854,6 @@
 /area/quartermaster/office)
 "bBo" = (
 /obj/machinery/hologram/holopad,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bBp" = (
@@ -42686,8 +41863,8 @@
 	},
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 4
 	},
 /area/quartermaster/office)
 "bBq" = (
@@ -42742,15 +41919,18 @@
 /area/security/vacantoffice)
 "bBu" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/security_space_law,
-/obj/structure/snow,
+/obj/item/radio/intercom/command,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "bBv" = (
-/obj/structure/chair/comfy/green{
+/obj/item/book/manual/security_space_law,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
+/area/bridge/meeting_room)
+"bBw" = (
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "bBx" = (
@@ -42781,8 +41961,8 @@
 /area/turret_protected/ai_upload)
 "bBA" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/turret_protected/ai_upload)
 "bBB" = (
@@ -42868,12 +42048,12 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -42886,12 +42066,6 @@
 /area/medical/reception)
 "bBM" = (
 /obj/structure/disposalpipe/segment,
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/md,
-/obj/item/toy/therapy,
-/obj/item/toy/foamblade,
-/obj/item/nanomob_card,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "white"
@@ -42966,9 +42140,9 @@
 /area/crew_quarters/locker)
 "bBX" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall14";
 	icon_state = "swall14";
-	tag = "icon-swall14"
+	dir = 2
 	},
 /area/shuttle/escape)
 "bBZ" = (
@@ -43010,8 +42184,8 @@
 	dir = 4
 	},
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "heater"
+	icon_state = "heater";
+	dir = 8
 	},
 /turf/unsimulated/floor,
 /area/shuttle/specops)
@@ -43221,24 +42395,15 @@
 	},
 /obj/machinery/light/small,
 /obj/structure/chair/wood/wings{
-	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (WEST)"
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bCC" = (
-/obj/structure/chair/comfy/red{
-	dir = 8
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
-	},
+/obj/item/folder/blue,
+/obj/structure/table/wood,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "bCD" = (
@@ -43247,12 +42412,9 @@
 /area/bridge/meeting_room)
 "bCE" = (
 /obj/structure/filingcabinet/filingcabinet,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 4
 	},
 /area/quartermaster/office)
 "bCF" = (
@@ -43261,18 +42423,15 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/central/west)
 "bCG" = (
+/obj/item/pen,
 /obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/structure/snow,
+/obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "bCH" = (
@@ -43304,25 +42463,7 @@
 	dir = 1;
 	network = list("SS13")
 	},
-/obj/structure/table/wood,
-/obj/item/candle{
-	pixel_y = -5
-	},
-/obj/item/decorations/sticky_decorations/flammable/mistletoe{
-	pixel_y = 10
-	},
-/obj/item/kitchen/utensil/fork{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/structure/snow,
+/obj/machinery/gameboard,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bCJ" = (
@@ -43342,10 +42483,6 @@
 	pixel_x = 0;
 	pixel_y = -21
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bCL" = (
@@ -43353,10 +42490,6 @@
 /obj/item/radio/intercom/private{
 	pixel_x = 0;
 	pixel_y = -28
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
@@ -43399,9 +42532,6 @@
 /area/crew_quarters/captain)
 "bCQ" = (
 /mob/living/simple_animal/pet/dog/fox/Renault,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "bCR" = (
@@ -43409,12 +42539,21 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bCS" = (
-/obj/machinery/light/small,
-/obj/structure/chair/comfy/green{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/library)
+"bCT" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/exit)
 "bCU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -43435,9 +42574,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bCW" = (
+/obj/structure/table,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/item/storage/box/cups{
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -43445,23 +42589,25 @@
 	pixel_y = 0;
 	req_access_txt = "0"
 	},
-/obj/structure/flora/tree/pine/xmas,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/obj/structure/snow,
+/obj/item/roller,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
+"bCX" = (
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/exit)
 "bCY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -43492,21 +42638,16 @@
 	},
 /area/hallway/primary/starboard/west)
 "bDc" = (
+/obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/virologist,
-/obj/item/toy/therapy,
-/obj/item/toy/plushie/deer,
-/obj/item/nanomob_card,
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whiteblue (SOUTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/reception)
 "bDd" = (
@@ -43516,16 +42657,15 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bDe" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bDf" = (
@@ -43552,9 +42692,6 @@
 "bDi" = (
 /obj/structure/chair/office/light{
 	dir = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -43589,6 +42726,16 @@
 	icon_state = "white"
 	},
 /area/medical/chemistry)
+"bDk" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	dir = 0;
+	icon_state = "green"
+	},
+/area/hallway/secondary/exit)
 "bDl" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -43613,23 +42760,22 @@
 /obj/effect/landmark/start{
 	name = "Chemist"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
 "bDo" = (
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/nanomob_card,
-/obj/item/toy/figure/hop,
-/obj/item/toy/figure/ian,
-/obj/item/toy/plushie/corgi,
-/obj/item/toy/plushie/girly_corgi,
+/obj/item/assembly/timer,
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bDp" = (
-/obj/structure/snow,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "green"
@@ -43649,9 +42795,8 @@
 	},
 /area/hallway/primary/starboard/east)
 "bDs" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
@@ -43666,12 +42811,12 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -43682,8 +42827,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -43717,7 +42862,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bDy" = (
-/obj/structure/snow,
+/obj/structure/table,
+/obj/item/book/manual/sop_general,
+/obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bDz" = (
@@ -43747,9 +42894,9 @@
 /area/maintenance/disposal)
 "bDG" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -43877,10 +43024,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bDT" = (
@@ -43996,10 +43139,9 @@
 	pixel_y = 7
 	},
 /obj/structure/table/reinforced,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 4
 	},
 /area/quartermaster/office)
 "bEg" = (
@@ -44082,11 +43224,17 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
+"bEs" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "bEt" = (
 /obj/machinery/optable,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -44251,12 +43399,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/nanomob_card,
-/obj/item/toy/figure/captain,
-/obj/item/toy/nuke,
-/obj/item/toy/plushie/orange_fox,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bER" = (
@@ -44292,13 +43434,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bEV" = (
+/obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "bEW" = (
@@ -44325,7 +43464,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "bFa" = (
@@ -44433,9 +43571,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 2;
+	tag = "icon-pipe-j2";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44510,7 +43648,6 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/decorations/sticky_decorations/flammable/snowman,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bFr" = (
@@ -44551,7 +43688,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bFu" = (
@@ -44607,20 +43743,15 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/partial,
 /obj/effect/decal/warning_stripes/arrow,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bFy" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 4
 	},
 /area/quartermaster/office)
 "bFz" = (
@@ -44694,10 +43825,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bFI" = (
@@ -44705,10 +43832,6 @@
 	dir = 1;
 	icon_state = "alarm0";
 	pixel_y = -22
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
@@ -44726,25 +43849,18 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding2 (NORTH)";
 	icon_state = "siding2";
-	tag = "icon-siding2 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding1 (NORTH)";
 	icon_state = "siding1";
-	tag = "icon-siding1 (NORTH)"
+	dir = 1
 	},
 /area/hydroponics)
 "bFK" = (
 /obj/machinery/computer/communications,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bFL" = (
@@ -44798,9 +43914,9 @@
 /area/engine/gravitygenerator)
 "bFQ" = (
 /obj/structure/morgue{
-	dir = 8;
+	tag = "icon-morgue1 (WEST)";
 	icon_state = "morgue1";
-	tag = "icon-morgue1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44831,9 +43947,9 @@
 /area/crew_quarters/toilet)
 "bFT" = (
 /obj/structure/morgue{
-	dir = 8;
+	tag = "icon-morgue1 (WEST)";
 	icon_state = "morgue1";
-	tag = "icon-morgue1 (WEST)"
+	dir = 8
 	},
 /obj/effect/landmark{
 	name = "revenantspawn"
@@ -44958,9 +44074,9 @@
 /area/maintenance/port)
 "bGc" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -44973,31 +44089,27 @@
 	},
 /area/assembly/robotics)
 "bGd" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bGe" = (
 /obj/effect/decal/warning_stripes/blue/partial{
 	dir = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "white"
 	},
 /area/medical/reception)
 "bGf" = (
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/teal{
 	dir = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bGg" = (
@@ -45015,7 +44127,6 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whiteblue";
@@ -45023,10 +44134,12 @@
 	},
 /area/medical/paramedic)
 "bGh" = (
-/obj/structure/snow,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hallway/secondary/exit)
 "bGi" = (
@@ -45045,13 +44158,12 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bGk" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -45089,6 +44201,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
+"bGo" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "bGp" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -45111,14 +44232,10 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/reception)
 "bGr" = (
@@ -45131,19 +44248,15 @@
 /area/hallway/secondary/exit)
 "bGt" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	dir = 4
 	},
 /area/medical/reception)
 "bGu" = (
 /obj/machinery/computer/rdconsole/robotics,
 /obj/machinery/alarm{
 	pixel_y = 25
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -45541,10 +44654,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bHg" = (
-/obj/structure/chair/comfy/red{
-	dir = 4
-	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bHh" = (
@@ -45599,13 +44708,9 @@
 	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 4
 	},
 /area/quartermaster/office)
 "bHo" = (
@@ -45623,10 +44728,6 @@
 /area/hallway/primary/central/east)
 "bHp" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bHq" = (
@@ -45643,12 +44744,12 @@
 	opacity = 0
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -45703,10 +44804,6 @@
 /area/maintenance/port)
 "bHw" = (
 /obj/machinery/computer/card,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bHx" = (
@@ -45729,8 +44826,8 @@
 /area/hallway/primary/starboard/west)
 "bHz" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/engine/gravitygenerator)
 "bHA" = (
@@ -45746,8 +44843,8 @@
 /area/hallway/primary/starboard/west)
 "bHB" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 1
 	},
 /area/engine/gravitygenerator)
 "bHC" = (
@@ -45775,8 +44872,8 @@
 /area/hallway/primary/starboard/east)
 "bHD" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 4
 	},
 /area/engine/gravitygenerator)
 "bHE" = (
@@ -45788,9 +44885,6 @@
 	},
 /obj/item/storage/box/gloves{
 	pixel_y = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45889,9 +44983,9 @@
 /area/assembly/chargebay)
 "bHO" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bHP" = (
@@ -46013,7 +45107,6 @@
 /area/engine/equipmentstorage)
 "bHZ" = (
 /obj/machinery/vending/tool,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "bIa" = (
@@ -46100,14 +45193,10 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whiteblue (NORTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/reception)
 "bIi" = (
@@ -46135,9 +45224,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whiteblue (NORTHEAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	dir = 5
 	},
 /area/medical/reception)
 "bIk" = (
@@ -46243,9 +45332,9 @@
 	req_access_txt = "47"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	dir = 1
 	},
 /area/toxins/lab)
 "bIv" = (
@@ -46257,9 +45346,9 @@
 /obj/item/disk/design_disk,
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	dir = 1
 	},
 /area/toxins/lab)
 "bIw" = (
@@ -46279,9 +45368,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bIx" = (
@@ -46297,9 +45383,6 @@
 	name = "station intercom (General)";
 	pixel_x = 28
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -46314,8 +45397,8 @@
 "bIA" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f5"
+	icon_state = "swall_f5";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bIB" = (
@@ -46324,8 +45407,8 @@
 /area/maintenance/disposal)
 "bIC" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall11"
+	icon_state = "swall11";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bID" = (
@@ -46337,15 +45420,15 @@
 /area/maintenance/disposal)
 "bIE" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall7"
+	icon_state = "swall7";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bIF" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/escape)
 "bIG" = (
@@ -46359,10 +45442,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/telepad_cargo,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -46383,17 +45462,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bIK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bIL" = (
@@ -46476,10 +45550,6 @@
 /area/hallway/primary/central/east)
 "bIS" = (
 /obj/structure/closet/secure_closet/cargotech,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bIT" = (
@@ -46505,12 +45575,16 @@
 	pixel_y = 3
 	},
 /obj/item/hand_labeler,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bIV" = (
 /obj/structure/table,
-/obj/structure/snow,
+/obj/item/clothing/head/soft,
+/obj/item/stamp/granted{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/soft,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bIW" = (
@@ -46528,10 +45602,6 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bIY" = (
@@ -46543,13 +45613,6 @@
 	name = "station intercom (General)";
 	pixel_y = 25
 	},
-/obj/item/clothing/head/soft,
-/obj/item/stamp/granted{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/soft,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bIZ" = (
@@ -46560,7 +45623,6 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bJa" = (
@@ -46574,8 +45636,8 @@
 /area/hallway/primary/starboard/west)
 "bJc" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -46616,8 +45678,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitehall"
+	icon_state = "whitehall";
+	dir = 2
 	},
 /area/hallway/primary/starboard/west)
 "bJf" = (
@@ -46626,7 +45688,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bJg" = (
@@ -46804,8 +45865,8 @@
 	dir = 1;
 	icon_state = "pipe-j2s";
 	name = "Disposals Maint";
-	sortType = 1;
-	sortdir = 0
+	sortdir = 0;
+	sortType = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -46886,9 +45947,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/reception)
 "bJB" = (
@@ -46908,13 +45969,9 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
 "bJD" = (
@@ -46928,7 +45985,6 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -46970,19 +46026,11 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bJH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
@@ -47004,10 +46052,6 @@
 /area/bridge/meeting_room)
 "bJJ" = (
 /obj/machinery/computer/crew,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -47028,9 +46072,9 @@
 	name = "Chemist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bJN" = (
@@ -47063,9 +46107,9 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whiteblue (SOUTHEAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	dir = 6
 	},
 /area/medical/reception)
 "bJQ" = (
@@ -47074,8 +46118,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/computer/arcade,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bJR" = (
@@ -47151,9 +46193,6 @@
 /area/crew_quarters/bar)
 "bJW" = (
 /obj/structure/closet/wardrobe/chemistry_white,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteyellow"
@@ -47346,9 +46385,9 @@
 /area/shuttle/escape)
 "bKn" = (
 /obj/machinery/shower{
-	dir = 8;
+	tag = "icon-shower (WEST)";
 	icon_state = "shower";
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -47441,7 +46480,6 @@
 /area/quartermaster/storage)
 "bKA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bKB" = (
@@ -47452,7 +46490,6 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageExternal"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bKD" = (
@@ -47525,10 +46562,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -47567,18 +46600,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bKM" = (
 /obj/structure/filingcabinet,
 /obj/item/radio/intercom/private{
 	pixel_x = -28
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -47767,15 +46794,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bLi" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/engine/gravitygenerator)
 "bLj" = (
@@ -47831,14 +46858,14 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding1 (NORTH)";
 	icon_state = "siding1";
-	tag = "icon-siding1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding2 (NORTH)";
 	icon_state = "siding2";
-	tag = "icon-siding2 (NORTH)"
+	dir = 1
 	},
 /area/hydroponics)
 "bLo" = (
@@ -47864,10 +46891,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bLq" = (
@@ -47879,10 +46902,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -47901,7 +46920,6 @@
 	initialize_directions = 10;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bLs" = (
@@ -47921,8 +46939,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
 "bLu" = (
@@ -47938,13 +46956,6 @@
 	opacity = 0
 	},
 /obj/machinery/computer/med_data,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue";
@@ -47966,12 +46977,9 @@
 /obj/effect/landmark/start{
 	name = "Chemist"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bLw" = (
@@ -47989,8 +46997,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/paramedic)
 "bLx" = (
@@ -48004,15 +47012,15 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bLy" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bLz" = (
@@ -48055,9 +47063,6 @@
 /area/hallway/secondary/entry)
 "bLD" = (
 /obj/structure/closet/secure_closet/reagents,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = -17
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteyellow"
@@ -48135,8 +47140,8 @@
 "bLN" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -48162,8 +47167,8 @@
 "bLP" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
@@ -48203,8 +47208,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bLT" = (
@@ -48254,14 +47259,14 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding1 (NORTH)";
 	icon_state = "siding1";
-	tag = "icon-siding1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-siding2 (NORTH)";
 	icon_state = "siding2";
-	tag = "icon-siding2 (NORTH)"
+	dir = 1
 	},
 /area/hydroponics)
 "bLV" = (
@@ -48282,8 +47287,8 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bLW" = (
@@ -48398,9 +47403,6 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bMi" = (
@@ -48411,7 +47413,6 @@
 	pixel_y = 24;
 	req_access_txt = "31"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bMj" = (
@@ -48420,10 +47421,6 @@
 	},
 /obj/machinery/computer/rdconsole/core,
 /obj/effect/decal/warning_stripes/southwest,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "bMk" = (
@@ -48464,10 +47461,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "browncorner"
@@ -48475,17 +47468,17 @@
 /area/hallway/primary/central/west)
 "bMo" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall12";
 	icon_state = "swall12";
-	tag = "icon-swall12"
+	dir = 2
 	},
 /area/shuttle/supply)
 "bMp" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f6";
 	icon_state = "swall_f6";
-	tag = "icon-swall_f6"
+	dir = 2
 	},
 /area/shuttle/supply)
 "bMq" = (
@@ -48496,15 +47489,14 @@
 	pixel_y = 27
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bMr" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f10";
 	icon_state = "swall_f10";
-	tag = "icon-swall_f10"
+	dir = 2
 	},
 /area/shuttle/supply)
 "bMs" = (
@@ -48539,10 +47531,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bMx" = (
@@ -48561,16 +47549,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
-"bMz" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/bridge)
 "bMA" = (
 /obj/machinery/mineral/ore_redemption,
 /turf/simulated/floor/plasteel,
@@ -48581,9 +47559,9 @@
 /area/maintenance/maintcentral)
 "bMC" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -48596,10 +47574,6 @@
 "bMD" = (
 /obj/machinery/computer/account_database{
 	anchored = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room)
@@ -48619,7 +47593,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -48736,9 +47709,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -48887,8 +47857,8 @@
 /obj/item/storage/firstaid/fire,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bMY" = (
@@ -48907,8 +47877,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bMZ" = (
@@ -49193,9 +48163,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -49265,10 +48232,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bNx" = (
@@ -49292,8 +48255,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bNz" = (
@@ -49395,12 +48358,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bNI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bNJ" = (
@@ -49431,12 +48392,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bNM" = (
@@ -49501,8 +48459,8 @@
 /area/maintenance/port)
 "bNQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -49524,8 +48482,8 @@
 /area/quartermaster/storage)
 "bNU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Research Research and Development Lab";
@@ -49655,16 +48613,16 @@
 /area/maintenance/disposal)
 "bOe" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall3";
 	icon_state = "swall3";
-	tag = "icon-swall3"
+	dir = 2
 	},
 /area/shuttle/supply)
 "bOf" = (
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
@@ -49690,6 +48648,20 @@
 	req_access_txt = "0"
 	},
 /obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/quartermaster/storage)
+"bOh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bOi" = (
@@ -49735,7 +48707,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bOl" = (
@@ -49833,10 +48804,6 @@
 	broadcasting = 0;
 	name = "station intercom (General)";
 	pixel_y = 25
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -49947,10 +48914,6 @@
 	pixel_x = -22;
 	pixel_y = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "blue"
@@ -49968,8 +48931,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bOC" = (
@@ -49986,9 +48949,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bOE" = (
@@ -50001,8 +48964,8 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
@@ -50047,8 +49010,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
@@ -50102,8 +49065,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -50150,8 +49113,8 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bOS" = (
@@ -50172,20 +49135,17 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bOU" = (
 /turf/simulated/wall,
 /area/medical/chemistry)
 "bOV" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bOW" = (
@@ -50219,8 +49179,8 @@
 "bOZ" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/item/radio/intercom{
 	dir = 8;
@@ -50299,16 +49259,16 @@
 	shock_proof = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bPh" = (
@@ -50336,9 +49296,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/reception)
 "bPi" = (
@@ -50415,9 +49375,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "bPo" = (
@@ -50474,8 +49431,8 @@
 	},
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f6"
+	icon_state = "swall_f6";
+	dir = 2
 	},
 /area/shuttle/transport)
 "bPw" = (
@@ -50580,9 +49537,9 @@
 	name = "Scientist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	dir = 1
 	},
 /area/toxins/lab)
 "bPE" = (
@@ -50666,9 +49623,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 2;
+	tag = "icon-pipe-j2";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	dir = 2
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -50729,20 +49686,17 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bPP" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/quartermaster/storage)
 "bPQ" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -50778,8 +49732,8 @@
 	},
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f5"
+	icon_state = "swall_f5";
+	dir = 2
 	},
 /area/shuttle/transport)
 "bPV" = (
@@ -50788,9 +49742,6 @@
 	},
 /obj/structure/chair/office/dark{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -50804,7 +49755,6 @@
 	pixel_x = 5;
 	pixel_y = 30
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bPY" = (
@@ -50813,10 +49763,6 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/west,
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bPZ" = (
@@ -50856,7 +49802,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bQd" = (
@@ -50900,8 +49845,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 4
 	},
 /area/hallway/primary/central/sw)
 "bQi" = (
@@ -50972,8 +49917,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/crew_quarters/heads)
 "bQl" = (
@@ -51036,8 +49981,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -51102,8 +50047,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -51141,9 +50086,9 @@
 	req_access_txt = "0"
 	},
 /obj/machinery/shower{
-	dir = 4;
+	tag = "icon-shower (EAST)";
 	icon_state = "shower";
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
@@ -51174,9 +50119,6 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteyellow"
@@ -51194,18 +50136,15 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bQC" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bQD" = (
@@ -51238,8 +50177,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bQF" = (
@@ -51383,9 +50322,9 @@
 	req_access_txt = "66"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/paramedic)
 "bQQ" = (
@@ -51401,8 +50340,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bQS" = (
@@ -51422,9 +50361,9 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bQT" = (
@@ -51506,8 +50445,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bRc" = (
@@ -51536,8 +50475,8 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bRd" = (
@@ -51578,9 +50517,9 @@
 /area/hallway/primary/central/se)
 "bRg" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -51960,10 +50899,6 @@
 /area/quartermaster/office)
 "bRN" = (
 /obj/machinery/computer/supplycomp,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bRO" = (
@@ -52081,8 +51016,8 @@
 "bRZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "redcorner";
+	dir = 4
 	},
 /area/hallway/primary/central/sw)
 "bSa" = (
@@ -52098,9 +51033,9 @@
 "bSb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -52120,22 +51055,14 @@
 /area/hallway/secondary/exit)
 "bSd" = (
 /obj/machinery/computer/card,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/crew_quarters/heads)
 "bSe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -52144,8 +51071,8 @@
 /obj/item/paper,
 /obj/item/pen,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -52165,7 +51092,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bSh" = (
@@ -52194,7 +51120,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bSk" = (
@@ -52241,7 +51166,6 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bSn" = (
@@ -52306,9 +51230,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whiteblue (SOUTHEAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	dir = 6
 	},
 /area/medical/reception)
 "bSr" = (
@@ -52323,8 +51247,8 @@
 "bSs" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "bSt" = (
@@ -52494,8 +51418,8 @@
 /area/medical/genetics_cloning)
 "bSF" = (
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -52548,8 +51472,8 @@
 	name = "Surgery Cleaner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitehall"
+	icon_state = "whitehall";
+	dir = 4
 	},
 /area/assembly/robotics)
 "bSK" = (
@@ -52727,9 +51651,6 @@
 	pixel_y = -24;
 	req_access_txt = "29"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -52781,8 +51702,8 @@
 /area/crew_quarters/heads)
 "bTd" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -52838,7 +51759,6 @@
 	name = "Research and Development Desk";
 	req_access_txt = "47"
 	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -52899,9 +51819,9 @@
 /area/hallway/primary/central/sw)
 "bTl" = (
 /obj/machinery/light/spot{
-	dir = 4;
+	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -52915,10 +51835,6 @@
 	pixel_y = 12
 	},
 /obj/item/gps,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
 "bTn" = (
@@ -52939,9 +51855,9 @@
 /area/shuttle/administration)
 "bTo" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -53025,8 +51941,8 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	departmentType = 2;
 	name = "Cargo Requests Console";
+	departmentType = 2;
 	pixel_x = -30;
 	pixel_y = 0
 	},
@@ -53065,8 +51981,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
@@ -53210,15 +52126,15 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bTN" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -53249,8 +52165,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
 "bTR" = (
@@ -53286,12 +52202,9 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "bTV" = (
@@ -53365,9 +52278,6 @@
 	},
 /area/medical/genetics_cloning)
 "bUc" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -53486,9 +52396,6 @@
 	initialize_directions = 10;
 	level = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bUo" = (
@@ -53507,9 +52414,6 @@
 "bUq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
@@ -53656,12 +52560,12 @@
 "bUC" = (
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -53671,16 +52575,13 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "bUE" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/quartermaster/office)
@@ -53689,10 +52590,6 @@
 	name = "Robotics Operating Computer"
 	},
 /obj/machinery/light,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53754,12 +52651,12 @@
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -53782,8 +52679,8 @@
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bUN" = (
@@ -54073,17 +52970,17 @@
 /area/quartermaster/storage)
 "bVm" = (
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
 "bVn" = (
 /obj/machinery/light/spot{
-	dir = 4;
+	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
@@ -54179,9 +53076,6 @@
 /area/quartermaster/office)
 "bVu" = (
 /obj/structure/closet/secure_closet/hop2,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = -17
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
 "bVv" = (
@@ -54280,9 +53174,6 @@
 	pixel_x = 4;
 	pixel_y = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitecorner"
@@ -54309,8 +53200,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitehall"
+	icon_state = "whitehall";
+	dir = 2
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -54478,8 +53369,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/hallway/primary/central/se)
 "bVU" = (
@@ -54626,8 +53517,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -54660,9 +53551,6 @@
 	pixel_y = 0
 	},
 /obj/structure/closet/secure_closet/roboticist,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = -17
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -54889,9 +53777,9 @@
 "bWx" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/sleeper)
 "bWy" = (
@@ -54943,10 +53831,6 @@
 /area/medical/genetics_cloning)
 "bWC" = (
 /obj/machinery/computer/cloning,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -54987,9 +53871,9 @@
 /area/medical/genetics_cloning)
 "bWG" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
+	tag = "icon-heater (WEST)";
 	icon_state = "heater";
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -55112,12 +53996,12 @@
 	opacity = 0
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 4
 	},
 /obj/machinery/ticket_machine{
 	layer = 4;
@@ -55132,10 +54016,6 @@
 "bWU" = (
 /obj/machinery/light,
 /obj/machinery/computer/merch,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bWV" = (
@@ -55210,10 +54090,6 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "blue"
@@ -55223,10 +54099,6 @@
 /obj/machinery/computer/message_monitor,
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -55370,9 +54242,9 @@
 /area/crew_quarters/heads)
 "bXr" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -55388,9 +54260,9 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitepurple (WEST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	dir = 8
 	},
 /area/medical/genetics)
 "bXt" = (
@@ -55431,9 +54303,9 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitepurple (EAST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	dir = 4
 	},
 /area/medical/genetics)
 "bXw" = (
@@ -55448,24 +54320,18 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "bXx" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24;
 	shock_proof = 0
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
@@ -55536,9 +54402,9 @@
 "bXE" = (
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/sleeper)
 "bXF" = (
@@ -55550,9 +54416,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whiteblue (NORTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/sleeper)
 "bXG" = (
@@ -55623,9 +54489,9 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/sleeper)
 "bXK" = (
@@ -55671,8 +54537,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -55728,8 +54594,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
@@ -55759,13 +54625,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitepurple (WEST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	dir = 8
 	},
 /area/medical/genetics)
 "bXW" = (
@@ -55864,8 +54730,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/hallway/primary/central/se)
 "bYc" = (
@@ -55950,9 +54816,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
@@ -55967,9 +54833,9 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitepurple (EAST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	dir = 4
 	},
 /area/medical/genetics)
 "bYl" = (
@@ -56048,9 +54914,9 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/sleeper)
 "bYt" = (
@@ -56075,9 +54941,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/reception)
 "bYv" = (
@@ -56149,8 +55015,8 @@
 /obj/item/roller,
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bYD" = (
@@ -56313,8 +55179,8 @@
 "bYR" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/hallway/primary/central/sw)
 "bYS" = (
@@ -56341,8 +55207,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/crew_quarters/heads)
 "bYU" = (
@@ -56534,9 +55400,9 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whiteblue (NORTHWEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/sleeper)
 "bZk" = (
@@ -56606,9 +55472,6 @@
 	dir = 1
 	},
 /obj/machinery/hologram/holopad,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -56648,8 +55511,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/hallway/primary/central/se)
 "bZu" = (
@@ -56680,10 +55543,6 @@
 	name = "station intercom (General)";
 	pixel_x = -32;
 	pixel_y = -8
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -56722,8 +55581,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
@@ -56803,9 +55662,9 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "bZF" = (
@@ -57160,9 +56019,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
@@ -57175,10 +56034,6 @@
 	name = "Research Director Requests Console";
 	pixel_x = -2;
 	pixel_y = 30
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -57394,18 +56249,10 @@
 /area/quartermaster/qm)
 "cap" = (
 /obj/machinery/computer/supplycomp,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "caq" = (
 /obj/machinery/computer/security/mining,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "car" = (
@@ -57419,10 +56266,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 8;
+	tag = "icon-window5_end (WEST)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
@@ -57448,10 +56295,6 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -57512,13 +56355,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/sleeper)
 "caA" = (
@@ -57803,10 +56646,6 @@
 /area/medical/medbay2)
 "caR" = (
 /obj/machinery/computer/crew,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -57874,18 +56713,14 @@
 	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whitepurple (SOUTHWEST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/genetics)
 "caX" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/structure/window/reinforced,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplefull";
@@ -57900,9 +56735,9 @@
 	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whitepurple (SOUTHEAST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	dir = 6
 	},
 /area/medical/genetics)
 "caZ" = (
@@ -58048,10 +56883,6 @@
 	})
 "cbl" = (
 /obj/machinery/computer/teleporter,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plating,
 /area/teleporter)
 "cbm" = (
@@ -58117,10 +56948,6 @@
 /area/crew_quarters/hor)
 "cbq" = (
 /obj/machinery/computer/robotics,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -58142,8 +56969,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "cbs" = (
@@ -58183,9 +57010,9 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cbv" = (
@@ -58194,9 +57021,9 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cbw" = (
@@ -58219,8 +57046,8 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
 /area/medical/biostorage)
 "cbz" = (
@@ -58258,8 +57085,8 @@
 "cbB" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	icon_state = "swall_f10";
-	tag = "icon-swall_f10"
+	tag = "icon-swall_f10";
+	icon_state = "swall_f10"
 	},
 /area/shuttle/supply)
 "cbC" = (
@@ -58268,23 +57095,23 @@
 /area/shuttle/supply)
 "cbD" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall7";
 	icon_state = "swall7";
-	tag = "icon-swall7"
+	dir = 2
 	},
 /area/shuttle/supply)
 "cbE" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	icon_state = "swall_f6";
-	tag = "icon-swall_f6"
+	tag = "icon-swall_f6";
+	icon_state = "swall_f6"
 	},
 /area/shuttle/supply)
 "cbF" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall11";
 	icon_state = "swall11";
-	tag = "icon-swall11"
+	dir = 2
 	},
 /area/shuttle/supply)
 "cbG" = (
@@ -58355,17 +57182,9 @@
 /obj/effect/landmark/start{
 	name = "Quartermaster"
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cbM" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cbN" = (
@@ -58380,17 +57199,17 @@
 /area/medical/medbay2)
 "cbO" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cbP" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cbQ" = (
@@ -58413,7 +57232,6 @@
 	pixel_x = 28
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cbS" = (
@@ -58437,9 +57255,9 @@
 "cbU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cbV" = (
@@ -58493,8 +57311,8 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	icon_state = "airlock_unres_helper";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -58529,8 +57347,8 @@
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccb" = (
@@ -58823,8 +57641,8 @@
 /obj/structure/cable,
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccr" = (
@@ -58851,8 +57669,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "cct" = (
@@ -58865,14 +57683,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccu" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ccv" = (
@@ -58996,9 +57814,9 @@
 "ccC" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "ccD" = (
@@ -59019,9 +57837,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "ccF" = (
@@ -59043,8 +57861,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -59088,8 +57906,8 @@
 	shock_proof = 0
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -59104,9 +57922,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/blueshield)
 "ccL" = (
@@ -59157,9 +57972,6 @@
 	name = "station intercom (General)";
 	pixel_y = 25
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = -17
-	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "ccP" = (
@@ -59168,13 +57980,10 @@
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
 "ccQ" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitepurple (WEST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	dir = 8
 	},
 /area/medical/genetics)
 "ccR" = (
@@ -59199,9 +58008,9 @@
 "ccT" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
+	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
+	dir = 6
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/toxins/server_coldroom)
@@ -59213,9 +58022,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8;
+	tag = "icon-intact (WEST)";
 	icon_state = "intact";
-	tag = "icon-intact (WEST)"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -59322,8 +58131,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	tag = "icon-vault";
+	icon_state = "vault"
 	},
 /area/engine/gravitygenerator)
 "cdb" = (
@@ -59396,10 +58205,6 @@
 /area/crew_quarters/hor)
 "cdg" = (
 /obj/machinery/computer/mecha,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -59490,9 +58295,9 @@
 "cdp" = (
 /obj/machinery/clonepod/upgraded,
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -59522,8 +58327,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	icon_state = "airlock_unres_helper";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -59548,18 +58353,18 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	dir = 4;
+	tag = "icon-window5_end (EAST)";
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	tag = "icon-window5_end (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
 "cdt" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall15";
 	icon_state = "swall15";
-	tag = "icon-swall15"
+	dir = 2
 	},
 /area/shuttle/supply)
 "cdu" = (
@@ -59572,17 +58377,17 @@
 "cdv" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f5";
 	icon_state = "swall_f5";
-	tag = "icon-swall_f5"
+	dir = 2
 	},
 /area/shuttle/supply)
 "cdw" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f9";
 	icon_state = "swall_f9";
-	tag = "icon-swall_f9"
+	dir = 2
 	},
 /area/shuttle/supply)
 "cdx" = (
@@ -59600,14 +58405,11 @@
 /obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	departmentType = 2;
 	name = "Cargo Requests Console";
+	departmentType = 2;
 	pixel_x = -30;
 	pixel_y = 0
 	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/rice,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/rice,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/rice,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cdz" = (
@@ -59632,9 +58434,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cdB" = (
@@ -59677,7 +58476,6 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cdE" = (
@@ -59686,7 +58484,6 @@
 	c_tag = "Quartermaster's Office";
 	dir = 8
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cdF" = (
@@ -59711,13 +58508,6 @@
 	layer = 4;
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/nougat{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/nougat,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/nougat{
-	pixel_x = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -59766,9 +58556,6 @@
 /obj/effect/landmark/start{
 	name = "Research Director"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -59805,8 +58592,8 @@
 "cdQ" = (
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	departmentType = 2;
 	name = "Cargo Requests Console";
+	departmentType = 2;
 	pixel_x = -30;
 	pixel_y = 0
 	},
@@ -59824,9 +58611,9 @@
 /area/quartermaster/qm)
 "cdS" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -59873,9 +58660,9 @@
 /area/hallway/primary/central/south)
 "cdY" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j1 (EAST)";
 	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59985,9 +58772,6 @@
 /area/medical/medbay2)
 "cej" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -60001,9 +58785,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -60014,9 +58795,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"
@@ -60069,9 +58847,9 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -60178,10 +58956,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "ceF" = (
@@ -60349,8 +59123,8 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	icon_state = "airlock_unres_helper";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -60360,23 +59134,23 @@
 /area/shuttle/supply)
 "ceV" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "burst_l";
-	tag = "icon-burst_l"
+	tag = "icon-burst_l";
+	icon_state = "burst_l"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "ceW" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "burst_r";
-	tag = "icon-burst_r"
+	tag = "icon-burst_r";
+	icon_state = "burst_r"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "ceX" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f6"
+	icon_state = "swall_f6";
+	dir = 2
 	},
 /area/shuttle/mining)
 "ceY" = (
@@ -60386,16 +59160,16 @@
 /area/shuttle/mining)
 "ceZ" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall12"
+	icon_state = "swall12";
+	dir = 2
 	},
 /area/shuttle/mining)
 "cfa" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f10";
 	icon_state = "swall_f10";
-	tag = "icon-swall_f10"
+	dir = 2
 	},
 /area/shuttle/mining)
 "cfb" = (
@@ -60406,10 +59180,6 @@
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
 	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cfd" = (
@@ -60419,10 +59189,6 @@
 	pixel_y = 7
 	},
 /obj/item/megaphone,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cfe" = (
@@ -60438,9 +59204,6 @@
 	pixel_y = -4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cff" = (
@@ -60455,13 +59218,6 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cfg" = (
@@ -60471,7 +59227,6 @@
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cfh" = (
@@ -60588,8 +59343,8 @@
 /area/janitor)
 "cfp" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -60710,13 +59465,10 @@
 	pixel_x = 0;
 	pixel_y = 25
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/surgery1)
 "cfB" = (
@@ -60745,8 +59497,8 @@
 /obj/item/stack/medical/bruise_pack/advanced,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery2)
 "cfD" = (
@@ -60835,9 +59587,6 @@
 	pixel_x = 0;
 	pixel_y = 25
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whitebluecorner";
@@ -60853,8 +59602,8 @@
 	},
 /obj/item/surgicaldrill,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery2)
 "cfM" = (
@@ -60879,8 +59628,8 @@
 /obj/structure/table/tray,
 /obj/item/scalpel,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/medical/surgery2)
 "cfN" = (
@@ -61058,7 +59807,6 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/item/toy/cattoy,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbluecorners"
@@ -61124,9 +59872,9 @@
 "cgc" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
+	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
-	tag = "icon-intact (NORTHEAST)"
+	dir = 5
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/toxins/server_coldroom)
@@ -61155,18 +59903,10 @@
 /obj/machinery/light_switch{
 	pixel_y = -23
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
 "cgg" = (
 /obj/machinery/computer/message_monitor,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
 "cgh" = (
@@ -61334,9 +60074,9 @@
 /area/shuttle/administration)
 "cgA" = (
 /obj/machinery/light/spot{
-	dir = 4;
+	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -61367,16 +60107,12 @@
 	})
 "cgF" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/mining)
 "cgG" = (
 /obj/structure/closet/wardrobe/miner,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -61384,10 +60120,6 @@
 /area/quartermaster/miningdock)
 "cgH" = (
 /obj/machinery/computer/shuttle/mining,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -61486,7 +60218,6 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cgO" = (
@@ -61518,10 +60249,6 @@
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -61705,8 +60432,8 @@
 	req_one_access_txt = "5;9"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	icon_state = "airlock_unres_helper";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -61736,9 +60463,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkblue"
@@ -61746,9 +60470,9 @@
 /area/medical/surgery1)
 "chl" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/surgery1)
 "chm" = (
@@ -61759,9 +60483,6 @@
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -61799,9 +60520,6 @@
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkblue"
@@ -61826,9 +60544,6 @@
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -61917,9 +60632,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "chy" = (
@@ -61949,9 +60664,6 @@
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/clothing/mask/gas,
 /obj/item/storage/briefcase,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkblue"
@@ -62036,10 +60748,6 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/ntrep)
 "chI" = (
@@ -62064,8 +60772,8 @@
 /area/medical/surgery1)
 "chL" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -62172,9 +60880,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -62278,10 +60983,6 @@
 "chX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -62418,7 +61119,6 @@
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cis" = (
@@ -62434,7 +61134,6 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cit" = (
@@ -62451,36 +61150,20 @@
 /area/quartermaster/miningdock)
 "ciu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "civ" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "ciw" = (
 /obj/structure/closet/secure_closet/quartermaster,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cix" = (
 /obj/structure/table,
 /obj/item/coin/silver,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "ciy" = (
@@ -62510,7 +61193,6 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "ciA" = (
@@ -62567,10 +61249,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/operating,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"
@@ -62629,10 +61307,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/operating,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -62793,9 +61467,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "ciV" = (
@@ -62913,15 +61587,10 @@
 	pixel_x = 32
 	},
 /obj/machinery/photocopier,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/blueshield)
 "cjd" = (
 /obj/machinery/photocopier,
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/ntrep)
 "cje" = (
@@ -62932,16 +61601,10 @@
 /obj/item/folder,
 /obj/item/pen/multi/fountain,
 /obj/item/stamp/rep,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "cjf" = (
 /obj/structure/table/wood,
-/obj/structure/snow,
-/obj/item/a_gift,
-/obj/item/id_decal/centcom,
-/obj/item/gun/projectile/shotgun/toy/tommygun,
-/obj/item/ammo_box/magazine/internal/shot/toy/tommygun,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "cjg" = (
@@ -62953,10 +61616,6 @@
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
 	pixel_y = 0
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -63011,9 +61670,9 @@
 /area/hallway/primary/central/south)
 "cjk" = (
 /obj/structure/disposalpipe/junction{
-	dir = 2;
+	tag = "icon-pipe-j2";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	dir = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -63142,9 +61801,6 @@
 /obj/item/clothing/under/rank/medical/blue,
 /obj/item/clothing/under/rank/medical/green,
 /obj/item/clothing/under/rank/medical/purple,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -63182,9 +61838,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/surgery1)
 "cjy" = (
@@ -63487,9 +62143,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -63521,7 +62174,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cjV" = (
@@ -63588,9 +62240,9 @@
 /area/toxins/mixing)
 "ckf" = (
 /obj/machinery/light/spot{
-	dir = 4;
+	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -63600,9 +62252,9 @@
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /obj/machinery/light/spot{
-	dir = 8;
+	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -63690,7 +62342,6 @@
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "ckp" = (
@@ -63720,7 +62371,6 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "ckr" = (
@@ -63754,10 +62404,6 @@
 	},
 /area/medical/surgery2)
 "ckt" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -63790,7 +62436,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cky" = (
@@ -63843,9 +62488,9 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "ckC" = (
@@ -63889,8 +62534,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Break Room";
@@ -63914,7 +62559,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "ckH" = (
@@ -63929,7 +62573,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "ckI" = (
@@ -63972,10 +62615,6 @@
 /obj/item/flag/nt,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -64051,17 +62690,17 @@
 	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/surgery1)
 "ckV" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/surgery1)
 "ckW" = (
@@ -64078,9 +62717,9 @@
 /area/medical/surgery1)
 "ckX" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/surgery1)
 "ckY" = (
@@ -64151,9 +62790,9 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/surgery2)
 "cld" = (
@@ -64179,9 +62818,9 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/surgery2)
 "clf" = (
@@ -64197,9 +62836,9 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/medical/surgery2)
 "clg" = (
@@ -64227,9 +62866,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cli" = (
@@ -64239,9 +62878,6 @@
 	d2 = 4;
 	icon_state = "2-4";
 	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -64267,9 +62903,6 @@
 	dir = 8;
 	pixel_x = 25;
 	pixel_y = 0
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -64335,7 +62968,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cls" = (
@@ -64348,8 +62980,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "clt" = (
@@ -64371,7 +63001,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "clw" = (
@@ -64572,9 +63201,9 @@
 /area/maintenance/asmaint)
 "clT" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -64629,8 +63258,8 @@
 /area/toxins/storage)
 "clY" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -64680,8 +63309,8 @@
 "cmc" = (
 /obj/machinery/requests_console{
 	department = "Janitorial";
-	departmentType = 1;
 	name = "Janitor Requests Console";
+	departmentType = 1;
 	pixel_y = -29
 	},
 /obj/machinery/disposal,
@@ -64720,10 +63349,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/blueshield)
 "cmh" = (
@@ -64731,13 +63356,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -64820,9 +63438,9 @@
 "cmn" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -64836,9 +63454,9 @@
 "cmp" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	dir = 5
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -64965,10 +63583,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -65032,13 +63646,6 @@
 "cmD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/britcup,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -65087,7 +63694,6 @@
 "cmK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -65100,9 +63706,6 @@
 "cmM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "cmN" = (
@@ -65116,9 +63719,9 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -65180,9 +63783,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -65380,9 +63980,6 @@
 /area/maintenance/apmaint)
 "cno" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "brown"
@@ -65456,7 +64053,6 @@
 /area/toxins/explab_chamber)
 "cnu" = (
 /obj/structure/chair/office/dark,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "cnv" = (
@@ -65535,9 +64131,9 @@
 	})
 "cnC" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -65657,9 +64253,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cnN" = (
@@ -65695,10 +64291,6 @@
 /area/medical/medbreak)
 "cnQ" = (
 /obj/machinery/computer/med_data,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -65745,10 +64337,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -65873,9 +64461,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -66009,7 +64597,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -66017,10 +64604,6 @@
 "col" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -66031,7 +64614,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -66039,10 +64621,6 @@
 "con" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
@@ -66052,7 +64630,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "cop" = (
@@ -66266,10 +64843,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -66311,7 +64884,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -66323,8 +64895,8 @@
 "coO" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f5"
+	icon_state = "swall_f5";
+	dir = 2
 	},
 /area/shuttle/mining)
 "coP" = (
@@ -66339,8 +64911,8 @@
 "coQ" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/mining)
 "coR" = (
@@ -66379,16 +64951,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "coV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -66397,7 +64964,6 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "coX" = (
@@ -66410,7 +64976,6 @@
 	pixel_x = 7;
 	pixel_y = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -66425,7 +64990,6 @@
 	name = "Desk Door";
 	req_access_txt = "67"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/blueshield)
 "coZ" = (
@@ -66604,7 +65168,6 @@
 	},
 /obj/item/paper/blueshield,
 /obj/item/book/manual/sop_command,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -66645,9 +65208,9 @@
 	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cpi" = (
@@ -66720,9 +65283,9 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	dir = 8
 	},
 /area/medical/surgery1)
 "cpo" = (
@@ -66747,9 +65310,9 @@
 /area/medical/surgery2)
 "cpp" = (
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -66907,9 +65470,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	dir = 6
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -67123,9 +65686,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cpT" = (
@@ -67150,37 +65713,27 @@
 "cpU" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whitepurple (NORTHWEST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	dir = 9
 	},
 /area/toxins/explab)
 "cpV" = (
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/book/manual/experimentor,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whitepurple (NORTHEAST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/explab)
 "cpW" = (
 /obj/machinery/computer/rdconsole/experiment,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	dir = 1
 	},
 /area/toxins/explab)
 "cpX" = (
@@ -67209,9 +65762,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whitepurple (NORTHEAST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/explab)
 "cpZ" = (
@@ -67350,10 +65903,6 @@
 	sensors = list("burn_sensor" = "Burn Mix")
 	},
 /obj/effect/decal/warning_stripes/north,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -67449,8 +65998,8 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -67511,8 +66060,8 @@
 "cqs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -67681,8 +66230,8 @@
 /area/maintenance/asmaint)
 "cqE" = (
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -67698,9 +66247,9 @@
 /area/maintenance/apmaint)
 "cqG" = (
 /obj/machinery/shower{
-	dir = 8;
+	tag = "icon-shower (WEST)";
 	icon_state = "shower";
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -67725,31 +66274,26 @@
 /obj/effect/landmark/start{
 	name = "Blueshield"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
 "cqJ" = (
 /obj/structure/table/wood,
-/obj/structure/snow,
-/obj/item/a_gift,
-/obj/item/id_decal/centcom,
-/obj/item/gun/projectile/automatic/toy,
-/obj/item/ammo_box/magazine/toy/smg,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/blueshield)
+"cqK" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
 "cqL" = (
 /obj/item/flag/nt,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/blueshield)
 "cqM" = (
@@ -67763,6 +66307,12 @@
 	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/virology)
+"cqO" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/ntrep)
 "cqP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -67792,10 +66342,6 @@
 /obj/effect/landmark/start{
 	name = "Nanotrasen Representative"
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "cqR" = (
@@ -67805,10 +66351,6 @@
 	departmentType = 5;
 	name = "Blueshield Requests Console";
 	pixel_x = -30
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -67820,7 +66362,6 @@
 	},
 /obj/item/paper/ntrep,
 /obj/item/paper_bin/nanotrasen,
-/obj/structure/snow,
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "cqT" = (
@@ -67832,7 +66373,6 @@
 	name = "NT Representative Requests Console";
 	pixel_x = 30
 	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/ntrep)
 "cqU" = (
@@ -67993,9 +66533,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "darkblue"
@@ -68004,9 +66541,6 @@
 "crf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -68036,9 +66570,9 @@
 "crh" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whitepurple (NORTHWEST)";
 	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	dir = 9
 	},
 /area/toxins/explab)
 "cri" = (
@@ -68058,8 +66592,8 @@
 	pixel_y = -23
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -68094,9 +66628,9 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "crn" = (
@@ -68188,13 +66722,10 @@
 	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	dir = 4
 	},
 /area/medical/virology)
 "crv" = (
@@ -68209,9 +66740,6 @@
 	},
 /obj/effect/landmark/start{
 	name = "Virologist"
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68371,9 +66899,6 @@
 	},
 /area/toxins/mixing)
 "crL" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68384,10 +66909,6 @@
 	},
 /obj/effect/landmark/start{
 	name = "Scientist"
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68412,11 +66933,6 @@
 /area/toxins/mixing)
 "crO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
-/obj/item/toy/figure/chemist,
-/obj/item/a_gift,
-/obj/item/nanomob_card,
-/obj/item/toy/figure/syndie,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68592,9 +67108,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -68804,10 +67317,6 @@
 /area/maintenance/apmaint)
 "csv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68833,14 +67342,6 @@
 	pixel_y = -24;
 	req_access_txt = "67"
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/blueshield)
 "csy" = (
@@ -68848,9 +67349,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -68866,10 +67364,6 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/wood,
 /area/blueshield)
 "csA" = (
@@ -68879,7 +67373,6 @@
 	name = "Science Requests Console";
 	pixel_y = 30
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68898,7 +67391,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "csC" = (
@@ -68917,14 +67409,6 @@
 	pixel_x = 6;
 	pixel_y = -24;
 	req_access_txt = "73"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -68945,7 +67429,6 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/obj/structure/snow,
 /turf/simulated/floor/wood,
 /area/ntrep)
 "csF" = (
@@ -69084,13 +67567,9 @@
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 5
 	},
 /area/engine/controlroom)
 "csR" = (
@@ -69127,13 +67606,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "csT" = (
@@ -69493,8 +67972,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/medical/cmostore)
 "ctq" = (
@@ -69548,7 +68027,6 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -69568,10 +68046,6 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -69590,7 +68064,6 @@
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -69628,7 +68101,6 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -69903,9 +68375,9 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 2;
+	tag = "icon-pipe-j2";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	dir = 2
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69938,9 +68410,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "cue" = (
@@ -69993,13 +68465,9 @@
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/engineering,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/engine/controlroom)
 "cuj" = (
@@ -70015,12 +68483,12 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -70196,8 +68664,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
@@ -70266,13 +68734,10 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/virology)
 "cuG" = (
@@ -70336,10 +68801,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70372,7 +68833,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70389,11 +68849,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
-/obj/item/toy/figure/geneticist,
-/obj/item/a_gift,
-/obj/item/nanomob_card,
-/obj/item/toy/plushie/nukeplushie,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70411,8 +68866,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/flora/tree/pine/xmas,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70448,7 +68901,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70471,7 +68923,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70482,7 +68933,6 @@
 	},
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70505,7 +68955,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70537,7 +68986,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70781,9 +69229,9 @@
 	network = list("SS13")
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/structure/rack{
 	dir = 8;
@@ -70951,8 +69399,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/engine/controlroom)
 "cvN" = (
@@ -71010,8 +69458,8 @@
 /area/medical/psych)
 "cvS" = (
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -71032,8 +69480,6 @@
 	name = "station intercom (General)";
 	pixel_y = -28
 	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -71104,17 +69550,17 @@
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/virology)
 "cwb" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	dir = 5
 	},
 /area/medical/virology)
 "cwc" = (
@@ -71159,13 +69605,10 @@
 	dir = 4;
 	level = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	dir = 5
 	},
 /area/medical/virology)
 "cwf" = (
@@ -71192,9 +69635,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	dir = 9
 	},
 /area/medical/virology)
 "cwh" = (
@@ -71223,9 +69666,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	dir = 5
 	},
 /area/medical/virology)
 "cwj" = (
@@ -71259,10 +69702,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -71270,7 +69709,6 @@
 "cwm" = (
 /obj/machinery/light,
 /obj/machinery/telepad_cargo,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -71288,8 +69726,8 @@
 	req_access_txt = "40"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/medical/cmostore)
 "cwo" = (
@@ -71352,8 +69790,8 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/medical/cmostore)
 "cws" = (
@@ -71370,8 +69808,8 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/medical/cmostore)
 "cwt" = (
@@ -71547,21 +69985,21 @@
 /area/storage/tech)
 "cwP" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cwQ" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -71569,18 +70007,14 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cwR" = (
 /obj/machinery/computer/station_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cwS" = (
@@ -71614,8 +70048,8 @@
 /area/medical/medbay2)
 "cwU" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -71766,13 +70200,9 @@
 	name = "Tank Monitor";
 	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/engine/controlroom)
 "cxh" = (
@@ -71814,8 +70244,8 @@
 /area/medical/medbay2)
 "cxk" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -71829,9 +70259,9 @@
 /area/construction)
 "cxl" = (
 /obj/machinery/light/small{
-	dir = 4;
+	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -71903,9 +70333,9 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "cxu" = (
@@ -71914,9 +70344,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	dir = 4
 	},
 /area/medical/virology)
 "cxv" = (
@@ -71934,9 +70364,9 @@
 "cxw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "cxx" = (
@@ -71946,9 +70376,9 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	dir = 4
 	},
 /area/medical/virology)
 "cxy" = (
@@ -72008,10 +70438,6 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cxD" = (
@@ -72046,17 +70472,17 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/virology)
 "cxG" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	dir = 6
 	},
 /area/medical/virology)
 "cxH" = (
@@ -72111,9 +70537,9 @@
 /obj/item/storage/box/donkpockets,
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	dir = 4
 	},
 /area/medical/virology)
 "cxM" = (
@@ -72347,7 +70773,6 @@
 	req_access_txt = "32";
 	req_one_access_txt = "0"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cyi" = (
@@ -72428,9 +70853,9 @@
 /area/storage/tech)
 "cyr" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
@@ -72622,14 +71047,14 @@
 /obj/structure/table,
 /obj/item/t_scanner,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/engine/controlroom)
 "cyH" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -72707,10 +71132,6 @@
 	tag = ""
 	},
 /obj/machinery/computer/atmos_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cyR" = (
@@ -72780,9 +71201,9 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/virology)
 "cyW" = (
@@ -72796,9 +71217,9 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	dir = 6
 	},
 /area/medical/virology)
 "cyX" = (
@@ -72813,9 +71234,9 @@
 "cyY" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	dir = 10
 	},
 /area/medical/virology)
 "cyZ" = (
@@ -72830,9 +71251,9 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	dir = 6
 	},
 /area/medical/virology)
 "czb" = (
@@ -72992,8 +71413,8 @@
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/maintenance/asmaint)
 "czv" = (
@@ -73259,9 +71680,9 @@
 /area/maintenance/incinerator)
 "czR" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -73343,8 +71764,8 @@
 	pixel_y = 0
 	},
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -73456,10 +71877,6 @@
 /area/toxins/xenobiology)
 "cAg" = (
 /obj/machinery/computer/atmos_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -73471,10 +71888,6 @@
 	level = 3;
 	name = "Distribution and Waste Monitor";
 	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -73645,9 +72058,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitebluecorner (WEST)";
 	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	dir = 8
 	},
 /area/medical/medbay2)
 "cAu" = (
@@ -73714,8 +72127,8 @@
 /area/maintenance/asmaint)
 "cAC" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/maintenance/asmaint)
 "cAD" = (
@@ -73826,8 +72239,8 @@
 /area/hallway/primary/aft)
 "cAN" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -74163,8 +72576,8 @@
 "cBv" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/hallway/primary/aft)
 "cBw" = (
@@ -74207,8 +72620,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/medical/cmostore)
 "cBz" = (
@@ -74216,8 +72629,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/medical/cmostore)
 "cBA" = (
@@ -74251,9 +72664,9 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cBD" = (
@@ -74467,9 +72880,6 @@
 	dir = 1;
 	on = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -74482,18 +72892,15 @@
 	network = list("Research","SS13");
 	pixel_x = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/misc_lab)
 "cCg" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -74547,9 +72954,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cCk" = (
@@ -74558,9 +72965,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cCl" = (
@@ -74572,9 +72979,9 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cCm" = (
@@ -74585,17 +72992,17 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cCn" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cCo" = (
@@ -74877,8 +73284,8 @@
 /area/construction)
 "cCM" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
@@ -74886,8 +73293,8 @@
 /area/storage/tech)
 "cCN" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -75206,9 +73613,9 @@
 	name = "Air To Distro"
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -75271,9 +73678,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cDu" = (
@@ -75343,9 +73750,9 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 6;
+	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75384,9 +73791,9 @@
 	name = "Scientist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cDE" = (
@@ -75407,25 +73814,25 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cDG" = (
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cDH" = (
 /obj/machinery/chem_dispenser,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cDI" = (
@@ -75434,10 +73841,6 @@
 	pixel_y = -28
 	},
 /obj/machinery/computer/drone_control,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cDJ" = (
@@ -75630,8 +74033,8 @@
 	tag = ""
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -75703,8 +74106,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 8
 	},
 /area/hallway/primary/aft)
 "cEj" = (
@@ -75942,10 +74345,6 @@
 	},
 /obj/machinery/computer/podtracker,
 /obj/effect/decal/warning_stripes/east,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
 "cEL" = (
@@ -75974,14 +74373,14 @@
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/engine/mechanic_workshop)
 "cEN" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/power/apc{
@@ -75991,8 +74390,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/engine/mechanic_workshop)
 "cEO" = (
@@ -76016,8 +74415,8 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "vault";
+	dir = 8
 	},
 /area/engine/mechanic_workshop)
 "cEQ" = (
@@ -76134,9 +74533,9 @@
 "cFb" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cFc" = (
@@ -76201,12 +74600,12 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 8
 	},
 /area/hallway/primary/aft)
 "cFi" = (
@@ -76325,9 +74724,9 @@
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9;
+	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
-	tag = "icon-intact (NORTHWEST)"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76358,16 +74757,16 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "cFy" = (
@@ -76379,9 +74778,9 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	dir = 4
 	},
 /area/medical/virology)
 "cFz" = (
@@ -76536,7 +74935,6 @@
 /obj/item/assembly/timer,
 /obj/item/assembly/timer,
 /obj/item/assembly/timer,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -76666,9 +75064,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -76718,9 +75113,9 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cFV" = (
@@ -76741,9 +75136,9 @@
 	},
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cFZ" = (
@@ -76764,9 +75159,9 @@
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/pillbottles,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cGa" = (
@@ -76779,9 +75174,9 @@
 /obj/item/reagent_containers/dropper/precision,
 /obj/item/reagent_containers/dropper/precision,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cGb" = (
@@ -76813,9 +75208,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 5
 	},
 /area/toxins/misc_lab)
 "cGe" = (
@@ -76864,7 +75259,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
 "cGi" = (
@@ -76941,9 +75335,9 @@
 /area/hallway/primary/aft)
 "cGp" = (
 /obj/structure/disposalpipe/junction{
-	dir = 2;
+	tag = "icon-pipe-j2";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2"
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76977,10 +75371,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/computer/station_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cGu" = (
@@ -76997,8 +75387,8 @@
 	network = list("SS13")
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/table,
 /obj/item/book/manual/atmospipes,
@@ -77022,15 +75412,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "cGx" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -77040,9 +75430,9 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology)
 "cGy" = (
@@ -77055,15 +75445,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	dir = 4
 	},
 /area/medical/virology)
 "cGz" = (
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -77135,10 +75525,6 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
 "cGF" = (
@@ -77147,14 +75533,6 @@
 /area/engine/mechanic_workshop)
 "cGG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77169,7 +75547,6 @@
 	req_one_access_txt = "0"
 	},
 /obj/machinery/cell_charger,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77181,7 +75558,6 @@
 /obj/effect/landmark/start{
 	name = "Mechanic"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77236,9 +75612,9 @@
 "cGN" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 1;
+	tag = "icon-map (NORTH)";
 	icon_state = "map";
-	tag = "icon-map (NORTH)"
+	dir = 1
 	},
 /turf/simulated/wall,
 /area/engine/controlroom)
@@ -77297,9 +75673,6 @@
 	},
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -77444,10 +75817,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -77621,8 +75990,8 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 5
 	},
 /area/engine/break_room)
 "cHu" = (
@@ -77666,9 +76035,6 @@
 "cHy" = (
 /obj/structure/chair/office/dark{
 	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -77714,9 +76080,6 @@
 "cHC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/structure/snow{
-	icon_state = "snow_surround"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -77893,9 +76256,6 @@
 "cHS" = (
 /obj/structure/table,
 /obj/item/book/manual/supermatter_engine,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cHT" = (
@@ -77903,7 +76263,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cHU" = (
@@ -77912,9 +76271,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9;
+	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
-	tag = "icon-intact (NORTHWEST)"
+	dir = 9
 	},
 /turf/simulated/wall,
 /area/engine/break_room)
@@ -77930,16 +76289,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cHW" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	dir = 8
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -77965,10 +76321,6 @@
 /obj/machinery/alarm{
 	frequency = 1439;
 	pixel_y = 23
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -78009,9 +76361,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -78063,9 +76412,6 @@
 	initialize_directions = 10;
 	level = 1
 	},
-/obj/structure/chair/comfy/red{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cIi" = (
@@ -78084,8 +76430,8 @@
 /area/atmos/control)
 "cIj" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	tag = "icon-wood-broken7";
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cIk" = (
@@ -78095,8 +76441,8 @@
 "cIl" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	tag = "icon-wood-broken3";
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/asmaint)
 "cIm" = (
@@ -78255,8 +76601,8 @@
 /area/toxins/xenobiology)
 "cIB" = (
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -78415,9 +76761,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/shower{
-	dir = 4;
+	tag = "icon-shower (EAST)";
 	icon_state = "shower";
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -78512,6 +76858,9 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cIX" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
 	initialize_directions = 11;
@@ -78519,9 +76868,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/chair/comfy/green{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -78713,9 +77059,9 @@
 /area/maintenance/aft)
 "cJo" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/structure/rack{
 	dir = 8;
@@ -78742,20 +77088,12 @@
 /area/engine/break_room)
 "cJp" = (
 /obj/machinery/computer/atmoscontrol,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -78770,8 +77108,8 @@
 /area/toxins/xenobiology)
 "cJs" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	tag = "icon-wood-broken6";
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/asmaint)
 "cJt" = (
@@ -78783,8 +77121,8 @@
 /area/maintenance/asmaint)
 "cJv" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	tag = "icon-wood-broken";
+	icon_state = "wood-broken"
 	},
 /area/maintenance/asmaint)
 "cJw" = (
@@ -78857,10 +77195,6 @@
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -79009,9 +77343,6 @@
 	pixel_x = -25
 	},
 /obj/effect/decal/warning_stripes/northwest,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJN" = (
@@ -79113,18 +77444,19 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/mechanic_workshop)
+"cJV" = (
+/turf/simulated/floor/plasteel,
+/area/engine/mechanic_workshop)
 "cJW" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/engine/mechanic_workshop)
 "cJX" = (
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79190,7 +77522,6 @@
 /obj/item/folder/yellow,
 /obj/item/pen,
 /obj/item/book/manual/sop_engineering,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79374,12 +77705,12 @@
 /area/toxins/xenobiology)
 "cKt" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
+	tag_exterior_door = "xeno_airlock_exterior";
 	id_tag = "xeno_airlock_control";
+	tag_interior_door = "xeno_airlock_interior";
 	name = "Xenobiology Access Console";
 	pixel_x = 8;
-	pixel_y = 22;
-	tag_exterior_door = "xeno_airlock_exterior";
-	tag_interior_door = "xeno_airlock_interior"
+	pixel_y = 22
 	},
 /obj/machinery/light_switch{
 	pixel_x = -6;
@@ -79401,21 +77732,21 @@
 /area/maintenance/asmaint)
 "cKv" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
+	tag = "icon-wooden_chair_wings (EAST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
 "cKw" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	tag = "icon-wood-broken7";
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cKx" = (
@@ -79474,10 +77805,6 @@
 	name = "Atmospherics Requests Console";
 	pixel_x = 30;
 	pixel_y = 0
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -79605,8 +77932,8 @@
 "cKM" = (
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	tag = "icon-wood-broken";
+	icon_state = "wood-broken"
 	},
 /area/maintenance/asmaint)
 "cKN" = (
@@ -79643,8 +77970,8 @@
 /area/toxins/xenobiology)
 "cKS" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	tag = "icon-wood-broken3";
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/asmaint)
 "cKT" = (
@@ -79713,19 +78040,18 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "cKX" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -79913,17 +78239,15 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
 "cLs" = (
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
+	dir = 2;
 	pixel_x = 0;
 	pixel_y = -22
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -79940,7 +78264,6 @@
 	dir = 8
 	},
 /obj/machinery/vending/coffee,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79951,11 +78274,6 @@
 	pixel_y = -28
 	},
 /obj/machinery/computer/rdconsole/mechanics,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79975,9 +78293,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -80039,10 +78354,6 @@
 /obj/structure/computerframe,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cLF" = (
@@ -80075,9 +78386,6 @@
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/decal/warning_stripes/north,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = -16
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cLK" = (
@@ -80174,17 +78482,13 @@
 "cLS" = (
 /obj/machinery/computer/security/engineering,
 /obj/effect/decal/warning_stripes/northeast,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cLT" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 4
 	},
 /area/hallway/primary/aft)
 "cLU" = (
@@ -80230,15 +78534,15 @@
 "cLY" = (
 /obj/item/stack/sheet/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	tag = "icon-wood-broken5";
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/asmaint)
 "cLZ" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
+	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
@@ -80264,8 +78568,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	tag = "icon-wood-broken7";
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cMc" = (
@@ -80584,8 +78888,8 @@
 "cML" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 4
 	},
 /area/hallway/primary/aft)
 "cMM" = (
@@ -80718,7 +79022,6 @@
 /area/engine/break_room)
 "cMX" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cMY" = (
@@ -80859,8 +79162,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -80946,8 +79249,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -80980,8 +79283,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -81040,8 +79343,8 @@
 /area/space/nearstation)
 "cNF" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -81143,29 +79446,23 @@
 /obj/effect/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/black{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cNP" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cNQ" = (
 /obj/effect/landmark/start{
 	name = "Life Support Specialist"
 	},
-/obj/structure/chair/comfy/green{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cNR" = (
@@ -81216,8 +79513,8 @@
 /area/engine/break_room)
 "cNV" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/northwest,
@@ -81273,8 +79570,8 @@
 /area/engine/engineering)
 "cOb" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/west,
@@ -81321,10 +79618,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOf" = (
@@ -81355,7 +79648,6 @@
 	pixel_x = 1;
 	pixel_y = 9
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOi" = (
@@ -81394,7 +79686,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/vending/cigarette,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOm" = (
@@ -81551,12 +79842,12 @@
 /area/atmos/distribution)
 "cOB" = (
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -81570,8 +79861,8 @@
 /area/maintenance/asmaint2)
 "cOD" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
@@ -81581,12 +79872,12 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	icon_state = "3";
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	icon_state = "4";
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -81687,10 +79978,9 @@
 /obj/effect/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOO" = (
@@ -81733,7 +80023,6 @@
 /area/toxins/xenobiology)
 "cOS" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -81784,8 +80073,8 @@
 	pixel_y = 0
 	},
 /obj/structure/sink{
-	dir = 8;
 	icon_state = "sink";
+	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -81803,7 +80092,6 @@
 	pixel_y = 4
 	},
 /obj/item/book/manual/sop_engineering,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cPa" = (
@@ -81864,8 +80152,8 @@
 /area/maintenance/genetics)
 "cPg" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/southwest,
@@ -81896,10 +80184,6 @@
 	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/effect/decal/warning_stripes/east,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cPj" = (
@@ -81945,8 +80229,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -81974,8 +80258,8 @@
 	network = list("SS13")
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/power/apc{
@@ -82002,8 +80286,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/structure/flora/tree/pine/xmas,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cPr" = (
@@ -82114,8 +80396,8 @@
 "cPC" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -82176,8 +80458,8 @@
 /area/solar/port)
 "cPI" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -82231,10 +80513,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cPO" = (
@@ -82251,14 +80529,13 @@
 	network = list("SS13")
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/structure/engineeringcart,
 /obj/item/radio/intercom{
 	pixel_x = 28
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cPQ" = (
@@ -82338,13 +80615,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/camera_advanced/xenobio,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -82375,10 +80645,6 @@
 "cQb" = (
 /obj/machinery/particle_accelerator/control_box,
 /obj/structure/cable/yellow,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cQc" = (
@@ -82458,13 +80724,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/computer/camera_advanced/xenobio,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -82504,8 +80763,8 @@
 /area/space/nearstation)
 "cQq" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -82604,8 +80863,8 @@
 /area/toxins/xenobiology)
 "cQB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plasteel{
@@ -82791,7 +81050,6 @@
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cQP" = (
@@ -82801,10 +81059,6 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -82830,8 +81084,8 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/medical/cmostore)
 "cQS" = (
@@ -83204,8 +81458,8 @@
 	},
 /obj/item/storage/firstaid/toxin,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 4
 	},
 /area/medical/cmostore)
 "cRv" = (
@@ -83273,8 +81527,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -83477,10 +81731,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRT" = (
@@ -83521,7 +81771,6 @@
 /obj/item/stack/rods{
 	amount = 50
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRV" = (
@@ -83529,10 +81778,6 @@
 	dir = 4;
 	initialize_directions = 11;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -83552,8 +81797,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cRX" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cRY" = (
@@ -83616,7 +81859,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/vending/engivend,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cSb" = (
@@ -83668,14 +81910,14 @@
 /area/toxins/xenobiology)
 "cSi" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	tag_airpump = "engineering_west_pump";
+	tag_exterior_door = "engineering_west_outer";
 	frequency = 1379;
 	id_tag = "engineering_west_airlock";
+	tag_interior_door = "engineering_west_inner";
 	pixel_x = 25;
 	req_access_txt = "10;13";
-	tag_airpump = "engineering_west_pump";
-	tag_chamber_sensor = "engineering_west_sensor";
-	tag_exterior_door = "engineering_west_outer";
-	tag_interior_door = "engineering_west_inner"
+	tag_chamber_sensor = "engineering_west_sensor"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -83844,14 +82086,14 @@
 /area/engine/engineering)
 "cSy" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	tag_airpump = "engineering_east_pump";
+	tag_exterior_door = "engineering_east_outer";
 	frequency = 1379;
 	id_tag = "engineering_east_airlock";
+	tag_interior_door = "engineering_east_inner";
 	pixel_x = -25;
 	req_access_txt = "10;13";
-	tag_airpump = "engineering_east_pump";
-	tag_chamber_sensor = "engineering_east_sensor";
-	tag_exterior_door = "engineering_east_outer";
-	tag_interior_door = "engineering_east_inner"
+	tag_chamber_sensor = "engineering_east_sensor"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -84068,10 +82310,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cSQ" = (
@@ -84173,10 +82411,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cTa" = (
@@ -84184,8 +82418,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -84227,14 +82461,14 @@
 	name = "Robotics Operating Computer";
 	stat = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/assembly/assembly_line)
+"cTe" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/engine/equipmentstorage)
 "cTf" = (
 /obj/machinery/newscaster{
 	pixel_x = 0;
@@ -84408,13 +82642,9 @@
 	output_tag = "waste_out";
 	sensors = list("waste_sensor" = "Tank")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/atmos/distribution)
 "cTv" = (
@@ -84589,8 +82819,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -84623,9 +82853,6 @@
 	dir = 10;
 	initialize_directions = 10;
 	level = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -84745,8 +82972,8 @@
 /area/solar/starboard)
 "cTX" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10;
@@ -84774,15 +83001,15 @@
 	id_tag = "robotics_solar_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	tag_airpump = "robotics_solar_pump";
+	tag_exterior_door = "robotics_solar_outer";
 	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
+	tag_interior_door = "robotics_solar_inner";
 	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "13";
-	tag_airpump = "robotics_solar_pump";
-	tag_chamber_sensor = "robotics_solar_sensor";
-	tag_exterior_door = "robotics_solar_outer";
-	tag_interior_door = "robotics_solar_inner"
+	tag_chamber_sensor = "robotics_solar_sensor"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -85092,10 +83319,6 @@
 /area/atmos)
 "cUy" = (
 /obj/machinery/computer/atmos_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -85324,8 +83547,8 @@
 	name = "Gas Mix Inlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 6
 	},
 /area/atmos/distribution)
 "cUT" = (
@@ -85485,10 +83708,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVi" = (
@@ -85525,10 +83744,6 @@
 	track = 0
 	},
 /obj/structure/cable,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "cVm" = (
@@ -85636,16 +83851,18 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVt" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/effect/landmark/start{
 	name = "Civilian"
 	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "green";
+	dir = 4
 	},
 /area/hallway/secondary/exit)
 "cVu" = (
@@ -85935,11 +84152,8 @@
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cVV" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "cVW" = (
 /obj/machinery/shieldgen,
@@ -86030,6 +84244,18 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
+"cWh" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "cWi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -86040,8 +84266,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -86213,12 +84439,8 @@
 	name = "Grid Power Monitoring Computer"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -86247,9 +84469,6 @@
 /obj/structure/closet/secure_closet/engineering_chief{
 	req_access_txt = "0"
 	},
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_x = -17
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -86270,12 +84489,12 @@
 /area/engine/engineering)
 "cWG" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
+	tag = "icon-left (WEST)";
 	name = "Bar Delivery";
+	icon_state = "left";
+	dir = 8;
 	req_access_txt = "25";
-	tag = "icon-left (WEST)"
+	base_state = "left"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -86538,8 +84757,8 @@
 	name = "N2O Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "escape"
+	icon_state = "escape";
+	dir = 5
 	},
 /area/atmos)
 "cXe" = (
@@ -86655,11 +84874,18 @@
 	icon_state = "purple"
 	},
 /area/hallway/secondary/exit)
+"cXp" = (
+/obj/structure/chair,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/exit)
 "cXq" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -86677,6 +84903,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"cXs" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/exit)
 "cXt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86719,10 +84957,6 @@
 /area/toxins/xenobiology)
 "cXw" = (
 /obj/machinery/computer/station_alert,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXx" = (
@@ -86891,8 +85125,8 @@
 	location = "Kitchen"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/maintenance/fsmaint2)
 "cXL" = (
@@ -86941,8 +85175,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXP" = (
@@ -87074,20 +85306,23 @@
 	output_tag = "n2o_out";
 	sensors = list("n2o_sensor" = "Tank")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "escape"
+	icon_state = "escape";
+	dir = 4
 	},
 /area/atmos)
-"cYe" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
+"cYd" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1;
+	on = 1
 	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/secondary/exit)
+"cYe" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "green"
@@ -87604,8 +85839,8 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Particle Accelerator";
 	dir = 2;
-	network = list("Singularity","SS13");
-	pixel_x = 23
+	pixel_x = 23;
+	network = list("Singularity","SS13")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -87631,8 +85866,8 @@
 	level = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "escape"
+	icon_state = "escape";
+	dir = 6
 	},
 /area/atmos)
 "cZh" = (
@@ -88245,9 +86480,9 @@
 /area/escapepodbay)
 "dau" = (
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -88260,16 +86495,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -88278,7 +86508,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daz" = (
@@ -88457,10 +86686,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daR" = (
@@ -88548,8 +86773,8 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
@@ -88908,7 +87133,6 @@
 	network = list("SS13")
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dbL" = (
@@ -88919,7 +87143,6 @@
 	tag = ""
 	},
 /obj/structure/reagent_dispensers/watertank/high,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dbM" = (
@@ -88970,8 +87193,8 @@
 	state = 2
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Singularity East";
@@ -89046,8 +87269,8 @@
 /area/space/nearstation)
 "dcb" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 8
 	},
 /area/hallway/primary/central/north)
 "dcc" = (
@@ -89088,9 +87311,9 @@
 	anchored = 1
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
@@ -89123,10 +87346,6 @@
 /area/engine/break_room)
 "dck" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "dcl" = (
@@ -89161,10 +87380,6 @@
 	d2 = 4;
 	icon_state = "1-4";
 	tag = ""
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
@@ -89215,7 +87430,6 @@
 /area/maintenance/asmaint)
 "dct" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dcu" = (
@@ -89252,8 +87466,8 @@
 /area/maintenance/turbine)
 "dcx" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	icon_state = "term";
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -89291,11 +87505,11 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "dcB" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /obj/effect/landmark/start{
 	name = "Life Support Specialist"
-	},
-/obj/structure/chair/comfy/green{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -89311,15 +87525,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dcE" = (
-/obj/effect/landmark/start{
-	name = "Life Support Specialist"
-	},
-/obj/structure/chair/comfy/red{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
+/obj/effect/landmark/start{
+	name = "Life Support Specialist"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -89388,7 +87598,6 @@
 	tag = ""
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dcN" = (
@@ -89592,7 +87801,6 @@
 /area/maintenance/turbine)
 "ddm" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "ddn" = (
@@ -89620,10 +87828,6 @@
 	id = "incineratorturbine"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "ddq" = (
@@ -89642,7 +87846,6 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "ddt" = (
@@ -89897,8 +88100,8 @@
 /area/engine/engineering)
 "ddT" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -89996,8 +88199,8 @@
 /area/atmos)
 "ded" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -90049,7 +88252,6 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dei" = (
@@ -90078,8 +88280,8 @@
 	name = "CO2 Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 5
 	},
 /area/atmos)
 "del" = (
@@ -90260,7 +88462,6 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deE" = (
@@ -90291,7 +88492,6 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deH" = (
@@ -90299,15 +88499,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deJ" = (
@@ -90347,7 +88542,6 @@
 	name = "Atmospherics Maintenance";
 	req_access_txt = "24"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
 "deM" = (
@@ -90361,7 +88555,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deN" = (
@@ -90381,8 +88574,8 @@
 /area/maintenance/starboardsolar)
 "deO" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 6
@@ -90393,7 +88586,6 @@
 	pixel_x = -24;
 	shock_proof = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deP" = (
@@ -90420,8 +88612,8 @@
 /area/atmos)
 "deS" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -90451,13 +88643,9 @@
 	output_tag = "co2_out";
 	sensors = list("co2_sensor" = "Tank")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "caution";
+	dir = 4
 	},
 /area/atmos)
 "deW" = (
@@ -90562,8 +88750,8 @@
 /area/maintenance/asmaint2)
 "dfj" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	icon_state = "term";
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -90626,12 +88814,8 @@
 	track = 0
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
@@ -90711,14 +88895,14 @@
 	tag = ""
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	tag_airpump = "solar_xeno_pump";
+	tag_exterior_door = "solar_xeno_outer";
 	frequency = 1379;
 	id_tag = "solar_xeno_airlock";
+	tag_interior_door = "solar_xeno_inner";
 	pixel_x = 25;
 	req_access_txt = "13";
-	tag_airpump = "solar_xeno_pump";
-	tag_chamber_sensor = "solar_xeno_sensor";
-	tag_exterior_door = "solar_xeno_outer";
-	tag_interior_door = "solar_xeno_inner"
+	tag_chamber_sensor = "solar_xeno_sensor"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -90739,7 +88923,6 @@
 /area/maintenance/storage)
 "dfy" = (
 /obj/structure/chair/stool,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfz" = (
@@ -90897,8 +89080,8 @@
 /area/maintenance/asmaint2)
 "dfQ" = (
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
+	dir = 2;
 	pixel_x = 0;
 	pixel_y = -22
 	},
@@ -90980,8 +89163,8 @@
 /area/maintenance/storage)
 "dgd" = (
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 6
 	},
 /area/maintenance/storage)
 "dge" = (
@@ -91083,7 +89266,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgs" = (
@@ -91097,10 +89279,6 @@
 	pixel_y = 4
 	},
 /obj/item/radio,
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgt" = (
@@ -91139,9 +89317,9 @@
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f6";
 	icon_state = "swall_f6";
-	tag = "icon-swall_f6"
+	dir = 2
 	},
 /area/shuttle/pod_4)
 "dgE" = (
@@ -91207,10 +89385,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 5
-	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -91416,8 +89590,8 @@
 /area/shuttle/trade/sol)
 "dhn" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall13"
+	icon_state = "swall13";
+	dir = 2
 	},
 /area/shuttle/trade/sol)
 "dho" = (
@@ -91467,8 +89641,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "dhs" = (
@@ -91477,8 +89651,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 1
 	},
 /area/crew_quarters/dorms)
 "dht" = (
@@ -91577,18 +89751,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	level = 2
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
 /area/atmos)
 "dhB" = (
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 10
 	},
 /area/atmos)
 "dhC" = (
@@ -91596,8 +89766,8 @@
 	name = "Nitrogen Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 6
 	},
 /area/atmos)
 "dhD" = (
@@ -91607,10 +89777,6 @@
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
 	sensors = list("o2_sensor" = "Tank")
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -91622,8 +89788,8 @@
 	level = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 10
 	},
 /area/atmos)
 "dhF" = (
@@ -91631,8 +89797,8 @@
 	name = "Oxygen Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "blue"
+	icon_state = "blue";
+	dir = 6
 	},
 /area/atmos)
 "dhG" = (
@@ -91644,10 +89810,6 @@
 	pressure_setting = 2000;
 	sensors = list("air_sensor" = "Tank")
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -91657,8 +89819,8 @@
 	level = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 10
 	},
 /area/atmos)
 "dhI" = (
@@ -91682,8 +89844,8 @@
 	name = "Mixed Air Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "arrival"
+	icon_state = "arrival";
+	dir = 6
 	},
 /area/atmos)
 "dhK" = (
@@ -91766,9 +89928,9 @@
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f5";
 	icon_state = "swall_f5";
-	tag = "icon-swall_f5"
+	dir = 2
 	},
 /area/shuttle/pod_4)
 "dhV" = (
@@ -91832,8 +89994,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/maintenance/fsmaint2)
 "dii" = (
@@ -92333,8 +90495,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutral"
+	icon_state = "neutral";
+	dir = 4
 	},
 /area/crew_quarters/dorms)
 "djg" = (
@@ -92353,20 +90515,14 @@
 	pixel_y = 24
 	},
 /obj/structure/table/reinforced,
-/obj/item/toy/xmas_cracker,
-/obj/item/toy/xmas_cracker,
-/obj/item/toy/xmas_cracker,
-/obj/item/toy/xmas_cracker,
-/obj/item/toy/xmas_cracker,
-/obj/item/toy/xmas_cracker,
-/obj/item/storage/fancy/crayons,
-/obj/item/wirecutters,
-/obj/item/stack/tape_roll,
-/obj/item/stack/tape_roll,
-/obj/item/paper{
-	info = "Here are the materials needed to create decorations for the holidays. Please use them at your discretion to create a nice, warm atmosphere to spread the holiday cheer.";
-	name = "Dearest Bartender"
+/obj/item/stack/packageWrap,
+/obj/item/book/manual/sop_service,
+/obj/item/pen/blue{
+	pixel_x = 0;
+	pixel_y = 4
 	},
+/obj/item/book/manual/barman_recipes,
+/obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -92472,11 +90628,11 @@
 /area/storage/secure)
 "djt" = (
 /obj/machinery/door/window/eastright{
-	dir = 2;
-	icon_state = "right";
+	tag = "icon-right";
 	name = "Hydroponics Delivery";
-	req_access_txt = "35";
-	tag = "icon-right"
+	icon_state = "right";
+	dir = 2;
+	req_access_txt = "35"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment{
@@ -92776,9 +90932,9 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -92991,8 +91147,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/hallway/primary/central/ne)
 "dkn" = (
@@ -93011,8 +91167,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 4
 	},
 /area/hallway/primary/central/ne)
 "dkp" = (
@@ -93214,13 +91370,12 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/book/manual/barman_recipes,
-/obj/item/stack/packageWrap,
-/obj/item/book/manual/sop_service,
-/obj/item/lighter/zippo,
-/obj/item/pen/blue{
-	pixel_x = 0;
-	pixel_y = 4
+/obj/item/phone{
+	attack_verb = list("bounced a check off","checked-out","tipped");
+	desc = "Also known as a cash register, or, more commonly, \"robbery magnet\". It's old and rusty, clearly non-functional and decorative only.";
+	icon = 'icons/obj/machines/pos.dmi';
+	icon_state = "pos";
+	name = "point of sale"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -93284,10 +91439,6 @@
 	dir = 8
 	},
 /obj/structure/kitchenspike,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -93675,9 +91826,6 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
@@ -94032,9 +92180,9 @@
 	})
 "dml" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
+	tag = "icon-pipe-j2 (EAST)";
 	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	name = "Waste Out";
@@ -94413,9 +92561,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94449,7 +92594,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94500,7 +92644,6 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94528,7 +92671,16 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/snow,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "dark";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/turret_protected/ai)
+"dni" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94548,7 +92700,6 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94566,7 +92717,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94587,7 +92737,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94627,10 +92776,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -94691,7 +92836,6 @@
 /area/turret_protected/ai)
 "dnu" = (
 /obj/structure/kitchenspike,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -94710,10 +92854,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -94918,13 +93058,10 @@
 	pixel_y = 0
 	},
 /obj/item/book/codex_gigas,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	tag = "icon-cult";
 	icon_state = "cult";
-	tag = "icon-cult"
+	dir = 2
 	},
 /area/library)
 "dnN" = (
@@ -95139,8 +93276,8 @@
 /area/maintenance/fsmaint2)
 "doh" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	d2 = 2
 	},
 /obj/machinery/power/solar{
 	id = "starboardsolar";
@@ -95160,13 +93297,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 1
 	},
 /area/security/checkpoint2)
 "doj" = (
@@ -95174,8 +93307,8 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "red";
+	dir = 5
 	},
 /area/security/checkpoint2)
 "dok" = (
@@ -95266,8 +93399,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria"
+	icon_state = "cafeteria";
+	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "dor" = (
@@ -95293,9 +93426,9 @@
 /area/engine/controlroom)
 "dou" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall12";
 	icon_state = "swall12";
-	tag = "icon-swall12"
+	dir = 2
 	},
 /area/shuttle/pod_4)
 "dov" = (
@@ -95329,8 +93462,8 @@
 "dow" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/pod_4)
 "dox" = (
@@ -95465,10 +93598,6 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -95478,8 +93607,8 @@
 "doV" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	dir = 2
 	},
 /area/shuttle/pod_4)
 "doW" = (
@@ -95524,10 +93653,6 @@
 /area/turret_protected/aisat_interior)
 "dpb" = (
 /obj/machinery/computer/teleporter,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "dpd" = (
@@ -95569,14 +93694,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/turret_protected/aisat_interior)
-"dpi" = (
-/obj/structure/chair/comfy/red{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/secondary/entry)
 "dpl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/rack,
@@ -95682,8 +93799,8 @@
 	})
 "dpF" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
@@ -95695,10 +93812,6 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
 	},
 /turf/simulated/floor/plating,
 /area/aisat/entrance{
@@ -95807,8 +93920,8 @@
 	})
 "dpZ" = (
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/power/apc{
@@ -95856,9 +93969,6 @@
 /obj/machinery/porta_turret{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault";
@@ -95891,9 +94001,6 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
@@ -95917,9 +94024,6 @@
 /obj/machinery/porta_turret{
 	dir = 8
 	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault";
@@ -95939,16 +94043,13 @@
 /area/aisat)
 "dqM" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/porta_turret{
 	dir = 4;
 	installation = /obj/item/gun/energy/gun;
 	name = "hallway turret"
-	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
 	},
 /turf/simulated/floor/bluegrid,
 /area/aisat{
@@ -95956,16 +94057,13 @@
 	})
 "dqO" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /obj/machinery/porta_turret{
 	dir = 8;
 	installation = /obj/item/gun/energy/gun;
 	name = "hallway turret"
-	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
 	},
 /turf/simulated/floor/bluegrid,
 /area/aisat{
@@ -96035,10 +94133,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -96048,10 +94142,6 @@
 "drt" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -96077,7 +94167,6 @@
 	pixel_y = 0
 	},
 /obj/structure/chair/office/dark,
-/obj/structure/snow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -96101,8 +94190,8 @@
 /area/turret_protected/ai)
 "drG" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -96116,9 +94205,6 @@
 /obj/machinery/porta_turret{
 	dir = 4
 	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
-	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "drK" = (
@@ -96126,10 +94212,6 @@
 	dir = 10;
 	initialize_directions = 10;
 	level = 1
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -96141,25 +94223,24 @@
 /obj/machinery/porta_turret{
 	dir = 8
 	},
-/obj/item/decorations/sticky_decorations/flammable/googlyeyes{
-	pixel_y = 8
-	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "drN" = (
 /turf/simulated/wall,
 /area/turret_protected/ai)
 "drO" = (
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
 	},
-/obj/structure/snow{
-	icon_state = "snow_surround"
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor/bluegrid,
+/area/turret_protected/ai)
 "drP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -96173,7 +94254,6 @@
 	req_access = null;
 	req_access_txt = "16"
 	},
-/obj/item/toy/plushie/ipcplushie,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "drQ" = (
@@ -96335,8 +94415,8 @@
 /area/turret_protected/ai)
 "dse" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	icon_state = "term";
+	dir = 1
 	},
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -96476,9 +94556,6 @@
 /area/engine/engineering)
 "dsK" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/item/decorations/sticky_decorations/flammable/christmas_stocking{
-	pixel_y = 17
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dsL" = (
@@ -96701,7 +94778,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dtw" = (
@@ -96718,13 +94794,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"dvh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/snow{
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "dwn" = (
 /obj/item/flag/med,
 /turf/simulated/floor/plasteel{
@@ -96732,13 +94801,6 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
-"dzR" = (
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
 "dEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -96754,29 +94816,6 @@
 	icon_state = "neutral"
 	},
 /area/shuttle/escape)
-"dLi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"dMw" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"dNE" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/security/main)
 "dQC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -96791,21 +94830,15 @@
 "dSc" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"dSC" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
 "dUh" = (
 /obj/machinery/status_display,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/escape)
 "dVs" = (
@@ -96816,77 +94849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
-"eap" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitecorner"
-	},
-/area/hallway/primary/starboard/west)
-"egY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"eiU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"ejx" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"eoC" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
-"epP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/warden)
-"ese" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "esI" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -96899,82 +94861,12 @@
 	icon_state = "redcorner"
 	},
 /area/shuttle/escape)
-"esS" = (
-/obj/structure/table/reinforced,
-/obj/item/phone{
-	attack_verb = list("bounced a check off","checked-out","tipped");
-	desc = "Also known as a cash register, or, more commonly, \"robbery magnet\". It's old and rusty, clearly non-functional and decorative only.";
-	icon = 'icons/obj/machines/pos.dmi';
-	icon_state = "pos";
-	name = "point of sale"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
-"etR" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"evY" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
-	},
-/area/blueshield)
-"eyt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/bar)
-"eEt" = (
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"eEX" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"eGK" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"eHF" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/heads)
 "eJA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/wall,
 /area/maintenance/fsmaint)
-"eML" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/detectives_office)
-"eSM" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
-	},
-/area/blueshield)
 "eTE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	req_access_txt = "0"
@@ -96993,26 +94885,6 @@
 /obj/machinery/computer/mob_battle_terminal/red,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"feB" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
-"fgD" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/security/main)
 "fho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -97021,70 +94893,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"fjG" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"fnn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/carpet,
-/area/library)
-"fnB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/port)
-"fpb" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
-	},
-/area/medical/biostorage)
 "fpO" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
 /area/shuttle/escape)
-"frt" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/primary/starboard/west)
-"fuP" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
-"fwM" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
 "fyM" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex/nitrile,
@@ -97110,18 +94923,11 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/chamber)
-"fCH" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
 "fGr" = (
 /obj/structure/sign/greencross,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall12"
+	icon_state = "swall12";
+	dir = 2
 	},
 /area/shuttle/escape)
 "fGD" = (
@@ -97132,22 +94938,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"fHf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/prison/cell_block/A)
 "fRL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
@@ -97155,60 +94949,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"fTX" = (
-/obj/structure/snow,
-/obj/item/a_gift,
-/obj/item/a_gift,
-/obj/item/nanomob_card,
-/turf/simulated/floor/carpet/black,
-/area/chapel/office)
 "fUo" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
-/area/shuttle/escape)
-"fWZ" = (
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
-"fYr" = (
-/obj/structure/chair/sofa{
+	icon_state = "bot";
 	dir = 1
 	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"fYH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/window/eastleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/item/reagent_containers/food/snacks/candy/gummybear/wtf,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
+/area/shuttle/escape)
 "fZO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/medic,
@@ -97222,125 +94972,26 @@
 /obj/structure/table/reinforced,
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
-"gdQ" = (
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/scientist,
-/obj/item/nanomob_card,
-/obj/item/toy/plushie/slimeplushie,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
 "ghD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"gkX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
 "gmY" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"gpk" = (
-/obj/structure/snow,
-/obj/item/a_gift,
-/obj/item/toy/figure/engineer,
-/obj/item/toy/spinningtoy,
-/obj/item/toy/carpplushie/dragon,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"gqt" = (
-/obj/structure/snow,
-/turf/simulated/floor/carpet,
-/area/ntrep)
-"grx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/window/eastleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/item/reagent_containers/food/snacks/candy/jellybean/wtf,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
-"gvu" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
-"gxv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/security/prison/cell_block/A)
 "gyR" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	dir = 1
 	},
 /area/shuttle/escape)
-"gyU" = (
-/obj/structure/chair/stool,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"gAw" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/security/permabrig)
-"gAT" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/wood,
-/area/security/vacantoffice)
-"gDP" = (
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "gFG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -97351,18 +95002,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"gGg" = (
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"gLx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
 "gMZ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -97381,125 +95020,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
-"gOo" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
-"gQy" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cult";
-	tag = "icon-cult"
-	},
-/area/magistrateoffice)
 "gQL" = (
 /obj/machinery/computer/card,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"gSs" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/bonfire/dense,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"gUP" = (
-/obj/structure/flora/tree/pine/xmas,
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
-	},
-/area/crew_quarters/dorms)
-"gWg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/turret_protected/ai)
-"haz" = (
-/obj/structure/chair/stool,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"haB" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "white"
-	},
-/area/medical/reception)
-"haF" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"hcT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"heR" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin/nanotrasen,
-/obj/item/pen,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
-"hlm" = (
-/obj/effect/decal/warning_stripes/white/hollow,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/dorms)
-"hlT" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "white"
-	},
-/area/medical/reception)
-"hnS" = (
-/obj/structure/chair/sofa,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
 "hsy" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -97521,18 +95047,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
-"hxa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/chair/comfy/red{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/captain)
 "hyv" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -97545,74 +95059,12 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
-"hCY" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
-"hDe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"hED" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
-"hFn" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"hHC" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/security/main)
 "hJi" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	tag = "icon-whiteblue";
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
-"hLc" = (
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
 "iau" = (
 /obj/structure/closet/crate/internals,
 /obj/item/clothing/mask/breath,
@@ -97624,64 +95076,20 @@
 /obj/item/tank/emergency_oxygen/engi,
 /obj/item/tank/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"idV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research{
-	name = "Research Division"
-	})
-"ihL" = (
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"ihP" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
 "ioI" = (
 /obj/structure/reagent_dispensers/fueltank/chem{
 	pixel_x = -32;
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"iqh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/turret_protected/ai)
 "iwt" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/sign/poster/official/nanotrasen_logo{
@@ -97693,32 +95101,6 @@
 	icon_state = "darkyellow"
 	},
 /area/shuttle/escape)
-"iwP" = (
-/obj/structure/chair/comfy/green{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/secondary/entry)
-"iyx" = (
-/obj/structure/chair/sofa/corner,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"iyH" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/snow,
-/obj/item/gift,
-/obj/item/toy/figure/cmo,
-/obj/item/toy/prize/odysseus,
-/obj/item/toy/plushie/tuxedo_cat,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "white"
-	},
-/area/medical/reception)
 "izn" = (
 /obj/machinery/atmospherics/unary/passive_vent{
 	dir = 1
@@ -97733,14 +95115,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
-"iDx" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
 "iJf" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/door/poddoor{
@@ -97760,26 +95134,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
-"iLE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/security/main)
-"iMO" = (
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
 "iNz" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -97791,57 +95145,13 @@
 "iPL" = (
 /obj/structure/sign/greencross,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/escape)
-"iRt" = (
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/blueshield)
-"iRU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"iSS" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "iUc" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
-"iXO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research{
-	name = "Research Division"
-	})
 "iZs" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97853,22 +95163,11 @@
 	icon_state = "brown"
 	},
 /area/shuttle/escape)
-"jjr" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"jlo" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/carpet,
-/area/ntrep)
 "jnJ" = (
 /obj/machinery/light/spot{
-	dir = 1;
+	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
@@ -97893,51 +95192,18 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"jrK" = (
-/obj/item/gift,
-/obj/item/clothing/head/cowboyhat/white,
-/obj/structure/snow,
-/obj/item/toy/figure/warden,
-/obj/item/toy/prize/durand,
-/obj/item/nanomob_card,
-/obj/item/gun/projectile/shotgun/toy,
-/obj/item/ammo_box/magazine/internal/shot/toy,
-/turf/simulated/floor/plasteel,
-/area/security/main)
-"jGi" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/carpet,
-/area/lawoffice)
-"jJe" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
 "jJT" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
-"jMO" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
 "jMV" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	dir = 4
 	},
 /area/shuttle/escape)
 "jPN" = (
@@ -97969,21 +95235,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"jSU" = (
-/obj/structure/snow,
-/obj/item/a_gift,
-/obj/item/nanomob_card,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "kaG" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	dir = 4
 	},
 /area/shuttle/escape)
 "kcF" = (
@@ -97998,8 +95258,8 @@
 /obj/structure/table/wood,
 /obj/item/deck/cards,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "kjI" = (
@@ -98012,59 +95272,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"kmj" = (
-/obj/structure/chair/sofa/right{
-	dir = 8
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"koB" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
-"ksw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research{
-	name = "Research Division"
-	})
 "ksF" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
-"ktV" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"kvd" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (WEST)"
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "kyW" = (
 /obj/structure/table,
 /obj/item/weldingtool/largetank{
@@ -98079,17 +95292,10 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"kBs" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
 "kCz" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/closet/firecloset,
@@ -98102,8 +95308,8 @@
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
 "kHU" = (
@@ -98114,33 +95320,11 @@
 	icon_state = "vault"
 	},
 /area/shuttle/escape)
-"kHX" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
 "kIR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/space,
 /area/space/nearstation)
-"kJO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
-"kJW" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
 "kLF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -98156,13 +95340,13 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/light/small{
-	dir = 8;
+	tag = "icon-bulb1 (WEST)";
 	icon_state = "bulb1";
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
 "kNZ" = (
@@ -98184,31 +95368,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"kQD" = (
-/obj/structure/snow,
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/turret_protected/ai)
-"kTw" = (
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
-"kTV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
 "kUs" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
@@ -98219,8 +95378,8 @@
 "law" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/escape)
 "lax" = (
@@ -98229,57 +95388,19 @@
 	icon_state = "redcorner"
 	},
 /area/shuttle/escape)
-"laU" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards,
-/obj/item/dice/d20,
-/obj/item/dice,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "ldp" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
 "leU" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	dir = 2
 	},
 /area/shuttle/escape)
-"lgQ" = (
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
-"ljp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/effect/landmark{
-	name = "Marauder Entry"
-	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/bridge)
-"ljD" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedbar)
 "lkw" = (
 /obj/machinery/light{
 	dir = 8
@@ -98295,16 +95416,6 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
-"lmr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "lop" = (
 /obj/structure/chair{
 	dir = 8
@@ -98314,74 +95425,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"lqp" = (
-/obj/structure/chair/wood/wings,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"ltW" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/misc_lab)
-"luD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
-"lvS" = (
-/obj/structure/table/reinforced,
-/obj/item/folder{
-	pixel_x = -4
-	},
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/obj/item/folder/blue{
-	pixel_x = 5
-	},
-/obj/item/folder/yellow{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stamp/law,
-/obj/item/pen/multi,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cult";
-	tag = "icon-cult"
-	},
-/area/lawoffice)
 "lxD" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
 	},
 /area/shuttle/escape)
-"lJY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
-"lKx" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/security/permabrig)
 "lKS" = (
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -98394,7 +95443,6 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/structure/snow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "lLQ" = (
@@ -98404,46 +95452,17 @@
 	icon_state = "darkblue"
 	},
 /area/shuttle/escape)
-"lPZ" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/carpet,
-/area/chapel/main)
 "lQS" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f6";
 	icon_state = "swall_f6";
-	tag = "icon-swall_f6"
+	dir = 2
 	},
 /area/shuttle/pod_3)
-"lTc" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cult";
-	tag = "icon-cult"
-	},
-/area/magistrateoffice)
-"mam" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "white"
-	},
-/area/medical/reception)
-"mkp" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/chocolateegg,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
 "mkE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -98478,19 +95497,10 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"mtS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "mxT" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
@@ -98506,18 +95516,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"mzR" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
-"mzT" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
 "mGt" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/storage/toolbox/electrical{
@@ -98530,15 +95528,10 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"mLi" = (
-/obj/structure/snow,
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "mMw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -98550,35 +95543,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/escape)
-"mSl" = (
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"mVw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research{
-	name = "Research Division"
-	})
-"mXd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6;
-	initialize_directions = 6;
-	level = 2
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "naH" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -98591,30 +95555,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/fsmaint)
-"nkG" = (
-/obj/structure/snow,
-/obj/item/a_gift,
-/obj/item/toy/figure/ce,
-/obj/item/toy/carpplushie/gold,
-/obj/item/toy/blink,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"npO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
 "nqX" = (
 /obj/structure/table,
 /obj/item/paper{
@@ -98624,16 +95564,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"nrk" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
 "ntp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -98643,27 +95573,12 @@
 	icon_state = "vault"
 	},
 /area/shuttle/escape)
-"nua" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/ntrep)
 "nvl" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/shuttle/escape)
-"nAk" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/carpet,
-/area/magistrateoffice)
 "nCT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -98682,25 +95597,13 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"nGo" = (
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/clown,
-/obj/item/toy/prize/honk,
-/obj/item/toy/crayon/mime,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
-	},
-/area/crew_quarters/dorms)
 "nHW" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
 "nIj" = (
@@ -98714,89 +95617,18 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
-"nLS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
 "nMi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
 /turf/space,
 /area/space/nearstation)
-"nMD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"nOb" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/mime,
-/obj/item/toy/prize/seraph,
-/obj/item/toy/crayon/rainbow,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/dorms)
-"nOr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"nRM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/bridge)
 "nRP" = (
 /obj/structure/table,
 /obj/item/storage/firstaid,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"nSR" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
-	},
-/obj/structure/chair/comfy/red{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
 "nVM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -98817,38 +95649,6 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
-"ofR" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "caution"
-	},
-/area/crew_quarters/dorms)
-"ook" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/turret_protected/ai)
-"opx" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
-	},
-/obj/structure/chair/comfy/green{
-	dir = 8
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
-"oqm" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
 "oqQ" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/shuttle{
@@ -98858,31 +95658,11 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
-"osF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
-"otC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
 "oyv" = (
 /obj/machinery/hologram/holopad,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "oDA" = (
@@ -98890,28 +95670,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"oKO" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/security/main)
-"oNH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/port)
-"oOM" = (
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
 "oOZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/wall/r_wall,
@@ -98942,31 +95704,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/tcommsat/chamber)
-"oQO" = (
-/obj/structure/snow{
-	dir = 9;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"oRw" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/flora/tree/pine/xmas,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"oRL" = (
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
 "oRM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -98975,8 +95712,8 @@
 "oUw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/item/reagent_containers/food/drinks/mug/med,
 /turf/simulated/floor/plasteel{
@@ -98984,18 +95721,6 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
-"oUJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
-"oWs" = (
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/qm,
-/obj/item/toy/prize/fireripley,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
 "oZV" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
@@ -99014,52 +95739,6 @@
 	},
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
-"pfa" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
-"pgr" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cult";
-	tag = "icon-cult"
-	},
-/area/lawoffice)
-"pjK" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"pmA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"pqc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/security/processing)
 "pwN" = (
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
@@ -99075,15 +95754,6 @@
 /obj/effect/landmark/battle_mob_point,
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
-"pyk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/sliceable/turkey{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/snacks/turkeyslice,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "pzr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99104,14 +95774,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"pDb" = (
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (EAST)"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "pDl" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -99122,62 +95784,16 @@
 "pGQ" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"pKw" = (
-/obj/structure/chair/comfy/green{
-	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/secondary/entry)
-"pUZ" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
-"pWt" = (
-/obj/machinery/dna_scannernew,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplefull";
-	tag = "icon-whitepurple (WEST)"
-	},
-/area/medical/genetics)
-"pXx" = (
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
 /turf/space,
 /area/space/nearstation)
-"qau" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
 "qdA" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
@@ -99185,16 +95801,6 @@
 	icon_state = "darkred"
 	},
 /area/shuttle/escape)
-"qeu" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
 "qgG" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -99206,27 +95812,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"qig" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"qkV" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
-"qnb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
 "qpX" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -99235,47 +95820,12 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
-"qqe" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
-"qsu" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/carpet,
-/area/ntrep)
 "qsT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
-"qtT" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"quH" = (
-/obj/structure/snow,
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
 "qxC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/o2{
@@ -99288,20 +95838,11 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	tag = "icon-whiteblue (NORTHEAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	dir = 5
 	},
 /area/shuttle/escape)
-"qFa" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/maintenance/abandonedbar)
 "qFg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -99315,16 +95856,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"qKW" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/security/processing)
 "qOo" = (
 /obj/structure/chair{
 	dir = 4
@@ -99332,117 +95863,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"qPF" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
-"qQm" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
-"qQU" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/hallway/primary/central/west)
-"qRM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
-"qSE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
 "qUv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space/nearstation)
-"qWE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/lab)
-"qZf" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "white"
-	},
-/area/medical/reception)
-"qZB" = (
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"qZX" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/cargotech,
-/obj/item/toy/prize/deathripley,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"rat" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
-"rbV" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/command,
-/obj/structure/snow,
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
-"rdi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/carpet,
-/area/library)
 "reA" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -99497,38 +95921,11 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/storage/secure)
-"rss" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
-"rzz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/item/reagent_containers/food/snacks/candy/jawbreaker,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "rAt" = (
 /obj/structure/extinguisher_cabinet,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall3"
+	icon_state = "swall3";
+	dir = 2
 	},
 /area/shuttle/escape)
 "rEw" = (
@@ -99553,20 +95950,10 @@
 /obj/item/wrench,
 /obj/item/radio,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"rHe" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
-	},
-/area/security/brig)
 "rIF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
@@ -99606,15 +95993,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/turret_protected/aisat_interior)
-"rXk" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
-	},
-/area/blueshield)
 "rYq" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
@@ -99631,92 +96009,6 @@
 	icon_state = "wall3"
 	},
 /area/shuttle/escape)
-"set" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/crew_quarters/locker)
-"sfN" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
-"siD" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/security/main)
-"slj" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"stO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research{
-	name = "Research Division"
-	})
-"sug" = (
-/obj/structure/chair/comfy/green{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/captain)
-"suo" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/dorms)
-"sBH" = (
-/obj/structure/closet/secure_closet/medical3,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
-	},
-/area/medical/biostorage)
-"sCf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "sDw" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -99728,16 +96020,6 @@
 "sHt" = (
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
-"sNK" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/bridge)
-"sOc" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "sPb" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -99750,23 +96032,11 @@
 /area/crew_quarters/dorms)
 "sPV" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	tag = "icon-browncorner (EAST)";
 	icon_state = "browncorner";
-	tag = "icon-browncorner (EAST)"
+	dir = 4
 	},
 /area/shuttle/escape)
-"sTZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "sUK" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -99775,54 +96045,18 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
-"sUY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "caution"
-	},
-/area/crew_quarters/dorms)
-"sVn" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/chemistry)
 "sVQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
-"sVX" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
 "tbC" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"tcd" = (
-/obj/structure/chair/comfy/red,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/secondary/entry)
 "tdh" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -99836,261 +96070,19 @@
 	icon_state = "neutralcorner"
 	},
 /area/shuttle/escape)
-"tlj" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"tmg" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
-"tmo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
-"tob" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/carpet,
-/area/security/vacantoffice)
 "toq" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
 	},
 /area/shuttle/escape)
-"trn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel,
-/area/storage/primary)
-"tsU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
-"tuN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/west)
-"txa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"txC" = (
-/obj/structure/chair/wood/wings{
-	dir = 1;
-	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (NORTH)"
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"tBt" = (
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/bartender,
-/obj/item/toy/katana,
-/obj/item/id_decal/silver,
-/obj/item/nanomob_card,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"tBT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/sleeper)
-"tDj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"tEg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/atmos)
-"tGI" = (
-/obj/structure/table/wood,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"tHd" = (
-/obj/structure/chair/stool,
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "tIz" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"tKz" = (
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/miner,
-/obj/item/toy/prize/ripley,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"tKB" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"tPa" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
-"tQs" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/detectives_office)
-"tSs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
-"tYi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"udn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"ufT" = (
-/obj/item/radio/intercom/department/security{
-	pixel_y = 33
-	},
-/obj/machinery/light_switch{
-	pixel_y = 27
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/security/main)
-"ugr" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
-"uiW" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	icon_state = "wooden_chair_wings";
-	tag = "icon-wooden_chair_wings (WEST)"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "uom" = (
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"urE" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
-	},
-/area/security/permabrig)
 "usf" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/plasteel{
@@ -100098,33 +96090,17 @@
 	icon_state = "darkblue"
 	},
 /area/shuttle/escape)
-"ute" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
 "utw" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
+	tag = "icon-swall_f5";
 	icon_state = "swall_f5";
-	tag = "icon-swall_f5"
+	dir = 2
 	},
 /area/shuttle/pod_3)
-"uww" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
-/turf/simulated/floor/plasteel,
-/area/security/main)
 "uxy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -100144,24 +96120,6 @@
 	icon_state = "darkred"
 	},
 /area/shuttle/escape)
-"uyo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/rd,
-/obj/item/toy/plushie/face_hugger,
-/obj/item/toy/prize/phazon,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
 "uBM" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
@@ -100172,102 +96130,19 @@
 /area/shuttle/administration)
 "uDK" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
+	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
-	tag = "icon-intact (NORTHEAST)"
+	dir = 5
 	},
 /turf/space,
 /area/space/nearstation)
-"uGR" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
-"uNG" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/dorms)
-"uOv" = (
-/obj/structure/chair/comfy/green{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"uPv" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
 "uXX" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"uYV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"uZi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/roboticist,
-/obj/item/toy/plushie/ipcplushie,
-/obj/item/nanomob_card,
-/obj/item/toy/plushie/robo_corgi,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
-"vdt" = (
-/obj/effect/decal/warning_stripes/blue/partial{
-	dir = 1
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "white"
-	},
-/area/medical/reception)
-"vfX" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/explab)
-"viw" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/crew_quarters/courtroom)
-"vum" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
 "vup" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -100275,25 +96150,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"vzE" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/bridge)
-"vAc" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
-"vDR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
 "vFZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -100323,14 +96179,6 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
-"vIP" = (
-/obj/item/decorations/sticky_decorations/flammable/snowman,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/hallway/primary/central/west)
 "vJw" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -100340,14 +96188,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/shuttle/escape)
-"vKh" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/lab)
 "vMh" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -100359,37 +96199,6 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
-"vRF" = (
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
-"vSW" = (
-/obj/structure/table/reinforced,
-/obj/item/folder{
-	pixel_x = -4
-	},
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/obj/item/folder/blue{
-	pixel_x = 5
-	},
-/obj/item/folder/yellow{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stamp/law,
-/obj/item/pen/multi,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cult";
-	tag = "icon-cult"
-	},
-/area/lawoffice)
 "vUG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -100411,14 +96220,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/shuttle/escape)
-"vVP" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"vYr" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
 "wbr" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -100434,38 +96235,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/chamber)
-"wco" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
-"wep" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
 "whv" = (
 /obj/machinery/computer/HolodeckControl,
-/obj/item/decorations/sticky_decorations/flammable/holly{
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"wjY" = (
-/obj/structure/snow{
-	dir = 10;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research{
-	name = "Research Division"
-	})
 "wkg" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit";
@@ -100477,66 +96250,6 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
-"wlq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/hallway/secondary/entry)
-"wlw" = (
-/obj/structure/chair/sofa{
-	dir = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/green{
-	pixel_y = 19
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
-"woy" = (
-/obj/structure/snow{
-	dir = 6;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cult";
-	tag = "icon-cult"
-	},
-/area/magistrateoffice)
-"wsp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/assembly/robotics)
-"wwt" = (
-/obj/structure/table,
-/obj/item/toy/xmas_cracker{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/toy/xmas_cracker,
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_surround"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "wxQ" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/shuttle{
@@ -100546,59 +96259,12 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
-"wya" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
-	},
-/obj/structure/chair/comfy/green{
-	dir = 4
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/engine/break_room)
-"wGT" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/yellow{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel,
-/area/atmos)
 "wHx" = (
 /obj/machinery/door/airlock/shuttle/glass{
 	name = "Shuttle Cargo Hatch"
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"wIF" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/purple{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/assembly/robotics)
-"wLB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/carpet,
-/area/bridge/meeting_room)
-"wNF" = (
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "green"
-	},
-/area/hallway/secondary/exit)
 "wOS" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -100610,30 +96276,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"wRQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/courtroom)
-"wTD" = (
-/obj/structure/snow{
-	dir = 4;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "wVD" = (
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
@@ -100643,31 +96285,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
-"xan" = (
-/obj/structure/snow{
-	dir = 8;
-	icon_state = "snow_corner"
-	},
-/obj/structure/snow{
-	dir = 1;
-	icon_state = "snow_corner"
-	},
-/obj/item/a_gift,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
-	},
-/area/crew_quarters/dorms)
-"xbw" = (
-/obj/structure/snow,
-/obj/item/a_gift,
-/obj/item/toy/figure/atmos,
-/obj/item/toy/minimeteor,
-/obj/item/toy/carpplushie/electric,
-/obj/item/nanomob_card,
-/turf/simulated/floor/plasteel,
-/area/engine/equipmentstorage)
 "xcB" = (
 /obj/structure/chair{
 	dir = 8
@@ -100686,15 +96303,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"xgx" = (
-/obj/structure/chair/stool,
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/security/permabrig)
 "xgN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
@@ -100704,9 +96312,9 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	tag = "icon-whiteblue (SOUTHEAST)";
 	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	dir = 6
 	},
 /area/shuttle/escape)
 "xlr" = (
@@ -100717,15 +96325,15 @@
 /area/crew_quarters/dorms)
 "xlz" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
 "xnj" = (
@@ -100733,30 +96341,14 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
-	},
-/area/shuttle/escape)
-"xpD" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/blue{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "white"
-	},
-/area/medical/reception)
-"xpY" = (
-/obj/structure/chair/sofa/corner{
+	icon_state = "bot";
 	dir = 1
 	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
+/area/shuttle/escape)
 "xtk" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -100764,22 +96356,6 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
-"xux" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
-"xvD" = (
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"xxP" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/snow,
-/turf/simulated/floor/plasteel,
-/area/bridge)
 "xyo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -100790,13 +96366,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
-"xzc" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
-	},
-/obj/structure/snow,
-/turf/simulated/floor/wood,
-/area/hallway/secondary/exit)
 "xAw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -100812,8 +96381,8 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
 "xBR" = (
@@ -100822,19 +96391,10 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bot"
+	icon_state = "bot";
+	dir = 1
 	},
 /area/shuttle/escape)
-"xHS" = (
-/obj/item/gift,
-/obj/structure/snow,
-/obj/item/toy/figure/chef,
-/obj/item/toy/minigibber,
-/obj/item/id_decal/emag,
-/obj/item/nanomob_card,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "xTB" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -100845,61 +96405,18 @@
 "xVt" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
 /area/crew_quarters/dorms)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
+	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
+	dir = 6
 	},
 /turf/space,
 /area/space/nearstation)
-"xWp" = (
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/security/permabrig)
-"xXs" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/obj/item/decorations/sticky_decorations/flammable/tinsel/red{
-	pixel_y = 19
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ai_monitored/storage/eva)
-"xXS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
-"ydk" = (
-/obj/structure/snow{
-	dir = 5;
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/starboard/west)
 "yeP" = (
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
@@ -100908,8 +96425,8 @@
 	req_access_txt = "101"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -100926,28 +96443,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
-"ylU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/snow{
-	icon_state = "snow_corner"
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/port)
 
 (1,1,1) = {"
 aaa
@@ -114427,16 +109922,16 @@ aZW
 bcX
 bgu
 bhL
-tcd
+aSW
 bgj
 bjO
-pKw
+bmo
 brk
 aSf
 bqr
 buX
 btF
-gAT
+brU
 bBt
 btF
 bqr
@@ -114693,7 +110188,7 @@ bpF
 bqr
 btF
 btG
-tob
+bvn
 bBH
 btF
 bqr
@@ -114944,7 +110439,7 @@ bhN
 aSW
 bhm
 bhm
-dpi
+bmo
 brl
 bss
 bqr
@@ -115200,9 +110695,9 @@ bgB
 bhO
 aSY
 bhv
-iwP
+bhv
 aSY
-wlq
+brk
 boT
 bqr
 btF
@@ -118030,7 +113525,7 @@ biJ
 bkg
 blM
 bnr
-wTD
+bnD
 bnD
 bvk
 bnD
@@ -118544,9 +114039,9 @@ biJ
 bki
 blM
 bnB
-vVP
-gyU
-tHd
+bnD
+bqv
+bqv
 bvS
 bvs
 bvs
@@ -118791,7 +114286,7 @@ aGn
 aUy
 aVi
 aWn
-trn
+aXM
 aXQ
 aXQ
 bde
@@ -118801,9 +114296,9 @@ biJ
 bkb
 blM
 bnC
-vVP
+bnD
 bqw
-bqw
+bqx
 bvZ
 bzU
 bBQ
@@ -119055,15 +114550,15 @@ bcT
 aVi
 bgz
 biJ
-oNH
+bkg
 bkx
-sOc
-vVP
-vVP
+bnD
+bnD
+bqx
 bsg
 bvW
-vVP
-set
+bnD
+bwT
 byp
 bzy
 blM
@@ -119305,21 +114800,21 @@ aGn
 aUy
 aVi
 aWo
-trn
+aXM
 aXQ
 bbm
 bdg
 aVi
 bgz
-ylU
+blO
 bpg
 bqh
 brv
 brv
 bug
-bug
+bvt
 bwb
-ejx
+bnD
 bBU
 bwT
 bzA
@@ -119569,12 +115064,12 @@ bdh
 aVi
 bgz
 biJ
-fnB
+bkg
 blM
 bnF
 bpd
-vVP
-sOc
+bqv
+bqv
 bwa
 bng
 blM
@@ -119829,10 +115324,10 @@ biJ
 bkf
 blM
 bnG
-vVP
-gyU
-gyU
-pmA
+bnD
+bnD
+bnD
+bwa
 bAb
 brN
 brN
@@ -119846,7 +115341,7 @@ bMh
 bNH
 bQc
 bSg
-haF
+bKz
 bRR
 bKz
 bXd
@@ -120049,7 +115544,7 @@ aab
 abN
 abN
 aqs
-lKx
+anf
 atz
 avf
 awO
@@ -120086,9 +115581,9 @@ blH
 bkg
 blM
 bnH
-pXx
-hFn
-wwt
+bnD
+bnD
+bnD
 bwd
 bzV
 bst
@@ -120102,8 +115597,8 @@ bxb
 bxb
 bxb
 bMq
-npO
-iDx
+bOh
+bHh
 bRR
 bHh
 bXd
@@ -120305,8 +115800,8 @@ aab
 aab
 abN
 anc
-lKx
-lKx
+anf
+anf
 atH
 avi
 ado
@@ -120357,10 +115852,10 @@ bCk
 bKy
 bxb
 bIV
-oRw
-tKz
-npO
-iDx
+bKz
+bKz
+bOh
+bHh
 bRR
 bHh
 bXd
@@ -120562,11 +116057,11 @@ abN
 abN
 abN
 amX
-lKx
+anf
 asj
 atD
 avh
-lKx
+anf
 ado
 azp
 aAn
@@ -120614,10 +116109,10 @@ bJy
 bKG
 bxb
 bIU
-qZX
-oWs
+bKz
+bKz
 bSj
-iDx
+bHh
 bRR
 bHh
 bXe
@@ -120819,8 +116314,8 @@ abN
 ajc
 adN
 ado
-lKx
-ado
+anf
+asl
 atQ
 avk
 awU
@@ -120871,9 +116366,9 @@ bCk
 bFd
 bxb
 bIY
-fjG
-tKB
-hDe
+bKz
+bKz
+bOh
 bPO
 bRR
 bKz
@@ -121128,10 +116623,10 @@ bJB
 bKH
 bxb
 bIX
-pjK
-oqm
-npO
-haF
+bKz
+bKz
+bOh
+bKz
 bPQ
 bKz
 bXd
@@ -121331,17 +116826,17 @@ aaa
 aab
 abN
 ajg
-gAw
+adN
 ado
-lKx
+anf
 asr
 atS
 avm
-lKx
-lKx
-lKx
-urE
-urE
+anf
+anf
+anf
+aAr
+aAr
 aCE
 aPi
 aPi
@@ -121385,14 +116880,14 @@ bCk
 bnK
 bxb
 bIS
-pjK
-pjK
+bKz
+bKz
 bOk
 ceE
-uYV
-uYV
+bJf
+bJf
 bXg
-uYV
+bJf
 bYE
 bxb
 aab
@@ -121588,16 +117083,16 @@ aaa
 aab
 abN
 ajf
-xgx
-lKx
+akL
+anf
 aqM
 abN
 asg
 avl
 abN
 ayx
-xWp
-lKx
+anf
+anf
 aBJ
 abN
 aDG
@@ -121645,9 +117140,9 @@ bIZ
 bNI
 bKA
 bSm
-xux
-iRU
-tYi
+bPP
+bPP
+bPP
 bXf
 bYr
 bKz
@@ -121845,7 +117340,7 @@ aaa
 aaa
 abN
 aji
-xgx
+akL
 ado
 abN
 abN
@@ -121853,7 +117348,7 @@ atZ
 avo
 abN
 abN
-lKx
+anf
 akL
 aBL
 abN
@@ -121901,8 +117396,8 @@ bIw
 bJf
 bJf
 bMw
-udn
-kBs
+bOh
+bKz
 bRL
 bQf
 bQf
@@ -122156,9 +117651,9 @@ byw
 bFp
 bFm
 bMi
-oQO
+bKz
 bQg
-eiU
+bOh
 bKz
 bxb
 bRo
@@ -122189,7 +117684,7 @@ cEW
 cEJ
 cFM
 cGD
-fWZ
+cJV
 bTm
 cEY
 cLm
@@ -122446,7 +117941,7 @@ cEW
 cEL
 cFP
 cGF
-fuP
+cJV
 cLr
 cEY
 cLm
@@ -122703,7 +118198,7 @@ cEW
 cEK
 cFO
 cGE
-uGR
+cJV
 cGh
 cEY
 cLm
@@ -122941,7 +118436,7 @@ cbI
 cdy
 cff
 cir
-ihP
+cfb
 cfb
 cnS
 cno
@@ -123197,8 +118692,8 @@ cam
 cbH
 cdx
 chX
-gOo
-gvu
+cfb
+cfb
 cfb
 cnS
 cno
@@ -123456,7 +118951,7 @@ cdA
 cis
 ckq
 cls
-qqe
+cls
 cnU
 cno
 cam
@@ -123632,13 +119127,13 @@ aaa
 aaa
 aaa
 aaa
-acF
+atM
 auy
-acF
+atM
 adZ
-acF
+atM
 auy
-acF
+atM
 akZ
 akZ
 akZ
@@ -123987,7 +119482,7 @@ cwF
 cvo
 cER
 cGc
-jMO
+cnA
 cJZ
 cLy
 cLi
@@ -124206,11 +119701,11 @@ bvJ
 bxd
 byl
 bzF
-mzT
-vDR
-vDR
+bzF
+bzF
+bzF
 bFt
-tPa
+bBn
 bMk
 bNV
 bzJ
@@ -124463,11 +119958,11 @@ bvJ
 bxf
 byB
 bzI
-sVX
+bBn
 bIK
-lJY
-kJO
-kJO
+bzE
+bzE
+bzE
 bzE
 bNX
 bVH
@@ -124722,9 +120217,9 @@ byB
 bzH
 bBo
 bIJ
-rss
+bBn
 box
-rss
+bBn
 bKC
 bFx
 bMA
@@ -125493,9 +120988,9 @@ bEj
 bzM
 bBq
 bCF
-qQU
-qQU
-vIP
+bEj
+bEj
+bEj
 bMn
 bKS
 bMJ
@@ -125720,7 +121215,7 @@ aIW
 aKj
 aLN
 aNa
-osF
+aOu
 aEl
 aEl
 aEl
@@ -125750,9 +121245,9 @@ bDO
 bDO
 bGZ
 bDO
-tuN
-tuN
-tuN
+bDO
+bDO
+bDO
 bMm
 bNY
 bQn
@@ -125973,11 +121468,11 @@ aDL
 aBn
 aGs
 aHy
-tmg
+aAp
 aKl
 aLQ
 aKl
-nLS
+aOu
 aPx
 aRP
 aEl
@@ -126220,7 +121715,7 @@ aqY
 asN
 asN
 asN
-jGi
+asN
 asN
 azA
 aAD
@@ -126228,14 +121723,14 @@ aCb
 aDa
 aDL
 aFh
-rat
-oOM
-viw
+aAp
+aAp
+aAp
 aKk
 aLO
 aNb
-bto
-qkV
+aOu
+aAp
 aRM
 aEl
 aVD
@@ -126473,7 +121968,7 @@ aig
 ajO
 ald
 aKs
-pgr
+aKs
 asN
 atf
 avS
@@ -126485,8 +121980,8 @@ aCc
 aDd
 aDM
 aFl
-gLx
-luD
+aGt
+aGt
 aIZ
 aIZ
 aIZ
@@ -126542,7 +122037,7 @@ cgS
 ciA
 clR
 col
-iRt
+clR
 coY
 cqR
 csy
@@ -126730,13 +122225,13 @@ aie
 ajM
 alc
 aob
-lvS
+ara
 asP
 aut
 avR
 axr
 ayI
-vSW
+ara
 aAG
 aCb
 aDc
@@ -126777,7 +122272,7 @@ bxl
 byH
 bEN
 bHg
-uOv
+bHg
 bJG
 bxl
 bxl
@@ -126799,7 +122294,7 @@ cgU
 ciB
 ckt
 cok
-evY
+ckt
 coX
 cqI
 csx
@@ -127033,8 +122528,8 @@ bwg
 bxl
 byI
 bEZ
-rbV
-heR
+bDs
+bDs
 bJH
 bJa
 bxl
@@ -127292,7 +122787,7 @@ byJ
 bEV
 bBu
 bCG
-tSs
+bJH
 bFF
 bxl
 bMB
@@ -127311,12 +122806,12 @@ cft
 ciC
 cgV
 ciD
-rXk
-rXk
+ckt
+ckt
 coH
-eSM
-eSM
-iRt
+ckt
+cqK
+clR
 ctR
 aaa
 cwQ
@@ -127511,7 +123006,7 @@ azE
 aIl
 aCe
 aDi
-woy
+aDi
 aFo
 aIl
 aHC
@@ -127546,10 +123041,10 @@ bwV
 bmc
 bxm
 byL
-qSE
+bEV
 bBv
 bCC
-qnb
+bJH
 bFI
 bxl
 bxl
@@ -127803,10 +123298,10 @@ bwU
 bwc
 bxm
 byK
-tsU
-bDs
-kTw
-wLB
+bEZ
+bBw
+bBw
+bJH
 bKJ
 bxm
 bMD
@@ -127818,7 +123313,7 @@ bVb
 bVM
 bXp
 bXa
-eHF
+bVv
 bMG
 cdX
 cfx
@@ -128024,7 +123519,7 @@ ayM
 aIl
 aIl
 aCg
-lTc
+aDi
 aDU
 aFq
 azF
@@ -128061,7 +123556,7 @@ bAC
 bCw
 bDS
 bFa
-sCf
+bHj
 bHj
 bJI
 bKK
@@ -128340,11 +123835,11 @@ ciS
 cgY
 ciG
 ckw
-qsu
+ckw
 coU
-jlo
-gqt
-nua
+ckw
+cqO
+ckv
 cgW
 cvy
 cwW
@@ -128371,7 +123866,7 @@ cOg
 dsY
 dta
 dtk
-slj
+cVj
 cWS
 dbr
 dbr
@@ -128558,7 +124053,7 @@ bbS
 aEN
 aRw
 biM
-xXs
+bat
 beg
 dbO
 aRw
@@ -128569,7 +124064,7 @@ blU
 bnU
 bpr
 bqR
-bMz
+bqS
 bxu
 bvV
 bvX
@@ -128628,7 +124123,7 @@ cOg
 dsY
 dtb
 dtl
-slj
+cVj
 cXy
 cVj
 cVj
@@ -128795,11 +124290,11 @@ ayN
 azF
 aAN
 aCi
-nAk
+aCf
 aCn
 aFr
 aKx
-wRQ
+aHG
 aHG
 aKv
 aLX
@@ -128825,8 +124320,8 @@ bkz
 blU
 bnR
 bpo
-vzE
-vzE
+bqS
+bqS
 bxr
 bvX
 bvX
@@ -129052,7 +124547,7 @@ ayP
 aIl
 aIl
 aCl
-gQy
+aDi
 aEg
 aFt
 aIl
@@ -129081,8 +124576,8 @@ bne
 bpv
 blY
 bnW
-xxP
-vzE
+bpt
+bqS
 bsy
 bxA
 bvX
@@ -129293,7 +124788,7 @@ agt
 amA
 any
 aot
-epP
+amy
 alT
 agM
 ash
@@ -129853,7 +125348,7 @@ bkB
 bma
 bnX
 bps
-sNK
+bqS
 bsz
 bxC
 bAD
@@ -130111,7 +125606,7 @@ bma
 boa
 bpw
 bqV
-ljp
+bsA
 bxO
 bvX
 bxt
@@ -130598,7 +126093,7 @@ aAx
 aEm
 aFA
 aFA
-btf
+aFw
 aJj
 aKA
 awl
@@ -130623,8 +126118,8 @@ bnk
 bpy
 blY
 brS
-xxP
-vzE
+bpt
+bqS
 bvC
 bxY
 bvX
@@ -130678,7 +126173,7 @@ cOY
 cOf
 cOy
 cPo
-eEt
+cRX
 cUt
 cUt
 cWB
@@ -130845,7 +126340,7 @@ aow
 apz
 ata
 auN
-fHf
+avX
 awJ
 ayT
 azK
@@ -131188,12 +126683,12 @@ cHX
 dcj
 dcj
 dcj
-wep
+dcj
 cHT
 bHY
-otC
+cTe
 cPO
-oUJ
+cTe
 cRQ
 cWJ
 cPO
@@ -131357,12 +126852,12 @@ alM
 awK
 aoW
 arn
-gxv
+atd
 auP
-fHf
+avX
 axG
 ayU
-gxv
+atd
 azx
 aCr
 aHE
@@ -131397,7 +126892,7 @@ bmc
 bmc
 bqZ
 bsE
-nRM
+bwU
 bvU
 bxv
 byS
@@ -131445,8 +126940,8 @@ cHV
 cIV
 dcB
 cNO
-wya
-nSR
+cNO
+cNO
 cQN
 cSa
 cPN
@@ -131706,8 +127201,8 @@ cOZ
 cOh
 cQN
 bHZ
-vYr
-ute
+cRX
+cRX
 cRT
 cWL
 cTT
@@ -131916,7 +127411,7 @@ bwc
 bxv
 byT
 bFg
-lgQ
+bzY
 bIO
 bJK
 bKL
@@ -131960,11 +127455,11 @@ cIW
 dcE
 cNQ
 cON
-opx
+cON
 cQN
-nkG
 cRX
-vYr
+cRX
+cRX
 cRS
 cWK
 cTP
@@ -132173,7 +127668,7 @@ bmc
 bxv
 byW
 bzZ
-sug
+bzZ
 bCP
 bEh
 bFK
@@ -132211,16 +127706,16 @@ cCJ
 cvI
 cHQ
 cdG
-hCY
+dcj
 cHX
-ugr
-mzR
-mzR
-hED
-mzR
+dcj
+dcj
+dcj
+dcj
+dcj
 cyh
-gpk
-xbw
+cRX
+cRX
 cQP
 cRV
 cSY
@@ -132398,7 +127893,7 @@ aEq
 aFE
 aGC
 aHZ
-tQs
+awG
 aKB
 axe
 aNU
@@ -132468,7 +127963,7 @@ cCa
 cDR
 cHQ
 cGu
-hCY
+dcj
 cIh
 cIX
 cJq
@@ -132655,7 +128150,7 @@ aEt
 axe
 aGF
 aIb
-eML
+awG
 aKD
 axe
 aNU
@@ -132687,11 +128182,11 @@ bwg
 bxv
 byY
 bAd
-hxa
+bAd
 bCU
-mtS
-mtS
-mtS
+bEs
+bEs
+bEs
 bMR
 bLd
 bQD
@@ -132943,11 +128438,11 @@ byr
 bwf
 bxv
 byX
-lgQ
-lgQ
-lgQ
+bzY
+bzY
+bzY
 bEk
-lgQ
+bzY
 bLf
 bMQ
 bLd
@@ -133205,7 +128700,7 @@ bBE
 bCV
 bEv
 doB
-qQm
+bzY
 bMS
 bOy
 bQM
@@ -133412,9 +128907,9 @@ aso
 atE
 auE
 avA
-pqc
+avA
 arv
-qKW
+ayp
 awi
 axQ
 aAx
@@ -133510,7 +129005,7 @@ cSd
 cSd
 cWT
 cXQ
-dMw
+cSd
 lLC
 cXO
 dbK
@@ -133692,7 +129187,7 @@ aQp
 aSB
 aTI
 aWE
-uNG
+aZv
 aZv
 bce
 bef
@@ -133768,8 +129263,8 @@ cVI
 cWU
 cXV
 cVI
-ese
-tEg
+cVI
+cVI
 dbL
 dcL
 dds
@@ -133777,7 +129272,7 @@ deh
 deD
 deM
 dgs
-wGT
+deH
 dhB
 dik
 diU
@@ -133916,9 +129411,9 @@ anA
 akv
 alp
 alG
-oKO
+aoJ
 anQ
-iLE
+aoI
 aoR
 aqA
 ago
@@ -134026,14 +129521,14 @@ cTq
 cUz
 cEr
 cEr
-dLi
-nMD
-nMD
+cEr
+cEr
+cEr
 dav
 daQ
 deH
 dfy
-haz
+dfy
 dgN
 dhA
 dij
@@ -134172,10 +129667,10 @@ anA
 anA
 akF
 adX
-jrK
+aoJ
 amM
 anQ
-iLE
+aoI
 apM
 apR
 ahC
@@ -134203,7 +129698,7 @@ aDP
 aDP
 aDP
 aQr
-sUY
+aSB
 aTR
 aWF
 aZt
@@ -134284,13 +129779,13 @@ cXR
 cYT
 cZU
 daM
-txa
-egY
+daM
+daM
 day
-nOr
+daM
 deI
-mXd
-lmr
+deQ
+dgg
 dgP
 dhC
 dip
@@ -134427,7 +129922,7 @@ acx
 acE
 acE
 anA
-ufT
+aoJ
 alq
 afK
 amr
@@ -134546,7 +130041,7 @@ daN
 daw
 daR
 deJ
-tDj
+dfF
 dgh
 dgO
 dhx
@@ -134682,9 +130177,9 @@ aaa
 anA
 acB
 acB
-dNE
+acw
 adp
-oKO
+aoJ
 alu
 amn
 amO
@@ -134735,11 +130230,11 @@ bja
 bkM
 bcU
 bok
-lqp
+bmq
 brf
-txC
-gDP
-tGI
+bmq
+bmq
+bmq
 bxx
 aUS
 bAh
@@ -134941,15 +130436,15 @@ anA
 anA
 anA
 anA
-fgD
+aoJ
 adY
 amm
 amN
 ahf
 aoN
-siD
+aoJ
 apT
-koB
+ago
 aiU
 aFL
 alS
@@ -134992,12 +130487,12 @@ aZR
 bkM
 bmr
 brT
+btf
+btf
 bmq
-brg
-gDP
-jSU
-tBt
-xHS
+byD
+bmq
+bmq
 aUS
 bAi
 bHt
@@ -135005,7 +130500,7 @@ bAi
 bEp
 aTS
 bBM
-iyH
+bBM
 bGg
 bJC
 bLw
@@ -135199,14 +130694,14 @@ anA
 acV
 anH
 akI
-hHC
-uww
+alF
+alF
 amQ
-uww
+alF
 afn
 apO
 anx
-rHe
+aqX
 aiW
 akC
 avF
@@ -135249,11 +130744,11 @@ boc
 bkP
 bmr
 brV
+btg
+bqi
 bmq
-pDb
-drO
-jSU
-mLi
+buN
+bmq
 aVG
 aUS
 cMK
@@ -135261,7 +130756,7 @@ bHy
 bAk
 bEp
 aTV
-haB
+bDf
 bGd
 bGi
 bJJ
@@ -135505,12 +131000,12 @@ aYd
 bnQ
 bkO
 bmr
-wco
+bmM
+brg
+brg
 bmq
-laU
-tGI
-gDP
-gDP
+bqk
+bmq
 bJQ
 aUS
 bAk
@@ -135518,7 +131013,7 @@ bHy
 bCZ
 bEp
 aTU
-mam
+bDf
 bDd
 bEp
 bIq
@@ -135762,20 +131257,20 @@ aZR
 bop
 bkO
 bmr
-wco
+bmM
 bmq
-uiW
-kvd
-brg
-gDP
-gDP
-eyt
-vRF
+bmq
+bmq
+bmq
+bmq
+bmq
+bAv
+bAk
 bHy
 bAk
 bEp
 aTY
-qZf
+bDf
 bGf
 bIh
 bJL
@@ -136002,7 +131497,7 @@ aJf
 aGN
 aPf
 aQz
-sTZ
+aSD
 aUJ
 aWL
 aZz
@@ -136017,22 +131512,22 @@ aUS
 dji
 biS
 bom
-esS
+bkO
 bmr
-wco
+bmM
 btm
 brh
-brh
-qtT
-dvh
+btn
+buQ
+aZV
 bzn
 bsN
-ydk
+bAk
 bHy
 bDA
 bEq
 aTW
-hlT
+bDf
 bGe
 bGq
 bDe
@@ -136046,7 +131541,7 @@ cbv
 caA
 caA
 bXJ
-tBT
+caE
 cca
 caA
 cfA
@@ -136276,21 +131771,21 @@ dkL
 boH
 bpC
 bmr
-wco
+bmM
 btw
+bri
+bto
+buR
 bmq
-etR
-mLi
-gDP
-gDP
-eyt
-qPF
-qRM
+bmq
+bAv
+bAk
+bHy
 bDb
 bEy
 aUP
-xpD
-vdt
+bDf
+bGe
 bJA
 bLv
 bTQ
@@ -136535,14 +132030,14 @@ bjm
 bmq
 brW
 btq
-pDb
-mSl
-brg
-gDP
+bmq
+bmq
+bmq
+bmq
 bzo
 bze
-qPF
-qRM
+bAk
+bHy
 bDb
 bEp
 aUO
@@ -136776,8 +132271,8 @@ aQv
 aSM
 aVo
 aWU
-suo
-ofR
+aWU
+bbv
 aSD
 beW
 aOI
@@ -136793,12 +132288,12 @@ bqy
 brX
 btx
 buq
-pyk
-hcT
+buq
+buq
 bAU
 bCI
 aUS
-fwM
+bAk
 bHy
 bDb
 aTL
@@ -137032,7 +132527,7 @@ aPf
 aQv
 aSM
 aUT
-xan
+aWT
 aZC
 bbu
 bdf
@@ -137051,7 +132546,7 @@ bmq
 bqi
 brH
 btr
-bmq
+bqi
 bAH
 bCB
 aUS
@@ -137159,7 +132654,7 @@ drg
 dro
 drt
 drv
-iMO
+dry
 dnr
 dny
 dnz
@@ -137289,7 +132784,7 @@ aFI
 aZs
 aSM
 aVp
-gUP
+aWT
 aZD
 bbu
 bdl
@@ -137306,9 +132801,9 @@ bdT
 bnm
 bmq
 bqk
-uiW
 bqk
-bmq
+bqk
+bqk
 bAV
 bmq
 aUS
@@ -137416,7 +132911,7 @@ drf
 drq
 dnl
 drv
-ook
+drE
 dnw
 drQ
 drN
@@ -137545,9 +133040,9 @@ aFI
 aFI
 aQE
 aSM
-nOb
-nGo
-hlm
+aUT
+aWT
+aZC
 bbu
 bdj
 bfr
@@ -137820,9 +133315,9 @@ bdT
 bmj
 bog
 bpN
-fYH
-rzz
-grx
+bog
+bpN
+bog
 bPM
 bdT
 bdT
@@ -137927,11 +133422,11 @@ dqw
 dqw
 dqw
 dnc
-gWg
-kQD
+dni
+drE
 drv
-ook
-iqh
+drE
+dni
 drR
 drN
 drN
@@ -138187,7 +133682,7 @@ drg
 dnh
 drA
 drv
-quH
+dry
 drK
 drB
 dnA
@@ -138328,7 +133823,7 @@ bbh
 bdT
 bdM
 bhX
-tmo
+biU
 boS
 bdT
 bmt
@@ -138345,7 +133840,7 @@ bHy
 bAk
 bEo
 aWO
-sVn
+bSn
 bSn
 bOG
 bLF
@@ -138444,13 +133939,13 @@ drf
 drf
 drf
 drf
-hLc
-eGK
+dry
+drO
 drM
 dry
 drE
 drM
-eGK
+drO
 dry
 drf
 drf
@@ -139107,7 +134602,7 @@ boj
 btJ
 bus
 bsS
-vAc
+bof
 bof
 bxH
 bzf
@@ -139367,7 +134862,7 @@ bsV
 buJ
 bof
 bxJ
-eap
+bzf
 bAk
 bHy
 bAk
@@ -139379,7 +134874,7 @@ bEu
 bLV
 bOR
 bQC
-sBH
+bQC
 bNK
 bXA
 bZJ
@@ -139621,7 +135116,7 @@ boo
 btM
 brm
 bsU
-vAc
+bof
 bof
 bxI
 bzf
@@ -139881,7 +135376,7 @@ bof
 bof
 bof
 bxJ
-eap
+bzf
 bAk
 bHy
 bAk
@@ -139893,7 +135388,7 @@ bEu
 bMY
 bOV
 bQE
-fpb
+bOV
 cby
 cuo
 bZP
@@ -141167,7 +136662,7 @@ brr
 brr
 bxL
 bzj
-frt
+bAr
 bHy
 bAk
 bEu
@@ -142452,7 +137947,7 @@ byM
 bru
 bxL
 bzj
-frt
+bAr
 bHy
 bJh
 bEu
@@ -142984,7 +138479,7 @@ bUJ
 bVZ
 bXv
 bYk
-pWt
+bZB
 caX
 bWi
 clp
@@ -144277,9 +139772,9 @@ clo
 cow
 coi
 cpV
-vfX
-uyo
-uZi
+crL
+ctw
+cuK
 cvT
 cpR
 cxO
@@ -144537,7 +140032,7 @@ cpR
 csA
 ctB
 cuO
-gdQ
+crL
 cpR
 cxO
 cAe
@@ -145027,7 +140522,7 @@ bHI
 bwv
 bEA
 bGA
-wIF
+bId
 bNh
 bPa
 bRy
@@ -145049,7 +140544,7 @@ clp
 cod
 cpY
 crP
-qeu
+crL
 cuS
 cpR
 cxI
@@ -145275,7 +140770,7 @@ bcp
 btV
 bry
 bth
-rdi
+buV
 blj
 bxS
 bau
@@ -145563,7 +141058,7 @@ coB
 chI
 crj
 cbj
-mVw
+ctv
 cuX
 bIi
 cpI
@@ -145799,7 +141294,7 @@ bwv
 bEJ
 bGB
 bIc
-wsp
+bNJ
 bId
 bRz
 bId
@@ -145820,7 +141315,7 @@ coA
 ceK
 cri
 csB
-idV
+bYm
 cuV
 bIi
 cxi
@@ -146046,7 +141541,7 @@ bau
 bpY
 buy
 btj
-fnn
+buV
 blj
 bxV
 bau
@@ -146077,8 +141572,8 @@ cmV
 cmV
 chT
 cbj
-wjY
-ksw
+bLR
+cvF
 bIi
 cxU
 cxT
@@ -146303,7 +141798,7 @@ bau
 bqc
 bkQ
 btb
-rdi
+buV
 blj
 bxW
 bau
@@ -146335,7 +141830,7 @@ cmV
 cbj
 cbj
 ctC
-stO
+cvF
 bIi
 cxM
 cxT
@@ -146560,7 +142055,7 @@ boy
 bcp
 brA
 btl
-fnn
+buV
 blj
 bCS
 bau
@@ -146817,7 +142312,7 @@ bau
 bqd
 brB
 brG
-rdi
+buV
 blj
 bCR
 bau
@@ -147064,7 +142559,7 @@ aXd
 baz
 bcw
 bet
-fTX
+bcx
 biw
 baz
 aYP
@@ -147324,7 +142819,7 @@ ber
 bga
 bis
 bvN
-sfN
+bcD
 bld
 blw
 bmI
@@ -147811,7 +143306,7 @@ aaa
 aaa
 aAg
 aBc
-qFa
+aBV
 aCQ
 aDX
 aEV
@@ -147834,7 +143329,7 @@ aXk
 aXe
 baI
 bcx
-bPP
+bcx
 bhA
 bix
 bgg
@@ -147861,7 +143356,7 @@ bMj
 bPz
 bRp
 bTg
-iXO
+bWn
 bLR
 bYh
 bZT
@@ -147896,7 +143391,7 @@ cKs
 cNI
 cQt
 cOS
-gkX
+cSH
 cQu
 cxN
 cEH
@@ -148091,14 +143586,14 @@ aYx
 aXo
 baz
 bcC
-dSC
-pUZ
-dSC
+bcz
+bcz
+bcz
 baz
 bjD
 bpO
 blz
-eoC
+boJ
 boJ
 boJ
 boJ
@@ -148348,14 +143843,14 @@ aYP
 aYP
 baz
 bcB
-pfa
-dSC
-dSC
+bcz
+bcz
+bcz
 baz
 bjA
 bpM
 blx
-lPZ
+boJ
 boJ
 boJ
 bxB
@@ -148369,7 +143864,7 @@ bwv
 bEM
 bGK
 bIv
-qWE
+bKi
 bKx
 bMt
 bUi
@@ -148612,7 +144107,7 @@ baz
 bjI
 bpO
 blz
-eoC
+boJ
 boJ
 boJ
 boJ
@@ -148862,7 +144357,7 @@ aYz
 bay
 aZl
 bcF
-iSS
+bcD
 bhC
 bcD
 bjs
@@ -148882,7 +144377,7 @@ bHR
 bDq
 bED
 bGC
-vKh
+bIp
 bKi
 bLW
 bIp
@@ -148911,7 +144406,7 @@ bGG
 cyR
 cAP
 cBZ
-ltW
+cDw
 cDb
 cEt
 cFE
@@ -149096,7 +144591,7 @@ aaa
 aaa
 aAg
 aBj
-ljD
+aBg
 aCV
 aEa
 aFb
@@ -149168,7 +144663,7 @@ cxS
 cBx
 cAP
 cCh
-ltW
+cDw
 cDr
 cDw
 cFI
@@ -149425,7 +144920,7 @@ cxZ
 cyR
 cAP
 cCb
-ltW
+cDw
 cDe
 cDw
 cHw
@@ -150161,10 +145656,10 @@ bsP
 buH
 bBd
 buH
-qig
+buH
 bGj
 dck
-qZB
+bmm
 bmm
 bmm
 bBc
@@ -150417,12 +145912,12 @@ bEG
 bsO
 bmm
 bBc
-qZB
+bmm
 bAJ
 bGh
 cVt
 bGh
-kHX
+bAJ
 bmm
 bBc
 cYw
@@ -150673,14 +146168,14 @@ aab
 bEG
 bta
 bmm
-xXS
-bDp
-xpY
-tlj
-gGg
-kJW
-uPv
-cYe
+bBc
+bCX
+bAK
+bjR
+bjR
+bjR
+bEF
+cXs
 bBc
 cYw
 cZk
@@ -150931,13 +146426,13 @@ bjR
 bzO
 bzs
 bBh
-oRL
-hnS
+bCT
+bjR
 bwD
 cVV
-bxz
-wlw
-jJe
+bwD
+bjR
+cXp
 bLp
 bNu
 bxX
@@ -151188,13 +146683,13 @@ bjR
 btc
 bmm
 bBc
-wNF
-hnS
+bDk
+bjR
 bwC
-gSs
-mkp
-fYr
-jJe
+bzd
+bwC
+bjR
+cYd
 bLr
 bNw
 bPu
@@ -151445,13 +146940,13 @@ bjR
 bzO
 bzw
 bBi
-wNF
-hnS
+bCT
+bjR
 bxz
-cVV
-bwD
-wlw
-nrk
+bzm
+bxz
+bjR
+cXp
 bLq
 bNv
 boD
@@ -151702,14 +147197,14 @@ bEG
 btd
 bmm
 bBc
-wNF
-iyx
-qau
-eEX
-kmj
-xzc
-jJe
-kTV
+bDp
+bEF
+bjR
+bjR
+bjR
+bAK
+cYe
+cYk
 cYw
 cZm
 cZm
@@ -151959,13 +147454,13 @@ bEG
 bEG
 buT
 bBc
-jjr
-fCH
-feB
-fCH
-fCH
-fCH
-ihL
+bmm
+bAL
+bGo
+cWh
+bGo
+bAL
+bmm
 cYk
 cYw
 bjR
@@ -152216,12 +147711,12 @@ brd
 bEG
 bEG
 bBc
-jjr
-xvD
-ktV
-dzR
-xvD
-ihL
+bmm
+bmm
+bmm
+bmm
+bmm
+bmm
 bmm
 cYk
 cYw
@@ -152474,10 +147969,10 @@ bvP
 bzx
 bBl
 bmm
-vum
 bmm
-bzd
-vum
+bmm
+bmm
+bmm
 bmm
 bmm
 cYk


### PR DESCRIPTION
## What Does This PR Do
Reverts cyberiad.dmm back 2 versions in the [history](https://github.com/ParadiseSS13/Paradise/commits/master/_maps/map_files/cyberiad/cyberiad.dmm) to f110cef, the last version before the Christmas map edits. Effectively removing the Christmas map edits but keeping things like snow in the codebase so they can be used again in future.

## Why It's Good For The Game
The goat hated Christmas! The whole Christmas season!
Now, please don't ask why. No one quite knows the reason.

It could be, perhaps, that his suit was too tight.
It could be, his radio key, wasn't screwed in just right.

But I think that the most likely reason of all,
May have been the map conflicts, stacked up wide and tall.

But, whatever the reason, his suit or the queues,
He stood there in January, ready to choose.

Staring from his goat cave with a bahhhd, goaty frown,
As the snow fell everywhere, it kept raining down.

For he knew every assistant, for all he could gauge,
Had already had their donksoft rampage.

"They're even given up on snow angels", he said at long last,
"Its already January. Face it... Christmas is past!"

## Changelog
:cl: Kyep
tweak: Reverted Cyberiad map to the pre-Christmas version.
/:cl: