### PR TITLE
Two handed Shotguns

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -330,6 +330,7 @@
 	icon_state = "dshotgun"
 	item_state = "shotgun"
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 	force = 10
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
@@ -362,6 +363,9 @@
 	else
 		return ..()
 
+/obj/item/gun/projectile/revolver/doublebarrel/sawoff(mob/user)
+    . = ..()
+    weapon_weight = WEAPON_MEDIUM
 /obj/item/gun/projectile/revolver/doublebarrel/attack_self(mob/living/user)
 	var/num_unloaded = 0
 	while(get_ammo() > 0)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -366,6 +366,7 @@
 /obj/item/gun/projectile/revolver/doublebarrel/sawoff(mob/user)
     . = ..()
     weapon_weight = WEAPON_MEDIUM
+
 /obj/item/gun/projectile/revolver/doublebarrel/attack_self(mob/living/user)
 	var/num_unloaded = 0
 	while(get_ammo() > 0)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -131,7 +131,7 @@
 	name = "assault shotgun"
 	desc = sawn_desc
 	w_class = WEIGHT_CLASS_NORMAL
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 	current_skin = "riotshotgun-short"
 	item_state = "gun"			//phil235 is it different with different skin?
 	slot_flags &= ~SLOT_BACK    //you can't sling it on your back

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -83,7 +83,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	sawn_state = SAWN_INTACT
-	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/projectile/shotgun/riot/attackby(obj/item/A, mob/user, params)
 	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -83,6 +83,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	sawn_state = SAWN_INTACT
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/projectile/shotgun/riot/attackby(obj/item/A, mob/user, params)
 	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))
@@ -308,6 +309,7 @@
 	origin_tech = "combat=6"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
+	weapon_weight = WEAPON_HEAVY
 
 //Dual Feed Shotgun
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -12,7 +12,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
 	fire_sound = 'sound/weapons/gunshots/gunshot_shotgun.ogg'
 	var/recentpump = 0 // to prevent spammage
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/projectile/shotgun/attackby(obj/item/A, mob/user, params)
 	. = ..()
@@ -131,6 +131,7 @@
 	name = "assault shotgun"
 	desc = sawn_desc
 	w_class = WEIGHT_CLASS_NORMAL
+	weapon_weight = WEAPON_MEDIUM
 	current_skin = "riotshotgun-short"
 	item_state = "gun"			//phil235 is it different with different skin?
 	slot_flags &= ~SLOT_BACK    //you can't sling it on your back
@@ -320,6 +321,7 @@
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube
 	w_class = WEIGHT_CLASS_HUGE
+	weapon_weight = WEAPON_HEAVY
 	var/toggled = 0
 	var/obj/item/ammo_box/magazine/internal/shot/alternate_magazine
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -131,7 +131,6 @@
 	name = "assault shotgun"
 	desc = sawn_desc
 	w_class = WEIGHT_CLASS_NORMAL
-	weapon_weight = WEAPON_HEAVY
 	current_skin = "riotshotgun-short"
 	item_state = "gun"			//phil235 is it different with different skin?
 	slot_flags &= ~SLOT_BACK    //you can't sling it on your back
@@ -310,7 +309,6 @@
 	origin_tech = "combat=6"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
-	weapon_weight = WEAPON_HEAVY
 
 //Dual Feed Shotgun
 
@@ -321,7 +319,6 @@
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube
 	w_class = WEIGHT_CLASS_HUGE
-	weapon_weight = WEAPON_HEAVY
 	var/toggled = 0
 	var/obj/item/ammo_box/magazine/internal/shot/alternate_magazine
 


### PR DESCRIPTION
## What Does This PR Do
Makes it so you must have your other hand empty to shoot a shotgun with lethal capabilities with one hand, the exception being sawn-off improvised and sawn-off double-barrel shotguns.

## Why It's Good For The Game
Shotguns need some kind of nerf. Them being used in tandem with shields to deal high amounts of damage and have a decent chance at blocking damage or stuns coming your way isn't very balanced. The same goes for using a shotgun at the same time as say, an e-sword. I also think that being able to shoot and pump and fire a shotgun with one hand is a bit much if you do end up pairing it with something

## Images of changes
![shotgun](https://user-images.githubusercontent.com/68139038/103835720-dd3d3280-503b-11eb-87b0-655d55c465a3.png)

## Changelog
:cl:
Tweak: You can no longer have both of your hands full While holding any shotgun with lethal capabilities. The exception being sawn-off improvised shotguns and sawn-off double-barreled shotguns.
/:cl: