### PR TITLE
Blood colouring in syringes

### DIFF
--- a/code/modules/reagents/chemistry/colors.dm
+++ b/code/modules/reagents/chemistry/colors.dm
@@ -16,14 +16,16 @@ GLOBAL_LIST_INIT(random_color_list, list("#00aedb","#a200ff","#f47835","#d41243"
 	for(var/datum/reagent/reagent in reagent_list)
 		if(reagent.id == "blood" && reagent.data && reagent.data["blood_color"])
 			reagent_color = reagent.data["blood_color"]
+		else if(reagent.id == "slimejelly" && reagent.data && reagent.data["colour"])
+			reagent_color = reagent.data["colour"]
 		else
 			reagent_color = reagent.color
 
 		vol_temp = reagent.volume
 		vol_counter += vol_temp
 
-		if(isnull(color))
-			color = reagent.color
+		if(isnull(color)) // `color` will always be null so I'm not sure what these `else`s are for.
+			color = reagent_color
 		else if(length(color) >= length(reagent_color))
 			color = BlendRGB(color, reagent_color, vol_temp/vol_counter)
 		else

--- a/code/modules/reagents/chemistry/colors.dm
+++ b/code/modules/reagents/chemistry/colors.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(random_color_list, list("#00aedb","#a200ff","#f47835","#d41243"
 		vol_temp = reagent.volume
 		vol_counter += vol_temp
 
-		if(isnull(color)) // `color` will always be null so I'm not sure what these `else`s are for.
+		if(isnull(color))
 			color = reagent_color
 		else if(length(color) >= length(reagent_color))
 			color = BlendRGB(color, reagent_color, vol_temp/vol_counter)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes a typo in the reagent colouring code in order to allow different blood colours to show correctly in reagent containers, primarily syringes.
Also allowed the same thing for slime jelly colouring, since that uses a slightly different system.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Aside from the obvious consistency benefits, this not being a feature in the first place was most likely just a typo. `reagent.color` rather than `reagent_color`.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
**BEFORE/AFTER:**
![Before](https://user-images.githubusercontent.com/57483089/109396785-13f04480-792b-11eb-8e23-bf5459b9fb38.png) ![Blood Colours](https://user-images.githubusercontent.com/57483089/109396581-3a61b000-792a-11eb-9d79-0f6fa2124701.png)

## Changelog
:cl:
tweak: Made the 'Blood' reagent show the species' blood colour. e.g. A syringe full of Skrell blood will be blue rather than red.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
