### PR TITLE
Species Bans!

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -21,6 +21,7 @@
 #define BANTYPE_APPEARANCE  6
 #define BANTYPE_ADMIN_PERMA	7
 #define BANTYPE_ADMIN_TEMP	8
+#define BANTYPE_SPECIES		9
 
 //Please don't edit these values without speaking to Errorage first	~Carn
 //Admin Permissions

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -387,8 +387,8 @@ SUBSYSTEM_DEF(ticker)
 			else if(!player.mind.assigned_role)
 				continue
 			else
-				player.create_character()
-				qdel(player)
+				if(player.create_character())
+					qdel(player)
 
 /datum/controller/subsystem/ticker/proc/equip_characters()
 	var/captainless = TRUE

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -121,12 +121,19 @@
 			else
 				race_list += GLOB.whitelisted_species
 
+
+			// Format the list
+			var/list/formatted_races = list()
+			for(var/species in race_list)
+				if(!is_species_banned(H.ckey, species))
+					formatted_races += species
+
 			var/datum/ui_module/appearance_changer/AC = ui_users[user]
 			if(!AC)
 				AC = new(src, user)
 				AC.name = "Magic Mirror"
 				AC.flags = APPEARANCE_ALL
-				AC.whitelist = race_list
+				AC.whitelist = formatted_races
 				ui_users[user] = AC
 			AC.ui_interact(user)
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -61,6 +61,7 @@ GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 // If it doesnt need to happen IMMEDIATELY on world load, make a subsystem for it
 /world/proc/startup_procs()
 	LoadBans() // Load up who is banned and who isnt. DONT PUT THIS IN A SUBSYSTEM IT WILL TAKE TOO LONG TO BE CALLED
+	load_all_species_bans() // Load up species bans. See above and below comments.
 	jobban_loadbanfile() // Load up jobbans. Again, DO NOT PUT THIS IN A SUBSYSTEM IT WILL TAKE TOO LONG TO BE CALLED
 	load_motd() // Loads up the MOTD (Welcome message players see when joining the server)
 	load_mode() // Loads up the gamemode

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -148,11 +148,15 @@ GLOBAL_DATUM_INIT(jobban_regex, /regex, regex("(\[\\S]+) - (\[^#]+\[^# ])(?: ## 
 
 	if(!client || !ckey)
 		return
+
 	if(config.ban_legacy_system)
 		//using the legacy .txt ban system
 		to_chat(src, "The server is using the legacy ban system. Ask an administrator for help!")
 
 	else
+		// Dont let the client melt the server with SQL queries on a macro'd verb
+		if(client.handle_db_verb_limit())
+			return
 		//using the SQL ban system
 		var/is_actually_banned = FALSE
 		var/datum/db_query/select_query = SSdbcore.NewQuery({"

--- a/code/modules/admin/db_ban/functions.dm
+++ b/code/modules/admin/db_ban/functions.dm
@@ -189,7 +189,7 @@
 
 	if(isjobban)
 		jobban_client_fullban(ckey, job)
-	else if (is_species_ban)
+	else if(is_species_ban)
 		add_species_ban(ckey, job)
 	else
 		flag_account_for_forum_sync(ckey)
@@ -695,4 +695,3 @@
 	// We do nothing with output here so we dont need to wrap the warn_execute() inside an if statement
 	adm_query.warn_execute()
 	qdel(adm_query)
-

--- a/code/modules/admin/species_ban.dm
+++ b/code/modules/admin/species_ban.dm
@@ -1,0 +1,107 @@
+// Species ban system.
+// Disallows a player from using a specific species, but lets them play the game regardless
+// Useful if someone isnt playing a species properly at all (IE: Not following hard-driven species lore)
+
+/// Global list of all species bans. Key is a ckey, value is a list of species. Its a global list to avoid mass DB lookups.
+GLOBAL_LIST_EMPTY(species_bans_assoc)
+//GLOBAL_PROTECT(species_bans_assoc) // Mainly just to save space in the already bloated VV window
+
+/datum/admins/proc/add_species_ban(ckey, species)
+	if(!ckey || !species)
+		return
+	if(!GLOB.species_bans_assoc["[ckey]"]) // Incase someone has a ckey thats just all numbers
+		GLOB.species_bans_assoc["[ckey]"] = list()
+
+	GLOB.species_bans_assoc["[ckey]"] |= species // Only add once
+
+/datum/admins/proc/remove_species_ban(ckey, species)
+	if(!ckey || !species)
+		return
+	if(!GLOB.species_bans_assoc["[ckey]"]) // Incase someone has a ckey thats just all numbers
+		GLOB.species_bans_assoc["[ckey]"] = list()
+
+	GLOB.species_bans_assoc["[ckey]"] -= species
+
+// Global so it can be called from world/New()
+/proc/load_all_species_bans()
+	var/datum/db_query/select_query = SSdbcore.NewQuery("SELECT ckey, job FROM [format_table_name("ban")] WHERE bantype='SPECIES_BAN' AND isnull(unbanned)")
+
+	if(!select_query.warn_execute(async = FALSE)) // NOT async because its called in world/New()
+		qdel(select_query)
+		return FALSE
+
+	while(select_query.NextRow())
+		// Prep it all
+		var/banned_ckey = select_query.item[1]
+		var/banned_species = select_query.item[2]
+
+		if(!GLOB.species_bans_assoc["[banned_ckey]"]) // Incase someone has a ckey thats just all numbers
+			GLOB.species_bans_assoc["[banned_ckey]"] = list()
+
+		GLOB.species_bans_assoc["[banned_ckey]"] |= banned_species // Incase someone gets banned twice
+
+	qdel(select_query)
+
+// Global so it can be used in other places (IE: Conversion to another species)
+/proc/is_species_banned(ckey, species)
+	ASSERT(ckey)
+	ASSERT(species)
+	if(!GLOB.species_bans_assoc["[ckey]"]) // If they dont have an entry in the glob, they aint banned
+		return FALSE
+
+	// Cast to local list
+	var/list/species_cache = GLOB.species_bans_assoc["[ckey]"]
+	if(species in species_cache)
+		// If they in the list, they banned from it
+		return TRUE
+
+	// If we here, they aint banned
+	return FALSE
+
+
+/mob/verb/display_species_bans()
+	set category = "OOC"
+	set name = "Display Current Species Bans"
+	set desc = "Displays all of your current species bans."
+
+	if(!client || !ckey)
+		return
+
+	if(config.ban_legacy_system)
+		to_chat(src, "The server is using the legacy ban system. Species bans are not active.")
+		return
+
+	// Dont let the client melt the server with SQL queries on a macro'd verb
+	if(client.handle_db_verb_limit())
+		return
+
+	var/is_actually_banned = FALSE
+	var/datum/db_query/select_query = SSdbcore.NewQuery({"
+		SELECT bantime, reason, job, a_ckey FROM [format_table_name("ban")]
+		WHERE ckey=:ckey AND bantype='SPECIES_BAN' AND isnull(unbanned)
+		ORDER BY bantime"},
+		list("ckey" = ckey)
+	)
+
+	if(!select_query.warn_execute())
+		qdel(select_query)
+		return FALSE
+
+	while(select_query.NextRow())
+
+		var/bantime = select_query.item[1]
+		var/reason = select_query.item[2]
+		var/species = select_query.item[3]
+		var/ackey = select_query.item[4]
+
+		to_chat(src, "<span class='warning'>[species] - REASON: [reason]<br>Applied by [ackey] at [bantime]</span>")
+
+		is_actually_banned = TRUE
+
+	qdel(select_query)
+
+	if(is_actually_banned)
+		if(config.banappeals)
+			to_chat(src, "<span class='warning'>You can appeal the bans at: [config.banappeals]</span>")
+	else
+		to_chat(src, "<span class='notice'>You have no active species bans!</span>")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -106,6 +106,7 @@
 		var/bancid = href_list["dbbanaddcid"]
 		var/banduration = text2num(href_list["dbbaddduration"])
 		var/banjob = href_list["dbbanaddjob"]
+		var/banspecies = href_list["dbbanaddspecies"]
 		var/banreason = href_list["dbbanreason"]
 
 		var/job_ban = FALSE
@@ -121,39 +122,52 @@
 					return
 				banduration = null
 				banjob = null
+				banspecies = null
 			if(BANTYPE_TEMP)
 				if(!banckey || !banreason || !banduration)
 					to_chat(usr, "<span class='warning'>Not enough parameters (Requires ckey, reason and duration)</span>")
 					return
 				banjob = null
+				banspecies = null
 			if(BANTYPE_JOB_PERMA)
 				if(!banckey || !banreason || !banjob)
 					to_chat(usr, "<span class='warning'>Not enough parameters (Requires ckey, reason and job)</span>")
 					return
 				banduration = null
 				job_ban = TRUE
+				banspecies = null
 			if(BANTYPE_JOB_TEMP)
 				if(!banckey || !banreason || !banjob || !banduration)
 					to_chat(usr, "<span class='warning'>Not enough parameters (Requires ckey, reason and job)</span>")
 					return
 				job_ban = TRUE
+				banspecies = null
 			if(BANTYPE_APPEARANCE)
 				if(!banckey || !banreason)
 					to_chat(usr, "<span class='warning'>Not enough parameters (Requires ckey and reason)</span>")
 					return
 				banduration = null
 				banjob = null
+				banspecies = null
 			if(BANTYPE_ADMIN_PERMA)
 				if(!banckey || !banreason)
 					to_chat(usr, "<span class='warning'>Not enough parameters (Requires ckey and reason)</span>")
 					return
 				banduration = null
 				banjob = null
+				banspecies = null
 			if(BANTYPE_ADMIN_TEMP)
 				if(!banckey || !banreason || !banduration)
 					to_chat(usr, "<span class='warning'>Not enough parameters (Requires ckey, reason and duration)</span>")
 					return
 				banjob = null
+				banspecies = null
+			if(BANTYPE_SPECIES)
+				if(!banckey || !banspecies)
+					to_chat(usr, "<span class='warning'>Not enough parameters (Requires ckey and species)</span>")
+					return
+				// We piggyback on job bans here to avoid another column in the DB
+				banjob = banspecies
 
 		var/mob/playermob
 
@@ -231,7 +245,6 @@
 
 			for(var/job in notbannedlist)
 				DB_ban_record(bantype, playermob, banduration, banreason, job, null, banckey, banip, bancid)
-
 		// Otherwise, do it normally
 		else
 			DB_ban_record(bantype, playermob, banduration, banreason, banjob, null, banckey, banip, bancid)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -112,6 +112,9 @@
 	/// Is the client watchlisted
 	var/watchlisted = FALSE
 
+	/// Time of last DB verb used (Avoids DB spam with verbs)
+	var/last_db_verb = 0
+
 /client/vv_edit_var(var_name, var_value)
 	switch(var_name)
 		// I know we will never be in a world where admins are editing client vars to let people bypass TOS

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1214,6 +1214,20 @@
 			message_admins("<font color='red'>[ckey] has just connected and has a history of [cidcount] different CIDs.</font> (<a href='?_src_=holder;webtools=[ckey]'>WebInfo</a>) (<a href='?_src_=holder;suppresscidwarning=[ckey]'>Suppress Warning</a>)")
 
 
+#define DB_VERB_COOLDOWN 2 SECONDS // Edit this if you see fit in the future -aa
+/// Helper to make sure client cant macro-spam verbs which make DB lookups. 2 second delay between each one.
+/client/proc/handle_db_verb_limit()
+	if(last_db_verb < world.time)
+		last_db_verb = world.time + DB_VERB_COOLDOWN
+		return FALSE
+
+	// If they tried to spam it, reset their cooldown
+	last_db_verb = world.time + DB_VERB_COOLDOWN
+	to_chat(usr, "<span class='warning'>You cant press that so quickly. Please wait [DB_VERB_COOLDOWN / 10] seconds.</span>")
+	return TRUE
+
+#undef DB_VERB_COOLDOWN
+
 #undef LIMITER_SIZE
 #undef CURRENT_SECOND
 #undef SECOND_COUNT

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1223,7 +1223,7 @@
 
 	// If they tried to spam it, reset their cooldown
 	last_db_verb = world.time + DB_VERB_COOLDOWN
-	to_chat(usr, "<span class='warning'>You cant press that so quickly. Please wait [DB_VERB_COOLDOWN / 10] seconds.</span>")
+	to_chat(usr, "<span class='warning'>You cannot press that so quickly. Please wait [DB_VERB_COOLDOWN / 10] seconds.</span>")
 	return TRUE
 
 #undef DB_VERB_COOLDOWN

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1318,7 +1318,14 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 					else //Not using the whitelist? Aliens for everyone!
 						new_species += GLOB.whitelisted_species
 
-					species = input("Please select a species", "Character Generation", null) in sortTim(new_species, /proc/cmp_text_asc)
+					var/formatted_species = list()
+					for(var/species in new_species)
+						if(is_species_banned(user.ckey, species))
+							formatted_species += "--[species]-- BANNED" // This name is not only a good identifier for a user, it also isnt a valid name to select from the GLOB list
+						else
+							formatted_species += species
+
+					species = input("Please select a species", "Character Generation", null) in sortTim(formatted_species, /proc/cmp_text_asc)
 					var/datum/species/NS = GLOB.all_species[species]
 					if(!istype(NS)) //The species was invalid. Notify the user and fail out.
 						species = prev_species

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -298,6 +298,9 @@
 	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
 		to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 		return 0
+	if(is_species_banned(ckey, client.prefs.species))
+		to_chat(usr, "<span class='danger'>You are banned from [client.prefs.species]. You have been returned to lobby.</span>")
+		return FALSE // Do NOT spawn them
 	if(!GLOB.enter_allowed)
 		to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 		return 0
@@ -528,6 +531,9 @@
 	popup.open(0) // 0 is passed to open so that it doesn't use the onclose() proc
 
 /mob/new_player/proc/create_character()
+	if(is_species_banned(ckey, client.prefs.species))
+		to_chat(client, "<span class='danger'>You are banned from [client.prefs.species]. You have been returned to lobby.</span>")
+		return FALSE // Do NOT spawn them
 	spawning = 1
 	close_spawn_windows()
 

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -34,6 +34,9 @@
 	switch(action)
 		if("race")
 			if(can_change(APPEARANCE_RACE) && (params["race"] in valid_species))
+				if(is_species_banned(owner.ckey, params["race"]))
+					to_chat(owner, "<span class='danger'>You are banned from [params["race"]]. You cannot transform to them.</span>")
+					return FALSE
 				var/datum/species/S = GLOB.all_species[params["race"]]
 				if(owner.set_species(S.type))
 					cut_and_generate_data()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1211,6 +1211,7 @@
 #include "code\modules\admin\outfits.dm"
 #include "code\modules\admin\player_panel.dm"
 #include "code\modules\admin\secrets.dm"
+#include "code\modules\admin\species_ban.dm"
 #include "code\modules\admin\sql_notes.dm"
 #include "code\modules\admin\stickyban.dm"
 #include "code\modules\admin\topic.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds functionality to ban people from specific species. This can be useful is a user is going extremely against species lore and refuses to change, but isn't bad enough to constitute an entire server ban (EG: A vox speaking in perfect ~~english~~ galactic common and refusing to change). **THIS IS MERELY AN EXAMPLE OF HOW THE SYSTEM *COULD* BE USED, NOT HOW WE WILL USE IT. PLEASE PUT YOUR PITCHFORKS DOWN**

## Why It's Good For The Game
More admin buttons

## Images
Character setup
![image](https://user-images.githubusercontent.com/25063394/105193456-6e2e0680-5b30-11eb-9ee7-b3dfda5d2dfe.png)

"View active species bans" verb
![image](https://user-images.githubusercontent.com/25063394/105193495-771ed800-5b30-11eb-87ad-6356164348df.png)

Attempting to join when banned from a species
![image](https://user-images.githubusercontent.com/25063394/105193525-7ede7c80-5b30-11eb-93e1-2e0f4d52b7a7.png)


## Changelog
:cl: AffectedArc07
add: [Admin] Added the option to ban users from specific species
/:cl:
