### PR TITLE
Fixes disposals pipe verbs being in the 'Commands' tab

### DIFF
--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -76,6 +76,7 @@
 // flip and rotate verbs
 /obj/structure/disposalconstruct/verb/rotate()
 	set name = "Rotate Pipe"
+	set category = "Object"
 	set src in view(1)
 
 	if(usr.stat)
@@ -98,6 +99,7 @@
 
 /obj/structure/disposalconstruct/verb/flip()
 	set name = "Flip Pipe"
+	set category = "Object"
 	set src in view(1)
 	if(usr.stat)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes the 'Flip Pipe' and 'Rotate Pipe' verbs for disposals pipes being in the 'Commands' tab for some reason, rather than the 'Object' tab like regular pipes.
Fixes #13942

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This has been in the game since *at least* 2011, how has nobody noticed until now. :eyes:

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
**Before:**
![Commands](https://user-images.githubusercontent.com/57483089/109408300-0fa24680-7980-11eb-9ed1-ea55a7eb2a98.PNG)

## Changelog
:cl:
fix: Fixed the 'Flip Pipe' and 'Rotate Pipe' verbs for disposals pipes being in the 'Commands' tab rather than 'Object'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
