### PR TITLE
Fixes msay admin rights error

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -26,7 +26,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Asay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/get_admin_say()
-	if(check_rights(R_ADMIN))
+	if(check_rights(R_ADMIN, FALSE))
 		var/msg = input(src, null, "asay \"text\"") as text|null
 		cmd_admin_say(msg)
 	else if(check_rights(R_MENTOR))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes this when pressing F5 as a mentor, since it opens 'msay' now:
![image](https://user-images.githubusercontent.com/57483089/103889021-a4ee3080-50dd-11eb-933e-84aa85534c17.png)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Somehow got through testing in #15246

## Changelog
:cl:
fix: Fixed mentors getting an admin rights error when pressing F5 to open msay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
