### PR TITLE
Explosive Implants now always possible to activate (Meant for Nukies especially)

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -383,6 +383,9 @@
 /datum/action/item_action/hands_free/activate
 	name = "Activate"
 
+/datum/action/item_action/hands_free/activate/always
+    check_flags = null
+
 /datum/action/item_action/toggle_research_scanner
 	name = "Toggle Research Scanner"
 	button_icon_state = "scan_mode"

--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -3,6 +3,7 @@
 	desc = "And boom goes the weasel."
 	icon_state = "explosive"
 	origin_tech = "materials=2;combat=3;biotech=4;syndicate=4"
+	actions_types = list(/datum/action/item_action/hands_free/activate/always)
 	var/weak = 2
 	var/medium = 0.8
 	var/heavy = 0.4

--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -136,6 +136,7 @@
 	desc = "An alarm which monitors host vital signs, transmitting a radio message and dusting the corpse on death."
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "remains"
+	actions_types = list(/datum/action/item_action/hands_free/activate/always)
 
 /obj/item/implant/dust/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Explosive implants are now always possible to activate, even while asleep, stunned or other. Also adds a new subtype of the action datum that can be used for other items or implants. Did the same change to Dust implants as well.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR is primarily for nukies, who often go down, but dont push the button in time, which in turn means they are looted for gear then used against the other nukies. It is actually possible to blow up regardless, by suiciding, which means that exploding the implant is an option with or without this PR. As such making this choice a lot more obvious by the "blow up" button, makes nukies a lot more able to use it, especially new ones. Dust implants are the same, and may be even more relevant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/65926304/108237042-cf54f400-7147-11eb-98e6-43c803e5bfb3.png)
The button is available even while asleep as shown above
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Can now always activate the Explosive Implants (Nukies for example), the same applies to dust implants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
