### PR TITLE
Allows forcing of runechat colour for readability

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -54,8 +54,9 @@
 #define PREFTOGGLE_2_EMOTE_BUBBLE	256
 // Yes I know this being an "enable to disable" is misleading, but it avoids having to tweak all existing pref entries
 #define PREFTOGGLE_2_REVERB_DISABLE	512
+#define PREFTOGGLE_2_FORCE_WHITE_RUNECHAT	1024
 
-#define TOGGLES_2_TOTAL 			1023 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
+#define TOGGLES_2_TOTAL 			2047 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 
 #define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_2_DEATHMESSAGE|PREFTOGGLE_2_EMOTE_BUBBLE)
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -205,6 +205,8 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	var/gear_tab = "General"
 	// Parallax
 	var/parallax = PARALLAX_HIGH
+	/// Do we want to force our runechat colour to be white?
+	var/force_white_runechat = FALSE
 
 /datum/preferences/New(client/C)
 	parent = C

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -340,3 +340,11 @@
 	prefs.toggles2 ^= PREFTOGGLE_2_REVERB_DISABLE
 	prefs.save_preferences(src)
 	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_REVERB_DISABLE) ? "no longer" : "now"] get reverb on ingame sounds.")
+
+/client/verb/toggle_forced_white_runechat()
+	set name = "Toggle Runechat Colour Forcing"
+	set category = "Preferences"
+	set desc = "Toggles forcing your runechat colour to white"
+	prefs.toggles2 ^= PREFTOGGLE_2_FORCE_WHITE_RUNECHAT
+	prefs.save_preferences(src)
+	to_chat(src, "Your runechats will [(prefs.toggles2 & PREFTOGGLE_2_FORCE_WHITE_RUNECHAT) ? "no longer" : "now"] be forced to be white.")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1978,7 +1978,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
   * Basically just a quick redirect to the DNA handler that gets the species-specific colour handler
   */
 /mob/living/carbon/human/get_runechat_color()
-   return dna.species.get_species_runechat_color(src)
+	if(client?.prefs.toggles2 & PREFTOGGLE_2_FORCE_WHITE_RUNECHAT)
+		return "#FFFFFF" // Force white if they want it
+	return dna.species.get_species_runechat_color(src)
 
 /mob/living/carbon/human/update_runechat_msg_location()
 	if(ismecha(loc))


### PR DESCRIPTION
## What Does This PR Do
This PR adds a verb to force you to set your runechat colour to white
![image](https://user-images.githubusercontent.com/25063394/109425347-aeaa5b00-79df-11eb-9d4d-ac1ac8f91ea1.png)
![image](https://user-images.githubusercontent.com/25063394/109425350-b1a54b80-79df-11eb-8e78-1e06908cf5f7.png)

## Why It's Good For The Game
Having runechat based on character colour properties allows the chats to be easily identified to their speaker, however, if someone is playing a dark-skinned character (Default IPC or vulp colour), the runechats arent that readable. This PR allows them to opt into force-readable runechat.

## Changelog
:cl: AffectedArc07
add: You can now force your runechat colour to white if it is less than readable due to species colour properties. 
/:cl:
