### PR TITLE
AI Detector can now only detect AI, not Abductors, Xenobio consoles or Shuttles

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -4,7 +4,7 @@
 	. = ..()
 	var/obj/machinery/hologram/holopad/H = origin
 	H.move_hologram(eye_user, loc)
-	show_on_multitool = FALSE // Holocalls dont trigger the Ai Detector
+	ai_detector_visible = FALSE // Holocalls dont trigger the Ai Detector
 
 //this datum manages it's own references
 

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -4,7 +4,7 @@
 	. = ..()
 	var/obj/machinery/hologram/holopad/H = origin
 	H.move_hologram(eye_user, loc)
-	AiDetector = FALSE
+	AiDetector = FALSE // Holocalls dont trigger the Ai Detector
 
 //this datum manages it's own references
 

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -4,7 +4,7 @@
 	. = ..()
 	var/obj/machinery/hologram/holopad/H = origin
 	H.move_hologram(eye_user, loc)
-	AiDetector = FALSE // Holocalls dont trigger the Ai Detector
+	show_on_multitool = FALSE // Holocalls dont trigger the Ai Detector
 
 //this datum manages it's own references
 

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -4,6 +4,7 @@
 	. = ..()
 	var/obj/machinery/hologram/holopad/H = origin
 	H.move_hologram(eye_user, loc)
+	AiDetector = FALSE
 
 //this datum manages it's own references
 

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -101,7 +101,8 @@
 
 /mob/camera/aiEye/remote
 	name = "Inactive Camera Eye"
-	AiDetector = FALSE // Abductors dont trigger the Ai Detector
+	// Abductors dont trigger the Ai Detector
+	show_on_multitool = FALSE
 	var/sprint = 10
 	var/cooldown = 0
 	var/acceleration = 1

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -101,7 +101,7 @@
 
 /mob/camera/aiEye/remote
 	name = "Inactive Camera Eye"
-	AiDetector = FALSE
+	AiDetector = FALSE // Abductors dont trigger the Ai Detector
 	var/sprint = 10
 	var/cooldown = 0
 	var/acceleration = 1

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -101,6 +101,7 @@
 
 /mob/camera/aiEye/remote
 	name = "Inactive Camera Eye"
+	AiDetector = FALSE
 	var/sprint = 10
 	var/cooldown = 0
 	var/acceleration = 1

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -102,7 +102,7 @@
 /mob/camera/aiEye/remote
 	name = "Inactive Camera Eye"
 	// Abductors dont trigger the Ai Detector
-	show_on_multitool = FALSE
+	ai_detector_visible = FALSE
 	var/sprint = 10
 	var/cooldown = 0
 	var/acceleration = 1

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -82,7 +82,7 @@
 		if(chunk)
 			if(chunk.seenby.len)
 				for(var/mob/camera/aiEye/A in chunk.seenby)
-					if(!A.AiDetector)
+					if(!A.AiDetector) //Checks if the A is to be detected or not
 						continue
 					var/turf/detect_turf = get_turf(A)
 					if(get_dist(our_turf, detect_turf) < rangealert)

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -82,7 +82,8 @@
 		if(chunk)
 			if(chunk.seenby.len)
 				for(var/mob/camera/aiEye/A in chunk.seenby)
-					if(!A.AiDetector) //Checks if the A is to be detected or not
+					//Checks if the A is to be detected or not
+					if(!A.show_on_multitool)
 						continue
 					var/turf/detect_turf = get_turf(A)
 					if(get_dist(our_turf, detect_turf) < rangealert)

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -83,7 +83,7 @@
 			if(chunk.seenby.len)
 				for(var/mob/camera/aiEye/A in chunk.seenby)
 					//Checks if the A is to be detected or not
-					if(!A.show_on_multitool)
+					if(!A.ai_detector_visible)
 						continue
 					var/turf/detect_turf = get_turf(A)
 					if(get_dist(our_turf, detect_turf) < rangealert)

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -82,6 +82,8 @@
 		if(chunk)
 			if(chunk.seenby.len)
 				for(var/mob/camera/aiEye/A in chunk.seenby)
+					if(!A.AiDetector)
+						continue
 					var/turf/detect_turf = get_turf(A)
 					if(get_dist(our_turf, detect_turf) < rangealert)
 						detect_state = PROXIMITY_ON_SCREEN

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -17,7 +17,7 @@
 	var/use_static = TRUE
 	var/static_visibility_range = 16
 	// Decides if it is shown by AI Detector or not
-	var/show_on_multitool = TRUE
+	var/ai_detector_visible = TRUE
 
 
 // Use this when setting the aiEye's location.

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -16,7 +16,7 @@
 	var/relay_speech = FALSE
 	var/use_static = TRUE
 	var/static_visibility_range = 16
-	var/AiDetector = TRUE
+	var/AiDetector = TRUE // Decides if it is shown by AI Detector or not
 
 
 // Use this when setting the aiEye's location.

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -16,7 +16,8 @@
 	var/relay_speech = FALSE
 	var/use_static = TRUE
 	var/static_visibility_range = 16
-	var/AiDetector = TRUE // Decides if it is shown by AI Detector or not
+	// Decides if it is shown by AI Detector or not
+	var/show_on_multitool = TRUE
 
 
 // Use this when setting the aiEye's location.

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -16,6 +16,7 @@
 	var/relay_speech = FALSE
 	var/use_static = TRUE
 	var/static_visibility_range = 16
+	var/AiDetector = TRUE
 
 
 // Use this when setting the aiEye's location.

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -4,7 +4,8 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "camera_target"
 	var/allowed_area = null
-	AiDetector = FALSE // The Xenobio Console does not trigger the AI Detector
+	// The Xenobio Console does not trigger the AI Detector
+	show_on_multitool = FALSE
 
 /mob/camera/aiEye/remote/xenobio/New(loc)
 	var/area/A = get_area(loc)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "camera_target"
 	var/allowed_area = null
-	AiDetector = FALSE
+	AiDetector = FALSE // The Xenobio Console does not trigger the AI Detector
 
 /mob/camera/aiEye/remote/xenobio/New(loc)
 	var/area/A = get_area(loc)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "camera_target"
 	var/allowed_area = null
+	AiDetector = FALSE
 
 /mob/camera/aiEye/remote/xenobio/New(loc)
 	var/area/A = get_area(loc)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -5,7 +5,7 @@
 	icon_state = "camera_target"
 	var/allowed_area = null
 	// The Xenobio Console does not trigger the AI Detector
-	show_on_multitool = FALSE
+	ai_detector_visible = FALSE
 
 /mob/camera/aiEye/remote/xenobio/New(loc)
 	var/area/A = get_area(loc)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -264,7 +264,7 @@
 	visible_icon = FALSE
 	use_static = FALSE
 	simulated = FALSE
-	AiDetector = FALSE
+	AiDetector = FALSE // The Shuttle Docker does not trigger the AI Detector
 	var/list/placement_images = list()
 	var/list/placed_images = list()
 

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -4,6 +4,7 @@
 	icon_screen = "navigation"
 	icon_keyboard = "med_key"
 	jump_action = null
+	AiDetector = FALSE
 	var/datum/action/innate/shuttledocker_rotate/rotate_action = new
 	var/datum/action/innate/shuttledocker_place/place_action = new
 	var/shuttleId = ""

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -4,7 +4,6 @@
 	icon_screen = "navigation"
 	icon_keyboard = "med_key"
 	jump_action = null
-	AiDetector = FALSE
 	var/datum/action/innate/shuttledocker_rotate/rotate_action = new
 	var/datum/action/innate/shuttledocker_place/place_action = new
 	var/shuttleId = ""

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -264,7 +264,8 @@
 	visible_icon = FALSE
 	use_static = FALSE
 	simulated = FALSE
-	AiDetector = FALSE // The Shuttle Docker does not trigger the AI Detector
+	// The Shuttle Docker does not trigger the AI Detector
+	show_on_multitool = FALSE
 	var/list/placement_images = list()
 	var/list/placed_images = list()
 

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -265,7 +265,7 @@
 	use_static = FALSE
 	simulated = FALSE
 	// The Shuttle Docker does not trigger the AI Detector
-	show_on_multitool = FALSE
+	ai_detector_visible = FALSE
 	var/list/placement_images = list()
 	var/list/placed_images = list()
 

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -264,6 +264,7 @@
 	visible_icon = FALSE
 	use_static = FALSE
 	simulated = FALSE
+	AiDetector = FALSE
 	var/list/placement_images = list()
 	var/list/placed_images = list()
 


### PR DESCRIPTION
Fix for issue #14830
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes the AI detector (Multitool) only able to detect the AI, instead of all subtypes who use AiEye. This includes the Abductor Console, The Shuttle Console, The Xenobiology Console as well as holocalls.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The AI detector should be just that, an AI detector (Multitool), it makes little sense for it to be able to detect abductors, or shuttles looking for landing sites. The Xenobiology console too would be detected as watching. All of these would result in a false positive for what it said it did, detect if the AI is watching.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: AI Detector Multitool only detects the AI, not Abductors nor the Xenobio console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
