### PR TITLE
Sharp kitchen utensils

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -465,9 +465,9 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
 	new /datum/stack_recipe("plastic crate", /obj/structure/closet/crate/plastic, 10, one_per_turf = 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic ashtray", /obj/item/ashtray/plastic, 2, one_per_turf = 1, on_floor = 1), \
-	new /datum/stack_recipe("plastic fork", /obj/item/kitchen/utensil/pfork, 1, on_floor = 1), \
-	new /datum/stack_recipe("plastic spoon", /obj/item/kitchen/utensil/pspoon, 1, on_floor = 1), \
-	new /datum/stack_recipe("plastic spork", /obj/item/kitchen/utensil/pspork, 1, on_floor = 1), \
+	new /datum/stack_recipe("plastic fork", /obj/item/kitchen/utensil/fork/plastic, 1, on_floor = 1), \
+	new /datum/stack_recipe("plastic spoon", /obj/item/kitchen/utensil/spoon/plastic, 1, on_floor = 1), \
+	new /datum/stack_recipe("plastic spork", /obj/item/kitchen/utensil/spork/plastic, 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic knife", /obj/item/kitchen/knife/plastic, 1, on_floor = 1), \
 	new /datum/stack_recipe("plastic bag", /obj/item/storage/bag/plasticbag, 3, on_floor = 1), \
 	new /datum/stack_recipe("bear mould", /obj/item/kitchen/mould/bear, 1, on_floor = 1), \

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -29,7 +29,7 @@
 	attack_verb = list("attacked", "stabbed", "poked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
-	sharp = FALSE
+	sharp = TRUE
 	var/max_contents = 1
 
 /obj/item/kitchen/utensil/Initialize(mapload)
@@ -68,6 +68,7 @@
 	name = "plastic fork"
 	desc = "Yay, no washing up to do."
 	icon_state = "pfork"
+	sharp = FALSE
 
 /obj/item/kitchen/utensil/spoon
 	name = "spoon"
@@ -79,6 +80,7 @@
 	name = "plastic spoon"
 	desc = "It's a plastic spoon. How dull."
 	icon_state = "pspoon"
+	sharp = FALSE
 
 /obj/item/kitchen/utensil/spork
 	name = "spork"
@@ -90,6 +92,7 @@
 	name = "plastic spork"
 	desc = "It's a plastic spork. It's the fork side of the spoon!"
 	icon_state = "pspork"
+	sharp = FALSE
 
 /*
  * Knives

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -75,12 +75,12 @@
 	desc = "It's a spoon. You can see your own upside-down face in it."
 	icon_state = "spoon"
 	attack_verb = list("attacked", "poked")
+	sharp = FALSE // It's a spoon.
 
 /obj/item/kitchen/utensil/spoon/plastic
 	name = "plastic spoon"
 	desc = "It's a plastic spoon. How dull."
 	icon_state = "pspoon"
-	sharp = FALSE
 
 /obj/item/kitchen/utensil/spork
 	name = "spork"

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -17,34 +17,31 @@
 	origin_tech = "materials=1"
 
 
-
-
 /*
  * Utensils
  */
 /obj/item/kitchen/utensil
-	force = 5.0
+	force = 5
 	w_class = WEIGHT_CLASS_TINY
-	throwforce = 0.0
 	throw_speed = 3
 	throw_range = 5
 	flags = CONDUCT
 	attack_verb = list("attacked", "stabbed", "poked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
-	sharp = 0
+	sharp = FALSE
 	var/max_contents = 1
 
-/obj/item/kitchen/utensil/New()
-	..()
+/obj/item/kitchen/utensil/Initialize(mapload)
+	. = ..()
 	if(prob(60))
-		src.pixel_y = rand(0, 4)
-
+		pixel_y = rand(0, 4)
 	create_reagents(5)
 
-/obj/item/kitchen/utensil/attack(mob/living/carbon/C, mob/living/carbon/user)
-	if(!istype(C))
+/obj/item/kitchen/utensil/attack(mob/living/M, mob/living/carbon/user, def_zone)
+	if(!iscarbon(M))
 		return ..()
+	var/mob/living/carbon/C = M
 
 	if(user.a_intent != INTENT_HELP)
 		if(user.zone_selected == "head" || user.zone_selected == "eyes")
@@ -60,7 +57,6 @@
 			if(C.eat(toEat, user))
 				toEat.On_Consume(C, user)
 				overlays.Cut()
-				return
 
 
 /obj/item/kitchen/utensil/fork
@@ -68,7 +64,7 @@
 	desc = "It's a fork. Sure is pointy."
 	icon_state = "fork"
 
-/obj/item/kitchen/utensil/pfork
+/obj/item/kitchen/utensil/fork/plastic
 	name = "plastic fork"
 	desc = "Yay, no washing up to do."
 	icon_state = "pfork"
@@ -79,11 +75,10 @@
 	icon_state = "spoon"
 	attack_verb = list("attacked", "poked")
 
-/obj/item/kitchen/utensil/pspoon
+/obj/item/kitchen/utensil/spoon/plastic
 	name = "plastic spoon"
 	desc = "It's a plastic spoon. How dull."
 	icon_state = "pspoon"
-	attack_verb = list("attacked", "poked")
 
 /obj/item/kitchen/utensil/spork
 	name = "spork"
@@ -91,11 +86,10 @@
 	icon_state = "spork"
 	attack_verb = list("attacked", "sporked")
 
-/obj/item/kitchen/utensil/pspork
+/obj/item/kitchen/utensil/spork/plastic
 	name = "plastic spork"
 	desc = "It's a plastic spork. It's the fork side of the spoon!"
 	icon_state = "pspork"
-	attack_verb = list("attacked", "sporked")
 
 /*
  * Knives


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Made all kitchen utensils sharp, except for the plastic versions and spoons. 
Also made the plastic ones a subtype of the regular ones.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Cutting food with a fork, scooping someone's brain out with a spork.

## Changelog
:cl:
tweak: Made kitchen utensils (Fork, Knife, Spork) sharp, so that they can cut food and cause bleeding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
