### PR TITLE
Prevents diagonal teleports on the syndicate handheld teleporter

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -273,26 +273,10 @@ effective or pretty fucking useless.
 /obj/item/teleporter/proc/dir_correction(mob/user) //Direction movement, screws with teleport distance and saving throw, and thus must be removed first
 	var/temp_direction = user.dir
 	switch(temp_direction)
-		if(NORTHEAST)
-			if(prob(50))
-				user.dir = NORTH
-			else
-				user.dir = EAST
-		if(NORTHWEST)
-			if(prob(50))
-				user.dir = NORTH
-			else
-				user.dir = WEST
-		if(SOUTHEAST)
-			if(prob(50))
-				user.dir = SOUTH
-			else
-				user.dir = EAST
-		if(SOUTHWEST)
-			if(prob(50))
-				user.dir = SOUTH
-			else
-				user.dir = WEST
+		if(NORTHEAST || SOUTHEAST)
+			user.dir = EAST
+		if(NORTHWEST || SOUTHWEST)
+			user.dir = WEST
 
 /obj/item/teleporter/proc/panic_teleport(mob/user, turf/destination, direction = NORTH)
 	var/saving_throw

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -219,6 +219,7 @@ effective or pretty fucking useless.
 			qdel(src)
 
 /obj/item/teleporter/proc/attempt_teleport(mob/user, EMP_D = FALSE)
+	dir_correction(user)
 	if(!charges)
 		to_chat(user, "<span class='warning'>The [src] is recharging still.</span>")
 		return
@@ -268,6 +269,30 @@ effective or pretty fucking useless.
 /obj/item/teleporter/proc/tile_check(turf/T)
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/space) || istype(T, /turf/simulated/shuttle/floor) || istype(T, /turf/simulated/shuttle/floor4) || istype(T, /turf/simulated/shuttle/plating))
 		return TRUE
+
+/obj/item/teleporter/proc/dir_correction(mob/user) //Direction movement, screws with teleport distance and saving throw, and thus must be removed first
+	var/temp_direction = user.dir
+	switch(temp_direction)
+		if(NORTHEAST)
+			if(prob(50))
+				user.dir = NORTH
+			else
+				user.dir = EAST
+		if(NORTHWEST)
+			if(prob(50))
+				user.dir = NORTH
+			else
+				user.dir = WEST
+		if(SOUTHEAST)
+			if(prob(50))
+				user.dir = SOUTH
+			else
+				user.dir = EAST
+		if(SOUTHWEST)
+			if(prob(50))
+				user.dir = SOUTH
+			else
+				user.dir = WEST
 
 /obj/item/teleporter/proc/panic_teleport(mob/user, turf/destination, direction = NORTH)
 	var/saving_throw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR changes the direction of a user when they use the syndicate handheld teleporter before they teleport, to north east south or west, changing their direction to either pure east or west, like their sprite.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Diagonal teleports were not intended when this device was added, it is more movement then it should have, even harder to plan around, messes with the saving throw teleport by forcing it to use the fallback direction of north, and confuses people when their sprite was facing east, and yet they teleport north east into a different location.

## Changelog
:cl:
tweak: Handheld syndicate teleporter can no longer teleport you diagonally.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
