### PR TITLE
Station ceiling collapsing fix

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -131,10 +131,6 @@
 	drop_x = x
 	drop_y = y
 	drop_z = z - 1
-	var/turf/T = locate(drop_x, drop_y, drop_z)
-	if(T)
-		T.visible_message("<span class='boldwarning'>The ceiling gives way!</span>")
-		playsound(T, 'sound/effects/break_stone.ogg', 50, 1)
 
 /turf/simulated/floor/chasm/straight_down/lava_land_surface
 	oxygen = 14


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes the 'The ceiling gives way!' message on station if a miner destroys a tendril on lavaland. This was clearly intended for some sort of multi-z thing but since we don't have that it's just confusing.

Fixes #15398

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The Ceiling is not real.
The Ceiling has never been real.
Do not think about The Ceiling.

## Changelog
:cl:
tweak: Removed the 'The ceiling gives way!' message on the station when a miner destroys a tendril.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
