### PR TITLE
Adds a playstyle string to laughter demons

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -302,6 +302,11 @@
 	health = 175
 	melee_damage_lower = 25
 	melee_damage_upper = 25
+	playstyle_string = "<B>You are the Laughter Demon, an adorable creature from another existence. You have a single desire: to hug and tickle.  \
+						You may use the blood crawl icon when on blood pools to travel through them, appearing and dissapearing from the station at will. \
+						Pulling a dead or critical mob while you enter a pool will pull them in with you, allowing you to hug them. \
+						You move quickly upon leaving a pool of blood, but the material world will soon sap your strength and leave you sluggish. \
+						(You should be attacking people on harm intent, and not nuzzling them.)</B>"
 
 	attack_sound = 'sound/items/bikehorn.ogg'
 	feast_sound = 'sound/spookoween/scary_horn2.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Adds a playstyle string specific to laughter demons, partially for flavor, but mainly to prevent confusion of if laughter demons are supposed to nuzzle crew or attack them.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

See above, to avoid the confusion of a newer player getting demon, and nuzzling crew instead of attacking them to bring them to their hugspace.

## Changelog
:cl:
add: Laughter demons now have a playstyle string, to help indicate they do need to attack people, instead of nuzzling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
