### PR TITLE
Disaster Counters

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -81119,10 +81119,10 @@
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
 "cXf" = (
-/obj/machinery/status_display{
+/obj/structure/closet/secure_closet/reagents,
+/obj/structure/disaster_counter/chemistry{
 	pixel_x = -32
 	},
-/obj/structure/closet/secure_closet/reagents,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitegreen";

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -95264,6 +95264,9 @@
 	network = list("Research Outpost")
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disaster_counter/toxins{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "dxe" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67017,6 +67017,9 @@
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/item/storage/backpack/satchel_chem,
 /obj/effect/decal/warning_stripes/south,
+/obj/structure/disaster_counter/chemistry{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -73776,6 +73776,9 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/disaster_counter/toxins{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing{
 	name = "\improper Toxins Lab"
@@ -84092,6 +84095,9 @@
 	},
 /obj/structure/noticeboard{
 	pixel_y = 30
+	},
+/obj/structure/disaster_counter/scichem{
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -60287,7 +60287,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/alarm{
-	pixel_y = 25
+	pixel_y = 31
+	},
+/obj/machinery/driver_button{
+	dir = 2;
+	id_tag = "toxinsdriver";
+	pixel_y = 22;
+	range = 18
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/launch{
@@ -61435,14 +61441,11 @@
 	name = "Toxins Launch Room"
 	})
 "cqq" = (
-/obj/machinery/driver_button{
-	dir = 2;
-	id_tag = "toxinsdriver";
-	pixel_y = 24;
-	range = 18
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/disaster_counter/toxins{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/launch{
@@ -68303,12 +68306,12 @@
 	},
 /area/toxins/misc_lab)
 "cCl" = (
-/obj/machinery/newscaster{
-	pixel_y = 34
-	},
 /obj/machinery/light{
 	dir = 1;
 	on = 1
+	},
+/obj/structure/disaster_counter/scichem{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -68331,6 +68334,9 @@
 /area/toxins/misc_lab)
 "cCn" = (
 /obj/machinery/chem_heater,
+/obj/machinery/newscaster{
+	pixel_y = 34
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "vault";

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -43596,6 +43596,9 @@
 /area/hallway/secondary/entry)
 "bLD" = (
 /obj/structure/closet/secure_closet/reagents,
+/obj/structure/disaster_counter/chemistry{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteyellow"
@@ -44752,12 +44755,6 @@
 /area/medical/reception)
 "bNA" = (
 /obj/effect/decal/warning_stripes/northeast,
-/obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 22
-	},
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
 "bNB" = (
@@ -78694,6 +78691,9 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/light,
+/obj/structure/disaster_counter/supermatter{
+	pixel_y = -32
+	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "cVB" = (

--- a/code/game/objects/structures/disaster_counter.dm
+++ b/code/game/objects/structures/disaster_counter.dm
@@ -1,0 +1,75 @@
+/**
+  * # Disaster counter.
+  *
+  * Tracks how many shifts it has been since the counter with that ID was exploded.
+  */
+/obj/structure/disaster_counter
+	name = "disaster counter"
+	desc = "This magical device will count up how many shifts it has been since a major disaster in this area."
+	icon = 'icons/obj/status_display.dmi'
+	icon_state = "frame"
+	maptext_y = 10 // Offset by 10 so it renders properly
+	/// ID of the counter. Must be overriden
+	var/counter_id
+	/// Current count number
+	var/current_count = 0
+
+/obj/structure/disaster_counter/examine(mob/user)
+	. = ..()
+	. += "The display reads 'Currently [current_count] shifts without an accident!'"
+
+/obj/structure/disaster_counter/Initialize(mapload)
+	. = ..()
+	if(!counter_id)
+		stack_trace("Disaster counter at [x],[y],[z] does not have a counter_id set. Deleting...")
+		return INITIALIZE_HINT_QDEL
+
+	// If we still exist, put ourselves in
+	SSpersistent_data.register(src)
+
+/obj/structure/disaster_counter/ex_act(severity)
+	if(severity < 2)
+		current_count = -1
+		persistent_save()
+	. = ..()
+
+/obj/structure/disaster_counter/Destroy()
+	if(counter_id)
+		SSpersistent_data.registered_atoms -= src // Take us out the list
+	return ..()
+
+/obj/structure/disaster_counter/persistent_load()
+	// Just incase some bad actor sets the counter ID to "../../../../Windows/System32"
+	// Yes I am that paranoid
+	if(counter_id != paranoid_sanitize(counter_id))
+		stack_trace("Counter ID did not pass sanitization for disaster counter at [x],[y],[z]. Potential attempt at filesystem manipulation.")
+		qdel(src)
+
+	var/savefile/S = new /savefile("data/disaster_counters/[counter_id].sav")
+	S["count"] >> current_count
+
+	if(isnull(current_count))
+		current_count = 0
+	else
+		current_count++ // Increase by 1 since this is the next shift without a disaster (yet)
+	log_debug("Persistent data for [src] loaded (current_count: [current_count])")
+	maptext = "<span class='maptext' style='text-align: center'>[current_count]</span>"
+
+/obj/structure/disaster_counter/persistent_save()
+	if(counter_id != paranoid_sanitize(counter_id))
+		stack_trace("Counter ID did not pass sanitization for disaster counter at [x],[y],[z]. Potential attempt at filesystem manipulation.")
+		qdel(src)
+
+	var/savefile/S = new /savefile("data/disaster_counters/[counter_id].sav")
+
+	S["count"] << current_count
+	log_debug("Persistent data for [src] saved (current_count: [current_count])")
+
+// Prefab definitions to make mapping easier
+/obj/structure/disaster_counter/supermatter
+	name = "supermatter disaster counter"
+	counter_id = "supermatter"
+
+/obj/structure/disaster_counter/chemistry
+	name = "chemistry disaster counter"
+	counter_id = "chemistry"

--- a/code/game/objects/structures/disaster_counter.dm
+++ b/code/game/objects/structures/disaster_counter.dm
@@ -46,6 +46,7 @@
 	if(counter_id != paranoid_sanitize(counter_id))
 		stack_trace("Counter ID did not pass sanitization for disaster counter at [x],[y],[z]. Potential attempt at filesystem manipulation.")
 		qdel(src)
+		return
 
 	var/savefile/S = new /savefile("data/disaster_counters/[counter_id].sav")
 	S["count"] >> current_count
@@ -69,6 +70,7 @@
 	if(counter_id != paranoid_sanitize(counter_id))
 		stack_trace("Counter ID did not pass sanitization for disaster counter at [x],[y],[z]. Potential attempt at filesystem manipulation.")
 		qdel(src)
+		return
 
 	var/savefile/S = new /savefile("data/disaster_counters/[counter_id].sav")
 

--- a/code/game/objects/structures/disaster_counter.dm
+++ b/code/game/objects/structures/disaster_counter.dm
@@ -5,7 +5,7 @@
   */
 /obj/structure/disaster_counter
 	name = "disaster counter"
-	desc = "This device will counts how many shifts it has been since a major disaster in this area. A safe workplace is a productive workplace."
+	desc = "This device will count how many shifts it has been since a major disaster in this area. A safe workplace is a productive workplace."
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "frame"
 	maptext_y = 10 // Offset by 10 so it renders properly

--- a/code/game/objects/structures/disaster_counter.dm
+++ b/code/game/objects/structures/disaster_counter.dm
@@ -5,18 +5,20 @@
   */
 /obj/structure/disaster_counter
 	name = "disaster counter"
-	desc = "This magical device will count up how many shifts it has been since a major disaster in this area."
+	desc = "This device will counts how many shifts it has been since a major disaster in this area. A safe workplace is a productive workplace."
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "frame"
 	maptext_y = 10 // Offset by 10 so it renders properly
-	/// ID of the counter. Must be overriden
+	/// ID of the counter. Must be overriden. Use alphanumerics with no spaces only, as this is used in the filesystem.
 	var/counter_id
 	/// Current count number
 	var/current_count = 0
+	/// Record count
+	var/record_count = 0
 
 /obj/structure/disaster_counter/examine(mob/user)
 	. = ..()
-	. += "The display reads 'Currently [current_count] shifts without an accident!'"
+	. += "The display reads 'Currently [current_count] shifts without an accident, with a record of [record_count] shifts!'"
 
 /obj/structure/disaster_counter/Initialize(mapload)
 	. = ..()
@@ -47,13 +49,21 @@
 
 	var/savefile/S = new /savefile("data/disaster_counters/[counter_id].sav")
 	S["count"] >> current_count
+	S["record"] >> record_count
 
 	if(isnull(current_count))
 		current_count = 0
 	else
 		current_count++ // Increase by 1 since this is the next shift without a disaster (yet)
-	log_debug("Persistent data for [src] loaded (current_count: [current_count])")
-	maptext = "<span class='maptext' style='text-align: center'>[current_count]</span>"
+
+	if(isnull(record_count))
+		record_count = current_count
+	else
+		// NEW RECORD
+		if(current_count > record_count)
+			record_count = current_count
+	log_debug("Persistent data for [src] loaded (current_count: [current_count] | record_count: [record_count])")
+	maptext = "<span class='maptext' style='text-align: center'>[current_count]/[record_count]</span>"
 
 /obj/structure/disaster_counter/persistent_save()
 	if(counter_id != paranoid_sanitize(counter_id))
@@ -63,7 +73,8 @@
 	var/savefile/S = new /savefile("data/disaster_counters/[counter_id].sav")
 
 	S["count"] << current_count
-	log_debug("Persistent data for [src] saved (current_count: [current_count])")
+	S["record"] << record_count
+	log_debug("Persistent data for [src] saved (current_count: [current_count] | record_count: [record_count])")
 
 // Prefab definitions to make mapping easier
 /obj/structure/disaster_counter/supermatter
@@ -73,3 +84,11 @@
 /obj/structure/disaster_counter/chemistry
 	name = "chemistry disaster counter"
 	counter_id = "chemistry"
+
+/obj/structure/disaster_counter/scichem
+	name = "science chemistry disaster counter"
+	counter_id = "scichem"
+
+/obj/structure/disaster_counter/toxins
+	name = "toxins launch room disaster counter"
+	counter_id = "toxinslaunch"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1085,6 +1085,7 @@
 #include "code\game\objects\structures\coathanger.dm"
 #include "code\game\objects\structures\curtains.dm"
 #include "code\game\objects\structures\depot.dm"
+#include "code\game\objects\structures\disaster_counter.dm"
 #include "code\game\objects\structures\displaycase.dm"
 #include "code\game\objects\structures\door_assembly.dm"
 #include "code\game\objects\structures\door_assembly_types.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds in disaster counters. I was inspired to make these from the age old skit of "X days without an accident!" type stuff. They exist in chemistry and toxins on all maps, and scichem + the supermatter on boxstation.

![image](https://user-images.githubusercontent.com/25063394/108061613-7bb3af00-7050-11eb-8f2f-0890ffc9b21a.png)

![image](https://user-images.githubusercontent.com/25063394/108061629-81a99000-7050-11eb-844a-0d8ba26f110d.png)

![image](https://user-images.githubusercontent.com/25063394/108061643-85d5ad80-7050-11eb-9022-c571b80fe2fb.png)

![image](https://user-images.githubusercontent.com/25063394/108061741-a867c680-7050-11eb-9f02-2db8ebeb9131.png)

![image](https://user-images.githubusercontent.com/25063394/108061752-abfb4d80-7050-11eb-811e-b8616a41582c.png)

If these counters get hit by a major explosion, they will reset their counter and then be 0 on the next shift.

## Why It's Good For The Game
A bit of persistent fun, and a nice tracker for how long its been since a major disaster.

## Changelog
:cl: AffectedArc07
add: Added disaster counters. Now the game will count how many shifts it has been since some dingus exploded chemistry or the supermatter.
/:cl:
