### PR TITLE
Tasers have a brief slowdown period before stun.

### DIFF
--- a/code/game/gamemodes/changeling/powers/epinephrine.dm
+++ b/code/game/gamemodes/changeling/powers/epinephrine.dm
@@ -24,6 +24,7 @@
 	user.update_canmove()
 	user.reagents.add_reagent("synaptizine", 20)
 	user.adjustStaminaLoss(-75)
+	user.SetSlowed(0)
 
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return 1

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -158,6 +158,7 @@
 	user.SetParalysis(0)
 	user.SetSleeping(0)
 	U.adjustStaminaLoss(-75)
+	user.SetSlowed(0)
 	to_chat(user, "<span class='notice'>You instill your body with clean blood and remove any incapacitating effects.</span>")
 	spawn(1)
 		if(usr.mind.vampire.get_ability(/datum/vampire_passive/regen))

--- a/code/game/objects/items/weapons/implants/implant_misc.dm
+++ b/code/game/objects/items/weapons/implants/implant_misc.dm
@@ -41,6 +41,7 @@
 	imp_in.adjustStaminaLoss(-75)
 	imp_in.lying = 0
 	imp_in.update_canmove()
+	imp_in.SetSlowed(0)
 
 	imp_in.reagents.add_reagent("synaptizine", 10)
 	imp_in.reagents.add_reagent("omnizine", 10)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -11,8 +11,6 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 	nodamage = 1
-	stun = 5
-	weaken = 5
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/tase.ogg'
@@ -21,11 +19,13 @@
 
 /obj/item/projectile/energy/electrode/on_hit(var/atom/target, var/blocked = 0)
 	. = ..()
+	var/mob/living/carbon/C = target
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, 1, src)
 	else if(iscarbon(target))
-		var/mob/living/carbon/C = target
 		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK, 33)
+		C.Slowed(3)
+		addtimer(CALLBACK(C, /mob/living/.proc/Weaken, 3), 4 SECONDS)
 		if(HAS_TRAIT(C, TRAIT_HULK))
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 		else if(C.status_flags & CANWEAKEN)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -19,10 +19,10 @@
 
 /obj/item/projectile/energy/electrode/on_hit(var/atom/target, var/blocked = 0)
 	. = ..()
-	var/mob/living/carbon/C = target
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, 1, src)
 	else if(iscarbon(target))
+		var/mob/living/carbon/C = target
 		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK, 33)
 		C.Slowed(3)
 		addtimer(CALLBACK(C, /mob/living/.proc/Weaken, 3), 4 SECONDS)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -917,6 +917,7 @@
 	update_flags |= M.AdjustStunned(-3, FALSE)
 	update_flags |= M.AdjustWeakened(-3, FALSE)
 	update_flags |= M.adjustStaminaLoss(-5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	update_flags |= M.AdjustSlowed(-2, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/stimulative_agent/on_mob_delete(mob/living/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tasers now apply slowdown, then stun after a delay.
Antag antistun powers (rejuv, adrenals, epi OD) now removes slowdown aswell.
## Why It's Good For The Game
Tasers are not a healthy mechanic in the game. Many people hate ranged instant stuns because they are far too strong. Clicking on an antag once from a ranged and them losing is not interesting gameplay. This PR helps to reduce this by 1) nerfing how much tasers actually stun from 8-10 seconds to 4-6. and 2) giving the person who is shot by the taser a 4 second window to react with their own stun/getaway option. Sec now actually has to tase then get close and baton them. Hopefully this will reduce the amount of antags that just get game ended by one click. 

This will also help reduce the cliché of a powered vamp getting 3 aegs and being uncatchable by sec because they instantly tase whoever walks near them. 


## Changelog
:cl:
tweak: tasers now stun after a 4 second period of slowdown
tweak: antag antistun powers now remove slowdown
tweak: tasers now have reduced stun times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
