### PR TITLE
Adds proper access controls to mech fabricator

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -18,7 +18,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 20
 	active_power_usage = 5000
-	req_access = list(ACCESS_ROBOTICS)
+	req_access = list(ACCESS_ROBOTICS, ACCESS_FREE_GOLEMS)
 	// Settings
 	/// Bitflags of design types that can be produced.
 	var/allowed_design_types = MECHFAB

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -18,6 +18,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 20
 	active_power_usage = 5000
+	req_access = list(ACCESS_ROBOTICS)
 	// Settings
 	/// Bitflags of design types that can be produced.
 	var/allowed_design_types = MECHFAB
@@ -441,6 +442,13 @@
 		else
 			return FALSE
 	add_fingerprint(usr)
+
+/obj/machinery/mecha_part_fabricator/emag_act(user as mob)
+	if(!emagged)
+		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
+		req_access = list()
+		emagged = TRUE
+		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
 
 /**
   * # Exosuit Fabricator (upgraded)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Applies an ID restriction to the mech fabricator, locking it to robotics access.

Allows the emagging of the mech fabricator and space pod fabricator to remove access requirements.

## Why It's Good For The Game
First off, it's a design inconsistency, that the space pod fabricator is locked and the mech fabricator is not. Further, the general R&D machines are locked, but the mech fabricator is not.

This allows scientists to effectively function as robotics+, as there is nothing stopping them from doing robotic's job, while robotics is not allowed to interact with the R&D setup. This should help encourage science and robotics to cooperate and "Stay in their lanes" so to speak, rather than building machines to do the other's job.

This also prevents any random person who walks into robotics from making whatever they want on the fabricator, making it harder for greytiders and griefers to annoy robotics. They already can't make whatever they want in R&D so this is just consistency in my mind.

Further, it's a positive option for interaction to let emags bypass the access restrictions on both of these machines.

## Changelog
:cl:
add: Added the ability to emag into mech fabricator and space pod fabricator
add: Locked mech fabricator to robotics (and golem) access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
