### PR TITLE
Removes camera alarms

### DIFF
--- a/code/controllers/subsystem/alarm.dm
+++ b/code/controllers/subsystem/alarm.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(alarm)
 	name = "Alarm"
 	flags = SS_NO_INIT | SS_NO_FIRE
-	var/list/alarms = list("Motion" = list(), "Fire" = list(), "Atmosphere" = list(), "Power" = list(), "Camera" = list(), "Burglar" = list())
+	var/list/alarms = list("Motion" = list(), "Fire" = list(), "Atmosphere" = list(), "Power" = list(), "Burglar" = list())
 
 /datum/controller/subsystem/alarm/proc/triggerAlarm(class, area/A, list/O, obj/alarmsource)
 	var/list/L = alarms[class]

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -66,7 +66,6 @@
 	if(istype(A))
 		A.motioncameras -= src
 	area_motion = null
-	cancelCameraAlarm()
 	cancelAlarm()
 	return ..()
 
@@ -86,7 +85,6 @@
 			var/thisemp = emped //Take note of which EMP this proc is for
 			spawn(900)
 				if(!QDELETED(src))
-					triggerCameraAlarm() //camera alarm triggers even if multiple EMPs are in effect.
 					if(emped == thisemp) //Only fix it if the camera hasn't been EMP'd again
 						network = previous_network
 						stat &= ~EMPED
@@ -94,9 +92,6 @@
 						if(can_use())
 							GLOB.cameranet.addCamera(src)
 						emped = 0 //Resets the consecutive EMP count
-						spawn(100)
-							if(!QDELETED(src))
-								cancelCameraAlarm()
 			for(var/mob/M in GLOB.player_list)
 				if(M.client && M.client.eye == src)
 					M.unset_machine()
@@ -229,7 +224,6 @@
 
 /obj/machinery/camera/obj_break(damage_flag)
 	if(status && !(flags & NODECONSTRUCT))
-		triggerCameraAlarm()
 		toggle_cam(null, FALSE)
 		wires.cut_all()
 
@@ -275,10 +269,6 @@
 	var/change_msg = "deactivates"
 	if(status)
 		change_msg = "reactivates"
-		triggerCameraAlarm()
-		spawn(100)
-			if(!QDELETED(src))
-				cancelCameraAlarm()
 	if(displaymessage)
 		if(user)
 			visible_message("<span class='danger'>[user] [change_msg] [src]!</span>")
@@ -297,14 +287,6 @@
 			O.unset_machine()
 			O.reset_perspective(null)
 			to_chat(O, "The screen bursts into static.")
-
-/obj/machinery/camera/proc/triggerCameraAlarm()
-	alarm_on = TRUE
-	SSalarm.triggerAlarm("Camera", get_area(src), list(UID()), src)
-
-/obj/machinery/camera/proc/cancelCameraAlarm()
-	alarm_on = FALSE
-	SSalarm.cancelAlarm("Camera", get_area(src), src)
 
 /obj/machinery/camera/proc/can_use()
 	if(!status)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	var/list/connected_robots = list()
 	var/aiRestorePowerRoutine = 0
 	//var/list/laws = list()
-	alarms_listend_for = list("Motion", "Fire", "Atmosphere", "Power", "Camera", "Burglar")
+	alarms_listend_for = list("Motion", "Fire", "Atmosphere", "Power", "Burglar")
 	var/viewalerts = 0
 	var/icon/holo_icon//Default is assigned when AI is created.
 	var/obj/mecha/controlled_mech //For controlled_mech a mech, to determine whether to relaymove or use the AI eye.

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -13,9 +13,9 @@
 	var/list/stating_laws = list()// Channels laws are currently being stated on
 	var/list/alarms_to_show = list()
 	var/list/alarms_to_clear = list()
-	var/list/alarm_types_show = list("Motion" = 0, "Fire" = 0, "Atmosphere" = 0, "Power" = 0, "Camera" = 0)
-	var/list/alarm_types_clear = list("Motion" = 0, "Fire" = 0, "Atmosphere" = 0, "Power" = 0, "Camera" = 0)
-	var/list/alarms_listend_for = list("Motion", "Fire", "Atmosphere", "Power", "Camera")
+	var/list/alarm_types_show = list("Motion" = 0, "Fire" = 0, "Atmosphere" = 0, "Power" = 0)
+	var/list/alarm_types_clear = list("Motion" = 0, "Fire" = 0, "Atmosphere" = 0, "Power" = 0)
+	var/list/alarms_listend_for = list("Motion", "Fire", "Atmosphere", "Power")
 	//var/list/hud_list[10]
 	var/list/speech_synthesizer_langs = list()	//which languages can be vocalized by the speech synthesizer
 	var/designation = ""
@@ -106,9 +106,6 @@
 		if(alarm_types_show["Power"])
 			msg += "POWER: [alarm_types_show["Power"]] alarms detected. - "
 
-		if(alarm_types_show["Camera"])
-			msg += "CAMERA: [alarm_types_show["Camera"]] alarms detected. - "
-
 		msg += "<A href=?src=[UID()];showalerts=1'>\[Show Alerts\]</a>"
 		var/msg_text = msg.Join("")
 		to_chat(src, msg_text)
@@ -131,9 +128,6 @@
 
 		if(alarm_types_clear["Power"])
 			msg += "POWER: [alarm_types_clear["Power"]] alarms cleared. - "
-
-		if(alarm_types_show["Camera"])
-			msg += "CAMERA: [alarm_types_clear["Camera"]] alarms cleared. - "
 
 		msg += "<A href=?src=[UID()];showalerts=1'>\[Show Alerts\]</a>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes camera alarms that AIs and borgs used to get whenever a camera was destroyed or deactivated.

Edit: motion sensor alarms are still a thing and not impacted by this in any way.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Two issues we have that keep being brought up are 1) validhunting AIs that seem to think they're a part of sec and need to redtext every antag and 2) the station (especially maint) being too small, with very little hidden space to do hidden things.

As long as you are in a room with a camera, you could be watched at any moment. Any kind of sneaky move you might try pulling could be totally undone because the AI just happens to scroll by. A major argument against letting AIs have multi-window view was that it simply made the AI too omnipresent. So why, exactly, do we let the AI know exactly when one of its eyes gets destroyed or deactivated? Shouldn't we reward and enable the smart counter-play of taking out cameras beforehand, preparing your crime scene?

SS13 is usually a game that rewards being prepared and having a plan. But taking out cameras at the moment is a total trap. Nothing screams 'please come arrest me' as much as destroying a camera, and you can bet that a sec borg or three are on their way as soon as you snip a single camera wire.

By allowing antags to create 'camera-dead' zones within the station where they can potentially commit crimes, we take some 'pressure' out of maint as well and give them more options.

Cameras can also be a big issue for biohazards. They are naturally restricted to nesting or setting up in places without cameras, because if they destroy a camera they are sure to be found. Now, a blob, xeno or tspider could feasibly find a remote room, smash the camera and set up a nest there. The AI still has a chance to notice the camera is gone by the hole in its perception, but that requires the AI player to be actively monitoring the situation and moving around, instead of giving him a giant, glaring 'check this out' sign.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
del: Camera alarms have been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
