### PR TITLE
Removes Shaft Miners and the Mechanic as possible Contractor targets

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
@@ -8,6 +8,8 @@
 	/// Jobs that cannot be the kidnapping target.
 	var/static/list/forbidden_jobs = list(
 		"Captain",
+		"Mechanic",
+		"Shaft Miner",
 	)
 	/// Static whitelist of area names that can be used as an extraction zone, structured by difficulty.
 	/// An area's difficulty should be measured in how crowded it generally is, how out of the way it is and so on.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds 'Mechanic' and 'Shaft Miner' to the list of excluded jobs for Contractor targets.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's hard to kidnap someone alive when they're gibbed on another Z-level.

## Changelog
:cl:
tweak: Shaft Miners and the Mechanic can no longer be given as Contractor targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
