### PR TITLE
Buffs Potassium Iodine and Pentetic Acid's radiation healing.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -411,7 +411,7 @@
 
 /datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/M)
 	if(prob(80))
-		M.radiation = max(0, M.radiation-1)
+		M.radiation = max(0, M.radiation-10)
 	return ..()
 
 /datum/reagent/medicine/pen_acid
@@ -428,7 +428,7 @@
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
 			M.reagents.remove_reagent(R.id,4)
-	M.radiation = max(0, M.radiation-7)
+	M.radiation = max(0, M.radiation-70)
 	if(prob(75))
 		update_flags |= M.adjustToxLoss(-4*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	if(prob(33))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Increases how much radiation potassium iodine and pentetic acid purges by a factor of 10

## Why It's Good For The Game
Ever since the radiation refractor, it has been exceptionally easy to accrue a massive amount of rads during SM delams because you aren't the CE. The chamber of the SM during a delamination is, extremely hot, radioactive, and pressurised. It is best to be immune to the pressure and heat effects with an atmos hardsuit (outside of the CE's hardsuit) because this is the most direct source of damage, however this means you can easily stack up 8k+ rads. Currently that would take 1000 cycles to remove with both potassium iodine and pentetic in you at the same time. This isn't feasible. Hopefully this buff will prevent people being ancored to medbay for 40+ minutes constantly having pentetic and iodine in you and chems to counteract the negatives of pentetic.  Sitting in medbay for 40 minutes, with both chems in you constantly, to 44 HOURS with just potassium iodine in you isn't exactly fun or feasible for a poor slime person that they cannot clone or the medical doctors and chemists constantly making and supplying chems.  


## Changelog
:cl:
tweak: increased potassium iodine and pentetic adic's radiation healing by a factor of 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
