### PR TITLE
Makes C Toggle Move Intents

### DIFF
--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -33,7 +33,7 @@
 			if("E")
 				quick_equip()
 				return
-			if("Alt")
+			if("C")
 				toggle_move_intent()
 				return
 	else
@@ -66,7 +66,7 @@
 			if("E")
 				quick_equip()
 				return
-			if("Alt")
+			if("C")
 				toggle_move_intent()
 				return
 		//Bodypart selections
@@ -139,7 +139,7 @@
 
 /mob/key_up(_key, client/user)
 	switch(_key)
-		if("Alt")
+		if("C")
 			toggle_move_intent()
 			return
 	return ..()


### PR DESCRIPTION
Makes C toggles intent on `key_down` and `key_up` instead of Alt.

Having alt toggle movement intents is just bad---alt is a defining click mechanism in the game that a lot of unique actions are tied to--suddenly having your intent toggled to walk, while you're using them, is non-sensical---it also leads to situations where using Alt-Click, on the fly, means you suddenly are moving at a snails pace---this just feels wrong and isn't intuitive at all.

:cl: Fox McCloud
tweak: Holding Alt no longer toggles walk/run intent
tweak: Holding C toggles walk/run intent
/:cl: