### PR TITLE
Adds runechat to various things that were missing it (MMIs, soulstones, and more)

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -193,10 +193,6 @@
 	// Display visual above source
 	new /datum/chatmessage(raw_message, speaker, src, italics, size)
 
-// Set the speaker to `container` here so the runechat messsage appears above the MMI/robotic brain that we're inside of.
-/mob/living/carbon/brain/create_chat_message(atom/movable/speaker, raw_message, italics, size)
-	speaker = container
-	return ..()
 
 // Tweak these defines to change the available color ranges
 #define CM_COLOR_SAT_MIN	0.6

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -193,6 +193,10 @@
 	// Display visual above source
 	new /datum/chatmessage(raw_message, speaker, src, italics, size)
 
+// Set the speaker to `container` here so the runechat messsage appears above the MMI/robotic brain that we're inside of.
+/mob/living/carbon/brain/create_chat_message(atom/movable/speaker, raw_message, italics, size)
+	speaker = container
+	return ..()
 
 // Tweak these defines to change the available color ranges
 #define CM_COLOR_SAT_MIN	0.6

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -300,6 +300,7 @@
 	if(client)
 		reset_perspective(destination)
 	update_canmove() //if the mob was asleep inside a container and then got forceMoved out we need to make them fall.
+	update_runechat_msg_location()
 
 
 //Called whenever an object moves and by mobs when they attempt to move themselves through space

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -297,7 +297,7 @@
 				if(length(contents))
 					to_chat(user, "<span class='danger'>Capture failed!</span>: The soul stone is full! Use or free an existing soul to make room.")
 				else
-					T.loc = src //put shade in stone
+					T.forceMove(src) // Put the shade into the stone.
 					T.canmove = 0
 					T.health = T.maxHealth
 					icon_state = icon_state_full

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -920,7 +920,7 @@
 			AI.aiRestorePowerRoutine = 0//So the AI initially has power.
 			AI.control_disabled = 1
 			AI.aiRadio.disabledAi = 1
-			AI.loc = card
+			AI.forceMove(card)
 			occupant = null
 			AI.controlled_mech = null
 			AI.remote_control = null
@@ -956,7 +956,7 @@
 //Hack and From Card interactions share some code, so leave that here for both to use.
 /obj/mecha/proc/ai_enter_mech(mob/living/silicon/ai/AI, interaction)
 	AI.aiRestorePowerRoutine = 0
-	AI.loc = src
+	AI.forceMove(src)
 	occupant = AI
 	icon_state = initial(icon_state)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
@@ -1165,7 +1165,7 @@
 		if(!user.unEquip(mmi_as_oc))
 			to_chat(user, "<span class='notice'>\the [mmi_as_oc] is stuck to your hand, you cannot put it in \the [src]</span>")
 			return FALSE
-		var/mob/brainmob = mmi_as_oc.brainmob
+		var/mob/living/carbon/brain/brainmob = mmi_as_oc.brainmob
 		brainmob.reset_perspective(src)
 		occupant = brainmob
 		brainmob.forceMove(src) //should allow relaymove
@@ -1250,7 +1250,7 @@
 		if(istype(mob_container, /obj/item/mmi))
 			var/obj/item/mmi/mmi = mob_container
 			if(mmi.brainmob)
-				L.loc = mmi
+				L.forceMove(mmi)
 				L.reset_perspective()
 			mmi.mecha = null
 			mmi.update_icon()

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -107,7 +107,7 @@
 
 		// Create map text message
 		if (client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) // can_hear is checked up there on L99
-			create_chat_message(speaker, message_clean, italics)
+			create_chat_message(speaker.runechat_msg_location, message_clean, italics)
 
 		if(speech_sound && (get_dist(speaker, src) <= world.view && src.z == speaker.z))
 			var/turf/source = speaker? get_turf(speaker) : get_turf(src)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -47,8 +47,8 @@
 			visible_message("<span class='notice'>[user] sticks \a [O] into \the [src].</span>")
 			brainmob = B.brainmob
 			B.brainmob = null
-			brainmob.forceMove(src)
 			brainmob.container = src
+			brainmob.forceMove(src)
 			brainmob.stat = CONSCIOUS
 			brainmob.see_invisible = initial(brainmob.see_invisible)
 			GLOB.respawnable_list -= brainmob

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -110,7 +110,9 @@ I'm using this for Stat to give it a more nifty interface to work with
 	. = TRUE
 
 /mob/living/carbon/brain/update_runechat_msg_location()
-	if(container)
+	if(ismecha(loc))
+		runechat_msg_location = loc
+	else if(container)
 		runechat_msg_location = container
 	else
 		runechat_msg_location = src

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -108,3 +108,9 @@ I'm using this for Stat to give it a more nifty interface to work with
 
 /mob/living/carbon/brain/can_hear()
 	. = TRUE
+
+/mob/living/carbon/brain/update_runechat_msg_location()
+	if(container)
+		runechat_msg_location = container
+	else
+		return ..()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -113,4 +113,4 @@ I'm using this for Stat to give it a more nifty interface to work with
 	if(container)
 		runechat_msg_location = container
 	else
-		return ..()
+		runechat_msg_location = src

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1975,3 +1975,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
   */
 /mob/living/carbon/human/get_runechat_color()
    return dna.species.get_species_runechat_color(src)
+
+/mob/living/carbon/human/update_runechat_msg_location()
+	if(ismecha(loc))
+		runechat_msg_location = loc
+	else
+		runechat_msg_location = src

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1241,7 +1241,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		aiRestorePowerRoutine = 0//So the AI initially has power.
 		control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		aiRadio.disabledAi = 1 	//No talking on the built-in radio for you either!
-		loc = card//Throw AI into the card.
+		forceMove(card) //Throw AI into the card.
 		to_chat(src, "You have been downloaded to a mobile storage device. Remote device connection severed.")
 		to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory.")
 
@@ -1389,3 +1389,9 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
 	sync_lighting_plane_alpha()
+
+/mob/living/silicon/ai/update_runechat_msg_location()
+	if(istype(loc, /obj/item/aicard) || ismecha(loc))
+		runechat_msg_location = loc
+	else
+		runechat_msg_location = src

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1275,7 +1275,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	var/rendered = "<i><span class='game say'>Relayed Speech: <span class='name'>[name_used]</span> [message]</span></i>"
 	if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
 		var/message_clean = combine_message(message_pieces, null, M)
-		create_chat_message(M, message_clean)
+		create_chat_message(M.runechat_msg_location, message_clean)
 	show_message(rendered, 2)
 
 /mob/living/silicon/ai/proc/malfhacked(obj/machinery/power/apc/apc)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -529,3 +529,9 @@
 	flashlight_on = FALSE
 	set_light(0)
 	card.set_light(0)
+
+/mob/living/silicon/pai/update_runechat_msg_location()
+	if(istype(loc, /obj/item/paicard))
+		runechat_msg_location = loc
+	else
+		runechat_msg_location = src

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -67,4 +67,4 @@
 	if(istype(loc, /obj/item/soulstone))
 		runechat_msg_location = loc
 	else
-		return ..()
+		runechat_msg_location = src

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -62,3 +62,9 @@
 /mob/living/simple_animal/shade/sword/Initialize(mapload)
 	.=..()
 	status_flags |= GODMODE
+
+/mob/living/simple_animal/shade/update_runechat_msg_location()
+	if(istype(loc, /obj/item/soulstone))
+		runechat_msg_location = loc
+	else
+		return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -30,6 +30,8 @@
 		GLOB.alive_mob_list += src
 	set_focus(src)
 	prepare_huds()
+	runechat_msg_location = src
+	update_runechat_msg_location()
 	. = ..()
 
 /atom/proc/prepare_huds()
@@ -1452,3 +1454,9 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		blood_state = BLOOD_STATE_NOT_BLOODY
 		update_inv_shoes()
 	update_icons()	//apply the now updated overlays to the mob
+
+/**
+ * Updates the mob's runechat maptext display location.
+ */
+/mob/proc/update_runechat_msg_location()
+	return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -201,3 +201,6 @@
 	var/registered_z
 
 	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
+
+	/// The location our runechat message should appear. Should be src by default.
+	var/atom/runechat_msg_location


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Added runechat to:

- MMIs, robotic brains and positronic brains.
- AIs inside of intellicards
- pAIs while they're in "card form"
- Mechs with *any* type of pilot (humanoid, AI, MMI, etc)
- Shades while they're inside of soulstones

**You cannot see the runechat of these things if they're inside of something such as a backpack.**

Fixes  #14994
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It easy to miss MMI/robobrain speech because they have no visual indicator of them speaking, not even a chat bubble. People need to have their eyes glued to the chat window or they'll miss what the brains are saying. Sometimes this means they can sit there for quite a while, being ignored. The same can apply for the other items.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/42044220/109019167-5b05dd80-767e-11eb-8bcc-5cfc589b53ad.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Adds runechat to various mobs who didn't have it before, such as all types of MMIs, and shades inside of soulstones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
