### PR TITLE
Updates the vscode debugger engine

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -7,3 +7,6 @@ disallow_relative_proc_definitions = true
 
 [dmdoc]
 use_typepath_names = true
+
+[debugger]
+engine = "auxtools"

--- a/code/__HELPERS/debugger.dm
+++ b/code/__HELPERS/debugger.dm
@@ -1,0 +1,22 @@
+// All the stuff in here is related to the auxtools debugger, supplied as part of the DM Language Server VSCode extension
+// These procs are named EXACTLY as they are since the debugger itself will hook into these procs internally
+// Do not change these names. Please. -aa
+
+/proc/auxtools_stack_trace(msg)
+	CRASH(msg)
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")
+
+// Called in world/New()
+/world/proc/enable_auxtools_debugger()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_init")()
+		enable_debugging()
+
+// Called in world/Del(). This is VERY important, otherwise you get phantom threads which try to lookup RAM they arent allowed to
+/world/proc/disable_auxtools_debugger()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_shutdown")()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -5,10 +5,12 @@ GLOBAL_LIST_INIT(map_transition_config, MAP_TRANSITION_CONFIG)
 	// If you do any SQL operations inside this proc, they must ***NOT*** be ran async. Otherwise players can join mid query
 	// This is BAD.
 
+	// Right off the bat
+	enable_auxtools_debugger()
+
 	//temporary file used to record errors with loading config and the database, moved to log directory once logging is set up
 	GLOB.config_error_log = GLOB.world_game_log = GLOB.world_runtime_log = GLOB.sql_log = "data/logs/config_error.log"
 	load_configuration()
-	enable_debugger() // Enable the extools debugger
 
 	// Right off the bat, load up the DB
 	SSdbcore.CheckSchemaVersion() // This doesnt just check the schema version, it also connects to the db! This needs to happen super early! I cannot stress this enough!
@@ -268,14 +270,7 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	fdel(F)
 	F << GLOB.log_directory
 
-// Proc to enable the extools debugger, which allows breakpoints, live var checking, and many other useful tools
-// The DLL is injected into the env by visual studio code. If not running VSCode, the proc will not call the initialization
-/world/proc/enable_debugger()
-    var/dll = world.GetConfig("env", "EXTOOLS_DLL")
-    if (dll)
-        call(dll, "debug_initialize")()
-
-
 /world/Del()
 	rustg_close_async_http_client() // Close the HTTP client. If you dont do this, youll get phantom threads which can crash DD from memory access violations
+	disable_auxtools_debugger() // Disables the debugger if running. See above comment
 	..()

--- a/paradise.dme
+++ b/paradise.dme
@@ -94,6 +94,7 @@
 #include "code\__HELPERS\AnimationLibrary.dm"
 #include "code\__HELPERS\cmp.dm"
 #include "code\__HELPERS\constants.dm"
+#include "code\__HELPERS\debugger.dm"
 #include "code\__HELPERS\experimental.dm"
 #include "code\__HELPERS\files.dm"
 #include "code\__HELPERS\game.dm"


### PR DESCRIPTION
## What Does This PR Do
Migrates the debug engine from extools (c++) to auxtools (rust). This comes with a few notable improvements:
- Injected separately as opposed to conflicting with a DLL if we ever go the auxtools route (We likely wont but its still an improvement)
- **MUCH** faster (It loads the entire thread list instantly instead of taking 10 full seconds to pause on a breakpoint)
- Fixes a bunch of issues relating to internal BYOND procs not being stepped properly
- Able to render special lists like `contents` and `vars`

## Why It's Good For The Game
Makes dev life much nicer

## Changelog
N/A, dev only