### PR TITLE
Cyborg can no longer interact with airlocks or APCs while locked or unpowered

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -16,7 +16,7 @@
 	changeNext_click(1)
 
 	if(!cell || cell.charge <= 0 || lockcharge) // Disable UIs if the Borg is unpowered or locked.
-		to_chat(user, "<span class='notice'>You failed to connect to the device, due to being offline.</span>")
+		to_chat(src, "<span class='notice'>You failed to connect to the device, due to being offline.</span>")
 		return
 	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
 		return

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -15,6 +15,9 @@
 		return
 	changeNext_click(1)
 
+	if(!cell || cell.charge <= 0 || lockcharge) // Disable UIs if the Borg is unpowered or locked.
+		to_chat(user, "<span class='notice'>You failed to connect to the device, due to being offline.</span>")
+		return
 	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
 		return
 	if(stat == DEAD)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -16,7 +16,6 @@
 	changeNext_click(1)
 
 	if(!cell || cell.charge <= 0 || lockcharge) // Disable UIs if the Borg is unpowered or locked.
-		to_chat(src, "<span class='notice'>You failed to connect to the device, due to being offline.</span>")
 		return
 	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
 		return

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -72,7 +72,7 @@
 
 /mob/living/silicon/robot/shared_ui_interaction(src_object)
 	if(!cell || cell.charge <= 0 || lockcharge) // Disable UIs if the Borg is unpowered or locked.
-		return STATUS_DISABLED
+		return STATUS_CLOSE
 	return ..()
 
 /**


### PR DESCRIPTION
Fixes #15265
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Solve the issue in (https://github.com/ParadiseSS13/Paradise/issues/15265), makes it so borgs who try to interact with airlocks or APCs cannot do so.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Borgs can no longer resist while locked or without power or cells. Which was reported as a bug and is one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Borgs no longer can interact with devices while locked or unpowered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
