### PR TITLE
Fixes equipping deployed welding helmet hiding currently worn mask

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -62,7 +62,7 @@
 		flags_cover |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
 		flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 		icon_state = initial(icon_state)
-		to_chat(usr, "You flip the [src] down to protect your eyes.")
+		to_chat(usr, "You flip [src] down to protect your eyes.")
 		flash_protect = 2
 		tint = 2
 	else
@@ -70,12 +70,14 @@
 		flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
 		flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 		icon_state = "[initial(icon_state)]up"
-		to_chat(usr, "You push the [src] up out of your face.")
+		to_chat(usr, "You push [src] up out of your face.")
 		flash_protect = 0
 		tint = 0
 	var/mob/living/carbon/user = usr
 	user.update_tint()
-	user.update_inv_head()	//so our mob-overlays update
+	//so our mob-overlays update
+	user.update_inv_wear_mask()
+	user.update_inv_head()
 
 	for(var/X in actions)
 		var/datum/action/A = X


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Fixes an issue where equipping a deployed welding helmet (thus hiding the mask layer on the mob) then flipping it up wouldn't make the mask layer visible again.
  - Fixes #12412
- Removes unneeded "the"

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfix

## Changelog
:cl:
fix: Fix a bug where equipping a deployed welding helmet would hide the currently worn mask until it's re-equipped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
