### PR TITLE
Gives better feedback when control or alt-clicking pressure pumps, volume pumps, etc.

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -658,11 +658,11 @@ Class Procs:
  * * user - the mob who is trying to interact with the machine.
  */
 /obj/machinery/proc/can_use_shortcut(mob/living/user)
-	if(!ishuman(user) && !issilicon(user))
-		return FALSE
-	if(!in_range(src, user) && !issilicon(user))
-		return FALSE
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return FALSE
-	return TRUE
+	if(ishuman(user) && in_range(src, user))
+		return TRUE
+	if(issilicon(user))
+		return TRUE
+	return FALSE

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -650,3 +650,19 @@ Class Procs:
 	. = . % 9
 	AM.pixel_x = -8 + ((.%3)*8)
 	AM.pixel_y = -8 + (round( . / 3)*8)
+
+/**
+ * Makes sure the user is allowed to interact with the machine when they use a shortcut, like Control or Alt-clicking.
+ *
+ * Arguments:
+ * * user - the mob who is trying to interact with the machine.
+ */
+/obj/machinery/proc/can_use_shortcut(mob/living/user)
+	if(!ishuman(user) && !issilicon(user))
+		return FALSE
+	if(!in_range(src, user) && !issilicon(user))
+		return FALSE
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return FALSE
+	return TRUE

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -366,9 +366,10 @@ Pipelines + Other Objects -> Pipe network
  * * user - the mob who is toggling the machine.
  */
 /obj/machinery/atmospherics/proc/toggle(mob/living/user)
-	if(powered())
-		on = !on
-		update_icon()
+	if(!powered())
+		return
+	on = !on
+	update_icon()
 	if(user)
 		to_chat(user, "<span class='notice'>You toggle [src] [on ? "on" : "off"].</span>")
 
@@ -381,8 +382,9 @@ Pipelines + Other Objects -> Pipe network
  * * user - the mob who is setting the output pressure to maximum.
  */
 /obj/machinery/atmospherics/proc/set_max(mob/living/user)
-	if(powered())
-		target_pressure = MAX_OUTPUT_PRESSURE
-		update_icon()
+	if(!powered())
+		return
+	target_pressure = MAX_OUTPUT_PRESSURE
+	update_icon()
 	if(user)
 		to_chat(user, "<span class='notice'>You set the target pressure of [src] to maximum.</span>")

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -20,7 +20,10 @@ Pipelines + Other Objects -> Pipe network
 	on_blueprints = TRUE
 	var/nodealert = 0
 	var/can_unwrench = 0
-
+	/// If the machine is currently operating or not.
+	var/on = FALSE
+	/// The amount of pressure the machine wants to operate at.
+	var/target_pressure = 0
 	var/connect_types[] = list(1) //1=regular, 2=supply, 3=scrubber
 	var/connected_to = 1 //same as above, currently not used for anything
 	var/icon_connect_type = "" //"-supply" or "-scrubbers"
@@ -353,3 +356,33 @@ Pipelines + Other Objects -> Pipe network
 //Used for certain children of obj/machinery/atmospherics to not show pipe vision when mob is inside it.
 /obj/machinery/atmospherics/proc/can_see_pipes()
 	return TRUE
+
+/**
+ * Turns the machine either on, or off. If this is done by a user, display a message to them.
+ *
+ * NOTE: Only applies to atmospherics machines which can be toggled on or off, such as pumps, or other devices.
+ *
+ * Arguments:
+ * * user - the mob who is toggling the machine.
+ */
+/obj/machinery/atmospherics/proc/toggle(mob/living/user)
+	if(powered())
+		on = !on
+		update_icon()
+	if(user)
+		to_chat(user, "<span class='notice'>You toggle [src] [on ? "on" : "off"].</span>")
+
+/**
+ * Maxes the output pressure of the machine. If this is done by a user, display a message to them.
+ *
+ * NOTE: Only applies to atmospherics machines which allow a `target_pressure` to be set, such as pumps, or other devices.
+ *
+ * Arguments:
+ * * user - the mob who is setting the output pressure to maximum.
+ */
+/obj/machinery/atmospherics/proc/set_max(mob/living/user)
+	if(powered())
+		target_pressure = MAX_OUTPUT_PRESSURE
+		update_icon()
+	if(user)
+		to_chat(user, "<span class='notice'>You set the target pressure of [src] to maximum.</span>")

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -16,7 +16,6 @@
 
 	connect_types = list(1,2,3) //connects to regular, supply and scrubbers pipes
 
-	var/on = 0
 	var/pump_direction = 1 //0 = siphoning, 1 = releasing
 
 	var/external_pressure_bound = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -9,8 +9,7 @@
 
 	can_unwrench = 1
 
-	var/on = 0
-	var/target_pressure = ONE_ATMOSPHERE
+	target_pressure = ONE_ATMOSPHERE
 
 	var/id = null
 
@@ -173,11 +172,6 @@
 			. = TRUE
 	if(.)
 		investigate_log("was set to [target_pressure] kPa by [key_name(usr)]", "atmos")
-
-/obj/machinery/atmospherics/binary/passive_gate/proc/toggle()
-	if(powered())
-		on = !on
-		update_icon()
 
 /obj/machinery/atmospherics/binary/passive_gate/attackby(obj/item/W, mob/user, params)
 	if(!istype(W, /obj/item/wrench))

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -44,7 +44,6 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/pump/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-	return
 
 /obj/machinery/atmospherics/binary/pump/AIAltClick()
 	set_max()

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -21,53 +21,34 @@ Thus, the two variables affect pump operation are set in New():
 
 	can_unwrench = 1
 
-	var/on = 0
-	var/target_pressure = ONE_ATMOSPHERE
+	target_pressure = ONE_ATMOSPHERE
 
 	var/id = null
 
 /obj/machinery/atmospherics/binary/pump/detailed_examine()
 	return "This moves gas from one pipe to another. A higher target pressure demands more energy. The side with the red end is the output."
 
+// So we can CtrlClick without triggering the anchored message.
+/obj/machinery/atmospherics/binary/pump/can_be_pulled(user, grab_state, force, show_message)
+	return FALSE
+
 /obj/machinery/atmospherics/binary/pump/CtrlClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	toggle()
+	if(can_use_shortcut(user))
+		toggle(user)
 	return ..()
 
-/obj/machinery/atmospherics/binary/pump/AICtrlClick()
-	toggle()
+/obj/machinery/atmospherics/binary/pump/AICtrlClick(mob/living/silicon/user)
+	toggle(user)
 	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	set_max()
+	if(can_use_shortcut(user))
+		set_max(user)
 	return
 
 /obj/machinery/atmospherics/binary/pump/AIAltClick()
 	set_max()
 	return ..()
-
-/obj/machinery/atmospherics/binary/pump/proc/toggle()
-	if(powered())
-		on = !on
-		update_icon()
-
-/obj/machinery/atmospherics/binary/pump/proc/set_max()
-	if(powered())
-		target_pressure = MAX_OUTPUT_PRESSURE
-		update_icon()
 
 /obj/machinery/atmospherics/binary/pump/Destroy()
 	if(SSradio)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -39,15 +39,13 @@ Thus, the two variables affect pump operation are set in New():
 
 /obj/machinery/atmospherics/binary/pump/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
 
-/obj/machinery/atmospherics/binary/pump/AIAltClick()
-	set_max()
-	return ..()
+/obj/machinery/atmospherics/binary/pump/AIAltClick(mob/living/silicon/user)
+	set_max(user)
 
 /obj/machinery/atmospherics/binary/pump/Destroy()
 	if(SSradio)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -21,50 +21,31 @@ Thus, the two variables affect pump operation are set in New():
 
 	can_unwrench = 1
 
-	var/on = 0
 	var/transfer_rate = 200
 
 	var/id = null
 
+// So we can CtrlClick without triggering the anchored message.
+/obj/machinery/atmospherics/binary/volume_pump/can_be_pulled(user, grab_state, force, show_message)
+	return FALSE
+
 /obj/machinery/atmospherics/binary/volume_pump/CtrlClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	toggle()
+	if(can_use_shortcut(user))
+		toggle(user)
 	return ..()
 
-/obj/machinery/atmospherics/binary/volume_pump/AICtrlClick()
-	toggle()
+/obj/machinery/atmospherics/binary/volume_pump/AICtrlClick(mob/living/silicon/user)
+	toggle(user)
 	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	set_max()
+	if(can_use_shortcut(user))
+		set_max(user)
 	return
 
 /obj/machinery/atmospherics/binary/volume_pump/AIAltClick()
 	set_max()
 	return ..()
-
-/obj/machinery/atmospherics/binary/volume_pump/proc/toggle()
-	if(powered())
-		on = !on
-		update_icon()
-
-/obj/machinery/atmospherics/binary/volume_pump/proc/set_max()
-	if(powered())
-		transfer_rate = MAX_TRANSFER_RATE
-		update_icon()
 
 /obj/machinery/atmospherics/binary/volume_pump/Destroy()
 	if(SSradio)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -36,15 +36,13 @@ Thus, the two variables affect pump operation are set in New():
 
 /obj/machinery/atmospherics/binary/volume_pump/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
 
-/obj/machinery/atmospherics/binary/volume_pump/AIAltClick()
-	set_max()
-	return ..()
+/obj/machinery/atmospherics/binary/volume_pump/AIAltClick(mob/living/silicon/user)
+	set_max(user)
 
 /obj/machinery/atmospherics/binary/volume_pump/Destroy()
 	if(SSradio)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -41,7 +41,6 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/volume_pump/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-	return
 
 /obj/machinery/atmospherics/binary/volume_pump/AIAltClick()
 	set_max()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -42,15 +42,13 @@
 
 /obj/machinery/atmospherics/trinary/filter/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
 
-/obj/machinery/atmospherics/trinary/filter/AIAltClick()
-	set_max()
-	return ..()
+/obj/machinery/atmospherics/trinary/filter/AIAltClick(mob/living/silicon/user)
+	set_max(user)
 
 /obj/machinery/atmospherics/trinary/filter/Destroy()
 	if(SSradio)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -47,7 +47,6 @@
 /obj/machinery/atmospherics/trinary/filter/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-	return
 
 /obj/machinery/atmospherics/trinary/filter/AIAltClick()
 	set_max()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -17,8 +17,8 @@
 	icon = 'icons/atmos/filter.dmi'
 	icon_state = "map"
 	can_unwrench = TRUE
-	/// The amount of pressure the filter wants to operate at.
-	var/target_pressure = ONE_ATMOSPHERE
+
+	target_pressure = ONE_ATMOSPHERE
 	/// The type of gas we want to filter. Valid values that go here are from the `FILTER` defines at the top of the file.
 	var/filter_type = FILTER_TOXINS
 	/// A list of available filter options. Used with `ui_data`.
@@ -31,45 +31,27 @@
 		"N2O" = FILTER_N2O
 	)
 
+// So we can CtrlClick without triggering the anchored message.
+/obj/machinery/atmospherics/trinary/filter/can_be_pulled(user, grab_state, force, show_message)
+	return FALSE
+
 /obj/machinery/atmospherics/trinary/filter/CtrlClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	toggle()
+	if(can_use_shortcut(user))
+		toggle(user)
 	return ..()
 
-/obj/machinery/atmospherics/trinary/filter/AICtrlClick()
-	toggle()
+/obj/machinery/atmospherics/trinary/filter/AICtrlClick(mob/living/silicon/user)
+	toggle(user)
 	return ..()
 
 /obj/machinery/atmospherics/trinary/filter/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	set_max()
+	if(can_use_shortcut(user))
+		set_max(user)
 	return
 
 /obj/machinery/atmospherics/trinary/filter/AIAltClick()
 	set_max()
 	return ..()
-
-/obj/machinery/atmospherics/trinary/filter/proc/toggle()
-	if(powered())
-		on = !on
-		update_icon()
-
-/obj/machinery/atmospherics/trinary/filter/proc/set_max()
-	if(powered())
-		target_pressure = MAX_OUTPUT_PRESSURE
-		update_icon()
 
 /obj/machinery/atmospherics/trinary/filter/Destroy()
 	if(SSradio)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -28,7 +28,6 @@
 /obj/machinery/atmospherics/trinary/mixer/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
-	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AIAltClick()
 	set_max()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -23,15 +23,13 @@
 
 /obj/machinery/atmospherics/trinary/mixer/AICtrlClick(mob/living/silicon/user)
 	toggle(user)
-	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AltClick(mob/living/user)
 	if(can_use_shortcut(user))
 		set_max(user)
 
-/obj/machinery/atmospherics/trinary/mixer/AIAltClick()
-	set_max()
-	return ..()
+/obj/machinery/atmospherics/trinary/mixer/AIAltClick(mob/living/silicon/user)
+	set_max(user)
 
 /obj/machinery/atmospherics/trinary/mixer/flipped
 	icon_state = "mmap"

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -6,37 +6,29 @@
 
 	name = "gas mixer"
 
-	var/target_pressure = ONE_ATMOSPHERE
+	target_pressure = ONE_ATMOSPHERE
 	var/node1_concentration = 0.5
 	var/node2_concentration = 0.5
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
+// So we can CtrlClick without triggering the anchored message.
+/obj/machinery/atmospherics/trinary/mixer/can_be_pulled(user, grab_state, force, show_message)
+	return FALSE
+
 /obj/machinery/atmospherics/trinary/mixer/CtrlClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	toggle()
+	if(can_use_shortcut(user))
+		toggle(user)
 	return ..()
 
-/obj/machinery/atmospherics/trinary/mixer/AICtrlClick()
-	toggle()
+/obj/machinery/atmospherics/trinary/mixer/AICtrlClick(mob/living/silicon/user)
+	toggle(user)
 	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user) && !issilicon(usr))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	set_max()
-	return
+	if(can_use_shortcut(user))
+		set_max(user)
+	return ..()
 
 /obj/machinery/atmospherics/trinary/mixer/AIAltClick()
 	set_max()
@@ -45,16 +37,6 @@
 /obj/machinery/atmospherics/trinary/mixer/flipped
 	icon_state = "mmap"
 	flipped = 1
-
-/obj/machinery/atmospherics/trinary/mixer/proc/toggle()
-	if(powered())
-		on = !on
-		update_icon()
-
-/obj/machinery/atmospherics/trinary/mixer/proc/set_max()
-	if(powered())
-		target_pressure = MAX_OUTPUT_PRESSURE
-		update_icon()
 
 /obj/machinery/atmospherics/trinary/mixer/update_icon(safety = 0)
 	..()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_base.dm
@@ -3,7 +3,6 @@
 	initialize_directions = SOUTH|NORTH|WEST
 	use_power = IDLE_POWER_USE
 
-	var/on = 0
 	layer = GAS_FILTER_LAYER
 
 	var/datum/gas_mixture/air1

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -13,7 +13,6 @@
 	interact_offline = 1
 	max_integrity = 350
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 30, "acid" = 30)
-	var/on = FALSE
 	var/temperature_archived
 	var/mob/living/carbon/occupant = null
 	var/obj/item/reagent_containers/glass/beaker = null

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -13,7 +13,6 @@
 
 	req_one_access_txt = "24;10"
 
-	var/on = 0
 	var/injecting = 0
 
 	var/volume_rate = 50

--- a/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
@@ -9,8 +9,6 @@
 	dir = SOUTH
 	initialize_directions = SOUTH
 
-	var/on = 0
-
 	var/oxygen_content = 10
 
 /obj/machinery/atmospherics/unary/oxygen_generator/update_icon()

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -10,8 +10,6 @@
 
 	var/obj/machinery/portable_atmospherics/connected_device
 
-	var/on = 0
-
 /obj/machinery/atmospherics/unary/portables_connector/Destroy()
 	if(connected_device)
 		connected_device.disconnect()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -10,9 +10,6 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 30)
 	layer = OBJ_LAYER
 
-	///Check if the device should be on or off
-	var/on = FALSE
-
 	var/icon_state_off = "freezer"
 	var/icon_state_on = "freezer_1"
 	var/icon_state_open = "freezer-o"

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -20,7 +20,6 @@
 
 	req_one_access_txt = "24;10"
 
-	var/on = 0
 	var/pump_direction = 1 //0 = siphoning, 1 = releasing
 
 	var/external_pressure_bound = EXTERNAL_PRESSURE_BOUND

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -20,7 +20,6 @@
 
 	var/list/turf/simulated/adjacent_turfs = list()
 
-	var/on = 0
 	var/scrubbing = 1 //0 = siphoning, 1 = scrubbing
 	var/scrub_O2 = 0
 	var/scrub_N2 = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

1. Removes the "It's anchored to the floor!" messages when you control-click on pressure pumps, volume pumps, gas filters, and gas mixers. Adds a new chat message for this: "You toggle X on/off".
2. Adds a new chat message for alt-clicking these devices: "You set the target pressure of X to maximum."
3. Small refactor of some variables. I had to unfortunately change a bunch of files because tons of atmos machinery were declaring `var/on` and `var/target_pressure` all over the place. Made these base vars on `/obj/machinery/atmospherics`

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better, and correct feedback to players.

Fixes #15400
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removes the "It's anchored to the floor!" messages when you control-click on pressure pumps, volume pumps, gas filters, and gas mixers
tweak: Adds feedback messages when alt or control-clicking on pressure pumps, volume pumps, gas filters, and gas mixers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
