### PR TITLE
Nerfs botany potatoes

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -224,7 +224,7 @@
 	// Cell recharging trait. Charges all mob's power cells to (potency*rate)% mark when eaten.
 	// Generates sparks on squash.
 	// Small (potency*rate*5) chance to shock squish or slip target for (potency*rate*5) damage.
-	// Multiplies max charge by (rate*1000) when used in potato power cells.
+	// Multiplies max charge by (rate*100) when used in potato power cells.
 	name = "Electrical Activity"
 	rate = 0.2
 	origin_tech = list("powerstorage" = 5)
@@ -375,8 +375,8 @@
 
 			// The secret of potato supercells!
 			var/datum/plant_gene/trait/cell_charge/CG = G.seed.get_gene(/datum/plant_gene/trait/cell_charge)
-			if(CG) // 10x charge for deafult cell charge gene - 20 000 with 100 potency.
-				pocell.maxcharge *= CG.rate*1000
+			if(CG) // 20x charge for deafult cell charge gene - 40 000 with 100 potency.
+				pocell.maxcharge *= CG.rate*100
 			pocell.charge = pocell.maxcharge
 			pocell.name = "[G] battery"
 			pocell.desc = "A rechargable plant based power cell. This one has a power rating of [pocell.maxcharge], and you should not swallow it."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This reduces the effect of the electrical activity gene when combined with Capacitive Cell Production by a factor of 10.
This reduced the max power of a fully optimized plant cell from 400000 to 40000, the same as a bluespace cell.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

From a balance and realism standpoint, a potato that can be mass produced should not store 10x the power of the best science nanotrasen (TM) has to offer going into a bluespace cell. Apart from the fact it makes no logical sense, it allows crew to have things that are already insanely strong, to be stronger.  Mechs, batons, borgs will effectively never run out of power with this cell in them, even if they are using the most power intensive modules. 

Sure, yellow cells exist, but they can be drained and force the item to recharge a bit, when the most power intensive actions are taken. This cell however, with its 400k capacity, is for all intents and purposes, infinite, or at least has enough power to constantly fire a borgs laser gun with self repair and ion thrusters for at least 10 minutes, while at least with a yellow cell eventually, that power runs low, and a break needs to be taken. 

## Changelog
:cl:
tweak: Plant cells power capacity when combined with electrical activity gene, is 10x weaker than before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
