### PR TITLE
Fixes Cigarettes rendering on mob when on the ears

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -18,7 +18,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	icon_state = "cigoff"
 	throw_speed = 0.5
 	item_state = "cigoff"
-	slot_flags = SLOT_EARS|SLOT_MASK
+	slot_flags = SLOT_MASK
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	attack_verb = null


### PR DESCRIPTION
Things aren't really meant to be equipped to the ears as a standard, and their icon handling for them isn't great, resulting in things equipped to them rendering as if they were in another slot.

Unsurprisingly, things that are equipped to the ears are typically *only* equippable to the ears.

Having dual ear + other slot just doesn't render properly and results in a lot of oddities.

This fixes that for cigs and their subtypes.

:cl: Fox McCloud
fix: Fixes items on your ear rendering as if they were equipped to another slot
del: can't requip cigs to your ears anymore
/:cl: