### PR TITLE
Save logdir to data/logpath.txt

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -281,6 +281,10 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 		fcopy(GLOB.config_error_log, "[GLOB.log_directory]/config_error.log")
 		fdel(GLOB.config_error_log)
 
+	// Save the current round's log path to a text file for other scripts to use.
+	var/F = file("data/logpath.txt")
+	fdel(F)
+	F << GLOB.log_directory
 
 // Proc to enable the extools debugger, which allows breakpoints, live var checking, and many other useful tools
 // The DLL is injected into the env by visual studio code. If not running VSCode, the proc will not call the initialization


### PR DESCRIPTION
## What Does This PR Do
Saves the path to the current round's logs to data/logpath.txt

## Why It's Good For The Game
According to https://www.paradisestation.org/forum/topic/17887-github-contributors-runtime-logs/ our Github Contributors are meant to have access to complete runtime logs from last round, to help them fix runtime errors.
Unfortunately, after https://github.com/ParadiseSS13/Paradise/pull/15132 was merged, this broke.
On the backend, I was running a script that copied runtime.txt from the current day's path (data/logs/YEAR/MONTH/DAY/) to the webserver.
Unfortunately the new log file path format (YEAR/MONTH/DAY/ROUNDID/) broke this.
Backend scripts need to be explicitly told what the path is to the current round's logs, and they need to be told via a method they can easily check (e.g: text file). Hence data/logpath.txt
With this file in place, I can have my backend scripts simply cd to whatever that directory is, then upload its runtime.txt to the webserver.
Ultimately, this enables me to fix the issue (reported by @SabreML) where contributors no longer got access to full runtime logs.

## Changelog
:cl:
tweak: Started saving data/logpath.txt which contains the full path to the current round's logs. This is necessary for certain backend log-uploading scripts to work.
/:cl: