### PR TITLE
fixes firelocks et al. preventing the movement of air

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -284,14 +284,8 @@ SUBSYSTEM_DEF(air)
 			add_to_active(S)
 
 /datum/controller/subsystem/air/proc/setup_allturfs(list/turfs_to_init = block(locate(1, 1, 1), locate(world.maxx, world.maxy, world.maxz)))
-	var/list/active_turfs = src.active_turfs
-
-	// Clear active turfs - faster than removing every single turf in the world
-	// one-by-one, and Initalize_Atmos only ever adds `src` back in.
-	active_turfs.Cut()
-
-	for(var/thing in turfs_to_init)
-		var/turf/T = thing
+	for(var/turf/T as anything in turfs_to_init)
+		remove_from_active(T)
 		if(T.blocks_air)
 			continue
 		T.Initialize_Atmos(times_fired)


### PR DESCRIPTION
certain objects like firelocks, single-pane windows, windoors, and potentially others would prevent the movement of air until they were "woken up" by opening/closing the firelock, breathing on it or removing/adding the floor tile underneath.

image attached demonstrates this, with the plasma being very secure and stable within its region and never moving passed the firelock.

![fix_atmos_firelocks](https://user-images.githubusercontent.com/16431567/111169815-afafc080-8579-11eb-88c8-ee46361a0e97.png)

:cl: anon
fix: firelocks and others no longer prevent movement of air until "awoken" after server intializations
/:cl:


