### PR TITLE
Rapid Cyborg Disabler Upgrade now requires way higher Tech levels

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -104,7 +104,7 @@
 	name = "cyborg rapid disabler cooling module"
 	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."
 	icon_state = "cyborg_upgrade3"
-	origin_tech = "engineering=4;powerstorage=4;combat=4"
+	origin_tech = "engineering=7;powerstorage=7;combat=7"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/security
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It changes the Cyborg disabler to require Engineering 7, Power 7 and Combat 7.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There have been many complaints of borgs as of lately, and the disabler being OP has been one of them. This PR would delay the potential to build them, and some rounds will not reach them at all. To get it with this PR one would need prototypes form Cargo as well as either a Slime core from Xeno or glowcaps from Botany, thus one would in certain rounds never reach this at all. The fact that one could make these just with Techs at Engi 4, Power 4 and Combat 4 will no longer be the case. (These are reachable in about 10 minutes in game time at the earliest)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Tweaked tech requirements for Cyborg Disablers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
