### PR TITLE
Makes the SM drop anomaly cores

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -819,12 +819,12 @@
 	if(L)
 		switch(type)
 			if(FLUX_ANOMALY)
-				var/obj/effect/anomaly/flux/A = new(L, 300, FALSE)
+				var/obj/effect/anomaly/flux/A = new(L, 300)
 				A.explosive = FALSE
 			if(GRAVITATIONAL_ANOMALY)
-				new /obj/effect/anomaly/grav(L, 250, FALSE)
+				new /obj/effect/anomaly/grav(L, 250)
 			if(PYRO_ANOMALY)
-				new /obj/effect/anomaly/pyro(L, 200, FALSE)
+				new /obj/effect/anomaly/pyro(L, 200)
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 4000, zap_flags = ZAP_SUPERMATTER_FLAGS, list/targets_hit = list())
 	if(QDELETED(zapstart))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Anomalies spawned from the SM now drop anomaly cores

## Why It's Good For The Game
Firstly, let me say that this will NOT mean crew can farm endless phazons, The SM doesn't make bluespace anomalies.

Anomaly cores dropping from the SM seems to have been intended, it was mentioned in #13546. 

Giving engineering more things to do and more incentive to do them is a welcome change, means that engineering once they have built the DNA vault/station shields in 10 minutes they still can do something. There aren't always breaches and making bars does get old after a while. adding more fun things that engineering can do to help out science and the station I think is a positive.


## Changelog
:cl:
Tweak: anomalies from the SM now drop cores
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
