### PR TITLE
Refactors Organ Shocking To Use Signals

### DIFF
--- a/code/game/objects/items/devices/handheld_defib.dm
+++ b/code/game/objects/items/devices/handheld_defib.dm
@@ -67,7 +67,7 @@
 			H.AdjustWeakened(5)
 			H.AdjustStuttering(10)
 			to_chat(H, "<span class='danger'>You feel a powerful jolt!</span>")
-			H.shock_internal_organs(100)
+			SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 
 			if(emagged && prob(10))
 				to_chat(user, "<span class='danger'>[src]'s on board scanner indicates that the target is undergoing a cardiac arrest!</span>")

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -348,7 +348,7 @@
 			H.emote("gasp")
 			if(!H.undergoing_cardiac_arrest() && (prob(10) || defib.combat)) // Your heart explodes.
 				H.set_heartattack(TRUE)
-			H.shock_internal_organs(100)
+			SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 			add_attack_logs(user, M, "Stunned with [src]")
 			defib.deductcharge(revivecost)
 			cooldown = TRUE
@@ -399,7 +399,7 @@
 							update_icon()
 							return
 						H.set_heartattack(FALSE)
-						H.shock_internal_organs(100)
+						SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 						user.visible_message("<span class='boldnotice'>[defib] pings: Cardiac arrhythmia corrected.</span>")
 						M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
@@ -434,7 +434,7 @@
 						H.emote("gasp")
 						if(tplus > tloss)
 							H.setBrainLoss( max(0, min(99, ((tlimit - tplus) / tlimit * 100))))
-						H.shock_internal_organs(100)
+						SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 						H.med_hud_set_health()
 						H.med_hud_set_status()
 						defib.deductcharge(revivecost)
@@ -497,7 +497,7 @@
 			H.Weaken(5)
 			if(!H.undergoing_cardiac_arrest() && prob(10)) // Your heart explodes.
 				H.set_heartattack(TRUE)
-			H.shock_internal_organs(100)
+			SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 			playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 			H.emote("gasp")
 			add_attack_logs(user, M, "Stunned with [src]")
@@ -553,7 +553,7 @@
 						H.emote("gasp")
 						if(tplus > tloss)
 							H.setBrainLoss( max(0, min(99, ((tlimit - tplus) / tlimit * 100))))
-						H.shock_internal_organs(100)
+						SEND_SIGNAL(H, COMSIG_LIVING_MINOR_SHOCK, 100)
 						if(isrobot(user))
 							var/mob/living/silicon/robot/R = user
 							R.cell.use(revivecost)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -168,9 +168,7 @@
 			return
 		H.forcesay(GLOB.hit_appends)
 
-	if(iscarbon(L))
-		var/mob/living/carbon/C = L
-		C.shock_internal_organs(33)
+	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)
 
 	L.Stun(stunforce)
 	L.Weaken(stunforce)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -173,7 +173,6 @@
 	AdjustJitter(1000)
 	do_jitter_animation(jitteriness)
 	AdjustStuttering(2)
-	shock_internal_organs(shock_damage)
 	addtimer(CALLBACK(src, .proc/secondary_shock, should_stun), 20)
 	return shock_damage
 
@@ -1168,10 +1167,6 @@ so that different stomachs can handle things in different ways VB*/
 	if(I.flags_inv & HIDEMASK || forced)
 		update_inv_wear_mask()
 	update_inv_head()
-
-/mob/living/carbon/proc/shock_internal_organs(intensity)
-	for(var/obj/item/organ/O in internal_organs)
-		O.shock_organ(intensity)
 
 /mob/living/carbon/update_sight()
 	if(!client)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -25,6 +25,7 @@
 		do_sparks(1, 1, src)
 	else if(iscarbon(target))
 		var/mob/living/carbon/C = target
+		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK, 33)
 		if(HAS_TRAIT(C, TRAIT_HULK))
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 		else if(C.status_flags & CANWEAKEN)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -245,7 +245,7 @@
 		return
 	necrotize()
 
-/obj/item/organ/internal/heart/cybernetic/upgraded/proc/shock_heart(datum/source, intensity)
+/obj/item/organ/internal/heart/cybernetic/upgraded/proc/shock_heart(mob/living/carbon/human/source, intensity)
 	SIGNAL_HANDLER
 
 	if(!ishuman(owner))

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -155,6 +155,17 @@
 	dead_icon = "heart-c-u-off"
 	var/attempted_restart = FALSE
 
+/obj/item/organ/internal/heart/cybernetic/upgraded/insert(mob/living/carbon/M, special = FALSE)
+	..()
+	RegisterSignal(M, COMSIG_LIVING_MINOR_SHOCK, .proc/shock_heart)
+	RegisterSignal(M, COMSIG_LIVING_ELECTROCUTE_ACT, .proc/shock_heart)
+
+/obj/item/organ/internal/heart/cybernetic/upgraded/remove(mob/living/carbon/M, special = FALSE)
+	UnregisterSignal(M, COMSIG_LIVING_MINOR_SHOCK)
+	UnregisterSignal(M, COMSIG_LIVING_ELECTROCUTE_ACT)
+	return  ..()
+
+
 /obj/item/organ/internal/heart/cybernetic/upgraded/on_life()
 	if(!ishuman(owner))
 		return
@@ -234,8 +245,9 @@
 		return
 	necrotize()
 
+/obj/item/organ/internal/heart/cybernetic/upgraded/proc/shock_heart(datum/source, intensity)
+	SIGNAL_HANDLER
 
-/obj/item/organ/internal/heart/cybernetic/upgraded/shock_organ(intensity)
 	if(!ishuman(owner))
 		return
 	if(emp_proof)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -246,7 +246,7 @@
 	necrotize()
 
 /obj/item/organ/internal/heart/cybernetic/upgraded/proc/shock_heart(mob/living/carbon/human/source, intensity)
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER_DOES_SLEEP
 
 	if(!ishuman(owner))
 		return

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -230,9 +230,6 @@
 	status &= ~ORGAN_SPLINTED
 	status |= ORGAN_ROBOT
 
-/obj/item/organ/proc/shock_organ(intensity)
-	return
-
 /obj/item/organ/proc/remove(var/mob/living/user,special = 0)
 	if(!istype(owner))
 		return


### PR DESCRIPTION
Pretty simple.

Adds TG's `COMSIG_LIVING_MINOR_SHOCK` to the same places they have it, but also adds an argument for intensity.

Axes `shock_internal_organs` in favor of signals, to handle the same thing.

Technically, this does mean tasers can impact upgraded cybernetic heart.

:cl: Fox McCloud
tweak: tasers can impact upgraded cybernetic hearts
/:cl: