### PR TITLE
Fixes Skrell Headpockets

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -332,8 +332,7 @@
 		if(slot_wear_mask in obscured)
 			dat += "<tr><td><font color=grey>&nbsp;&#8627;<B>Headpocket:</B></font></td><td><font color=grey>Obscured</font></td></tr>"
 		else
-			var/list/items = C.get_contents()
-			if(items.len)
+			if(C.held_item)
 				dat += "<tr><td>&nbsp;&#8627;<B>Headpocket:</B></td><td><A href='?src=[UID()];dislodge_headpocket=1'>Dislodge Items</A></td></tr>"
 			else
 				dat += "<tr><td>&nbsp;&#8627;<B>Headpocket:</B></td><td><font color=grey>Empty</font></td></tr>"

--- a/code/modules/surgery/organs/subtypes/skrell.dm
+++ b/code/modules/surgery/organs/subtypes/skrell.dm
@@ -23,18 +23,18 @@
 	..()
 	var/obj/item/organ/external/head/head = owner.get_organ("head")
 	if(held_item && !findtextEx(head.h_style, "Tentacles"))
-		owner.visible_message("<span class='notice'>[held_item] falls from [owner]'s [src]!</span>", "<span class='notice'>[held_item] falls from your [src]!</span>")
+		owner.visible_message("<span class='notice'>[held_item] falls from [owner]'s [name]!</span>", "<span class='notice'>[held_item] falls from your [name]!</span>")
 		empty_contents()
 
 /obj/item/organ/internal/headpocket/ui_action_click()
 	if(held_item)
-		owner.visible_message("<span class='notice'>[owner] removes [held_item] from [owner.p_their()] [src].</span>", "<span class='notice'>You remove [held_item] from your [src].</span>")
+		owner.visible_message("<span class='notice'>[owner] removes [held_item] from [owner.p_their()] [name].</span>", "<span class='notice'>You remove [held_item] from your [name].</span>")
 		owner.put_in_hands(held_item)
 		held_item = null
 	else
 		var/obj/item/I = owner.get_active_hand()
 		if(I && I.w_class <= WEIGHT_CLASS_SMALL && !istype(I, /obj/item/disk/nuclear) && owner.unEquip(I))
-			owner.visible_message("<span class='notice'>[owner] places [I] into [owner.p_their()] [src].</span>", "<span class='notice'>You place [I] into your [src].</span>")
+			owner.visible_message("<span class='notice'>[owner] places [I] into [owner.p_their()] [name].</span>", "<span class='notice'>You place [I] into your [name].</span>")
 			I.forceMove(src)
 			held_item = I
 

--- a/code/modules/surgery/organs/subtypes/skrell.dm
+++ b/code/modules/surgery/organs/subtypes/skrell.dm
@@ -9,42 +9,34 @@
 	icon = 'icons/obj/species_organs/skrell.dmi'
 	icon_state = "skrell_headpocket"
 	origin_tech = "biotech=2"
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_SMALL
 	parent_organ = "head"
 	slot = "headpocket"
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
-	var/obj/item/storage/internal/pocket
-
-/obj/item/organ/internal/headpocket/New()
-	pocket = new /obj/item/storage/internal(src)
-	pocket.storage_slots = 1
-	// Fit only pocket sized items
-	pocket.max_w_class = WEIGHT_CLASS_SMALL
-	pocket.max_combined_w_class = 2
-	..()
+	var/obj/item/held_item
 
 /obj/item/organ/internal/headpocket/Destroy()
-	QDEL_NULL(pocket)
-	return ..()
-
-/obj/item/organ/internal/headpocket/insert(mob/living/carbon/M, special = FALSE, dont_remove_slot = 0)
-	. = ..()
-	pocket.master_item = M // So headpockets work with adjacency checks
-
-/obj/item/organ/internal/headpocket/remove(mob/living/carbon/M, special = 0)
-	pocket.master_item = src
+	QDEL_NULL(held_item)
 	return ..()
 
 /obj/item/organ/internal/headpocket/on_life()
 	..()
 	var/obj/item/organ/external/head/head = owner.get_organ("head")
-	if(pocket.contents.len && !findtextEx(head.h_style, "Tentacles"))
-		owner.visible_message("<span class='notice'>Something falls from [owner]'s head!</span>",
-													"<span class='notice'>Something falls from your head!</span>")
+	if(held_item && !findtextEx(head.h_style, "Tentacles"))
+		owner.visible_message("<span class='notice'>[held_item] falls from [owner]'s [src]!</span>", "<span class='notice'>[held_item] falls from your [src]!</span>")
 		empty_contents()
 
 /obj/item/organ/internal/headpocket/ui_action_click()
-	pocket.MouseDrop(owner)
+	if(held_item)
+		owner.visible_message("<span class='notice'>[owner] removes [held_item] from [owner.p_their()] [src].</span>", "<span class='notice'>You remove [held_item] from your [src].</span>")
+		owner.put_in_hands(held_item)
+		held_item = null
+	else
+		var/obj/item/I = owner.get_active_hand()
+		if(I && I.w_class <= WEIGHT_CLASS_SMALL && !istype(I, /obj/item/disk/nuclear) && owner.unEquip(I))
+			owner.visible_message("<span class='notice'>[owner] places [I] into [owner.p_their()] [src].</span>", "<span class='notice'>You place [I] into your [src].</span>")
+			I.forceMove(src)
+			held_item = I
 
 /obj/item/organ/internal/headpocket/on_owner_death()
 	empty_contents()
@@ -54,22 +46,20 @@
 	. = ..()
 
 /obj/item/organ/internal/headpocket/proc/empty_contents()
-	for(var/obj/item/I in pocket.contents)
-		pocket.remove_from_storage(I, get_turf(owner))
-
-/obj/item/organ/internal/headpocket/proc/get_contents()
-	return pocket.contents
+	if(held_item)
+		held_item.forceMove(get_turf(owner))
+		held_item = null
 
 /obj/item/organ/internal/headpocket/emp_act(severity)
-	pocket.emp_act(severity)
+	held_item.emp_act(severity)
 	..()
 
-/obj/item/organ/internal/headpocket/hear_talk(mob/living/M as mob, list/message_pieces)
-	pocket.hear_talk(M, message_pieces)
+/obj/item/organ/internal/headpocket/hear_talk(mob/living/M, list/message_pieces)
+	held_item.hear_talk(M, message_pieces)
 	..()
 
-/obj/item/organ/internal/headpocket/hear_message(mob/living/M as mob, msg)
-	pocket.hear_message(M, msg)
+/obj/item/organ/internal/headpocket/hear_message(mob/living/M, msg)
+	held_item.hear_message(M, msg)
 	..()
 
 /obj/item/organ/internal/heart/skrell


### PR DESCRIPTION
Fixes Skrell headpockets misbehaving.

Skrell headpockets are no longer explicitly a storage subtype that has internal storage; instead if just uses a holder var to hold the item.

I'd have to rewrite some click code and storage code for headpockets to work properly, and that's just not feasible just to fix a feature for *one* species, at the moment.

Also, you'll no longer be able to hold the nuke disk in the headpocket, because, you never should have to begin with; hidden storage tpyically bars it, specifically.

fixes: https://github.com/ParadiseSS13/Paradise/issues/15659

:cl: Fox McCloud
fix: Fixes skrell headpocket weirdness
fix: Fixes being able to hide nuke disk in the Skrell headpocket
/:cl: