### PR TITLE
Fixes unbreakable grab exploit

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -715,8 +715,8 @@
 
 	for(var/I in grabbed_by) // Otherwise, if you're being stunned by a grab
 		var/obj/item/grab/G = I
-		if(G.state == GRAB_AGGRESSIVE || G.state == GRAB_NECK)
-			return FALSE // Allow the user to break out of grab stuns
+		if(G.state == GRAB_NECK)
+			return FALSE // Allow the user to break out of neck grabs
 
 	return TRUE
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -170,15 +170,15 @@
 	var/breathing_tube = affecting.get_organ_slot("breathing_tube")
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(5)  //It will hamper your voice, being choked and all.
+		affecting.Stun(2)  //It will hamper your voice, being choked and all.
 		if(isliving(affecting) && !breathing_tube)
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)
 
 	if(state >= GRAB_KILL)
 		//affecting.apply_effect(STUTTER, 5) //would do this, but affecting isn't declared as mob/living for some stupid reason.
-		affecting.Stuttering(5) //It will hamper your voice, being choked and all.
-		affecting.Weaken(5)	//Should keep you down unless you get help.
+		affecting.Stuttering(2) //It will hamper your voice, being choked and all.
+		affecting.Weaken(2)	//Should keep you down unless you get help.
 		if(!breathing_tube)
 			affecting.AdjustLoseBreath(2, bound_lower = 0, bound_upper = 3)
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -170,15 +170,15 @@
 	var/breathing_tube = affecting.get_organ_slot("breathing_tube")
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(2)  //It will hamper your voice, being choked and all.
+		affecting.Stun(3)  //It will hamper your voice, being choked and all.
 		if(isliving(affecting) && !breathing_tube)
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)
 
 	if(state >= GRAB_KILL)
 		//affecting.apply_effect(STUTTER, 5) //would do this, but affecting isn't declared as mob/living for some stupid reason.
-		affecting.Stuttering(2) //It will hamper your voice, being choked and all.
-		affecting.Weaken(2)	//Should keep you down unless you get help.
+		affecting.Stuttering(3) //It will hamper your voice, being choked and all.
+		affecting.Weaken(3)	//Should keep you down unless you get help.
 		if(!breathing_tube)
 			affecting.AdjustLoseBreath(2, bound_lower = 0, bound_upper = 3)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes being able to permanently stunlock someone if you have them in a neck grab.
This was caused by `can_resist()` failing if `IsStunned()` was `TRUE`, which will always be the case since the grab stuns the user every tick.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's clearly intended to be escapable considering that `resist_grab()` exists, but right now it's literally inescapable no matter how hard you spam the resist button.

As for the stun time decrease, a 10 second stun after being relased is just ridiculous, and I assume that whoever coded it meant for it to be 5 seconds instead.

## Changelog
:cl:
tweak: Reduced the stun time after being released from a neck or kill grab from 10 seconds to 6.
fix: Fixed neck grabs being unbreakable stuns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
