### PR TITLE
Fixes `rank` being a reserved SQL keyword

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -159,7 +159,7 @@ DROP TABLE IF EXISTS `admin`;
 CREATE TABLE `admin` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `ckey` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `rank` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'Administrator',
+  `admin_rank` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'Administrator',
   `level` int(2) NOT NULL DEFAULT '0',
   `flags` int(16) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),

--- a/SQL/paradise_schema_prefixed.sql
+++ b/SQL/paradise_schema_prefixed.sql
@@ -158,7 +158,7 @@ DROP TABLE IF EXISTS `SS13_admin`;
 CREATE TABLE `SS13_admin` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `ckey` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `rank` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'Administrator',
+  `admin_rank` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'Administrator',
   `level` int(2) NOT NULL DEFAULT '0',
   `flags` int(16) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),

--- a/SQL/updates/21-22.sql
+++ b/SQL/updates/21-22.sql
@@ -1,0 +1,4 @@
+# Updating DB from 21-22, -AffectedArc07
+# Changes `rank` to `admin_rank` to remove use of reserved keyword
+
+ALTER TABLE `admin` CHANGE COLUMN `rank` `admin_rank` VARCHAR(32) NOT NULL DEFAULT 'Administrator' COLLATE 'utf8mb4_unicode_ci' AFTER `ckey`;

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -363,7 +363,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 21
+#define SQL_VERSION 22
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -117,7 +117,7 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 			load_admins()
 			return
 
-		var/datum/db_query/query = SSdbcore.NewQuery("SELECT ckey, rank, level, flags FROM [format_table_name("admin")]")
+		var/datum/db_query/query = SSdbcore.NewQuery("SELECT ckey, admin_rank, level, flags FROM [format_table_name("admin")]")
 		if(!query.warn_execute(async=run_async))
 			qdel(query)
 			return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -696,7 +696,7 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 			return
 
 		var/datum/db_query/rank_read = SSdbcore.NewQuery(
-			"SELECT rank FROM [format_table_name("admin")] WHERE ckey=:ckey",
+			"SELECT admin_rank FROM [format_table_name("admin")] WHERE ckey=:ckey",
 			list("ckey" = ckey)
 		)
 
@@ -722,7 +722,7 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 				return
 
 			var/datum/db_query/admin_read = SSdbcore.NewQuery(
-				"SELECT ckey, rank, flags FROM [format_table_name("admin")] WHERE ckey=:ckey",
+				"SELECT ckey, admin_rank, flags FROM [format_table_name("admin")] WHERE ckey=:ckey",
 				list("ckey" = ckey)
 			)
 

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -90,7 +90,7 @@
 	qdel(select_query)
 	flag_account_for_forum_sync(adm_ckey)
 	if(new_admin)
-		var/datum/db_query/insert_query = SSdbcore.NewQuery("INSERT INTO [format_table_name("admin")] (`id`, `ckey`, `rank`, `level`, `flags`) VALUES (null, :adm_ckey, :new_rank, -1, 0)", list(
+		var/datum/db_query/insert_query = SSdbcore.NewQuery("INSERT INTO [format_table_name("admin")] (`id`, `ckey`, `admin_rank`, `level`, `flags`) VALUES (null, :adm_ckey, :new_rank, -1, 0)", list(
 			"adm_ckey" = adm_ckey,
 			"new_rank" = new_rank
 		))
@@ -113,7 +113,7 @@
 		to_chat(usr, "<span class='notice'>New admin added.</span>")
 	else
 		if(!isnull(admin_id) && isnum(admin_id))
-			var/datum/db_query/insert_query = SSdbcore.NewQuery("UPDATE [format_table_name("admin")] SET rank=:new_rank WHERE id=:admin_id", list(
+			var/datum/db_query/insert_query = SSdbcore.NewQuery("UPDATE [format_table_name("admin")] SET admin_rank=:new_rank WHERE id=:admin_id", list(
 				"new_rank" = new_rank,
 				"admin_id" = admin_id,
 			))

--- a/config/example/dbconfig.txt
+++ b/config/example/dbconfig.txt
@@ -9,7 +9,7 @@
 ## This value must be set to the version of the paradise schema in use.
 ## If this value does not match, the SQL database will not be loaded and an error will be generated.
 ## Roundstart will be delayed.
-DB_VERSION 21
+DB_VERSION 22
 
 ## Server the MySQL database can be found at.
 # Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.

--- a/tools/ci/dbconfig.txt
+++ b/tools/ci/dbconfig.txt
@@ -2,7 +2,7 @@
 # Dont use it ingame
 # Remember to update this when you increase the SQL version! -aa
 SQL_ENABLED
-DB_VERSION 21
+DB_VERSION 22
 ADDRESS 127.0.0.1
 PORT 3306
 FEEDBACK_DATABASE feedback


### PR DESCRIPTION
## What Does This PR Do
Tweaks the DB schema `admin` table to use `admin_rank` instead of `rank`, since `rank` is a reserved keyword in MySQL.

Fixes #10568

Ranks still load
![image](https://user-images.githubusercontent.com/25063394/109997091-c4818e00-7d07-11eb-900f-e43af41dc531.png)
![image](https://user-images.githubusercontent.com/25063394/109997115-c9ded880-7d07-11eb-9703-6bfcec7cbad8.png)

## Why It's Good For The Game
People shouldnt be confined to using MariaDB, even though it is the superior SQL server.

## Changelog
:cl: AffectedArc07
fix: The DB schema no longer requires MariaDB, it will work with plain MySQL again. 
/:cl:
