### PR TITLE
Fixes the Medical Hardsuit Helmet not blocking hair

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -479,7 +479,6 @@
 	item_color = "medical"
 	flash_protect = 0
 	armor = list("melee" = 30, "bullet" = 5, "laser" = 10, "energy" = 5, "bomb" = 10, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 75)
-	flags = STOPSPRESSUREDMAGE | THICKMATERIAL
 	scan_reagents = 1 //Generally worn by the CMO, so they'd get utility off of seeing reagents
 
 /obj/item/clothing/suit/space/hardsuit/medical


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removed the `flags` from the medical hardsuit helmet, since they were exactly the same as the parent but without `BLOCKHAIR`.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Looks pretty odd with long hair/hair-like extremities.
Also, it's a hardsuit and should probably be airtight.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
### Before:
![NSS Cyberiad 2021-01-24 054138](https://user-images.githubusercontent.com/57483089/107562613-f8b9d100-6bd7-11eb-8916-fa77bce3da72.png)![NSS Cyberiad 2021-01-24 054142](https://user-images.githubusercontent.com/57483089/107562618-f9526780-6bd7-11eb-8c03-f1cdaae88be3.png)

### After:
![NSS Cyberiad 2021-01-24 054216](https://user-images.githubusercontent.com/57483089/107562644-01aaa280-6bd8-11eb-923c-33869c92eaec.png)![NSS Cyberiad 2021-01-24 054217](https://user-images.githubusercontent.com/57483089/107562647-02dbcf80-6bd8-11eb-95e2-c9ef9041a38e.png)

## Changelog
:cl:
fix: Fixed the medical hardsuit helmet not blocking hair.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
