### PR TITLE
Makes emaging make cloners malfunction

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -439,9 +439,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 		anchored = TRUE
 
 /obj/machinery/clonepod/emag_act(user)
-	if(isnull(occupant))
-		return
-	go_out()
+	malfunction()
 
 /obj/machinery/clonepod/proc/update_clone_antag(var/mob/living/carbon/human/H)
 	// Check to see if the clone's mind is an antagonist of any kind and handle them accordingly to make sure they get their spells, HUD/whatever else back.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Changes emaging a cloning pod from simply ejecting the occupent, to calling malfunction like an EMP can, stopping the clone and making it a mess.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Emaging a cloning pod right now is sorta useful, you can early eject the person to kill them. The issue is, emping the pod is cheaper, and better, with the chance to outright stop the cloning in process. Thus, a small change to make emaging have the same potential effect EMP'd, seems reasonable.

## Changelog
:cl:
tweak: Emaging a cloning pod now causes the cloning pod to stop cloning and malfunction, instead of ejecting the half cloned occupant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
