### PR TITLE
Adds a stat for supermatter delaminations

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -289,6 +289,7 @@
 	explode()
 
 /obj/machinery/power/supermatter_crystal/proc/explode()
+	SSblackbox.record_feedback("amount", "supermatter_delaminations", 1)
 	for(var/mob in GLOB.alive_mob_list)
 		var/mob/living/L = mob
 		if(istype(L) && atoms_share_level(L, src))


### PR DESCRIPTION
## What Does This PR Do
Adds a blackbox stat to track SM delaminations
![image](https://user-images.githubusercontent.com/25063394/106385621-25e0d500-63c9-11eb-8013-2877367058ed.png)


## Why It's Good For The Game
This will be ~~entertaining~~ interesting data

## Changelog
:cl: AffectedArc07
add: Added blackbox stat for SM delaminations
/:cl:
