### PR TITLE
Reverb preference

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -52,8 +52,10 @@
 #define PREFTOGGLE_2_RUNECHAT		64
 #define PREFTOGGLE_2_DEATHMESSAGE	128
 #define PREFTOGGLE_2_EMOTE_BUBBLE	256
+// Yes I know this being an "enable to disable" is misleading, but it avoids having to tweak all existing pref entries
+#define PREFTOGGLE_2_REVERB_DISABLE	512
 
-#define TOGGLES_2_TOTAL 			511 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
+#define TOGGLES_2_TOTAL 			1023 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 
 #define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_2_DEATHMESSAGE|PREFTOGGLE_2_EMOTE_BUBBLE)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -125,8 +125,10 @@
 			S.environment = A.sound_environment
 
 		if(use_reverb && S.environment != SOUND_ENVIRONMENT_NONE) //We have reverb, reset our echo setting
-			S.echo[3] = 0 //Room setting, 0 means normal reverb
-			S.echo[4] = 0 //RoomHF setting, 0 means normal reverb.
+			// Check that the user has reverb enabled in their prefs
+			if(!(client?.prefs?.toggles2 & PREFTOGGLE_2_REVERB_DISABLE))
+				S.echo[3] = 0 //Room setting, 0 means normal reverb
+				S.echo[4] = 0 //RoomHF setting, 0 means normal reverb.
 
 	SEND_SOUND(src, S)
 

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -331,3 +331,11 @@
 	prefs.toggles2 ^= PREFTOGGLE_2_DEATHMESSAGE
 	prefs.save_preferences(src)
 	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_DEATHMESSAGE) ? "now" : "no longer"] see a notification in deadchat when a player dies.")
+
+/client/verb/toggle_reverb()
+	set name = "Enable/Disable Reverb"
+	set category = "Preferences"
+	set desc = "Toggle ingame reverb effects"
+	prefs.toggles2 ^= PREFTOGGLE_2_REVERB_DISABLE
+	prefs.save_preferences(src)
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_REVERB_DISABLE) ? "no longer" : "now"] get reverb on ingame sounds.")


### PR DESCRIPTION
## What Does This PR Do
Adds a preference to enable/disable the reverb effects

## Why It's Good For The Game
Some people dislike this. Even if they are objectively wrong, we should cater to them.

## Changelog
:cl: AffectedArc07
add: Added a verb to enable/disable the new sound reverb effects.
/:cl:
