### PR TITLE
Fixes Elbow drop instakilling regardless of health

### DIFF
--- a/code/modules/martial_arts/combos/sleeping_carp/elbow_drop.dm
+++ b/code/modules/martial_arts/combos/sleeping_carp/elbow_drop.dm
@@ -8,7 +8,8 @@
 		user.do_attack_animation(target, ATTACK_EFFECT_PUNCH)
 		target.visible_message("<span class='warning'>[user] elbow drops [target]!</span>", \
 						  "<span class='userdanger'>[user] piledrives you with [user.p_their()] elbow!</span>")
-		target.death() //FINISH HIM!
+		if(target.health <= 0) //so it actually checks for crit now
+			target.death() //FINISH HIM!
 		target.apply_damage(50, BRUTE, "chest")
 		playsound(get_turf(target), 'sound/weapons/punch1.ogg', 75, 1, -1)
 		add_attack_logs(user, target, "Melee attacked with martial-art [src] :  Elbow Drop", ATKLOG_ALL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Elbow drop now only kills targets if they are in crit

## Why It's Good For The Game
Elbow drop is clearly intended to only work on a target that is in crit as per the description. Bugs bad, oneshotting people bad.

this was a part of  #15254 however i would rather take it into its own PR so it can get fixed sooner
## Changelog
:cl:
fix: Fixed a elbow drop instakilling anyone who is horizontal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
