### PR TITLE
Adds 3 bomb casings and toxins payload to toxins vendor, bomb tweaks

### DIFF
--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -2,7 +2,7 @@
 	randomize = TRUE
 	holder_type = /obj/machinery/syndicatebomb
 	wire_count = 5
-	proper_name = "Syndicate bomb"
+	proper_name = "Bomb"
 	window_x = 320
 	window_y = 22
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -115,6 +115,9 @@
 		if(open_panel)
 			wires.Interact(user)
 	else if(istype(I, /obj/item/bombcore))
+		if(!open_panel)
+			to_chat(user, "<span class='warning'>The cover is screwed on, you can't reach inside!</span>")
+			return
 		if(!payload)
 			if(!user.drop_item())
 				return
@@ -123,6 +126,9 @@
 			payload.forceMove(src)
 		else
 			to_chat(user, "<span class='notice'>[payload] is already loaded into [src], you'll have to remove it first.</span>")
+	else if(!payload && istype(I, /obj/item/transfer_valve))
+		to_chat(user, "<span class='notice'>[I] doesn't fit in [src], you'll need to use a toxins payload.</span>")
+		return
 	else
 		return ..()
 
@@ -292,16 +298,21 @@
 	beepsound = 'sound/items/bikehorn.ogg'
 
 /obj/machinery/syndicatebomb/empty
-	name = "bomb"
+	name = "bomb casing"
 	icon_state = "base-bomb"
-	desc = "An ominous looking device designed to detonate an explosive payload. Can be bolted down using a wrench."
+	desc = "A plasteel bomb casing. Load a payload and mend the wires before use. Can be bolted down using a wrench."
 	payload = null
 	open_panel = TRUE
-	timer_set = 120
 
 /obj/machinery/syndicatebomb/empty/New()
 	..()
 	wires.cut_all()
+
+/obj/machinery/syndicatebomb/empty/activate()
+	name = "bomb"
+	desc = "A plasteel bomb. Can be bolted down using a wrench."
+	..()
+
 
 /obj/machinery/syndicatebomb/self_destruct
 	name = "self destruct device"
@@ -613,7 +624,7 @@
 
 /obj/item/bombcore/toxins
 	name = "toxins payload"
-	desc = "A payload casing designed to secure a gas based bomb. Must be loaded with a tank transfer valve and installed into a plasteel bomb frame in order to be detonated."
+	desc = "A payload designed to secure a gas based bomb. Must be loaded with a tank transfer valve bomb and installed into a plasteel bomb casing in order to be detonated."
 	origin_tech = "materials=1;engineering=1"
 	icon_state = "chemcore"
 	var/obj/item/transfer_valve/ttv = null

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1257,7 +1257,7 @@
 	name = "\improper Toximate 3000"
 	desc = "All the fine parts you need in one vending machine!"
 	products = list(/obj/item/assembly/prox_sensor = 8, /obj/item/assembly/igniter = 8, /obj/item/assembly/signaler = 8,
-					/obj/item/wirecutters = 1, /obj/item/assembly/timer = 8)
+					/obj/item/wirecutters = 1, /obj/item/assembly/timer = 8, /obj/machinery/syndicatebomb/empty = 3, /obj/item/bombcore/toxins = 3)
 	contraband = list(/obj/item/flashlight = 5, /obj/item/assembly/voice = 3, /obj/item/assembly/health = 3, /obj/item/assembly/infra = 3)
 
 /obj/machinery/vending/wallmed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR adds three empty bomb casings and three toxins payloads to the toxins lab vendor. It also tweaks names and descriptions of bomb components to make their assembly easier to figure out.

It also updates the name of wire panel from 'Syndicate Bomb' to 'Bomb' to avoid scientists being mistakenly arrested for S contraband, when plasteel bombs are not.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Custom plasteel bombs are an underused feature due to the additional step of having to craft the components necessary for it. 
Having a few available for free at the toxins lab will encourage scientists and/or antags to experiment with it.

Plasteel bombs can be used to secure a toxins bomb before testing, or to make its activation easier and less deadly in the rare situations security might request a bomb from science (Offstation space cult base...)

Plasteel bombs are more interactive than using raw tank transfer valves, they have a 90 second minimum timer if not triggered early by wirecutting, it allows crewmembers to attempt to defuse it, and it beeps loudly (like syndicate bombs) to indicate to crew that they have to evacuate the area. 

This encourages usage of toxin bombs for area denial (with, of course, admin approval) instead of just mass murder.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/22121511/106356328-214fea00-62ff-11eb-8ac8-07d1345fda36.png)

## Changelog
:cl:
add: Adds 3 toxins payload and bomb casings to the toxins lab vendor.
tweak: Rename 'Syndicate Bomb' wire panel to 'Bomb'.
fix: Prevent installing a payload into a bomb with closed panel.
tweak: Updated name and description of empty bomb casings and toxins payload.
tweak: Empty bomb casings will now update their name and description to match a bomb once activated.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
