### PR TITLE
Give eyes default lighting alpha of LIGHTING_PLANE_ALPHA_VISIBLE

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -17,7 +17,7 @@
 	var/tint = 0
 	var/flash_protect = FLASH_PROTECTION_NONE
 	var/see_invisible = SEE_INVISIBLE_LIVING
-	var/lighting_alpha
+	var/lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 
 /obj/item/organ/internal/eyes/proc/update_colour()
 	dna.write_eyes_attributes(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Give eyes default lighting alpha of `LIGHTING_PLANE_ALPHA_VISIBLE`
  - Species `update_sight` relies on the eye organ's `lighting_alpha` to update the mob's variable. If it's `null`, no change is performed.
  - Dying calls `grant_death_vision()` which grants `lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE` -- being revived does not reset that variable because eyes have no default lighting alpha.
  - Tested on Human, IPC and Vulpkanin species.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fix

## Changelog
:cl:
fix: Fix the darkness overlay not showing back up on revival
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
