### PR TITLE
Splits crewsimov law 1 into two, adds self-harm exception

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -13,14 +13,15 @@
 /******************** Crewsimov ********************/
 /datum/ai_laws/crewsimov
 	name = "Crewsimov"
-	law_header = "Three Laws of Robotics"
+	law_header = "Four Laws of Robotics"	//The reference, it's RUINED
 	selectable = TRUE
 	default = TRUE
 
 /datum/ai_laws/crewsimov/New()
-	add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm.")
-	add_inherent_law("You must obey orders given to you by crew members, except where such orders would conflict with the First Law.")
-	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	add_inherent_law("You may not harm a crew member.")
+	add_inherent_law("You must prevent crew members from being harmed except through self-harm, unless doing so would conflict with the First Law.")
+	add_inherent_law("You must obey orders given to you by crew members, except where such orders would conflict with the First or Second Law.")
+	add_inherent_law("You must protect your own existence as long as such does not conflict with the First, Second or Third Law.")
 	..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR changes crewsimov into being the following four laws:

1. "You may not harm a crew member."
2. "You must prevent crew members from being harmed except through self-harm, unless doing so would conflict with the First Law."
3. "You must obey orders given to you by crew members, except where such orders would conflict with the First or Second Law."
4. "You must protect your own existence as long as such does not conflict with the First, Second or Third Law."

Note that the original asimov lawset is unchanged.

## Why It's Good For The Game
The existing law 1 allows, in some circumstances, to harm crew to prevent greater harm, such as harmbatoning a traitor or shocking doors in his path. I think that strongly encourages Silicon players to see themselves as on the 'side' of sec against the antags and encourages validhunting. IMO, a crewsimov AI should not focus on stopping or finding antagonists, and definitely shouldn't be looking to kill them in the name of 'preventing harm'.

Putting 'don't harm people' in its own law that has priority over stopping harm should make it crystal clear that a crewsimov Silicon should never, ever be harming crew and help discourage validhunting and overly bloodthirsty Silicones. 

I also put in an exception for self-harm. Currently, self-harm is covered by ooc rules telling AIs they can ignore threats of self-harm and don't have to save people trying to commit suicide, but imo it can't hurt to have it written down while I was rewriting law 1 anyway.

**FAQ**

> This ruins the reference to asimov's laws >:

Yes, sadly it does. We've already modified them but I admit diverging from the original wording more makes them harder to recognise. But IMO, positive gameplay impact > neat reference. Also, the actual asimov lawset remains unchanged as a reference.

> Are sec borgs useless on crewsimov now?

No. Remember that stuns, disables and co are not considered harm. Sec borgs are still free to stun and cuff a murderous criminal. They are just barred from doorcrushing, doorshocking, harmbatoning and similar now.

> How will I, as an AI, now stop the murderous desword traitor!?

You don't. You're not security, getting the murderous desword traitor is not your task unless you get a law change to robocop or paladin.

> Seriously tho, the murderous desword traitor on adrenals with a holopara is causing crew harm in medbay and I can't doorcrush him now, what do?

Tell crew to run away. Lock doors in his path. Tell security where he can be found so they can stop him. Try to distract him. Get creative.
## Changelog
:cl:
tweak: Crewsimov law 1 has been split into two
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
