### PR TITLE
Initialized singulo

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -25,8 +25,8 @@
 	grav_pull = 10
 	consume_range = 12 //How many tiles out do we eat
 
-/obj/singularity/narsie/large/New()
-	..()
+/obj/singularity/narsie/large/Initialize(mapload, starting_energy)
+	. = ..()
 	icon_state = SSticker.cultdat?.entity_icon_state
 	name = SSticker.cultdat?.entity_name
 	to_chat(world, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")
@@ -41,9 +41,10 @@
 		var/image/alert_overlay = image('icons/effects/cult_effects.dmi', "ghostalertsie")
 		notify_ghosts("[name] has risen in \the [A.name]. Reach out to the Geometer to be given a new shell for your soul.", source = src, alert_overlay = alert_overlay, action = NOTIFY_ATTACK)
 
-	narsie_spawn_animation()
+	INVOKE_ASYNC(src, .proc/narsie_spawn_animation)
+	addtimer(CALLBACK(src, .proc/call_shuttle), 7 SECONDS)
 
-	sleep(7 SECONDS)
+/obj/singularity/narsie/large/proc/call_shuttle()
 	SSshuttle.emergency.request(null, 0.3)
 	SSshuttle.emergency.canRecall = FALSE // Cannot recall
 


### PR DESCRIPTION
## What Does This PR Do
Wow this was easier than expected, since the only singulo that didnt initialize was narnar. 

This makes all types of `/obj/singularity` stop using `/New()` and move it to `/Initialize()`. The death toll is now
![image](https://user-images.githubusercontent.com/25063394/106816033-ae32d480-666c-11eb-926d-af388650c819.png)

## Why It's Good For The Game
I can hear `/New()` quivering 

