### PR TITLE
Should fix emitters from failing due to SMES settings

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -79456,6 +79456,13 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"cNW" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cNX" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -79479,10 +79486,10 @@
 /area/assembly/assembly_line)
 "cOa" = (
 /obj/structure/cable/cyan{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /obj/structure/cable/cyan{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -80829,6 +80836,11 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -83421,6 +83433,11 @@
 	req_access_txt = "10"
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVd" = (
@@ -83691,6 +83708,11 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVz" = (
@@ -83819,6 +83841,11 @@
 "cVN" = (
 /obj/item/wirecutters,
 /obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVO" = (
@@ -83874,6 +83901,11 @@
 /area/engine/engineering)
 "cVT" = (
 /obj/effect/decal/warning_stripes/southeast,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVU" = (
@@ -84849,6 +84881,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXF" = (
@@ -85211,6 +85248,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cYn" = (
@@ -85492,8 +85534,10 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85555,13 +85599,15 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cYZ" = (
 /obj/effect/decal/warning_stripes/northeast,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZa" = (
@@ -85642,8 +85688,10 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -87465,6 +87513,9 @@
 /area/maintenance/turbine)
 "ddb" = (
 /obj/structure/particle_accelerator/end_cap,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "ddc" = (
@@ -95274,6 +95325,15 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
+"mJq" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "mMw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -95523,21 +95583,6 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
-"pEb" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Singularity";
-	name = "Singularity Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
 "pGQ" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/simulated/floor/plasteel{
@@ -95900,6 +95945,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
+"vfN" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "vup" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -95936,6 +95990,21 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
+"vIU" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Singularity";
+	name = "Singularity Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "vJw" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -124141,7 +124210,7 @@ cWC
 cXx
 dbs
 cYF
-cQG
+cNW
 cSx
 cRf
 cRp
@@ -125426,11 +125495,11 @@ cSl
 cXH
 dbG
 cZf
-acF
+cOg
 cVj
 deC
 dfs
-cSv
+vfN
 dfo
 cSF
 afO
@@ -125686,7 +125755,7 @@ cYZ
 cQG
 cVc
 cVy
-cQH
+mJq
 cVT
 dfo
 cSF
@@ -126713,7 +126782,7 @@ cYo
 cZE
 cZQ
 cSv
-pEb
+vIU
 cRp
 dfo
 afO

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -46,10 +46,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_mid";
+	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_mid";
-	dir = 2
+	tag = "icon-window5_mid"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -69,10 +69,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end";
+	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 2
+	tag = "icon-window5_end"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -87,10 +87,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (NORTH)";
+	dir = 1;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 1
+	tag = "icon-window5_end (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -214,9 +214,9 @@
 /area/shuttle/syndicate)
 "acf" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -284,8 +284,8 @@
 /obj/effect/decal/warning_stripes/southwest,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/range)
 "acp" = (
@@ -321,23 +321,23 @@
 "act" = (
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/range)
 "acu" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/range)
 "acv" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/range)
 "acw" = (
@@ -376,9 +376,9 @@
 /area/shuttle/syndicate)
 "acB" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
+	dir = 8;
 	icon_state = "shower";
-	dir = 8
+	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower/security,
 /turf/simulated/floor/plasteel{
@@ -392,9 +392,9 @@
 /obj/item/target,
 /obj/item/target,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -422,13 +422,11 @@
 	},
 /area/security/main)
 "acF" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/security/prisonershuttle)
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "acG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -977,8 +975,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -1149,9 +1147,9 @@
 /area/security/range)
 "adS" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/machinery/suit_storage_unit/syndicate/secure,
 /turf/simulated/shuttle/floor{
@@ -1170,9 +1168,9 @@
 /area/shuttle/syndicate)
 "adU" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -1368,8 +1366,8 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/main)
 "aek" = (
@@ -1442,9 +1440,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/security/medbay)
 "aeq" = (
@@ -1470,9 +1468,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/security/medbay)
 "aes" = (
@@ -1509,16 +1507,16 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/range)
 "aev" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/range)
 "aew" = (
@@ -1650,9 +1648,9 @@
 /obj/item/reagent_containers/syringe/charcoal,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/security/medbay)
 "aeK" = (
@@ -1678,9 +1676,9 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/security/medbay)
 "aeM" = (
@@ -1799,9 +1797,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/security/medbay)
 "aeU" = (
@@ -1951,9 +1949,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/security/medbay)
 "afe" = (
@@ -2145,9 +2143,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/security/medbay)
 "afv" = (
@@ -2337,9 +2335,9 @@
 	req_access_txt = "150"
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -2351,9 +2349,9 @@
 	req_access_txt = "150"
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -2445,9 +2443,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/security/medbay)
 "afZ" = (
@@ -2529,9 +2527,9 @@
 /area/shuttle/vox)
 "agf" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2734,9 +2732,9 @@
 	req_access_txt = "152"
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2759,10 +2757,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end";
+	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 2
+	tag = "icon-window5_end"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2777,10 +2775,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (NORTH)";
+	dir = 1;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 1
+	tag = "icon-window5_end (NORTH)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2795,10 +2793,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_mid";
+	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_mid";
-	dir = 2
+	tag = "icon-window5_mid"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -2810,9 +2808,9 @@
 	req_access_txt = "152"
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3035,9 +3033,9 @@
 /area/security/securearmoury)
 "agT" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3169,8 +3167,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/main)
 "ahg" = (
@@ -3256,10 +3254,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (WEST)";
+	dir = 8;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 8
+	tag = "icon-window5_end (WEST)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3286,10 +3284,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (WEST)";
+	dir = 8;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 8
+	tag = "icon-window5_end (WEST)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3441,8 +3439,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/armoury)
 "ahI" = (
@@ -3464,10 +3462,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (EAST)";
+	dir = 4;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 4
+	tag = "icon-window5_end (EAST)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -3493,17 +3491,17 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (EAST)";
+	dir = 4;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 4
+	tag = "icon-window5_end (EAST)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "ahN" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l";
-	icon_state = "propulsion_l"
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -3513,8 +3511,8 @@
 /area/shuttle/syndicate)
 "ahP" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r";
-	icon_state = "propulsion_r"
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate)
@@ -3541,8 +3539,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/armoury)
 "ahS" = (
@@ -3554,8 +3552,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/armoury)
 "ahT" = (
@@ -3567,8 +3565,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/armoury)
 "ahU" = (
@@ -3713,8 +3711,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/armoury)
 "aig" = (
@@ -3783,8 +3781,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/armoury)
 "aio" = (
@@ -3794,8 +3792,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -3938,8 +3936,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "aix" = (
@@ -3977,8 +3975,8 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "aiA" = (
@@ -4477,8 +4475,8 @@
 /obj/vehicle/secway,
 /obj/item/key/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "ajl" = (
@@ -4974,9 +4972,9 @@
 /obj/item/harpoon,
 /obj/item/tank/nitrogen,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
@@ -5203,8 +5201,8 @@
 /area/security/podbay)
 "akp" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l";
-	icon_state = "propulsion_l"
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/vox)
@@ -5362,9 +5360,9 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -5378,9 +5376,9 @@
 "akH" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
@@ -5463,10 +5461,10 @@
 "akP" = (
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (NORTH)";
+	dir = 1;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 1
+	tag = "icon-window5_end (NORTH)"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
@@ -5487,18 +5485,18 @@
 "akR" = (
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end";
+	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 2
+	tag = "icon-window5_end"
 	},
 /turf/simulated/shuttle/plating/vox,
 /area/shuttle/vox)
 "akS" = (
 /obj/structure/bed,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "akT" = (
@@ -5509,8 +5507,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "akU" = (
@@ -5678,9 +5676,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "ale" = (
@@ -5704,30 +5702,30 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "alg" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "alh" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "ali" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "alj" = (
@@ -5949,16 +5947,16 @@
 	tag = ""
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "alD" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/tracker,
 /obj/structure/lattice/catwalk,
@@ -6260,8 +6258,8 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/main)
 "amd" = (
@@ -6270,8 +6268,8 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/main)
 "ame" = (
@@ -6300,8 +6298,8 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/main)
 "amg" = (
@@ -6362,8 +6360,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/main)
 "amn" = (
@@ -6411,9 +6409,9 @@
 "amq" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -6560,9 +6558,9 @@
 "amD" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -6582,8 +6580,8 @@
 "amG" = (
 /obj/machinery/vending/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/seceqstorage)
 "amH" = (
@@ -6605,8 +6603,8 @@
 	},
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/seceqstorage)
 "amI" = (
@@ -6627,8 +6625,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/seceqstorage)
 "amK" = (
@@ -6641,17 +6639,17 @@
 /area/maintenance/fsmaint)
 "amL" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
+	dir = 8;
 	icon_state = "shower";
-	dir = 8
+	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "amM" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/main)
 "amN" = (
@@ -6702,8 +6700,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/main)
 "amQ" = (
@@ -6760,8 +6758,8 @@
 /area/security/hos)
 "amU" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/tracker,
 /obj/structure/lattice/catwalk,
@@ -6929,8 +6927,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "anp" = (
@@ -7304,8 +7302,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/main)
 "anT" = (
@@ -7382,9 +7380,9 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aoa" = (
@@ -7403,9 +7401,9 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aob" = (
@@ -7414,9 +7412,9 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aoc" = (
@@ -7446,9 +7444,9 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aof" = (
@@ -7500,9 +7498,9 @@
 "aoj" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -7517,8 +7515,8 @@
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "aol" = (
@@ -7558,8 +7556,8 @@
 /area/security/lobby)
 "aoo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -7585,15 +7583,15 @@
 	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "aoq" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -7683,8 +7681,8 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "aox" = (
@@ -7714,8 +7712,8 @@
 /obj/item/crowbar,
 /obj/item/radio,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/seceqstorage)
 "aoA" = (
@@ -7883,8 +7881,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/main)
 "aoN" = (
@@ -7894,8 +7892,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/main)
 "aoO" = (
@@ -7936,8 +7934,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/main)
 "aoQ" = (
@@ -7982,8 +7980,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "aoV" = (
@@ -8010,8 +8008,8 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "aoX" = (
@@ -8227,8 +8225,8 @@
 /area/space/nearstation)
 "app" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -8253,22 +8251,22 @@
 /area/solar/auxstarboard)
 "apr" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
 /area/shuttle/trade/sol)
 "aps" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
+	dir = 2;
 	icon_state = "swall_f6";
-	dir = 2
+	tag = "icon-swall_f6"
 	},
 /area/shuttle/trade/sol)
 "apt" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall14";
-	dir = 2
+	dir = 2;
+	icon_state = "swall14"
 	},
 /area/shuttle/trade/sol)
 "apu" = (
@@ -8287,8 +8285,8 @@
 "apv" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/trade/sol)
 "apw" = (
@@ -8298,8 +8296,8 @@
 /area/shuttle/trade/sol)
 "apx" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/trade/sol)
 "apy" = (
@@ -8349,8 +8347,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/seceqstorage)
 "apB" = (
@@ -8414,9 +8412,9 @@
 /area/security/medbay)
 "apG" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8521,9 +8519,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -8620,9 +8618,9 @@
 "apY" = (
 /obj/structure/bed,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -8669,9 +8667,9 @@
 /area/shuttle/trade/sol)
 "aqg" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/effect/spawner/lootdrop/trade_sol/donksoft,
 /obj/structure/closet,
@@ -8692,9 +8690,9 @@
 /area/shuttle/trade/sol)
 "aqj" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/trade/sol)
@@ -8864,9 +8862,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -9068,9 +9066,9 @@
 	},
 /obj/item/pen,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -9135,9 +9133,9 @@
 "aqY" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aqZ" = (
@@ -9162,9 +9160,9 @@
 /obj/item/stamp/law,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "arb" = (
@@ -9175,9 +9173,9 @@
 "arc" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9249,8 +9247,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "ark" = (
@@ -9279,9 +9277,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -9312,8 +9310,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "aro" = (
@@ -9334,8 +9332,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "arq" = (
@@ -9435,8 +9433,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -9447,8 +9445,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "arw" = (
@@ -9501,8 +9499,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "arz" = (
@@ -9575,8 +9573,8 @@
 	pixel_y = -7
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "arF" = (
@@ -9587,8 +9585,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "arG" = (
@@ -9612,8 +9610,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "arI" = (
@@ -9653,8 +9651,8 @@
 	shock_proof = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -9781,8 +9779,8 @@
 /area/maintenance/fsmaint)
 "arU" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -9802,8 +9800,8 @@
 /area/shuttle/trade/sol)
 "arX" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -9925,8 +9923,8 @@
 /obj/item/seeds/wheat/rice,
 /obj/item/seeds/wheat/rice,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/security/permabrig)
 "asj" = (
@@ -10366,16 +10364,16 @@
 "asJ" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
+	dir = 2;
 	icon_state = "swall_f5";
-	dir = 2
+	tag = "icon-swall_f5"
 	},
 /area/shuttle/trade/sol)
 "asK" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/trade/sol)
 "asL" = (
@@ -10426,9 +10424,9 @@
 	req_access_txt = "2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "asP" = (
@@ -10436,15 +10434,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "asQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -10465,8 +10463,8 @@
 "asS" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f6"
 	},
 /area/shuttle/siberia)
 "asT" = (
@@ -10487,9 +10485,9 @@
 "asV" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f10";
+	dir = 2;
 	icon_state = "swall_f10";
-	dir = 2
+	tag = "icon-swall_f10"
 	},
 /area/shuttle/siberia)
 "asW" = (
@@ -10607,8 +10605,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "ate" = (
@@ -10659,8 +10657,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "atj" = (
@@ -10888,8 +10886,8 @@
 /obj/item/seeds/corn,
 /obj/item/seeds/corn,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/security/permabrig)
 "atB" = (
@@ -10976,8 +10974,8 @@
 /area/maintenance/fsmaint)
 "atH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/rack,
 /obj/item/plant_analyzer,
@@ -10987,8 +10985,8 @@
 /area/security/permabrig)
 "atI" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/siberia)
 "atJ" = (
@@ -11020,16 +11018,16 @@
 "atM" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "atN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -11051,8 +11049,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
@@ -11061,8 +11059,8 @@
 /obj/item/dice/d20,
 /obj/item/instrument/harmonica,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -11326,9 +11324,9 @@
 "aui" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/seceqstorage)
@@ -11461,24 +11459,24 @@
 /area/maintenance/fsmaint)
 "auq" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall12";
+	dir = 2;
 	icon_state = "swall12";
-	dir = 2
+	tag = "icon-swall12"
 	},
 /area/shuttle/pod_3)
 "aur" = (
 /obj/structure/filingcabinet/employment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aus" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/pod_3)
 "aut" = (
@@ -11486,9 +11484,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "auu" = (
@@ -11595,8 +11593,8 @@
 "auF" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "auG" = (
@@ -11687,8 +11685,8 @@
 "auL" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "auM" = (
@@ -11705,8 +11703,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "auN" = (
@@ -11956,8 +11954,8 @@
 /area/maintenance/fsmaint)
 "avd" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "ave" = (
@@ -11997,8 +11995,8 @@
 /obj/item/seeds/chili,
 /obj/item/seeds/chili,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/security/permabrig)
 "avh" = (
@@ -12192,8 +12190,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "avs" = (
@@ -12258,9 +12256,9 @@
 "avz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -12278,8 +12276,8 @@
 /area/security/processing)
 "avB" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "avC" = (
@@ -12513,9 +12511,9 @@
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "avR" = (
@@ -12526,9 +12524,9 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "avS" = (
@@ -12570,9 +12568,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "avX" = (
@@ -12643,8 +12641,8 @@
 	req_access_txt = "63"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_unres_helper"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12707,8 +12705,8 @@
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "awg" = (
@@ -12743,8 +12741,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "awi" = (
@@ -12756,8 +12754,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "awj" = (
@@ -12787,9 +12785,9 @@
 	req_access_txt = "13"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -12800,8 +12798,8 @@
 "awm" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/pod_3)
 "awn" = (
@@ -12834,17 +12832,17 @@
 /area/shuttle/syndicate_elite)
 "awp" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)";
+	dir = 1;
 	icon_state = "propulsion";
-	dir = 1
+	tag = "icon-propulsion (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
 "awq" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
@@ -12857,9 +12855,9 @@
 /area/shuttle/syndicate_elite)
 "aws" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
@@ -12872,17 +12870,17 @@
 /area/shuttle/syndicate_sit)
 "awu" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)";
+	dir = 1;
 	icon_state = "propulsion";
-	dir = 1
+	tag = "icon-propulsion (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
 "awv" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_r";
-	dir = 1
+	tag = "icon-propulsion_r (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
@@ -12895,9 +12893,9 @@
 /area/shuttle/syndicate_sit)
 "awx" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
+	dir = 1;
 	icon_state = "propulsion_l";
-	dir = 1
+	tag = "icon-propulsion_l (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
@@ -12934,8 +12932,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "awB" = (
@@ -12974,8 +12972,8 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "awD" = (
@@ -13087,8 +13085,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_unres_helper"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -13183,8 +13181,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "axa" = (
@@ -13209,8 +13207,8 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "axb" = (
@@ -13306,9 +13304,9 @@
 "axj" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
+	dir = 1;
 	icon_state = "heater";
-	dir = 1
+	tag = "icon-heater (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite)
@@ -13321,9 +13319,9 @@
 "axl" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
+	dir = 1;
 	icon_state = "heater";
-	dir = 1
+	tag = "icon-heater (NORTH)"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_sit)
@@ -13372,13 +13370,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "axq" = (
@@ -13397,9 +13395,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "axs" = (
@@ -13508,8 +13506,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "axC" = (
@@ -13538,9 +13536,9 @@
 /area/security/evidence)
 "axD" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j1";
-	dir = 4
+	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -13836,8 +13834,8 @@
 /area/maintenance/fsmaint)
 "axZ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/lobby)
 "aya" = (
@@ -13910,8 +13908,8 @@
 "ayj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "ayk" = (
@@ -13958,8 +13956,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/processing)
 "ayq" = (
@@ -14222,17 +14220,17 @@
 	},
 /obj/machinery/vending/coffee/free,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "ayI" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "ayJ" = (
@@ -14263,8 +14261,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "ayL" = (
@@ -14569,9 +14567,9 @@
 /area/security/interrogation)
 "aze" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -14582,9 +14580,9 @@
 /area/shuttle/syndicate_elite)
 "azf" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/shuttle{
@@ -14700,8 +14698,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "azu" = (
@@ -14713,8 +14711,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "azv" = (
@@ -14776,8 +14774,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "azy" = (
@@ -14830,9 +14828,9 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "azB" = (
@@ -14847,9 +14845,9 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "azC" = (
@@ -14859,9 +14857,9 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "azD" = (
@@ -14877,8 +14875,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "azF" = (
@@ -14895,8 +14893,8 @@
 /area/magistrateoffice)
 "azG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster/official/random{
@@ -14965,8 +14963,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "azL" = (
@@ -14996,8 +14994,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "azO" = (
@@ -15019,8 +15017,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "azQ" = (
@@ -15045,8 +15043,8 @@
 "azR" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "azS" = (
@@ -15174,8 +15172,8 @@
 "aAe" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f5"
 	},
 /area/shuttle/siberia)
 "aAf" = (
@@ -15202,8 +15200,8 @@
 "aAj" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/siberia)
 "aAk" = (
@@ -15242,9 +15240,9 @@
 /area/security/permabrig)
 "aAo" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
+	dir = 4;
 	icon_state = "shower";
-	dir = 4
+	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -15310,8 +15308,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/permabrig)
 "aAw" = (
@@ -15337,8 +15335,8 @@
 /area/security/execution)
 "aAz" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/security/lobby)
 "aAA" = (
@@ -15391,9 +15389,9 @@
 "aAD" = (
 /obj/structure/closet/lawcloset,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aAE" = (
@@ -15414,8 +15412,8 @@
 	pixel_y = -5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -25;
@@ -15426,9 +15424,9 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aAF" = (
@@ -15442,9 +15440,9 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aAH" = (
@@ -15454,9 +15452,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aAI" = (
@@ -15469,9 +15467,9 @@
 	},
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aAJ" = (
@@ -15483,9 +15481,9 @@
 /area/maintenance/fsmaint)
 "aAK" = (
 /obj/machinery/atmospherics/binary/valve/open{
-	tag = "icon-map_valve1 (EAST)";
+	dir = 4;
 	icon_state = "map_valve1";
-	dir = 4
+	tag = "icon-map_valve1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -15740,17 +15738,17 @@
 /area/maintenance/abandonedbar)
 "aBd" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/abandonedbar)
 "aBe" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair_wings";
-	dir = 8
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -15759,9 +15757,9 @@
 /area/maintenance/abandonedbar)
 "aBf" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedbar)
@@ -15946,14 +15944,14 @@
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "solar_tool_pump";
-	tag_exterior_door = "solar_tool_outer";
 	frequency = 1379;
 	id_tag = "solar_tool_airlock";
-	tag_interior_door = "solar_tool_inner";
 	pixel_x = 25;
 	req_access_txt = "13";
-	tag_chamber_sensor = "solar_tool_sensor"
+	tag_airpump = "solar_tool_pump";
+	tag_chamber_sensor = "solar_tool_sensor";
+	tag_exterior_door = "solar_tool_outer";
+	tag_interior_door = "solar_tool_inner"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15990,9 +15988,9 @@
 "aBH" = (
 /obj/item/soap,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -16119,8 +16117,8 @@
 "aBY" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aBZ" = (
@@ -16132,8 +16130,8 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aCb" = (
@@ -16160,9 +16158,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aCd" = (
@@ -16175,9 +16173,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aCe" = (
@@ -16197,9 +16195,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aCf" = (
@@ -16212,9 +16210,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aCh" = (
@@ -16248,9 +16246,9 @@
 "aCl" = (
 /obj/structure/closet/secure_closet/magistrate,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aCm" = (
@@ -16323,8 +16321,8 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
 "aCs" = (
@@ -16382,8 +16380,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aCw" = (
@@ -16400,8 +16398,8 @@
 /area/security/prison/cell_block/A)
 "aCx" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aCy" = (
@@ -16619,9 +16617,9 @@
 /area/maintenance/abandonedbar)
 "aCT" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -16664,9 +16662,9 @@
 /area/shuttle/syndicate_elite)
 "aCY" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -16675,12 +16673,12 @@
 "aCZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aDa" = (
@@ -16774,16 +16772,16 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aDi" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aDj" = (
@@ -16828,8 +16826,8 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aDn" = (
@@ -16917,8 +16915,8 @@
 	track = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -17005,9 +17003,9 @@
 "aDE" = (
 /obj/item/seeds/ambrosia,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /obj/structure/toilet{
 	dir = 4
@@ -17117,9 +17115,9 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aDS" = (
@@ -17147,9 +17145,9 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aDV" = (
@@ -17228,9 +17226,9 @@
 "aEg" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aEh" = (
@@ -17722,8 +17720,8 @@
 /area/shuttle/syndicate_elite)
 "aFh" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -17738,8 +17736,8 @@
 /area/shuttle/syndicate_sit)
 "aFj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -17776,9 +17774,9 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aFn" = (
@@ -17797,9 +17795,9 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aFp" = (
@@ -17814,9 +17812,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aFq" = (
@@ -17829,9 +17827,9 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aFr" = (
@@ -17849,9 +17847,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aFs" = (
@@ -17859,9 +17857,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aFt" = (
@@ -17870,16 +17868,16 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aFu" = (
@@ -17936,8 +17934,8 @@
 /area/hallway/primary/fore)
 "aFy" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aFz" = (
@@ -18080,8 +18078,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -18245,8 +18243,8 @@
 "aGl" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/maintenance/fpmaint)
 "aGm" = (
@@ -18264,8 +18262,8 @@
 "aGp" = (
 /obj/machinery/vending/coffee/free,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
 	},
 /area/maintenance/fpmaint)
 "aGq" = (
@@ -18287,8 +18285,8 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/crew_quarters/courtroom)
 "aGs" = (
@@ -18297,8 +18295,8 @@
 	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/crew_quarters/courtroom)
 "aGt" = (
@@ -18438,9 +18436,9 @@
 /area/maintenance/fsmaint)
 "aGH" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -18581,8 +18579,8 @@
 	track = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -18653,9 +18651,9 @@
 "aHd" = (
 /obj/item/toy/crayon/white,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -18716,8 +18714,8 @@
 "aHm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/maintenance/fpmaint2)
 "aHn" = (
@@ -18785,8 +18783,8 @@
 	req_access_txt = "2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/crew_quarters/courtroom)
 "aHx" = (
@@ -18799,8 +18797,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/crew_quarters/courtroom)
 "aHy" = (
@@ -18810,8 +18808,8 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/crew_quarters/courtroom)
 "aHz" = (
@@ -18893,8 +18891,8 @@
 "aHH" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aHI" = (
@@ -19242,8 +19240,8 @@
 /area/maintenance/fpmaint2)
 "aIy" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/maintenance/fpmaint2)
 "aIz" = (
@@ -19272,8 +19270,8 @@
 /area/maintenance/auxsolarstarboard)
 "aIB" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -19324,8 +19322,8 @@
 /area/maintenance/fpmaint2)
 "aIH" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/maintenance/fpmaint2)
 "aII" = (
@@ -19344,8 +19342,8 @@
 /area/maintenance/fpmaint2)
 "aIL" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
 	},
 /area/maintenance/fpmaint2)
 "aIM" = (
@@ -19355,9 +19353,9 @@
 	req_access_txt = "74"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aIN" = (
@@ -19376,8 +19374,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -19463,8 +19461,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/crew_quarters/courtroom)
 "aJc" = (
@@ -19472,8 +19470,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/crew_quarters/courtroom)
 "aJd" = (
@@ -19488,8 +19486,8 @@
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aJf" = (
@@ -19511,14 +19509,14 @@
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "arrivals_pump";
-	tag_exterior_door = "arrivals_outer";
 	frequency = 1379;
 	id_tag = "arrivals_airlock";
-	tag_interior_door = "arrivals_inner";
 	pixel_x = 25;
 	req_access_txt = "13";
-	tag_chamber_sensor = "arrivals_sensor"
+	tag_airpump = "arrivals_pump";
+	tag_chamber_sensor = "arrivals_sensor";
+	tag_exterior_door = "arrivals_outer";
+	tag_interior_door = "arrivals_inner"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -19590,11 +19588,11 @@
 /obj/item/camera_film,
 /obj/item/camera_film,
 /obj/item/camera{
-	name = "detectives camera";
 	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30;
 	pixel_x = 0;
-	pixel_y = 0;
-	pictures_left = 30
+	pixel_y = 0
 	},
 /obj/machinery/requests_console{
 	name = "Detective Requests Console";
@@ -19841,22 +19839,22 @@
 "aJP" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f6"
 	},
 /area/shuttle/pod_1)
 "aJQ" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/pod_1)
 "aJR" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f6"
 	},
 /area/shuttle/pod_2)
 "aJS" = (
@@ -19867,8 +19865,8 @@
 "aJT" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/pod_2)
 "aJU" = (
@@ -19890,8 +19888,8 @@
 /area/shuttle/pod_2)
 "aJW" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/maintenance/fpmaint)
 "aJX" = (
@@ -19934,8 +19932,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -20023,15 +20021,15 @@
 /area/crew_quarters/courtroom)
 "aKr" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/crew_quarters/courtroom)
 "aKs" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aKt" = (
@@ -20069,9 +20067,9 @@
 "aKw" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aKx" = (
@@ -20089,9 +20087,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aKy" = (
@@ -20178,8 +20176,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -20305,8 +20303,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -20346,8 +20344,8 @@
 /area/maintenance/fsmaint2)
 "aLa" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/pod_1)
 "aLb" = (
@@ -20376,8 +20374,8 @@
 /area/hallway/secondary/entry)
 "aLe" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/pod_2)
 "aLf" = (
@@ -20489,8 +20487,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/maintenance/fpmaint2)
 "aLo" = (
@@ -20689,8 +20687,8 @@
 /area/maintenance/fpmaint)
 "aLL" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/maintenance/fpmaint)
 "aLM" = (
@@ -20704,8 +20702,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom ";
@@ -20742,8 +20740,8 @@
 /area/crew_quarters/courtroom)
 "aLS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -20855,8 +20853,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aMa" = (
@@ -21215,9 +21213,9 @@
 /obj/item/pen,
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/lawoffice)
 "aMP" = (
@@ -21420,16 +21418,16 @@
 "aNp" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aNq" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/bluegrid,
 /area/maintenance/electrical)
@@ -21627,15 +21625,15 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aNM" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j2";
-	dir = 4
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -21670,8 +21668,8 @@
 "aNQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aNR" = (
@@ -21738,8 +21736,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
 "aNW" = (
@@ -22331,8 +22329,8 @@
 "aPk" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aPm" = (
@@ -22341,8 +22339,8 @@
 "aPn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aPs" = (
@@ -22427,8 +22425,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/crew_quarters/courtroom)
 "aPD" = (
@@ -22594,9 +22592,9 @@
 /area/hallway/secondary/entry)
 "aPS" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -22702,8 +22700,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
@@ -22739,8 +22737,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQl" = (
@@ -22758,8 +22756,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQn" = (
@@ -22773,8 +22771,8 @@
 	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQo" = (
@@ -22787,15 +22785,15 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQp" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQq" = (
@@ -22803,8 +22801,8 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQr" = (
@@ -22821,8 +22819,8 @@
 /obj/structure/table,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQs" = (
@@ -22848,8 +22846,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQu" = (
@@ -22861,15 +22859,15 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQv" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
+	dir = 1;
 	icon_state = "bluered";
-	dir = 1
+	tag = "icon-siding1 (NORTH)"
 	},
 /area/crew_quarters/dorms)
 "aQw" = (
@@ -22889,8 +22887,8 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQy" = (
@@ -22901,17 +22899,17 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 5
+	dir = 5;
+	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
 "aQz" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
+	dir = 1;
 	icon_state = "bluered";
-	dir = 1
+	tag = "icon-siding1 (NORTH)"
 	},
 /area/crew_quarters/dorms)
 "aQA" = (
@@ -22921,9 +22919,9 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
+	dir = 1;
 	icon_state = "bluered";
-	dir = 1
+	tag = "icon-siding1 (NORTH)"
 	},
 /area/crew_quarters/dorms)
 "aQB" = (
@@ -22936,9 +22934,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
+	dir = 1;
 	icon_state = "bluered";
-	dir = 1
+	tag = "icon-siding1 (NORTH)"
 	},
 /area/crew_quarters/dorms)
 "aQC" = (
@@ -22977,8 +22975,8 @@
 	req_access_txt = "0"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQG" = (
@@ -22990,15 +22988,15 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aQI" = (
@@ -23319,8 +23317,8 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f5"
 	},
 /area/shuttle/pod_1)
 "aRn" = (
@@ -23456,8 +23454,8 @@
 /area/ai_monitored/storage/eva)
 "aRx" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aRy" = (
@@ -23470,8 +23468,8 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/pod_1)
 "aRA" = (
@@ -23562,10 +23560,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "aRI" = (
@@ -23606,8 +23604,8 @@
 /area/maintenance/fsmaint2)
 "aRL" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -23695,14 +23693,14 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f5"
 	},
 /area/shuttle/pod_2)
 "aRW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -23722,8 +23720,8 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/pod_2)
 "aRZ" = (
@@ -23816,8 +23814,8 @@
 "aSk" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aSl" = (
@@ -23895,16 +23893,16 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aSw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -24111,8 +24109,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aSS" = (
@@ -24173,8 +24171,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTa" = (
@@ -24186,8 +24184,8 @@
 /area/hallway/primary/central/ne)
 "aTb" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTc" = (
@@ -24197,8 +24195,8 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTd" = (
@@ -24208,8 +24206,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTe" = (
@@ -24250,23 +24248,23 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTj" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aTk" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -24280,8 +24278,8 @@
 /area/maintenance/electrical)
 "aTm" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -24319,10 +24317,10 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "aTr" = (
@@ -24365,8 +24363,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/gateway)
 "aTw" = (
@@ -24382,8 +24380,8 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 4
+	dir = 4;
+	icon_state = "vault"
 	},
 /area/gateway)
 "aTy" = (
@@ -24391,8 +24389,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/gateway)
 "aTz" = (
@@ -24455,8 +24453,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTE" = (
@@ -24477,8 +24475,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
 "aTG" = (
@@ -24522,24 +24520,24 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 6
+	dir = 6;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aTL" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "aTM" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/medical/reception)
 "aTN" = (
@@ -24630,9 +24628,9 @@
 "aTT" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/medical/reception)
 "aTU" = (
@@ -24642,8 +24640,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "aTV" = (
@@ -24660,8 +24658,8 @@
 	name = "Civilian"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "aTW" = (
@@ -24669,8 +24667,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "aTX" = (
@@ -24689,8 +24687,8 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "aTZ" = (
@@ -24745,8 +24743,8 @@
 /area/maintenance/electrical)
 "aUg" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/smes{
 	charge = 0
@@ -24755,8 +24753,8 @@
 /area/maintenance/electrical)
 "aUh" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -24887,8 +24885,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aUx" = (
@@ -24949,8 +24947,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/gateway)
 "aUD" = (
@@ -24958,8 +24956,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/gateway)
 "aUE" = (
@@ -25021,9 +25019,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aUM" = (
@@ -25054,9 +25052,9 @@
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/medical/reception)
 "aUP" = (
@@ -25072,8 +25070,8 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "aUQ" = (
@@ -25106,8 +25104,8 @@
 /area/maintenance/fsmaint2)
 "aUV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -25216,8 +25214,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aVl" = (
@@ -25232,8 +25230,8 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 10
+	dir = 10;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aVm" = (
@@ -25268,8 +25266,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aVo" = (
@@ -25313,8 +25311,8 @@
 	name = "JoinLateGateway"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/gateway)
 "aVs" = (
@@ -25366,8 +25364,8 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory East";
@@ -25375,8 +25373,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aVx" = (
@@ -25387,9 +25385,9 @@
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHEAST)";
+	dir = 5;
 	icon_state = "whiteblue";
-	dir = 5
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/medical/reception)
 "aVy" = (
@@ -25667,8 +25665,8 @@
 /area/ai_monitored/storage/eva)
 "aVS" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
 /area/shuttle/arrival/station)
 "aVT" = (
@@ -25693,17 +25691,17 @@
 "aVV" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
+	dir = 2;
 	icon_state = "swall_f6";
-	dir = 2
+	tag = "icon-swall_f6"
 	},
 /area/shuttle/arrival/station)
 "aVW" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f10";
+	dir = 2;
 	icon_state = "swall_f10";
-	dir = 2
+	tag = "icon-swall_f10"
 	},
 /area/shuttle/arrival/station)
 "aVX" = (
@@ -25726,8 +25724,8 @@
 /area/shuttle/arrival/station)
 "aWa" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall14";
-	dir = 2
+	dir = 2;
+	icon_state = "swall14"
 	},
 /area/shuttle/arrival/station)
 "aWb" = (
@@ -25751,8 +25749,8 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aWd" = (
@@ -25765,8 +25763,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 9
+	dir = 9;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aWe" = (
@@ -25793,8 +25791,8 @@
 	network = list("SS13","Research Outpost","Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aWg" = (
@@ -25814,13 +25812,13 @@
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
 	department = "Security";
-	name = "Security Requests Console";
 	departmentType = 5;
+	name = "Security Requests Console";
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aWi" = (
@@ -25933,8 +25931,8 @@
 /area/storage/primary)
 "aWs" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 6
+	dir = 6;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aWt" = (
@@ -25943,14 +25941,14 @@
 /area/storage/primary)
 "aWu" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aWv" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 10
+	dir = 10;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aWw" = (
@@ -25964,14 +25962,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aWx" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 4
+	dir = 4;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aWy" = (
@@ -26032,8 +26030,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aWC" = (
@@ -26119,9 +26117,9 @@
 /area/crew_quarters/dorms)
 "aWN" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -26155,8 +26153,8 @@
 "aWP" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
 "aWQ" = (
@@ -26195,8 +26193,8 @@
 /area/medical/chemistry)
 "aWT" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/crew_quarters/dorms)
 "aWU" = (
@@ -26296,9 +26294,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aXd" = (
@@ -26313,9 +26311,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/maintenance/fsmaint2)
 "aXe" = (
@@ -26323,9 +26321,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aXf" = (
@@ -26346,9 +26344,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aXh" = (
@@ -26365,10 +26363,10 @@
 /area/chapel/main)
 "aXi" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "aXj" = (
@@ -26382,9 +26380,9 @@
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aXk" = (
@@ -26392,9 +26390,9 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aXl" = (
@@ -26408,8 +26406,8 @@
 /area/chapel/main)
 "aXm" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall11";
-	dir = 2
+	dir = 2;
+	icon_state = "swall11"
 	},
 /area/shuttle/arrival/station)
 "aXn" = (
@@ -26428,15 +26426,15 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aXp" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall7";
-	dir = 2
+	dir = 2;
+	icon_state = "swall7"
 	},
 /area/shuttle/arrival/station)
 "aXq" = (
@@ -26526,8 +26524,8 @@
 /obj/item/crowbar,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 8
+	dir = 8;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aXC" = (
@@ -26548,8 +26546,8 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aXF" = (
@@ -26676,8 +26674,8 @@
 	},
 /obj/item/storage/belt/champion,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aXP" = (
@@ -26719,8 +26717,8 @@
 	name = "Silver Crate"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 4
+	dir = 4;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aXU" = (
@@ -26735,10 +26733,10 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "aXV" = (
@@ -26748,10 +26746,10 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "aXW" = (
@@ -26939,8 +26937,8 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/security/armoury)
 "aYn" = (
@@ -27015,12 +27013,6 @@
 	},
 /area/crew_quarters/sleep)
 "aYt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/yellow,
@@ -27034,6 +27026,9 @@
 	},
 /obj/item/paper_bin/nanotrasen,
 /obj/item/paper/tcommskey,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -27093,9 +27088,9 @@
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/chapel/office)
 "aYy" = (
@@ -27116,15 +27111,15 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/chapel/main)
 "aYA" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/chapel/main)
 "aYB" = (
@@ -27145,8 +27140,8 @@
 "aYD" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f6"
 	},
 /area/shuttle/escape)
 "aYE" = (
@@ -27234,14 +27229,14 @@
 "aYM" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/arrival/station)
 "aYN" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/arrival/station)
 "aYO" = (
@@ -27284,8 +27279,8 @@
 /area/shuttle/escape)
 "aYV" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	icon_state = "heater"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27367,8 +27362,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aZc" = (
@@ -27398,8 +27393,8 @@
 "aZe" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/stack/cable_coil{
 	pixel_x = 2;
@@ -27444,8 +27439,8 @@
 "aZi" = (
 /mob/living/simple_animal/mouse/brown/Tom,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 6
+	dir = 6;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aZj" = (
@@ -27465,8 +27460,8 @@
 "aZk" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aZl" = (
@@ -27478,8 +27473,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/chapel/main)
 "aZm" = (
@@ -27502,8 +27497,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 10
+	dir = 10;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aZp" = (
@@ -27536,8 +27531,8 @@
 	amount = 100000
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 4
+	dir = 4;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "aZr" = (
@@ -27550,8 +27545,8 @@
 /area/storage/primary)
 "aZs" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aZt" = (
@@ -27672,8 +27667,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aZJ" = (
@@ -27698,10 +27693,10 @@
 /obj/item/paper_bin,
 /obj/item/toy/crayon/mime,
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "aZM" = (
@@ -27710,10 +27705,10 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "aZN" = (
@@ -27818,8 +27813,8 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "aZZ" = (
@@ -28051,8 +28046,8 @@
 /area/library)
 "bay" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/chapel/main)
 "baz" = (
@@ -28062,8 +28057,8 @@
 /obj/structure/rack,
 /obj/item/storage/fancy/candle_box/full,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/chapel/main)
 "baB" = (
@@ -28360,9 +28355,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j2";
-	dir = 4
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -28405,8 +28400,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/security/nuke_storage)
 "bbg" = (
@@ -28455,8 +28450,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bbj" = (
@@ -28530,9 +28525,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j1";
-	dir = 4
+	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -28575,8 +28570,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bby" = (
@@ -28620,23 +28615,23 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bbB" = (
 /obj/structure/closet/secure_closet/mime,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bbC" = (
@@ -28674,10 +28669,10 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bbE" = (
@@ -28897,8 +28892,8 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bca" = (
@@ -28910,8 +28905,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bcb" = (
@@ -29074,8 +29069,8 @@
 "bcr" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/arrival/station)
 "bcs" = (
@@ -29231,8 +29226,8 @@
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/chapel/main)
 "bcG" = (
@@ -29328,8 +29323,8 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -29438,8 +29433,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/hallway/primary/port)
 "bda" = (
@@ -29547,8 +29542,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bdn" = (
@@ -29603,10 +29598,10 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bdt" = (
@@ -29617,17 +29612,17 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bdu" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -29640,9 +29635,9 @@
 /area/hallway/primary/central/north)
 "bdw" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/item/flag/nt,
 /obj/machinery/power/apc{
@@ -29663,12 +29658,12 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -29735,9 +29730,9 @@
 /area/hallway/primary/central/north)
 "bdE" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /obj/structure/rack,
 /obj/item/tank/emergency_oxygen,
@@ -29854,8 +29849,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bdO" = (
@@ -29903,8 +29898,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bdR" = (
@@ -29928,8 +29923,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bdT" = (
@@ -29966,9 +29961,9 @@
 "bdW" = (
 /obj/structure/table,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/reagentgrinder,
 /obj/machinery/power/apc{
@@ -30153,9 +30148,9 @@
 "beh" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
+	dir = 2;
 	icon_state = "swall_f5";
-	dir = 2
+	tag = "icon-swall_f5"
 	},
 /area/shuttle/arrival/station)
 "bei" = (
@@ -30168,8 +30163,8 @@
 /area/hydroponics)
 "bej" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall13";
-	dir = 2
+	dir = 2;
+	icon_state = "swall13"
 	},
 /area/shuttle/arrival/station)
 "bek" = (
@@ -30427,8 +30422,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/hallway/primary/port)
 "beP" = (
@@ -30513,8 +30508,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "beX" = (
@@ -30543,21 +30538,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "beZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j2";
-	dir = 4
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfa" = (
@@ -30567,10 +30562,10 @@
 	req_access_txt = "46"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "tranquillite";
 	dir = 4;
+	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
-	icon_plating = "plating"
+	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bfb" = (
@@ -30590,8 +30585,8 @@
 	srange = 7
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfc" = (
@@ -30616,8 +30611,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfe" = (
@@ -30672,8 +30667,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfj" = (
@@ -30692,15 +30687,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfk" = (
 /obj/machinery/requests_console{
 	department = "Bar";
-	name = "Bar Requests Console";
 	departmentType = 2;
+	name = "Bar Requests Console";
 	pixel_x = 0;
 	pixel_y = 30
 	},
@@ -30749,9 +30744,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j1";
-	dir = 4
+	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -30759,9 +30754,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j2";
-	dir = 4
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -30782,8 +30777,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfr" = (
@@ -30806,8 +30801,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfs" = (
@@ -30855,8 +30850,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfw" = (
@@ -30889,8 +30884,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfy" = (
@@ -30906,8 +30901,8 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfz" = (
@@ -30923,8 +30918,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfA" = (
@@ -31252,9 +31247,9 @@
 "bge" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f9";
+	dir = 2;
 	icon_state = "swall_f9";
-	dir = 2
+	tag = "icon-swall_f9"
 	},
 /area/shuttle/arrival/station)
 "bgf" = (
@@ -31484,8 +31479,8 @@
 /area/hallway/secondary/entry)
 "bgH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/radio/intercom{
 	dir = 0;
@@ -31529,8 +31524,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 4
+	dir = 4;
+	icon_state = "vault"
 	},
 /area/gateway)
 "bgL" = (
@@ -31544,8 +31539,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/gateway)
 "bgM" = (
@@ -31560,8 +31555,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
@@ -31675,8 +31670,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bgY" = (
@@ -31695,8 +31690,8 @@
 "bgZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bha" = (
@@ -31725,27 +31720,27 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bhf" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bhg" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/ne)
 "bhh" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/north)
 "bhi" = (
@@ -31963,8 +31958,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
 "bhF" = (
@@ -32234,8 +32229,8 @@
 /area/hydroponics)
 "bic" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/escape)
 "bid" = (
@@ -32308,8 +32303,8 @@
 "bim" = (
 /obj/machinery/status_display,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
 /area/shuttle/escape)
 "bin" = (
@@ -32477,8 +32472,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 8
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "biB" = (
@@ -32632,8 +32627,8 @@
 	pixel_y = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
@@ -32751,8 +32746,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "biX" = (
@@ -32805,8 +32800,8 @@
 /area/crew_quarters/bar)
 "bja" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -32853,8 +32848,8 @@
 /area/crew_quarters/bar)
 "bjd" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -33060,8 +33055,8 @@
 /area/hydroponics)
 "bjC" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
 /area/shuttle/escape)
 "bjD" = (
@@ -33080,8 +33075,8 @@
 /area/library)
 "bjG" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall13";
-	dir = 2
+	dir = 2;
+	icon_state = "swall13"
 	},
 /area/shuttle/escape)
 "bjI" = (
@@ -33323,9 +33318,9 @@
 /area/hallway/primary/port)
 "bkh" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j2";
-	dir = 4
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -33792,9 +33787,9 @@
 	name = "Forbidden Knowledge"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/library)
 "bkY" = (
@@ -33819,9 +33814,9 @@
 /obj/item/stack/tape_roll,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/library)
 "bla" = (
@@ -33867,8 +33862,8 @@
 /area/hydroponics)
 "blf" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -33902,8 +33897,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 8
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "bli" = (
@@ -34055,8 +34050,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "blB" = (
@@ -34246,8 +34241,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -34285,8 +34280,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -34311,8 +34306,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
@@ -34337,12 +34332,12 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
@@ -34624,9 +34619,9 @@
 "bmE" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/library)
 "bmF" = (
@@ -34635,9 +34630,9 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/library)
 "bmG" = (
@@ -34648,9 +34643,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/library)
 "bmH" = (
@@ -35219,9 +35214,9 @@
 	name = "Bridge Power Monitoring Computer"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -35362,8 +35357,8 @@
 	},
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bok" = (
@@ -35486,8 +35481,8 @@
 "bou" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -35508,8 +35503,8 @@
 "bow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hydroponics)
 "box" = (
@@ -35525,9 +35520,9 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/library)
 "boz" = (
@@ -35822,9 +35817,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j1";
-	dir = 4
+	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -36003,8 +35998,8 @@
 /obj/item/aicard,
 /obj/item/multitool,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/bridge)
 "bpv" = (
@@ -36030,8 +36025,8 @@
 "bpw" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/bridge)
 "bpx" = (
@@ -36230,8 +36225,8 @@
 /area/chapel/main)
 "bpQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -36406,9 +36401,9 @@
 /area/maintenance/fsmaint2)
 "bqk" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair_wings";
-	dir = 8
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -36464,9 +36459,9 @@
 /area/shuttle/escape)
 "bqp" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall7";
+	dir = 2;
 	icon_state = "swall7";
-	dir = 2
+	tag = "icon-swall7"
 	},
 /area/shuttle/escape)
 "bqq" = (
@@ -36509,8 +36504,8 @@
 /area/maintenance/fpmaint2)
 "bqu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plasteel,
@@ -36754,8 +36749,8 @@
 /area/bridge)
 "bra" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/security/mining,
 /turf/simulated/floor/plasteel{
@@ -36806,8 +36801,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
 "brf" = (
@@ -36825,9 +36820,9 @@
 /area/crew_quarters/bar)
 "brg" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair_wings";
-	dir = 8
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
@@ -36871,8 +36866,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 1
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "brl" = (
@@ -36883,8 +36878,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 1
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "brm" = (
@@ -36910,8 +36905,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 1
+	dir = 1;
+	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "bro" = (
@@ -36931,8 +36926,8 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
 "brq" = (
@@ -36942,8 +36937,8 @@
 /area/hallway/primary/central/nw)
 "brr" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/hydroponics)
 "brs" = (
@@ -36963,8 +36958,8 @@
 /area/hydroponics)
 "bru" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hydroponics)
 "brv" = (
@@ -37127,15 +37122,15 @@
 /area/crew_quarters/locker)
 "brO" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
 /area/shuttle/transport)
 "brP" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/transport)
 "brQ" = (
@@ -37206,8 +37201,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hydroponics)
 "bsa" = (
@@ -37381,22 +37376,22 @@
 "bsu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
 "bsv" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "redcorner"
 	},
 /area/bridge)
 "bsw" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/bridge)
 "bsx" = (
@@ -37483,9 +37478,9 @@
 /area/bridge)
 "bsG" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-browncorner (EAST)";
+	dir = 4;
 	icon_state = "browncorner";
-	dir = 4
+	tag = "icon-browncorner (EAST)"
 	},
 /area/bridge)
 "bsH" = (
@@ -37595,8 +37590,8 @@
 	},
 /obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bsT" = (
@@ -37624,8 +37619,8 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bsV" = (
@@ -37638,8 +37633,8 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bsW" = (
@@ -37658,8 +37653,8 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bsY" = (
@@ -37730,9 +37725,9 @@
 /area/hallway/primary/starboard/east)
 "btf" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
@@ -37831,24 +37826,24 @@
 "btt" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "btu" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "btv" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	tag = "icon-swall_f9";
-	icon_state = "swall_f9"
+	icon_state = "swall_f9";
+	tag = "icon-swall_f9"
 	},
 /area/shuttle/transport)
 "btw" = (
@@ -37864,18 +37859,18 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bty" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -37884,9 +37879,9 @@
 /area/shuttle/transport)
 "btz" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor,
@@ -38081,8 +38076,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hydroponics)
 "btV" = (
@@ -38268,9 +38263,9 @@
 /area/bridge)
 "buq" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -38288,8 +38283,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "but" = (
@@ -38311,8 +38306,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/cream,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "buv" = (
@@ -38333,12 +38328,12 @@
 "bux" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 1
+	dir = 1;
+	icon_state = "4"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 1
+	dir = 1;
+	icon_state = "3"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -38469,14 +38464,14 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/requests_console{
 	department = "Kitchen";
-	name = "Kitchen Requests Console";
 	departmentType = 2;
+	name = "Kitchen Requests Console";
 	pixel_x = 30;
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "buL" = (
@@ -38537,17 +38532,17 @@
 "buQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair_wings";
-	dir = 1
+	tag = "icon-wooden_chair_wings (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "buR" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair_wings";
-	dir = 1
+	tag = "icon-wooden_chair_wings (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -38583,8 +38578,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "buV" = (
@@ -38778,8 +38773,8 @@
 /area/security/vacantoffice)
 "bvo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
@@ -38986,9 +38981,9 @@
 /area/chapel/office)
 "bvO" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -39093,8 +39088,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 6
+	dir = 6;
+	icon_state = "blue"
 	},
 /area/bridge)
 "bvW" = (
@@ -39120,8 +39115,8 @@
 "bvY" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/bridge)
 "bvZ" = (
@@ -39214,8 +39209,8 @@
 "bwf" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/ne)
 "bwg" = (
@@ -39427,8 +39422,8 @@
 "bwE" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	tag = "icon-swall_f10";
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	tag = "icon-swall_f10"
 	},
 /area/shuttle/transport)
 "bwF" = (
@@ -39506,8 +39501,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/nw)
 "bwO" = (
@@ -39635,12 +39630,12 @@
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 4
+	dir = 4;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 4
+	dir = 4;
+	icon_state = "4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -39883,8 +39878,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bxz" = (
@@ -40152,8 +40147,8 @@
 /area/library)
 "bxU" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light,
 /obj/machinery/power/apc{
@@ -40289,8 +40284,8 @@
 "byd" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/transport)
 "bye" = (
@@ -40440,8 +40435,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/ne)
 "bys" = (
@@ -40556,9 +40551,9 @@
 /area/quartermaster/office)
 "byD" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -40631,8 +40626,8 @@
 /area/bridge/meeting_room)
 "byL" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -40651,8 +40646,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hydroponics)
 "byN" = (
@@ -40923,8 +40918,8 @@
 /area/chapel/main)
 "bzm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -40941,9 +40936,9 @@
 "bzo" = (
 /obj/machinery/light,
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -41119,8 +41114,8 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	name = "Cargo Requests Console";
 	departmentType = 2;
+	name = "Cargo Requests Console";
 	pixel_y = 30
 	},
 /obj/item/stack/tape_roll,
@@ -41133,8 +41128,8 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 1
+	dir = 1;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bzI" = (
@@ -41149,8 +41144,8 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 1
+	dir = 1;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bzJ" = (
@@ -41163,8 +41158,8 @@
 /obj/item/stack/packageWrap,
 /obj/item/rcs,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 5
+	dir = 5;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bzL" = (
@@ -41362,8 +41357,8 @@
 /area/hallway/primary/starboard/west)
 "bAj" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -41522,8 +41517,8 @@
 "bAA" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 6
+	dir = 6;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/nw)
 "bAB" = (
@@ -41617,8 +41612,8 @@
 /area/hallway/secondary/exit)
 "bAJ" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
 "bAK" = (
@@ -41627,8 +41622,8 @@
 /area/hallway/secondary/exit)
 "bAL" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
 "bAM" = (
@@ -41666,9 +41661,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor{
@@ -41863,8 +41858,8 @@
 	},
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 4
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bBq" = (
@@ -41961,8 +41956,8 @@
 /area/turret_protected/ai_upload)
 "bBA" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/turret_protected/ai_upload)
 "bBB" = (
@@ -42048,12 +42043,12 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 4
+	dir = 4;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 4
+	dir = 4;
+	icon_state = "4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -42140,9 +42135,9 @@
 /area/crew_quarters/locker)
 "bBX" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall14";
+	dir = 2;
 	icon_state = "swall14";
-	dir = 2
+	tag = "icon-swall14"
 	},
 /area/shuttle/escape)
 "bBZ" = (
@@ -42184,8 +42179,8 @@
 	dir = 4
 	},
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	icon_state = "heater"
 	},
 /turf/unsimulated/floor,
 /area/shuttle/specops)
@@ -42395,9 +42390,9 @@
 	},
 /obj/machinery/light/small,
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair_wings";
-	dir = 8
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -42413,8 +42408,8 @@
 "bCE" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 4
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bCF" = (
@@ -42576,8 +42571,8 @@
 "bCW" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/storage/box/cups{
 	pixel_x = 6;
@@ -42591,9 +42586,9 @@
 	},
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "bCX" = (
@@ -42605,9 +42600,9 @@
 "bCY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -42645,9 +42640,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whiteblue";
-	dir = 10
+	tag = "icon-whiteblue (SOUTHWEST)"
 	},
 /area/medical/reception)
 "bDd" = (
@@ -42658,14 +42653,14 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/reception)
 "bDe" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "bDf" = (
@@ -42811,12 +42806,12 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 4
+	dir = 4;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 4
+	dir = 4;
+	icon_state = "4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -42827,8 +42822,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -42894,9 +42889,9 @@
 /area/maintenance/disposal)
 "bDG" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -43140,8 +43135,8 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 4
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bEg" = (
@@ -43571,9 +43566,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2";
+	dir = 2;
 	icon_state = "pipe-j2";
-	dir = 2
+	tag = "icon-pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43750,8 +43745,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 4
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bFz" = (
@@ -43849,14 +43844,14 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
+	dir = 1;
 	icon_state = "siding2";
-	dir = 1
+	tag = "icon-siding2 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
+	dir = 1;
 	icon_state = "siding1";
-	dir = 1
+	tag = "icon-siding1 (NORTH)"
 	},
 /area/hydroponics)
 "bFK" = (
@@ -43914,9 +43909,9 @@
 /area/engine/gravitygenerator)
 "bFQ" = (
 /obj/structure/morgue{
-	tag = "icon-morgue1 (WEST)";
+	dir = 8;
 	icon_state = "morgue1";
-	dir = 8
+	tag = "icon-morgue1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43947,9 +43942,9 @@
 /area/crew_quarters/toilet)
 "bFT" = (
 /obj/structure/morgue{
-	tag = "icon-morgue1 (WEST)";
+	dir = 8;
 	icon_state = "morgue1";
-	dir = 8
+	tag = "icon-morgue1 (WEST)"
 	},
 /obj/effect/landmark{
 	name = "revenantspawn"
@@ -44074,9 +44069,9 @@
 /area/maintenance/port)
 "bGc" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -44090,8 +44085,8 @@
 /area/assembly/robotics)
 "bGd" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/reception)
 "bGe" = (
@@ -44108,8 +44103,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/reception)
 "bGg" = (
@@ -44138,8 +44133,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
 "bGi" = (
@@ -44162,8 +44157,8 @@
 /area/hallway/secondary/exit)
 "bGk" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -44206,8 +44201,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
 "bGp" = (
@@ -44233,9 +44228,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/reception)
 "bGr" = (
@@ -44248,9 +44243,9 @@
 /area/hallway/secondary/exit)
 "bGt" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/medical/reception)
 "bGu" = (
@@ -44709,8 +44704,8 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 4
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/quartermaster/office)
 "bHo" = (
@@ -44744,12 +44739,12 @@
 	opacity = 0
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 8
+	dir = 8;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 8
+	dir = 8;
+	icon_state = "4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -44826,8 +44821,8 @@
 /area/hallway/primary/starboard/west)
 "bHz" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/engine/gravitygenerator)
 "bHA" = (
@@ -44843,8 +44838,8 @@
 /area/hallway/primary/starboard/west)
 "bHB" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/engine/gravitygenerator)
 "bHC" = (
@@ -44872,8 +44867,8 @@
 /area/hallway/primary/starboard/east)
 "bHD" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 4
+	dir = 4;
+	icon_state = "vault"
 	},
 /area/engine/gravitygenerator)
 "bHE" = (
@@ -44983,9 +44978,9 @@
 /area/assembly/chargebay)
 "bHO" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "bHP" = (
@@ -45194,9 +45189,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/medical/reception)
 "bIi" = (
@@ -45224,9 +45219,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHEAST)";
+	dir = 5;
 	icon_state = "whiteblue";
-	dir = 5
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/medical/reception)
 "bIk" = (
@@ -45332,9 +45327,9 @@
 	req_access_txt = "47"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTH)";
+	dir = 1;
 	icon_state = "whitepurple";
-	dir = 1
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "bIv" = (
@@ -45346,9 +45341,9 @@
 /obj/item/disk/design_disk,
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTH)";
+	dir = 1;
 	icon_state = "whitepurple";
-	dir = 1
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "bIw" = (
@@ -45397,8 +45392,8 @@
 "bIA" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f5"
 	},
 /area/shuttle/escape)
 "bIB" = (
@@ -45407,8 +45402,8 @@
 /area/maintenance/disposal)
 "bIC" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall11";
-	dir = 2
+	dir = 2;
+	icon_state = "swall11"
 	},
 /area/shuttle/escape)
 "bID" = (
@@ -45420,15 +45415,15 @@
 /area/maintenance/disposal)
 "bIE" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall7";
-	dir = 2
+	dir = 2;
+	icon_state = "swall7"
 	},
 /area/shuttle/escape)
 "bIF" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/escape)
 "bIG" = (
@@ -45636,8 +45631,8 @@
 /area/hallway/primary/starboard/west)
 "bJc" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -45678,8 +45673,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	dir = 2;
+	icon_state = "whitehall"
 	},
 /area/hallway/primary/starboard/west)
 "bJf" = (
@@ -45865,8 +45860,8 @@
 	dir = 1;
 	icon_state = "pipe-j2s";
 	name = "Disposals Maint";
-	sortdir = 0;
-	sortType = 1
+	sortType = 1;
+	sortdir = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -45947,9 +45942,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/reception)
 "bJB" = (
@@ -45970,8 +45965,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/paramedic)
 "bJD" = (
@@ -46072,9 +46067,9 @@
 	name = "Chemist"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "bJN" = (
@@ -46107,9 +46102,9 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whiteblue";
-	dir = 6
+	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/medical/reception)
 "bJQ" = (
@@ -46385,9 +46380,9 @@
 /area/shuttle/escape)
 "bKn" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
+	dir = 8;
 	icon_state = "shower";
-	dir = 8
+	tag = "icon-shower (WEST)"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -46794,15 +46789,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "bLi" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/engine/gravitygenerator)
 "bLj" = (
@@ -46858,14 +46853,14 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
+	dir = 1;
 	icon_state = "siding1";
-	dir = 1
+	tag = "icon-siding1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
+	dir = 1;
 	icon_state = "siding2";
-	dir = 1
+	tag = "icon-siding2 (NORTH)"
 	},
 /area/hydroponics)
 "bLo" = (
@@ -46939,8 +46934,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/paramedic)
 "bLu" = (
@@ -46978,8 +46973,8 @@
 	name = "Chemist"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "bLw" = (
@@ -46997,8 +46992,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/paramedic)
 "bLx" = (
@@ -47012,15 +47007,15 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "bLy" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/reception)
 "bLz" = (
@@ -47140,8 +47135,8 @@
 "bLN" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -47167,8 +47162,8 @@
 "bLP" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
@@ -47208,8 +47203,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bLT" = (
@@ -47259,14 +47254,14 @@
 	tag = "icon-asteroid (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
+	dir = 1;
 	icon_state = "siding1";
-	dir = 1
+	tag = "icon-siding1 (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
+	dir = 1;
 	icon_state = "siding2";
-	dir = 1
+	tag = "icon-siding2 (NORTH)"
 	},
 /area/hydroponics)
 "bLV" = (
@@ -47287,8 +47282,8 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bLW" = (
@@ -47468,17 +47463,17 @@
 /area/hallway/primary/central/west)
 "bMo" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall12";
+	dir = 2;
 	icon_state = "swall12";
-	dir = 2
+	tag = "icon-swall12"
 	},
 /area/shuttle/supply)
 "bMp" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
+	dir = 2;
 	icon_state = "swall_f6";
-	dir = 2
+	tag = "icon-swall_f6"
 	},
 /area/shuttle/supply)
 "bMq" = (
@@ -47494,9 +47489,9 @@
 "bMr" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f10";
+	dir = 2;
 	icon_state = "swall_f10";
-	dir = 2
+	tag = "icon-swall_f10"
 	},
 /area/shuttle/supply)
 "bMs" = (
@@ -47559,9 +47554,9 @@
 /area/maintenance/maintcentral)
 "bMC" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -47857,8 +47852,8 @@
 /obj/item/storage/firstaid/fire,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bMY" = (
@@ -47877,8 +47872,8 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bMZ" = (
@@ -48255,8 +48250,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "bNz" = (
@@ -48393,8 +48388,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bNM" = (
@@ -48459,8 +48454,8 @@
 /area/maintenance/port)
 "bNQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -48482,8 +48477,8 @@
 /area/quartermaster/storage)
 "bNU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera{
 	c_tag = "Research Research and Development Lab";
@@ -48613,16 +48608,16 @@
 /area/maintenance/disposal)
 "bOe" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall3";
+	dir = 2;
 	icon_state = "swall3";
-	dir = 2
+	tag = "icon-swall3"
 	},
 /area/shuttle/supply)
 "bOf" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
@@ -48931,8 +48926,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "bOC" = (
@@ -48949,9 +48944,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/reception)
 "bOE" = (
@@ -48964,8 +48959,8 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
@@ -49010,8 +49005,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/engine/gravitygenerator)
@@ -49065,8 +49060,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -49113,8 +49108,8 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bOS" = (
@@ -49135,8 +49130,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bOU" = (
@@ -49144,8 +49139,8 @@
 /area/medical/chemistry)
 "bOV" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bOW" = (
@@ -49179,8 +49174,8 @@
 "bOZ" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/item/radio/intercom{
 	dir = 8;
@@ -49259,16 +49254,16 @@
 	shock_proof = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "bPh" = (
@@ -49296,9 +49291,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/reception)
 "bPi" = (
@@ -49431,8 +49426,8 @@
 	},
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f6"
 	},
 /area/shuttle/transport)
 "bPw" = (
@@ -49537,9 +49532,9 @@
 	name = "Scientist"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTH)";
+	dir = 1;
 	icon_state = "whitepurple";
-	dir = 1
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/lab)
 "bPE" = (
@@ -49623,9 +49618,9 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2";
+	dir = 2;
 	icon_state = "pipe-j2";
-	dir = 2
+	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -49691,12 +49686,12 @@
 /area/quartermaster/storage)
 "bPQ" = (
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 4
+	dir = 4;
+	icon_state = "4"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 4
+	dir = 4;
+	icon_state = "3"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -49732,8 +49727,8 @@
 	},
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f5"
 	},
 /area/shuttle/transport)
 "bPV" = (
@@ -49845,8 +49840,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 4
+	dir = 4;
+	icon_state = "red"
 	},
 /area/hallway/primary/central/sw)
 "bQi" = (
@@ -49917,8 +49912,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/crew_quarters/heads)
 "bQl" = (
@@ -49981,8 +49976,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -50047,8 +50042,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -50086,9 +50081,9 @@
 	req_access_txt = "0"
 	},
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
+	dir = 4;
 	icon_state = "shower";
-	dir = 4
+	tag = "icon-shower (EAST)"
 	},
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
@@ -50136,15 +50131,15 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bQC" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bQD" = (
@@ -50177,8 +50172,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bQF" = (
@@ -50322,9 +50317,9 @@
 	req_access_txt = "66"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/paramedic)
 "bQQ" = (
@@ -50340,8 +50335,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/reception)
 "bQS" = (
@@ -50361,9 +50356,9 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "bQT" = (
@@ -50445,8 +50440,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bRc" = (
@@ -50475,8 +50470,8 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bRd" = (
@@ -50517,9 +50512,9 @@
 /area/hallway/primary/central/se)
 "bRg" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -51016,8 +51011,8 @@
 "bRZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/hallway/primary/central/sw)
 "bSa" = (
@@ -51033,9 +51028,9 @@
 "bSb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -51056,8 +51051,8 @@
 "bSd" = (
 /obj/machinery/computer/card,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/crew_quarters/heads)
 "bSe" = (
@@ -51071,8 +51066,8 @@
 /obj/item/paper,
 /obj/item/pen,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -51230,9 +51225,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whiteblue";
-	dir = 6
+	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/medical/reception)
 "bSr" = (
@@ -51247,8 +51242,8 @@
 "bSs" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/reception)
 "bSt" = (
@@ -51418,8 +51413,8 @@
 /area/medical/genetics_cloning)
 "bSF" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -51472,8 +51467,8 @@
 	name = "Surgery Cleaner"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 4
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/assembly/robotics)
 "bSK" = (
@@ -51702,8 +51697,8 @@
 /area/crew_quarters/heads)
 "bTd" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -51819,9 +51814,9 @@
 /area/hallway/primary/central/sw)
 "bTl" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -51855,9 +51850,9 @@
 /area/shuttle/administration)
 "bTo" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -51941,8 +51936,8 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	name = "Cargo Requests Console";
 	departmentType = 2;
+	name = "Cargo Requests Console";
 	pixel_x = -30;
 	pixel_y = 0
 	},
@@ -51981,8 +51976,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
@@ -52126,15 +52121,15 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "bTN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -52165,8 +52160,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/reception)
 "bTR" = (
@@ -52203,8 +52198,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "bTV" = (
@@ -52560,12 +52555,12 @@
 "bUC" = (
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 8
+	dir = 8;
+	icon_state = "4"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 8
+	dir = 8;
+	icon_state = "3"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -52579,9 +52574,9 @@
 /area/crew_quarters/captain/bedroom)
 "bUE" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j2";
-	dir = 4
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/wall,
 /area/quartermaster/office)
@@ -52651,12 +52646,12 @@
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 8
+	dir = 8;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 8
+	dir = 8;
+	icon_state = "4"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -52679,8 +52674,8 @@
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/sleeper)
 "bUN" = (
@@ -52970,17 +52965,17 @@
 /area/quartermaster/storage)
 "bVm" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/supply)
 "bVn" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
@@ -53200,8 +53195,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	dir = 2;
+	icon_state = "whitehall"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -53369,8 +53364,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/se)
 "bVU" = (
@@ -53517,8 +53512,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -53777,9 +53772,9 @@
 "bWx" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/sleeper)
 "bWy" = (
@@ -53871,9 +53866,9 @@
 /area/medical/genetics_cloning)
 "bWG" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
+	dir = 8;
 	icon_state = "heater";
-	dir = 8
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -53996,12 +53991,12 @@
 	opacity = 0
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 4
+	dir = 4;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 4
+	dir = 4;
+	icon_state = "4"
 	},
 /obj/machinery/ticket_machine{
 	layer = 4;
@@ -54242,9 +54237,9 @@
 /area/crew_quarters/heads)
 "bXr" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -54260,9 +54255,9 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (WEST)";
+	dir = 8;
 	icon_state = "whitepurple";
-	dir = 8
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/genetics)
 "bXt" = (
@@ -54303,9 +54298,9 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (EAST)";
+	dir = 4;
 	icon_state = "whitepurple";
-	dir = 4
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/genetics)
 "bXw" = (
@@ -54324,8 +54319,8 @@
 /area/teleporter)
 "bXx" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -54402,9 +54397,9 @@
 "bXE" = (
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/sleeper)
 "bXF" = (
@@ -54416,9 +54411,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/medical/sleeper)
 "bXG" = (
@@ -54489,9 +54484,9 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/sleeper)
 "bXK" = (
@@ -54537,8 +54532,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -54594,8 +54589,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
@@ -54625,13 +54620,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (WEST)";
+	dir = 8;
 	icon_state = "whitepurple";
-	dir = 8
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/genetics)
 "bXW" = (
@@ -54730,8 +54725,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/se)
 "bYc" = (
@@ -54816,9 +54811,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
@@ -54833,9 +54828,9 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (EAST)";
+	dir = 4;
 	icon_state = "whitepurple";
-	dir = 4
+	tag = "icon-whitepurple (EAST)"
 	},
 /area/medical/genetics)
 "bYl" = (
@@ -54914,9 +54909,9 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/sleeper)
 "bYt" = (
@@ -54941,9 +54936,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/reception)
 "bYv" = (
@@ -55015,8 +55010,8 @@
 /obj/item/roller,
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/sleeper)
 "bYD" = (
@@ -55179,8 +55174,8 @@
 "bYR" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/sw)
 "bYS" = (
@@ -55207,8 +55202,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/crew_quarters/heads)
 "bYU" = (
@@ -55400,9 +55395,9 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
+	dir = 9;
 	icon_state = "whiteblue";
-	dir = 9
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/medical/sleeper)
 "bZk" = (
@@ -55511,8 +55506,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/se)
 "bZu" = (
@@ -55581,8 +55576,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
@@ -55662,9 +55657,9 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/medbay2)
 "bZF" = (
@@ -56019,9 +56014,9 @@
 	tag = ""
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
@@ -56266,10 +56261,10 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (WEST)";
+	dir = 8;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 8
+	tag = "icon-window5_end (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
@@ -56355,13 +56350,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/sleeper)
 "caA" = (
@@ -56713,9 +56708,9 @@
 	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whitepurple";
-	dir = 10
+	tag = "icon-whitepurple (SOUTHWEST)"
 	},
 /area/medical/genetics)
 "caX" = (
@@ -56735,9 +56730,9 @@
 	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whitepurple";
-	dir = 6
+	tag = "icon-whitepurple (SOUTHEAST)"
 	},
 /area/medical/genetics)
 "caZ" = (
@@ -56969,8 +56964,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "cbs" = (
@@ -57010,9 +57005,9 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/medbay2)
 "cbv" = (
@@ -57021,9 +57016,9 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cbw" = (
@@ -57046,8 +57041,8 @@
 	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+	icon_state = "whitebluefull";
+	tag = "icon-whitebluefull"
 	},
 /area/medical/biostorage)
 "cbz" = (
@@ -57085,8 +57080,8 @@
 "cbB" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	tag = "icon-swall_f10";
-	icon_state = "swall_f10"
+	icon_state = "swall_f10";
+	tag = "icon-swall_f10"
 	},
 /area/shuttle/supply)
 "cbC" = (
@@ -57095,23 +57090,23 @@
 /area/shuttle/supply)
 "cbD" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall7";
+	dir = 2;
 	icon_state = "swall7";
-	dir = 2
+	tag = "icon-swall7"
 	},
 /area/shuttle/supply)
 "cbE" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall/interior{
-	tag = "icon-swall_f6";
-	icon_state = "swall_f6"
+	icon_state = "swall_f6";
+	tag = "icon-swall_f6"
 	},
 /area/shuttle/supply)
 "cbF" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall11";
+	dir = 2;
 	icon_state = "swall11";
-	dir = 2
+	tag = "icon-swall11"
 	},
 /area/shuttle/supply)
 "cbG" = (
@@ -57199,17 +57194,17 @@
 /area/medical/medbay2)
 "cbO" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cbP" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cbQ" = (
@@ -57255,9 +57250,9 @@
 "cbU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cbV" = (
@@ -57311,8 +57306,8 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_unres_helper"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -57347,8 +57342,8 @@
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/sleeper)
 "ccb" = (
@@ -57641,8 +57636,8 @@
 /obj/structure/cable,
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/sleeper)
 "ccr" = (
@@ -57669,8 +57664,8 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/sleeper)
 "cct" = (
@@ -57683,14 +57678,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/sleeper)
 "ccu" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/sleeper)
 "ccv" = (
@@ -57814,9 +57809,9 @@
 "ccC" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "ccD" = (
@@ -57837,9 +57832,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "ccF" = (
@@ -57861,8 +57856,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -57906,8 +57901,8 @@
 	shock_proof = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -57981,9 +57976,9 @@
 /area/escapepodbay)
 "ccQ" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (WEST)";
+	dir = 8;
 	icon_state = "whitepurple";
-	dir = 8
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/genetics)
 "ccR" = (
@@ -58008,9 +58003,9 @@
 "ccT" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/toxins/server_coldroom)
@@ -58022,9 +58017,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	tag = "icon-intact (WEST)";
+	dir = 8;
 	icon_state = "intact";
-	dir = 8
+	tag = "icon-intact (WEST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -58131,8 +58126,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
-	icon_state = "vault"
+	icon_state = "vault";
+	tag = "icon-vault"
 	},
 /area/engine/gravitygenerator)
 "cdb" = (
@@ -58295,9 +58290,9 @@
 "cdp" = (
 /obj/machinery/clonepod/upgraded,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -58327,8 +58322,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_unres_helper"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -58353,18 +58348,18 @@
 	},
 /obj/structure/grille,
 /obj/structure/shuttle/window{
-	tag = "icon-window5_end (EAST)";
+	dir = 4;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "window5_end";
-	dir = 4
+	tag = "icon-window5_end (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
 "cdt" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall15";
+	dir = 2;
 	icon_state = "swall15";
-	dir = 2
+	tag = "icon-swall15"
 	},
 /area/shuttle/supply)
 "cdu" = (
@@ -58377,17 +58372,17 @@
 "cdv" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
+	dir = 2;
 	icon_state = "swall_f5";
-	dir = 2
+	tag = "icon-swall_f5"
 	},
 /area/shuttle/supply)
 "cdw" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f9";
+	dir = 2;
 	icon_state = "swall_f9";
-	dir = 2
+	tag = "icon-swall_f9"
 	},
 /area/shuttle/supply)
 "cdx" = (
@@ -58405,8 +58400,8 @@
 /obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	name = "Cargo Requests Console";
 	departmentType = 2;
+	name = "Cargo Requests Console";
 	pixel_x = -30;
 	pixel_y = 0
 	},
@@ -58592,8 +58587,8 @@
 "cdQ" = (
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
-	name = "Cargo Requests Console";
 	departmentType = 2;
+	name = "Cargo Requests Console";
 	pixel_x = -30;
 	pixel_y = 0
 	},
@@ -58611,9 +58606,9 @@
 /area/quartermaster/qm)
 "cdS" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -58660,9 +58655,9 @@
 /area/hallway/primary/central/south)
 "cdY" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j1";
-	dir = 4
+	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -58847,9 +58842,9 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -59123,8 +59118,8 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_unres_helper"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -59134,23 +59129,23 @@
 /area/shuttle/supply)
 "ceV" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l";
-	icon_state = "burst_l"
+	icon_state = "burst_l";
+	tag = "icon-burst_l"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "ceW" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_r";
-	icon_state = "burst_r"
+	icon_state = "burst_r";
+	tag = "icon-burst_r"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/supply)
 "ceX" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f6"
 	},
 /area/shuttle/mining)
 "ceY" = (
@@ -59160,16 +59155,16 @@
 /area/shuttle/mining)
 "ceZ" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
 /area/shuttle/mining)
 "cfa" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f10";
+	dir = 2;
 	icon_state = "swall_f10";
-	dir = 2
+	tag = "icon-swall_f10"
 	},
 /area/shuttle/mining)
 "cfb" = (
@@ -59343,8 +59338,8 @@
 /area/janitor)
 "cfp" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -59466,9 +59461,9 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/surgery1)
 "cfB" = (
@@ -59497,8 +59492,8 @@
 /obj/item/stack/medical/bruise_pack/advanced,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/surgery2)
 "cfD" = (
@@ -59602,8 +59597,8 @@
 	},
 /obj/item/surgicaldrill,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/surgery2)
 "cfM" = (
@@ -59628,8 +59623,8 @@
 /obj/structure/table/tray,
 /obj/item/scalpel,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/medical/surgery2)
 "cfN" = (
@@ -59872,9 +59867,9 @@
 "cgc" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
 /area/toxins/server_coldroom)
@@ -60074,9 +60069,9 @@
 /area/shuttle/administration)
 "cgA" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -60107,8 +60102,8 @@
 	})
 "cgF" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/mining)
 "cgG" = (
@@ -60432,8 +60427,8 @@
 	req_one_access_txt = "5;9"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_unres_helper"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -60470,9 +60465,9 @@
 /area/medical/surgery1)
 "chl" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/surgery1)
 "chm" = (
@@ -60632,9 +60627,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "chy" = (
@@ -60772,8 +60767,8 @@
 /area/medical/surgery1)
 "chL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -61467,9 +61462,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "ciV" = (
@@ -61670,9 +61665,9 @@
 /area/hallway/primary/central/south)
 "cjk" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2";
+	dir = 2;
 	icon_state = "pipe-j2";
-	dir = 2
+	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -61838,9 +61833,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/surgery1)
 "cjy" = (
@@ -62240,9 +62235,9 @@
 /area/toxins/mixing)
 "ckf" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -62252,9 +62247,9 @@
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -62488,9 +62483,9 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "ckC" = (
@@ -62534,8 +62529,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Break Room";
@@ -62690,17 +62685,17 @@
 	pixel_x = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery1)
 "ckV" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery1)
 "ckW" = (
@@ -62717,9 +62712,9 @@
 /area/medical/surgery1)
 "ckX" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery1)
 "ckY" = (
@@ -62790,9 +62785,9 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery2)
 "cld" = (
@@ -62818,9 +62813,9 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery2)
 "clf" = (
@@ -62836,9 +62831,9 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/medical/surgery2)
 "clg" = (
@@ -62866,9 +62861,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cli" = (
@@ -63201,9 +63196,9 @@
 /area/maintenance/asmaint)
 "clT" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -63258,8 +63253,8 @@
 /area/toxins/storage)
 "clY" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -63309,8 +63304,8 @@
 "cmc" = (
 /obj/machinery/requests_console{
 	department = "Janitorial";
-	name = "Janitor Requests Console";
 	departmentType = 1;
+	name = "Janitor Requests Console";
 	pixel_y = -29
 	},
 /obj/machinery/disposal,
@@ -63438,9 +63433,9 @@
 "cmn" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (NORTHWEST)";
+	dir = 9;
 	icon_state = "whitegreen";
-	dir = 9
+	tag = "icon-whitegreen (NORTHWEST)"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -63454,9 +63449,9 @@
 "cmp" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (NORTHEAST)";
+	dir = 5;
 	icon_state = "whitegreen";
-	dir = 5
+	tag = "icon-whitegreen (NORTHEAST)"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -63719,9 +63714,9 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whitegreen";
-	dir = 10
+	tag = "icon-whitegreen (SOUTHWEST)"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -64131,9 +64126,9 @@
 	})
 "cnC" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -64253,9 +64248,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/medbay2)
 "cnN" = (
@@ -64461,9 +64456,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whitegreen";
-	dir = 10
+	tag = "icon-whitegreen (SOUTHWEST)"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -64895,8 +64890,8 @@
 "coO" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f5"
 	},
 /area/shuttle/mining)
 "coP" = (
@@ -64911,8 +64906,8 @@
 "coQ" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/mining)
 "coR" = (
@@ -65208,9 +65203,9 @@
 	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/medbay2)
 "cpi" = (
@@ -65283,9 +65278,9 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
+	dir = 8;
 	icon_state = "whiteblue";
-	dir = 8
+	tag = "icon-whiteblue (WEST)"
 	},
 /area/medical/surgery1)
 "cpo" = (
@@ -65310,9 +65305,9 @@
 /area/medical/surgery2)
 "cpp" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -65470,9 +65465,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whitegreen";
-	dir = 6
+	tag = "icon-whitegreen (SOUTHEAST)"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -65686,9 +65681,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cpT" = (
@@ -65713,9 +65708,9 @@
 "cpU" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHWEST)";
+	dir = 9;
 	icon_state = "whitepurple";
-	dir = 9
+	tag = "icon-whitepurple (NORTHWEST)"
 	},
 /area/toxins/explab)
 "cpV" = (
@@ -65723,17 +65718,17 @@
 /obj/item/clipboard,
 /obj/item/book/manual/experimentor,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHEAST)";
+	dir = 5;
 	icon_state = "whitepurple";
-	dir = 5
+	tag = "icon-whitepurple (NORTHEAST)"
 	},
 /area/toxins/explab)
 "cpW" = (
 /obj/machinery/computer/rdconsole/experiment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTH)";
+	dir = 1;
 	icon_state = "whitepurple";
-	dir = 1
+	tag = "icon-whitepurple (NORTH)"
 	},
 /area/toxins/explab)
 "cpX" = (
@@ -65762,9 +65757,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHEAST)";
+	dir = 5;
 	icon_state = "whitepurple";
-	dir = 5
+	tag = "icon-whitepurple (NORTHEAST)"
 	},
 /area/toxins/explab)
 "cpZ" = (
@@ -65998,8 +65993,8 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -66060,8 +66055,8 @@
 "cqs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -66230,8 +66225,8 @@
 /area/maintenance/asmaint)
 "cqE" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -66247,9 +66242,9 @@
 /area/maintenance/apmaint)
 "cqG" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
+	dir = 8;
 	icon_state = "shower";
-	dir = 8
+	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -66570,9 +66565,9 @@
 "crh" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitepurple (NORTHWEST)";
+	dir = 9;
 	icon_state = "whitepurple";
-	dir = 9
+	tag = "icon-whitepurple (NORTHWEST)"
 	},
 /area/toxins/explab)
 "cri" = (
@@ -66592,8 +66587,8 @@
 	pixel_y = -23
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -66628,9 +66623,9 @@
 	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "crn" = (
@@ -66723,9 +66718,9 @@
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (EAST)";
+	dir = 4;
 	icon_state = "whitegreen";
-	dir = 4
+	tag = "icon-whitegreen (EAST)"
 	},
 /area/medical/virology)
 "crv" = (
@@ -67568,8 +67563,8 @@
 	name = "Grid Power Monitoring Computer"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/engine/controlroom)
 "csR" = (
@@ -67606,13 +67601,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "csT" = (
@@ -67972,8 +67967,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "ctq" = (
@@ -68375,9 +68370,9 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2";
+	dir = 2;
 	icon_state = "pipe-j2";
-	dir = 2
+	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -68410,9 +68405,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "cue" = (
@@ -68466,8 +68461,8 @@
 	},
 /obj/machinery/computer/security/engineering,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/engine/controlroom)
 "cuj" = (
@@ -68483,12 +68478,12 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 4
+	dir = 4;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 4
+	dir = 4;
+	icon_state = "4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -68664,8 +68659,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
@@ -68735,9 +68730,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whitegreen";
-	dir = 10
+	tag = "icon-whitegreen (SOUTHWEST)"
 	},
 /area/medical/virology)
 "cuG" = (
@@ -69229,9 +69224,9 @@
 	network = list("SS13")
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/rack{
 	dir = 8;
@@ -69399,8 +69394,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/engine/controlroom)
 "cvN" = (
@@ -69458,8 +69453,8 @@
 /area/medical/psych)
 "cvS" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -69550,17 +69545,17 @@
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (NORTHWEST)";
+	dir = 9;
 	icon_state = "whitegreen";
-	dir = 9
+	tag = "icon-whitegreen (NORTHWEST)"
 	},
 /area/medical/virology)
 "cwb" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (NORTHEAST)";
+	dir = 5;
 	icon_state = "whitegreen";
-	dir = 5
+	tag = "icon-whitegreen (NORTHEAST)"
 	},
 /area/medical/virology)
 "cwc" = (
@@ -69606,9 +69601,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (NORTHEAST)";
+	dir = 5;
 	icon_state = "whitegreen";
-	dir = 5
+	tag = "icon-whitegreen (NORTHEAST)"
 	},
 /area/medical/virology)
 "cwf" = (
@@ -69635,9 +69630,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (NORTHWEST)";
+	dir = 9;
 	icon_state = "whitegreen";
-	dir = 9
+	tag = "icon-whitegreen (NORTHWEST)"
 	},
 /area/medical/virology)
 "cwh" = (
@@ -69666,9 +69661,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (NORTHEAST)";
+	dir = 5;
 	icon_state = "whitegreen";
-	dir = 5
+	tag = "icon-whitegreen (NORTHEAST)"
 	},
 /area/medical/virology)
 "cwj" = (
@@ -69726,8 +69721,8 @@
 	req_access_txt = "40"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "cwo" = (
@@ -69790,8 +69785,8 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "cws" = (
@@ -69808,8 +69803,8 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "cwt" = (
@@ -69985,21 +69980,21 @@
 /area/storage/tech)
 "cwP" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cwQ" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -70007,9 +70002,9 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -70048,8 +70043,8 @@
 /area/medical/medbay2)
 "cwU" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -70201,8 +70196,8 @@
 	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/engine/controlroom)
 "cxh" = (
@@ -70244,8 +70239,8 @@
 /area/medical/medbay2)
 "cxk" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -70259,9 +70254,9 @@
 /area/construction)
 "cxl" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
+	dir = 4;
 	icon_state = "bulb1";
-	dir = 4
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -70333,9 +70328,9 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "cxu" = (
@@ -70344,9 +70339,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (EAST)";
+	dir = 4;
 	icon_state = "whitegreen";
-	dir = 4
+	tag = "icon-whitegreen (EAST)"
 	},
 /area/medical/virology)
 "cxv" = (
@@ -70364,9 +70359,9 @@
 "cxw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "cxx" = (
@@ -70376,9 +70371,9 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (EAST)";
+	dir = 4;
 	icon_state = "whitegreen";
-	dir = 4
+	tag = "icon-whitegreen (EAST)"
 	},
 /area/medical/virology)
 "cxy" = (
@@ -70472,17 +70467,17 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whitegreen";
-	dir = 10
+	tag = "icon-whitegreen (SOUTHWEST)"
 	},
 /area/medical/virology)
 "cxG" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whitegreen";
-	dir = 6
+	tag = "icon-whitegreen (SOUTHEAST)"
 	},
 /area/medical/virology)
 "cxH" = (
@@ -70537,9 +70532,9 @@
 /obj/item/storage/box/donkpockets,
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (EAST)";
+	dir = 4;
 	icon_state = "whitegreen";
-	dir = 4
+	tag = "icon-whitegreen (EAST)"
 	},
 /area/medical/virology)
 "cxM" = (
@@ -70853,9 +70848,9 @@
 /area/storage/tech)
 "cyr" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
@@ -71047,14 +71042,14 @@
 /obj/structure/table,
 /obj/item/t_scanner,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/engine/controlroom)
 "cyH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -71201,9 +71196,9 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whitegreen";
-	dir = 10
+	tag = "icon-whitegreen (SOUTHWEST)"
 	},
 /area/medical/virology)
 "cyW" = (
@@ -71217,9 +71212,9 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whitegreen";
-	dir = 6
+	tag = "icon-whitegreen (SOUTHEAST)"
 	},
 /area/medical/virology)
 "cyX" = (
@@ -71234,9 +71229,9 @@
 "cyY" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHWEST)";
+	dir = 10;
 	icon_state = "whitegreen";
-	dir = 10
+	tag = "icon-whitegreen (SOUTHWEST)"
 	},
 /area/medical/virology)
 "cyZ" = (
@@ -71251,9 +71246,9 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whitegreen";
-	dir = 6
+	tag = "icon-whitegreen (SOUTHEAST)"
 	},
 /area/medical/virology)
 "czb" = (
@@ -71413,8 +71408,8 @@
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/maintenance/asmaint)
 "czv" = (
@@ -71680,9 +71675,9 @@
 /area/maintenance/incinerator)
 "czR" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -71764,8 +71759,8 @@
 	pixel_y = 0
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -72058,9 +72053,9 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitebluecorner (WEST)";
+	dir = 8;
 	icon_state = "whitebluecorner";
-	dir = 8
+	tag = "icon-whitebluecorner (WEST)"
 	},
 /area/medical/medbay2)
 "cAu" = (
@@ -72127,8 +72122,8 @@
 /area/maintenance/asmaint)
 "cAC" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/maintenance/asmaint)
 "cAD" = (
@@ -72239,8 +72234,8 @@
 /area/hallway/primary/aft)
 "cAN" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -72576,8 +72571,8 @@
 "cBv" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/hallway/primary/aft)
 "cBw" = (
@@ -72620,8 +72615,8 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "cBz" = (
@@ -72629,8 +72624,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "cBA" = (
@@ -72664,9 +72659,9 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cBD" = (
@@ -72898,9 +72893,9 @@
 /area/toxins/misc_lab)
 "cCg" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -72954,9 +72949,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cCk" = (
@@ -72965,9 +72960,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cCl" = (
@@ -72979,9 +72974,9 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cCm" = (
@@ -72992,17 +72987,17 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cCn" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cCo" = (
@@ -73284,8 +73279,8 @@
 /area/construction)
 "cCM" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
@@ -73293,8 +73288,8 @@
 /area/storage/tech)
 "cCN" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -73613,9 +73608,9 @@
 	name = "Air To Distro"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -73678,9 +73673,9 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cDu" = (
@@ -73750,9 +73745,9 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73791,9 +73786,9 @@
 	name = "Scientist"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cDE" = (
@@ -73814,25 +73809,25 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cDG" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cDH" = (
 /obj/machinery/chem_dispenser,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cDI" = (
@@ -74033,8 +74028,8 @@
 	tag = ""
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -74106,8 +74101,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 8
+	dir = 8;
+	icon_state = "arrival"
 	},
 /area/hallway/primary/aft)
 "cEj" = (
@@ -74373,14 +74368,14 @@
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
 "cEN" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/power/apc{
@@ -74390,8 +74385,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
 "cEO" = (
@@ -74415,8 +74410,8 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/engine/mechanic_workshop)
 "cEQ" = (
@@ -74533,9 +74528,9 @@
 "cFb" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cFc" = (
@@ -74600,12 +74595,12 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 8
+	dir = 8;
+	icon_state = "arrival"
 	},
 /area/hallway/primary/aft)
 "cFi" = (
@@ -74724,9 +74719,9 @@
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74757,16 +74752,16 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "cFy" = (
@@ -74778,9 +74773,9 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (EAST)";
+	dir = 4;
 	icon_state = "whitegreen";
-	dir = 4
+	tag = "icon-whitegreen (EAST)"
 	},
 /area/medical/virology)
 "cFz" = (
@@ -74809,9 +74804,7 @@
 /area/medical/psych)
 "cFC" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 0;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -75113,9 +75106,9 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cFV" = (
@@ -75136,9 +75129,9 @@
 	},
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cFZ" = (
@@ -75159,9 +75152,9 @@
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/pillbottles,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cGa" = (
@@ -75174,9 +75167,9 @@
 /obj/item/reagent_containers/dropper/precision,
 /obj/item/reagent_containers/dropper/precision,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cGb" = (
@@ -75208,9 +75201,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
+	dir = 5;
 	icon_state = "vault";
-	dir = 5
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/toxins/misc_lab)
 "cGe" = (
@@ -75335,9 +75328,9 @@
 /area/hallway/primary/aft)
 "cGp" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2";
+	dir = 2;
 	icon_state = "pipe-j2";
-	dir = 2
+	tag = "icon-pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75387,8 +75380,8 @@
 	network = list("SS13")
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/table,
 /obj/item/book/manual/atmospipes,
@@ -75412,15 +75405,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "cGx" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -75430,9 +75423,9 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology)
 "cGy" = (
@@ -75445,15 +75438,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (EAST)";
+	dir = 4;
 	icon_state = "whitegreen";
-	dir = 4
+	tag = "icon-whitegreen (EAST)"
 	},
 /area/medical/virology)
 "cGz" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -75612,9 +75605,9 @@
 "cGN" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/wall,
 /area/engine/controlroom)
@@ -75749,14 +75742,10 @@
 /obj/effect/landmark/start{
 	name = "Chief Engineer"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -75788,20 +75777,14 @@
 /area/gateway)
 "cHa" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 0;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
@@ -75813,9 +75796,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/computer/station_alert,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -75877,10 +75858,11 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cHh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -75899,7 +75881,7 @@
 /area/hallway/primary/aft)
 "cHk" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow,
+/obj/structure/cable/cyan,
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cHl" = (
@@ -75990,8 +75972,8 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/engine/break_room)
 "cHu" = (
@@ -76271,9 +76253,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/wall,
 /area/engine/break_room)
@@ -76293,9 +76275,9 @@
 /area/engine/break_room)
 "cHW" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitegreen (WEST)";
+	dir = 8;
 	icon_state = "whitegreen";
-	dir = 8
+	tag = "icon-whitegreen (WEST)"
 	},
 /area/medical/virology/lab{
 	name = "\improper Virology Lobby"
@@ -76352,15 +76334,11 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76374,9 +76352,7 @@
 	pixel_x = 24;
 	shock_proof = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 0;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -76430,8 +76406,8 @@
 /area/atmos/control)
 "cIj" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cIk" = (
@@ -76441,8 +76417,8 @@
 "cIl" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/maintenance/asmaint)
 "cIm" = (
@@ -76509,17 +76485,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
+/obj/structure/cable/cyan,
+/obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cIx" = (
@@ -76565,9 +76537,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 0;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -76601,8 +76571,8 @@
 /area/toxins/xenobiology)
 "cIB" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -76761,9 +76731,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
+	dir = 4;
 	icon_state = "shower";
-	dir = 4
+	tag = "icon-shower (EAST)"
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -77059,9 +77029,9 @@
 /area/maintenance/aft)
 "cJo" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/rack{
 	dir = 8;
@@ -77108,8 +77078,8 @@
 /area/toxins/xenobiology)
 "cJs" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
 	},
 /area/maintenance/asmaint)
 "cJt" = (
@@ -77121,8 +77091,8 @@
 /area/maintenance/asmaint)
 "cJv" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/maintenance/asmaint)
 "cJw" = (
@@ -77200,15 +77170,8 @@
 /area/engine/engineering)
 "cJC" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -77705,12 +77668,12 @@
 /area/toxins/xenobiology)
 "cKt" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
-	tag_exterior_door = "xeno_airlock_exterior";
 	id_tag = "xeno_airlock_control";
-	tag_interior_door = "xeno_airlock_interior";
 	name = "Xenobiology Access Console";
 	pixel_x = 8;
-	pixel_y = 22
+	pixel_y = 22;
+	tag_exterior_door = "xeno_airlock_exterior";
+	tag_interior_door = "xeno_airlock_interior"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -6;
@@ -77732,21 +77695,21 @@
 /area/maintenance/asmaint)
 "cKv" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair_wings";
-	dir = 4
+	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
 "cKw" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair_wings";
-	dir = 8
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cKx" = (
@@ -77854,9 +77817,8 @@
 /area/maintenance/genetics)
 "cKH" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable/yellow{
-	d1 = 0;
-	d2 = 2;
+/obj/structure/cable/cyan,
+/obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -77932,8 +77894,8 @@
 "cKM" = (
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken";
-	icon_state = "wood-broken"
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
 	},
 /area/maintenance/asmaint)
 "cKN" = (
@@ -77970,8 +77932,8 @@
 /area/toxins/xenobiology)
 "cKS" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/maintenance/asmaint)
 "cKT" = (
@@ -78040,8 +78002,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -78243,8 +78205,8 @@
 /area/engine/mechanic_workshop)
 "cLs" = (
 /obj/machinery/light_switch{
-	name = "light switch ";
 	dir = 2;
+	name = "light switch ";
 	pixel_x = 0;
 	pixel_y = -22
 	},
@@ -78487,8 +78449,8 @@
 "cLT" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 4
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/hallway/primary/aft)
 "cLU" = (
@@ -78534,15 +78496,15 @@
 "cLY" = (
 /obj/item/stack/sheet/wood,
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken5";
-	icon_state = "wood-broken5"
+	icon_state = "wood-broken5";
+	tag = "icon-wood-broken5"
 	},
 /area/maintenance/asmaint)
 "cLZ" = (
 /obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair_wings";
-	dir = 8
+	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
@@ -78568,8 +78530,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
 	},
 /area/maintenance/asmaint)
 "cMc" = (
@@ -78888,8 +78850,8 @@
 "cML" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 4
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/hallway/primary/aft)
 "cMM" = (
@@ -79040,11 +79002,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cNa" = (
@@ -79110,27 +79067,6 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"cNj" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"cNk" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "cNl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -79162,8 +79098,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -79249,8 +79185,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -79283,8 +79219,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -79343,8 +79279,8 @@
 /area/space/nearstation)
 "cNF" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -79513,25 +79449,11 @@
 /area/engine/break_room)
 "cNV" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"cNW" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cNX" = (
@@ -79556,22 +79478,18 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
 "cOa" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cOb" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/west,
@@ -79592,20 +79510,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
-"cOd" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "cOe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79635,9 +79539,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOg" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -79651,9 +79553,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "cOi" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -79842,12 +79742,12 @@
 /area/atmos/distribution)
 "cOB" = (
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 8
+	dir = 8;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 8
+	dir = 8;
+	icon_state = "4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -79861,8 +79761,8 @@
 /area/maintenance/asmaint2)
 "cOD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
@@ -79872,12 +79772,12 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	icon_state = "3";
-	dir = 4
+	dir = 4;
+	icon_state = "3"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	icon_state = "4";
-	dir = 4
+	dir = 4;
+	icon_state = "4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -80073,8 +79973,8 @@
 	pixel_y = 0
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -80152,8 +80052,8 @@
 /area/maintenance/genetics)
 "cPg" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
 /obj/effect/decal/warning_stripes/southwest,
@@ -80229,8 +80129,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -80258,8 +80158,8 @@
 	network = list("SS13")
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/power/apc{
@@ -80396,8 +80296,8 @@
 "cPC" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -80458,8 +80358,8 @@
 /area/solar/port)
 "cPI" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -80529,8 +80429,8 @@
 	network = list("SS13")
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/engineeringcart,
 /obj/item/radio/intercom{
@@ -80644,7 +80544,7 @@
 /area/solar/port)
 "cQb" = (
 /obj/machinery/particle_accelerator/control_box,
-/obj/structure/cable/yellow,
+/obj/structure/cable/cyan,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cQc" = (
@@ -80763,8 +80663,8 @@
 /area/space/nearstation)
 "cQq" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -80863,8 +80763,8 @@
 /area/toxins/xenobiology)
 "cQB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plasteel{
@@ -80919,26 +80819,17 @@
 	},
 /area/engine/chiefs_office)
 "cQF" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/effect/decal/warning_stripes/west,
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cQG" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cQH" = (
@@ -81084,8 +80975,8 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "cQS" = (
@@ -81135,12 +81026,10 @@
 	name = "Singularity Blast Doors";
 	opacity = 0
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cQW" = (
@@ -81193,9 +81082,7 @@
 	req_access = null;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -81222,9 +81109,9 @@
 	opacity = 0
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -81293,9 +81180,9 @@
 	pixel_y = 0
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -81315,9 +81202,7 @@
 	req_access = null;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -81401,9 +81286,7 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -81436,9 +81319,7 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = -32
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -81458,8 +81339,8 @@
 	},
 /obj/item/storage/firstaid/toxin,
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 4
+	dir = 4;
+	icon_state = "blue"
 	},
 /area/medical/cmostore)
 "cRv" = (
@@ -81480,12 +81361,10 @@
 	pixel_y = -20;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cRx" = (
@@ -81527,8 +81406,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -81618,24 +81497,17 @@
 /area/maintenance/aft)
 "cRJ" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
@@ -81651,24 +81523,20 @@
 	},
 /area/assembly/assembly_line)
 "cRL" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/engine/chiefs_office)
 "cRM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/machinery/suit_storage_unit/ce,
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/suit_storage_unit/ce,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -81910,14 +81778,14 @@
 /area/toxins/xenobiology)
 "cSi" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "engineering_west_pump";
-	tag_exterior_door = "engineering_west_outer";
 	frequency = 1379;
 	id_tag = "engineering_west_airlock";
-	tag_interior_door = "engineering_west_inner";
 	pixel_x = 25;
 	req_access_txt = "10;13";
-	tag_chamber_sensor = "engineering_west_sensor"
+	tag_airpump = "engineering_west_pump";
+	tag_chamber_sensor = "engineering_west_sensor";
+	tag_exterior_door = "engineering_west_outer";
+	tag_interior_door = "engineering_west_inner"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -81925,9 +81793,7 @@
 	pixel_x = 25;
 	pixel_y = 12
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -82076,24 +81942,19 @@
 	req_access_txt = "10"
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cSy" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "engineering_east_pump";
-	tag_exterior_door = "engineering_east_outer";
 	frequency = 1379;
 	id_tag = "engineering_east_airlock";
-	tag_interior_door = "engineering_east_inner";
 	pixel_x = -25;
 	req_access_txt = "10;13";
-	tag_chamber_sensor = "engineering_east_sensor"
+	tag_airpump = "engineering_east_pump";
+	tag_chamber_sensor = "engineering_east_sensor";
+	tag_exterior_door = "engineering_east_outer";
+	tag_interior_door = "engineering_east_inner"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -82101,9 +81962,7 @@
 	pixel_x = -25;
 	pixel_y = 12
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -82118,9 +81977,7 @@
 	req_access = null;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -82144,17 +82001,13 @@
 	req_access = null;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cSC" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -82171,9 +82024,7 @@
 	pixel_y = 20;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -82256,12 +82107,12 @@
 /area/space/nearstation)
 "cSN" = (
 /obj/structure/chair/stool,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cSO" = (
@@ -82418,8 +82269,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -82546,9 +82397,7 @@
 	},
 /area/atmos)
 "cTm" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
@@ -82618,17 +82467,13 @@
 	pixel_y = 20;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cTt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /obj/structure/grille,
@@ -82643,8 +82488,8 @@
 	sensors = list("waste_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/atmos/distribution)
 "cTv" = (
@@ -82677,45 +82522,15 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
-"cTy" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
 "cTz" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 4;
 	state = 2
 	},
-/obj/structure/cable/yellow{
-	d1 = 0;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
-"cTA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cTB" = (
@@ -82729,8 +82544,7 @@
 	dir = 8;
 	state = 2
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -82819,8 +82633,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -82972,8 +82786,8 @@
 /area/solar/starboard)
 "cTX" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10;
@@ -83001,15 +82815,15 @@
 	id_tag = "robotics_solar_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "robotics_solar_pump";
-	tag_exterior_door = "robotics_solar_outer";
 	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
-	tag_interior_door = "robotics_solar_inner";
 	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "13";
-	tag_chamber_sensor = "robotics_solar_sensor"
+	tag_airpump = "robotics_solar_pump";
+	tag_chamber_sensor = "robotics_solar_sensor";
+	tag_exterior_door = "robotics_solar_outer";
+	tag_interior_door = "robotics_solar_inner"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -83206,19 +83020,8 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"cUn" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
 "cUo" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
@@ -83228,12 +83031,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUq" = (
@@ -83241,12 +83042,10 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUr" = (
@@ -83350,11 +83149,6 @@
 	pixel_y = 0;
 	req_access_txt = "10"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -83378,42 +83172,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cUD" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUE" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUF" = (
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUG" = (
@@ -83429,43 +83211,33 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cUH" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUI" = (
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUJ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUK" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "cUL" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -83533,9 +83305,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cUR" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -83547,8 +83317,8 @@
 	name = "Gas Mix Inlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 6
+	dir = 6;
+	icon_state = "green"
 	},
 /area/atmos/distribution)
 "cUT" = (
@@ -83556,9 +83326,7 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "cUU" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -83614,9 +83382,7 @@
 	},
 /area/toxins/xenobiology)
 "cVa" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -83809,21 +83575,16 @@
 	req_access_txt = "10"
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVq" = (
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVr" = (
@@ -83833,11 +83594,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVs" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -83847,6 +83603,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -83861,8 +83620,8 @@
 	name = "Civilian"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
+	dir = 4;
+	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
 "cVu" = (
@@ -83875,12 +83634,10 @@
 	pixel_y = -20;
 	req_access_txt = "10;13"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVv" = (
@@ -83909,11 +83666,6 @@
 /obj/item/crowbar,
 /obj/machinery/light_switch{
 	pixel_x = -27
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -83956,11 +83708,6 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "cVB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -84003,11 +83750,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVG" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -84076,11 +83818,6 @@
 /area/atmos/distribution)
 "cVN" = (
 /obj/item/wirecutters,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -84129,11 +83866,10 @@
 /area/atmos/distribution)
 "cVS" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cVT" = (
@@ -84145,8 +83881,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
+/obj/structure/cable/cyan{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -84222,11 +83957,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/command/glass{
 	id_tag = "ceofficedoor";
 	name = "Chief Engineer";
@@ -84234,6 +83964,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
 "cWg" = (
@@ -84252,8 +83985,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
+	dir = 8;
+	icon_state = "green"
 	},
 /area/hallway/secondary/exit)
 "cWi" = (
@@ -84266,8 +83999,8 @@
 	opacity = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
@@ -84357,23 +84090,54 @@
 	},
 /area/toxins/xenobiology)
 "cWs" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Singularity";
+	name = "Singularity Blast Doors";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "cWt" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Singularity";
+	name = "Singularity Blast Doors";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
 /area/engine/engineering)
 "cWu" = (
 /obj/machinery/navbeacon{
@@ -84439,8 +84203,8 @@
 	name = "Grid Power Monitoring Computer"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -84489,12 +84253,12 @@
 /area/engine/engineering)
 "cWG" = (
 /obj/machinery/door/window/southleft{
-	tag = "icon-left (WEST)";
-	name = "Bar Delivery";
-	icon_state = "left";
+	base_state = "left";
 	dir = 8;
+	icon_state = "left";
+	name = "Bar Delivery";
 	req_access_txt = "25";
-	base_state = "left"
+	tag = "icon-left (WEST)"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -84580,11 +84344,6 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWN" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
 	initialize_directions = 11;
@@ -84594,6 +84353,11 @@
 	dir = 8;
 	initialize_directions = 11;
 	level = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -84635,6 +84399,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -84757,8 +84526,8 @@
 	name = "N2O Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 5
+	dir = 5;
+	icon_state = "escape"
 	},
 /area/atmos)
 "cXe" = (
@@ -84803,19 +84572,14 @@
 /area/hallway/primary/starboard/east)
 "cXi" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -84883,9 +84647,9 @@
 /area/hallway/secondary/exit)
 "cXq" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -84966,6 +84730,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXy" = (
@@ -84974,6 +84743,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85039,6 +84818,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXD" = (
@@ -85060,12 +84844,22 @@
 	initialize_directions = 11;
 	level = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXF" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXG" = (
@@ -85096,6 +84890,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXI" = (
@@ -85107,12 +84906,22 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85125,8 +84934,8 @@
 	location = "Kitchen"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/maintenance/fsmaint2)
 "cXL" = (
@@ -85138,21 +84947,26 @@
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cXM" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85168,6 +84982,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85207,11 +85026,6 @@
 	network = list("SS13")
 	},
 /obj/structure/dispenser,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
@@ -85219,6 +85033,9 @@
 	pixel_x = -24;
 	pixel_y = 0;
 	req_access_txt = "56"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85307,8 +85124,8 @@
 	sensors = list("n2o_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 4
+	dir = 4;
+	icon_state = "escape"
 	},
 /area/atmos)
 "cYd" = (
@@ -85407,18 +85224,18 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cYo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cYp" = (
@@ -85434,66 +85251,56 @@
 	},
 /area/hallway/secondary/exit)
 "cYq" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/storage/secure)
 "cYr" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/storage/secure)
 "cYs" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/storage/secure)
 "cYv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85531,25 +85338,18 @@
 	id_tag = "Secure Storage";
 	name = "Secure Storage Blast Doors"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "cYD" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
 	initialize_directions = 11;
@@ -85562,21 +85362,14 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cYE" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85691,11 +85484,6 @@
 	},
 /area/hallway/primary/central/west)
 "cYQ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -85703,6 +85491,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85760,14 +85551,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -85839,16 +85628,11 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Particle Accelerator";
 	dir = 2;
-	pixel_x = 23;
-	network = list("Singularity","SS13")
+	network = list("Singularity","SS13");
+	pixel_x = 23
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -85858,6 +85642,9 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZg" = (
@@ -85866,8 +85653,8 @@
 	level = 2
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "escape";
-	dir = 6
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/atmos)
 "cZh" = (
@@ -86093,13 +85880,13 @@
 	},
 /area/hallway/secondary/exit)
 "cZE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZF" = (
@@ -86170,21 +85957,17 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZO" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -86205,39 +85988,25 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cZR" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -86394,17 +86163,15 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dai" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
 	name = "standard air scrubber";
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -86426,13 +86193,11 @@
 /area/hallway/secondary/exit)
 "dal" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -86480,9 +86245,9 @@
 /area/escapepodbay)
 "dau" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -86773,8 +86538,8 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
@@ -86943,14 +86708,13 @@
 	dir = 4;
 	state = 2
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Singularity West";
 	dir = 4;
 	network = list("Singularity","SS13")
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
@@ -87192,14 +86956,13 @@
 	dir = 8;
 	state = 2
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Singularity East";
 	dir = 8;
 	network = list("Singularity","SS13")
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
@@ -87269,8 +87032,8 @@
 /area/space/nearstation)
 "dcb" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/hallway/primary/central/north)
 "dcc" = (
@@ -87311,9 +87074,9 @@
 	anchored = 1
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
@@ -87466,8 +87229,8 @@
 /area/maintenance/turbine)
 "dcx" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -88100,8 +87863,8 @@
 /area/engine/engineering)
 "ddT" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -88199,8 +87962,8 @@
 /area/atmos)
 "ded" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -88280,8 +88043,8 @@
 	name = "CO2 Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 5
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/atmos)
 "del" = (
@@ -88574,8 +88337,8 @@
 /area/maintenance/starboardsolar)
 "deO" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 6
@@ -88612,8 +88375,8 @@
 /area/atmos)
 "deS" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -88644,8 +88407,8 @@
 	sensors = list("co2_sensor" = "Tank")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 4
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/atmos)
 "deW" = (
@@ -88750,8 +88513,8 @@
 /area/maintenance/asmaint2)
 "dfj" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -88814,8 +88577,8 @@
 	track = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
@@ -88895,14 +88658,14 @@
 	tag = ""
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "solar_xeno_pump";
-	tag_exterior_door = "solar_xeno_outer";
 	frequency = 1379;
 	id_tag = "solar_xeno_airlock";
-	tag_interior_door = "solar_xeno_inner";
 	pixel_x = 25;
 	req_access_txt = "13";
-	tag_chamber_sensor = "solar_xeno_sensor"
+	tag_airpump = "solar_xeno_pump";
+	tag_chamber_sensor = "solar_xeno_sensor";
+	tag_exterior_door = "solar_xeno_outer";
+	tag_interior_door = "solar_xeno_inner"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -89080,8 +88843,8 @@
 /area/maintenance/asmaint2)
 "dfQ" = (
 /obj/machinery/light_switch{
-	name = "light switch ";
 	dir = 2;
+	name = "light switch ";
 	pixel_x = 0;
 	pixel_y = -22
 	},
@@ -89163,8 +88926,8 @@
 /area/maintenance/storage)
 "dgd" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 6
+	dir = 6;
+	icon_state = "blue"
 	},
 /area/maintenance/storage)
 "dge" = (
@@ -89317,9 +89080,9 @@
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
+	dir = 2;
 	icon_state = "swall_f6";
-	dir = 2
+	tag = "icon-swall_f6"
 	},
 /area/shuttle/pod_4)
 "dgE" = (
@@ -89590,8 +89353,8 @@
 /area/shuttle/trade/sol)
 "dhn" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall13";
-	dir = 2
+	dir = 2;
+	icon_state = "swall13"
 	},
 /area/shuttle/trade/sol)
 "dho" = (
@@ -89641,8 +89404,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "dhs" = (
@@ -89651,8 +89414,8 @@
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "dht" = (
@@ -89757,8 +89520,8 @@
 /area/atmos)
 "dhB" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 10
+	dir = 10;
+	icon_state = "red"
 	},
 /area/atmos)
 "dhC" = (
@@ -89766,8 +89529,8 @@
 	name = "Nitrogen Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 6
+	dir = 6;
+	icon_state = "red"
 	},
 /area/atmos)
 "dhD" = (
@@ -89788,8 +89551,8 @@
 	level = 2
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/atmos)
 "dhF" = (
@@ -89797,8 +89560,8 @@
 	name = "Oxygen Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue";
-	dir = 6
+	dir = 6;
+	icon_state = "blue"
 	},
 /area/atmos)
 "dhG" = (
@@ -89819,8 +89582,8 @@
 	level = 2
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 10
+	dir = 10;
+	icon_state = "arrival"
 	},
 /area/atmos)
 "dhI" = (
@@ -89844,8 +89607,8 @@
 	name = "Mixed Air Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival";
-	dir = 6
+	dir = 6;
+	icon_state = "arrival"
 	},
 /area/atmos)
 "dhK" = (
@@ -89928,9 +89691,9 @@
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
+	dir = 2;
 	icon_state = "swall_f5";
-	dir = 2
+	tag = "icon-swall_f5"
 	},
 /area/shuttle/pod_4)
 "dhV" = (
@@ -89994,8 +89757,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/maintenance/fsmaint2)
 "dii" = (
@@ -90495,8 +90258,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/crew_quarters/dorms)
 "djg" = (
@@ -90628,11 +90391,11 @@
 /area/storage/secure)
 "djt" = (
 /obj/machinery/door/window/eastright{
-	tag = "icon-right";
-	name = "Hydroponics Delivery";
-	icon_state = "right";
 	dir = 2;
-	req_access_txt = "35"
+	icon_state = "right";
+	name = "Hydroponics Delivery";
+	req_access_txt = "35";
+	tag = "icon-right"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment{
@@ -90932,9 +90695,9 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -91147,8 +90910,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/ne)
 "dkn" = (
@@ -91167,8 +90930,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/ne)
 "dkp" = (
@@ -92180,9 +91943,9 @@
 	})
 "dml" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (EAST)";
+	dir = 4;
 	icon_state = "pipe-j2";
-	dir = 4
+	tag = "icon-pipe-j2 (EAST)"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	name = "Waste Out";
@@ -93059,9 +92822,9 @@
 	},
 /obj/item/book/codex_gigas,
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
+	dir = 2;
 	icon_state = "cult";
-	dir = 2
+	tag = "icon-cult"
 	},
 /area/library)
 "dnN" = (
@@ -93276,8 +93039,8 @@
 /area/maintenance/fsmaint2)
 "doh" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "starboardsolar";
@@ -93298,8 +93061,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 1
+	dir = 1;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "doj" = (
@@ -93307,8 +93070,8 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red";
-	dir = 5
+	dir = 5;
+	icon_state = "red"
 	},
 /area/security/checkpoint2)
 "dok" = (
@@ -93399,8 +93162,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	dir = 2;
+	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "dor" = (
@@ -93426,9 +93189,9 @@
 /area/engine/controlroom)
 "dou" = (
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall12";
+	dir = 2;
 	icon_state = "swall12";
-	dir = 2
+	tag = "icon-swall12"
 	},
 /area/shuttle/pod_4)
 "dov" = (
@@ -93462,8 +93225,8 @@
 "dow" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/pod_4)
 "dox" = (
@@ -93607,8 +93370,8 @@
 "doV" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f9"
 	},
 /area/shuttle/pod_4)
 "doW" = (
@@ -93799,8 +93562,8 @@
 	})
 "dpF" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
@@ -93920,8 +93683,8 @@
 	})
 "dpZ" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/power/apc{
@@ -94043,8 +93806,8 @@
 /area/aisat)
 "dqM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/porta_turret{
 	dir = 4;
@@ -94057,8 +93820,8 @@
 	})
 "dqO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/porta_turret{
 	dir = 8;
@@ -94190,8 +93953,8 @@
 /area/turret_protected/ai)
 "drG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -94230,8 +93993,8 @@
 /area/turret_protected/ai)
 "drO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -94415,8 +94178,8 @@
 /area/turret_protected/ai)
 "dse" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -94528,11 +94291,6 @@
 "dsH" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dsI" = (
@@ -94548,9 +94306,8 @@
 	pixel_y = 24;
 	shock_proof = 1
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -94594,26 +94351,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dsP" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/cyan{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dsT" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/machinery/photocopier,
+/obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
-/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -94643,12 +94394,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dsX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dsY" = (
@@ -94735,11 +94484,6 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "dts" = (
@@ -94750,13 +94494,11 @@
 	pixel_y = 24;
 	shock_proof = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 0;
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/reagent_dispensers/watertank,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "dtt" = (
@@ -94830,15 +94572,15 @@
 "dSc" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "dUh" = (
 /obj/machinery/status_display,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/escape)
 "dVs" = (
@@ -94926,8 +94668,8 @@
 "fGr" = (
 /obj/structure/sign/greencross,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
+	dir = 2;
+	icon_state = "swall12"
 	},
 /area/shuttle/escape)
 "fGD" = (
@@ -94938,8 +94680,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "fRL" = (
@@ -94955,8 +94697,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "fZO" = (
@@ -94981,15 +94723,15 @@
 "gmY" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "gyR" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
+	dir = 1;
 	icon_state = "whiteblue";
-	dir = 1
+	tag = "icon-whiteblue (NORTH)"
 	},
 /area/shuttle/escape)
 "gFG" = (
@@ -95061,8 +94803,8 @@
 /area/tcommsat/chamber)
 "hJi" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "whiteblue";
+	tag = "icon-whiteblue"
 	},
 /area/shuttle/escape)
 "iau" = (
@@ -95076,8 +94818,8 @@
 /obj/item/tank/emergency_oxygen/engi,
 /obj/item/tank/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "ioI" = (
@@ -95086,8 +94828,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "iwt" = (
@@ -95145,8 +94887,8 @@
 "iPL" = (
 /obj/structure/sign/greencross,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/escape)
 "iUc" = (
@@ -95165,9 +94907,9 @@
 /area/shuttle/escape)
 "jnJ" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/door_control{
 	id = "adminshuttleblast";
@@ -95201,9 +94943,9 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/shuttle/escape)
 "jPN" = (
@@ -95241,9 +94983,9 @@
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
+	dir = 4;
 	icon_state = "whiteblue";
-	dir = 4
+	tag = "icon-whiteblue (EAST)"
 	},
 /area/shuttle/escape)
 "kcF" = (
@@ -95258,8 +95000,8 @@
 /obj/structure/table/wood,
 /obj/item/deck/cards,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "kjI" = (
@@ -95292,8 +95034,8 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "kCz" = (
@@ -95308,8 +95050,8 @@
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "kHU" = (
@@ -95340,13 +95082,13 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "kNZ" = (
@@ -95378,8 +95120,8 @@
 "law" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/escape)
 "lax" = (
@@ -95390,15 +95132,15 @@
 /area/shuttle/escape)
 "ldp" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "leU" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_f10"
 	},
 /area/shuttle/escape)
 "lkw" = (
@@ -95458,9 +95200,9 @@
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
+	dir = 2;
 	icon_state = "swall_f6";
-	dir = 2
+	tag = "icon-swall_f6"
 	},
 /area/shuttle/pod_3)
 "mkE" = (
@@ -95497,8 +95239,8 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "mxT" = (
@@ -95528,8 +95270,8 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "mMw" = (
@@ -95602,8 +95344,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "nIj" = (
@@ -95661,8 +95403,8 @@
 "oyv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "oDA" = (
@@ -95670,8 +95412,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "oOZ" = (
@@ -95712,8 +95454,8 @@
 "oUw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/reagent_containers/food/drinks/mug/med,
 /turf/simulated/floor/plasteel{
@@ -95781,11 +95523,26 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
+"pEb" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Singularity";
+	name = "Singularity Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "pGQ" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "pZO" = (
@@ -95838,9 +95595,9 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHEAST)";
+	dir = 5;
 	icon_state = "whiteblue";
-	dir = 5
+	tag = "icon-whiteblue (NORTHEAST)"
 	},
 /area/shuttle/escape)
 "qFg" = (
@@ -95924,8 +95681,8 @@
 "rAt" = (
 /obj/structure/extinguisher_cabinet,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+	dir = 2;
+	icon_state = "swall3"
 	},
 /area/shuttle/escape)
 "rEw" = (
@@ -95950,8 +95707,8 @@
 /obj/item/wrench,
 /obj/item/radio,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "rIF" = (
@@ -96032,9 +95789,9 @@
 /area/crew_quarters/dorms)
 "sPV" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-browncorner (EAST)";
+	dir = 4;
 	icon_state = "browncorner";
-	dir = 4
+	tag = "icon-browncorner (EAST)"
 	},
 /area/shuttle/escape)
 "sUK" = (
@@ -96096,9 +95853,9 @@
 	},
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
+	dir = 2;
 	icon_state = "swall_f5";
-	dir = 2
+	tag = "icon-swall_f5"
 	},
 /area/shuttle/pod_3)
 "uxy" = (
@@ -96130,16 +95887,16 @@
 /area/shuttle/administration)
 "uDK" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/space,
 /area/space/nearstation)
 "uXX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
@@ -96312,9 +96069,9 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHEAST)";
+	dir = 6;
 	icon_state = "whiteblue";
-	dir = 6
+	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/shuttle/escape)
 "xlr" = (
@@ -96325,15 +96082,15 @@
 /area/crew_quarters/dorms)
 "xlz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "xnj" = (
@@ -96341,12 +96098,12 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "xtk" = (
@@ -96381,8 +96138,8 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "xBR" = (
@@ -96391,8 +96148,8 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
+	dir = 1;
+	icon_state = "bot"
 	},
 /area/shuttle/escape)
 "xTB" = (
@@ -96405,15 +96162,15 @@
 "xVt" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	dir = 2;
+	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -96425,8 +96182,8 @@
 	req_access_txt = "101"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -120668,7 +120425,7 @@ aaa
 aaa
 aaa
 aaa
-acF
+atM
 acW
 adr
 adK
@@ -122577,7 +122334,7 @@ cKb
 cOX
 cSU
 dsI
-cVj
+acF
 cVj
 cVj
 cVx
@@ -122850,9 +122607,9 @@ daG
 cSU
 cSC
 cTt
-cTy
+cUD
 cTt
-cUn
+cUF
 cSU
 cSU
 cSU
@@ -123095,7 +122852,7 @@ cOg
 cSl
 dbr
 cVF
-cOg
+cVj
 cWP
 cVj
 cYE
@@ -123352,7 +123109,7 @@ cOg
 cVj
 cVj
 cVD
-cWs
+cWH
 cWN
 cWH
 cYD
@@ -123609,11 +123366,11 @@ cOg
 cSp
 cTH
 cTH
-cWt
+cTH
 cXi
-cHh
-cMZ
-cNk
+cVj
+cVj
+cOg
 cSv
 deF
 dfk
@@ -123871,7 +123628,7 @@ cWS
 dbr
 dbr
 cZO
-cVq
+cSv
 cRb
 cRp
 dfo
@@ -124125,11 +123882,11 @@ dtb
 dtl
 cVj
 cXy
-cVj
-cVj
-cNj
+cMZ
+cMZ
+cZR
 cSN
-cRb
+cWs
 cRq
 dfo
 dgE
@@ -124384,7 +124141,7 @@ cWC
 cXx
 dbs
 cYF
-cNW
+cQG
 cSx
 cRf
 cRp
@@ -125159,7 +124916,7 @@ cOa
 cQb
 deA
 dfq
-cVS
+cSv
 dfo
 cSF
 afO
@@ -125669,7 +125426,7 @@ cSl
 cXH
 dbG
 cZf
-cNk
+acF
 cVj
 deC
 dfs
@@ -126440,7 +126197,7 @@ cWI
 cXI
 cSU
 cZl
-cOd
+cQF
 cVp
 cRb
 cRp
@@ -126696,10 +126453,10 @@ cYR
 cZM
 cXN
 cSU
-cVj
+cVS
 cZR
 cVq
-cRb
+cWt
 cRp
 dfo
 dgE
@@ -126955,8 +126712,8 @@ cXM
 cYo
 cZE
 cZQ
-cVq
-cRb
+cSv
+pEb
 cRp
 dfo
 afO
@@ -127739,7 +127496,7 @@ cSC
 cTt
 cUq
 cTt
-cUn
+cUF
 dib
 dbQ
 cUI
@@ -127990,7 +127747,7 @@ daj
 cSU
 cTm
 cTt
-cTA
+cUE
 cTt
 cUo
 cSU

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -95325,15 +95325,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
-"mJq" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "mMw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -95945,15 +95936,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"vfN" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "vup" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -95990,21 +95972,6 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
-"vIU" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Singularity";
-	name = "Singularity Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
 "vJw" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
@@ -96085,6 +96052,21 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
+"wyr" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Singularity";
+	name = "Singularity Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "wHx" = (
 /obj/machinery/door/airlock/shuttle/glass{
 	name = "Shuttle Cargo Hatch"
@@ -96143,6 +96125,15 @@
 	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/shuttle/escape)
+"xio" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "xlr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -96175,6 +96166,15 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
+"xqR" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "xtk" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -125499,7 +125499,7 @@ cOg
 cVj
 deC
 dfs
-vfN
+xqR
 dfo
 cSF
 afO
@@ -125755,7 +125755,7 @@ cYZ
 cQG
 cVc
 cVy
-mJq
+xio
 cVT
 dfo
 cSF
@@ -126782,7 +126782,7 @@ cYo
 cZE
 cZQ
 cSv
-vIU
+wyr
 cRp
 dfo
 afO

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -422,11 +422,13 @@
 	},
 /area/security/main)
 "acF" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/turf/simulated/floor/plating,
+/area/security/prisonershuttle)
 "acG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -11015,14 +11017,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/siberia)
-"atM" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/security/prisonershuttle)
 "atN" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -75858,11 +75852,10 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cHh" = (
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -78996,14 +78989,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
-"cMZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "cNa" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/watertank,
@@ -79067,6 +79052,17 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"cNj" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "cNl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -82534,6 +82530,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
+"cTy" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/engine/engineering)
 "cTz" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -82542,6 +82548,16 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/engine/engineering)
+"cTA" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
@@ -83032,6 +83048,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
+"cUn" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
+/area/engine/engineering)
 "cUo" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
@@ -83183,33 +83206,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"cUD" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
-"cUE" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
-"cUF" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating/airless,
-/area/engine/engineering)
 "cUG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -83891,14 +83887,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
-"cVS" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "cVT" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/structure/cable/yellow{
@@ -84121,56 +84109,6 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
-"cWs" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Singularity";
-	name = "Singularity Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
-"cWt" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Singularity";
-	name = "Singularity Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/engine/engineering)
 "cWu" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -86044,17 +85982,6 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
-"cZR" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -94654,12 +94581,36 @@
 	icon_state = "redcorner"
 	},
 /area/shuttle/escape)
+"eDN" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Singularity";
+	name = "Singularity Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "eJA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/wall,
 /area/maintenance/fsmaint)
+"eLr" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "eTE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	req_access_txt = "0"
@@ -94686,11 +94637,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"fmm" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "fpO" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
 /area/shuttle/escape)
+"fxm" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "fyM" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex/nitrile,
@@ -94752,6 +94718,14 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
+"fVd" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "fZO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/medic,
@@ -95844,6 +95818,15 @@
 	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
+"tbu" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/engine/engineering)
 "tbC" = (
 /obj/structure/chair{
 	dir = 4
@@ -96052,7 +96035,13 @@
 	icon_state = "dark"
 	},
 /area/shuttle/escape)
-"wyr" = (
+"wHx" = (
+/obj/machinery/door/airlock/shuttle/glass{
+	name = "Shuttle Cargo Hatch"
+	},
+/turf/simulated/floor/plasteel,
+/area/shuttle/escape)
+"wJb" = (
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -96061,18 +96050,22 @@
 	opacity = 0
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
-"wHx" = (
-/obj/machinery/door/airlock/shuttle/glass{
-	name = "Shuttle Cargo Hatch"
-	},
-/turf/simulated/floor/plasteel,
-/area/shuttle/escape)
 "wOS" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -96125,15 +96118,6 @@
 	tag = "icon-whiteblue (SOUTHEAST)"
 	},
 /area/shuttle/escape)
-"xio" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "xlr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -96166,15 +96150,6 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
-"xqR" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/engineering)
 "xtk" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -96258,6 +96233,31 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"yis" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Singularity";
+	name = "Singularity Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/engine/engineering)
 "ylx" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
@@ -118953,13 +118953,13 @@ aaa
 aaa
 aaa
 aaa
-atM
+acF
 auy
-atM
+acF
 adZ
-atM
+acF
 auy
-atM
+acF
 akZ
 akZ
 akZ
@@ -120494,7 +120494,7 @@ aaa
 aaa
 aaa
 aaa
-atM
+acF
 acW
 adr
 adK
@@ -122403,7 +122403,7 @@ cKb
 cOX
 cSU
 dsI
-acF
+fmm
 cVj
 cVj
 cVx
@@ -122676,16 +122676,16 @@ daG
 cSU
 cSC
 cTt
-cUD
+cTy
 cTt
-cUF
+cUn
 cSU
 cSU
 cSU
 cSC
 cTt
-cUD
-cUF
+cTy
+cUn
 cSU
 cSU
 aaa
@@ -122925,7 +122925,7 @@ cVj
 cWP
 cVj
 cYE
-cHh
+tbu
 cRw
 cQY
 cRo
@@ -123951,11 +123951,11 @@ dtb
 dtl
 cVj
 cXy
-cMZ
-cMZ
-cZR
+cHh
+cHh
+cNj
 cSN
-cWs
+wJb
 cRq
 dfo
 dgE
@@ -125499,7 +125499,7 @@ cOg
 cVj
 deC
 dfs
-xqR
+eLr
 dfo
 cSF
 afO
@@ -125755,7 +125755,7 @@ cYZ
 cQG
 cVc
 cVy
-xio
+fxm
 cVT
 dfo
 cSF
@@ -126522,10 +126522,10 @@ cYR
 cZM
 cXN
 cSU
-cVS
-cZR
+fVd
+cNj
 cVq
-cWt
+yis
 cRp
 dfo
 dgE
@@ -126782,7 +126782,7 @@ cYo
 cZE
 cZQ
 cSv
-wyr
+eDN
 cRp
 dfo
 afO
@@ -127565,7 +127565,7 @@ cSC
 cTt
 cUq
 cTt
-cUF
+cUn
 dib
 dbQ
 cUI
@@ -127816,7 +127816,7 @@ daj
 cSU
 cTm
 cTt
-cUE
+cTA
 cTt
 cUo
 cSU
@@ -127824,7 +127824,7 @@ cSU
 cSU
 cTm
 cTt
-cUE
+cTA
 cUK
 cSU
 cSU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Separates the engine SMES output (the one on the left) from the station SMESs on the right.
Cyan cables = emitter cables.
Yellow cables = the tesla coils/rad collectors.
Potentially fixes #14346

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/44811257/103976471-6d62a100-513c-11eb-9d1c-645123863423.png)

## Changelog
:cl:
tweak: Separated the engine grid into two separate grids. One for the emitters, and one for the rad collectors/tesla coils.
fix: Should fix the station SMESs from draining the engine SMES/emitters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
