### PR TITLE
Robotics oil tank replacement

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -41848,7 +41848,7 @@
 	dir = 2;
 	network = list("Research","SS13")
 	},
-/obj/structure/reagent_dispensers/oil,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteredcorner"
@@ -47749,7 +47749,7 @@
 	},
 /area/medical/genetics)
 "bSI" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bSJ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Replaces the Robotics oil tank with a welding fuel tank, and the welding fuel tank with a water tank.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Oil isn't actually used for IPC maintenance anymore, so it makes a lot more sense to have a fuel tank instead.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
**Before:**
![old](https://user-images.githubusercontent.com/57483089/108536326-415a4400-72d4-11eb-8177-fd9e2f6ef153.png)

**After:**
![new](https://user-images.githubusercontent.com/57483089/108536346-46b78e80-72d4-11eb-8353-e2977fc3323e.png)

## Changelog
:cl:
tweak: Removed the oil tank from Robotics, and replaced it with a welding fuel tank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
