### PR TITLE
(Almost) All /turf now Initialize()

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -59,6 +59,7 @@
 
 	var/atmos_overlay_type = null //current active overlay
 
+// Dont make this Initialize(), youll break all of atmos
 /turf/simulated/New()
 	..()
 	if(!blocks_air)

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -332,10 +332,9 @@
 	icon_state = "grass1"
 	floor_tile = /obj/item/stack/tile/grass
 
-/turf/simulated/floor/holofloor/grass/New()
-	..()
-	spawn(1)
-		update_icon()
+/turf/simulated/floor/holofloor/grass/Initialize(mapload)
+	. = ..()
+	update_icon()
 
 /turf/simulated/floor/holofloor/grass/update_icon()
 	..()

--- a/code/modules/awaymissions/zvis.dm
+++ b/code/modules/awaymissions/zvis.dm
@@ -87,11 +87,11 @@
 	if(istype(T) && T.lighting_object && !T.lighting_object.needs_update)
 		var/atom/movable/lighting_object/O = T.lighting_object
 		var/hash = 0
-		
+
 		for(var/lighting_corner in O)
 			var/datum/lighting_corner/C = lighting_corner
 			hash = hash + C.lum_r + C.lum_g + C.lum_b
-			
+
 		if(hash != light_hash)
 			light_hash = hash
 			trigger()
@@ -109,8 +109,8 @@
 	var/turf/lower_turf
 	var/obj/effect/portal_sensor/sensor
 
-/turf/unsimulated/floor/upperlevel/New()
-	..()
+/turf/unsimulated/floor/upperlevel/Initialize(mapload)
+	. = ..()
 	var/obj/effect/levelref/R = locate() in get_area(src)
 	if(R && R.other)
 		init(R)


### PR DESCRIPTION
## What Does This PR Do
Makes almost all turfs use /Initialize() over /New(). The only exception now is `/turf/simulated/New()`
![image](https://user-images.githubusercontent.com/25063394/106132391-cd58d000-615b-11eb-95a1-6f54f2b767c5.png)

If you change this to `Initialize()`, atmos breaks badly.

## Why It's Good For The Game
Less startup lag, and the crusade can continue

## Changelog
N/A