### PR TITLE
Makes printed welding tools/fire extinguishers start empty

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -25,6 +25,8 @@
 	var/maximum_fuel = 20
 	var/requires_fuel = TRUE //Set to FALSE if it doesn't need fuel, but serves equally well as a cost modifier
 	var/refills_over_time = FALSE //Do we regenerate fuel?
+	/// Does it start with no fuel?
+	var/empty = FALSE
 	var/activation_sound = 'sound/items/welderactivate.ogg'
 	var/deactivation_sound = 'sound/items/welderdeactivate.ogg'
 	var/light_intensity = 2
@@ -32,9 +34,10 @@
 	var/progress_flash_divisor = 10 //Length of time between each "eye flash"
 
 /obj/item/weldingtool/Initialize(mapload)
-	..()
+	. = ..()
 	create_reagents(maximum_fuel)
-	reagents.add_reagent("fuel", maximum_fuel)
+	if(!empty)
+		reagents.add_reagent("fuel", maximum_fuel)
 	update_icon()
 
 /obj/item/weldingtool/Destroy()
@@ -175,6 +178,8 @@
 	update_torch()
 	..()
 
+/obj/item/weldingtool/empty
+	empty = TRUE
 
 /obj/item/weldingtool/largetank
 	name = "industrial welding tool"
@@ -183,6 +188,9 @@
 	maximum_fuel = 40
 	materials = list(MAT_METAL=70, MAT_GLASS=60)
 	origin_tech = "engineering=2;plasmatech=2"
+
+/obj/item/weldingtool/largetank/empty
+	empty = TRUE
 
 /obj/item/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
@@ -197,6 +205,9 @@
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 	low_fuel_changes_icon = FALSE
+
+/obj/item/weldingtool/mini/empty
+	empty = TRUE
 
 /obj/item/weldingtool/abductor
 	name = "alien welding tool"
@@ -218,6 +229,9 @@
 	maximum_fuel = 80
 	materials = list(MAT_METAL=70, MAT_GLASS=120)
 	origin_tech = "engineering=3;plasmatech=2"
+
+/obj/item/weldingtool/hugetank/empty
+	empty = TRUE
 
 /obj/item/weldingtool/experimental
 	name = "experimental welding tool"

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -17,6 +17,8 @@
 	dog_fashion = /datum/dog_fashion/back
 	resistance_flags = FIRE_PROOF
 	var/max_water = 50
+	/// Does it start with no water?
+	var/empty = FALSE
 	var/last_use = 1.0
 	var/safety = 1
 	var/refilling = FALSE
@@ -24,6 +26,9 @@
 	var/power = 5 //Maximum distance launched water will travel
 	var/precision = 0 //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row
 	var/cooling_power = 2 //Sets the cooling_temperature of the water reagent datum inside of the extinguisher when it is refilled
+
+/obj/item/extinguisher/empty
+	empty = TRUE
 
 /obj/item/extinguisher/mini
 	name = "pocket fire extinguisher"
@@ -40,20 +45,20 @@
 	sprite_name = "miniFE"
 	dog_fashion = null
 
+/obj/item/extinguisher/Initialize(mapload)
+	. = ..()
+	create_reagents(max_water)
+	if(!empty)
+		reagents.add_reagent("water", max_water)
+
 /obj/item/extinguisher/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>The safety is [safety ? "on" : "off"].</span>"
 
-
-/obj/item/extinguisher/New()
-	..()
-	create_reagents(max_water)
-	reagents.add_reagent("water", max_water)
-
-/obj/item/extinguisher/attack_self(mob/user as mob)
+/obj/item/extinguisher/attack_self(mob/user)
 	safety = !safety
-	src.icon_state = "[sprite_name][!safety]"
-	src.desc = "The safety is [safety ? "on" : "off"]."
+	icon_state = "[sprite_name][!safety]"
+	desc = "The safety is [safety ? "on" : "off"]."
 	to_chat(user, "The safety is [safety ? "on" : "off"].")
 	return
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -31,7 +31,7 @@
 	id = "extinguisher"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 90)
-	build_path = /obj/item/extinguisher
+	build_path = /obj/item/extinguisher/empty
 	category = list("initial","Tools")
 
 /datum/design/multitool
@@ -63,7 +63,7 @@
 	id = "welding_tool"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 70, MAT_GLASS = 20)
-	build_path = /obj/item/weldingtool
+	build_path = /obj/item/weldingtool/empty
 	category = list("initial","Tools")
 
 /datum/design/mini_weldingtool
@@ -71,7 +71,7 @@
 	id = "mini_welding_tool"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30, MAT_GLASS = 10)
-	build_path = /obj/item/weldingtool/mini
+	build_path = /obj/item/weldingtool/mini/empty
 	category = list("initial","Tools")
 
 /datum/design/screwdriver
@@ -709,7 +709,7 @@
 	id = "large_welding_tool"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
-	build_path = /obj/item/weldingtool/largetank
+	build_path = /obj/item/weldingtool/largetank/empty
 	category = list("hacked", "Tools")
 
 /datum/design/handcuffs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Makes Welding tools and Fire extinguishers that are printed from an autolathe start empty, rather than fully fueled.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Even with fancy bluespace future technology, I don't think it makes much sense for a lathe to be able to turn metal and glass into welding fuel and water.

## Changelog
:cl:
tweak: Welding tools and Fire extinguishers that are printed from an autolathe will now start empty, rather than fully fueled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
