### PR TITLE
Stops the cryo sleepers from putting items into null space. Fixing the pinpointer runtime. Fix recall items from being wacky in some cases

### DIFF
--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -12,7 +12,8 @@
 	include_user = 1
 
 	var/obj/marked_item
-
+	/// List of objects which will result in the spell stopping with the recursion search
+	var/static/list/blacklisted_summons = list(/obj/machinery/computer/cryopod, /obj/machinery/atmospherics, /obj/structure/disposalholder, /obj/machinery/disposal)
 	action_icon_state = "summons"
 
 /obj/effect/proc_holder/spell/targeted/summonitem/cast(list/targets, mob/user = usr)
@@ -89,7 +90,7 @@
 						var/obj/machinery/portable_atmospherics/P = item_to_retrieve.loc
 						P.disconnect()
 						P.update_icon()
-					if(istype(item_to_retrieve.loc, /obj/structure/disposalholder) || istype(item_to_retrieve.loc, /obj/machinery/disposal))//fixes the breaking of disposals. No more bluespace connected disposal bins!
+					if(is_type_in_list(item_to_retrieve.loc, blacklisted_summons))
 						break
 					item_to_retrieve = item_to_retrieve.loc
 

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -13,7 +13,7 @@
 
 	var/obj/marked_item
 	/// List of objects which will result in the spell stopping with the recursion search
-	var/static/list/blacklisted_summons = list(/obj/machinery/computer/cryopod, /obj/machinery/atmospherics, /obj/structure/disposalholder, /obj/machinery/disposal)
+	var/static/list/blacklisted_summons = list(/obj/machinery/computer/cryopod = TRUE, /obj/machinery/atmospherics = TRUE, /obj/structure/disposalholder = TRUE, /obj/machinery/disposal = TRUE)
 	action_icon_state = "summons"
 
 /obj/effect/proc_holder/spell/targeted/summonitem/cast(list/targets, mob/user = usr)
@@ -90,7 +90,7 @@
 						var/obj/machinery/portable_atmospherics/P = item_to_retrieve.loc
 						P.disconnect()
 						P.update_icon()
-					if(is_type_in_list(item_to_retrieve.loc, blacklisted_summons))
+					if(is_type_in_typecache(item_to_retrieve.loc, blacklisted_summons))
 						break
 					item_to_retrieve = item_to_retrieve.loc
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -367,7 +367,7 @@
 			control_computer.frozen_items += I
 			if(preserve == CRYO_OBJECTIVE)
 				control_computer.objective_items += I
-			I.loc = null
+			I.forceMove(control_computer)
 		else
 			I.forceMove(loc)
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -156,8 +156,7 @@
 /obj/machinery/computer/cryopod/proc/dispense_item(obj/item/I)
 	if(!(I in frozen_items))
 		return
-	I.forceMove(get_turf(src))
-	item_got_removed(I)
+	I.forceMove(get_turf(src)) // Will call item_got_removed due to the signal being registered to COMSIG_MOVABLE_MOVED
 
 /obj/machinery/computer/cryopod/emag_act(mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -1,3 +1,7 @@
+#define CRYO_DESTROY 0
+#define CRYO_PRESERVE 1
+#define CRYO_OBJECTIVE 2
+
 /*
  * Cryogenic refrigeration unit. Basically a despawner.
  * Stealing a lot of concepts/code from sleepers due to massive laziness.
@@ -137,12 +141,23 @@
 	updateUsrDialog()
 	return
 
+/obj/machinery/computer/cryopod/proc/freeze_item(obj/item/I, preserve_status)
+	frozen_items += I
+	if(preserve_status == CRYO_OBJECTIVE)
+		objective_items += I
+	I.forceMove(src)
+	RegisterSignal(I, COMSIG_MOVABLE_MOVED, .proc/item_got_removed)
+
+/obj/machinery/computer/cryopod/proc/item_got_removed(obj/item/I)
+	objective_items -= I
+	frozen_items -= I
+	UnregisterSignal(I, COMSIG_MOVABLE_MOVED)
+
 /obj/machinery/computer/cryopod/proc/dispense_item(obj/item/I)
 	if(!(I in frozen_items))
 		return
 	I.forceMove(get_turf(src))
-	objective_items -= I
-	frozen_items -= I
+	item_got_removed(I)
 
 /obj/machinery/computer/cryopod/emag_act(mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -314,10 +329,6 @@
 
 			despawn_occupant()
 
-#define CRYO_DESTROY 0
-#define CRYO_PRESERVE 1
-#define CRYO_OBJECTIVE 2
-
 /obj/machinery/cryopod/proc/should_preserve_item(obj/item/I)
 	for(var/datum/theft_objective/T in control_computer.theft_cache)
 		if(istype(I, T.typepath) && T.check_special_completion(I))
@@ -364,10 +375,7 @@
 		if(preserve == CRYO_DESTROY)
 			qdel(I)
 		else if(control_computer && control_computer.allow_items)
-			control_computer.frozen_items += I
-			if(preserve == CRYO_OBJECTIVE)
-				control_computer.objective_items += I
-			I.forceMove(control_computer)
+			control_computer.freeze_item(I, preserve)
 		else
 			I.forceMove(loc)
 
@@ -444,9 +452,6 @@
 	QDEL_NULL(occupant)
 	name = initial(name)
 
-#undef CRYO_DESTROY
-#undef CRYO_PRESERVE
-#undef CRYO_OBJECTIVE
 
 /obj/machinery/cryopod/attackby(obj/item/I, mob/user, params)
 
@@ -774,3 +779,7 @@
 	if(istype(person_to_cryo.loc, /obj/machinery/cryopod))
 		var/obj/machinery/cryopod/P = person_to_cryo.loc
 		P.despawn_occupant()
+
+#undef CRYO_DESTROY
+#undef CRYO_PRESERVE
+#undef CRYO_OBJECTIVE


### PR DESCRIPTION
## What Does This PR Do
Makes it so that items being stored in cryo get put in the console. And not in nullspace

Also fixes summonitems from breaking cryo dorms and atmos.

fixes:
```
Runtime in pinpointer.dm,359: Cannot read null.z
   proc name: trackable (/obj/item/pinpointer/crew/proc/trackable)
   src: the crew pinpointer (/obj/item/pinpointer/crew)
   src.loc: null
   call stack:
   the crew pinpointer (/obj/item/pinpointer/crew): trackable(NAME (/mob/living/carbon/human))
   the crew pinpointer (/obj/item/pinpointer/crew): point at(NAME (/mob/living/carbon/human))
   the crew pinpointer (/obj/item/pinpointer/crew): process(2)
   Fast Processing (/datum/controller/subsystem/processing/fastprocess): fire(0)
   Fast Processing (/datum/controller/subsystem/processing/fastprocess): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game
Putting items into nullspace can lead to a ton of issues down the line as shown with the pinpointer.

## Changelog
:cl:
fix: Recall items no longer pulls vents to you when you use it while the item is in the vent
/:cl: