### PR TITLE
Fixes Mentor asay

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -26,8 +26,9 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Asay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/get_admin_say()
-	var/msg = input(src, null, "asay \"text\"") as text|null
-	cmd_admin_say(msg)
+	if(check_rights(R_ADMIN))
+		var/msg = input(src, null, "asay \"text\"") as text|null
+		cmd_admin_say(msg)
 
 /client/proc/cmd_mentor_say(msg as text)
 	set category = "Admin"

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -29,6 +29,9 @@
 	if(check_rights(R_ADMIN))
 		var/msg = input(src, null, "asay \"text\"") as text|null
 		cmd_admin_say(msg)
+	else if(check_rights(R_MENTOR))
+		var/msg = input(src, null, "msay \"text\"") as text|null
+		cmd_mentor_say(msg)
 
 /client/proc/cmd_mentor_say(msg as text)
 	set category = "Admin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes the ability for mentors to (somewhat) access the 'asay' verb by pressing F5. The input will get sent to 'msay' now instead.

~~*(Only been a mentor for half a day and I'm already fixing things, smh.)*~~

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Nothing typed into the input box would actually get through to the asay chat, but it probably still shouldn't appear in the first place.

## Changelog
:cl:
fix: Mentors pressing F5 will now open a window for 'msay', rather than 'asay'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
