### PR TITLE
Nerfs drake form.

### DIFF
--- a/code/datums/spells/shapeshift.dm
+++ b/code/datums/spells/shapeshift.dm
@@ -73,13 +73,21 @@
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/dragon
 	name = "Dragon Form"
-	desc = "Take on the shape a lesser ash drake."
-	invocation = "RAAAAAAAAWR!"
+	desc = "Take on the shape a lesser ash drake after a short delay."
+	invocation = "*scream"
 
 	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser
 	current_shapes = list(/mob/living/simple_animal/hostile/megafauna/dragon/lesser)
 	current_casters = list()
 	possible_shapes = list(/mob/living/simple_animal/hostile/megafauna/dragon/lesser)
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/Shapeshift(mob/living/caster)
+	caster.visible_message("<span class='danger'>[caster] screams in agony as bones and claws erupt out of their flesh!</span>",
+		"<span class='danger'>You begin channeling the transformation.</span>")
+	if(!do_after(caster, 5 SECONDS, FALSE, caster))
+		to_chat(caster, "<span class='warning'>You lose concentration of the spell!</span>")
+		return
+	return ..()
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bats
 	name = "Bat Form"

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -119,7 +119,7 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/random = rand(1,3)
+	var/random = rand(1, 3)
 
 	switch(random)
 		if(1)
@@ -134,7 +134,7 @@
 			to_chat(user, "<span class='danger'>You feel like you could walk straight through lava now.</span>")
 			H.weather_immunities |= "lava"
 
-	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
+	playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)
 	qdel(src)
 
 /datum/disease/transformation/dragon

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -588,16 +588,6 @@ Difficulty: Medium
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
 	attack_action_types = list()
 
-/mob/living/simple_animal/hostile/megafauna/dragon/lesser/AltClickOn(atom/movable/A)
-	if(!istype(A))
-		return
-	if(player_cooldown >= world.time)
-		to_chat(src, "<span class='warning'>You need to wait [(player_cooldown - world.time) / 10] seconds before swooping again!</span>")
-		return
-	swoop_attack(FALSE, A)
-	lava_pools(10, 2) // less pools but longer delay before spawns
-	player_cooldown = world.time + 200 // needs seperate cooldown or cant use fire attacks
-
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a progress bar to transforming into a drake, which can be interrupted. Removes the swoop function of the lesser drake. 

## Why It's Good For The Game
Currently, lesser drake is extremely powerful, you can use it instantly to escape many bad situations, such as being stunned/handcuffed by sec, being put into crit or being in a hostile atmosphere. This PR helps to make lesser drake less of an "oh shit button" that you can freely use instantly as a get out of jail free card.

Swooping as a drake is extraordinarily powerful, it deals a large enough damage when combined with the lava pools to instantly put someone into crit, and they are on fire, and in AOE. Then the swoop has a large amount of utility being able to jump over station walls as long as there is an item you can alt click on is very powerful. Finally the swoop has a tendency to accidentally perma kill people, swoop onto someone in crit, it gibs them, then the lava burns their brain. Overall it isn't fun to be on the receiving end of.

Hopefully this PR aims to make the lesser drake form less frustrating to fight while still retaining the awesomeness of the being able to turn into a dragon.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

![TaxFWgOmc0](https://user-images.githubusercontent.com/69320440/103480502-bb8a4400-4dcc-11eb-908e-c1c053fecd7d.gif)

## Changelog
:cl:
tweak: added a delay to transforming into a lesser drake
tweak: removed the swoop alt-click function from lesser drakes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
