### PR TITLE
Improves Geiger Counters; Allows Toggle

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -370,7 +370,7 @@
 	return ..()
 
 /datum/action/item_action/toggle_geiger_counter
-	name = "Toggle Gieger Counter"
+	name = "Toggle Geiger Counter"
 
 /datum/action/item_action/toggle_geiger_counter/Trigger()
 	var/obj/item/clothing/head/helmet/space/hardsuit/H = target

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -369,6 +369,14 @@
 		return FALSE
 	return ..()
 
+/datum/action/item_action/toggle_geiger_counter
+	name = "Toggle Gieger Counter"
+
+/datum/action/item_action/toggle_geiger_counter/Trigger()
+	var/obj/item/clothing/head/helmet/space/hardsuit/H = target
+	if(istype(H))
+		H.toggle_geiger_counter()
+
 /datum/action/item_action/hands_free
 	check_flags = AB_CHECK_CONSCIOUS
 

--- a/code/datums/elements/rad_insulation.dm
+++ b/code/datums/elements/rad_insulation.dm
@@ -6,7 +6,7 @@
 /datum/element/rad_insulation/Attach(datum/target, _amount = RAD_MEDIUM_INSULATION, protects = TRUE, contamination_proof = TRUE)
 	. = ..()
 	if(!isatom(target))
-		return COMPONENT_INCOMPATIBLE
+		return ELEMENT_INCOMPATIBLE
 
 	if(protects) // Does this protect things in its contents from being affected?
 		RegisterSignal(target, COMSIG_ATOM_RAD_PROBE, .proc/rad_probe_react)

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -4,7 +4,7 @@
 	/// The center of the wave
 	var/turf/master_turf
 	/// How far we've moved
-	var/steps=0
+	var/steps = 0
 	/// How strong it was originaly
 	var/intensity
 	/// How much contaminated material it still has
@@ -101,7 +101,7 @@
 
 /datum/radiation_wave/proc/radiate(list/atoms, strength)
 	var/can_contam = strength >= RAD_MINIMUM_CONTAMINATION
-	var/contamination_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
+	var/contamination_strength = (strength - RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
 	contamination_strength = max(contamination_strength, RAD_BACKGROUND_RADIATION)
 	// It'll never reach 100% chance but the further out it gets the more likely it'll contaminate
 	var/contamination_chance = 100 - (90 / (1 + steps * 0.1))

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -33,30 +33,28 @@
 
 /obj/item/geiger_counter/Destroy()
 	STOP_PROCESSING(SSobj, src)
+	QDEL_NULL(soundloop)
 	return ..()
 
 
 /obj/item/geiger_counter/process()
-	update_icon()
-	update_sound()
+	if(scanning)
+		radiation_count -= radiation_count / RAD_GEIGER_MEASURE_SMOOTHING
+		radiation_count += current_tick_amount / RAD_GEIGER_MEASURE_SMOOTHING
 
-	if(!scanning)
-		current_tick_amount = 0
-		return
+		if(current_tick_amount)
+			grace = RAD_GEIGER_GRACE_PERIOD
+			last_tick_amount = current_tick_amount
 
-	radiation_count -= radiation_count / RAD_GEIGER_MEASURE_SMOOTHING
-	radiation_count += current_tick_amount / RAD_GEIGER_MEASURE_SMOOTHING
-
-	if(current_tick_amount)
-		grace = RAD_GEIGER_GRACE_PERIOD
-		last_tick_amount = current_tick_amount
-
-	else if(!emagged)
-		grace--
-		if(grace <= 0)
-			radiation_count = 0
+		else if(!emagged)
+			grace--
+			if(grace <= 0)
+				radiation_count = 0
 
 	current_tick_amount = 0
+
+	update_icon()
+	update_sound()
 
 /obj/item/geiger_counter/examine(mob/user)
 	. = ..()
@@ -169,13 +167,13 @@
 		return ..()
 
 /obj/item/geiger_counter/AltClick(mob/living/user)
-	if(!istype(user) || !!user.Adjacent(src))
+	if(!istype(user) || !user.Adjacent(src))
 		return ..()
 	if(!scanning)
 		to_chat(usr, "<span class='warning'>[src] must be on to reset its radiation level!</span>")
 		return
 	radiation_count = 0
-	to_chat(usr, "<span class='notice'>You flush [src]'s radiation counts, resetting it to normal.</span>")
+	to_chat(user, "<span class='notice'>You flush [src]'s radiation counts, resetting it to normal.</span>")
 	update_icon()
 
 /obj/item/geiger_counter/emag_act(mob/user)

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -102,10 +102,7 @@
 
 /obj/item/geiger_counter/proc/update_sound()
 	var/datum/looping_sound/geiger/loop = soundloop
-	if(!scanning)
-		loop.stop()
-		return
-	if(!radiation_count)
+	if(!scanning || !radiation_count)
 		loop.stop()
 		return
 	loop.last_radiation = radiation_count
@@ -170,7 +167,7 @@
 	if(!istype(user) || !user.Adjacent(src))
 		return ..()
 	if(!scanning)
-		to_chat(usr, "<span class='warning'>[src] must be on to reset its radiation level!</span>")
+		to_chat(user, "<span class='warning'>[src] must be on to reset its radiation level!</span>")
 		return
 	radiation_count = 0
 	to_chat(user, "<span class='notice'>You flush [src]'s radiation counts, resetting it to normal.</span>")

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -125,10 +125,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/proc/update_sound()
 	var/datum/looping_sound/geiger/loop = soundloop
-	if(!scanning)
-		loop.stop(loc)
-		return
-	if(!radiation_count)
+	if(!scanning || !radiation_count)
 		loop.stop(loc)
 		return
 	loop.last_radiation = radiation_count

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -121,7 +121,7 @@
 	current_tick_amount = 0
 
 	if(ishuman(loc))
-		update_sound(loc)
+		update_sound()
 
 /obj/item/clothing/head/helmet/space/hardsuit/proc/update_sound()
 	var/datum/looping_sound/geiger/loop = soundloop


### PR DESCRIPTION
Refactors Geiger counters a bit--they should be a hair bit more responsive than they previously were---this was partially inspired by TG, but they use a whole other system called `delta_time` to handle processing differently.

This also corrects a couple of issues @SteelSlayer brought up in the original radiation PR review.

And lastly, this also allows you to toggle a hardsuit helmet's geiger counter on or off--after having witnessed this, the past few days, there's definitely circumstances where you'd just not want to put up with it blaring out when it's obvious you or the things around you are emitting radiation and you just don't need to know anymore. The counter, though, defaults to `on` for hardsuit helmets, unlike regular geiger counters.

:cl: Fox McCloud
tweak: Geiger counters should be a hair bit more responsive
add: Can toggle hardsuit helmet's geiger counter on and off now
/:cl: