### PR TITLE
Adds GBS bottle as a 20 TC hijack item for Virologists

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -297,6 +297,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 	job = list("Virologist")
 
+/datum/uplink_item/jobspecific/gbs_bottle
+	name = "Bottle of GBS"
+	desc = "An extremely dangerous illness caused by contagious micro-singularities that will cause the human body to be torn apart from the inside. The initial phase begins in the lungs and mimics flu symptoms. Wear your protective suit."
+	reference = "GBS"
+	item = /obj/item/reagent_containers/glass/bottle/gbs
+	cost = 20
+	job = list("Virologist")
+	surplus = 0 //No lucky chances from the crate; if you get this, this is ALL you're getting
+	hijack_only = TRUE //This is an extremely lethal disease and will do similar damage to the crew that a mass bombing would
+
 /datum/uplink_item/jobspecific/cat_grenade
 	name = "Feral Cat Delivery Grenade"
 	desc = "The feral cat delivery grenade contains 5 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds a bottle of real GBS as a hijack item for virologists. This will cost them 20 TC and not come in a viral injector, so they need to find a way to distribute it and protect themselves from it.

## Why It's Good For The Game
This PR gives GBS an actual place in the game. gives virology a dangerous hijack only item. This item is also very easy to kill yourself with, and very hard to distribute without proper planning. On the safety side though, everything to cure it is already easily accessible to medical via nanomedplus or virology smart fridge + sulfur from chem. This should help add some more flavor to the hijack meta as well for non atmos/engineer/chaplain/scientist.

## Changelog
:cl:
add: Adds GBS as a 20 TC hijack item for Virologists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
