### PR TITLE
Fixes dead AIs making cryo announcements

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -431,8 +431,11 @@
 	control_computer.frozen_crew += "[occupant.real_name]"
 
 	var/list/ailist = list()
-	for(var/mob/living/silicon/ai/A in GLOB.silicon_mob_list)
-		ailist += A
+	for(var/thing in GLOB.ai_list)
+		var/mob/living/silicon/ai/AI = thing
+		if(AI.stat)
+			continue
+		ailist += AI
 	if(length(ailist))
 		var/mob/living/silicon/ai/announcer = pick(ailist)
 		if(announce_rank)
@@ -441,7 +444,7 @@
 			announcer.say(";[occupant.real_name] [on_store_message]", ignore_languages = TRUE)
 	else
 		if(announce_rank)
-			announce.autosay("[occupant.real_name]  ([announce_rank]) [on_store_message]", "[on_store_name]")
+			announce.autosay("[occupant.real_name] ([announce_rank]) [on_store_message]", "[on_store_name]")
 		else
 			announce.autosay("[occupant.real_name] [on_store_message]", "[on_store_name]")
 	visible_message("<span class='notice'>[src] hums and hisses as it moves [occupant.real_name] into storage.</span>")

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -33,6 +33,6 @@
 
 /mob/dead/observer/handle_speaker_name(var/mob/speaker = null, var/vname, var/hard_to_hear)
 	var/speaker_name = ..()
-	if(speaker && (speaker_name != speaker.real_name) && !isAI(speaker)) //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
+	if(speaker && (speaker_name != speaker.real_name) && !isAI(speaker) && !istype(speaker, /mob/living/automatedannouncer)) //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
 		speaker_name = "[speaker.real_name] ([speaker_name])"
 	return speaker_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Fixes dead AIs making cryo announcements
  - Fixes #15694
- Opportunistic fixes:
  - Double space removal on specific cryo message (no AI, has a job)
  - Automated announcements no longer appear as ` (NAME)`

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fix

## Changelog
:cl:
fix: Fix AIs making cryo storage announcements from the grave
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
