### PR TITLE
Mindshield crates are more expensive

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -479,7 +479,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/security/armory/mindshield
 	name = "Mindshield Implants Crate"
 	contains = list (/obj/item/storage/lockbox/mindshield)
-	cost = 40
+	cost = 80
 	containername = "mindshield implant crate"
 
 /datum/supply_packs/security/armory/trackingimp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR increases the cost of mindshield crates to 80 points, or 20 points per mindshield.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's no real need for the crew/sec to order large amounts of mindshields. The station supply should be more than enough to re-mindshield cloned sec officers, and if they really run out they could simply remove the implants from the dead. The only reason to order lots of mindshield crates is to mindshield lots of non-sec crew. The only gamemode balanced around that is revolution, and the word 'balanced' is a pretty big overstatement there. Revolution is out of rotation, has been for a long-ass time and is never used.

Other conversion antags aren't really designed around most of the crew being mindshielded and immune to conversion. Not to mention mass mindshielding even unlocks the cult's final objective faster, if I remember right.

Lastly, if mindshields were cheap, why doesn't NT just mindshield everyone just as a general precaution? Mindshields are supposed to be something rare and reserved for security, not something the station can just spam on a lark.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: mindshield crates are more expensive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
