### PR TITLE
Adds saline glucose, epinephrine, and spaceacillin to syndicate medical cyborg

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -31,7 +31,7 @@
 	icon_state = "borghypo_s"
 	charge_cost = 20
 	recharge_time = 2
-	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone")
+	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone", "salglu_solution", "epinephrine", "spaceacillin")
 	bypass_protection = 1
 
 /obj/item/reagent_containers/borghypo/New()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As the title states, this adds saline glucose, epinephrine, and spaceacillin to the syndicate medical cyborg's hypospray.

## Why It's Good For The Game
Currently, the syndicate cyborg is a bit helpless when it comes to new crit. The normal medical borg has these tools to treat shock and heart failure. Shock is more of the minor one as they can treat the damage causing shock, but there isn't really harm in giving them saline glucose when they have nanites already. Heart failure is the more significant issue as they have no way to cure this disease, in fact, the only way to save a nukie with heart failure is to take them to the sleeper on their ship as of now. Finally I'm giving them spaceacillin because the normal medical borg has it, and it prevents needing surgery to deal with an infection.

## Changelog
:cl:
add: Adds saline glucose, epinephrine, and spaceacillin to syndicate medical cyborg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
