### PR TITLE
Allows AI to roll traitor on traitor cling, Allows more clings / vampires in (cling/vampire)traitor mode.

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -2,11 +2,13 @@
 	name = "traitor+changeling"
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
-	restricted_jobs = list("AI", "Cyborg")
+	restricted_jobs = list("Cyborg")
+	secondary_restricted_jobs = list("AI") // Allows AI to roll traitor, but not changeling
 	required_players = 10
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
-	var/protected_species_changeling = list("Machine")
+	secondary_enemies_scaling = 0.025
+	secondary_protected_species = list("Machine")
 
 /datum/game_mode/traitor/changeling/announce()
 	to_chat(world, "<B>The current game mode is - Traitor+Changeling!</B>")
@@ -18,17 +20,23 @@
 		restricted_jobs += protected_jobs
 
 	var/list/datum/mind/possible_changelings = get_players_for_role(ROLE_CHANGELING)
+	secondary_enemies = CEILING((secondary_enemies_scaling * num_players()), 1)
 
 	for(var/mob/new_player/player in GLOB.player_list)
-		if((player.mind in possible_changelings) && (player.client.prefs.species in protected_species_changeling))
+		if((player.mind in possible_changelings) && (player.client.prefs.species in secondary_protected_species))
 			possible_changelings -= player.mind
 
 	if(possible_changelings.len > 0)
-		var/datum/mind/changeling = pick(possible_changelings)
-		changelings += changeling
-		modePlayer += changelings
-		changeling.restricted_roles = restricted_jobs
-		changeling.special_role = SPECIAL_ROLE_CHANGELING
+		for(var/I in possible_changelings)
+			if(changelings.len >= secondary_enemies)
+				break
+			var/datum/mind/changeling = pick(possible_changelings)
+			changelings += changeling
+			modePlayer += changelings
+			possible_changelings -= changeling
+			changeling.restricted_roles = (restricted_jobs += secondary_restricted_jobs)
+			changeling.special_role = SPECIAL_ROLE_CHANGELING
+
 		return ..()
 	else
 		return 0

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -28,13 +28,13 @@
 
 	if(possible_changelings.len > 0)
 		for(var/I in possible_changelings)
-			if(changelings.len >= secondary_enemies)
+			if(length(changelings) >= secondary_enemies)
 				break
 			var/datum/mind/changeling = pick(possible_changelings)
 			changelings += changeling
 			modePlayer += changelings
 			possible_changelings -= changeling
-			changeling.restricted_roles = (restricted_jobs += secondary_restricted_jobs)
+			changeling.restricted_roles = (restricted_jobs + secondary_restricted_jobs)
 			changeling.special_role = SPECIAL_ROLE_CHANGELING
 
 		return ..()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -20,11 +20,15 @@
 	var/explosion_in_progress = 0 //sit back and relax
 	var/list/datum/mind/modePlayer = new
 	var/list/restricted_jobs = list()	// Jobs it doesn't make sense to be.  I.E chaplain or AI cultist
+	var/list/secondary_restricted_jobs = list() // Same as above, but for secondary antagonists
 	var/list/protected_jobs = list()	// Jobs that can't be traitors
 	var/list/protected_species = list() // Species that can't be traitors
+	var/list/secondary_protected_species = list() // Same as above, but for secondary antagonists
 	var/required_players = 0
 	var/required_enemies = 0
 	var/recommended_enemies = 0
+	var/secondary_enemies = 0
+	var/secondary_enemies_scaling = 0 // Scaling rate of secondary enemies
 	var/newscaster_announcements = null
 	var/ert_disabled = 0
 	var/uplink_welcome = "Syndicate Uplink Console:"

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -3,11 +3,13 @@
 	config_tag = "traitorvamp"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer")
-	restricted_jobs = list("AI", "Cyborg")
+	restricted_jobs = list("Cyborg")
+	secondary_restricted_jobs = list("AI")
 	required_players = 10
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
-	var/protected_species_vampire = list("Machine")
+	secondary_enemies_scaling = 0.025
+	secondary_protected_species = list("Machine")
 
 /datum/game_mode/traitor/vampire/announce()
 	to_chat(world, "<B>The current game mode is - Traitor+Vampire!</B>")
@@ -19,20 +21,26 @@
 		restricted_jobs += protected_jobs
 
 	var/list/datum/mind/possible_vampires = get_players_for_role(ROLE_VAMPIRE)
+	secondary_enemies = CEILING((secondary_enemies_scaling * num_players()), 1)
 
 	for(var/mob/new_player/player in GLOB.player_list)
-		if((player.mind in possible_vampires) && (player.client.prefs.species in protected_species_vampire))
+		if((player.mind in possible_vampires) && (player.client.prefs.species in secondary_protected_species))
 			possible_vampires -= player.mind
 
 	if(possible_vampires.len > 0)
-		var/datum/mind/vampire = pick(possible_vampires)
-		vampires += vampire
-		modePlayer += vampires
-		var/datum/mindslaves/slaved = new()
-		slaved.masters += vampire
-		vampire.som = slaved //we MIGT want to mindslave someone
-		vampire.restricted_roles = restricted_jobs
-		vampire.special_role = SPECIAL_ROLE_VAMPIRE
+		for(var/I in possible_vampires)
+			if(vampires.len >= secondary_enemies)
+				break
+			var/datum/mind/vampire = pick(possible_vampires)
+			vampires += vampire
+			modePlayer += vampires
+			possible_vampires -= vampire
+			var/datum/mindslaves/slaved = new()
+			slaved.masters += vampire
+			vampire.som = slaved //we MIGHT want to mindslave someone
+			vampire.restricted_roles = (restricted_jobs += secondary_restricted_jobs)
+			vampire.special_role = SPECIAL_ROLE_VAMPIRE
+
 		..()
 		return 1
 	else

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -29,7 +29,7 @@
 
 	if(possible_vampires.len > 0)
 		for(var/I in possible_vampires)
-			if(vampires.len >= secondary_enemies)
+			if(length(vampires) >= secondary_enemies)
 				break
 			var/datum/mind/vampire = pick(possible_vampires)
 			vampires += vampire
@@ -38,7 +38,7 @@
 			var/datum/mindslaves/slaved = new()
 			slaved.masters += vampire
 			vampire.som = slaved //we MIGHT want to mindslave someone
-			vampire.restricted_roles = (restricted_jobs += secondary_restricted_jobs)
+			vampire.restricted_roles = (restricted_jobs + secondary_restricted_jobs)
 			vampire.special_role = SPECIAL_ROLE_VAMPIRE
 
 		..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR allows for secondary restricted jobs, allowing for things like vampires / changelings to restrict AI in their hybrid tratior rounds, but still allowing for a traitor AI.
Adds secondary antagonist species restriction, so we can restrict IPC from cling / vampire, without a specific variable added to both cling traitor and vamp traitor.
Adds scaling to cling/vampire + traitor mode, currently set to 1 cling per 40 people, rounded up.
1 cling 0-40, 2 clings 41-80, 3 clings 81-120, 4 clings 120-160, ect.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Ai should be able to be a traitor on cling traitor game modes, and right now, (vampire / changeling) + traitor modes are not the most interesting. Sure, it has an extra vampire, or changeling to go with it, but a single one isn't that interesting, especially when population hits 80+. This means they scale, meaning you might have some clings talking to each other while traitors are doing their stuff, or there may actually be multiple vampires in maintenance, while traitors are being active.

## Changelog
:cl:
tweak: AI can now be traitor on (vampire/cling) and traitor gamemodes.
tweak: There can now be multiple (vampires or clings) in the (vampire or cling) and traitors game mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
