### PR TITLE
Changes wall welding to be intent based

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -7,7 +7,7 @@
 	desc = "A huge chunk of metal used to seperate rooms."
 	icon = 'icons/turf/walls/wall.dmi'
 	icon_state = "wall"
-	var/rotting = 0
+	var/rotting = FALSE
 
 	var/damage = 0
 	var/damage_cap = 100 //Wall will break down to girders if damage reaches this point
@@ -28,7 +28,7 @@
 
 	var/can_dismantle_with_welder = TRUE
 	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
-	var/slicing_duration = 100
+	var/slicing_duration = 10 SECONDS
 	var/engraving //engraving on the wall
 	var/engraving_quality
 	var/list/dent_decals
@@ -76,7 +76,7 @@
 	if(!damage)
 		if(damage_overlay)
 			overlays -= damage_overlays[damage_overlay]
-			damage_overlay = 0
+			damage_overlay = null
 		return
 
 	var/overlay = round(damage / damage_cap * damage_overlays.len) + 1
@@ -330,38 +330,38 @@
 			to_chat(user, "<span class='notice'>You burn off the fungi with [I].</span>")
 		return
 
-	if(!I.tool_use_check(user, 0)) //Wall repair stuff
+	// Wall repair stuff
+	if(!I.tool_use_check(user, 0))
 		return
 
-	var/time_required = slicing_duration
-	var/intention
-	if(can_dismantle_with_welder)
-		intention = "Dismantle"
-	if(damage || LAZYLEN(dent_decals))
-		intention = "Repair"
+	var/repairing
+	var/time
+	if(user.a_intent == INTENT_HARM) // Harm intent
 		if(can_dismantle_with_welder)
-			var/moved_away = user.loc
-			intention = alert(user, "Would you like to repair or dismantle [src]?", "[src]", "Repair", "Dismantle")
-			if(user.loc != moved_away)
-				to_chat(user, "<span class='notice'>Stay still while doing this!</span>")
-				return
-			if(intention == "Repair")
-				time_required = max(5, damage / 5)
-	if(!intention)
-		return
-	if(intention == "Dismantle")
-		WELDER_ATTEMPT_SLICING_MESSAGE
-	else
-		WELDER_ATTEMPT_REPAIR_MESSAGE
-	if(I.use_tool(src, user, time_required, volume = I.tool_volume))
-		if(intention == "Dismantle")
-			WELDER_SLICING_SUCCESS_MESSAGE
-			dismantle_wall()
+			repairing = FALSE
+			time = slicing_duration
+			WELDER_ATTEMPT_SLICING_MESSAGE
 		else
+			return
+
+	else // Any other intents
+		if(damage || LAZYLEN(dent_decals))
+			repairing = TRUE
+			time = max(5, damage / 5)
+			WELDER_ATTEMPT_REPAIR_MESSAGE
+		else
+			to_chat(user, "<span class='warning'>[src] doesn't need repairing.</span>")
+			return
+
+	if(I.use_tool(src, user, time, volume = I.tool_volume))
+		if(repairing)
 			WELDER_REPAIR_SUCCESS_MESSAGE
 			cut_overlay(dent_decals)
-			dent_decals?.Cut()
+			dent_decals?.Cut() // I feel like this isn't needed but it can't hurt to keep it in anyway
 			take_damage(-damage)
+		else
+			WELDER_SLICING_SUCCESS_MESSAGE
+			dismantle_wall()
 
 /turf/simulated/wall/proc/try_rot(obj/item/I, mob/user, params)
 	if((!is_sharp(I) && I.force >= 10) || I.force >= 20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Changes repairing or dismantling a wall to be based on intent rather than a popup.
Help, Disarm, or Grab intent to repair.
Harm intent to dismantle.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Massively improves the flow of repairing walls, since you don't have to click on a popup every time you want to do something.
I personally also find it more intuitive to use, since it's similar to other things like welding an airlock.

## Changelog
:cl:
tweak: Repairing/Dismanting a wall with a welder is now intent based rather than popup based.
tweak: Help/Disarm/Grab intent to repair, Harm intent to dismantle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
