### PR TITLE
Bloodbags ordered at cargo have blood in them again

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -29,10 +29,10 @@
 		amount_per_transfer_from_this = N
 
 /obj/item/reagent_containers/New()
+	create_reagents(volume, temperature_min, temperature_max)
 	..()
 	if(!possible_transfer_amounts)
 		verbs -= /obj/item/reagent_containers/verb/set_APTFT
-	create_reagents(volume, temperature_min, temperature_max)
 	if(spawned_disease)
 		var/datum/disease/F = new spawned_disease(0)
 		var/list/data = list("viruses" = list(F), "blood_color" = "#A10808")


### PR DESCRIPTION
## What Does This PR Do
Makes sure that `reagents` is not null when `Initialize` of a reagent is called. Thus fixing the bloodbags being empty

Roundstart bloodbags worked because Initialize was called later on startup

Fixes #15250

## Why It's Good For The Game
Bug fix. No more scams

## Changelog
:cl:
fix: Blood bags are now not empty anymore when buying them from cargo
/:cl: