### PR TITLE
Fixes Declaration of War HTML tags

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -48,7 +48,7 @@
 	if(!check_allowed(user) || !war_declaration)
 		return
 
-	GLOB.event_announcement.Announce(war_declaration, "Declaration of War", 'sound/effects/siren.ogg')
+	GLOB.event_announcement.Announce(war_declaration, "Declaration of War", 'sound/effects/siren.ogg', msg_sanitized = TRUE)
 
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 	to_chat(user, "<b>Your bonus telecrystals have been split between your team's uplinks.</b>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes the announcement message for the nukie Declaration of War not having HTML tags decoded.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It kind of ruins the effect of the declaration.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
**Before:** *(Taken from a real nukie round!)*
![hello #coding_chat!](https://user-images.githubusercontent.com/57483089/105118221-e3182680-5ac5-11eb-9e59-0031ab731a19.PNG)

**After:**
![fixed](https://user-images.githubusercontent.com/57483089/105118229-e7dcda80-5ac5-11eb-9d3e-dc86c7aaf9c1.PNG)

## Changelog
:cl:
fix: Fixed the message in the nukie Declaration of War not having its HTML tags decoded. (No more `&#39;`)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
