### PR TITLE
Fixes a bug with white infections in gateway

### DIFF
--- a/code/modules/surgery/organs/parasites.dm
+++ b/code/modules/surgery/organs/parasites.dm
@@ -52,9 +52,13 @@
 	var/egg_progress = 0 // # of on_life() cycles completed, unlike cycle_num this is reset on each hatch event
 	var/egg_progress_per_hatch = 90 // if egg_progress > this, chance to hatch and reset egg_progress
 	var/eggs_hatched = 0 // num of hatch events completed
-	var/awaymission_checked = FALSE
 	var/awaymission_infection = FALSE // TRUE if infection occurred inside gateway
 
+/obj/item/organ/internal/body_egg/terror_eggs/Initialize(mapload)
+	. = ..()
+	var/turf/T = get_turf(src)
+	if(istype(T) && is_away_level(T.z))
+		awaymission_infection = TRUE
 
 /obj/item/organ/internal/body_egg/terror_eggs/on_life()
 	// Safety first.
@@ -67,10 +71,6 @@
 	egg_progress += calc_variable_progress()
 
 	// Detect & stop people attempting to bring a gateway white spider infection back to the main station.
-	if(!awaymission_checked)
-		awaymission_checked = TRUE
-		if(is_away_level(owner.z))
-			awaymission_infection = TRUE
 	if(awaymission_infection)
 		var/turf/T = get_turf(owner)
 		if(istype(T) && !is_away_level(T.z))


### PR DESCRIPTION
## What Does This PR Do
Fixes a case where a gateway explorer who entered the gateway, got bitten by a white terror, and returned, all within about two seconds, wouldn't gib. This meant that if a white terror was kited right up to the gate, and subsequent explorers popped in/out, it was in theory possible to get the infection onto the main station.

## Changelog
:cl: Kyep
fix: Fixed explorers being able to return to the station with a white terror infection in rare cases where the white terror was standing literally next to the gateway and bit them the second they entered, and they immediately returned.
/:cl: