### PR TITLE
Reverts the Vox silent footstep removal

### DIFF
--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -23,7 +23,7 @@
 	eyes = "vox_eyes_s"
 
 	species_traits = list(NO_CLONESCAN, IS_WHITELISTED, NOTRANSSTING)
-	inherent_traits = list(TRAIT_NOGERMS, TRAIT_NODECAY)
+	inherent_traits = list(TRAIT_NOGERMS, TRAIT_NODECAY, TRAIT_SILENT_FOOTSTEPS)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS //Species-fitted 'em all.
 	dietflags = DIET_OMNI
 	bodyflags = HAS_ICON_SKIN_TONE | HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_BODY_MARKINGS | HAS_TAIL_MARKINGS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds `TRAIT_SILENT_FOOTSTEPS` to the Vox species in order to preserve their silent footsteps mechanic.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As stated on #15628, I feel that the removal of silent footsteps from Vox is completely unneccesary.
With the new footstep system in place silent footsteps *will* have an effect on gameplay, and I don't consider that a bad thing at all. 
Removing what is realistically the only mechanic that *isn't* immediately countered by a nerf just because "It actually gives a benefit to Vox players now" is not a valid excuse in my opinion.
All of the remaining features are in some way balanced to keep Vox as a very weak species, for example:
* Claws **|** +20% Brute Damage, so no real combat advantage.
* Immune to Decay **|** Doesn't actually make a difference without cloning.
* No germs or infections **|** Strongly countered by Strange Reagent, and in regular surgeries you could just inject Spacacillin.
* Able to process both Synthetic and Organic reagents **|** Honestly a pretty cool fluff feature, but almost useless since Synthetic reagents have the exact same effects as Organic, and nobody ever makes them.

Please note note that I am *not* complaining about these, or suggesting that Vox should have no downsides. Personally I don't really mind the malluses. My issue is that the only mechanical advantage to playing Vox has been removed without much thought. Even if it is a very small one.

I feel it would be much better for this mechanic to be voted on in a separate PR (This one), rather than attached to a popular change.
If this fails to go through then I'll accept that, but I want it to be considered on it's own merits.

## Changelog
:cl:
tweak: Reverted the Vox silent footstep removal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
