### PR TITLE
Adds an adjacent check for sleeper beaker removal

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -462,7 +462,7 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(usr.incapacitated()) //are you cuffed, dying, lying, stunned or other
+	if(usr.incapacitated() || !Adjacent(usr))
 		return
 
 	if(beaker)


### PR DESCRIPTION
## What Does This PR Do
No more long range beaker removals

## Why It's Good For The Game
Bug fix

## Changelog
:cl:
fix: Removing a sleeper beaker now checks if you're adjacent to it before it tries to put the beaker into your hands
/:cl: