### PR TITLE
Nanomaps action tweaks

### DIFF
--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -5,10 +5,9 @@
 # -aa
 name: 'Render Nanomaps'
 on:
-  push:
-    branches: master
-    paths:
-      - '_maps/map_files/**'
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   generate_maps:
@@ -17,8 +16,13 @@ jobs:
     steps:
     - name: 'Update Branch'
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
+
+    - name: Branch
+      run: |
+        git fetch origin
+        git branch -f nanomap-render
+        git checkout nanomap-render
+        git reset --hard origin/master
 
     - name: 'Generate Maps'
       run: './tools/github-actions/nanomap-renderer-invoker.sh'
@@ -29,7 +33,20 @@ jobs:
         git config --local user.name "NanoMap Generation"
         git pull origin master
         git commit -m "NanoMap Auto-Update (`date`)" -a || true
+        git push -f -u origin nanomap-render
+
     - name: 'Push Maps'
       uses: ad-m/github-push-action@master
       with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create Pull Request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: "nanomap-render"
+        destination_branch: "master"
+        pr_title: "Automatic NanoMap Update"
+        pr_body: "This pull request updates the server NanoMaps. Please review the diff images before merging."
+        pr_label: "NanoMaps"
+        pr_allow_empty: false
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What Does This PR Do
This PR converts the Nanomap action into one which will create a PR, in the same way that the DMAPI action does. This has 2 benefits

1. People who have forked no longer need to disable actions to avoid spurious commits
2. This allows for branch protection rules to the repo master branch, as this is currently the last service which creates commits to the master branch

## Why It's Good For The Repo
Direct commits bad, branch protection good

## Changelog
N/A