### PR TITLE
Better way for syndie medical borgs to treat newcrit, v2

### DIFF
--- a/code/datums/diseases/critical.dm
+++ b/code/datums/diseases/critical.dm
@@ -25,7 +25,7 @@
 	max_stages = 3
 	spread_flags = SPECIAL
 	cure_text = "Saline-Glucose Solution"
-	cures = list("salglu_solution")
+	cures = list("salglu_solution", "syndicate_nanites")
 	cure_chance = 10
 	viable_mobtypes = list(/mob/living/carbon/human)
 	stage_prob = 6
@@ -86,7 +86,7 @@
 	max_stages = 3
 	spread_flags = SPECIAL
 	cure_text = "Atropine, Epinephrine, or Heparin"
-	cures = list("atropine", "epinephrine", "heparin")
+	cures = list("atropine", "epinephrine", "heparin", "syndicate_nanites")
 	cure_chance = 10
 	needs_all_cures = FALSE
 	viable_mobtypes = list(/mob/living/carbon/human)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -31,7 +31,7 @@
 	icon_state = "borghypo_s"
 	charge_cost = 20
 	recharge_time = 2
-	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone", "salglu_solution", "epinephrine", "spaceacillin")
+	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone")
 	bypass_protection = 1
 
 /obj/item/reagent_containers/borghypo/New()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This is basically #15538 which also reverts #15517

To sum up, syndicate nanites now cure shock and heart attacks, on top of their other properties. This means syndie medical borgs no longer need to cycle through 6 different chems, which is very clunky. The newcrit treatment meds were removed from syndie medical borgs again, as well as spaceacillin 

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
First: Why am I reopening a PR that got closed by a maint, surely they considered both alternatives and decided against mine, right? :hammer:

By my understanding, #15517 got approval from both fox and kyet for a merge _before_ my alternative PR was made, so they didn't know there was an alternative even being put forward, which led to it being merged before anyone commented on my alternative (kyet's approval being timestamped two hours before mine was made). If maints/head decided against my PR on its merits rather than how the timing worked out, I apologize of course and will close this again.

Considering my PR got 6 thumbs up while the alternative got none, and that even the author of #15517 states he prefers my take on it, I decided to open this. Being able to treat newcrit is a good thing for a syndie med borg, agreed, but why go for the clunkier way to do it?

To reiterate why I think this approach is better: Borg hyposprays work by cycling through chems one at a time. Going from 3 to 6 chems to cycle through makes them a good deal less usable and more clunky. Syndicate nanites are used nowhere else and have good justifications for being very powerful, so serving as a cure-all for newcrit conditions seems fair to me. 

I decided against also adding infection treatment to syndie nanites for two reasons: 1) duplicating the infection treatment code from spaceallin seemed very clunky and 2) Nukie rounds are over quicker than an infection can really come into play, imo.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
del: Syndicate medical borgs no longer have saline glucose, epinephrine or spaceacillin 
tweak: Syndicate nanites now cure shock and heart attacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
