### PR TITLE
Fixes mentors being able to see people who are on the admin watchlist

### DIFF
--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -48,7 +48,8 @@
 			if(include_link && C)
 				. += "<a href='?priv_msg=[C.ckey];type=[type]'>"
 			. += key
-			if(C && C.watchlisted)
+			// See if the player is on the watchlist. Requires admin permissions.
+			if(check_rights(R_ADMIN, FALSE) && C && C.watchlisted)
 				. += "<font color='orange'><b>(W)</b></font>"
 
 		if(include_link)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the ability for mentors see the orange `(W)` next to someone's name in certain places like the 'Check Player Playtime' verb, indicating they're on the admin watch list.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #15545
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes mentors being able to see who is on the admin watchlist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
