### PR TITLE
Removes Malf AI Module from Ashwalker Nest

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -169,7 +169,6 @@
 /obj/structure/stone_tile/cracked{
 	dir = 8
 	},
-/obj/item/malf_upgrade,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "aB" = (


### PR DESCRIPTION
The malf module is an interesting addition, to be sure, but it doesn't work well, with Paradise.

Ashwalkers can't go as agrro as they can elsewhere, and our silicon policy and leniency lends itself towards AI players who are prone to validhunting and skirting their laws---not to mention Crewsimov isn't the order of the day either.

End result, a module like this just makes the AI even more effective at validhunting and it almost never gets utilized by the ashwalkers themselves, either, so it tends to just get scooped up by the crew quickly and given to the AI.

I don't think this is good for the game---even if our culture was different, I still kinda question if this should be included--while it certainly *is* very interesting, conceptually---I don't think it has a healthy impact on the overall gameflow.

:cl: Fox McCloud
del: Removes the malf AI module from the ashwalker ruin
/:cl: