### PR TITLE
Adds the ability to fix broken grilles under windows

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -117,27 +117,27 @@
 		var/atom/movable/mover = caller
 		. = . || mover.checkpass(PASSGRILLE)
 
-/obj/structure/grille/attackby(obj/item/W, mob/user, params)
+/obj/structure/grille/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
-	if(istype(W, /obj/item/stack/rods) && broken)
-		var/obj/item/stack/rods/R = W
-		if(!shock(user, 90))
-			user.visible_message("<span class='notice'>[user] rebuilds the broken grille.</span>", \
-								 "<span class='notice'>You rebuild the broken grille.</span>")
-			new grille_type(loc)
-			R.use(1)
-			qdel(src)
-			return
+	if(istype(I, /obj/item/stack/rods) && broken)
+		repair(user, I)
 
 //window placing begin
-	else if(is_glass_sheet(W))
-		build_window(W, user)
+	else if(is_glass_sheet(I))
+		build_window(I, user)
 		return
 //window placing end
 
-	else if(istype(W, /obj/item/shard) || !shock(user, 70))
+	else if(istype(I, /obj/item/shard) || !shock(user, 70))
 		return ..()
+
+/obj/structure/grille/proc/repair(mob/user, obj/item/stack/rods/R)
+	user.visible_message("<span class='notice'>[user] rebuilds the broken grille.</span>",
+		"<span class='notice'>You rebuild the broken grille.</span>")
+	new grille_type(loc)
+	R.use(1)
+	qdel(src)
 
 /obj/structure/grille/wirecutter_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -166,7 +166,15 @@
 		return 1 //skip the afterattack
 
 	add_fingerprint(user)
-	if(istype(I, /obj/item/grab) && get_dist(src, user) < 2)
+	if(istype(I, /obj/item/stack/rods) && user.a_intent == INTENT_HELP)
+		for(var/obj/structure/grille/G in get_turf(src))
+			if(!G.broken)
+				continue
+			to_chat(user, "<span class='notice'>You start rebuilding the broken grille.</span>")
+			if(do_after(user, 4 SECONDS, FALSE, G))
+				G.repair(user, I)
+
+	else if(istype(I, /obj/item/grab) && get_dist(src, user) < 2)
 		var/obj/item/grab/G = I
 		if(isliving(G.affecting))
 			var/mob/living/M = G.affecting
@@ -193,8 +201,8 @@
 					M.Weaken(5)
 					M.apply_damage(30)
 					take_damage(75)
-			return
-	return ..()
+	else
+		return ..()
 
 
 /obj/structure/window/crowbar_act(mob/user, obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Allows people to repair broken grilles underneath windows by clicking on the window with metal rods.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
A grille being broken under a window is a pretty common occurance, with welderbombs and most other explosives almost guaranteed to cause it. Having to dismantle and rebuild the entire window to fix the grille is incredibly tedious, especially if there's a lot of them.
While this solution will still leave a rod on the window tile, that can always just be picked up or dragged away, so I personally consider this the best solution when comparing it to the time it took to repair with directional windows.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![NMct2eCM6I](https://user-images.githubusercontent.com/57483089/108568581-40d8a200-7302-11eb-9d66-3c9637201b7a.gif)

## Changelog
:cl:
add: Broken grilles under windows are now repairable by clicking the window with metal rods in help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
