### PR TITLE
Fixes ghosts being able to swap items in storage objects

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -645,7 +645,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	closeToolTip(usr)
 
 /obj/item/MouseDrop_T(obj/item/I, mob/user)
-	if(!user || !iscarbon(user) || src == I)
+	if(!user || user.incapacitated(ignore_lying = TRUE) || src == I)
 		return
 
 	if(loc && I.loc == loc && istype(loc, /obj/item/storage) && loc.Adjacent(user)) // Are we trying to swap two items in the storage?

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -645,10 +645,10 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	closeToolTip(usr)
 
 /obj/item/MouseDrop_T(obj/item/I, mob/user)
-	if(!user || src == I)
+	if(!user || !iscarbon(user) || src == I)
 		return
 
-	if(loc && I.loc == loc && istype(loc, /obj/item/storage)) // Are we trying to swap two items in the storage?
+	if(loc && I.loc == loc && istype(loc, /obj/item/storage) && loc.Adjacent(user)) // Are we trying to swap two items in the storage?
 		var/obj/item/storage/S = loc
 		S.swap_items(src, I, user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Fixes #15247

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Mom I'm scared of ghosts (and bugs)

## Changelog
:cl:
fix: Ghosts can no longer swap items in boxes, etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
