### PR TITLE
Adds missing things to drone cleaning 

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1285,6 +1285,7 @@ About the new airlock wires panel:
 		sleep(6)
 		if(QDELETED(src))
 			return
+		electronics = new /obj/item/airlock_electronics/destroyed()
 		operating = FALSE
 		if(!open())
 			update_icon(AIRLOCK_CLOSED, 1)
@@ -1394,10 +1395,6 @@ About the new airlock wires panel:
 		if(user)
 			to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 		var/obj/item/airlock_electronics/ae
-		if(emagged)
-			electronics = new /obj/item/airlock_electronics/destroyed()
-			operating = FALSE
-
 		if(!electronics)
 			ae = new/obj/item/airlock_electronics(loc)
 			check_access()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1396,7 +1396,7 @@ About the new airlock wires panel:
 		var/obj/item/airlock_electronics/ae
 		if(emagged)
 			electronics = new /obj/item/airlock_electronics/destroyed()
-			operating = 0
+			operating = FALSE
 
 		if(!electronics)
 			ae = new/obj/item/airlock_electronics(loc)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1394,6 +1394,10 @@ About the new airlock wires panel:
 		if(user)
 			to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 		var/obj/item/airlock_electronics/ae
+		if(emagged)
+			electronics = new/obj/item/airlock_electronics/destroyed()
+			operating = 0
+
 		if(!electronics)
 			ae = new/obj/item/airlock_electronics(loc)
 			check_access()
@@ -1406,9 +1410,6 @@ About the new airlock wires panel:
 			ae = electronics
 			electronics = null
 			ae.forceMove(loc)
-		if(emagged)
-			ae.icon_state = "door_electronics_smoked"
-			operating = 0
 	qdel(src)
 
 /obj/machinery/door/airlock/proc/note_type() //Returns a string representing the type of note pinned to this airlock

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1395,7 +1395,7 @@ About the new airlock wires panel:
 			to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 		var/obj/item/airlock_electronics/ae
 		if(emagged)
-			electronics = new/obj/item/airlock_electronics/destroyed()
+			electronics = new /obj/item/airlock_electronics/destroyed()
 			operating = 0
 
 		if(!electronics)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -107,7 +107,7 @@
 	name = "burned-out airlock electronics"
 	icon_state = "door_electronics_smoked"
 
-/obj/item/airlock_electronics/attack_self(mob/user)
+/obj/item/airlock_electronics/destroyed/attack_self(mob/user)
 	return
 
 /obj/item/airlock_electronics/destroyed/decompile_act(obj/item/matter_decompiler/C, mob/user)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -102,3 +102,16 @@
 
 		if("clear_all")
 			selected_accesses = list()
+
+/obj/item/airlock_electronics/destroyed
+	name = "burned-out airlock electronics"
+	icon_state = "door_electronics_smoked"
+
+/obj/item/airlock_electronics/attack_self(mob/user)
+	return
+
+/obj/item/airlock_electronics/destroyed/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["metal"] += 1
+	C.stored_comms["glass"] += 1
+	qdel(src)
+	return TRUE

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -219,7 +219,7 @@
 	if(!operating && density && !emagged)
 		emagged = TRUE
 		operating = TRUE
-		electronics = new/obj/item/airlock_electronics/destroyed()
+		electronics = new /obj/item/airlock_electronics/destroyed()
 		flick("[base_state]spark", src)
 		playsound(src, "sparks", 75, 1)
 		sleep(6)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -219,6 +219,7 @@
 	if(!operating && density && !emagged)
 		emagged = TRUE
 		operating = TRUE
+		electronics = new/obj/item/airlock_electronics/destroyed()
 		flick("[base_state]spark", src)
 		playsound(src, "sparks", 75, 1)
 		sleep(6)
@@ -278,11 +279,6 @@
 				WA.ini_dir = dir
 				WA.update_icon()
 				WA.created_name = name
-
-				if(emagged)
-					to_chat(user, "<span class='warning'>You discard the damaged electronics.</span>")
-					qdel(src)
-					return
 
 				to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -58,14 +58,14 @@
 /obj/effect/decal/straw/edge
 	icon_state = "strawscatterededge"
 
-/obj/effect/decal/ants
+/obj/effect/decal/cleanable/ants
 	name = "space ants"
 	desc = "A bunch of space ants."
 	icon = 'icons/goonstation/effects/effects.dmi'
 	icon_state = "spaceants"
 	scoop_reagents = list("ants" = 20)
 
-/obj/effect/decal/ants/Initialize(mapload)
+/obj/effect/decal/cleanable/ants/Initialize(mapload)
 	. = ..()
 	var/scale = (rand(2, 10) / 10) + (rand(0, 5) / 100)
 	transform = matrix(transform, scale, scale, MATRIX_SCALE)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -192,5 +192,10 @@
 	desc = "A pair of broken zipties."
 	icon_state = "cuff_white_used"
 
+/obj/item/restraints/handcuffs/cable/zipties/used/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	C.stored_comms["glass"] += 1
+	qdel(src)
+	return TRUE
+
 /obj/item/restraints/handcuffs/cable/zipties/used/attack()
 	return

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -75,7 +75,7 @@
 			state = AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS
 			to_chat(user, "<span class='notice'>You wire the airlock assembly.</span>")
 
-	else if(istype(W, /obj/item/airlock_electronics) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS && W.icon_state != "door_electronics_smoked")
+	else if(istype(W, /obj/item/airlock_electronics) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS && !istype(W, /obj/item/airlock_electronics/destroyed))
 		playsound(loc, W.usesound, 100, 1)
 		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly...")
 
@@ -187,6 +187,7 @@
 		door.name = base_name
 	door.previous_airlock = previous_assembly
 	electronics.forceMove(door)
+	electronics = null
 	qdel(src)
 	update_icon()
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -131,7 +131,7 @@
 
 		if("02")
 			//Adding airlock electronics for access. Step 6 complete.
-			if(istype(W, /obj/item/airlock_electronics))
+			if(istype(W, /obj/item/airlock_electronics) && !istype(W, /obj/item/airlock_electronics/destroyed))
 				playsound(loc, W.usesound, 100, 1)
 				user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly...")
 				user.drop_item()

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -44,8 +44,8 @@
 	if(isturf(loc) && !locate(/obj/structure/table) in T)
 		if(ant_location == T)
 			if(prob(15))
-				if(!locate(/obj/effect/decal/ants) in T)
-					new /obj/effect/decal/ants(T)
+				if(!locate(/obj/effect/decal/cleanable/ants) in T)
+					new /obj/effect/decal/cleanable/ants(T)
 					antable = FALSE
 					desc += " It appears to be infested with ants. Yuck!"
 					reagents.add_reagent("ants", 1) // Don't eat things with ants in i you weirdo.

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -88,6 +88,13 @@
 				to_chat(user, "<span class='notice'>There is no bullet in the casing to inscribe anything into.</span>")
 		..()
 
+/obj/item/ammo_casing/decompile_act(obj/item/matter_decompiler/C, mob/user)
+	if(!BB)
+		C.stored_comms["metal"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
+
 //Boxes of ammo
 /obj/item/ammo_box
 	name = "ammo box (generic)"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1077,7 +1077,7 @@
 	return ..() | update_flags
 
 /datum/reagent/pestkiller/reaction_obj(obj/O, volume)
-	if(istype(O, /obj/effect/decal/ants))
+	if(istype(O, /obj/effect/decal/cleanable/ants))
 		O.visible_message("<span class='warning'>The ants die.</span>")
 		qdel(O)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
 - Allows drones to decompile used zip ties.
 - Allows drones to decompile empty shell casings.
 - Allows drones to decompile empty burned-out airlock circuits. (Also refactors them to be a separate item)
 - In the process of fixing the above, I fixed a bug that prevented you from getting airlock circuits back from taking apart airlocks. 
 - You now get burned-out boards from emagged windoors.
 - Allows you to clean up ants like other messes.

## Why It's Good For The Game
It's expected that maintenance drones are able to clean up various trash around the station and there are a lot of edge cases that are easily missed. This fixes several of them.

On the ants thing, it's quite annoying that janitors and janitorial cyborgs in addition to drones that they can't clean them up.

## Changelog
:cl:
add: Allows drones to decompile used zip ties, spent bullet casings, and burnt-out airlock circuits.
tweak: Allows ants to be cleaned up like other messes.
tweak: Emagged windoors now provide burned-out electronics
fix: Fixed airlock electronics not coming out of disassembled airlocks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
