### PR TITLE
Allows health scanners / ghosts to see cybernetic organs in health scan

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -239,9 +239,9 @@ REAGENT SCANNER
 
 	to_chat(user, "<span class='notice'>Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span>")
 	var/implant_detect
-	for(var/obj/item/organ/internal/cyberimp/CI in H.internal_organs)
-		if(CI.is_robotic())
-			implant_detect += "[H.name] is modified with a [CI.name].<br>"
+	for(var/obj/item/organ/internal/O in H.internal_organs)
+		if(O.is_robotic())
+			implant_detect += "[H.name] is modified with a [O.name].<br>"
 	if(implant_detect)
 		to_chat(user, "<span class='notice'>Detected cybernetic modifications:</span>")
 		to_chat(user, "<span class='notice'>[implant_detect]</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->


Changes the healthscan proc to check for all cybernetic organs, instead of just cybernetic implants, which is used by health scanners and the ghost health scan.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Just a small tweak, as if a health scanner, advanced or standard, can detect cybernetic implants, it can probably detect cybernetic organs as well. This does not tell the scanner if the organs are damaged. Also good for admins who want to see if someone has thermals / xray like they could before, without having to view variables on someone.


## Changelog
:cl:
tweak: Health scanners / ghosts can detect all cybernetic organs in a person, instead of just cybernetic implants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
