### PR TITLE
Fixes shadow walk spamming chat messages every time you move

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -80,10 +80,12 @@
 	var/blacklisted_lights = list(/obj/item/flashlight/flare, /obj/item/flashlight/slime)
 	action_icon_state = "veil"
 
-/obj/effect/proc_holder/spell/aoe_turf/veil/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/aoe_turf/veil/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/user = usr)
 	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
+		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/spell/aoe_turf/veil/cast(list/targets, mob/user = usr)
 	to_chat(user, "<span class='shadowling'>You silently disable all nearby lights.</span>")
 	for(var/obj/structure/glowshroom/G in orange(2, user)) //Why the fuck was this in the loop below?
 		G.visible_message("<span class='warning'>[G] withers away!</span>")
@@ -103,10 +105,12 @@
 	include_user = 1
 	action_icon_state = "shadow_walk"
 
-/obj/effect/proc_holder/spell/targeted/shadow_walk/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/targeted/shadow_walk/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/user = usr)
 	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
+		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/spell/targeted/shadow_walk/cast(list/targets, mob/user = usr)
 	for(var/mob/living/target in targets)
 		playsound(user.loc, 'sound/effects/bamf.ogg', 50, 1)
 		target.visible_message("<span class='warning'>[target] vanishes in a puff of black mist!</span>", "<span class='shadowling'>You enter the space between worlds as a passageway.</span>")
@@ -176,10 +180,12 @@
 	clothes_req = 0
 	action_icon_state = "icy_veins"
 
-/obj/effect/proc_holder/spell/aoe_turf/flashfreeze/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/aoe_turf/flashfreeze/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
 	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
+		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/spell/aoe_turf/flashfreeze/cast(list/targets, mob/user = usr)
 	to_chat(user, "<span class='shadowling'>You freeze the nearby air.</span>")
 	playsound(user.loc, 'sound/effects/ghost2.ogg', 50, 1)
 
@@ -215,8 +221,11 @@
 	selection_deactivated_message	= "<span class='notice'>Your mind relaxes.</span>"
 	allowed_type = /mob/living/carbon/human
 
-/obj/effect/proc_holder/spell/targeted/click/enthrall/can_cast(mob/user = usr, charge_check = TRUE, show_message = FALSE)
-	if(enthralling || !shadowling_check(user))
+/obj/effect/proc_holder/spell/targeted/click/enthrall/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
+	if(enthralling)
+		to_chat(user, "<span class='warning'>You're already enthralling someone!</span>")
+		return FALSE
+	if(!shadowling_check(user))
 		return FALSE
 	return ..()
 
@@ -311,10 +320,12 @@
 	var/reviveThrallAcquired
 	action_icon_state = "collective_mind"
 
-/obj/effect/proc_holder/spell/targeted/collective_mind/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/targeted/collective_mind/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
 	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
+		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/spell/targeted/collective_mind/cast(list/targets, mob/user = usr)
 	for(var/mob/living/target in targets)
 		var/thralls = 0
 		var/victory_threshold = SSticker.mode.required_thralls
@@ -386,10 +397,12 @@
 	include_user = 1
 	action_icon_state = "black_smoke"
 
-/obj/effect/proc_holder/spell/targeted/blindness_smoke/cast(list/targets, mob/user = usr) //Extremely hacky
+/obj/effect/proc_holder/spell/targeted/blindness_smoke/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
 	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
+		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/spell/targeted/blindness_smoke/cast(list/targets, mob/user = usr) //Extremely hacky
 	for(var/mob/living/target in targets)
 		target.visible_message("<span class='warning'>[target] suddenly bends over and coughs out a cloud of black smoke, which begins to spread rapidly!</span>")
 		to_chat(target, "<span class='deadsay'>You regurgitate a vast cloud of blinding smoke.</span>")
@@ -435,10 +448,12 @@
 	clothes_req = 0
 	action_icon_state = "screech"
 
-/obj/effect/proc_holder/spell/aoe_turf/unearthly_screech/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/aoe_turf/unearthly_screech/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
 	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
+		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/spell/aoe_turf/unearthly_screech/cast(list/targets, mob/user = usr)
 	user.audible_message("<span class='warning'><b>[user] lets out a horrible scream!</b></span>")
 	playsound(user.loc, 'sound/effects/screech.ogg', 100, 1)
 
@@ -472,11 +487,12 @@
 	clothes_req = FALSE
 	action_icon_state = "null_charge"
 
-/obj/effect/proc_holder/spell/aoe_turf/null_charge/cast(mob/user = usr)
+/obj/effect/proc_holder/spell/aoe_turf/null_charge/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
 	if(!shadowling_check(user))
-		charge_counter = charge_max
-		return
+		return FALSE
+	return ..()
 
+/obj/effect/proc_holder/spell/aoe_turf/null_charge/cast(mob/user = usr)
 	var/list/local_objs = view(1, user)
 	var/obj/machinery/power/apc/target_apc
 	for(var/object in local_objs)
@@ -532,7 +548,7 @@
 	selection_deactivated_message	= "<span class='notice'>Your mind relaxes.</span>"
 	allowed_type = /mob/living/carbon/human
 
-/obj/effect/proc_holder/spell/targeted/click/reviveThrall/can_cast(mob/user = usr)
+/obj/effect/proc_holder/spell/targeted/click/reviveThrall/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
 	if(!shadowling_check(user))
 		return FALSE
 	return ..()
@@ -622,9 +638,12 @@
 	action_icon_state = "extend_shuttle"
 	var/global/extendlimit = 0
 
-/obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/can_cast(mob/user = usr, charge_check = TRUE, show_message = FALSE)
+/obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
 	if(!shadowling_check(user))
 		return FALSE
+	return ..()
+
+/obj/effect/proc_holder/spell/targeted/click/shadowling_extend_shuttle/can_cast(mob/user = usr, charge_check = TRUE, show_message = FALSE)
 	if(extendlimit == 1)
 		if(show_message)
 			to_chat(user, "<span class='warning'>Shuttle was already delayed.</span>")

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -122,10 +122,13 @@ GLOBAL_LIST_INIT(possibleShadowlingNames, list("U'ruan", "Y`shej", "Nex", "Hel-u
 	include_user = 1
 	action_icon_state = "ascend"
 
+/obj/effect/proc_holder/spell/targeted/shadowling_ascend/cast_check(charge_check = TRUE, start_recharge = TRUE, mob/living/user = usr)
+	if(!shadowling_check(user))
+		return FALSE
+	return ..()
+
 /obj/effect/proc_holder/spell/targeted/shadowling_ascend/cast(list/targets, mob/user = usr)
 	var/mob/living/carbon/human/H = user
-	if(!shadowling_check(H))
-		return
 	for(H in targets)
 		var/hatch_or_no = alert(H,"It is time to ascend. Are you sure about this?",,"Yes","No")
 		switch(hatch_or_no)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This was a weird one. The issue here was that for **every tile** you move while in shadow walk, a long proc call stack is executed, ultimately calling for updates on each of your spells/action buttons to make sure you can still use them. Some of these spells, like enthrall, were problematic because they had `shadowling_check()` inside of `can_cast()`, and because your `incorporeal_move` is set to true, `shadowling_check()` would spam you with tons of messages.

(Call stack is executed from bottom to top)
![image](https://user-images.githubusercontent.com/42044220/110193376-279f1d80-7df9-11eb-8a7b-1701ed979fc0.png)


This PR fixes this issue and additionally standardizes all shadowling spells which used `shadowling_check()` and moves it to `cast_check()` to avoid the above issue.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes  #15309
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes shadow walk spamming chat messages every time you move
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
