### PR TITLE
Adds a slight warning that you may have screwed up to the nuclear bomb

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -69,7 +69,7 @@ GLOBAL_VAR(bomb_set)
 			to_chat(user, "<span class='notice'>You need to deploy [src] first.</span>")
 		return
 	else if(istype(O, /obj/item/disk/plantgene))
-		to_chat(user, "<span class='warning'> You try to put the Nuclear Authentication Disk into the nuke, but it does not fi- Wait, this isn't the right disk!</span>")
+		to_chat(user, "<span class='warning'>You try to plant the disk, but despite rooting around, it won't fit! After you branch out to read the instructions, you find out where the problem stems from. You've been bamboo-zled, this isn't a nuclear disk at all!</span>")
 		return
 	return ..()
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -68,6 +68,9 @@ GLOBAL_VAR(bomb_set)
 		else
 			to_chat(user, "<span class='notice'>You need to deploy [src] first.</span>")
 		return
+	else if(istype(O, /obj/item/disk/plantgene))
+		to_chat(user, "<span class='warning'> You try to put the Nuclear Authentication Disk into the nuke, but it does not fi- Wait, this isn't the right disk!</span>")
+		return
 	return ..()
 
 /obj/machinery/nuclearbomb/crowbar_act(mob/user, obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Adds a message to a person attempting to put a plant gene disk into the nuke that they are using a wrong disk.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A funny realization to the nuclear operative that looted the captain that they looted the wrong disk.

This doesn't ruin the prank either, nuke ops should never do this as they have a pinpointer, which would keep most from not falling for the prank, and if they use the wrong disk currently, it just bounces off. This just makes it a little funnier.

## Changelog
:cl:
add: Adds a message for when someone tries to put a plant disk into the nuke.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
