### PR TITLE
Rapid Cyborg Disabler Upgrade now requires way higher Tech levels V2

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1056,7 +1056,7 @@
 	id = "borg_upgrade_disablercooler"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/disablercooler
-	req_tech = list("combat" = 5, "powerstorage" = 4, "engineering" = 4)
+	req_tech = list("combat" = 7, "powerstorage" = 7, "engineering" = 7)
 	materials = list(MAT_METAL=80000 , MAT_GLASS=6000 , MAT_GOLD= 2000, MAT_DIAMOND = 500)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
(Uploaded again as the last version edited the wrong file, and was as such a weird buff of a kind https://github.com/ParadiseSS13/Paradise/pull/15513)

## What Does This PR Do
It changes the Cyborg disabler to require Engineering 7, Power 7 and Combat 7.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There have been many complaints of borgs as of lately, and the disabler being OP has been one of them. This PR would delay the potential to build them, and some rounds will not reach them at all. To get it with this PR one would need prototypes form Cargo as well as either a Slime core from Xeno or glowcaps from Botany, thus one would in certain rounds never reach this at all. The fact that one could make these just with Techs at Engi 4, Power 4 and Combat 4 will no longer be the case. (These are reachable in about 10 minutes in game time at the earliest)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Tweaked tech requirements for Cyborg Disablers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
