### PR TITLE
Antagonist playtime requirements increase

### DIFF
--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -11,30 +11,30 @@ GLOBAL_LIST_INIT(role_playtime_requirements, list(
 	ROLE_DRONE = 10, // High, because they're like mini engineering cyborgs that can ignore the AI, ventcrawl, and respawn themselves
 
 	// SOLO ANTAGS
-	ROLE_TRAITOR = 3,
-	ROLE_CHANGELING = 3,
-	ROLE_WIZARD = 3,
-	ROLE_VAMPIRE = 3,
-	ROLE_BLOB = 3,
+	ROLE_TRAITOR = 5,
+	ROLE_CHANGELING = 5,
+	ROLE_WIZARD = 50,
+	ROLE_VAMPIRE = 5,
+	ROLE_BLOB = 20,
 	ROLE_REVENANT = 3,
 	ROLE_BORER = 3,
-	ROLE_NINJA = 3,
-	ROLE_MORPH = 3,
-	ROLE_DEMON = 3,
+	ROLE_NINJA = 50,
+	ROLE_MORPH = 5,
+	ROLE_DEMON = 5,
 
 	// DUO ANTAGS
-	ROLE_GUARDIAN = 5,
+	ROLE_GUARDIAN = 20,
 	ROLE_GSPIDER = 5,
 
 	// TEAM ANTAGS
 	// Higher numbers here, because they require more experience to be played correctly
-	ROLE_SHADOWLING = 10,
+	ROLE_SHADOWLING = 40,
 	ROLE_REV = 10,
-	ROLE_OPERATIVE = 10,
-	ROLE_CULTIST = 10,
+	ROLE_OPERATIVE = 40,
+	ROLE_CULTIST = 20,
 	ROLE_RAIDER = 10,
 	ROLE_ALIEN = 10,
-	ROLE_ABDUCTOR = 10,
+	ROLE_ABDUCTOR = 20,
 ))
 
 // Client Verbs

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -13,12 +13,12 @@ GLOBAL_LIST_INIT(role_playtime_requirements, list(
 	// SOLO ANTAGS
 	ROLE_TRAITOR = 5,
 	ROLE_CHANGELING = 5,
-	ROLE_WIZARD = 50,
+	ROLE_WIZARD = 20,
 	ROLE_VAMPIRE = 5,
 	ROLE_BLOB = 20,
 	ROLE_REVENANT = 3,
 	ROLE_BORER = 3,
-	ROLE_NINJA = 50,
+	ROLE_NINJA = 20,
 	ROLE_MORPH = 5,
 	ROLE_DEMON = 5,
 
@@ -28,9 +28,9 @@ GLOBAL_LIST_INIT(role_playtime_requirements, list(
 
 	// TEAM ANTAGS
 	// Higher numbers here, because they require more experience to be played correctly
-	ROLE_SHADOWLING = 40,
+	ROLE_SHADOWLING = 20,
 	ROLE_REV = 10,
-	ROLE_OPERATIVE = 40,
+	ROLE_OPERATIVE = 20,
 	ROLE_CULTIST = 20,
 	ROLE_RAIDER = 10,
 	ROLE_ALIEN = 10,


### PR DESCRIPTION
## What Does This PR Do
Ups the playtime as crew needed to play the following antagonists:
- Minor Responsibility Solo Antags (Traitors / Changelings / Vampires): 3hs -> 5hs
- Major Responsibility Solo Antags (Wizard / Ninja): 3hs -> 20hs
- Minor Responsibility Team Antags (Cult / Abductor) 10hs -> 20hs
- Major Responsibility Team Antags (Nukies / Shadowlings): 10hs -> 20hs
- Blob: 3hs -> 20hs
- Holoparasite/Guardian: 5hs -> 20hs
- Morph/Slaughter Demon: 3hs -> 5hs

## Why It's Good For The Game
I made this PR for three reasons:
- Our current antagonist balance is "Overpowered but played by newbies so it's ok", this is most apparent with team antags like nukies, slings or cult; Upping the playtime is a step in the direction to seeing what mechanics are actually broken by taking into account that whoever is playing them knows how to correctly thrall someone, where their nukie uplink is located, how to carve runes, etc.
- Some of these antagonists are involved in gamemodes that end instantly once they die, so it's good to have someone that knows the bare minimum to not have the round end in less than twenty minutes (looking at you wizard)
- Holoparasites/Guardians are a huge expense on the traitor's part, having them be able to get a 5hs player seems unfair to them (I know that you can re-roll the holoparasite once, but you can still get another 5hs player / get none at all)

## Changelog
:cl:
tweak: Traitor, Changeling, Vampire, Morph and Slaughter demon had their playtime requirement increased to five hours.
tweak: Nuclear operatives, Shadowlings, Wizard, Ninja, Blob, Holoparasite, Cult and Abductors had their playtime requirement increased to twenty hours.
/:cl: