### PR TITLE
Adds reactive teleport armor construction, ports repulsive armor from TG

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -254,7 +254,7 @@
 	loot = list(
 				// Robotics
 				/obj/item/mmi/robotic_brain = 50, // Low-value, but we want to encourage getting more players back in the round.
-				/obj/item/assembly/signaler/anomaly = 50, // anomaly core
+				/obj/item/assembly/signaler/anomaly/random = 50, // anomaly core
 				/obj/item/mecha_parts/mecha_equipment/weapon/energy/xray = 25, // mecha x-ray laser
 				/obj/item/mecha_parts/mecha_equipment/teleporter/precise = 25, // upgraded mecha teleporter
 				/obj/item/autoimplanter = 50,

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -318,10 +318,7 @@
 	if(prob(hit_reaction_chance))
 		if(istype(hitby, /obj/item/projectile))
 			var/obj/item/projectile/P = hitby
-			if(P.nodamage)
-				if(P.stun) //tasers
-					return TRUE
-			else
+			if(!P.nodamage)
 				return TRUE
 		else
 			return TRUE

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -361,7 +361,7 @@
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
-		return TRUE
+		return FALSE
 	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
 		for(var/mob/living/carbon/C in range(6, owner))

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -314,6 +314,18 @@
 		var/mob/living/carbon/human/C = loc
 		C.update_inv_wear_suit()
 
+/obj/item/clothing/suit/armor/reactive/proc/reaction_check(hitby)
+	if(prob(hit_reaction_chance))
+		if(istype(hitby, /obj/item/projectile))
+			var/obj/item/projectile/P = hitby
+			if(P.nodamage)
+				if(P.stun) //tasers
+					return TRUE
+			else
+				return TRUE
+		else
+			return TRUE
+
 //When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive/teleport
 	name = "reactive teleport armor"
@@ -323,7 +335,7 @@
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return 0
-	if(prob(hit_reaction_chance))
+	if(reaction_check(hitby))
 		var/mob/living/carbon/human/H = owner
 		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
 		var/list/turfs = new/list()
@@ -353,7 +365,7 @@
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return TRUE
-	if(prob(hit_reaction_chance))
+	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
 		for(var/mob/living/carbon/C in range(6, owner))
 			if(C != owner)
@@ -371,7 +383,7 @@
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
-	if(prob(hit_reaction_chance))
+	if(reaction_check(hitby))
 		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
 		E.Copy_Parent(owner, 50)
 		E.GiveTarget(owner) //so it starts running right away
@@ -389,7 +401,7 @@
 /obj/item/clothing/suit/armor/reactive/tesla/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
-	if(prob(hit_reaction_chance))
+	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out arcs of lightning!</span>")
 		for(var/mob/living/M in view(6, owner))
 			if(M == owner)
@@ -411,7 +423,7 @@
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
-	if(prob(hit_reaction_chance))
+	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], converting the attack into a wave of force!</span>")
 		var/list/thrownatoms = list()
 		for(var/turf/T in range(repulse_range, owner)) //Done this way so things don't get thrown all around hilariously.

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -343,8 +343,8 @@
 		if(!isturf(picked))
 			return
 		H.forceMove(picked)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/item/clothing/suit/armor/reactive/fire
 	name = "reactive incendiary armor"
@@ -352,7 +352,7 @@
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
-		return 0
+		return TRUE
 	if(prob(hit_reaction_chance))
 		owner.visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
 		for(var/mob/living/carbon/C in range(6, owner))
@@ -360,8 +360,8 @@
 				C.fire_stacks += 8
 				C.IgniteMob()
 		owner.fire_stacks = -20
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 
 /obj/item/clothing/suit/armor/reactive/stealth
@@ -370,7 +370,7 @@
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
-		return 0
+		return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
 		E.Copy_Parent(owner, 50)
@@ -380,7 +380,7 @@
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
 		spawn(40)
 			owner.alpha = initial(owner.alpha)
-		return 1
+		return TRUE
 
 /obj/item/clothing/suit/armor/reactive/tesla
 	name = "reactive tesla armor"
@@ -388,7 +388,7 @@
 
 /obj/item/clothing/suit/armor/reactive/tesla/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
-		return 0
+		return FALSE
 	if(prob(hit_reaction_chance))
 		owner.visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out arcs of lightning!</span>")
 		for(var/mob/living/M in view(6, owner))
@@ -437,7 +437,7 @@
 				spawn(0)
 					AM.throw_at(throwtarget, ((clamp((repulse_power - (clamp(distfromuser - 2, 0, distfromuser))), 3, repulse_power))), 1)//So stuff gets tossed around at the same time.
 		disable(rand(2, 5))
-		return 1
+		return TRUE
 
 //All of the armor below is mostly unused
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -295,7 +295,7 @@
 	disable(emp_power)
 	..()
 
-/obj/item/clothing/suit/armor/reactive/proc/disable(var/disable_time = 0)
+/obj/item/clothing/suit/armor/reactive/proc/disable(disable_time = 0)
 	active = FALSE
 	disabled = TRUE
 	icon_state = "reactiveoff"
@@ -310,7 +310,7 @@
 	active = TRUE
 	icon_state = "reactive"
 	item_state = "reactive"
-	if(istype(loc, /mob/living/carbon/human))
+	if(ishuman(loc))
 		var/mob/living/carbon/human/C = loc
 		C.update_inv_wear_suit()
 
@@ -398,7 +398,7 @@
 			M.adjustFireLoss(20)
 			playsound(M, 'sound/machines/defib_zap.ogg', 50, 1, -1)
 		disable(rand(2, 5)) // let's not have buckshot set it off 4 times and do 80 burn damage.
-		return 1
+		return TRUE
 
 /obj/item/clothing/suit/armor/reactive/repulse
 	name = "reactive repulse armor"
@@ -410,12 +410,10 @@
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
-		return 0
+		return FALSE
 	if(prob(hit_reaction_chance))
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], converting the attack into a wave of force!</span>")
 		var/list/thrownatoms = list()
-		var/atom/throwtarget
-		var/distfromuser
 		for(var/turf/T in range(repulse_range, owner)) //Done this way so things don't get thrown all around hilariously.
 			for(var/atom/movable/AM in T)
 				thrownatoms += AM
@@ -425,8 +423,8 @@
 			if(AM == owner || AM.anchored)
 				continue
 
-			throwtarget = get_edge_target_turf(owner, get_dir(owner, get_step_away(AM, owner)))
-			distfromuser= get_dist(owner, AM)
+			var/throwtarget = get_edge_target_turf(owner, get_dir(owner, get_step_away(AM, owner)))
+			var/distfromuser = get_dist(owner, AM)
 			if(distfromuser == 0)
 				if(isliving(AM))
 					var/mob/living/M = AM

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -261,6 +261,7 @@
 	name = "reactive armor"
 	desc = "Doesn't seem to do much for some reason."
 	var/active = FALSE
+	/// Is the armor disabled, and prevented from reactivating temporarly?
 	var/disabled = FALSE
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"

--- a/code/modules/research/anomaly/anomaly.dm
+++ b/code/modules/research/anomaly/anomaly.dm
@@ -69,7 +69,7 @@
 	icon = 'icons/obj/clothing/suits.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/reactive_armour_shell/attackby(obj/item/I as obj, mob/user, params)
+/obj/item/reactive_armour_shell/attackby(obj/item/I, mob/user, params)
 	var/static/list/anomaly_armour_types = list(
 		/obj/item/assembly/signaler/anomaly/grav = /obj/item/clothing/suit/armor/reactive/repulse,
 		/obj/item/assembly/signaler/anomaly/flux = /obj/item/clothing/suit/armor/reactive/tesla,

--- a/code/modules/research/anomaly/anomaly.dm
+++ b/code/modules/research/anomaly/anomaly.dm
@@ -51,3 +51,47 @@
 	icon_state = "vortex_core"
 	anomaly_type = /obj/effect/anomaly/bhole
 	origin_tech = "engineering=7"
+
+/obj/item/assembly/signaler/anomaly/random
+	name = "Random anomaly core"
+
+/obj/item/assembly/signaler/anomaly/random/New()
+	..()
+	var/list/types = list(/obj/item/assembly/signaler/anomaly/pyro, /obj/item/assembly/signaler/anomaly/grav, /obj/item/assembly/signaler/anomaly/flux, /obj/item/assembly/signaler/anomaly/bluespace, /obj/item/assembly/signaler/anomaly/vortex)
+	var/A = pick(types)
+	new A(loc)
+	qdel(src)
+
+/obj/item/reactive_armour_shell
+	name = "reactive armour shell"
+	desc = "An experimental suit of armour, awaiting installation of an anomaly core."
+	icon_state = "reactiveoff"
+	icon = 'icons/obj/clothing/suits.dmi'
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/reactive_armour_shell/attackby(obj/item/I as obj, mob/user, params)
+	var/static/list/anomaly_armour_types = list(
+		/obj/item/assembly/signaler/anomaly/grav = /obj/item/clothing/suit/armor/reactive/repulse,
+		/obj/item/assembly/signaler/anomaly/flux = /obj/item/clothing/suit/armor/reactive/tesla,
+		/obj/item/assembly/signaler/anomaly/bluespace = /obj/item/clothing/suit/armor/reactive/teleport,
+		/obj/item/assembly/signaler/anomaly/pyro = /obj/item/clothing/suit/armor/reactive/fire
+		)
+
+	if(istype(I, /obj/item/assembly/signaler/anomaly))
+		var/obj/item/assembly/signaler/anomaly/A = I
+		var/armour_path = /obj/item/clothing/suit/armor/reactive/stealth //Fallback
+		if(istype(I, /obj/item/assembly/signaler/anomaly/grav))
+			armour_path = /obj/item/clothing/suit/armor/reactive/repulse
+		if(istype(I, /obj/item/assembly/signaler/anomaly/flux))
+			armour_path = /obj/item/clothing/suit/armor/reactive/tesla
+		if(istype(I, /obj/item/assembly/signaler/anomaly/bluespace))
+			armour_path = /obj/item/clothing/suit/armor/reactive/teleport
+		if(istype(I, /obj/item/assembly/signaler/anomaly/pyro))
+			armour_path = /obj/item/clothing/suit/armor/reactive/fire
+		if(istype(I, /obj/item/assembly/signaler/anomaly/vortex))
+			armour_path = /obj/item/clothing/suit/armor/reactive/stealth // Vortex needs one, this is just temporary(TM) till one is coded for them.
+		to_chat(user, "<span class='notice'>You insert [A] into the chest plate, and the armour gently hums to life.</span>")
+		new armour_path(get_turf(src))
+		qdel(src)
+		qdel(A)
+	return ..()

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -266,6 +266,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_PLASMA = 8000, MAT_TITANIUM = 14000, MAT_BLUESPACE = 6000) //Big strong armor needs big-ish investment
 	build_path = /obj/item/reactive_armour_shell
-	locked = 1
+	locked = TRUE
 	access_requirement = list(ACCESS_RD)
 	category = list("Weapons")

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -257,3 +257,15 @@
 	build_path = /obj/item/gun/energy/immolator
 	locked = 1
 	category = list("Weapons")
+
+/datum/design/reactive_armour
+	name = "Reactive Armor Shell"
+	desc = "A reactive armor shell, that can have an anomaly core inserted to make a reactive armor"
+	id = "reactivearmor"
+	req_tech = list("combat" = 6, "materials" = 7, "engineering" = 5)
+	build_type = PROTOLATHE
+	materials = list(MAT_PLASMA = 8000, MAT_TITANIUM = 14000, MAT_BLUESPACE = 6000) //Big strong armor needs big-ish investment
+	build_path = /obj/item/reactive_armour_shell
+	locked = 1
+	access_requirement = list(ACCESS_RD)
+	category = list("Weapons")

--- a/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
+++ b/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
@@ -25,7 +25,7 @@
 	STOP_PROCESSING(SSprocessing, src)
 
 /obj/structure/lavaland/ash_walker/deconstruct(disassembled)
-	new /obj/item/assembly/signaler/anomaly(get_step(loc, pick(GLOB.alldirs)))
+	new /obj/item/assembly/signaler/anomaly/random(get_step(loc, pick(GLOB.alldirs)))
 	new	/obj/effect/collapse(loc)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Port of reactive teleport armor from TG.

Adds reactive teleport armor shells, which can be produced in an RD locked lockbox from RND, for some plasma titanium and bluespace, with combat 6 mat 7 engineering 5

Using an anomaly core on the armor will make a reactive armor, related to the type of core put in.

Teleport for bluespace, fire for pyro, tesla for flux, repulse for gravitational, and stealth for vortex, due to not having an armor dedicated to it at the moment.

Armor that has been disabled from emp, or now armor effects, will now reactivate when the emp / armor cooldown wears off.

Tesla armor, which was not something crew could obtain before, now has a cooldown between activation, between 2 - 5 seconds, and its damage reduced from 25 to 20, to prevent a buckshot blast dealing 100 burn damage to everyone in a 6 tile radius.

Repulsive armor acts like wizard repulse, throwing everything in a 5 tile radius 3 tiles, only stunning people if they are under the user, or if they are thrown into a wall.

Traders now spawn with a random anomaly core,  instead of an anomaly core with no effects.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Uses for anomaly cores for things other than deconstruction is nice, as bluespace is the only one that can be used in phazon, and we are now able to potentially farm cores from a super matter. 
Allowing other armors that we had in the code to be used is nice, and can be interesting if a security officer, antagonist, or otherwise is using it, be it to help the station, defend it from spiders, or just trying to kill the captain.


## Changelog
:cl:
add: Reactive armor shells can now be printed in an RD lockbox from RND
add: Reactive armors can now be crafted with an anomaly core and a reactive armor shell.
tweak: Traders now spawn with a random anomaly core, instead of an anomaly core with no type.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
