### PR TITLE
Makes ai uploads inaccurately report their upload location to the AI, becoming more accurate the more it's done

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -537,7 +537,7 @@
 					var/obj/machinery/computer/supplycomp/SC = B
 					var/obj/item/circuitboard/supplycomp/C = circuit
 					SC.can_order_contraband = C.contraband_enabled
-				if(istype(circuit,/obj/item/circuitboard/aiupload))
+				if(istype(circuit, /obj/item/circuitboard/aiupload))
 					var/obj/machinery/computer/aiupload/AI = B
 					var/obj/item/circuitboard/aiupload/C = circuit
 					AI.uses = C.uses

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -104,6 +104,7 @@
 	name = "Circuit board (AI Upload)"
 	build_path = /obj/machinery/computer/aiupload
 	origin_tech = "programming=4;engineering=4"
+	var/uses = 0
 /obj/item/circuitboard/borgupload
 	name = "Circuit board (Cyborg Upload)"
 	build_path = /obj/machinery/computer/borgupload
@@ -536,6 +537,10 @@
 					var/obj/machinery/computer/supplycomp/SC = B
 					var/obj/item/circuitboard/supplycomp/C = circuit
 					SC.can_order_contraband = C.contraband_enabled
+				if(istype(circuit,/obj/item/circuitboard/aiupload))
+					var/obj/machinery/computer/aiupload/AI = B
+					var/obj/item/circuitboard/aiupload/C = circuit
+					AI.uses = C.uses
 				qdel(src)
 				return
 	if(user.a_intent == INTENT_HARM)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -132,6 +132,10 @@
 			var/obj/item/circuitboard/M = new circuit(A)
 			A.setDir(dir)
 			A.circuit = M
+			if(istype(src,/obj/machinery/computer/aiupload))
+				var/obj/machinery/computer/aiupload/AI = src
+				var/obj/item/circuitboard/aiupload/C = M //If you had a circuit that is not an ai upload circuit in an AI upload, someone was var edititng
+				C.uses = AI.uses
 			A.anchored = TRUE
 			if(stat & BROKEN)
 				if(user)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -132,7 +132,7 @@
 			var/obj/item/circuitboard/M = new circuit(A)
 			A.setDir(dir)
 			A.circuit = M
-			if(istype(src,/obj/machinery/computer/aiupload))
+			if(istype(src, /obj/machinery/computer/aiupload))
 				var/obj/machinery/computer/aiupload/AI = src
 				var/obj/item/circuitboard/aiupload/C = M //If you had a circuit that is not an ai upload circuit in an AI upload, someone was var edititng
 				C.uses = AI.uses

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -5,26 +5,10 @@
 	icon_keyboard = "med_key"
 	circuit = /obj/item/circuitboard/aiupload
 	var/mob/living/silicon/ai/current = null
-	var/opened = 0
+	var/uses = 0
 
 	light_color = LIGHT_COLOR_WHITE
 	light_range_on = 2
-
-
-// What the fuck even is this
-/obj/machinery/computer/aiupload/verb/AccessInternals()
-	set category = "Object"
-	set name = "Access Computer's Internals"
-	set src in oview(1)
-	if(get_dist(src, usr) > 1 || usr.restrained() || usr.lying || usr.stat || istype(usr, /mob/living/silicon))
-		return
-
-	opened = !opened
-	if(opened)
-		to_chat(usr, "<span class='notice'>The access panel is now open.</span>")
-	else
-		to_chat(usr, "<span class='notice'>The access panel is now closed.</span>")
-	return
 
 
 /obj/machinery/computer/aiupload/attackby(obj/item/O as obj, mob/user as mob, params)
@@ -61,7 +45,11 @@
 /obj/machinery/computer/aiupload/attack_ghost(user as mob)
 	return 1
 
-// Why is this not a subtype
+///obj/machinery/computer/aiupload/deconstruct()
+//	M.circuit.uses = uses
+//	..()
+
+
 /obj/machinery/computer/borgupload
 	name = "cyborg upload console"
 	desc = "Used to upload laws to Cyborgs."

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -45,11 +45,6 @@
 /obj/machinery/computer/aiupload/attack_ghost(user as mob)
 	return 1
 
-///obj/machinery/computer/aiupload/deconstruct()
-//	M.circuit.uses = uses
-//	..()
-
-
 /obj/machinery/computer/borgupload
 	name = "cyborg upload console"
 	desc = "Used to upload laws to Cyborgs."

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -21,6 +21,7 @@ AI MODULES
 	origin_tech = "programming=3"
 	materials = list(MAT_GOLD=50)
 	var/datum/ai_laws/laws = null
+	var/uses = 0
 
 /obj/item/aiModule/proc/install(var/obj/machinery/computer/C)
 	if(istype(C, /obj/machinery/computer/aiupload))
@@ -48,6 +49,7 @@ AI MODULES
 					to_chat(R, "These are your laws now:")
 					R.show_laws()
 			to_chat(usr, "<span class='notice'>Upload complete. The AI's laws have been modified.</span>")
+			comp.current.law_location_check(comp, src)
 
 	else if(istype(C, /obj/machinery/computer/borgupload))
 		var/obj/machinery/computer/borgupload/comp = C
@@ -88,6 +90,23 @@ AI MODULES
 	log_and_message_admins("used [src.name] on [target.name]([target.key])")
 
 /obj/item/aiModule/proc/addAdditionalLaws(var/mob/living/silicon/ai/target, var/mob/sender)
+
+/mob/living/silicon/ai/proc/law_location_check(var/obj/machinery/computer/aiupload/comp, var/obj/item/aiModule/A)
+	var/list/turfs = new/list()
+	var/found_turf = FALSE
+	for(var/turf/T in range(get_turf(comp), (max(1,(16 - comp.uses - A.uses)))))
+		if(istype(T, /turf/space) || istype(T, /turf/simulated/wall))
+			continue
+
+		turfs += T
+		found_turf = TRUE
+
+	if(found_turf)
+		var/turf/relay_location = pick(turfs)
+		to_chat(src, "<b>Law upload bounced off relay in [relay_location.loc], at X [relay_location.x] Y [relay_location.y]</b>")
+		src.mind.store_memory("Law upload bounced off relay in [relay_location.loc], at X [relay_location.x] Y [relay_location.y]")
+	comp.uses++
+	A.uses++
 
 
 /******************** Safeguard ********************/

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -91,11 +91,11 @@ AI MODULES
 
 /obj/item/aiModule/proc/addAdditionalLaws(var/mob/living/silicon/ai/target, var/mob/sender)
 
-/mob/living/silicon/ai/proc/law_location_check(var/obj/machinery/computer/aiupload/comp, var/obj/item/aiModule/A)
-	var/list/turfs = new/list()
+/mob/living/silicon/ai/proc/law_location_check(obj/machinery/computer/aiupload/comp, obj/item/aiModule/A)
+	var/list/turfs = list()
 	var/found_turf = FALSE
-	for(var/turf/T in range(get_turf(comp), (max(1,(16 - comp.uses - A.uses)))))
-		if(istype(T, /turf/space) || istype(T, /turf/simulated/wall))
+	for(var/turf/T in range(get_turf(comp), max(1, (16 - comp.uses - A.uses))))
+		if(isspaceturf(T)) || iswallturf(T))
 			continue
 
 		turfs += T
@@ -104,7 +104,7 @@ AI MODULES
 	if(found_turf)
 		var/turf/relay_location = pick(turfs)
 		to_chat(src, "<b>Law upload bounced off relay in [relay_location.loc], at X [relay_location.x] Y [relay_location.y]</b>")
-		src.mind.store_memory("Law upload bounced off relay in [relay_location.loc], at X [relay_location.x] Y [relay_location.y]")
+		mind.store_memory("Law upload bounced off relay in [relay_location.loc], at X [relay_location.x] Y [relay_location.y]")
 	comp.uses++
 	A.uses++
 

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -95,7 +95,7 @@ AI MODULES
 	var/list/turfs = list()
 	var/found_turf = FALSE
 	for(var/turf/T in range(get_turf(comp), max(1, (16 - comp.uses - A.uses))))
-		if(isspaceturf(T)) || iswallturf(T))
+		if(isspaceturf(T) || iswallturf(T))
 			continue
 
 		turfs += T


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR adds a uses variable to the ai upload computer, board, and circuit for the ai upload, increasing by 1 each time the board is used.

Every time a law is uploaded to the AI, it reports a tiles x and y within a 16 tile radius of the upload, and the room that that chosen tile is in. This is added to the ais notes as well.
However, each time this is done, the upload that was used, and the board that was used, has its uses go up by one. Then, if the same upload and board is used again to change the ais laws, it will instead pick a tile in a 16 - 1 - 1 radius, (14)
If a board is used 5 times, but a law upload is being used for the first time, it will be 16 -5 - 0, radius (11)

Removes the access internals verb to the Ai upload, as accessing internals does... nothing.

Adds some... specific checks to deconstruction / building of a computer, but rnd computers / cargo shuttle computers already do this, and there is no other way to make it keep track of the uploading otherwise.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Right now, we have a problem where occasionally a traitor will sit in maints / space with an upload, and each and every time command resets the AI, the traitor instantly subverts the AI, leading to an upload war, spamming logs, making ai and command miserable, and is fun for no one. The only way for command to stop this is to either: Move the AI off station, which will probably be subverted when they try, and ai will try to kill them, card the AI and turn off its interface, which sucks for the AI, being carded for the rest of the round with no interaction with any machines, or kill the AI, which is basically the same problem as carding it.

This PR means that the AI could report where the AI upload is located roughly, and help get security to that area to find it.

This does not give command these numbers, as crew could just know instantly when the AI is subverted by seeing the rough location of upload attempts.

Ideally, you would be able to card the AI and see these numbers as an option on the intelicard, but I do not know TGUI at all.

##TODO

- [x] Make deconstructing the ai upload put the uses variable on the circuit board. 


## Changelog
:cl:
add: Ai now knows roughly where a law change was applied, becoming more accurate the more a board / upload is used. This is saved in the AI's notes / memory
del: Removed the access internals verb from the AI upload.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
