### PR TITLE
Adds a heal point system to the rod of Asclupius

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -109,8 +109,8 @@
 	alert_type = null
 	var/hand
 	var/deathTick = 0
-	/// How many points the rod has to heal with, starts with 25, maxes at 50, or whatever heal_points_max is set to.
-	var/heal_points = 25
+	/// How many points the rod has to heal with, maxes at 50, or whatever heal_points_max is set to.
+	var/heal_points = 50
 	/// Max heal points for the rod to spend on healing people
 	var/max_heal_points = 50
 
@@ -181,9 +181,9 @@
 			itemUser.adjustStaminaLoss(-1.5)
 			itemUser.adjustBrainLoss(-1.5)
 			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
-		//Heal all those around you, unbiased
 		if(heal_points < (max_heal_points))
 			heal_points = min(heal_points += 3, max_heal_points)
+		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
 			if(heal_points <= 0)
 				break

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -181,7 +181,7 @@
 			itemUser.adjustStaminaLoss(-1.5)
 			itemUser.adjustBrainLoss(-1.5)
 			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
-		if(heal_points < (max_heal_points))
+		if(heal_points < max_heal_points)
 			heal_points = min(heal_points += 3, max_heal_points)
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -183,7 +183,7 @@
 			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
 		//Heal all those around you, unbiased
 		if(heal_points < (max_heal_points))
-			heal_points = min((heal_points += 3), max_heal_points)
+			heal_points = min(heal_points += 3, max_heal_points)
 		for(var/mob/living/L in view(7, owner))
 			if(heal_points <= 0)
 				break

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -183,7 +183,7 @@
 			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
 		//Heal all those around you, unbiased
 		if(heal_points < (max_heal_points))
-			heal_points = max((heal_points += 3), max_heal_points)
+			heal_points = min((heal_points += 3), max_heal_points)
 		for(var/mob/living/L in view(7, owner))
 			if(heal_points <= 0)
 				break

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -109,6 +109,10 @@
 	alert_type = null
 	var/hand
 	var/deathTick = 0
+	/// How many points the rod has to heal with, starts with 25, maxes at 50, or whatever heal_points_max is set to.
+	var/heal_points = 25
+	/// Max heal points for the rod to spend on healing people
+	var/max_heal_points = 50
 
 /datum/status_effect/hippocraticOath/on_apply()
 	//Makes the user passive, it's in their oath not to harm!
@@ -178,7 +182,11 @@
 			itemUser.adjustBrainLoss(-1.5)
 			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
 		//Heal all those around you, unbiased
+		if(heal_points < (max_heal_points))
+			heal_points = max((heal_points += 3), max_heal_points)
 		for(var/mob/living/L in view(7, owner))
+			if(heal_points <= 0)
+				break
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
 			if(iscarbon(L))
@@ -189,18 +197,23 @@
 				L.adjustStaminaLoss(-3.5)
 				L.adjustBrainLoss(-3.5)
 				L.adjustCloneLoss(-1) //Becasue apparently clone damage is the bastion of all health
+				heal_points--
 				if(ishuman(L))
 					var/mob/living/carbon/human/H = L
 					for(var/obj/item/organ/external/E in H.bodyparts)
 						if(prob(10))
 							E.mend_fracture()
 							E.internal_bleeding = FALSE
+							heal_points--
 			else if(issilicon(L))
 				L.adjustBruteLoss(-3.5)
 				L.adjustFireLoss(-3.5)
+				heal_points--
 			else if(isanimal(L))
 				var/mob/living/simple_animal/SM = L
 				SM.adjustHealth(-3.5)
+				if(prob(50))
+					heal_points -- // Animals are simpler
 
 /obj/screen/alert/status_effect/regenerative_core
 	name = "Reinforcing Tendrils"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
The status affect from the rod of asclepius now has "healing points" The buff has a max storage of 50 healing points, and generates 3 per buff tick. Every time the buff ticks, for each mob in range (including the own user) it uses a healing point to try to heal them, and an extra healing point if it tries to heal a limb. Thus, the rod is going to work perfectly fine when only the user and one other person is near them, but if 2 people are near the user, it will very slowly deplete over time, and if it is 8 people fighting a blob, it will run out of healing charge quick.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The rod of asclupius is can heal more damage types than a medbeam, is AOE instead of one target, doesn't explode, and is broken when used to combat a blob or just sitting around in medbay, as you rapidly heal crew and fix their internal injuries. 

Many times this has been used against a blob or similar threat, healing all crew fighting the threat faster than the threat can deal damage, and even if the person breaks a bone or gets IB, instead of having to go to medbay, just standing around the person with the rod will eventually fix it.

After this change, the rod still heals just as much damage, but can not heal a whole bunch of people at once, and instead is better healing 1 or 2  people other than the user at a time, or a group of 4-6 for a short period of time quickly.


## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Rod of Asclupius now has a heal point system that regenerates over time, and is spent when trying to heal people. Now works better when healing small groups of people, and will stop working for a while if too many people are attempted to be healed at once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
