### PR TITLE
supermatter_pull() now unbuckles mobs

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -773,6 +773,10 @@
 			var/mob/M = P
 			if(M.mob_negates_gravity())
 				continue //You can't pull someone nailed to the deck
+			else if(M.buckled)
+				var/atom/movable/buckler = M.buckled
+				if(buckler.unbuckle_mob(M, TRUE))
+					visible_message("<span class='danger'>[src]'s sheer force rips [M] away from [buckler]!</span>")
 		step_towards(P,center)
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_anomaly_gen(turf/anomalycenter, type = FLUX_ANOMALY, anomalyrange = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Pinging @Fox-McCloud as they worked on the SM.

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Supermatter crystal pull now unbuckles nearby mobs.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes an exploit allowing people to get front-row seats with the SM without getting pulled. This also means monkeys can no longer be used as immovable radiation accumulators.

## Changelog
:cl:
add: Supermatter crystal now unbuckles nearby mobs when pulling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
