### PR TITLE
Allows Janitor borg's EMAG lube to refill in a charger

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -295,6 +295,12 @@
 
 	fix_modules()
 
+/obj/item/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R)
+	if(emag)
+		var/obj/item/reagent_containers/spray/S = emag
+		S.reagents.add_reagent("lube", 5)
+	..()
+
 /obj/item/robot_module/butler
 	name = "service robot module"
 	module_type = "Service"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -295,7 +295,7 @@
 
 	fix_modules()
 
-/obj/item/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R)
+/obj/item/robot_module/janitor/respawn_consumable(mob/living/silicon/robot/R)
 	if(emag)
 		var/obj/item/reagent_containers/spray/S = emag
 		S.reagents.add_reagent("lube", 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Janitor borg's get a lube spray bottle as their EMAG item, however, they can not refill it. This PR makes it so it refills at 5 units per tick in a recharger.

## Why It's Good For The Game
Having your EMAG item be limited use isn't fun, and janitor borgs don't get a particularly strong one anyway. I feel like this is nothing more than a QoL fix for them, with how infrequent it even comes up.


## Changelog
:cl:
add: Emaged janitor borg space lube now refills in a charger at 5 units per tick.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
