### PR TITLE
SM engine APCs no longer short out during APC short/overload events

### DIFF
--- a/code/modules/events/apc_overload.dm
+++ b/code/modules/events/apc_overload.dm
@@ -29,6 +29,7 @@
 /proc/apc_overload_failure(announce=TRUE)
 	var/list/skipped_areas_apc = list(
 		/area/engine/engineering,
+		/area/engine/supermatter,
 		/area/turret_protected/ai)
 
 	if(announce)

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -29,6 +29,7 @@
 /proc/power_failure(announce=TRUE)
 	var/list/skipped_areas_apc = list(
 		/area/engine/engineering,
+		/area/engine/supermatter,
 		/area/turret_protected/ai)
 
 	if(announce)


### PR DESCRIPTION
## What Does This PR Do
Stops the APC short/overload events from disabling the SM that powers SM cooling.

## Why It's Good For The Game
Fixes #15394 

## Changelog
:cl: Kyep
fix: APC short/overload events can no longer delaminate the SM.
/:cl: