### PR TITLE
Makes random teleporter teleports more random

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -401,7 +401,9 @@
 		if(!calibrated && com.cc_beacon)
 			visible_message("<span class='alert'>Cannot lock on target. Please calibrate the teleporter before attempting long range teleportation.</span>")
 		else if(!calibrated && prob(25 - ((accurate) * 10)) && !com.cc_beacon) //oh dear a problem
-			. = do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2, bypass_area_flag = com.area_bypass)
+			var/list/target_z = levels_by_trait(REACHABLE)
+			target_z -= M.z //Where to sir? Anywhere but here.
+			. = do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), pick(target_z)), 2, bypass_area_flag = com.area_bypass)
 		else
 			. = do_teleport(M, com.target, bypass_area_flag = com.area_bypass)
 		calibrated = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR selects all reachable zlvls (2, 3, 5, 6, 7, 8, 9, which is station, mining, random space 1, random space 2, random space 3, random space 4, and empty space), when a person rolls the random teleport chance from not calibrating the teleporter, and selects one of them, not including the zlvl they are on, to be the zlvl they teleport to, instead of always z3

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The random teleport always being a random zlvl, instead of always lavaland, makes it a little bit more interesting, and also meaning that someone with a hand teleporter that ends up on lavaland cant instantly teleport back out, only taking a tiny bit of damage from not breathing, and instead taking some space damage.

## Changelog
:cl:
tweak: An un-calibrated teleporter sends you to a random reachable zlvl, instead of always lavaland.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
