### PR TITLE
Optimizes steal objective

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -31,26 +31,31 @@
 	name = "the captain's antique laser gun"
 	typepath = /obj/item/gun/energy/laser/captain
 	protected_jobs = list("Captain")
+	location_override = "the Captain's Office"
 
 /datum/theft_objective/captains_jetpack
 	name = "the captain's deluxe jetpack"
 	typepath = /obj/item/tank/jetpack/oxygen/captain
 	protected_jobs = list("Captain")
+	location_override = "the Captain's Office"
 
 /datum/theft_objective/captains_rapier
 	name = "the captain's rapier"
 	typepath = /obj/item/melee/rapier
 	protected_jobs = list("Captain")
+	location_override = "the Captain's Office"
 
 /datum/theft_objective/hoslaser
 	name = "the head of security's X-01 multiphase energy gun"
 	typepath = /obj/item/gun/energy/gun/hos
 	protected_jobs = list("Head Of Security")
+	location_override = "the Head of Security's Office"
 
 /datum/theft_objective/hand_tele
 	name = "a hand teleporter"
 	typepath = /obj/item/hand_tele
 	protected_jobs = list("Captain", "Research Director", "Chief Engineer")
+	location_override = "Teleporter"
 
 /datum/theft_objective/ai
 	name = "a functional AI"
@@ -68,17 +73,20 @@
 	name = "a compact defibrillator"
 	typepath = /obj/item/defibrillator/compact
 	protected_jobs = list("Chief Medical Officer", "Paramedic")
+	location_override = "the Chief Medical Officer's Office"
 
 /datum/theft_objective/magboots
 	name = "the chief engineer's advanced magnetic boots"
 	typepath = /obj/item/clothing/shoes/magboots/advance
 	protected_jobs = list("Chief Engineer")
+	location_override = "the Chief Engineer's Office"
 
 /datum/theft_objective/blueprints
 	name = "the station blueprints"
 	typepath = /obj/item/areaeditor/blueprints/ce
 	protected_jobs = list("Chief Engineer")
 	altitems = list(/obj/item/photo)
+	location_override = "the Chief Engineer's Office"
 
 /datum/objective_item/steal/blueprints/check_special_completion(obj/item/I)
 	if(istype(I, /obj/item/areaeditor/blueprints/ce))
@@ -93,35 +101,42 @@
 	name = "the medal of captaincy"
 	typepath = /obj/item/clothing/accessory/medal/gold/captain
 	protected_jobs = list("Captain")
+	location_override = "the Captain's Office"
 
 /datum/theft_objective/nukedisc
 	name = "the nuclear authentication disk"
 	typepath = /obj/item/disk/nuclear
 	protected_jobs = list("Captain")
+	location_override = "the Captain's Office"
 
 /datum/theft_objective/reactive
 	name = "the reactive teleport armor"
 	typepath = /obj/item/clothing/suit/armor/reactive/teleport
 	protected_jobs = list("Research Director")
+	location_override = "the Research Director's Office"
 
 /datum/theft_objective/steal/documents
 	name = "any set of secret documents of any organization"
 	typepath = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's
+	location_override = "the Vault"
 
 /datum/theft_objective/hypospray
 	name = "the Chief Medical Officer's hypospray"
 	typepath = /obj/item/reagent_containers/hypospray/CMO
 	protected_jobs = list("Chief Medical Officer")
+	location_override = "the Chief Medical Officer's Office"
 
 /datum/theft_objective/ablative
 	name = "an ablative armor vest"
 	typepath = /obj/item/clothing/suit/armor/laserproof
 	protected_jobs = list("Head of Security", "Warden")
+	location_override = "the Armory"
 
 /datum/theft_objective/krav
 	name = "the warden's krav maga martial arts gloves"
 	typepath = /obj/item/clothing/gloves/color/black/krav_maga/sec
 	protected_jobs = list("Head Of Security", "Warden")
+	location_override = "the Warden's Office"
 
 /datum/theft_objective/number
 	var/min=0
@@ -160,7 +175,9 @@
 /datum/theft_objective/unique/docs_red
 	name = "the \"Red\" secret documents"
 	typepath = /obj/item/documents/syndicate/red
+	location_override = "a Syndicate agent's possession"
 
 /datum/theft_objective/unique/docs_blue
 	name = "the \"Blue\" secret documents"
 	typepath = /obj/item/documents/syndicate/blue
+	location_override = "a Syndicate agent's possession"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Optimizes `/datum/objective/steal/proc/get_location` by axing the `world`-wide lookup for the target item and its location (when there are tens of thousands of atoms in a world, this is a TERRIBLE idea) and instead hardcoding the item's initial location in `/datum/theft_objective`.
- Optimizes `/datum/objective/steal/find_target` by using `pick_n_take` and ensuring potential theft targets aren't checked over redundantly.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
```
                                                         Profile results (total time)
Proc Name                                                                                      Self CPU    Total CPU    Real Time     Overtime        Calls
------------------------------------------------------------------------------------------    ---------    ---------    ---------    ---------    ---------
/datum/objective/steal/find_target                                                                0.000        0.457       17.100        0.000           11
/datum/objective/steal/proc/get_location                                                          0.000        0.457       17.100        0.000           11
/proc/get_all_of_type                                                                             0.450        0.457       17.100        0.000           10
```
This profile says it all. `/proc/get_all_of_type` looks **through the entire world** for a datum or otherwise, and that takes a long time. Killing it will majorly reduce a steal objective's generation time, resulting in faster round starts.

## Changelog
:cl:
fix: Fix steal objectives being slow to generate - rounds should start faster now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
