### PR TITLE
Crematorium now needs power to work and consumes power, and a lot of power when burning

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -457,7 +457,10 @@
 	name = "crematorium igniter"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "crema_switch"
-	power_channel = ENVIRON
+	power_channel = EQUIP
+	use_power = IDLE_POWER_USE
+	idle_power_usage = 2
+	active_power_usage = 1000
 	anchored = 1.0
 	req_access = list(ACCESS_CREMATORIUM)
 	var/on = 0
@@ -470,13 +473,17 @@
 		return attack_hand(user)
 
 /obj/machinery/crema_switch/attack_hand(mob/user)
-	if(allowed(usr) || user.can_advanced_admin_interact())
-		for(var/obj/structure/crematorium/C in world)
-			if(C.id == id)
-				if(!C.cremating)
-					C.cremate(user)
-	else
-		to_chat(usr, "<span class='warning'>Access denied.</span>")
+	if(powered(power_channel))
+		if(allowed(usr) || user.can_advanced_admin_interact())
+			for(var/obj/structure/crematorium/C in world)
+				if(C.id == id)
+					if(!C.cremating)
+						use_power = ACTIVE_POWER_USE
+						C.cremate(user)
+						addtimer(10)
+						use_power = IDLE_POWER_USE
+		else
+			to_chat(usr, "<span class='warning'>Access denied.</span>")
 
 /mob/proc/update_morgue()
 	if(stat == DEAD)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -475,7 +475,7 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
-			use_power(200000)
+			use_power(400000)
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -476,10 +476,11 @@
 		if(allowed(usr) || user.can_advanced_admin_interact())
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
+					use_power = ACTIVE_POWER_USE
 					if(!C.cremating)
-						use_power = ACTIVE_POWER_USE
 						C.cremate(user)
-						addtimer(20)
+
+					addtimer(20)
 						use_power = IDLE_POWER_USE
 		else
 			to_chat(usr, "<span class='warning'>Access denied.</span>")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -480,8 +480,8 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
-			update_use_power(ACTIVE_POWER_USE)
-			addtimer(CALLBACK(src, update_use_power(IDLE_POWER_USE)), 10 SECONDS)
+			set_power_use()
+			addtimer(CALLBACK(src, set_power_use()), 10 SECONDS)
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -467,6 +467,12 @@
 	var/otherarea = null
 	var/id = 1
 
+/obj/machinery/crema_switch/proc/set_power_use()
+	if(use_power == IDLE_POWER_USE)
+		use_power = ACTIVE_POWER_USE
+	else
+		use_power = IDLE_POWER_USE
+
 /obj/machinery/crema_switch/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
 		return attack_hand(user)
@@ -474,14 +480,14 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
+			update_use_power(ACTIVE_POWER_USE)
+			addtimer(CALLBACK(src, update_use_power(IDLE_POWER_USE)) 10 SECONDS)
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
-					use_power = ACTIVE_POWER_USE
 					if(!C.cremating)
 						C.cremate(user)
 
-					addtimer(20)
-						use_power = IDLE_POWER_USE
+
 		else
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -457,10 +457,9 @@
 	name = "crematorium igniter"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "crema_switch"
-	power_channel = EQUIP
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
-	active_power_usage = 1000
+	active_power_usage = 1500 // Not used, uses 1500 total
 	anchored = 1.0
 	req_access = list(ACCESS_CREMATORIUM)
 	var/on = 0
@@ -473,15 +472,13 @@
 		return attack_hand(user)
 
 /obj/machinery/crema_switch/attack_hand(mob/user)
-	if(powered(power_channel))
+	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)
-						use_power = ACTIVE_POWER_USE
+						use_power(1500) // Power is consumed
 						C.cremate(user)
-						addtimer(10)
-						use_power = IDLE_POWER_USE
 		else
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -481,7 +481,7 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
-			new_use_power = ACTIVE_POWER_USE
+			update_use_power(ACTIVE_POWER_USE)
 			set_power_use()
 			addtimer(CALLBACK(src, set_power_use()), 10 SECONDS)
 			for(var/obj/structure/crematorium/C in world)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -457,6 +457,7 @@
 	name = "crematorium igniter"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "crema_switch"
+	power_channel = ENVIRON
 	anchored = 1.0
 	req_access = list(ACCESS_CREMATORIUM)
 	var/on = 0

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -477,7 +477,7 @@
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)
-						use_power(1500) // Power is consumed
+						use_power(15000) // Power is consumed
 						C.cremate(user)
 		else
 			to_chat(usr, "<span class='warning'>Access denied.</span>")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -468,12 +468,6 @@
 	var/otherarea = null
 	var/id = 1
 
-/obj/machinery/crema_switch/proc/set_power_use()
-	if(use_power == IDLE_POWER_USE)
-		use_power = ACTIVE_POWER_USE
-	else
-		use_power = IDLE_POWER_USE
-
 /obj/machinery/crema_switch/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
 		return attack_hand(user)
@@ -481,9 +475,7 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
-			update_use_power(ACTIVE_POWER_USE)
-			set_power_use()
-			addtimer(CALLBACK(src, set_power_use()), 10 SECONDS)
+			use_power(2000)
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -475,7 +475,7 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
-			use_power(2000)
+			use_power(200000)
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -459,7 +459,7 @@
 	icon_state = "crema_switch"
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
-	active_power_usage = 1500 // Not used, uses 1500 total
+	active_power_usage = 5000
 	anchored = 1.0
 	req_access = list(ACCESS_CREMATORIUM)
 	var/on = 0
@@ -477,8 +477,9 @@
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)
-						use_power(15000) // Power is consumed
+						use_power = ACTIVE_POWER_USE
 						C.cremate(user)
+						addtimer(20)
 		else
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -480,8 +480,8 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
-			update_use_power(ACTIVE_POWER_USE)
-			addtimer(CALLBACK(src, update_use_power(IDLE_POWER_USE)) 10 SECONDS)
+			use_power(2)
+			addtimer(CALLBACK(src, use_power(1)), 10 SECONDS)
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -480,6 +480,7 @@
 						use_power = ACTIVE_POWER_USE
 						C.cremate(user)
 						addtimer(20)
+						use_power = IDLE_POWER_USE
 		else
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -457,8 +457,9 @@
 	name = "crematorium igniter"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "crema_switch"
+	power_channel = EQUIP
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 2
+	idle_power_usage = 100
 	active_power_usage = 5000
 	anchored = 1.0
 	req_access = list(ACCESS_CREMATORIUM)
@@ -480,6 +481,7 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
+			new_use_power = ACTIVE_POWER_USE
 			set_power_use()
 			addtimer(CALLBACK(src, set_power_use()), 10 SECONDS)
 			for(var/obj/structure/crematorium/C in world)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -480,8 +480,8 @@
 /obj/machinery/crema_switch/attack_hand(mob/user)
 	if(powered(power_channel)) // Do we have power?
 		if(allowed(usr) || user.can_advanced_admin_interact())
-			use_power(2)
-			addtimer(CALLBACK(src, use_power(1)), 10 SECONDS)
+			update_use_power(ACTIVE_POWER_USE)
+			addtimer(CALLBACK(src, update_use_power(IDLE_POWER_USE)), 10 SECONDS)
 			for(var/obj/structure/crematorium/C in world)
 				if(C.id == id)
 					if(!C.cremating)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/15184

## What Does This PR Do
Makes the crematorium (Or rather the button, but in effect the crematorium) consume power, and need power to start. It needs equipment to be on, as that is its source of power. In addition it consumes 40%ish percent of the starting cell in Chapel Office.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
First of all making it need power makes it a lot easier for antags to sabotage it, apart from breaking it. Second, it now will not work if there is no power available, as one would expect. AIs and borgs now can hinder its use in other ways than locking its doors. Clings EMP will also hinder it (as it now relies on the APC). 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Crematorium now consumes power, and a lot of power when it burns (40% percent of the starting cell)
fix: Crematorium now needs power to be on to work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
