### PR TITLE
Tweaks to PDAPainter for quicker and more fluid paint.

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -25,6 +25,7 @@
 	if(istype(A, /obj/))
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/item/guardian_bomb/B = new /obj/item/guardian_bomb(get_turf(A))
+			add_attack_logs(src, A, "booby trapped (summoner: [summoner])")
 			to_chat(src, "<span class='danger'>Success! Bomb on [A] armed!</span>")
 			if(summoner)
 				to_chat(summoner, "<span class='warning'>Your guardian has primed [A] to explode!</span>")
@@ -53,6 +54,7 @@
 	addtimer(CALLBACK(src, .proc/disable), 600)
 
 /obj/item/guardian_bomb/proc/disable()
+	add_attack_logs(null, stored_obj, "booby trap expired")
 	stored_obj.forceMove(get_turf(src))
 	if(spawner)
 		to_chat(spawner, "<span class='danger'>Failure! Your trap on [stored_obj] didn't catch anyone this time.</span>")
@@ -65,10 +67,12 @@
 	if(istype(spawner, /mob/living/simple_animal/hostile/guardian))
 		var/mob/living/simple_animal/hostile/guardian/G = spawner
 		if(user == G.summoner)
+			add_attack_logs(user, stored_obj, "booby trap defused")
 			to_chat(user, "<span class='danger'>You knew this because of your link with your guardian, so you smartly defuse the bomb.</span>")
 			stored_obj.forceMove(get_turf(loc))
 			qdel(src)
 			return
+	add_attack_logs(user, stored_obj, "booby trap TRIGGERED (spawner: [spawner])")
 	to_chat(spawner, "<span class='danger'>Success! Your trap on [src] caught [user]!</span>")
 	stored_obj.forceMove(get_turf(loc))
 	playsound(get_turf(src),'sound/effects/explosion2.ogg', 200, 1)

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -102,6 +102,7 @@
 
 		storedpda.icon_state = P
 		storedpda.desc = colorlist[P]
+		ejectpda()
 
 	else
 		to_chat(user, "<span class='notice'>The [src] is empty.</span>")

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -32,7 +32,8 @@
 		return
 
 	R.reset_module()
-
+	R.shown_robot_modules = 0
+	R.client.screen -= R.robot_modules_background
 	return TRUE
 
 /obj/item/borg/upgrade/rename

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -32,8 +32,6 @@
 		return
 
 	R.reset_module()
-	R.shown_robot_modules = 0
-	R.client.screen -= R.robot_modules_background
 	return TRUE
 
 /obj/item/borg/upgrade/rename


### PR DESCRIPTION
## What Does This PR Do
The PR is a minor tweak that has the eject function called when a pda is painted. So the HoP does not have to click (insert), click (paint), click (eject). It cuts out one of the steps, making it a more fluid experience. 

## Why It's Good For The Game
Makes the painting of PDAs more time-efficient.

## Images of changes
![Uge77ncSpg](https://user-images.githubusercontent.com/78467505/107861148-bbc33800-6e7e-11eb-8e98-6875ec746252.gif)

## Changelog
:cl:
tweak: made PDA painting more efficient.
/:cl:
