### PR TITLE
Fixes a runtime caused by bees spawning in nullspace

### DIFF
--- a/code/game/objects/items/weapons/bee_briefcase.dm
+++ b/code/game/objects/items/weapons/bee_briefcase.dm
@@ -65,8 +65,7 @@
 
 		//Release up to 5 bees per use. Without using strange reagent, that means two uses. WITH strange reagent, you can get more if you don't release the last bee
 		for(var/bee = min(5, bees_left), bee > 0, bee--)
-			var/mob/living/simple_animal/hostile/poison/bees/syndi/B = new /mob/living/simple_animal/hostile/poison/bees/syndi(src)
+			var/mob/living/simple_animal/hostile/poison/bees/syndi/B = new /mob/living/simple_animal/hostile/poison/bees/syndi(get_turf(user)) // RELEASE THE BEES!
 			B.master_and_friends = blood_list.Copy()	//Doesn't automatically add the person who opens the case, so the bees will attack the user unless they gave their blood
-			B.forceMove(get_turf(user))			//RELEASE THE BEES!
 			bees_released++
 		bees_left -= bees_released

--- a/code/game/objects/items/weapons/bee_briefcase.dm
+++ b/code/game/objects/items/weapons/bee_briefcase.dm
@@ -1,4 +1,3 @@
-
 /obj/item/bee_briefcase
 	name = "briefcase"
 	desc = "This briefcase has easy-release clasps and smells vaguely of honey and blood..."
@@ -9,7 +8,6 @@
 	flags = CONDUCT
 	hitsound = "swing_hit"
 	force = 10
-	throw_speed = 2
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
@@ -55,7 +53,7 @@
 		to_chat(user, "You spray [I] into [src].")
 		playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
 
-/obj/item/bee_briefcase/attack_self(mob/user as mob)
+/obj/item/bee_briefcase/attack_self(mob/user)
 	var/bees_released
 	if(!bees_left)
 		to_chat(user, "<span class='danger'>The lack of all and any bees at this event has been somewhat of a let-down...</span>")
@@ -67,7 +65,7 @@
 
 		//Release up to 5 bees per use. Without using strange reagent, that means two uses. WITH strange reagent, you can get more if you don't release the last bee
 		for(var/bee = min(5, bees_left), bee > 0, bee--)
-			var/mob/living/simple_animal/hostile/poison/bees/syndi/B = new /mob/living/simple_animal/hostile/poison/bees/syndi(null)
+			var/mob/living/simple_animal/hostile/poison/bees/syndi/B = new /mob/living/simple_animal/hostile/poison/bees/syndi(src)
 			B.master_and_friends = blood_list.Copy()	//Doesn't automatically add the person who opens the case, so the bees will attack the user unless they gave their blood
 			B.forceMove(get_turf(user))			//RELEASE THE BEES!
 			bees_released++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Makes the 'Briefcase full of Bees' spawn the bees directly onto the turf, rather than in nullspace and then moving them.
Fixes this: `Runtime in unsorted.dm,2016: Simple animal being instantiated in nullspace`

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
hWhat's this? An overabundance of bees in nullspace? My PR full of BEES ought to put a stop to that!

## Changelog
:cl:
fix: Fixed a runtime caused by the Bee Briefcase spawning bees in nullspace.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
