### PR TITLE
Fixes bad icons on runtime-maploaded disposal pipes (and other things probably)

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -174,7 +174,7 @@
 
 /turf/proc/levelupdate()
 	for(var/obj/O in src)
-		if(O.level == 1)
+		if(O.level == 1 && O.initialized) // Only do this if the object has initialized
 			O.hide(src.intact)
 
 // override for space turfs, since they should never hide anything

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1157,11 +1157,12 @@
 	return ..()
 
 /obj/structure/disposalpipe/trunk/proc/getlinked()
-	var/obj/machinery/disposal/D = locate() in src.loc
+	var/turf/T = get_turf(src)
+	var/obj/machinery/disposal/D = locate() in T
 	if(D)
 		nicely_link_to_other_stuff(D)
 		return
-	var/obj/structure/disposaloutlet/O = locate() in src.loc
+	var/obj/structure/disposaloutlet/O = locate() in T
 	if(O)
 		nicely_link_to_other_stuff(O)
 


### PR DESCRIPTION
## What Does This PR Do
See title. Fixes pipes being invisible.
![image](https://user-images.githubusercontent.com/25063394/103655506-48650700-4f5f-11eb-8523-5b1bd7559816.png)

## Why It's Good For The Game
Runtime-maploaded pipes should be visible. This also fixes a bug that would be introduced when map rotation gets rolling.

## Changelog
:cl: AffectedArc07
fix: Disposal trunk pipes in runtime loaded maps (Gateways, ruins, etc) no longer have invisible icons
/:cl:
