### PR TITLE
Purging Will Continue Until Simulations Improve

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
@@ -10,7 +10,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "d" = (
-/turf/unsimulated/wall,
+/turf/simulated/wall/indestructible/riveted,
 /area/lavaland/surface/outdoors)
 "e" = (
 /obj/machinery/wish_granter,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/unsimulated/wall,
+/turf/simulated/wall/indestructible/riveted,
 /area/ruin/unpowered/misc_lavaruin)
 "b" = (
 /turf/simulated/floor/plating/lava/smooth/lava_land_surface,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
@@ -7,66 +7,66 @@
 /area/lavaland/surface/outdoors)
 "c" = (
 /obj/machinery/abductor/experiment,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "d" = (
 /turf/simulated/wall/mineral/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "e" = (
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "g" = (
 /obj/machinery/abductor/pad,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "h" = (
 /obj/item/hemostat/alien,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "i" = (
 /obj/effect/mob_spawn/human/abductor,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "j" = (
 /obj/structure/closet/abductor,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "k" = (
 /obj/effect/baseturf_helper/lava_land/surface,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "l" = (
 /obj/machinery/optable/abductor,
 /obj/item/cautery/alien,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "m" = (
 /obj/structure/table/abductor,
 /obj/item/storage/box/alienhandcuffs,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "n" = (
 /obj/item/scalpel/alien,
 /obj/item/surgical_drapes,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "o" = (
 /obj/item/retractor/alien,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "p" = (
 /obj/machinery/abductor/gland_dispenser,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "q" = (
 /obj/structure/table/abductor,
 /obj/item/surgicaldrill/alien,
 /obj/item/circular_saw/alien,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "r" = (
 /obj/structure/bed/abductor,
-/turf/unsimulated/floor/abductor,
+/turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 
 (1,1,1) = {"

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -100,7 +100,7 @@
 /area/ruin/unpowered)
 "al" = (
 /obj/structure/flora/ausbushes/genericbush,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "am" = (
 /mob/living/simple_animal/hostile/poison/bees,
@@ -109,15 +109,15 @@
 /mob/living/simple_animal/hostile/poison/bees,
 /mob/living/simple_animal/hostile/poison/bees,
 /mob/living/simple_animal/hostile/poison/bees,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "an" = (
 /mob/living/simple_animal/hostile/poison/bees,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "ao" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "ap" = (
 /mob/living/simple_animal/hostile/asteroid/goldgrub{
@@ -127,7 +127,7 @@
 /area/ruin/unpowered)
 "aq" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "ar" = (
 /obj/structure/flora/rock/pile,
@@ -143,11 +143,11 @@
 "au" = (
 /obj/structure/flora/ausbushes/leafybush,
 /mob/living/simple_animal/hostile/poison/bees,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "av" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "aw" = (
 /obj/structure/flora/rock,
@@ -187,16 +187,16 @@
 /area/ruin/unpowered)
 "aA" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "aB" = (
 /obj/machinery/light,
 /mob/living/simple_animal/hostile/poison/bees,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "aC" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/unsimulated/floor/grass,
+/turf/simulated/floor/grass,
 /area/ruin/unpowered)
 "aD" = (
 /obj/structure/cable{

--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -212,7 +212,7 @@
 	},
 /area/ruin/powered)
 "M" = (
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "N" = (
 /turf/simulated/shuttle/wall{

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -68,7 +68,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "aj" = (
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/ruin/onehalf/hallway)
 "ak" = (
 /turf/simulated/wall,
@@ -481,7 +481,7 @@
 	dir = 2;
 	icon_state = "coil_red2"
 	},
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/ruin/onehalf/hallway)
 "bf" = (
 /obj/structure/disposalpipe/segment{
@@ -746,7 +746,7 @@
 /area/ruin/onehalf/drone_bay)
 "bJ" = (
 /obj/structure/girder,
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/ruin/onehalf/hallway)
 "bK" = (
 /obj/machinery/vending/coffee{
@@ -815,7 +815,7 @@
 /area/ruin/onehalf/hallway)
 "bW" = (
 /obj/structure/girder/reinforced,
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/ruin/onehalf/hallway)
 "bX" = (
 /turf/simulated/wall/r_wall,
@@ -902,7 +902,7 @@
 /area/ruin/onehalf/hallway)
 "ck" = (
 /obj/structure/girder/reinforced,
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cl" = (
 /obj/effect/landmark/damageturf,
@@ -1011,7 +1011,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "cw" = (
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cx" = (
 /obj/structure/lattice,

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
@@ -18,11 +18,11 @@
 /obj/item/reagent_containers/food/snacks/syndicake,
 /obj/item/reagent_containers/food/snacks/syndicake,
 /obj/item/reagent_containers/food/snacks/syndicake,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "dy" = (
 /obj/structure/lattice,
-/turf/unsimulated,
+/turf/simulated/floor/plating/airless,
 /area/template_noop)
 "es" = (
 /obj/structure/cable{
@@ -30,11 +30,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
-"eY" = (
-/turf/simulated/floor/plating,
-/area/ruin)
 "fq" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/plasteel,
@@ -50,6 +47,9 @@
 /obj/item/stack/sheet/metal,
 /turf/template_noop,
 /area/template_noop)
+"gy" = (
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/unpowered)
 "hm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61,11 +61,6 @@
 "ho" = (
 /turf/space,
 /area/ruin/space)
-"hs" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 4
-	},
-/area/ruin/unpowered)
 "iK" = (
 /obj/item/stack/sheet/metal,
 /obj/item/stack/sheet/metal,
@@ -137,7 +132,7 @@
 /obj/machinery/conveyor/east{
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/space)
 "ob" = (
 /obj/structure/lattice,
@@ -150,7 +145,7 @@
 /obj/item/reagent_containers/food/snacks/syndicake,
 /obj/item/reagent_containers/food/snacks/syndicake,
 /obj/item/reagent_containers/food/snacks/syndicake,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/space)
 "oJ" = (
 /obj/item/stack/rods,
@@ -160,7 +155,7 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Nexus"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "pb" = (
 /obj/structure/lattice/catwalk,
@@ -169,14 +164,11 @@
 "pd" = (
 /turf/template_noop,
 /area/space)
-"pp" = (
-/turf/unsimulated,
-/area/space)
 "pR" = (
 /obj/machinery/conveyor/northeast{
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "qS" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -203,9 +195,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
-"sd" = (
-/turf/simulated/floor/plating,
-/area/space)
 "sN" = (
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -226,14 +215,18 @@
 /obj/structure/plasticflaps{
 	canmove = 0
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "wB" = (
 /obj/item/trash/syndi_cakes,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
+"xB" = (
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/unpowered)
 "xT" = (
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "yU" = (
 /obj/item/stack/sheet/metal,
@@ -264,9 +257,8 @@
 /turf/template_noop,
 /area/space)
 "zF" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 8
-	},
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
 /area/ruin/unpowered)
 "zP" = (
 /obj/structure/rack{
@@ -307,7 +299,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "CY" = (
 /obj/item/stack/rods,
@@ -317,11 +309,11 @@
 /turf/space,
 /area/space)
 "Dz" = (
-/mob/living/simple_animal/pet/dog/corgi,
 /obj/machinery/conveyor/east{
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/mob/living/simple_animal/pet/dog/corgi,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "Ej" = (
 /obj/structure/closet/emcloset,
@@ -334,6 +326,16 @@
 /obj/item/stack/cable_coil/cut,
 /turf/template_noop,
 /area/template_noop)
+"Fy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0;
+	tag = ""
+	},
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/unpowered)
 "FO" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/simulated/floor/plasteel,
@@ -353,19 +355,19 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
 "Hx" = (
-/mob/living/simple_animal/pet/dog/corgi,
-/mob/living/simple_animal/pet/dog/corgi,
 /obj/machinery/conveyor/east{
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/mob/living/simple_animal/pet/dog/corgi,
+/mob/living/simple_animal/pet/dog/corgi,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "Hy" = (
 /turf/template_noop,
 /area/template_noop)
 "HQ" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "Ic" = (
 /turf/simulated/floor/plating/burnt,
@@ -378,9 +380,15 @@
 /obj/structure/lattice,
 /turf/space,
 /area/ruin/unpowered)
+"IJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/unpowered)
 "JI" = (
 /obj/effect/spawner/random_spawners/syndicate/loot,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "Ki" = (
 /obj/structure/lattice,
@@ -388,13 +396,13 @@
 /area/template_noop)
 "Kr" = (
 /obj/structure/girder,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/ruin/unpowered)
 "KD" = (
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
 "KS" = (
-/turf/unsimulated/floor/plating/airless,
+/turf/simulated/floor/plating/airless,
 /area/ruin)
 "Le" = (
 /obj/structure/cable{
@@ -404,12 +412,13 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
+"Lq" = (
+/mob/living/simple_animal/pet/dog/corgi,
+/turf/simulated/floor/plasteel/airless,
+/area/ruin/unpowered)
 "Mi" = (
-/turf/unsimulated,
+/turf/simulated/floor/plating/airless,
 /area/template_noop)
-"Mz" = (
-/turf/simulated/floor/plasteel,
-/area/ruin)
 "Nw" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/blue{
@@ -445,7 +454,7 @@
 	dir = 2;
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin)
 "QI" = (
 /obj/effect/spawner/random_spawners/wall_rusted_probably,
@@ -472,7 +481,7 @@
 /area/ruin/unpowered)
 "Ry" = (
 /obj/item/stack/cable_coil/random,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "RB" = (
 /mob/living/simple_animal/hostile/alien/sentinel{
@@ -527,7 +536,7 @@
 /obj/machinery/conveyor/east{
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin)
 "UC" = (
 /obj/machinery/tcomms/relay/ruskie{
@@ -549,7 +558,7 @@
 /obj/machinery/conveyor/north/ccw{
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "VH" = (
 /obj/structure/lattice,
@@ -558,7 +567,7 @@
 /area/space)
 "VR" = (
 /obj/structure/lattice,
-/turf/unsimulated,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "WL" = (
 /turf/space,
@@ -582,7 +591,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "YU" = (
 /obj/structure/chair/office/dark,
@@ -592,14 +601,14 @@
 /obj/machinery/conveyor/east{
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/ruin/unpowered)
 "Zt" = (
 /obj/machinery/conveyor/east{
 	dir = 2;
 	id = null
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/airless,
 /area/space)
 
 (1,1,1) = {"
@@ -780,10 +789,10 @@ Hy
 Hy
 EJ
 JI
-GB
-Vf
-sN
-sN
+Lq
+IJ
+gy
+gy
 EJ
 Ra
 sN
@@ -821,11 +830,11 @@ Hy
 Hy
 Hy
 EJ
-sN
+gy
 Hx
-GB
+Lq
 Dz
-sN
+gy
 EJ
 Nw
 hm
@@ -863,11 +872,11 @@ Hy
 Hy
 Hy
 EJ
-sN
+gy
 Dz
-sN
+gy
 Dz
-sN
+gy
 EJ
 UC
 sN
@@ -905,11 +914,11 @@ Hy
 Hy
 Hy
 EJ
-sN
+gy
 Zs
-sN
+gy
 Zs
-sN
+gy
 EJ
 fq
 sN
@@ -947,11 +956,11 @@ Hy
 Hy
 Hy
 EJ
-sN
+gy
 Zs
-sN
+gy
 Zs
-Id
+xB
 EJ
 sN
 GB
@@ -993,7 +1002,7 @@ pR
 Vt
 Vt
 Vt
-sN
+gy
 EJ
 XZ
 BI
@@ -1079,11 +1088,11 @@ TM
 Qv
 lK
 EJ
-sN
-Vf
-Gm
-sN
-sN
+gy
+IJ
+Fy
+gy
+gy
 Ry
 Kr
 OU
@@ -1116,7 +1125,7 @@ Hy
 Hy
 EJ
 Zs
-hs
+zF
 Tj
 zP
 Xd
@@ -1124,12 +1133,12 @@ ky
 Cp
 Cp
 es
-sN
+gy
 rJ
 rJ
 Kr
 rL
-eY
+KS
 OU
 EJ
 pd
@@ -1163,16 +1172,16 @@ sN
 wB
 sN
 BG
-sN
-sN
-sN
-sN
-sN
-sN
+gy
+gy
+gy
+gy
+gy
+gy
 oO
 OU
-eY
-eY
+KS
+KS
 EJ
 pd
 pd
@@ -1206,14 +1215,14 @@ RB
 wB
 EJ
 IB
-sN
-sN
-sN
-sN
-sN
+gy
+gy
+gy
+gy
+gy
 EJ
-eY
-eY
+KS
+KS
 rJ
 EJ
 pd
@@ -1242,20 +1251,20 @@ Hy
 Hy
 EJ
 Zs
-hs
+zF
 bb
 OA
 sN
 EJ
 WL
 IB
-sN
+gy
 YR
 HQ
 HQ
 EJ
 OU
-eY
+KS
 rJ
 EJ
 zt
@@ -1297,7 +1306,7 @@ EJ
 EJ
 EJ
 OU
-eY
+KS
 OK
 Da
 pd
@@ -1330,7 +1339,7 @@ OU
 OU
 KS
 KS
-Mz
+OU
 ho
 OU
 OU
@@ -1338,7 +1347,7 @@ OU
 OU
 ho
 iK
-eY
+KS
 Da
 OK
 OK
@@ -1379,7 +1388,7 @@ Ic
 ub
 NQ
 OU
-eY
+KS
 NQ
 NQ
 Da
@@ -1450,7 +1459,7 @@ Hy
 Hy
 Hy
 Ki
-pp
+xT
 pd
 Zt
 rJ
@@ -1492,7 +1501,7 @@ Hy
 Hy
 Hy
 Hy
-pp
+xT
 pd
 pd
 zo
@@ -1591,7 +1600,7 @@ QF
 QF
 QF
 Da
-sd
+xT
 oJ
 pd
 pd

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
@@ -453,9 +453,7 @@
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/simulated/floor/plating,
 /area/syndicate_depot/core)
 "br" = (
 /obj/machinery/door/airlock/external{
@@ -463,9 +461,7 @@
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/simulated/floor/plating,
 /area/syndicate_depot/outer)
 "bs" = (
 /obj/effect/spawner/random_spawners/syndicate/turret,

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -1,9 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/unsimulated/wall{
-	icon_state = "rock";
-	name = "rock"
-	},
+/turf/simulated/wall/indestructible/rock,
 /area/awaycontent/a3{
 	always_unpowered = 1;
 	ambientsounds = list('sound/ambience/ambimine.ogg');

--- a/_maps/map_files/RandomZLevels/terrorspiders.dmm
+++ b/_maps/map_files/RandomZLevels/terrorspiders.dmm
@@ -1,9 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/unsimulated/wall{
-	icon_state = "rock";
-	name = "rock"
-	},
+/turf/simulated/wall/indestructible/rock,
 /area/awaymission/UO71/outside)
 "ab" = (
 /turf/simulated/mineral/random/labormineral,
@@ -12253,17 +12250,11 @@
 	},
 /area/awaymission/UO71/outside)
 "zd" = (
-/turf/unsimulated/wall{
-	icon_state = "rock";
-	name = "rock"
-	},
+/turf/simulated/wall/indestructible/rock,
 /area/awaymission/UO71/queen)
 "ze" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/unsimulated/wall{
-	icon_state = "rock";
-	name = "rock"
-	},
+/turf/simulated/wall/indestructible/rock,
 /area/awaymission/UO71/queen)
 "zf" = (
 /turf/simulated/floor/plasteel,
@@ -12634,10 +12625,7 @@
 /turf/simulated/floor/vault,
 /area/awaymission/UO71/prince)
 "Lf" = (
-/turf/unsimulated/wall{
-	icon_state = "rock";
-	name = "rock"
-	},
+/turf/simulated/wall/indestructible/rock,
 /area/awaymission/UO71/loot)
 "Lw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{

--- a/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
@@ -1,9 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/unsimulated/wall{
-	icon_state = "rock";
-	name = "rock"
-	},
+/turf/simulated/wall/indestructible/rock,
 /area/awaycontent/a7{
 	always_unpowered = 1;
 	has_gravity = 1;

--- a/_maps/map_files/debug/smoothing.dmm
+++ b/_maps/map_files/debug/smoothing.dmm
@@ -27,7 +27,7 @@
 /area/centcom)
 "i" = (
 /obj/effect/landmark/start,
-/turf/unsimulated/floor,
+/turf/simulated/floor/plating,
 /area/start)
 "j" = (
 /obj/effect/landmark{

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -357,11 +357,12 @@
 
 /turf/simulated/floor/plating/abductor
 	name = "alien floor"
+	icon = 'icons/turf/floors.dmi'
 	icon_state = "alienpod1"
 
 /turf/simulated/floor/plating/abductor/Initialize(mapload)
 	. = ..()
-	icon_state = "alienpod[rand(1,9)]"
+	icon_state = "alienpod[rand(1, 9)]"
 
 /turf/simulated/floor/plating/ice
 	name = "ice sheet"

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -1,4 +1,7 @@
 /turf/simulated/wall/indestructible
+	name = "wall"
+	desc = "Effectively impervious to conventional methods of destruction."
+	explosion_block = 50
 
 /turf/simulated/wall/indestructible/dismantle_wall(devastated = 0, explode = 0)
 	return
@@ -50,7 +53,6 @@
 	desc = "A seemingly impenetrable wall."
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "necro"
-	explosion_block = 50
 	baseturf = /turf/simulated/wall/indestructible/necropolis
 
 /turf/simulated/wall/indestructible/boss
@@ -59,7 +61,6 @@
 	icon = 'icons/turf/walls/boss_wall.dmi'
 	icon_state = "wall"
 	canSmoothWith = list(/turf/simulated/wall/indestructible/boss, /turf/simulated/wall/indestructible/boss/see_through)
-	explosion_block = 50
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt
 	smooth = SMOOTH_TRUE
 
@@ -76,3 +77,13 @@
 /turf/simulated/wall/indestructible/uranium
 	icon = 'icons/turf/walls/uranium_wall.dmi'
 	icon_state = "uranium"
+
+/turf/simulated/wall/indestructible/rock
+	name = "dense rock"
+	desc = "An extremely densely-packed rock, most mining tools or explosives would never get through this."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "rock"
+
+/turf/simulated/wall/indestructible/riveted
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "riveted"

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -1,4 +1,3 @@
-
 /turf/unsimulated/floor
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'
@@ -9,17 +8,6 @@
 	name = "plating"
 	nitrogen = 100
 	oxygen = 0
-
-/turf/unsimulated/floor/plating/airless
-	icon_state = "plating"
-	name = "airless plating"
-	oxygen = 0
-	nitrogen = 0
-	temperature = TCMB
-
-/turf/unsimulated/floor/plating/airless/Initialize(mapload)
-	. = ..()
-	name = "plating"
 
 /turf/unsimulated/floor/grass
 	name = "grass patch"

--- a/code/modules/procedural_mapping/mapGeneratorModules/nature.dm
+++ b/code/modules/procedural_mapping/mapGeneratorModules/nature.dm
@@ -28,7 +28,7 @@
 
 //Grass turfs
 /datum/mapGeneratorModule/bottomLayer/grassTurfs
-	spawnableTurfs = list(/turf/unsimulated/floor/grass = 100)
+	spawnableTurfs = list(/turf/simulated/floor/grass = 100)
 
 
 //Grass tufts with a high spawn chance


### PR DESCRIPTION
Replaces the unsimulated turfs on all away missions (minus beach) and ruins with simulated variety.

Where a wall turf was meant to be impassable and indestructible, it was replaced with `/turf/simulated/wall/indestructible`

- Fixes simulated abductor turfs having no icon
- Fixes the syndicate cake factory having aired turfs in the middle of an airless area
  - Also why did this away mission use fake glass for no reason at all? This made no sense. To be fair, this is an awful away mission

. . . the way must be prepared . . .

:cl: Fox McCloud
tweak: Removes most unsimulated turfs with the exception of CentComm and Beach
/:cl:  