### PR TITLE
Adds a rad-proofing potion to xenobio 

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -54,6 +54,20 @@
 /datum/chemical_reaction/slimemutate/on_reaction(datum/reagents/holder)
 	SSblackbox.record_feedback("tally", "slime_cores_used", 1, type)
 
+/datum/chemical_reaction/slimerad
+	name = "Slime Rad-Proofing"
+	id = "slimerad"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/green
+	required_other = 1
+
+/datum/chemical_reaction/slimerad/on_reaction(datum/reagents/holder)
+	SSblackbox.record_feedback("tally", "slime_cores_used", 1, type)
+	var/obj/item/slimepotion/radproof/P = new /obj/item/slimepotion/radproof
+	P.forceMove(get_turf(holder.my_atom))
+
 //Metal
 /datum/chemical_reaction/slimemetal
 	name = "Slime Metal"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -392,6 +392,36 @@
 	if(loc == usr && loc.Adjacent(over_object))
 		afterattack(over_object, usr, TRUE)
 
+/obj/item/slimepotion/radproof
+	name = "slime rad-proofing potion"
+	desc = "A potent chemical mix that will radproof any article of clothing. Has three uses."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle16"
+	origin_tech = "biotech=5"
+	resistance_flags = FIRE_PROOF
+	var/uses = 3
+
+/obj/item/slimepotion/radproof/afterattack(obj/item/clothing/C, mob/user, proximity_flag)
+	..()
+	if(!proximity_flag)
+		return
+	if(!uses)
+		qdel(src)
+		return
+	if(!istype(C))
+		to_chat(user, "<span class='warning'>The potion can only be used on clothing!</span>")
+		return
+	if(C.armor.rad == 100)
+		to_chat(user, "<span class='warning'>[C] is already radproof!</span>")
+		return
+	to_chat(user, "<span class='notice'>You spread the green paste over [C], rad-proofing it.</span>")
+	C.name = "radproofed [C.name]"
+	C.armor.rad = 100
+	C.color = "#00FF00"
+	uses --
+	if(!uses)
+		qdel(src)
+
 /obj/item/slimepotion/fireproof
 	name = "slime chill potion"
 	desc = "A potent chemical mix that will fireproof any article of clothing. Has three uses."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a potion that can be used to rad proof an item of clothing, it has 3 uses and is made with water and a green slime extract

## Why It's Good For The Game
Rads are still really potent. There is only one rad  and fire proof suit on the station, the CEs. This is fine until the SM starts to delam in a spectacular fashion, spewing fire and rads everywhere. This makes this means that if the CE is dead/unavailable/incompetent, all of which happen alot there still might be a suit that is up to even stepping into engineering. 

Also it adds more ways for xenobio to contribute and help the  station that aren't armies of valid unga mobs.  



## Changelog
:cl:
add: Adds a water + green slime reaction that makes a rad-proofing potion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
