### PR TITLE
Adds door remote and the autopsy scanner to protected cryo items

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -249,7 +249,9 @@
 		/obj/item/clothing/gloves/color/black/krav_maga/sec,
 		/obj/item/spacepod_key,
 		/obj/item/nullrod,
-		/obj/item/key
+		/obj/item/key,
+		/obj/item/door_remote,
+		/obj/item/autopsy_scanner
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -251,7 +251,8 @@
 		/obj/item/nullrod,
 		/obj/item/key,
 		/obj/item/door_remote,
-		/obj/item/autopsy_scanner
+		/obj/item/autopsy_scanner,
+		/obj/item/holosign_creator/atmos
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR adds the door remote and autopsy scanner to the protected items cryopods save in storage.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Door remotes and autopsy scanners are irreplaceable, so it is good to save them in cryodorms, where they (might) be recovered.


## Changelog
:cl:
tweak: Cryodorms now store door remotes and autopsy scanners to items for cryodorms to store.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
