### PR TITLE
Prevents server-freezing spin() calls

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1348,8 +1348,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/spin(spintime, speed)
 	set waitfor = 0
 	if(!spintime || !speed || spintime > 100)
-		stack_trace("Aborted attempted call of /mob/proc/spin with invalid args ([spintime],[speed]) which could have frozen the server.")
-		return
+		CRASH("Aborted attempted call of /mob/proc/spin with invalid args ([spintime],[speed]) which could have frozen the server.")
 	var/D = dir
 	while(spintime >= speed)
 		sleep(speed)
@@ -1453,4 +1452,3 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		blood_state = BLOOD_STATE_NOT_BLOODY
 		update_inv_shoes()
 	update_icons()	//apply the now updated overlays to the mob
-

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1347,6 +1347,9 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 /mob/proc/spin(spintime, speed)
 	set waitfor = 0
+	if(!spintime || !speed || spintime > 100)
+		stack_trace("Aborted attempted call of /mob/proc/spin with invalid args ([spintime],[speed]) which could have frozen the server.")
+		return
 	var/D = dir
 	while(spintime >= speed)
 		sleep(speed)


### PR DESCRIPTION
## What Does This PR Do
Adds safety limits to /mob/proc/spin which prevent it being used to create a loop that's so long, or infinite, that it freezes the server for an indefinite period of time.
The primary cause of this happening is admins doing a proccall of spin() without specifying any arguments, which equates to spin(0, 0) and creates an infinite loop.

## Why It's Good For The Game
Prevents the server getting stuck in a semi-frozen state processing an infinite loop.

## Changelog
:cl: Kyep
fix: added sanity checking to prevent accidentally freezing or lagging the server using a function to spin mobs around.
/:cl: