### PR TITLE
fixes tile atmos overlays going invisible

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -273,6 +273,7 @@
 	var/atmos_overlay = get_atmos_overlay_by_name(atmos_overlay_type)
 	if(atmos_overlay)
 		vis_contents -= atmos_overlay
+		atmos_overlay_type = null
 
 	atmos_overlay = get_atmos_overlay_by_name(new_overlay_type)
 	if(atmos_overlay)


### PR DESCRIPTION
:cl: anon
fix: Tile atmospheric overlays (plasma and n2o) can no longer become invisible
/:cl:
