### PR TITLE
Adds admin logs for oil slime explosions

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -480,7 +480,7 @@
 	SSblackbox.record_feedback("tally", "slime_cores_used", 1, type)
 
 //Oil
-/datum/chemical_reaction/slimeexplosion
+/datum/chemical_reaction/slime_explosion
 	name = "Slime Explosion"
 	id = "m_explosion"
 	result = null
@@ -489,13 +489,20 @@
 	required_container = /obj/item/slime_extract/oil
 	required_other = 1
 
-/datum/chemical_reaction/slimeexplosion/on_reaction(datum/reagents/holder)
+/datum/chemical_reaction/slime_explosion/on_reaction(datum/reagents/holder)
 	SSblackbox.record_feedback("tally", "slime_cores_used", 1, type)
-	var/turf/T = get_turf(holder.my_atom)
-	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	spawn(50)
-		if(holder && holder.my_atom)
-			explosion(get_turf(holder.my_atom), 1 ,3, 6)
+	var/obj/item/slime_extract/oil/extract = holder.my_atom
+	extract.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
+	addtimer(CALLBACK(src, .proc/explode, extract), 5 SECONDS)
+
+/datum/chemical_reaction/slime_explosion/proc/explode(obj/item/slime_extract/oil/extract)
+	if(QDELETED(extract))
+		return
+	var/who = extract.injector_mob ? "[key_name_admin(extract.injector_mob)]" : "Unknown"
+	var/turf/extract_turf = get_turf(extract)
+	message_admins("[who] triggered an oil slime explosion at [COORD(extract_turf)].")
+	log_game("[who] triggered an oil slime explosion at [COORD(extract_turf)].")
+	explosion(extract_turf, 1, 3, 6)
 
 //Light Pink
 /datum/chemical_reaction/slimepotion2

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -13,7 +13,10 @@
 	throw_speed = 3
 	throw_range = 6
 	origin_tech = "biotech=3"
-	var/Uses = 1 // uses before it goes inert
+	/// Uses before it goes inert
+	var/Uses = 1
+	/// The mob who last injected the extract with plasma, water or blood. Used for logging.
+	var/mob/living/injector_mob
 
 /obj/item/slime_extract/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/slimepotion/enhancer))
@@ -23,6 +26,8 @@
 		to_chat(user, "<span class='notice'>You apply the enhancer to the slime extract. It may now be reused one more time.</span>")
 		Uses++
 		qdel(O)
+	if(istype(O, /obj/item/reagent_containers/syringe))
+		injector_mob = user
 	..()
 
 /obj/item/slime_extract/New()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds admin logs for oil slime explosions
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins should have accurate information for things like this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
The second line already exists for all explosions, but I included it anyway.

![image](https://user-images.githubusercontent.com/42044220/108631543-0705b980-7430-11eb-99fa-908657af190c.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Adds admin logs for oil slime explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
