### PR TITLE
Makes body bags unweldable

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -19,46 +19,48 @@
 	icon_state = "bodybag_closed"
 	icon_closed = "bodybag_closed"
 	icon_opened = "bodybag_open"
+	density = FALSE
+	integrity_failure = 0
 	sound = 'sound/items/zip.ogg'
 	var/item_path = /obj/item/bodybag
-	density = 0
-	integrity_failure = 0
 
 
-/obj/structure/closet/body_bag/attackby(W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/pen))
-		var/t = rename_interactive(user, W)
+/obj/structure/closet/body_bag/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/pen))
+		var/t = rename_interactive(user, I)
 		if(isnull(t))
 			return
 		cut_overlays()
 		if(t)
 			add_overlay(image(icon, "bodybag_label"))
 		return
-	if(istype(W, /obj/item/wirecutters))
-		to_chat(user, "You cut the tag off the bodybag")
-		name = "body bag"
+	if(istype(I, /obj/item/wirecutters))
+		to_chat(user, "<span class='notice'>You cut the tag off the bodybag.</span>")
+		name = initial(name)
 		cut_overlays()
 		return
 	return ..()
 
+/obj/structure/closet/body_bag/welder_act(mob/user, obj/item/I)
+	return // Can't weld a body bag shut
 
 /obj/structure/closet/body_bag/close()
 	if(..())
 		density = 0
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()
-	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
+	if(over_object == usr && (in_range(src, usr) || usr.contents.Find(src)))
 		if(!ishuman(usr) || opened || length(contents))
 			return FALSE
 		visible_message("[usr] folds up the [name]")
 		new item_path(get_turf(src))
 		qdel(src)
 
-/obj/structure/closet/body_bag/relaymove(mob/user as mob)
+/obj/structure/closet/body_bag/relaymove(mob/user)
 	if(user.stat)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes #15495
And cleans up the surrounding code a little.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Clearly an oversight, considering that:
1. There's no welded sprite.
2. Trying to escape one gives you a message about leaning on the back.
3. You can't really weld plastic.
4. And even if you could, unwelding would make it unusable.

## Changelog
:cl:
tweak: Body bags can no longer be welded shut.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
