### PR TITLE
Makes AI Core contain an actual AI circuitboard (Fix #15315)

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -8,7 +8,6 @@
 	var/state = 0
 	var/datum/ai_laws/laws = null
 	var/obj/item/circuitboard/circuit = null
-	circuit = /obj/item/circuitboard/aicore
 	var/obj/item/mmi/brain = null
 
 /obj/structure/AIcore/Destroy()
@@ -242,6 +241,7 @@
 	icon_state = "ai-empty"
 	anchored = TRUE
 	state = AI_READY_CORE
+	circuit = /obj/item/circuitboard/aicore
 
 /obj/structure/AIcore/deactivated/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -8,6 +8,7 @@
 	var/state = 0
 	var/datum/ai_laws/laws = null
 	var/obj/item/circuitboard/circuit = null
+	circuit = /obj/item/circuitboard/aicore
 	var/obj/item/mmi/brain = null
 
 /obj/structure/AIcore/Destroy()

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -7,7 +7,7 @@
 	max_integrity = 500
 	var/state = 0
 	var/datum/ai_laws/laws = null
-	var/obj/item/circuitboard/circuit = /obj/item/circuitboard/aicore
+	var/obj/item/circuitboard/aicore/circuit = null
 	var/obj/item/mmi/brain = null
 
 /obj/structure/AIcore/Destroy()

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -7,7 +7,7 @@
 	max_integrity = 500
 	var/state = 0
 	var/datum/ai_laws/laws = null
-	var/obj/item/circuitboard/circuit = null
+	var/obj/item/circuitboard/circuit = /obj/item/circuitboard/aicore
 	var/obj/item/mmi/brain = null
 
 /obj/structure/AIcore/Destroy()
@@ -241,7 +241,6 @@
 	icon_state = "ai-empty"
 	anchored = TRUE
 	state = AI_READY_CORE
-	circuit = /obj/item/circuitboard/aicore
 
 /obj/structure/AIcore/deactivated/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Fixes #15315

## What Does This PR Do
The admin spawned AI core as well as roundstart AI core/s now contain an AI core circuitboard, instead of a generic circuitboard.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One would expect this to be the case, but also makes it possible to deconstruct and then reconstruct an AI core.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Fixed the AI core to have actual AI circuitboards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
