### PR TITLE
Makes the plasmacutter and spellblade not delete cut of limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -104,11 +104,12 @@ emp_act
 	var/obj/item/organ/external/affecting = get_organ(check_zone(def_zone))
 	if(affecting && !affecting.cannot_amputate && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))
 		var/damtype = DROPLIMB_SHARP
-		switch(P.damage_type)
-			if(BRUTE)
-				damtype = DROPLIMB_BLUNT
-			if(BURN)
-				damtype = DROPLIMB_BURN
+		if(!P.sharp)
+			switch(P.damage_type)
+				if(BRUTE)
+					damtype = DROPLIMB_BLUNT
+				if(BURN)
+					damtype = DROPLIMB_BURN
 
 		affecting.droplimb(FALSE, damtype)
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -315,6 +315,7 @@
 	damage = 15
 	damage_type = BURN
 	flag = "magic"
+	sharp = TRUE
 	dismemberment = 50
 	nodamage = 0
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -246,6 +246,7 @@
 	damage = 5
 	range = 3
 	dismemberment = 20
+	sharp = TRUE
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 
 /obj/item/projectile/plasma/on_hit(atom/target)


### PR DESCRIPTION
## What Does This PR Do
As the title says. If projectiles are sharp and can dismember then they will dismember them in a clean way.
Only the case for the plasmacutter and spellblade now. The sniper still deletes limbs.

## Why It's Good For The Game
A plasma cutter cuts. It doesn't obliterate limbs. Same goes for the spell blade which projectiles look like sharp disks

## Changelog
:cl:
tweak: Plasmacutter shots now won't delete limbs. Instead they will be dismembered
tweak: Spellblade shots now won't delete limbs. Instead they will be dismembered
/:cl: