### PR TITLE
Removes the slipping effect from gluon grenades

### DIFF
--- a/code/game/objects/items/weapons/grenades/atmosgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/atmosgrenade.dm
@@ -31,7 +31,7 @@
 	spawn_amount = 500
 
 /obj/item/grenade/gluon
-	desc = "An advanced grenade that releases a harmful stream of gluons inducing radiation in those nearby. These gluon streams will also make victims feel exhausted, and induce shivering. This extreme coldness will also wet any nearby floors."
+	desc = "An advanced grenade that releases a harmful stream of gluons inducing radiation in those nearby. These gluon streams will also make victims feel exhausted, and induce shivering."
 	name = "gluon grenade"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "gluon"
@@ -45,10 +45,7 @@
 	playsound(loc, 'sound/effects/empulse.ogg', 50, 1)
 	radiation_pulse(src, rad_damage)
 	for(var/turf/T in view(freeze_range, loc))
-		if(isfloorturf(T))
-			var/turf/simulated/F = T
-			F.MakeSlippery(TURF_WET_PERMAFROST)
-			for(var/mob/living/carbon/L in T)
-				L.adjustStaminaLoss(stamina_damage)
-				L.adjust_bodytemperature(-230)
+		for(var/mob/living/carbon/L in T)
+			L.adjustStaminaLoss(stamina_damage)
+			L.adjust_bodytemperature(-230)
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes the AOE slipping effect from nukie gluon grenades.
All other effects of the grenade are unchanged, so it still irradiates and does stamina damage.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I'll admit that this is almost entirely an *"I'm dead pls nerf"* PR, but considering that the slipping actually ends up harming nukies more than helping, I definitely consider it worth changing.
For clarification: Noslips and Magboots are both useless against the 'Permafrost' tiles, you'll still slip either way.

## Changelog
:cl:
tweak: Removes the permafrost effect from nukie gluon grenades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
