### PR TITLE
Revert Explorer to Gateway Explorer not Mechanic-lite Explorer

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -465,8 +465,8 @@
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
-	access = list(ACCESS_MAINT_TUNNELS, ACCESS_GATEWAY, ACCESS_EVA, ACCESS_EXTERNAL_AIRLOCKS)
-	minimal_access = list(ACCESS_MAINT_TUNNELS, ACCESS_GATEWAY, ACCESS_EVA, ACCESS_EXTERNAL_AIRLOCKS)
+	access = list(ACCESS_MAINT_TUNNELS, ACCESS_GATEWAY, ACCESS_EVA)
+	minimal_access = list(ACCESS_MAINT_TUNNELS, ACCESS_GATEWAY, ACCESS_EVA)
 	outfit = /datum/outfit/job/explorer
 	hidden_from_job_prefs = TRUE
 


### PR DESCRIPTION
**## What Does This PR Do**
Returns Explorer to Gateway Explorer.

**## Why It's Good For The Game**
This PR uses the logic of other Karma jobs. That one cannot get transferred into a job they do not have unlocked or is barred (such as Magistrate). And any lite-mimics/imitation of the Job is not advised or repealed in-game.

The Explorer used to be custom-made and often only had Gateway/EVA. Not External. While Mechanic's job is not to solely Explore Space. It is what they do 9/10. With a Pod, of course. 

This argument that the Explorer and Mechanic are different because one has a pod, and the other does not. Is odd. Because lite-Blueshields do not have Combat Gloves or proper equipment. But still get bwoinked/reeled in. Magistrate-lite may not have CC authority but still get reeled in. 

Upon returning to the game. The fact Explorers reek so much of Mechanic, yet seems absent of Karma Job protections is odd to me.

Furthermore, it'll help Security reel in Explorers on Blue/Red. Who should be out of a job with Gateway shut down.
**## Images of changes**
![image](https://user-images.githubusercontent.com/78467505/107275288-82f51e80-6a8c-11eb-8e2e-343bbbde6657.png)


**## Changelog**
:cl:
tweak: removed external-airlock from Explorer job.
/:cl:
