### PR TITLE
Updating Clown Ruin and nerfing Staff of slipping.

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -961,7 +961,7 @@
 /area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/table/glass,
-/obj/item/gun/magic/wand/slipping
+/obj/item/gun/magic/wand/slipping,
 /turf/simulated/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bB" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -961,7 +961,7 @@
 /area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/table/glass,
-/obj/item/gun/magic/staff/slipping,
+/obj/item/gun/magic/staff/slipping/ruin,
 /turf/simulated/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bB" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -961,7 +961,7 @@
 /area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/table/glass,
-/obj/item/gun/magic/staff/slipping/ruin,
+/obj/item/gun/magic/wand/slipping
 /turf/simulated/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bB" = (

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -53,11 +53,20 @@
 	fire_sound = 'sound/magic/staff_door.ogg'
 
 /obj/item/gun/magic/staff/slipping
-	name = "staff of slipping"
+	name = "wand of slipping"
 	desc = "An artefact that spits... bananas?"
 	ammo_type = /obj/item/ammo_casing/magic/slipping
 	icon_state = "staffofslipping"
 	item_state = "staffofslipping"
+	fire_sound = 'sound/items/bikehorn.ogg'
+
+/obj/item/gun/magic/staff/slipping/ruin
+	name = "staff of slipping"
+	desc = "An artefact that spits... bananas? This one appears to be low on charge..."
+	ammo_type = /obj/item/ammo_casing/magic/slipping
+	icon_state = "staffofslipping"
+	item_state = "staffofslipping"
+	max_charges = 5
 	fire_sound = 'sound/items/bikehorn.ogg'
 
 /obj/item/gun/magic/staff/slipping/honkmother

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -60,15 +60,6 @@
 	item_state = "staffofslipping"
 	fire_sound = 'sound/items/bikehorn.ogg'
 
-/obj/item/gun/magic/staff/slipping/ruin
-	name = "staff of slipping"
-	desc = "An artefact that spits... bananas? This one appears to be low on charge..."
-	ammo_type = /obj/item/ammo_casing/magic/slipping
-	icon_state = "staffofslipping"
-	item_state = "staffofslipping"
-	max_charges = 5
-	fire_sound = 'sound/items/bikehorn.ogg'
-
 /obj/item/gun/magic/staff/slipping/honkmother
 	name = "staff of the honkmother"
 	desc = "An ancient artefact, sought after by clowns everywhere."

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -163,3 +163,19 @@
 	explosion(user.loc, -1, 0, 2, 3, 0, flame_range = 2)
 	charges--
 	..()
+
+/////////////////////////////////////
+//WAND OF SLIPPING
+/////////////////////////////////////
+/obj/item/gun/magic/wand/slipping
+    name = "wand of slipping"
+	desc = "This wand shoots... banana peels?"
+	fire_sound = 'sound/items/bikehorn.ogg'
+	ammo_type = /obj/item/ammo_casing/magic/slipping
+	icon_state = "staffofslipping"
+	max_charges = 5 //5, 3, 3, 2
+
+/obj/item/gun/magic/wand/slipping/zap_self(mob/living/user)
+	to_chat(user, "<span class='notice'>You feel rather silly!.</span>")
+	charges--
+	..()

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -167,8 +167,8 @@
 /////////////////////////////////////
 //WAND OF SLIPPING
 /////////////////////////////////////
-/obj/item/gun/magic/wand/slipping
-    name = "wand of slipping"
+obj/item/gun/magic/wand/slipping
+	name = "wand of slipping"
 	desc = "This wand shoots... banana peels?"
 	fire_sound = 'sound/items/bikehorn.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/slipping

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -167,13 +167,13 @@
 /////////////////////////////////////
 //WAND OF SLIPPING
 /////////////////////////////////////
-obj/item/gun/magic/wand/slipping
+/obj/item/gun/magic/wand/slipping
 	name = "wand of slipping"
 	desc = "This wand shoots... banana peels?"
 	fire_sound = 'sound/items/bikehorn.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/slipping
 	icon_state = "staffofslipping"
-	max_charges = 5 //5, 3, 3, 2
+	max_charges = 5 //5, 4, 3, 2
 
 /obj/item/gun/magic/wand/slipping/zap_self(mob/living/user)
 	to_chat(user, "<span class='notice'>You feel rather silly!.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Creates a new, nerfed version of the staff of slipping with less shots, and replaces the old infinite lavaland one with it.

## Why It's Good For The Game
Before, antags essentially had an infinite stun, which also affected borgs, and made them near unstoppable. Now the staffs only got 6 shots, which prevents abuse. (Your welcome security)

## Changelog
:cl:
add: Added weaker variant of clown staff.
tweak: Replaced Lavaland clown ruin Staff of slipping with nerfed version
/:cl:


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
