### PR TITLE
Multitool linking for Teleporter Stations

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -592,14 +592,17 @@
 		update_icon()
 		return TRUE
 
-/obj/machinery/teleport/station/wirecutter_act(mob/user, obj/item/I)
+/obj/machinery/teleport/station/multitool_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	if(panel_open)
+		if(teleporter_hub && teleporter_console)
+			to_chat(user, "<span class='warning'>The station is already linked!</span>")
+			return
 		link_console_and_hub()
-		to_chat(user, "<span class='caution'>You reconnect the station to nearby machinery.</span>")
-
+		to_chat(user, "<span class='notice'>You reconnect the station to nearby machinery.</span>")
+		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 
 /obj/machinery/teleport/station/attack_ai()
 	attack_hand()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Changes the way that teleporter stations are linked from `Screwdriver > Wirecutters`, to `Screwdriver > Multitool`.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's a lot more intuitive.

## Changelog
:cl:
tweak: Changed the linking method for teleporter stations from wirecutters to multitool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
