### PR TITLE
Removes refilling code from drinks for borgs. This fixes the shaker refilling issue.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -36,12 +36,6 @@
 	if(istype(M, /mob/living/carbon))
 		var/mob/living/carbon/C = M
 		if(C.eat(src, user))
-			if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-				var/mob/living/silicon/robot/borg = user
-				borg.cell.use(30)
-				var/refill = reagents.get_master_reagent_id()
-				if(refill in GLOB.drinks) // Only synthesize drinks
-					addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, bitesize), 600)
 			return TRUE
 	return FALSE
 
@@ -72,23 +66,8 @@
 			to_chat(user, "<span class='warning'> [target] is full.</span>")
 			return FALSE
 
-		var/datum/reagent/refill
-		var/datum/reagent/refillName
-		if(isrobot(user))
-			refill = reagents.get_master_reagent_id()
-			refillName = reagents.get_master_reagent_name()
-
 		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'> You transfer [trans] units of the solution to [target].</span>")
-
-		if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-			if(refill in GLOB.drinks) // Only synthesize drinks
-				var/mob/living/silicon/robot/bro = user
-				var/chargeAmount = max(30,4*trans)
-				bro.cell.use(chargeAmount)
-				to_chat(user, "<span class='notice'>Now synthesizing [trans] units of [refillName]...</span>")
-				addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, trans), 300)
-				addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, user, "<span class='notice'>Cyborg [src] refilled.</span>"), 300)
 
 	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
 		if(!is_refillable())

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -331,7 +331,7 @@
 /obj/item/robot_module/butler/respawn_consumable(var/mob/living/silicon/robot/R)
 	if(emag)
 		var/obj/item/reagent_containers/food/drinks/cans/beer/B = emag
-		B.reagents.add_reagent("beer2", 2)
+		B.reagents.add_reagent("beer2", 5)
 	..()
 
 /obj/item/robot_module/butler/add_languages(var/mob/living/silicon/robot/R)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes the legacy code that made drink containers in borg inventories refill with power. As this removes their emag item, beer2's ability to refill on its own, the rate beer2 refills in chargers have been raised from 2 units per charge tick to 5 units per charge tick.

It also stops borg shakers from auto refilling every time you try to empty them.

Fixes #12975

## Why It's Good For The Game
The refilling code is no longer needed because service borgs now have their reagent dispensers. The refill rate on beer2 can easily be reverted if unwanted, I just felt I shouldn't only remove the recharging without giving them something back.

To clarify, this PR exists mostly to fix the bug that make shakers auto refill with whatever drink was mixed in them, making them useless.

## Changelog
:cl:
del: Removed legacy code that refilled drink containers in borg inventories.
tweak: Increased recharge rate of beer2 in a cyborg recharger from 2 to 5.
fix: Shakers no longer keep refilling the drink that was mixed in them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
