### PR TITLE
Adjust Airlock Buttons Layers

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -146,6 +146,7 @@
 /obj/machinery/airlock_sensor
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_sensor_off"
+	layer = ABOVE_WINDOW_LAYER
 	name = "airlock sensor"
 	anchored = 1
 	resistance_flags = FIRE_PROOF
@@ -228,9 +229,9 @@
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "access_button_standby"
 	name = "access button"
+	layer = ABOVE_WINDOW_LAYER
 	anchored = 1
 	power_channel = ENVIRON
-
 	var/master_tag
 	frequency = AIRLOCK_FREQ
 	var/command = "cycle"

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -1,5 +1,6 @@
 //base type for controllers of two-door systems
 /obj/machinery/embedded_controller/radio/airlock
+	layer = ABOVE_WINDOW_LAYER
 	// Setup parameters only
 	radio_filter = RADIO_AIRLOCK
 	var/tag_exterior_door


### PR DESCRIPTION
Adjust the layer of of several airlock related buttons/infrastructure, so they're above windows and you press them, once again.

fixes: https://github.com/ParadiseSS13/Paradise/issues/15425

:cl: Fox McCloud
fix: Fixes the layering of airlock related buttons/infrastructure so you can interact with it, once again
/:cl: