### PR TITLE
Adds combat gloves plus, gives them to nukies.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -954,7 +954,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/combat_plus
 	name = "Combat Gloves Plus"
-	desc = "Combat gloves but with installed nanochips that teach you krav maga when worn, great as a cheap backup weapon"
+	desc = "Combat gloves but with installed nanochips that teach you krav maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC"
 	reference = "CGP"
 	item = /obj/item/clothing/gloves/color/black/krav_maga/combat
 	cost = 5

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -954,7 +954,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/combat_plus
 	name = "Combat Gloves Plus"
-	desc = "Combat gloves but with installed nanochips that teach you krav maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC"
+	desc = "Combat gloves but with installed nanochips that teach you Krav Maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC."
 	reference = "CGP"
 	item = /obj/item/clothing/gloves/color/black/krav_maga/combat
 	cost = 5

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -952,6 +952,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/toy/carpplushie/dehy_carp
 	cost = 2
 
+/datum/uplink_item/stealthy_weapons/combat_plus
+	name = "Combat Gloves Plus"
+	desc = "Combat gloves but with installed nanochips that teach you krav maga when worn, great as a cheap backup weapon"
+	reference = "CGP"
+	item = /obj/item/clothing/gloves/color/black/krav_maga/combat
+	cost = 5
+	gamemodes = list(/datum/game_mode/nuclear)
+
 // GRENADES AND EXPLOSIVES
 
 /datum/uplink_item/explosives

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -954,7 +954,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/combat_plus
 	name = "Combat Gloves Plus"
-	desc = "Combat gloves but with installed nanochips that teach you Krav Maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC."
+	desc = "Combat gloves with installed nanochips that teach you Krav Maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC."
 	reference = "CGP"
 	item = /obj/item/clothing/gloves/color/black/krav_maga/combat
 	cost = 5

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -135,12 +135,12 @@
 
 /obj/item/clothing/gloves/color/black/krav_maga/combat // for nukies
 	name = "combat gloves plus"
-	desc = "These combat gloves have been upgraded with nanochips that teach the wearer Krav Maga"
+	desc = "These combat gloves have been upgraded with nanochips that teach the wearer Krav Maga."
 	icon_state = "combat"
 	item_state = "swat_gl"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
-	strip_delay = 80
+	strip_delay = 8 SECONDS
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -132,3 +132,18 @@
 	desc = "These gloves can teach you to perform Krav Maga using nanochips."
 	icon_state = "fightgloves"
 	item_state = "fightgloves"
+
+/obj/item/clothing/gloves/color/black/krav_maga/combat // for nukies
+	name = "combat gloves plus"
+	desc = "These combat gloves have been upgraded with nanochips that teach the wearer Krav Maga"
+	icon_state = "combat"
+	item_state = "swat_gl"
+	siemens_coefficient = 0
+	permeability_coefficient = 0.05
+	strip_delay = 80
+	cold_protection = HANDS
+	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
+	heat_protection = HANDS
+	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	resistance_flags = NONE
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 50)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds combat gloves that teach you krav maga. Adds these gloves to the nukie uplink for 5tc

## Why It's Good For The Game
Gives nukies more variety in things that they can buy. Isn't too OP because it cannot be combined with gloves of the northstar. Makes fighting as/against nukies more varied. Also allows nukies to run fun gimmicks or as a backup weapon by running round leg sweeping people and stomping them to death.

## Changelog
:cl:
add: adds combat gloves plus, combat gloves that teach the wearer krav maga. Gives these gloves to nukies for 5tc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
