### PR TITLE
Suit Storage Units now clean radiation (and blood)

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -793,7 +793,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 /atom/proc/clean_blood(radiation_clean = FALSE)
 	germ_level = 0
 	if(radiation_clean)
-		clean_radiation(clean_factor = 2)
+		clean_radiation()
 	if(islist(blood_DNA))
 		blood_DNA = null
 		return TRUE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -793,14 +793,25 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 /atom/proc/clean_blood(radiation_clean = FALSE)
 	germ_level = 0
 	if(radiation_clean)
-		var/datum/component/radioactive/healthy_green_glow = GetComponent(/datum/component/radioactive)
-		if(!QDELETED(healthy_green_glow))
-			healthy_green_glow.strength = max(0, (healthy_green_glow.strength - (RAD_BACKGROUND_RADIATION * 2)))
-			if(healthy_green_glow.strength <= RAD_BACKGROUND_RADIATION)
-				qdel(healthy_green_glow)
+		clean_radiation(clean_factor = 2)
 	if(islist(blood_DNA))
 		blood_DNA = null
 		return TRUE
+
+/**
+  * Removes some radiation from an atom
+  *
+  * Removes a configurable amount of radiation from an atom
+  * and stops green glow if radiation gets low enough through it.
+  * Arguments:
+  * * clean_factor - How much radiation to remove, as a multiple of RAD_BACKGROUND_RADIATION (currently 9)
+  */
+/atom/proc/clean_radiation(clean_factor = 2)
+	var/datum/component/radioactive/healthy_green_glow = GetComponent(/datum/component/radioactive)
+	if(!QDELETED(healthy_green_glow))
+		healthy_green_glow.strength = max(0, (healthy_green_glow.strength - (RAD_BACKGROUND_RADIATION * clean_factor)))
+		if(healthy_green_glow.strength <= RAD_BACKGROUND_RADIATION)
+			qdel(healthy_green_glow)
 
 /obj/effect/decal/cleanable/blood/clean_blood(radiation_clean = FALSE)
 	return // While this seems nonsensical, clean_blood isn't supposed to be used like this on a blood decal.

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -402,8 +402,6 @@
 		uv = TRUE
 		locked = TRUE
 		update_icon()
-		for(var/atom/A in contents)
-			A.clean_blood(radiation_clean = TRUE)
 		if(occupant)
 			var/mob/living/mob_occupant = occupant
 			if(uv_super)
@@ -416,6 +414,9 @@
 		uv_cycles = initial(uv_cycles)
 		uv = FALSE
 		locked = FALSE
+		for(var/atom/A in contents)
+			A.clean_blood(radiation_clean = FALSE)	// we invoke the radiation cleaning proc directly
+			A.clean_radiation(clean_factor = 12)	// instead of letting clean_blood do it
 		if(uv_super)
 			visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A cloud of foul black smoke escapes from its chamber.</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 50, 1)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -416,7 +416,7 @@
 		locked = FALSE
 		for(var/atom/A in contents)
 			A.clean_blood(radiation_clean = FALSE)	// we invoke the radiation cleaning proc directly
-			A.clean_radiation(clean_factor = 12)	// instead of letting clean_blood do it
+			A.clean_radiation(12)	// instead of letting clean_blood do it
 		if(uv_super)
 			visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A cloud of foul black smoke escapes from its chamber.</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 50, 1)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -402,6 +402,8 @@
 		uv = TRUE
 		locked = TRUE
 		update_icon()
+		for(var/atom/A in contents)
+			A.clean_blood(radiation_clean = TRUE)
 		if(occupant)
 			var/mob/living/mob_occupant = occupant
 			if(uv_super)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The cleaning cycle of suit storage units, so far only useful as a murder tool, now serve their actual function and clean blood as well as radiation from their content.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes sense. It also gives cleaning cycles an actual use beyond impractical murder.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Suit Storage unit's cleaning cycle now removes radiation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
