### PR TITLE
Makes query_round_start synchronous

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -180,7 +180,7 @@ SUBSYSTEM_DEF(dbcore)
 		"UPDATE [format_table_name("round")] SET start_datetime=NOW(), commit_hash=:hash WHERE id=:round_id",
 		list("hash" = GLOB.revision_info.commit_hash, "round_id" = GLOB.round_id)
 	)
-	query_round_start.Execute()
+	query_round_start.Execute(async = FALSE) // This happens during a time of intense server lag, so should be non-async
 	qdel(query_round_start)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Makes the query marking the round start time synchronous (checked with @AffectedArc07)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Round start is time intensive so async calls don't really help there.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
