### PR TITLE
Improves existing projectile logging. Deflect/Reflect etc

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -295,15 +295,6 @@
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
 	apply_damage(5, BRUTE, affecting, run_armor_check(affecting, "melee"))
 
-/mob/living/carbon/human/bullet_act()
-	if(mind && mind.martial_art && mind.martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
-		if(!prob(mind.martial_art.deflection_chance))
-			return ..()
-		if(!src.lying && !(HULK in mutations)) //But only if they're not lying down, and hulks can't do it
-			visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
-			return 0
-	..()
-
 /mob/living/carbon/human/get_restraining_item()
 	. = ..()
 	if(!. && istype(wear_suit, /obj/item/clothing/suit/straight_jacket))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -11,33 +11,40 @@ emp_act
 
 /mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone)
 	if(!dna.species.bullet_act(P, src))
+		add_attack_logs(P.firer, src, "hit by [P.type] but got deflected by species '[dna.species]'")
 		return FALSE
 	if(P.is_reflectable)
 		var/can_reflect = check_reflect(def_zone)
-		if(can_reflect == 1) // proper reflection
+		var/reflected = FALSE
+
+		switch(can_reflect)
+			if(1) // proper reflection
+				reflected = TRUE
+			if(2) //If target is holding a toy sword
+				var/static/list/safe_list = list(/obj/item/projectile/beam/lasertag, /obj/item/projectile/beam/practice)
+				reflected = is_type_in_list(P, safe_list) //And it's safe
+
+		if(reflected)
 			visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
-						"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
+				   "<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
+			add_attack_logs(P.firer, src, "hit by [P.type] but got reflected")
 			P.reflect_back(src)
-			return -1 // complete projectile permutation
-
-		else if(can_reflect == 2) //If target is holding a toy sword
-			var/list/safe_list = list(/obj/item/projectile/beam/lasertag, /obj/item/projectile/beam/practice)
-			if(is_type_in_list(P, safe_list)) //And it's safe
-				visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
-				   "<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")		
-				P.reflect_back(src)
-				return -1 // complete projectile permutation
-
+			return -1
 
 	//Shields
 	if(check_shields(P, P.damage, "the [P.name]", PROJECTILE_ATTACK, P.armour_penetration))
 		P.on_hit(src, 100, def_zone)
 		return 2
 
+	if(mind?.martial_art?.deflection_chance) //Some martial arts users can deflect projectiles!
+		if(!lying && !(HULK in mutations) && prob(mind.martial_art.deflection_chance)) //But only if they're not lying down, and hulks can't do it
+			add_attack_logs(P.firer, src, "hit by [P.type] but got deflected by martial arts '[mind.martial_art]'")
+			visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+			return FALSE
+
 	var/obj/item/organ/external/organ = get_organ(check_zone(def_zone))
 	if(isnull(organ))
-		. = bullet_act(P, "chest") //act on chest instead
-		return
+		return bullet_act(P, "chest") //act on chest instead
 
 	organ.add_autopsy_data(P.name, P.damage) // Add the bullet's name to the autopsy data
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -148,19 +148,18 @@
 			L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 								"<span class='userdanger'>[L] is hit by \a [src][organ_hit_text]!</span>")	//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 
-	var/reagent_note
-	var/has_reagents = FALSE
+	var/additional_log_text
+	if(blocked)
+		additional_log_text = " [blocked]% blocked"
 	if(reagents && reagents.reagent_list)
-		reagent_note = " REAGENTS:"
+		var/reagent_note = "REAGENTS:"
 		for(var/datum/reagent/R in reagents.reagent_list)
 			reagent_note += R.id + " ("
 			reagent_note += num2text(R.volume) + ") "
-			has_reagents = TRUE
+		additional_log_text = "[additional_log_text] (containing [reagent_note])"
+
 	if(!log_override && firer && !alwayslog)
-		if(has_reagents)
-			add_attack_logs(firer, L, "Shot with a [type] (containing [reagent_note])")
-		else
-			add_attack_logs(firer, L, "Shot with a [type]")
+		add_attack_logs(firer, L, "Shot with a [type][additional_log_text]")
 	return L.apply_effects(stun, weaken, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
 
 /obj/item/projectile/proc/get_splatter_blockage(var/turf/step_over, var/atom/target, var/splatter_dir, var/target_loca) //Check whether the place we want to splatter blood is blocked (i.e. by windows).


### PR DESCRIPTION
## What Does This PR Do
Improves existing projectile logging.

1. Logs deflects by the species
2. Logs deflects by martial arts
3. Logs reflects by worn items
4. Adds the percentage of the damage that got blocked (if applicable)
5. Fixes a bug where deflecting a bullet would add a log record to your autopsy data. 

## Why It's Good For The Game
Gives admins more needed info

## Images of changes
![image](https://user-images.githubusercontent.com/15887760/104296463-eb6ad300-54c1-11eb-94d9-1b55f8b32621.png)


## Changelog
:cl:
tweak: Logs projectile deflects by the species
tweak: Logs projectile deflects by martial arts
tweak: Logs projectile reflects by worn items
tweak: Adds the percentage of the damage that got blocked (if applicable)
fix: Deflecting a projectile with martial arts now won't generate an autopsy log saying you got hit
/:cl: