### PR TITLE
SSU now reject nodrop items

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -331,28 +331,42 @@
 	if(default_deconstruction_screwdriver(user, "panel", "close", I))
 		I.play_tool_sound(user, I.tool_volume)
 
+/**
+  * Tries to store the item into whatever slot it can go, returns true if the item is stored successfully.
+  *
+**/
 /obj/machinery/suit_storage_unit/proc/store_item(obj/item/I, mob/user)
-	if(!user.canUnEquip(I))
-		return
-	. = FALSE
 	if(istype(I, /obj/item/clothing/suit) && !suit)
-		suit = I
-		. = TRUE
+		if(try_store_item(I, user))
+			suit = I
+			return TRUE
 	if(istype(I, /obj/item/clothing/head) && !helmet)
-		helmet = I
-		. = TRUE
+		if(try_store_item(I, user))
+			helmet = I
+			return TRUE
 	if(istype(I, /obj/item/clothing/mask) && !mask)
-		mask = I
-		. = TRUE
+		if(try_store_item(I, user))
+			mask = I
+			return TRUE
 	if(istype(I, /obj/item/clothing/shoes) && !boots)
-		boots = I
-		. = TRUE
-	if((istype(I, /obj/item/tank) || I.w_class <= WEIGHT_CLASS_SMALL) && !storage && !.)
-		storage = I
-		. = TRUE
-	if(.)
-		user.drop_item()
+		if(try_store_item(I, user))
+			boots = I
+			return TRUE
+	if((istype(I, /obj/item/tank) || I.w_class <= WEIGHT_CLASS_SMALL) && !storage)
+		if(try_store_item(I, user))
+			storage = I
+			return TRUE
+	return FALSE
+
+/**
+  * Tries to store the item, returns true if it's moved successfully, false otherwise (because of nodrop etc)
+  *
+**/
+/obj/machinery/suit_storage_unit/proc/try_store_item(obj/item/I, mob/user)
+	if(user.drop_item())
 		I.forceMove(src)
+		return TRUE
+	return FALSE
 
 
 /obj/machinery/suit_storage_unit/power_change()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -332,6 +332,8 @@
 		I.play_tool_sound(user, I.tool_volume)
 
 /obj/machinery/suit_storage_unit/proc/store_item(obj/item/I, mob/user)
+	if(I.flags & NODROP)
+		return
 	. = FALSE
 	if(istype(I, /obj/item/clothing/suit) && !suit)
 		suit = I

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -332,7 +332,7 @@
 		I.play_tool_sound(user, I.tool_volume)
 
 /obj/machinery/suit_storage_unit/proc/store_item(obj/item/I, mob/user)
-	if(I.flags & NODROP)
+	if(!user.canUnEquip(I))
 		return
 	. = FALSE
 	if(istype(I, /obj/item/clothing/suit) && !suit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can no longer store nodrop items in an SSU, creating a phantom copy of them.
This fixes #15596  as well.
Note that the issue existed even before #15540, that PR just made it more obvious as more items could now possibly be stored in an SSU.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Nodrop items, including borg tools, no longer fit in SSU storage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
