### PR TITLE
Adds a backstab effect to the edagger

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -142,11 +142,11 @@
 	light_color = LIGHT_COLOR_RED
 
 /obj/item/pen/edagger/attack(mob/living/M, mob/living/user, def_zone)
-	if(on == 1 && user.dir == M.dir && !M.weakened && user != M)
+	if(on && user.dir == M.dir && !M.incapacitated(TRUE) && user != M)
 		M.apply_damage(10, BRUTE, BODY_ZONE_CHEST)
 		M.Weaken(1)
-		M.visible_message("<span class='warning'>[user] stabs [M] in the back!", "<span class='userdanger'>[user] stabs you in the back! The energy blade makes you collapse in pain!")
-	. = ..()
+		M.visible_message("<span class='warning'>[user] stabs [M] in the back!</span>", "<span class='userdanger'>[user] stabs you in the back! The energy blade makes you collapse in pain!</span>")
+	return ..()
 
 /obj/item/pen/edagger/attack_self(mob/living/user)
 	if(on)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -137,10 +137,16 @@
  */
 /obj/item/pen/edagger
 	origin_tech = "combat=3;syndicate=1"
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") //these wont show up if the pen is off
 	var/on = 0
 	var/brightness_on = 2
 	light_color = LIGHT_COLOR_RED
+
+/obj/item/pen/edagger/attack(mob/living/M, mob/living/user, def_zone)
+	if(on == 1 && user.dir == M.dir && !M.weakened && user != M)
+		M.apply_damage(10, BRUTE, BODY_ZONE_CHEST)
+		M.Weaken(1)
+		M.visible_message("<span class='warning'>[user] stabs [M] in the back!", "<span class='userdanger'>[user] stabs you in the back! The energy blade makes you collapse in pain!")
+	. = ..()
 
 /obj/item/pen/edagger/attack_self(mob/living/user)
 	if(on)
@@ -148,6 +154,7 @@
 		force = initial(force)
 		sharp = 0
 		w_class = initial(w_class)
+		attack_verb = list() // no attack verbs when it is off
 		name = initial(name)
 		hitsound = initial(hitsound)
 		embed_chance = initial(embed_chance)
@@ -160,6 +167,7 @@
 		force = 18
 		sharp = 1
 		w_class = WEIGHT_CLASS_NORMAL
+		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 		name = "energy dagger"
 		hitsound = 'sound/weapons/blade1.ogg'
 		embed_chance = 100 //rule of cool


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Edaggers will now weaken for 1 cycle and do a bonus 10 damage if you stab your target from behind.

## Why It's Good For The Game
Edaggers are slightly underwhelming. They can be easily outclassed by a welder, kitchen knife or syndie toolbox in actual viability when you take into consideration all of those are easily available, cost no or less TC and they won't get you perma'd for owning them. Adding a situational combat buff to the Edagger makes it better at actually assassinating people and worth the 2tc you spend on it. It might also help people make cool antag builds revolving around being a knifed assassin. 

Overall adding more viable options that traitors can purchase will add variety to the game and make rounds less static.  

## Changelog
:cl:
add: Edagger now deals bonus damage and stuns for 0-2 seconds when stabbing your target from behind.
fix: fixes a bug where edaggers would give attack verbs when turned off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
