### PR TITLE
Removes all access requirements from R&D consoles.

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -468,7 +468,6 @@
 /obj/machinery/mecha_part_fabricator/spacepod
 	name = "spacepod fabricator"
 	allowed_design_types = PODFAB
-	req_access = list(ACCESS_MECHANIC)
 
 /obj/machinery/mecha_part_fabricator/spacepod/New()
 	..()

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -84,8 +84,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/id = 0			//ID of the computer (for server restrictions).
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
 
-	req_access = list(ACCESS_TOX)	//Data and setting manipulation requires scientist access.
-
 	var/selected_category
 	var/list/datum/design/matching_designs = list() //for the search function
 
@@ -207,13 +205,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		..()
 	SStgui.update_uis(src)
 	return
-
-/obj/machinery/computer/rdconsole/emag_act(user as mob)
-	if(!emagged)
-		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
-		req_access = list()
-		emagged = TRUE
-		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
 
 /obj/machinery/computer/rdconsole/proc/valid_nav(next_menu, next_submenu)
 	switch(next_menu)
@@ -932,7 +923,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	name = "robotics R&D console"
 	desc = "A console used to interface with R&D tools."
 	id = 2
-	req_access = list(ACCESS_ROBOTICS)
 	circuit = /obj/item/circuitboard/rdconsole/robotics
 
 /obj/machinery/computer/rdconsole/experiment
@@ -945,14 +935,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	name = "mechanics R&D console"
 	desc = "A console used to interface with R&D tools."
 	id = 4
-	req_access = list(ACCESS_MECHANIC)
 	circuit = /obj/item/circuitboard/rdconsole/mechanics
 
 /obj/machinery/computer/rdconsole/public
 	name = "public R&D console"
 	desc = "A console used to interface with R&D tools."
 	id = 5
-	req_access = list()
 	circuit = /obj/item/circuitboard/rdconsole/public
 
 #undef TECH_UPDATE_DELAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As the title states, this PR removes all access requirements from R&D consoles and all mechfabs. 

NOTE: The server will still control what consoles can upload and download.

## Why It's Good For The Game
I brought up the idea previously of making the mechfab consistent with the R&D console and the mechanic's space pod fab where it would be locked to robotics. See #15524. This PR exists as an alternative to achieve consistency in the other direction, as I was given feedback in the comments of the other PR that doors should be a sufficient barrier to prevent access, and if someone gets into the room they should be able to make things on the mech fab. This brings R&D and mechanic in line with the robotics fabricator where if you can get into the room you can make anything you want on the fabricator.

## Changelog
:cl:
del: Removed access requirement for R&D computer
del: Removed access requirement for robotics computer
del: Removed access requirement for mechanic computer and fabricator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
