### PR TITLE
Some Admin/Mentor help improvements

### DIFF
--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -286,7 +286,7 @@ SUBSYSTEM_DEF(tickets)
 
 /datum/controller/subsystem/tickets/proc/assignStaffToTicket(client/C, N)
 	var/datum/ticket/T = allTickets[N]
-	if(T.staffAssigned != null && T.staffAssigned != C && alert("Ticket is already assigned to [T.staffAssigned.ckey]. Are you sure you want to take it?","Take ticket","No","Yes") != "Yes")
+	if(T.staffAssigned != null && T.staffAssigned != C && alert("Ticket is already assigned to [T.staffAssigned.ckey]. Are you sure you want to take it?", "Take ticket", "Yes", "No") != "Yes")
 		return FALSE
 	T.assignStaff(C)
 	return TRUE

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -172,6 +172,9 @@ SUBSYSTEM_DEF(tickets)
 	if(!other_ticket_system_staff_check())
 		return
 	var/datum/ticket/T = allTickets[ticketId]
+	if(T.ticket_converted)
+		to_chat(usr, "<span class='warning'>This ticket has already been converted!</span>")
+		return
 	convert_ticket(T)
 
 /datum/controller/subsystem/tickets/proc/other_ticket_system_staff_check()
@@ -183,6 +186,7 @@ SUBSYSTEM_DEF(tickets)
 
 /datum/controller/subsystem/tickets/proc/convert_ticket(datum/ticket/T)
 	T.ticketState = TICKET_CLOSED
+	T.ticket_converted = TRUE
 	var/client/C = usr.client
 	var/client/owner = get_client_by_ckey(T.client_ckey)
 	to_chat_safe(owner, list("<span class='[span_class]'>[key_name_hidden(C)] has converted your ticket to a [other_ticket_name] ticket.</span>",\
@@ -290,21 +294,36 @@ SUBSYSTEM_DEF(tickets)
 //Single staff ticket
 
 /datum/ticket
-	var/ticketNum // Ticket number
-	/// ckey of the client who opened the ticket
+	/// Ticket number.
+	var/ticketNum
+	/// ckey of the client who opened the ticket.
 	var/client_ckey
-	var/timeOpened // Time the ticket was opened
-	var/title //The initial message with links
-	var/raw_title // The title without URLs added
-	var/list/content // content of the staff help
-	var/lastStaffResponse // Last staff member who responded
-	var/lastResponseTime // When the staff last responded
-	var/locationSent // Location the player was when they send the ticket
-	var/mobControlled // Mob they were controlling
-	var/ticketState // State of the ticket, open, closed, resolved etc
-	var/timeUntilStale // When the ticket goes stale
-	var/ticketCooldown // Cooldown before allowing the user to open another ticket.
-	var/client/staffAssigned // Staff member who has assigned themselves to this ticket
+	/// Time the ticket was opened.
+	var/timeOpened
+	/// The initial message with links.
+	var/title
+	/// The title without URLs added.
+	var/raw_title
+	/// Content of the staff help.
+	var/list/content
+	/// Last staff member who responded.
+	var/lastStaffResponse
+	/// When the staff last responded.
+	var/lastResponseTime
+	/// The location the player was when they sent the ticket.
+	var/locationSent
+	/// The mob the player was controlling when they sent the ticket.
+	var/mobControlled
+	/// State of the ticket, open, closed, resolved etc.
+	var/ticketState
+	/// Has the ticket been converted to another type? (Mhelp to Ahelp, etc.)
+	var/ticket_converted = FALSE
+	/// When the ticket goes stale.
+	var/timeUntilStale
+	/// Cooldown before allowing the user to open another ticket.
+	var/ticketCooldown
+	/// Staff member who has assigned themselves to this ticket.
+	var/client/staffAssigned
 
 /datum/ticket/New(tit, raw_tit, cont, num)
 	title = tit
@@ -328,6 +347,8 @@ SUBSYSTEM_DEF(tickets)
 
 //Return the ticket state as a colour coded text string.
 /datum/ticket/proc/state2text()
+	if(ticket_converted)
+		return "<font color='yellow'>CONVERTED</font>"
 	switch(ticketState)
 		if(TICKET_OPEN)
 			return "<font color='green'>OPEN</font>"
@@ -430,7 +451,7 @@ UI STUFF
 	dat += "<h2>Ticket #[T.ticketNum]</h2>"
 
 	dat += "<h3>[T.client_ckey] / [T.mobControlled] opened this [ticket_name] at [T.timeOpened] at location [T.locationSent]</h3>"
-	dat += "<h4>Ticket Status: <font color='red'>[status]</font>"
+	dat += "<h4>Ticket Status: [status]"
 	dat += "<table style='width:950px; border: 3px solid;'>"
 	dat += "<tr><td>[T.title]</td></tr>"
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -1,7 +1,5 @@
-
-
 //This is a list of words which are ignored by the parser when comparing message contents for names. MUST BE IN LOWER CASE!
-GLOBAL_LIST_INIT(adminhelp_ignored_words, list("unknown","the","a","an","of","monkey","alien","as"))
+GLOBAL_LIST_INIT(adminhelp_ignored_words, list("unknown", "the", "a", "an", "of", "monkey", "alien", "as"))
 
 /client/verb/adminhelp()
 	set category = "Admin"
@@ -12,27 +10,28 @@ GLOBAL_LIST_INIT(adminhelp_ignored_words, list("unknown","the","a","an","of","mo
 		to_chat(src, "<font color='red'>Error: Admin-PM: You cannot send adminhelps (Muted).</font>")
 		return
 
-	adminhelped = 1 //Determines if they get the message to reply by clicking the name.
+	adminhelped = TRUE //Determines if they get the message to reply by clicking the name.
 
 	var/msg
-	var/list/type = list("Mentorhelp","Adminhelp")
-	var/selected_type = input("Pick a category.", "Admin Help", null, null) as null|anything in type
+	var/list/type = list("Mentorhelp", "Adminhelp")
+	var/selected_type = input("Pick a category.", "Admin Help") as null|anything in type
 	if(selected_type)
-		msg = clean_input("Please enter your message.", "Admin Help", null)
+		msg = clean_input("Please enter your message.", selected_type)
 
-	//clean the input msg
 	if(!msg)
 		return
 
 	if(handle_spam_prevention(msg, MUTE_ADMINHELP, OOC_COOLDOWN))
 		return
 
-	msg = sanitize_simple(copytext(msg,1,MAX_MESSAGE_LEN))
-	if(!msg)	return
+	msg = sanitize_simple(copytext(msg, 1, MAX_MESSAGE_LEN))
+	if(!msg) // No message after sanitisation
+		return
+
 	if(selected_type == "Mentorhelp")
-		SSmentor_tickets.newHelpRequest(src, msg)
+		SSmentor_tickets.newHelpRequest(src, msg) // Mhelp
 	else
-		SStickets.newHelpRequest(src, msg)
+		SStickets.newHelpRequest(src, msg) // Ahelp
 
 	//show it to the person adminhelping too
 	to_chat(src, "<span class='boldnotice'>[selected_type]</b>: [msg]</span>")
@@ -54,7 +53,7 @@ GLOBAL_LIST_INIT(adminhelp_ignored_words, list("unknown","the","a","an","of","mo
 			var/inactive_mentors = mentorcount[3]
 
 			if(active_mentors <= 0)
-				if(inactive_mentors > 0)
+				if(inactive_mentors)
 					alerttext = " | **ALL MENTORS AFK**"
 				else
 					alerttext = " | **NO MENTORS ONLINE**"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
1. Made the 'Adminhelp' input window change to 'Mentorhelp' if applicable.
2. Adds a `ticket_converted` variable to admin/mentor tickets to prevent them from being converted by multiple people.
*(This doesn't stop converted tickets from being converted back, since converting makes a new ticket.)*
3. Added a yellow 'CONVERTED' status message if the mentor/admin ticket has been converted.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. Stops the worry that you might have selected the wrong ticket category by accident.
2. Stops potential spam, since it makes a new ticket each time it's clicked.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
**Ahelp**
![ahelp](https://user-images.githubusercontent.com/57483089/106562201-e083eb00-6521-11eb-90f1-d7145def2a9d.png)

**Mhelp**
![mhelp](https://user-images.githubusercontent.com/57483089/106562206-e37edb80-6521-11eb-9bc2-f3b2467f1079.png)

**Converted**
![converted](https://user-images.githubusercontent.com/57483089/106564080-a2d49180-6524-11eb-82d0-d20807bd0000.PNG)

## Changelog
:cl:
tweak: Choosing 'Mentorhelp' from the ahelp selection list now changes the window title to 'Mentorhelp', to prevent confusion.
fix: Fixed Admin/Mentor tickets being converted to the other type more than once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
