### PR TITLE
Gives some tells to using holy water on vampire thralls.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -249,6 +249,13 @@
 			if(prob(5))
 				M.AdjustCultSlur(5)//5 seems like a good number...
 				M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","Egkau'haom'nai en Chaous","Ho Diak'nos tou Ap'iron","R'ge Na'sie","Diabo us Vo'iscum","Si gn'um Co'nu"))
+		if(isvampirethrall(M))
+			if(prob(10))
+				M.say(pick("*gasp", "*cough", "*sneeze"))
+			if(prob(5)) //Same as cult, for the real big tell
+				for(var/mob/O in viewers(M, null))
+					O.show_message(text("<span class = 'warning'> A fog lifts from []'s eyes for a moment, but soon returns.</span>", M), 1)
+
 	if(current_cycle >= 75 && prob(33))	// 30 units, 150 seconds
 		M.AdjustConfused(3)
 		if(isvampirethrall(M))

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -253,8 +253,7 @@
 			if(prob(10))
 				M.say(pick("*gasp", "*cough", "*sneeze"))
 			if(prob(5)) //Same as cult, for the real big tell
-				for(var/mob/O in viewers(M, null))
-					O.show_message(text("<span class = 'warning'> A fog lifts from []'s eyes for a moment, but soon returns.</span>", M), 1)
+				M.visible_message("<span class='warning'>A fog lifts from [M]'s eyes for a moment, but soon returns.</span>")
 
 	if(current_cycle >= 75 && prob(33))	// 30 units, 150 seconds
 		M.AdjustConfused(3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Adds a 10% and 5% chance for tells on vampire thralls that they are a thrall, when holy water has been in their system for over 60 seconds.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Vampire thralls have been in a problematic state for deconversion. While you give a vampire 5 units to see if they are a vampire, thralls currently require _35 units_ to deconvert, and have no tells that they are in the process of being deconverted. This leads to a few things happening, be it vampire thralls never being deconverted, put into perma for aiding when they are thralled, being executed as officers think they are a vampire, and they show no reaction to holy water, ect.

This way, at least after a bit of time, you start to get evidence the person is a thrall, and know that with more time and holy water they will be deconverted.

Could probably use some better reactions to holy water if people can think of them, but they can not be the same as vampires, as that would just make officers think the thrall is a vampire, and lead to the same issue.

## Changelog
:cl:
tweak: Vampire thralls now have a tell that they are being deconverted, after 60 seconds of having holy water in their system..
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
