### PR TITLE
Makes mindless beings cryoing not break objectives without a targeted mind

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -377,10 +377,11 @@
 			SSticker.mode.cult_objs.ready_to_summon()
 
 	//Update any existing objectives involving this mob.
-	for(var/datum/objective/O in GLOB.all_objectives)
-		if(O.target != occupant.mind)
-			continue
-		O.on_target_cryo()
+	if(occupant.mind)
+		for(var/datum/objective/O in GLOB.all_objectives)
+			if(O.target != occupant.mind)
+				continue
+			O.on_target_cryo()
 	if(occupant.mind && occupant.mind.assigned_role)
 		//Handle job slot/tater cleanup.
 		var/job = occupant.mind.assigned_role


### PR DESCRIPTION
## What Does This PR Do
Makes it so that mindless beings being cryod not cause objectives to be checked.
Fixes:
```
Runtime in objective.dm,28: Cannot read null.targets
   proc name: is invalid target (/datum/objective/proc/is_invalid_target)
   src: /datum/objective/eldergod (/datum/objective/eldergod)
   call stack:
   /datum/objective/eldergod (/datum/objective/eldergod): is invalid target(NAME (/datum/mind))
   /datum/objective/eldergod (/datum/objective/eldergod): find target()
   /datum/objective/eldergod (/datum/objective/eldergod): post target cryo()
   ImmediateInvokeAsync(/datum/objective/eldergod (/datum/objective/eldergod), /datum/objective/proc/post_tar... (/datum/objective/proc/post_target_cryo))
   /datum/objective/eldergod (/datum/objective/eldergod): on target cryo()
   the cryogenic freezer (stok (3... (/obj/machinery/cryopod): despawn occupant()
   the cryogenic freezer (stok (3... (/obj/machinery/cryopod): process(2)
   Machines (/datum/controller/subsystem/machines): process machines(0)
   Machines (/datum/controller/subsystem/machines): fire(0)
   Machines (/datum/controller/subsystem/machines): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```
## Why It's Good For The Game
Bug b gone

## Changelog
:cl:
fix: Cryoing a farwa or so will now not break objectives without a targeted mind
/:cl: