### PR TITLE
Refactors human explosion damage, rebalance explosions and bomb armor

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -122,7 +122,6 @@
 #define EXPLODE_DEVASTATE 1
 #define EXPLODE_HEAVY 2
 #define EXPLODE_LIGHT 3
-#define EXPLODE_GIB_THRESHOLD 50 	//How much bomb armor you need to resist gibbing from max severity boom
 
 #define EMP_HEAVY 1
 #define EMP_LIGHT 2

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -122,6 +122,7 @@
 #define EXPLODE_DEVASTATE 1
 #define EXPLODE_HEAVY 2
 #define EXPLODE_LIGHT 3
+#define EXPLODE_GIB_THRESHOLD 50 	//How much bomb armor you need to resist gibbing from max severity boom
 
 #define EMP_HEAVY 1
 #define EMP_LIGHT 2

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -200,91 +200,54 @@
 		stat("Spacepod Integrity", "[!S.health ? "0" : "[(S.health / initial(S.health)) * 100]"]%")
 
 /mob/living/carbon/human/ex_act(severity)
-	var/shielded = 0
-	var/b_loss = null
-	var/f_loss = null
-
 	if(status_flags & GODMODE)
-		return 0
+		return FALSE
+
+	var/brute_loss = 0
+	var/burn_loss = 0
+	var/bomb_armor = getarmor(null, "bomb")
 
 	switch(severity)
-		if(1)
-			b_loss += 500
-			if(!prob(getarmor(null, "bomb")))
+		if(EXPLODE_DEVASTATE)
+			if(bomb_armor < EXPLODE_GIB_THRESHOLD)
 				gib()
-				return 0
+				return
 			else
+				brute_loss = 250
+				burn_loss = 250
 				var/atom/target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(target, 200, 4)
 
-				var/limbs_affected = pick(2,3,4)
-				var/obj/item/organ/external/processing_dismember
-				var/list/valid_limbs = bodyparts.Copy()
-
-				while(limbs_affected != 0 && valid_limbs.len > 0)
-					processing_dismember = pick(valid_limbs)
-					if(processing_dismember.limb_name != "chest" && processing_dismember.limb_name != "head" && processing_dismember.limb_name != "groin")
-						processing_dismember.droplimb(1,DROPLIMB_SHARP,0,1)
-						valid_limbs -= processing_dismember
-						limbs_affected -= 1
-					else valid_limbs -= processing_dismember
-
-		if(2)
-			if(!shielded) //literally nothing could change shielded before this so wth
-				b_loss += 60
-
-			f_loss += 60
-
-			var/limbs_affected = 0
-			var/obj/item/organ/external/processing_dismember
-			var/list/valid_limbs = bodyparts.Copy()
-
-			if(prob(getarmor(null, "bomb")))
-				b_loss = b_loss/1.5
-				f_loss = f_loss/1.5
-
-				limbs_affected = pick(1, 1, 2)
-			else
-				limbs_affected = pick(1, 2, 3)
-
-			while(limbs_affected != 0 && valid_limbs.len > 0)
-				processing_dismember = pick(valid_limbs)
-				if(processing_dismember.limb_name != "chest" && processing_dismember.limb_name != "head" && processing_dismember.limb_name != "groin")
-					processing_dismember.droplimb(1,DROPLIMB_SHARP,0,1)
-					valid_limbs -= processing_dismember
-					limbs_affected -= 1
-				else valid_limbs -= processing_dismember
-
+		if(EXPLODE_HEAVY)
+			brute_loss = 60
+			burn_loss = 60
+			if(bomb_armor)
+				brute_loss = 30 * (2 - round(bomb_armor * 0.01, 0.05))
+				burn_loss = brute_loss				//Damage gets reduced from 120 to up to 60 combined brute+burn
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(30, 120)
-			if(prob(70) && !shielded)
-				Paralyse(10)
+			Weaken(20 SECONDS_TO_LIFE_CYCLES - (bomb_armor * 1.6 / 10) SECONDS_TO_LIFE_CYCLES) 	//Between ~4 and ~20 seconds of knockdown depending on bomb armor
 
-		if(3)
-			b_loss += 30
-			if(prob(getarmor(null, "bomb")))
-				b_loss = b_loss/2
-
-			else
-
-				var/limbs_affected = pick(0, 1)
-				var/obj/item/organ/external/processing_dismember
-				var/list/valid_limbs = bodyparts.Copy()
-
-				while(limbs_affected != 0 && valid_limbs.len > 0)
-					processing_dismember = pick(valid_limbs)
-					if(processing_dismember.limb_name != "chest" && processing_dismember.limb_name != "head" && processing_dismember.limb_name != "groin")
-						processing_dismember.droplimb(1,DROPLIMB_SHARP,0,1)
-						valid_limbs -= processing_dismember
-						limbs_affected -= 1
-					else valid_limbs -= processing_dismember
-
+		if(EXPLODE_LIGHT)
+			brute_loss = 30
+			if(bomb_armor)
+				brute_loss = 15 * (2 - round(bomb_armor * 0.01, 0.05)) //Reduced from 30 to up to 15
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(15, 60)
-			if(prob(50) && !shielded)
-				Paralyse(10)
+			Weaken(16 SECONDS_TO_LIFE_CYCLES - (bomb_armor * 1.6 / 10) SECONDS_TO_LIFE_CYCLES) //Between no knockdown to ~16 seconds depending on bomb armor
 
-	take_overall_damage(b_loss,f_loss, TRUE, used_weapon = "Explosive Blast")
+	take_overall_damage(brute_loss, burn_loss, TRUE, used_weapon = "Explosive Blast")
+
+	//attempt to dismember bodyparts
+	if(severity <= EXPLODE_HEAVY || !bomb_armor)
+		var/max_limb_loss = round(4 / severity) //so you don't lose four limbs at severity 3.
+		for(var/X in bodyparts)
+			var/obj/item/organ/external/BP = X
+			if(prob(50 / severity) && !prob(getarmor(BP, "bomb")) && BP.limb_name != "head" && BP.limb_name != "chest" && BP.limb_name != "groin")
+				BP.droplimb(TRUE, DROPLIMB_SHARP, FALSE, TRUE)
+				max_limb_loss--
+				if(!max_limb_loss)
+					break
 
 	..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -213,17 +213,17 @@
 				gib()
 				return
 			else
-				brute_loss = 250
-				burn_loss = 250
+				brute_loss = 200
+				burn_loss = 200
 				var/atom/target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(target, 200, 4)
 
 		if(EXPLODE_HEAVY)
-			brute_loss = 60
-			burn_loss = 60
+			brute_loss = 50
+			burn_loss = 50
 			if(bomb_armor)
-				brute_loss = 30 * (2 - round(bomb_armor * 0.01, 0.05))
-				burn_loss = brute_loss				//Damage gets reduced from 120 to up to 60 combined brute+burn
+				brute_loss = 25 * (2 - round(bomb_armor * 0.01, 0.05))
+				burn_loss = brute_loss				//Damage gets reduced from 100 to up to 50 combined brute+burn
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(30, 120)
 			Weaken(20 SECONDS_TO_LIFE_CYCLES - (bomb_armor * 1.6 / 10) SECONDS_TO_LIFE_CYCLES) 	//Between ~4 and ~20 seconds of knockdown depending on bomb armor

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -209,7 +209,7 @@
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			if(bomb_armor < EXPLODE_GIB_THRESHOLD)
+			if(!prob(getarmor(null, "bomb")))
 				gib()
 				return
 			else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -242,8 +242,6 @@
 			valid_limbs = list("l_hand", "l_foot", "r_hand", "r_foot")
 			limb_loss_chance = 25
 
-	take_overall_damage(brute_loss, burn_loss, TRUE, used_weapon = "Explosive Blast")
-
 	//attempt to dismember bodyparts
 	for(var/X in valid_limbs)
 		var/obj/item/organ/external/BP = get_organ(X)
@@ -254,6 +252,8 @@
 		limbs_amount--
 		if(!limbs_amount)
 			break
+
+	take_overall_damage(brute_loss, burn_loss, TRUE, used_weapon = "Explosive Blast")
 
 	..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -212,7 +212,7 @@
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			if(!prob(getarmor(null, "bomb")))
+			if(!prob(bomb_armor))
 				gib()
 				return
 			else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -223,11 +223,11 @@
 				limbs_amount = 4
 
 		if(EXPLODE_HEAVY)
-			brute_loss = 50
-			burn_loss = 50
+			brute_loss = 60
+			burn_loss = 60
 			if(bomb_armor)
-				brute_loss = 25 * (2 - round(bomb_armor * 0.01, 0.05))
-				burn_loss = brute_loss				//Damage gets reduced from 100 to up to 50 combined brute+burn
+				brute_loss = 30 * (2 - round(bomb_armor * 0.01, 0.05))
+				burn_loss = brute_loss				//Damage gets reduced from 120 to up to 60 combined brute+burn
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				AdjustEarDamage(30, 120)
 			Weaken(20 SECONDS_TO_LIFE_CYCLES - (bomb_armor * 1.6 / 10) SECONDS_TO_LIFE_CYCLES) 	//Between ~4 and ~20 seconds of knockdown depending on bomb armor

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -209,7 +209,7 @@
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			if(!bomb_armor)
+			if(bomb_armor < EXPLODE_GIB_THRESHOLD)
 				gib()
 				return
 			else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -209,7 +209,7 @@
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			if(bomb_armor < EXPLODE_GIB_THRESHOLD)
+			if(!bomb_armor)
 				gib()
 				return
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR refactors and rebalances human mobs ex_act, mainly aimed at making explosions less effective on armored targets and less random in their effectiveness.

- Explosions no longer put you to sleep.
- Explosions reliably stun, with a duration variable on bomb armor and explosion severity.
- Bomb armor now protects limbs from being severed. At max armor (bomb suit, admin gear), delimbing is impossible. At lower armor, delimbing chance is reduced but still possible. This is based on the limb's armor, so a chest piece will not help prevent delimbing.
- Number of limbs removed is now based on explosion severity, instead of being random. Which limb is affected also varies, see below for details. Overall this should result in less limbs being removed at low severity or on high armor target.
- Bomb armor now reliably lowers the damage you take from explosions, with only half damage taken with a full suit.

<details>
<summary>
<i>Details of explosion changes for each severity</i>
</summary>
<p>

Devastating severity (On the same tile of a syndi minibomb, or close to a large bomb) : 
- Chance of gibbing is still based on bomb armor. Bomb suit = Gibbing impossible, unchanged from live.
- Damage if not gibbed is now 200 brute, 200 burn, from 500 brute
- Limbs removed : 50 percent chance to sever for each arm and each leg, reduced by bomb armor.

Heavy Severity (Right next to a minibomb, or a bit further from a large bomb)
- Damage is now reliably reduced by bomb armor. Maximum damage : 60 brute, 60 burn, minimum damage : 30 brute, 30 burn (Current damage is 60 brute 60 burn, with a chance to half it based on armor)
- Now stuns for 20 seconds instead of knocking out for 20 seconds. Duration is reduced based on bomb resistance, with a minimum of 4 seconds.
- Limbs removed : 50 percent chance to lose either an arm or a leg, reduced by bomb armor.

Light Severity (Close to a minibomb, or even further away from a large bomb)
- Maximum damage : 30 brute, minimum damage : 15 brute. (Current damage is 30 brute, with a chance to half it based on armor)
- Now stuns for 16 seconds instead of knocking out for 20 seconds. Duration is reduced based on bomb resistance, bomb suit wearers will not be stunned.
- Limbs removed : 25 percent chance to lose either a hand or a foot, reduced by bomb armor.

</p>
</details>


Significant balance changes that result from these : 

- You can no longer use fireballs to put people to sleep in order to soulstone them. However, fireballs (and all other explosions) will now reliably stun targets hit, instead of randomly leaving them up sometimes.

- Antags with antistun mechanics can use them against explosive stun, instead of being knocked out and unable to do anything about it.

- Syndicate hardsuit and wizard robes provide better resistance to explosions, but grenade/bombs are still significantly dangerous.

- Bomb suits are now worth consideration for security when facing explosive users, especially when combined with slime speed potion. They provide significant damage resistance, will negate or massively reduce stun duration, and prevent gibbing for max severety explosions.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Explosions are rarely used as a tool due to server rules. 
However, when they ARE used, they are currently frustrating for both parties : Explosions are unreliable as a crowd control tool since the chance to knock out isnt guaranteed, and explosions have little counters because bomb armor currently barely does anything, and you can't use any antistun/escape ability when knocked out.
This PR should hopefully make explosions more fun and less frustrating for both exploder and explodee.

## Changelog
:cl:
tweak: Explosions, including wizard fireballs, no longer knock out, but stun instead.
tweak: Explosion stun is now guaranteed, but the duration can be lowered by wearing armor with bomb resistance.
tweak: Explosion stun duration is further reduced if you are on the edge of the blast zone.
tweak: Wearing armor with bomb resistance will now lower the chance of losing limbs in explosions. Bomb suit negate limb loss entirely.
tweak: Limb loss chance has been reduced if you are on the edge of the blast zone.
tweak: Wearing armor with bomb resistance now reliably lowers the damage caused by explosions, up to a half taken for a complete bomb suit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
