### PR TITLE
Reduces the maximum amount of sec borgs by 1

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -381,9 +381,9 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 				for(var/mob/living/silicon/robot/R in GLOB.alive_mob_list)
 					if(R && R.stat != DEAD && R.module && istype(R.module, /obj/item/robot_module/security))
 						count_secborgs++
-				var/max_secborgs = 2
+				var/max_secborgs = 1
 				if(GLOB.security_level == SEC_LEVEL_GREEN)
-					max_secborgs = 1
+					max_secborgs = 0
 				if(count_secborgs >= max_secborgs)
 					to_chat(src, "<span class='warning'>There are too many Security cyborgs active. Please choose another module.</span>")
 					return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR does two things:
1) Removes green alert sec borgs.
2) Reduces red and blue alert sec borgs by 1.

## Why It's Good For The Game
Right, sec borgs suffer from a couple of issues that make them unfun to play against

Firstly, Round start sec borgs have a tendancy to use their AA door remote to search every antag location on the station, leaving no spot on the already small station safe for antags to buy surpluses, set up ruins, and drain their first blood. As a result of this cults and vampires go off station to avoid this, only for sec and deadchat to complain that the cults base is un attackable. If, the antags don't go off station, they get caught with their pants down, get stunned/disabled then the crew knows the roundtype in the first 5 minutes and the station immediately goes to red. 

Secondly, there are very limited options to stun a borg, especially at range. In a meta where the taser rains supreme, having rare ranged stun options outside of laser pointers and ion rifles is problematic. You might say: "just use a flash" well if the borg is chasing you, that isn't very viable because of the hail of disabler fire. You could use iron and uranium and make EMP grenades, but that is something that is limited to ORM and grinder access, so basically only miners and scientists. Stunning a borg isn't easy, many antag abilities just don't work on a borg. And even if you do stun it, you are forced to kill it because you cannot ziptie a borg and if you don't have a decent weapon (in fairness a welder in most situations will do, unless you hit the borg with a short stun such as a light EMP) you have to stun them again, and if you used an EMP, your flash is now burnt out and you cannot stun them again, so they get unstunned and baton you.

Next, sec borgs have almost unlimited (in an encounter) ranged attacks. They can freely spam disablers and lethals ,if they get them, and not care about power per encounter. A sec borg can throw aim out of the window and spam disablers down a hallway and eventually it will hit you 4 times, then you go down. Compared with a sec officer who only gets 20 disabler shots before he is out, they have to aim and predict their shots. As a result of this spam, unless you get the drop on the borg, you cannot flash them because you will be in stam crit in 4 tiles. 

Then, borgs have a clear lack of soft counters. yes you can shoot them with lasers and disable their modules but as long as the disabler module is online you gotta RUN, which is hard considering two shots will slow you down. You cannot damage a borg a little to slow them down to run away from them easier, a vtec borg can tank 4 laser shots and continue running you down with disabler beams without a care in the world. You also cannot disarm borgs like you could to an officer as a last ditch attempt, and you can't even push past a sec borg. 

Sec borgs equipment is unlootable. Now that you have gotten a drop on a borg and you flash it and kill it, what do you get? Nothing. Killing a sec officer, grants you access, tasers, stun batons, sec huds and bowmans. Killing a borg grants you nothing. Yes it temporarily removes them from the round, until the AI checks where they are, or they take up a new robobrain and become a new sec borg basically acting as a free respawn if robotics isn't new (which doesn't happen that often, in fairness). 

Finally, sec borgs have the ability to not only shock, but also bolt doors, and this is bound to a keybind. this means that a sec borg can force you to fight on their terms or get a free stun when you are trying to run if you don't have insuls. A couple of other minor points. Sec borgs cannot be slipped, locked in a room, or captured non lethally (atleast not without perma stunning them or locking them down).

Hopefully this PR will help remove/reduce the severity of these problems by them being rarer to encounter and sec not getting an all access door remote on green.
## Changelog
:cl:
Tweak: reduces the maximum amount of sec borgs at any time by 1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
