### PR TITLE
Fixes the possible qdel runtime hotspots can cause

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -164,12 +164,12 @@
 /obj/effect/hotspot/Destroy()
 	set_light(0)
 	SSair.hotspots -= src
-	if(!fake)
-		DestroyTurf()
-	if(istype(loc, /turf/simulated))
+	if(issimulatedturf(loc))
 		var/turf/simulated/T = loc
 		if(T.active_hotspot == src)
 			T.active_hotspot = null
+	if(!fake)
+		DestroyTurf()
 	return ..()
 
 /obj/effect/hotspot/proc/DestroyTurf()

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -74,7 +74,8 @@
 		air.temperature = temperature
 
 /turf/simulated/Destroy()
-	QDEL_NULL(active_hotspot)
+	if(!QDELETED(active_hotspot)) // hotspots being qdeleted can sometimes destroy the turf. Avoid a loop
+		qdel(active_hotspot)
 	QDEL_NULL(wet_overlay)
 	return ..()
 

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -75,7 +75,9 @@
 
 /turf/simulated/Destroy()
 	if(!QDELETED(active_hotspot)) // hotspots being qdeleted can sometimes destroy the turf. Avoid a loop
-		qdel(active_hotspot)
+		QDEL_NULL(active_hotspot)
+	else
+		active_hotspot = null
 	QDEL_NULL(wet_overlay)
 	return ..()
 

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -74,10 +74,7 @@
 		air.temperature = temperature
 
 /turf/simulated/Destroy()
-	if(!QDELETED(active_hotspot)) // hotspots being qdeleted can sometimes destroy the turf. Avoid a loop
-		QDEL_NULL(active_hotspot)
-	else
-		active_hotspot = null
+	QDEL_NULL(active_hotspot)
 	QDEL_NULL(wet_overlay)
 	return ..()
 


### PR DESCRIPTION
## What Does This PR Do
Hotspots being destroyed could cause the turf they are on to be destroyed. Which would result in the hotspot being qdeleted which causes the runtime below

Fixes:
```
Runtime in garbage.dm,323: /obj/effect/hotspot destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic
   proc name: qdel (/proc/qdel)
   src: null
   call stack:
   qdel(the hotspot (/obj/effect/hotspot), 0)
   the floor (192,107,1) (/turf/simulated/floor/plasteel): Destroy(0)
   qdel(the floor (192,107,1) (/turf/simulated/floor/plasteel), 0)
   the floor (192,107,1) (/turf/simulated/floor/plasteel): ChangeTurf(/turf/space (/turf/space), 0, 1, 0)
   the floor (192,107,1) (/turf/simulated/floor/plasteel): ChangeTurf(/turf/space (/turf/space), 0, 1, 0)
   the floor (192,107,1) (/turf/simulated/floor/plasteel): ChangeTurf(/turf/space (/turf/space), 0, 1, 0)
   the hotspot (/obj/effect/hotspot): DestroyTurf()
   the hotspot (/obj/effect/hotspot): Destroy(0)
   qdel(the hotspot (/obj/effect/hotspot), 0)
   the hotspot (/obj/effect/hotspot): process()
   Atmospherics (/datum/controller/subsystem/air): process hotspots(0)
   Atmospherics (/datum/controller/subsystem/air): fire(0)
   Atmospherics (/datum/controller/subsystem/air): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```

## Why It's Good For The Game
Bye runtime

## Changelog
No functional change