### PR TITLE
Fixes the shielded hardsuits helmet sprite and armour.

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -601,6 +601,12 @@
 	return mutable_appearance('icons/effects/effects.dmi', shield_state, MOB_LAYER + 0.01)
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded
+	name = "shielded hardsuit helmet"
+	desc = "A hardsuit helmet with built in energy shielding. Will rapidly recharge when not under fire."
+	icon_state = "hardsuit0-sec"
+	item_state = "sec_helm"
+	item_color = "sec"
+	armor = list("melee" = 30, "bullet" = 15, "laser" = 30, "energy" = 10, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the shielded hardsuit sprite to be a sec hardsuit helmet instead of an engi hardsuit helmet. 
Also alters the armour values to be in line with the suit.

## Why It's Good For The Game
Denthamos brought it up in #15652 .
the sprite probably should be correct.
the helmet should also probably have the same armour values as the helmet.


## Changelog
:cl:
fix: shielded hardsuit helmet has the proper sprite
fix: shielded hardsuit helmet has the proper armour values
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
