### PR TITLE
Fixes Mobs Being Immovable Titans

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -103,10 +103,6 @@
 	if(moving_diagonally) //no mob swap during diagonal moves.
 		return TRUE
 
-	if(a_intent == INTENT_HELP) // Help intent doesn't mob swap a mob pulling a structure
-		if(isstructure(M.pulling) || isstructure(pulling))
-			return TRUE
-
 	if(!M.buckled && !M.has_buckled_mobs())
 		var/mob_swap
 		//the puller can always swap with it's victim if on grab intent
@@ -157,9 +153,7 @@
 /mob/living/proc/PushAM(atom/movable/AM, force = move_force)
 
 	if(isstructure(AM) && AM.pulledby)
-		if(a_intent == INTENT_HELP && AM.pulledby != src) // Help intent doesn't push other peoples pulled structures
-			return FALSE
-		if(get_dist(get_step(AM, get_dir(src, AM)), AM.pulledby)>1)//Release pulled structures beyond 1 distance
+		if(get_dist(get_step(AM, get_dir(src, AM)), AM.pulledby) > 1) //Release pulled structures beyond 1 distance
 			AM.pulledby.stop_pulling()
 
 	if(now_pushing)


### PR DESCRIPTION
Fixes mobs being immovable titans if they're pulling a structure.

This code was added on the tentative basis of improving the life of people on help intent.

That said, it has the terrible side effect of making people *immovable* titans that you can't do anything about until they're no longer pulling a structure. This completely flies in the face of every single other mob movement and pushing interaction---especially since it ONLY applies specifically to *structures* (as if that's the only thing that the mob swap tango can happen with).

If you don't want the "body swap tango" to happen, there's already a super easy and *perfectly reasonable* solution to this; it's called changing your intent. If your intent is changed, no one can bodyswap you while you're pulling something, while not having all of these really bad and unintuitive side effects

:cl: Fox McCloud
fix: Fixes individuals pulling structures being immovable titans
/:cl: