### PR TITLE
Mobs are removed from closets first

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -75,10 +75,14 @@
 
 /obj/structure/closet/proc/dump_contents()
 	var/turf/T = get_turf(src)
-	for(var/atom/movable/AM in src)
-		AM.forceMove(T)
+	for(var/mob/AM1 in src) //Does the same as below but removes the mobs first to avoid forcing players to step on items in the locker (e.g. soap) when opened.
+		AM1.forceMove(T)
 		if(throwing) // you keep some momentum when getting out of a thrown closet
-			step(AM, dir)
+			step(AM1, dir)
+	for(var/atom/movable/AM2 in src)
+		AM2.forceMove(T)
+		if(throwing) // you keep some momentum when getting out of a thrown closet
+			step(AM2, dir)
 	if(throwing)
 		throwing.finalize(FALSE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the dump_contents() proc to remove mobs from a closet before anything else. 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This fixes the soap locker exploit detailed in issue [#7533](https://github.com/ParadiseSS13/Paradise/issues/7533) which allows a player to keep a victim in a closet with a bar of soap. As items are always removed first (thanks to the structure of close()), a player that resists out of a closet with soap will be considered to have stepped on it,; this means that a victim in a closet will be tripped and give the captor more than enough time to put them back in the closet without any difficulty.
By making this change, the mob is moved there first then the soap (and other items) are moved to the tile. This prevents the issue.
Fixes #7533
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
tweak: Mobs are removed from closets before anything else.
fix: Soap in a locker exploit is now prevented.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
