### PR TITLE
Fixes reverb being added to Lobby Music, Bwoinks, etc.

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -5,11 +5,20 @@
 GLOBAL_VAR_INIT(log_end, (world.system_type == UNIX ? ascii2text(13) : ""))
 GLOBAL_PROTECT(log_end)
 
+// why are these all in _logging.dm
 #define DIRECT_OUTPUT(A, B) A << B
 #define SEND_IMAGE(target, image) DIRECT_OUTPUT(target, image)
 #define SEND_SOUND(target, sound) DIRECT_OUTPUT(target, sound)
 #define SEND_TEXT(target, text) DIRECT_OUTPUT(target, text)
 #define WRITE_FILE(file, text) DIRECT_OUTPUT(file, text)
+
+/// Removes the echo/reverb from a sound input.
+#define SEND_SOUND_NO_ECHO(target, input) \
+	var/sound/output = input; \
+	if (!istype(output)) { \
+		output = sound(input) } \
+	output.echo = null; \
+	DIRECT_OUTPUT(target, output) \
 
 /proc/error(msg)
 	log_world("## ERROR: [msg]")

--- a/code/controllers/subsystem/afk.dm
+++ b/code/controllers/subsystem/afk.dm
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(afk)
 
 /datum/controller/subsystem/afk/proc/warn(mob/living/carbon/human/H, text)
 	to_chat(H, text)
-	SEND_SOUND(H, 'sound/effects/adminhelp.ogg')
+	SEND_SOUND_NO_ECHO(H, 'sound/effects/adminhelp.ogg')
 	if(H.client)
 		window_flash(H.client)
 

--- a/code/controllers/subsystem/ghost_spawns.dm
+++ b/code/controllers/subsystem/ghost_spawns.dm
@@ -63,7 +63,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 		if(!is_eligible(M, role, antag_age_check, role, min_hours, check_antaghud))
 			continue
 
-		SEND_SOUND(M, 'sound/misc/notice2.ogg')
+		SEND_SOUND_NO_ECHO(M, 'sound/misc/notice2.ogg')
 		if(flash_window)
 			window_flash(M.client)
 
@@ -245,7 +245,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 	if(time_left() <= 0)
 		if(!silent)
 			to_chat(M, "<span class='danger'>Sorry, you were too late for the consideration!</span>")
-			SEND_SOUND(M, 'sound/machines/buzz-sigh.ogg')
+			SEND_SOUND_NO_ECHO(M, 'sound/machines/buzz-sigh.ogg')
 		return
 
 	signed_up += M

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -574,7 +574,7 @@ SUBSYSTEM_DEF(ticker)
 	// Play a haha funny noise
 	var/round_end_sound = pick(GLOB.round_end_sounds)
 	var/sound_length = GLOB.round_end_sounds[round_end_sound]
-	world << round_end_sound
+	SEND_SOUND_NO_ECHO(world, round_end_sound)
 	sleep(sound_length)
 
 	world.Reboot()

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -142,8 +142,7 @@ SUBSYSTEM_DEF(tickets)
 
 	//Inform the user that they have opened a ticket
 	to_chat(C, "<span class='[span_class]'>You have opened [ticket_name] number #[(getTicketCounter() - 1)]! Please be patient and we will help you soon!</span>")
-	var/ticket_open_sound = sound('sound/effects/adminticketopen.ogg')
-	SEND_SOUND(C, ticket_open_sound)
+	SEND_SOUND_NO_ECHO(C, 'sound/effects/adminticketopen.ogg')
 
 	message_staff(url_title, NONE, TRUE)
 
@@ -245,8 +244,7 @@ SUBSYSTEM_DEF(tickets)
 		if("Mentorhelp")
 			convert_ticket(T)
 		else
-			var/msg_sound = sound('sound/effects/adminhelp.ogg')
-			SEND_SOUND(returnClient(N), msg_sound)
+			SEND_SOUND_NO_ECHO(returnClient(N), 'sound/effects/adminhelp.ogg')
 			to_chat_safe(returnClient(N), "<span class='[span_class]'>[key_name_hidden(C)] is autoresponding with: <span/> <span class='adminticketalt'>[response_phrases[message_key]]</span>")//for this we want the full value of whatever key this is to tell the player so we do response_phrases[message_key]
 			message_staff("[C] has auto responded to [ticket_owner]\'s adminhelp with:<span class='adminticketalt'> [message_key] </span>") //we want to use the short named keys for this instead of the full sentence which is why we just do message_key
 			T.lastStaffResponse = "Autoresponse: [message_key]"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -912,7 +912,7 @@
 					special_role = SPECIAL_ROLE_WIZARD
 					//ticker.mode.learn_basic_spells(current)
 					SSticker.mode.update_wiz_icons_added(src)
-					SEND_SOUND(current, 'sound/ambience/antag/ragesmages.ogg')
+					SEND_SOUND_NO_ECHO(current, 'sound/ambience/antag/ragesmages.ogg')
 					to_chat(current, "<span class='danger'>You are a Space Wizard!</span>")
 					current.faction = list("wizard")
 					log_admin("[key_name(usr)] has wizarded [key_name(current)]")
@@ -958,7 +958,7 @@
 					SSticker.mode.grant_changeling_powers(current)
 					SSticker.mode.update_change_icons_added(src)
 					special_role = SPECIAL_ROLE_CHANGELING
-					SEND_SOUND(current, 'sound/ambience/antag/ling_aler.ogg')
+					SEND_SOUND_NO_ECHO(current, 'sound/ambience/antag/ling_aler.ogg')
 					to_chat(current, "<B><font color='red'>Your powers have awoken. A flash of memory returns to us... we are a changeling!</font></B>")
 					log_admin("[key_name(usr)] has changelinged [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has changelinged [key_name_admin(current)]")
@@ -1003,7 +1003,7 @@
 					slaved.masters += src
 					som = slaved //we MIGT want to mindslave someone
 					special_role = SPECIAL_ROLE_VAMPIRE
-					SEND_SOUND(current, 'sound/ambience/antag/vampalert.ogg')
+					SEND_SOUND_NO_ECHO(current, 'sound/ambience/antag/vampalert.ogg')
 					to_chat(current, "<B><font color='red'>Your powers have awoken. Your lust for blood grows... You are a Vampire!</font></B>")
 					log_admin("[key_name(usr)] has vampired [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has vampired [key_name_admin(current)]")
@@ -1555,7 +1555,7 @@
 
 	else if(href_list["obj_announce"])
 		announce_objectives()
-		SEND_SOUND(current, sound('sound/ambience/alarm4.ogg'))
+		SEND_SOUND_NO_ECHO(current, sound('sound/ambience/alarm4.ogg'))
 		log_admin("[key_name(usr)] has announced [key_name(current)]'s objectives")
 		message_admins("[key_name_admin(usr)] has announced [key_name_admin(current)]'s objectives")
 

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -70,7 +70,7 @@
 			if(telegraph_message)
 				to_chat(M, telegraph_message)
 			if(telegraph_sound)
-				SEND_SOUND(M, sound(telegraph_sound))
+				SEND_SOUND_NO_ECHO(M, sound(telegraph_sound))
 	addtimer(CALLBACK(src, .proc/start), telegraph_duration)
 
 /datum/weather/proc/start()
@@ -84,7 +84,7 @@
 			if(weather_message)
 				to_chat(M, weather_message)
 			if(weather_sound)
-				SEND_SOUND(M, sound(weather_sound))
+				SEND_SOUND_NO_ECHO(M, sound(weather_sound))
 	addtimer(CALLBACK(src, .proc/wind_down), weather_duration)
 
 /datum/weather/proc/wind_down()
@@ -98,7 +98,7 @@
 			if(end_message)
 				to_chat(M, end_message)
 			if(end_sound)
-				SEND_SOUND(M, sound(end_sound))
+				SEND_SOUND_NO_ECHO(M, sound(end_sound))
 	addtimer(CALLBACK(src, .proc/end), end_duration)
 
 /datum/weather/proc/end()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -479,17 +479,17 @@
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
 	if(L && L.client && !L.client.ambience_playing && (L.client.prefs.sound & SOUND_BUZZ))	//split off the white noise from the rest of the ambience because of annoyance complaints - Kluys
 		L.client.ambience_playing = TRUE
-		SEND_SOUND(L, sound('sound/ambience/shipambience.ogg', repeat = TRUE, wait = FALSE, volume = 35, channel = CHANNEL_BUZZ))
+		SEND_SOUND_NO_ECHO(L, sound('sound/ambience/shipambience.ogg', repeat = TRUE, wait = FALSE, volume = 35, channel = CHANNEL_BUZZ))
 	else if(L && L.client && !(L.client.prefs.sound & SOUND_BUZZ))
 		L.client.ambience_playing = FALSE
 
 	if(prob(35) && L && L.client && (L.client.prefs.sound & SOUND_AMBIENCE))
-		var/sound = pick(ambientsounds)
+		var/ambience = pick(ambientsounds)
 
 		if(!L.client.played)
-			SEND_SOUND(L, sound(sound, repeat = FALSE, wait = FALSE, volume = 25, channel = CHANNEL_AMBIENCE))
+			SEND_SOUND_NO_ECHO(L, sound(ambience, repeat = FALSE, wait = FALSE, volume = 25, channel = CHANNEL_AMBIENCE))
 			L.client.played = TRUE
-			addtimer(CALLBACK(L.client, /client/proc/ResetAmbiencePlayed), 600)
+			addtimer(CALLBACK(L.client, /client/proc/ResetAmbiencePlayed), 60 SECONDS)
 
 /**
   * Reset the played var to false on the client

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	to_chat(blob.current, "<b>Find a good location to spawn the core and then take control and overwhelm the station!</b>")
 	to_chat(blob.current, "<b>When you have found a location, wait until you spawn; this will happen automatically and you cannot speed up the process.</b>")
 	to_chat(blob.current, "<b>If you go outside of the station level, or in space, then you will die; make sure your location has lots of ground to cover.</b>")
-	SEND_SOUND(blob.current, 'sound/magic/mutate.ogg')
+	SEND_SOUND_NO_ECHO(blob.current, 'sound/magic/mutate.ogg')
 	return
 
 /datum/game_mode/blob/proc/show_message(var/message)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -131,7 +131,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	return
 
 /datum/game_mode/proc/greet_changeling(datum/mind/changeling, you_are=1)
-	SEND_SOUND(changeling.current, 'sound/ambience/antag/ling_aler.ogg')
+	SEND_SOUND_NO_ECHO(changeling.current, 'sound/ambience/antag/ling_aler.ogg')
 	if(you_are)
 		to_chat(changeling.current, "<span class='danger'>You are a changeling!</span>")
 	to_chat(changeling.current, "<span class='danger'>Use say \":g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them.</span>")

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 	cult_objs.setup()
 
 	for(var/datum/mind/cult_mind in cult)
-		SEND_SOUND(cult_mind.current, 'sound/ambience/antag/bloodcult.ogg')
+		SEND_SOUND_NO_ECHO(cult_mind.current, 'sound/ambience/antag/bloodcult.ogg')
 		to_chat(cult_mind.current, CULT_GREETING)
 		equip_cultist(cult_mind.current)
 		cult_mind.current.faction |= "cult"
@@ -187,7 +187,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 			singlemutcheck(cult_mind.current, GLOB.clumsyblock, MUTCHK_FORCED)
 			var/datum/action/innate/toggle_clumsy/A = new
 			A.Grant(cult_mind.current)
-		SEND_SOUND(cult_mind.current, 'sound/ambience/antag/bloodcult.ogg')
+		SEND_SOUND_NO_ECHO(cult_mind.current, 'sound/ambience/antag/bloodcult.ogg')
 		cult_mind.current.create_attack_log("<span class='danger'>Has been converted to the cult!</span>")
 		cult_mind.current.create_log(CONVERSION_LOG, "converted to the cult")
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -603,7 +603,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			fail_invoke()
 			return
 
-	SEND_SOUND(mob_to_revive, 'sound/ambience/antag/bloodcult.ogg')
+	SEND_SOUND_NO_ECHO(mob_to_revive, 'sound/ambience/antag/bloodcult.ogg')
 	to_chat(mob_to_revive, "<span class='cultlarge'>\"PASNAR SAVRAE YAM'TOTH. Arise.\"</span>")
 	mob_to_revive.visible_message("<span class='warning'>[mob_to_revive] draws in a huge breath, red light shining from [mob_to_revive.p_their()] eyes.</span>", \
 								  "<span class='cultlarge'>You awaken suddenly from the void. You're alive!</span>")
@@ -1001,7 +1001,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	used = TRUE
 	color = rgb(255, 0, 0)
 	..()
-	SEND_SOUND(world, 'sound/effects/dimensional_rend.ogg')
+	SEND_SOUND_NO_ECHO(world, 'sound/effects/dimensional_rend.ogg')
 	to_chat(world, "<span class='cultitalic'><b>The veil... <span class='big'>is...</span> <span class='reallybig'>TORN!!!--</span></b></span>")
 	icon_state = "rune_large_distorted"
 	var/turf/T = get_turf(src)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -159,7 +159,7 @@
 
 /mob/living/simple_animal/revenant/proc/giveObjectivesandGoals()
 			mind.wipe_memory()
-			SEND_SOUND(src, 'sound/effects/ghost.ogg')
+			SEND_SOUND_NO_ECHO(src, 'sound/effects/ghost.ogg')
 			to_chat(src, "<br>")
 			to_chat(src, "<span class='deadsay'><font size=3><b>You are a revenant.</b></font></span>")
 			to_chat(src, "<b>Your formerly mundane spirit has been infused with alien energies and empowered into a revenant.</b>")

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -238,7 +238,7 @@
 
 
 /datum/game_mode/proc/greet_syndicate(var/datum/mind/syndicate, var/you_are=1)
-	SEND_SOUND(syndicate.current, 'sound/ambience/antag/ops.ogg')
+	SEND_SOUND_NO_ECHO(syndicate.current, 'sound/ambience/antag/ops.ogg')
 	if(you_are)
 		to_chat(syndicate.current, "<span class='notice'>You are a [syndicate_name()] agent!</span>")
 	var/obj_count = 1

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/proc/on_target_cryo()
 	if(owner?.current)
 		to_chat(owner.current, "<BR><span class='userdanger'>You get the feeling your target is no longer within reach. Time for Plan [pick("A","B","C","D","X","Y","Z")]. Objectives updated!</span>")
-		SEND_SOUND(owner.current, 'sound/ambience/alarm4.ogg')
+		SEND_SOUND_NO_ECHO(owner.current, 'sound/ambience/alarm4.ogg')
 	target = null
 	INVOKE_ASYNC(src, .proc/post_target_cryo)
 

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -175,7 +175,7 @@
 /datum/game_mode/proc/greet_vampire(var/datum/mind/vampire, var/you_are=1)
 	var/dat
 	if(you_are)
-		SEND_SOUND(vampire.current, 'sound/ambience/antag/vampalert.ogg')
+		SEND_SOUND_NO_ECHO(vampire.current, 'sound/ambience/antag/vampalert.ogg')
 		dat = "<span class='danger'>You are a Vampire!</span><br>"
 	dat += {"To bite someone, target the head and use harm intent with an empty hand. Drink blood to gain new powers.
 You are weak to holy things and starlight. Don't go into space and avoid the Chaplain, the chapel and especially Holy Water."}

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,5 +1,4 @@
-
-///Default override for echo
+// Default override for echo
 /sound
 	echo = list(
 		0, // Direct
@@ -150,7 +149,7 @@
 	if(!SSticker || !SSticker.login_music || config.disable_lobby_music)
 		return
 	if(prefs.sound & SOUND_LOBBY)
-		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = 85, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
+		SEND_SOUND_NO_ECHO(src, sound(SSticker.login_music, channel = CHANNEL_LOBBYMUSIC, volume = 85)) // MAD JAMS
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -34,7 +34,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 				to_chat(C, msg)
 			if(important)
 				if(C.prefs?.sound & SOUND_ADMINHELP)
-					SEND_SOUND(C, 'sound/effects/adminhelp.ogg')
+					SEND_SOUND_NO_ECHO(C, 'sound/effects/adminhelp.ogg')
 				window_flash(C)
 
 /**
@@ -51,7 +51,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 				to_chat(C, msg)
 			if(important)
 				if(C.prefs?.sound & SOUND_MENTORHELP)
-					SEND_SOUND(C, 'sound/effects/adminhelp.ogg')
+					SEND_SOUND_NO_ECHO(C, 'sound/effects/adminhelp.ogg')
 				window_flash(C)
 
 /proc/admin_ban_mobsearch(var/mob/M, var/ckey_to_find, var/mob/admin_to_notify)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -17,7 +17,7 @@
 		if(!isclient(C))
 			return
 
-		C << 'sound/effects/adminhelp.ogg'
+		SEND_SOUND_NO_ECHO(C, 'sound/effects/adminhelp.ogg')
 
 		to_chat(C, "<font color='red' size='4'><b>- AdminHelp Rejected! -</b></font>")
 		to_chat(C, "<font color='red'><b>Your admin help was rejected.</b></font>")
@@ -2326,7 +2326,7 @@
 			message_admins("[key_name_admin(usr)] sent [H.job] [H] to cryo.")
 			if(href_list["cryoafk"]) // Warn them if they are send to storage and are AFK
 				to_chat(H, "<span class='danger'>The admins have moved you to cryo storage for being AFK. Please eject yourself (right click, eject) out of the cryostorage if you want to avoid being despawned.</span>")
-				SEND_SOUND(H, 'sound/effects/adminhelp.ogg')
+				SEND_SOUND_NO_ECHO(H, 'sound/effects/adminhelp.ogg')
 				if(H.client)
 					window_flash(H.client)
 	else if(href_list["FaxReplyTemplate"])

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -169,7 +169,7 @@
 	//play the recieving admin the adminhelp sound (if they have them enabled)
 	//non-admins always hear the sound, as they cannot toggle it
 	if((!C.holder) || (C.prefs.sound & SOUND_ADMINHELP))
-		C << 'sound/effects/adminhelp.ogg'
+		SEND_SOUND_NO_ECHO(C, 'sound/effects/adminhelp.ogg')
 
 	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")
 	//we don't use message_admins here because the sender/receiver might get it too

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -16,7 +16,7 @@
 			if(R_ADMIN & C.holder.rights)
 				// Lets see if this admin was pinged in the asay message
 				if(findtext(msg, "@[C.ckey]") || findtext(msg, "@[C.key]")) // Check ckey and key, so you can type @AffectedArc07 or @affectedarc07
-					SEND_SOUND(C, 'sound/misc/ping.ogg')
+					SEND_SOUND_NO_ECHO(C, 'sound/misc/ping.ogg')
 					msg = replacetext(msg, "@[C.ckey]", "<font color='red'>@[C.ckey]</font>")
 					msg = replacetext(msg, "@[C.key]", "<font color='red'>@[C.key]</font>") // Same applies here. key and ckey.
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(sounds_cache)
 		if(M.client.prefs.sound & SOUND_MIDI)
 			if(isnewplayer(M) && (M.client.prefs.sound & SOUND_LOBBY))
 				M.stop_sound_channel(CHANNEL_LOBBYMUSIC)
-			SEND_SOUND(M, uploaded_sound)
+			SEND_SOUND_NO_ECHO(M, uploaded_sound)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Global Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -36,7 +36,7 @@
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
 			if(X.prefs.sound & SOUND_PRAYERNOTIFY)
-				SEND_SOUND(X, 'sound/items/PDA/ambicha4-short.ogg')
+				SEND_SOUND_NO_ECHO(X, 'sound/items/PDA/ambicha4-short.ogg')
 	to_chat(usr, "Your prayers have been received by the gods.")
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Pray") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -48,7 +48,7 @@
 		if(R_EVENT & X.holder.rights)
 			to_chat(X, msg)
 			if(X.prefs.sound & SOUND_ADMINHELP)
-				X << 'sound/effects/adminhelp.ogg'
+				SEND_SOUND_NO_ECHO(X, 'sound/effects/adminhelp.ogg')
 
 /proc/Syndicate_announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
@@ -57,7 +57,7 @@
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
 			if(X.prefs.sound & SOUND_ADMINHELP)
-				X << 'sound/effects/adminhelp.ogg'
+				SEND_SOUND_NO_ECHO(X, 'sound/effects/adminhelp.ogg')
 
 /proc/HONK_announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
@@ -66,7 +66,7 @@
 		if(R_EVENT & X.holder.rights)
 			to_chat(X, msg)
 			if(X.prefs.sound & SOUND_ADMINHELP)
-				X << 'sound/effects/adminhelp.ogg'
+				SEND_SOUND_NO_ECHO(X, 'sound/effects/adminhelp.ogg')
 
 /proc/ERT_Announce(var/text , var/mob/Sender, var/repeat_warning)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
@@ -77,7 +77,7 @@
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
 			if(X.prefs.sound & SOUND_ADMINHELP)
-				X << 'sound/effects/adminhelp.ogg'
+				SEND_SOUND_NO_ECHO(X, 'sound/effects/adminhelp.ogg')
 
 /proc/Nuke_request(text , mob/Sender)
 	var/nuke_code = get_nuke_code()
@@ -88,4 +88,4 @@
 			to_chat(X, msg)
 			to_chat(X, "<span class='adminnotice'><b>The nuke code is [nuke_code].</b></span>")
 			if(X.prefs.sound & SOUND_ADMINHELP)
-				X << 'sound/effects/adminhelp.ogg'
+				SEND_SOUND_NO_ECHO(X, 'sound/effects/adminhelp.ogg')

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -350,7 +350,7 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 		if(check_rights(R_EVENT, 0, C.mob))
 			to_chat(C, msg)
 			if(C.prefs.sound & SOUND_ADMINHELP)
-				C << 'sound/effects/adminhelp.ogg'
+				SEND_SOUND_NO_ECHO(C, 'sound/effects/adminhelp.ogg')
 
 /obj/machinery/photocopier/faxmachine/proc/become_mimic()
 	if(scan)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -30,7 +30,7 @@
 	icon_state = SSticker.cultdat?.entity_icon_state
 	name = SSticker.cultdat?.entity_name
 	to_chat(world, "<font size='15' color='red'><b> [uppertext(name)] HAS RISEN</b></font>")
-	SEND_SOUND(world, pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg'))
+	SEND_SOUND_NO_ECHO(world, pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg'))
 
 	var/datum/game_mode/gamemode = SSticker.mode
 	if(gamemode)
@@ -50,7 +50,7 @@
 
 /obj/singularity/narsie/large/Destroy()
 	to_chat(world, "<font size='15' color='red'><b> [uppertext(name)] HAS FALLEN</b></font>")
-	SEND_SOUND(world, 'sound/hallucinations/wail.ogg')
+	SEND_SOUND_NO_ECHO(world, 'sound/hallucinations/wail.ogg')
 	var/datum/game_mode/gamemode = SSticker.mode
 	if(gamemode)
 		gamemode.cult_objs.narsie_death()

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -33,7 +33,7 @@
 		deaf = max(deaf - 1, 0)
 		if((ear_damage > 10) && prob(ear_damage / 30))
 			AdjustEarDamage(0, 4)
-			SEND_SOUND(owner, sound('sound/weapons/flash_ring.ogg'))
+			SEND_SOUND_NO_ECHO(owner, sound('sound/weapons/flash_ring.ogg'))
 
 	if(deaf)
 		ADD_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)

--- a/code/modules/world_topic/adminmsg.dm
+++ b/code/modules/world_topic/adminmsg.dm
@@ -26,7 +26,7 @@
 	C.received_discord_pm = world.time
 	C.last_discord_pm_time = 0
 
-	SEND_SOUND(C, 'sound/effects/adminhelp.ogg')
+	SEND_SOUND_NO_ECHO(C, 'sound/effects/adminhelp.ogg')
 	to_chat(C, message)
 
 	for(var/client/A in GLOB.admins)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds the `SEND_SOUND_NO_ECHO()` define in order to remove the reverb from some things that really shouldn't have it, like lobby music, adminhelps/bwoinking, ambient music, etc.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As amusing as it may be to hear reverb on a bwoink sound, it really shouldn't happen. If only because it makes it sound like an ingame thing rather than being entirely OOC.

## Changelog
:cl:
fix: Fixed reverb being added to Lobby music, Round end sounds, Ambient sounds, Antag greetings, Admin/Mentorhelps, Bwoinking, and a few other things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
