### PR TITLE
Makes Turrets with Tasers and practice lasers unable to be set to lethal (Unless emagged)

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -107,6 +107,7 @@
 /obj/machinery/porta_turret/proc/weapon_setup(var/guntype)
 	switch(guntype)
 		if(/obj/item/gun/energy/laser/practice)
+			lethal_is_configurable = FALSE
 			iconholder = 1
 			eprojectile = /obj/item/projectile/beam
 
@@ -120,6 +121,7 @@
 			iconholder = 1
 
 		if(/obj/item/gun/energy/taser)
+			lethal_is_configurable = FALSE
 			eprojectile = /obj/item/projectile/beam
 			eshot_sound = 'sound/weapons/laser.ogg'
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Fixes #15530

## What Does This PR Do
Makes practice lasers and tasers in a turret, result in a turret unable to be lethal, unless an emag is used.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Practice lasers and tazers, should not result in a turret that can be set to lethal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Practice lasers and tazers now result in turrets unable to be set to lethal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
