### PR TITLE
Restricts "Delete All Security Records" to Magistrate or Armory access.

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -248,14 +248,19 @@
 			update_all_mob_security_hud()
 			set_temp("Security record deleted.")
 		if("delete_security_all") // Delete All Security Records
+			var/datum/ui_login/state = ui_login_get()
 			if(!logged_in)
 				return
-			for(var/datum/data/record/S in GLOB.data_core.security)
-				qdel(S)
-			message_admins("[key_name_admin(usr)] has deleted all security records at [ADMIN_COORDJMP(usr)]")
-			usr.create_log(MISC_LOG, "deleted all security records")
-			update_all_mob_security_hud()
-			set_temp("All security records deleted.")
+			if((ACCESS_MAGISTRATE in state.access) || (ACCESS_ARMORY in state.access))
+				for(var/datum/data/record/S in GLOB.data_core.security)
+					qdel(S)
+				message_admins("[key_name_admin(usr)] has deleted all security records at [ADMIN_COORDJMP(usr)]")
+				usr.create_log(MISC_LOG, "deleted all security records")
+				update_all_mob_security_hud()
+				set_temp("All security records deleted.")
+			else
+				set_temp("Insufficient permissions to delete all records!")
+				return
 		if("delete_cell_logs") // Delete All Cell Logs
 			if(!logged_in)
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR means only ID's with magistrate or armory access can use the "Delete All Security Records" option.
Regular sec ID's can still delete individual records.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stealing an ID to delete your (or a friend/enemy's) sec record is a valid antag tactic, and should not be changed.
However, the only thing that the option to delete all records does is harm security's ability to do anything useful with their HUDs until the records are manually re-created, one by one. This can take one user a significant amount of time, and the antagonist can just delete them all again in an instant.
Having it restricted to Magistrate/HoS/Warden/Captain/HoP (or any other ID with magistrate/armory access) will reduce the amount of cheese and "dickish" behaviour, but still leave it open for antags who can get their hands on such an ID.
It also does not stop antags that want to spend the time deleting records one by one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: "Delete All Security Records" now requires magistrate or armory access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
