### PR TITLE
Adds the Teleprod to the crafting menu and ups the cost per use

### DIFF
--- a/code/game/objects/items/weapons/teleprod.dm
+++ b/code/game/objects/items/weapons/teleprod.dm
@@ -4,6 +4,7 @@
 	icon_state = "teleprod_nocell"
 	base_icon = "teleprod"
 	item_state = "teleprod"
+	hitcost = 3000
 	origin_tech = "combat=2;bluespace=4;materials=3"
 
 /obj/item/melee/baton/cattleprod/teleprod/attack(mob/living/carbon/M, mob/living/carbon/user)//handles making things teleport when hit

--- a/code/game/objects/items/weapons/teleprod.dm
+++ b/code/game/objects/items/weapons/teleprod.dm
@@ -6,6 +6,7 @@
 	item_state = "teleprod"
 	hitcost = 3000
 	origin_tech = "combat=2;bluespace=4;materials=3"
+	var/uses = 0
 
 /obj/item/melee/baton/cattleprod/teleprod/attack(mob/living/carbon/M, mob/living/carbon/user)//handles making things teleport when hit
 	..()
@@ -18,3 +19,12 @@
 			do_teleport(user, get_turf(user), 50)//honk honk
 		else if(iscarbon(M) && !M.anchored)
 			do_teleport(M, get_turf(M), 15)
+		uses++
+		if(prob((uses-5)*2))
+			user.visible_message("<span class='danger'>The crystal on [user]'s [src] shatters!</span>", \
+								"<span class='userdanger'>Your [src]'s bluespace crystal shattered!</span>")
+			cell.forceMove(get_turf(user))
+			cell = null
+			qdel(src)
+			var/obj/item/wirerod/R = new
+			user.put_in_active_hand(R)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -45,6 +45,15 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/teleprod
+	name = "Teleprod"
+	result = /obj/item/melee/baton/cattleprod/teleprod
+	reqs = list(/obj/item/melee/baton/cattleprod = 1,
+	            /obj/item/stack/sheet/bluespace_crystal = 1)
+	time = 40
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/bola
 	name = "Bola"
 	result = /obj/item/restraints/legcuffs/bola


### PR DESCRIPTION
## What Does This PR Do
This allows the Teleprod to be crafted via the crafting menu via stunprod and a bluespace polycrystal. This also ups the cost of using the teleprod. A high-capacity power cell will use 30% of the cell per use compared to the stunprod using 20% or the baton using 10%. This can be changed if it's not enough of a cost, but I think it's fine.

## Why It's Good For The Game
Allows for variety in stuntools, and a non-lethal option (though it can space people by chance) for players to use. This is also a cool tool that currently can't be made, making it cost more battery to use and a chance to break will make it fit more in the game I think. If it isn't enough cost or too low of a chance to break, it can be adjusted.

## Images of changes
![teleprod](https://user-images.githubusercontent.com/68139038/106369841-90cad700-6309-11eb-8d6f-138c35d7467a.png)

## Changelog
:cl:
add: adds the teleprod to the crafting menu
tweak: raised teleprod cost and has limited uses
/:cl:
