### PR TITLE
Changes shadowling jaunt to be a subtype of wizard jaunt.

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -16,14 +16,16 @@
 	var/jaunt_duration = 50 //in deciseconds
 	var/jaunt_in_time = 5
 
-	///Do we do the glowy wizard thing on the tile the wizard entered / exit
+	/// Do we do the glowy wizard thing on the tile the wizard entered / exit
 	var/has_jaunt_effect = TRUE
+	/// Visual to make when entering jaunt
 	var/jaunt_in_type = /obj/effect/temp_visual/wizard
+	/// Visual to make when exiting jaunt.
 	var/jaunt_out_type = /obj/effect/temp_visual/wizard/out
 	/// Do we show the fun blue water effect spread out thing
 	var/has_smoke_jaunt_effect = TRUE
 
-	/// Sound to play on jaunting
+	/// Sound to play on entering jaunt
 	var/jaunt_enter_sound = 'sound/magic/ethereal_enter.ogg'
 
 	/// Sound to play when we start exiting jaunt
@@ -34,7 +36,9 @@
 
 	/// Do we play a message when activating / deactivating the spell, in the format of "<span class='warning'>(user's name) (message to be displayed)</span>"
 	var/plays_message = FALSE
+	/// Message to play to chat when entering jaunt
 	var/message_in = "Should not"
+	/// Message to play to chat when exiting jaunt.
 	var/message_out = "See this"
 
 	/// Do we pop out instantly when the spell ends (not reccomended if using jaunt effects)

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -23,8 +23,10 @@
 	/// Do we show the fun blue water effect spread out thing
 	var/has_smoke_jaunt_effect = TRUE
 
-	/// Sounds to play
+	/// Sound to play on jaunting
 	var/jaunt_enter_sound = 'sound/magic/ethereal_enter.ogg'
+
+	/// Sound to play when we start exiting jaunt
 	var/jaunt_exit_sound = 'sound/magic/ethereal_exit.ogg'
 
 	/// Do we unstun (currently shadowling)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -93,38 +93,23 @@
 		for(var/atom/A in T.contents)
 			A.extinguish_light()
 
-/obj/effect/proc_holder/spell/targeted/shadow_walk
+
+/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shadowling
 	name = "Shadow Walk"
 	desc = "Phases you into the space between worlds for a short time, allowing movement through walls and invisbility."
 	panel = "Shadowling Abilities"
-	charge_max = 300 //Used to be twice this, buffed
-	clothes_req = 0
-	range = -1
-	include_user = 1
-	action_icon_state = "shadow_walk"
 
-/obj/effect/proc_holder/spell/targeted/shadow_walk/cast(list/targets, mob/user = usr)
-	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
-	for(var/mob/living/target in targets)
-		playsound(user.loc, 'sound/effects/bamf.ogg', 50, 1)
-		target.visible_message("<span class='warning'>[target] vanishes in a puff of black mist!</span>", "<span class='shadowling'>You enter the space between worlds as a passageway.</span>")
-		target.SetStunned(0)
-		target.SetWeakened(0)
-		target.incorporeal_move = 1
-		target.alpha = 0
-		target.ExtinguishMob()
-		var/turf/T = get_turf(target)
-		target.forceMove(T) //to properly move the mob out of a potential container
-		if(target.pulledby)
-			target.pulledby.stop_pulling()
-		target.stop_pulling()
-		sleep(40) //4 seconds
-		target.visible_message("<span class='warning'>[target] suddenly manifests!</span>", "<span class='shadowling'>The pressure becomes too much and you vacate the interdimensional darkness.</span>")
-		target.incorporeal_move = 0
-		target.alpha = 255
-		target.forceMove(user.loc)
+	clothes_req = 0
+	action_icon_state = "shadow_walk"
+	has_jaunt_effect = FALSE
+	has_smoke_jaunt_effect = FALSE
+	jaunt_enter_sound = 'sound/effects/bamf.ogg'
+	jaunt_exit_sound = 'sound/effects/bamf.ogg'
+	unstuns = TRUE
+	plays_message = TRUE
+	instant_pop_out = TRUE
+	message_in = "vanishes in a puff of black mist!"
+	message_out = "suddenly manifests!"
 
 /obj/effect/proc_holder/spell/targeted/lesser_shadow_walk
 	name = "Guise"
@@ -588,7 +573,7 @@
 		thrallToRevive.set_species(/datum/species/shadow/ling/lesser)
 		thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/lesser_shadow_walk)
 		thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/click/glare(null))
-		thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_walk(null))
+		thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shadowling(null))
 	else if(thrallToRevive.stat == DEAD)
 		user.visible_message("<span class='danger'>[user] kneels over [thrallToRevive], placing [user.p_their()] hands on [thrallToRevive.p_their()] chest.</span>", \
 							"<span class='shadowling'>You crouch over the body of your thrall and begin gathering energy...</span>")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -99,8 +99,8 @@
 	desc = "Phases you into the space between worlds for a short time, allowing movement through walls and invisbility."
 	panel = "Shadowling Abilities"
 
-	jaunt_duration = 100
-	charge_max = 360 // If you are wondering why, this it to keep the ammount of time, 26 seconds out of jaunt, the same as before, when it was 4 seconds in jaunt, 26 out, now its 10 and 26
+	jaunt_duration = 10 SECONDS
+	charge_max = 36 SECONDS // If you are wondering why, this it to keep the ammount of time, 26 seconds out of jaunt, the same as before, when it was 4 seconds in jaunt, 26 out, now its 10 and 26
 	clothes_req = 0
 	action_icon_state = "shadow_walk"
 	has_jaunt_effect = FALSE

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -99,6 +99,8 @@
 	desc = "Phases you into the space between worlds for a short time, allowing movement through walls and invisbility."
 	panel = "Shadowling Abilities"
 
+	jaunt_duration = 100
+	charge_max = 360 // If you are wondering why, this it to keep the ammount of time, 26 seconds out of jaunt, the same as before, when it was 4 seconds in jaunt, 26 out, now its 10 and 26
 	clothes_req = 0
 	action_icon_state = "shadow_walk"
 	has_jaunt_effect = FALSE

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_INIT(possibleShadowlingNames, list("U'ruan", "Y`shej", "Nex", "Hel-u
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/click/enthrall(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/click/glare(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/veil(null))
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_walk(null))
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shadowling(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flashfreeze(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/collective_mind(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_regenarmor(null))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR basically removes shadow walk, makes shadowling walk instead a subtype of wizard jaunt, and makes it more modular.

You can now choose if you want jaunt to pause the user on disjaunting, if it unstuns user on use, if it has the visual effects like the blue smoke and animations, change the sounds that are used, and if it should display messages when used and exiting.

This DOES mean shadowling jaunt will not move a sling as far as before, in exchange for easier control over jaunting.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Every other sling round people complain about the shadow jaunt ability, and most rounds at least one shadowling is spaced by it. Therefore, we should use the jaunt spell, which already exists, and never seems to have a vampire or wizard get spaced by it. This should lead to less complaints about the ability, be more familiar to people that have played wizard / vampires, and overall lead to a better experience.

As stated before, this has less range then the old shadow walk, but WAY easier to control.

The ability still unstuns the user, still puts out fire, and still instantly pops them out when the spell ends

##Gif of shadow jaunting

https://imgur.com/a/xottw91

## Changelog
:cl:
tweak: Shadowling shadow walk is now a subtype of jaunt.
tweak: Shadow walk now lasts 10 seconds, up 6 from 4 seconds, and has a cooldown of 36 seconds, up 6 from 30.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
