### PR TITLE
Headslugs and Blobbernaughts now start on HARM intent

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -180,6 +180,7 @@
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	move_resist = MOVE_FORCE_OVERPOWERING
+	a_intent = INTENT_HARM
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life(seconds, times_fired)
 	if(stat != DEAD && (getBruteLoss() || getFireLoss())) // Heal on blob structures

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -22,6 +22,7 @@
 	pass_flags = PASSTABLE | PASSMOB
 	density = FALSE
 	ventcrawler = 2
+	a_intent = INTENT_HARM
 	var/datum/mind/origin
 	var/egg_lain = 0
 	sentience_type = SENTIENCE_OTHER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/15200

## What Does This PR Do
Makes Cling headslugs and Blob blobbernaughts start on HARM intent.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Blobbernaughts are hostile creatures, and have no real reason to start on help intent, other than to hinder friendly beating, which doesnt seem like a real issue. This would make blobbers slightly more effective as there would be no need to remember to turn on harm intent.

Headslugs are the same, they exist for one reason only, to get a new body. They are a hostile to all other lifeforms, and in a case where it was necessary to become a slug, it would likely be necessary to defend itself as well. It would also be a little less easy to push around, so little bit more likely to make it to a vent.

Both of these make the game slightly easier for new players, which I am also a fan of (and I forget both these all the time too).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Headslugs and blobbernaughts now start on harm intent, instead of help intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
