### PR TITLE
Tuulipoomi's Barsign Fix - Remastered

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -18,7 +18,7 @@
 /obj/structure/sign/barsign/New()
 	..()
 	//filling the barsigns lists
-	for(var/bartype in subtypesof(/datum/barsign))
+	for(var/bartype in typesof(/datum/barsign))
 		var/datum/barsign/signinfo = new bartype
 		if(!signinfo.hidden)
 			barsigns += signinfo
@@ -58,13 +58,17 @@
 
 /obj/structure/sign/barsign/attack_hand(mob/user)
 	if(panel_open)
-		if(broken)
-			to_chat(user, "<span class='danger'>The controls seem unresponsive.</span>")
-			return
+		if(allowed(user))
+			if(broken)
+				to_chat(user, "<span class='danger'>The controls seem unresponsive.</span>")
+				return
+			else
+				pick_sign()
+				to_chat(user, "<span class='notice'>You set the barsign and close the maintenance panel.</span>")
+				panel_open = FALSE
+				return
 		else
-			pick_sign()
-			to_chat(user, "<span class='notice'>You set the barsign and close the maintenance panel.</span>")
-			panel_open = FALSE
+			to_chat(user, "<span class='info'>Access denied.</span>")
 			return
 	else
 		to_chat(user, "<span class='info'>The maintenance panel is currently closed.</span>")
@@ -90,20 +94,17 @@
 		return
 
 /obj/structure/sign/barsign/screwdriver_act(mob/user)
-	if(allowed(user))
-		if(!panel_open)
-			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-			set_sign(new /datum/barsign/signoff)
-			panel_open = TRUE
-		else
-			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
-			panel_open = FALSE
+	if(!panel_open)
+		to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
+		set_sign(new /datum/barsign/signoff)
+		panel_open = TRUE
 	else
-		to_chat(user, "<span class='info'>Access denied.</span>")
-		return
+		to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
+		panel_open = FALSE
+	return
 
 /obj/structure/sign/barsign/proc/pick_sign()
-	var/list/signs = barsigns
+	var/list/signs = barsigns.Copy()
 	var/new_sign
 	if(!broken)
 		if(!emagged)
@@ -132,7 +133,7 @@
 		return
 	set_sign(new /datum/barsign/syndibarsign)
 	emagged = TRUE
-	req_access = list(ACCESS_SYNDICATE)
+	req_access += list(ACCESS_SYNDICATE)
 
 //Code below is to define useless variables for datums. It errors without these
 /datum/barsign

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -115,7 +115,7 @@
 			S.broken = broken
 			S.emagged = emagged
 			S.req_access = req_access
-			S.bolted = !bolted
+			S.bolted = TRUE
 			S.panel_open = !panel_open
 			qdel(src)
 		else
@@ -156,38 +156,15 @@
 		S.name = name
 		S.desc = desc
 		S.icon_state = sign_state
-		to_chat(user, "You fasten \the [S] with your wrench.")
+		S.broken = broken
+		S.emagged = emagged
+		S.req_access = req_access
+		S.bolted = bolted
+		S.panel_open = panel_open
+		to_chat(user, "You fasten \the [S] with your wrench, closing the maintenance panel in the process.")
 		qdel(src)
 	else
 		return
-
-/obj/item/sign/attackby(obj/item/tool, mob/user)	//construction
-	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
-		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
-		if(direction == "Cancel")
-			return
-		if(QDELETED(src))
-			return
-		var/obj/structure/sign/S = new(user.loc)
-		switch(direction)
-			if("North")
-				S.pixel_y = 32
-			if("East")
-				S.pixel_x = 32
-			if("South")
-				S.pixel_y = -32
-			if("West")
-				S.pixel_x = -32
-			else
-				return
-		S.name = name
-		S.desc = desc
-		S.icon_state = sign_state
-		to_chat(user, "You fasten \the [S] with your [tool].")
-		qdel(src)
-	else
-		return ..()
-
 
 /obj/structure/sign/barsign/proc/pick_sign()
 	var/list/signs = barsigns.Copy()

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -93,7 +93,7 @@
 	if(allowed(user))
 		if(!panel_open)
 			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-			set_sign(new /datum/barsign/hiddensigns/signoff)
+			set_sign(new /datum/barsign/signoff)
 			panel_open = TRUE
 		else
 			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
@@ -105,18 +105,19 @@
 /obj/structure/sign/barsign/proc/pick_sign()
 	var/list/signs = barsigns
 	var/new_sign
-	if(!broken && !emagged)
-		new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
-		set_sign(new_sign)
-	else if(!broken && emagged)
-		signs += hiddensigns
-		new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
-		set_sign(new_sign)
+	if(!broken)
+		if(!emagged)
+			new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
+			set_sign(new_sign)
+		else
+			signs += hiddensigns
+			new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
+			set_sign(new_sign)
 	else
-		set_sign(new /datum/barsign/hiddensigns/empbarsign)
+		set_sign(new /datum/barsign/empbarsign)
 
 /obj/structure/sign/barsign/emp_act(severity)
-	set_sign(new /datum/barsign/hiddensigns/empbarsign)
+	set_sign(new /datum/barsign/empbarsign)
 	broken = TRUE
 
 /obj/structure/sign/barsign/emag_act(mob/user)
@@ -129,7 +130,7 @@
 /obj/structure/sign/barsign/proc/post_emag()
 	if(broken || emagged)
 		return
-	set_sign(new /datum/barsign/hiddensigns/syndibarsign)
+	set_sign(new /datum/barsign/syndibarsign)
 	emagged = TRUE
 	req_access = list(ACCESS_SYNDICATE)
 
@@ -138,7 +139,7 @@
 	var/name = "Name"
 	var/icon = "Icon"
 	var/desc = "desc"
-	var/hidden = 0
+	var/hidden = FALSE
 
 
 //Anything below this is where all the specific signs are. If people want to add more signs, add them below.
@@ -362,21 +363,22 @@
 	icon = "spaceasshole"
 	desc = "Open since 2125, Not much has changed since then; the engineers still release the singulo and the damn miners still are more likely to cave your face in that deliver ores."
 
-/datum/barsign/hiddensigns
-	hidden = TRUE
 
 //Hidden signs list below this point
-/datum/barsign/hiddensigns/empbarsign
+/datum/barsign/empbarsign
 	name = "Haywire Barsign"
 	icon = "empbarsign"
 	desc = "Something has gone very wrong."
+	hidden = TRUE
 
-/datum/barsign/hiddensigns/syndibarsign
+/datum/barsign/syndibarsign
 	name = "Syndi Cat Takeover"
 	icon = "syndibarsign"
 	desc = "Syndicate or die."
+	hidden = TRUE
 
-/datum/barsign/hiddensigns/signoff
+/datum/barsign/signoff
 	name = "Bar Sign"
 	icon = "off"
 	desc = "This sign doesn't seem to be on."
+	hidden = TRUE

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -11,7 +11,7 @@
 	var/list/hiddensigns = list()
 	var/panel_open = FALSE
 	var/emagged = TRUE
-	var/bolted = FALSE
+	var/bolted = TRUE
 	var/prev_sign = ""
 	var/state = 0
 
@@ -102,6 +102,92 @@
 		to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
 		panel_open = FALSE
 	return
+
+/obj/structure/sign/barsign/wrench_act(mob/user)
+	if(!panel_open)
+		to_chat(user, "<span_class='notice>You must first open the maintenance panel before trying to unbolt the barsign.</span>")
+	else
+		if(bolted)
+			var/obj/item/sign/barsign/S = new(user.loc)
+			S.name = name
+			S.desc = desc
+			S.sign_state = "[icon_state]_s"	//The only sprite direction that exists is South.
+			S.broken = broken
+			S.emagged = emagged
+			S.req_access = req_access
+			S.bolted = !bolted
+			S.panel_open = !panel_open
+			qdel(src)
+		else
+			to_chat(user, "<span_class='warning'=Something bad has happened. Contact an Admin. Tell them to report this exact message to the Coders.</span>")
+
+/obj/item/sign/barsign
+	name = "barsign"
+	desc = ""
+	icon = 'icons/obj/barsigns.dmi'
+	sign_state = ""
+	w_class = WEIGHT_CLASS_NORMAL
+	resistance_flags = FLAMMABLE
+	var/panel_open
+	var/bolted
+	var/req_access
+	var/broken
+
+/obj/item/sign/barsign/wrench_act(mob/user)	//construction
+	if(isturf(user.loc))
+		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
+		//The only sprite that exists is South.
+		if(direction == "Cancel")
+			return
+		if(QDELETED(src))
+			return
+		var/obj/structure/sign/barsign/S = new(user.loc)
+		switch(direction)
+			if("North")
+				S.pixel_y = 32
+			if("East")
+				S.pixel_x = 32
+			if("South")
+				S.pixel_y = -32
+			if("West")
+				S.pixel_x = -32
+			else
+				return
+		S.name = name
+		S.desc = desc
+		S.icon_state = sign_state
+		to_chat(user, "You fasten \the [S] with your wrench.")
+		qdel(src)
+	else
+		return
+
+/obj/item/sign/attackby(obj/item/tool, mob/user)	//construction
+	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
+		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
+		if(direction == "Cancel")
+			return
+		if(QDELETED(src))
+			return
+		var/obj/structure/sign/S = new(user.loc)
+		switch(direction)
+			if("North")
+				S.pixel_y = 32
+			if("East")
+				S.pixel_x = 32
+			if("South")
+				S.pixel_y = -32
+			if("West")
+				S.pixel_x = -32
+			else
+				return
+		S.name = name
+		S.desc = desc
+		S.icon_state = sign_state
+		to_chat(user, "You fasten \the [S] with your [tool].")
+		qdel(src)
+	else
+		return ..()
+
 
 /obj/structure/sign/barsign/proc/pick_sign()
 	var/list/signs = barsigns.Copy()

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -11,7 +11,6 @@
 	var/list/hiddensigns = list()
 	var/panel_open = FALSE
 	var/emagged = TRUE
-	var/bolted = TRUE
 	var/prev_sign = ""
 	var/state = 0
 
@@ -106,37 +105,32 @@
 /obj/structure/sign/barsign/wrench_act(mob/user)
 	if(!panel_open)
 		to_chat(user, "<span_class='notice>You must first open the maintenance panel before trying to unbolt the barsign.</span>")
+		return
 	else
-		if(bolted)
-			var/obj/item/sign/barsign/S = new(user.loc)
-			S.name = name
-			S.desc = desc
-			S.sign_state = "[icon_state]_s"	//The only sprite direction that exists is South.
-			S.broken = broken
-			S.emagged = emagged
-			S.req_access = req_access
-			S.bolted = TRUE
-			S.panel_open = !panel_open
-			qdel(src)
-		else
-			to_chat(user, "<span_class='warning'=Something bad has happened. Contact an Admin. Tell them to report this exact message to the Coders.</span>")
+		var/obj/item/sign/barsign/S = new(user.loc)
+		S.name = name
+		S.desc = desc
+		S.icon_state = icon_state	//The only sprite direction that exists is South.
+		S.broken = broken
+		S.emagged = emagged
+		S.req_access = req_access
+		S.panel_open = !panel_open
+		qdel(src)
 
 /obj/item/sign/barsign
 	name = "barsign"
 	desc = ""
 	icon = 'icons/obj/barsigns.dmi'
-	sign_state = ""
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 	var/panel_open
-	var/bolted
-	var/req_access
 	var/broken
+	var/emagged
 
 /obj/item/sign/barsign/wrench_act(mob/user)	//construction
 	if(isturf(user.loc))
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
-		//The only sprite that exists is South.
+		//The only sprite that exists is South, but we forced this in when we dismantled the barsign.
 		if(direction == "Cancel")
 			return
 		if(QDELETED(src))
@@ -155,13 +149,13 @@
 				return
 		S.name = name
 		S.desc = desc
-		S.icon_state = sign_state
+		S.icon_state = icon_state
 		S.broken = broken
 		S.emagged = emagged
 		S.req_access = req_access
-		S.bolted = bolted
+
 		S.panel_open = panel_open
-		to_chat(user, "You fasten \the [S] with your wrench, closing the maintenance panel in the process.")
+		to_chat(user, "You bolt \the [S] with your wrench, closing the maintenance panel in the process.")
 		qdel(src)
 	else
 		return

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -11,7 +11,7 @@
 	switch(damage_type)
 		if(BRUTE)
 			if(damage_amount)
-				playsound(src.loc, 'sound/weapons/slash.ogg', 80, TRUE)
+				playsound(loc, 'sound/weapons/slash.ogg', 80, TRUE)
 			else
 				playsound(loc, 'sound/weapons/tap.ogg', 50, TRUE)
 		if(BURN)
@@ -24,7 +24,7 @@
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	to_chat(user, "You unfasten the sign with [I].")
-	var/obj/item/sign/S = new(src.loc)
+	var/obj/item/sign/S = new(loc)
 	S.name = name
 	S.desc = desc
 	S.icon_state = icon_state
@@ -42,7 +42,7 @@
 	resistance_flags = FLAMMABLE
 	var/sign_state = ""
 
-/obj/item/sign/attackby(obj/item/tool as obj, mob/user as mob)	//construction
+/obj/item/sign/attackby(obj/item/tool, mob/user)	//construction
 	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel")

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -42,8 +42,9 @@
 	resistance_flags = FLAMMABLE
 	var/sign_state = ""
 
-/obj/item/sign/attackby(obj/item/tool, mob/user)	//construction
-	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
+/obj/item/sign/screwdriver_act(mob/user)	//construction
+	if(isturf(user.loc) && !(istype(src, /obj/item/sign/barsign)))
+	// Please don't use a screwdriver on the sign/barsign.
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel")
 			return
@@ -64,10 +65,10 @@
 		S.name = name
 		S.desc = desc
 		S.icon_state = sign_state
-		to_chat(user, "You fasten \the [S] with your [tool].")
+		to_chat(user, "You fasten \the [S] with your screwdriver.")
 		qdel(src)
 	else
-		return ..()
+		return
 
 /obj/structure/sign/double/map
 	name = "station map"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Credit
A few PRs here have attempted to fix this with the most recent one being https://github.com/ParadiseSS13/Paradise/pull/15063 . 
The work completed by Tuulipoomi and the Maintainers and Reviewers was very close to mergeable code, just needing a few tweaks to become mergeable.

## What Does This PR Do

- Sets out to resolve Issue: https://github.com/ParadiseSS13/Paradise/issues/14884.
- If the barsign has been emagged, the list of signs will include the "hidden signs"


<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Invisible sign bad.
Choose signage good.
Now with menu - perhaps as originally intended?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/69871346/103378434-48bd5800-4ab0-11eb-87d0-976da98400b9.png)
![image](https://user-images.githubusercontent.com/69871346/103378452-57a40a80-4ab0-11eb-8afb-6f8c5d92831a.png)
**The above image is out of date. I coded a chunk to do this and then realized that there was already code to do this, so I deferred to that code. That's why the language does not match up.**
![image](https://user-images.githubusercontent.com/69871346/103378472-638fcc80-4ab0-11eb-9eec-c9d5be5387b3.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Barsign's maintenance panel can be opened using a screwdriver, open Barsign only be changed via attacking with hand by either Bartender or Syndicate Agents (post-emag), open Barsign can be dismantled and moved with a wrench by anyone.
fix: Barsign can no longer turns invisible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
