### PR TITLE
Makes Tech Disks show what is loaded onto them

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -539,7 +539,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			// Somehow this href makes me very nervous
 			var/datum/tech/known = files.known_tech[params["id"]]
 			if(t_disk && known)
-				t_disk.stored = known
+				t_disk.load_tech(known)
 			menu = MENU_DISK
 			submenu = SUBMENU_MAIN
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -356,14 +356,14 @@ datum/tech/robotics
 	var/default_name = "\improper Technology Disk"
 	var/default_desc = "A disk for storing technology data for further research."
 
-/obj/item/disk/tech_disk/New()
-	..()
-	src.pixel_x = rand(-5.0, 5)
-	src.pixel_y = rand(-5.0, 5)
+/obj/item/disk/tech_disk/Initialize(mapload)
+	. = ..()
+	pixel_x = rand(-5, 5)
+	pixel_y = rand(-5, 5)
 
 /obj/item/disk/tech_disk/proc/load_tech(datum/tech/T)
 	name = "[default_name] \[[T]\]"
-	desc = T.desc + " Level: '[T.level]'"
+	desc = T.desc + "\n <span class='notice'>Level: [T.level]</span>"
 	// NOTE: This is just a reference to the tech on the system it grabbed it from
 	// This seems highly fragile
 	stored = T
@@ -384,8 +384,8 @@ datum/tech/robotics
 	var/default_name = "\improper Component Design Disk"
 	var/default_desc = "A disk for storing device design data for construction in lathes."
 
-/obj/item/disk/design_disk/New()
-	..()
+/obj/item/disk/design_disk/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Makes tech disks show their loaded tech level in their name and on examine.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The proc was already there, it just wasn't being used for some reason.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![disk](https://user-images.githubusercontent.com/57483089/109329110-1cc11780-7852-11eb-91d9-8c3f6ea6aa1c.PNG)

## Changelog
:cl:
tweak: Tech disks will now show what research is loaded onto them in their name. (e.g: Technology Disk [Combat Systems Research])
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
