### PR TITLE
Makes the Clown All Powerful

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -272,6 +272,8 @@
 		/obj/item/instrument/bikehorn = 1
 	)
 
+	implants = list(/obj/item/implant/sad_trombone)
+
 	backpack = /obj/item/storage/backpack/clown
 	satchel = /obj/item/storage/backpack/clown
 	dufflebag = /obj/item/storage/backpack/duffel/clown

--- a/code/game/objects/items/weapons/implants/implant_clown.dm
+++ b/code/game/objects/items/weapons/implants/implant_clown.dm
@@ -1,0 +1,29 @@
+/obj/item/implant/sad_trombone
+	name = "sad trombone implant"
+	activated = 0
+
+/obj/item/implant/sad_trombone/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Honk Co. Sad Trombone Implant<BR>
+				<b>Life:</b> Activates upon death.<BR>
+				"}
+	return dat
+
+/obj/item/implant/sad_trombone/trigger(emote, mob/source, force)
+	if(force && emote == "deathgasp")
+		playsound(loc, 'sound/misc/sadtrombone.ogg', 50, FALSE)
+
+/obj/item/implanter/sad_trombone
+	name = "implanter (sad trombone)"
+
+/obj/item/implanter/sad_trombone/New() //gross
+	imp = new /obj/item/implant/sad_trombone
+	..()
+
+/obj/item/implantcase/sad_trombone
+	name = "implant case - 'Sad Trombone'"
+	desc = "A glass case containing a sad trombone implant."
+
+/obj/item/implantcase/sad_trombone/New() //gross
+	imp = new /obj/item/implant/sad_trombone
+	..()

--- a/code/game/objects/items/weapons/implants/implant_clown.dm
+++ b/code/game/objects/items/weapons/implants/implant_clown.dm
@@ -1,6 +1,6 @@
 /obj/item/implant/sad_trombone
 	name = "sad trombone implant"
-	activated = 0
+	activated = FALSE
 
 /obj/item/implant/sad_trombone/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -384,6 +384,8 @@
 				backpack_contents += list(/obj/item/stack/sheet/mineral/bananium = pickweight(list( 1 = 3, 2 = 2, 3 = 1)))
 			if(prob(10))
 				l_pocket = pickweight(list(/obj/item/bikehorn/golden = 3, /obj/item/bikehorn/airhorn= 1 ))
+			if(prob(10))
+				r_pocket = /obj/item/implanter/sad_trombone
 		if("Golem")
 			mob_species = pick(list(/datum/species/golem/adamantine, /datum/species/golem/plasma, /datum/species/golem/diamond, /datum/species/golem/gold, /datum/species/golem/silver, /datum/species/golem/plasteel, /datum/species/golem/titanium, /datum/species/golem/plastitanium))
 			if(prob(30))

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -533,6 +533,16 @@
 	build_path = /obj/item/implantcase/chem
 	category = list("Medical")
 
+/datum/design/implant_sadtrombone
+	name = "Sad Trombone Implant Case"
+	desc = "Makes death amusing."
+	id = "implant_trombone"
+	req_tech = list("materials" = 3, "biotech" = 5,)
+	build_type = PROTOLATHE
+	materials = list(MAT_GLASS = 500, MAT_BANANIUM = 500)
+	build_path = /obj/item/implantcase/sad_trombone
+	category = list("Medical")
+
 /datum/design/implant_tracking
 	name = "Tracking Implant Case"
 	desc = "A glass case containing an implant."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -527,7 +527,7 @@
 	name = "Chemical Implant Case"
 	desc = "A glass case containing an implant."
 	id = "implant_chem"
-	req_tech = list("materials" = 3, "biotech" = 5,)
+	req_tech = list("materials" = 3, "biotech" = 5)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 700)
 	build_path = /obj/item/implantcase/chem
@@ -537,7 +537,7 @@
 	name = "Sad Trombone Implant Case"
 	desc = "Makes death amusing."
 	id = "implant_trombone"
-	req_tech = list("materials" = 3, "biotech" = 5,)
+	req_tech = list("materials" = 3, "biotech" = 5)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 500, MAT_BANANIUM = 500)
 	build_path = /obj/item/implantcase/sad_trombone

--- a/paradise.dme
+++ b/paradise.dme
@@ -993,6 +993,7 @@
 #include "code\game\objects\items\weapons\implants\implant.dm"
 #include "code\game\objects\items\weapons\implants\implant_abductor.dm"
 #include "code\game\objects\items\weapons\implants\implant_chem.dm"
+#include "code\game\objects\items\weapons\implants\implant_clown.dm"
 #include "code\game\objects\items\weapons\implants\implant_death_alarm.dm"
 #include "code\game\objects\items\weapons\implants\implant_explosive.dm"
 #include "code\game\objects\items\weapons\implants\implant_freedom.dm"


### PR DESCRIPTION
It's time for the clown to ascend.

Gives the clown a sad trombone implant---when he dies,  it plays the sad trombone---what more could a clown want? Even in death, the honking must continue.

More generally, adds the sad trombone implant to the game; you can print one off from R&D if you have bananium and a handful of tech levels---or you might get lucky and find one on a dead clown in Lavaland.

:cl: Fox McCloud
add: Adds sad trombone implant; make it at R&D with a few tech levels and some bananium
add: Clown starts off with a sad trombone implant
/:cl: