### PR TITLE
Fixes the Teleporter Console not updating the target list

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -33,8 +33,8 @@
 
 /obj/machinery/computer/process()
 	if(stat & (NOPOWER|BROKEN))
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/machinery/computer/extinguish_light()
 	set_light(0)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -8,13 +8,17 @@
 	icon_screen = "teleport"
 	icon_keyboard = "teleport_key"
 	circuit = /obj/item/circuitboard/teleporter
-	var/obj/item/gps/locked = null /// A GPS with a locked destination
-	var/regime = REGIME_TELEPORT /// Switches mode between teleporter, gate and gps
+	/// A GPS with a locked destination
+	var/obj/item/gps/locked = null
+	/// Switches mode between teleporter, gate and gps
+	var/regime = REGIME_TELEPORT
 	var/id = null
-	var/obj/machinery/teleport/station/power_station /// The power station that's connected to the console
-	var/calibrating = FALSE /// Whether calibration is in progress or not. Calibration prevents changes.
-	var/turf/target ///The target turf of the teleporter
-	var/target_list ///lists of suitable teleport targets, dependent on regime. Used in the UI
+	/// The power station that's connected to the console
+	var/obj/machinery/teleport/station/power_station
+	/// Whether calibration is in progress or not. Calibration prevents changes.
+	var/calibrating = FALSE
+	/// The target turf of the teleporter
+	var/turf/target
 
 	/* 	var/area_bypass is for one-time-use teleport cards (such as clown planet coordinates.)
 		Setting this to TRUE will set var/obj/item/gps/locked to null after a player enters the portal and will not allow hand-teles to open portals to that location.
@@ -22,17 +26,11 @@
 	var/area_bypass = FALSE
 	var/cc_beacon = FALSE
 
-/obj/machinery/computer/teleporter/New()
-	src.id = "[rand(1000, 9999)]"
-	link_power_station()
-	..()
-	return
-
 /obj/machinery/computer/teleporter/Initialize()
 	..()
 	link_power_station()
 	update_icon()
-	target_list = targets_teleport()
+	id = "[rand(1000, 9999)]"
 
 /obj/machinery/computer/teleporter/Destroy()
 	if(power_station)
@@ -98,7 +96,14 @@
 	data["target"] = (!target || !targetarea) ? "None" : sanitize(targetarea.name)
 	data["calibrating"] = calibrating
 	data["locked"] = locked ? TRUE : FALSE
-	data["targetsTeleport"] = target_list
+	data["targetsTeleport"] = null
+	switch(regime)
+		if(REGIME_TELEPORT)
+			data["targetsTeleport"] = targets_teleport()
+		if(REGIME_GATE)
+			data["targetsTeleport"] = targets_gate()
+		if(REGIME_GPS)
+			data["targetsTeleport"] = null //clears existing entries, target is added by load action
 	return data
 
 /obj/machinery/computer/teleporter/ui_act(action, params)
@@ -118,21 +123,15 @@
 		if("eject") //eject gps device
 			eject()
 		if("load") //load gps coordinates
-			target = locate(locked.locked_location.x,locked.locked_location.y,locked.locked_location.z)
+			target = locate(locked.locked_location.x, locked.locked_location.y, locked.locked_location.z)
 		if("setregime")
 			regime = text2num(params["regime"])
-			if(regime == REGIME_TELEPORT)
-				target_list = targets_teleport()
-			if(regime == REGIME_GATE)
-				target_list = targets_gate()
-			if(regime == REGIME_GPS)
-				target_list = null //clears existing entries, target is added by load action
 			resetPowerstation()
 			target = null
 		if("settarget")
 			resetPowerstation()
-			var/turf/tmpTarget = locate(text2num(params["x"]),text2num(params["y"]),text2num(params["z"]))
-			if(!istype(tmpTarget, /turf))
+			var/turf/tmpTarget = locate(text2num(params["x"]), text2num(params["y"]), text2num(params["z"]))
+			if(!isturf(tmpTarget))
 				atom_say("No valid targets available.")
 				return
 			target = tmpTarget
@@ -188,7 +187,6 @@
 		locked.loc = loc
 		locked = null
 	regime = REGIME_TELEPORT
-	target_list = targets_teleport()
 
 /**
 *	Creates a list of viable targets for the teleport. Helper function of ui_data

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -27,7 +27,7 @@
 	var/cc_beacon = FALSE
 
 /obj/machinery/computer/teleporter/Initialize()
-	..()
+	. = ..()
 	link_power_station()
 	update_icon()
 	id = "[rand(1000, 9999)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes the list of teleporter console destinations not updating unless you change the 'Regime' or reconstruct the console.
Also removed the `target_list` variable, since I've moved the list stuff to `ui_data()`.
Fixes #14680
Fixes #14717

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Moving the tracking beacon off of the bridge now actually does something, as does implanting a prisoner with a tracking implant.

Stops people being able to teleport directly into containment via the engine teleport beacon, even after it's been chosen and activated.

## Changelog
:cl:
fix: Fixed the Teleporter Console target list not being updated. (Tracking beacons and Tracking implants now actually show on the list correctly.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
