### PR TITLE
Fixes an exploit with martial arts duping through boxing gloves/wardens gloves etc

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -144,6 +144,7 @@
 	H.verbs -= /mob/living/carbon/human/proc/martial_arts_help
 	if(base)
 		base.teach(H)
+		base = null
 
 /mob/living/carbon/human/proc/martial_arts_help()
 	set name = "Show Info"


### PR DESCRIPTION
## What Does This PR Do
Fixes: #15710

## Why It's Good For The Game
Exploits be gone


## Changelog
:cl:
fix: Boxing gloves or the wardens gloves now won't dupe martial arts
/:cl: