### PR TITLE
Prevent disposing things to the Captain's office in Boxstation with just one pipe or a chute

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -31335,8 +31335,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -31386,8 +31386,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -37102,10 +37102,6 @@
 	icon_state = "2-4";
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -37113,6 +37109,11 @@
 	dir = 1;
 	initialize_directions = 11;
 	level = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Captain's Office";
+	sortType = 18
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -89660,8 +89661,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d1 = 4;


### PR DESCRIPTION
## What Does This PR Do
Adds a sorting pipe within the confines of the bridge to filter out unwanted trash.

As it turns out, disposals can do a full 180 and go the opposite direction, so you can put sorting pipes without worrying about bursting floor tiles. Delta has a less robust version of that particular fail-safe mapped in, but with far too many unused pipes. This only uses one.

## Why It's Good For The Game
You can still screw with the captain or other people in some ways, but that will require more than just one pipe swap.

## Images of changes
![Box-CapShip-New](https://user-images.githubusercontent.com/80771500/111810877-dee16d00-88ac-11eb-841b-6824aca8ab93.PNG)
![Box-CapShip-Old](https://user-images.githubusercontent.com/80771500/111810900-e3a62100-88ac-11eb-97d4-1ac7c0f2fe07.PNG)

## Changelog
:cl:
tweak: Replaced one pipe leading toward the Captain's office with a sorting junction pipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
