### PR TITLE
Adds a discord ping for mhelps if there aren't any mentors online

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -247,6 +247,9 @@
 	/// Role ID to be pinged for administrative events
 	var/discord_admin_role_id = null // Intentional null usage
 
+	/// Role ID to be pinged for mentorhelps
+	var/discord_mentor_role_id = null
+
 	/// Webhook URLs for the main public webhook
 	var/list/discord_main_webhook_urls = list()
 
@@ -755,6 +758,8 @@
 					discord_webhooks_enabled = TRUE
 				if("discord_webhooks_admin_role_id")
 					discord_admin_role_id = "[value]" // This MUST be a string because BYOND doesnt like massive integers
+				if("discord_webhooks_mentor_role_id")
+					discord_mentor_role_id = "[value]"
 				if("discord_webhooks_main_url")
 					discord_main_webhook_urls = splittext(value, "|")
 				if("discord_webhooks_admin_url")

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -5,6 +5,8 @@ SUBSYSTEM_DEF(discord)
 	var/enabled = FALSE
 	/// Last time the administrator ping was dropped. This ensures administrators cannot be mass pinged if a large chunk of ahelps go off at once (IE: tesloose)
 	var/last_administration_ping = 0
+	/// Last time the mentor ping was dropped. This ensures mentors cannot be mass pinged if a large chunk of mhelps go off at once.
+	var/last_mentor_ping = 0
 
 /datum/controller/subsystem/discord/Initialize(start_timeofday)
 	if(config.discord_webhooks_enabled)
@@ -80,5 +82,15 @@ SUBSYSTEM_DEF(discord)
 
 		last_administration_ping = world.time + 60 SECONDS
 		return "<@&[config.discord_admin_role_id]>"
+
+	return ""
+
+/datum/controller/subsystem/discord/proc/handle_mentor_ping()
+	if(config.discord_mentor_role_id)
+		if(last_mentor_ping > world.time)
+			return "*(Role pinged recently)*"
+
+		last_mentor_ping = world.time + 60 SECONDS
+		return "<@&[config.discord_mentor_role_id]>"
 
 	return ""

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -47,16 +47,20 @@ GLOBAL_LIST_INIT(adminhelp_ignored_words, list("unknown", "the", "a", "an", "of"
 			SSdiscord.send2discord_simple_noadmins("**\[Adminhelp]** [key_name(src)]: [msg]", check_send_always = TRUE)
 
 		if("Mentorhelp")
+			// This is all copied from `send2discord_simple_noadmins()`, so I'm not really sure why it's not in its own proc.
+			// Todo: Get rid of the copy pasting here
 			var/alerttext
 			var/list/mentorcount = staff_countup(R_MENTOR)
 			var/active_mentors = mentorcount[1]
 			var/inactive_mentors = mentorcount[3]
+			var/add_ping = FALSE
 
 			if(active_mentors <= 0)
+				add_ping = TRUE
 				if(inactive_mentors)
-					alerttext = " | **ALL MENTORS AFK**"
+					alerttext = "| **ALL MENTORS AFK**"
 				else
-					alerttext = " | **NO MENTORS ONLINE**"
+					alerttext = "| **NO MENTORS ONLINE**"
 
 			log_admin("[selected_type]: [key_name(src)]: [msg] - heard by [active_mentors] non-AFK mentors.")
-			SSdiscord.send2discord_simple(DISCORD_WEBHOOK_MENTOR, "[key_name(src)]: [msg][alerttext]")
+			SSdiscord.send2discord_simple(DISCORD_WEBHOOK_MENTOR, "[key_name(src)]: [msg] [alerttext] [add_ping ? SSdiscord.handle_mentor_ping() : ""]")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -451,6 +451,10 @@ BYOND_ACCOUNT_AGE_THRESHOLD 7
 ## IF YOU ARE DISABLING THIS COMMENT IT OUT ENTIRELY, DONT LEAVE IT BLANK
 #DISCORD_WEBHOOKS_ADMIN_ROLE_ID
 
+## Role ID to be pinged with mentorhelps, if no mentors are ingame to take it.
+## IF YOU ARE DISABLING THIS COMMENT IT OUT ENTIRELY, DONT LEAVE IT BLANK
+#DISCORD_WEBHOOKS_MENTOR_ROLE_ID
+
 ## Webhook URLs for the main discord webhook. Separate multiple URLs with a | (EG: https://url1|https://url2)
 #DISCORD_WEBHOOKS_MAIN_URL
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a config setting to ping mentors on discord if there's no active mentors ingame, the same as the admin ping system.

**IMPORTANT**
I can't actually test this myself, both because I have no clue how to even start testing discord stuff and because I somehow managed to break my server database. It *should* work since it's mostly copied over from the admin system, but if @AffectedArc07 or someone could verify that this actually works I'd appreciate it.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Helps prevent this from happening:
![KjFicQg3M0](https://user-images.githubusercontent.com/57483089/107950767-219ee500-6f8f-11eb-9b32-b50a18b43ba8.png)

## Changelog
:cl:
add: Mentors will now be pinged on discord if someone mhelps with no mentors online.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
