### PR TITLE
Adds better logging for to_chat. Fixes update_inv_wear_mask runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -926,6 +926,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(wear_mask && (istype(wear_mask, /obj/item/clothing/mask) || istype(wear_mask, /obj/item/clothing/accessory)))
 		if(!(slot_wear_mask in check_obscured_slots()))
 			var/obj/item/organ/external/head/head_organ = get_organ("head")
+			if(!head_organ)
+				return // Nothing to update here
 			var/datum/sprite_accessory/alt_heads/alternate_head
 			if(head_organ.alt_head && head_organ.alt_head != "None")
 				alternate_head = GLOB.alt_heads_list[head_organ.alt_head]

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -296,13 +296,11 @@ var/to_chat_src
 			targetstring += ", [D.type]"
 
 		// The final output
-		log_runtime(new/exception("DEBUG: to_chat called with invalid message/target.", to_chat_filename, to_chat_line), to_chat_src, list("Message: '[message]'", "Target: [targetstring]"))
-		return
+		CRASH("DEBUG: to_chat called with invalid message/target. Message: '[message]'. Target: [targetstring].")
 
 	else if(is_valid_tochat_message(message))
 		if(istext(target))
-			log_runtime(EXCEPTION("Somehow, to_chat got a text as a target"))
-			return
+			CRASH("Somehow, to_chat got a text as a target, message: '[message]', target: '[target]'")
 
 		message = replacetext(message, "\n", "<br>")
 


### PR DESCRIPTION
## What Does This PR Do
Fixes a bug where `update_inv_wear_mask` could cause a runtime if it was called when the owner did not have a head. 
Adds better logging for `to_chat` being called incorrectly


Fixes:
```
Runtime in update_icons.dm,930: Cannot read null.alt_head
   proc name: update inv wear mask (/mob/living/carbon/human/update_inv_wear_mask)
   src: Unknown (/mob/living/carbon/human)
   src.loc: the lava (117,153,3) (/turf/simulated/floor/plating/lava/smooth)
   call stack:
   Unknown (/mob/living/carbon/human): update inv wear mask()
   Unknown (/mob/living/carbon/human): head update(the gladiator helmet (/obj/item/clothing/head/helmet/gladiator), null)
   Unknown (/mob/living/carbon/human): unEquip(the gladiator helmet (/obj/item/clothing/head/helmet/gladiator), null)
   NAME\'s head (/obj/item/organ/external/head): remove(Unknown (/mob/living/carbon/human), 1)
   NAME\'s head (/obj/item/organ/external/head): Destroy(0)
   NAME\'s head (/obj/item/organ/external/head): Destroy(0)
   qdel(NAME\'s head (/obj/item/organ/external/head), 0)
   the upper body (/obj/item/organ/external/chest): Destroy(0)
   qdel(the upper body (/obj/item/organ/external/chest), 0)
   the necropolis tendril nest (/obj/structure/lavaland/ash_walker): consume()
   the necropolis tendril nest (/obj/structure/lavaland/ash_walker): process(10)
   Processing (/datum/controller/subsystem/processing): fire(0)
   Processing (/datum/controller/subsystem/processing): ignite(0)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
```


## Why It's Good For The Game
Better logging is always good. Bug fix as well

## Changelog
No func changes