### PR TITLE
Removes Contractor upwards variation on TC payout

### DIFF
--- a/code/modules/antagonists/traitor/contractor/datums/contractor_hub.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/contractor_hub.dm
@@ -17,7 +17,7 @@
 		EXTRACTION_DIFFICULTY_HARD = 40,
 	)
 	/// Maximum variation a single contract's TC reward can have upon generation.
-	/// In other words: final_reward = CEILING((tc_threshold / num_contracts) * (1 + (rand(-100, 100) / 100) * tc_variation), 1)
+	/// In other words: final_reward = CEILING((tc_threshold / num_contracts) * (1 - (rand(0, 100) / 100) * tc_variation), 1)
 	var/tc_variation = 0.25
 	/// TC reward multiplier if the target was extracted DEAD. Should be a penalty so between 0 and 1.
 	/// The final amount is rounded up.
@@ -98,9 +98,6 @@
 		C.reward_tc = list(null, null, null)
 		for(var/difficulty in EXTRACTION_DIFFICULTY_EASY to EXTRACTION_DIFFICULTY_HARD)
 			var/amount_tc = calculate_tc_reward(num_to_generate, difficulty)
-			// Bump up the TC reward a little if it's too close to the lower difficulty's reward
-			if(difficulty > EXTRACTION_DIFFICULTY_EASY)
-				amount_tc = max(amount_tc, C.reward_tc[difficulty - 1] + (difficulty - 1))
 			C.reward_tc[difficulty] = amount_tc
 			total_earnable_tc[difficulty] += amount_tc
 		// Add to lists
@@ -111,11 +108,10 @@
 	for(var/difficulty in EXTRACTION_DIFFICULTY_EASY to EXTRACTION_DIFFICULTY_HARD)
 		var/total = total_earnable_tc[difficulty]
 		var/missing = difficulty_tc_thresholds[difficulty] - total
-		if(missing <= 0)
-			continue
-		// Just add the missing TC to a random contract
-		var/datum/syndicate_contract/C = pick(contracts)
-		C.reward_tc[difficulty] += missing
+		// Increment the TC payout of a random contract till we're even
+		while(missing-- > 0)
+			var/datum/syndicate_contract/C = pick(contracts)
+			C.reward_tc[difficulty]++
 
 /**
   * Generates an amount of TC to be used as a contract reward for the given difficulty.
@@ -126,7 +122,7 @@
   */
 /datum/contractor_hub/proc/calculate_tc_reward(total_contracts, difficulty = EXTRACTION_DIFFICULTY_EASY)
 	ASSERT(total_contracts > 0)
-	return CEILING((difficulty_tc_thresholds[difficulty] / total_contracts) * (1 + (rand(-100, 100) / 100) * tc_variation), 1)
+	return FLOOR((difficulty_tc_thresholds[difficulty] / total_contracts) * (1 - (rand(0, 100) / 100) * tc_variation), 1)
 
 /**
   * Called when a [/datum/syndicate_contract] has been completed.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Makes it so contracts no longer have a chance to overall give more than the per-difficulty cap, meaning completing all contracts in one difficulty gives 20/30/40 TC, not less, not more.
- Makes it so missing TCs (due to downwards variation) are distributed among all contracts randomly, instead of all into one.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Contractors could earn upwards of 50 TC and that's not right. The difficulty TC cap is now actually respected. It also means some easier locations could have a TC reward *close* to their harder counterpart, giving the contractor more of an incentive to go for an easy location.

## Changelog
:cl:
tweak: Completing all contracts in the same difficulty will no longer give more TC than intended for that difficulty
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
