### PR TITLE
Connects cargo/locker room maintenance

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -42387,11 +42387,6 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -42866,13 +42861,26 @@
 	},
 /area/medical/morgue)
 "bKf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKg" = (
@@ -43261,11 +43269,6 @@
 "bKV" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -43702,16 +43705,16 @@
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "bLO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bLP" = (
@@ -43878,6 +43881,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bMe" = (
@@ -43899,6 +43907,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -88896,11 +88909,22 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "dTF" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/maintenance/apmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "dVs" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -88941,9 +88965,8 @@
 /turf/space,
 /area/space/nearstation)
 "ekW" = (
-/obj/item/stack/spacecash/c10,
-/obj/structure/table/wood/fancy/black,
-/turf/simulated/floor/wood,
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "elO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -89006,11 +89029,6 @@
 /area/maintenance/storage)
 "ewI" = (
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "eBK" = (
@@ -89124,7 +89142,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
 "eWX" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "eYG" = (
@@ -89178,9 +89196,8 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "fyY" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "fAw" = (
@@ -89434,12 +89451,9 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "hvk" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	broken = 1;
+	icon_state = "wood-broken"
 	},
 /area/maintenance/apmaint)
 "hxf" = (
@@ -89468,12 +89482,12 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "hAO" = (
-/obj/effect/spawner/random_spawners/dirt_rare,
-/obj/structure/closet/crate,
+/obj/structure/girder,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "hHC" = (
-/obj/effect/spawner/random_spawners/dirt_frequent,
+/obj/effect/spawner/random_spawners/dirt_rare,
+/obj/structure/closet/crate,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "hIF" = (
@@ -89488,9 +89502,12 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "hMa" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/maintenance/apmaint)
 "hNQ" = (
@@ -89605,7 +89622,9 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "iAC" = (
-/obj/machinery/vending/snack,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "iBS" = (
@@ -89636,11 +89655,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "iHu" = (
-/obj/item/stack/spacecash/c200,
-/obj/item/stack/spacecash/c50,
-/obj/item/stack/spacecash/c50,
-/obj/structure/table/wood/fancy/black,
-/turf/simulated/floor/wood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "iJf" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
@@ -89668,6 +89689,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/damageturf,
+/obj/structure/grille/broken,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "iNz" = (
@@ -89688,10 +89710,8 @@
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
 "iVA" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/structure/falsewall,
+/turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "iXI" = (
 /obj/effect/decal/warning_stripes/east,
@@ -89730,11 +89750,8 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "jcP" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/turf/simulated/floor/plating/airless,
+/obj/machinery/vending/snack,
+/turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "jeb" = (
 /obj/structure/cable{
@@ -89778,8 +89795,11 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "jrs" = (
-/obj/structure/grille,
-/turf/simulated/floor/plating/airless,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 8;
+	name = "8maintenance loot spawner"
+	},
+/turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "jsQ" = (
 /obj/structure/cable{
@@ -89917,11 +89937,10 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "ktg" = (
-/obj/item/chair/stool/bar,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+/obj/structure/chair/wood{
+	dir = 4
 	},
+/turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "kwt" = (
 /obj/machinery/door/poddoor{
@@ -90050,6 +90069,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"kYW" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "lgC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90085,8 +90118,7 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "liw" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "lkw" = (
@@ -90233,10 +90265,26 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/spawner/random_spawners/cobweb_right_rare,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "moM" = (
+/obj/item/stack/spacecash/c10,
+/obj/structure/table/wood/fancy/black,
+/obj/item/storage/secure/safe{
+	pixel_x = 35;
+	pixel_y = 5
+	},
 /turf/simulated/floor/wood,
+/area/maintenance/apmaint)
+"mqB" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "mrw" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -90335,11 +90383,8 @@
 /turf/simulated/floor/plating,
 /area/engine/supermatter)
 "nkM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct/small{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "nqX" = (
 /obj/structure/table,
@@ -90362,13 +90407,12 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "nxr" = (
-/obj/machinery/power/treadmill{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/treadmill_monitor{
-	id = "Gym 1";
-	pixel_y = -32
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "nCz" = (
@@ -90417,7 +90461,10 @@
 	},
 /area/engine/engineering)
 "nLN" = (
-/obj/machinery/mineral/mint,
+/obj/machinery/door/airlock/maintenance{
+	locked = 1;
+	req_access_txt = "12"
+	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "nLT" = (
@@ -90486,11 +90533,21 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "nWf" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/obj/structure/girder,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"nWT" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "nXr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -90507,12 +90564,14 @@
 "ond" = (
 /obj/machinery/light/small,
 /obj/effect/landmark/damageturf,
-/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "osd" = (
-/obj/machinery/slot_machine,
-/turf/simulated/floor/plating/airless,
+/obj/item/chair/stool/bar,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
+	},
 /area/maintenance/apmaint)
 "oyv" = (
 /obj/machinery/hologram/holopad,
@@ -90537,7 +90596,13 @@
 	},
 /area/engine/engineering)
 "oEJ" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "oOZ" = (
@@ -90584,10 +90649,6 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "oXH" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
-	},
 /turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "paA" = (
@@ -90636,10 +90697,7 @@
 /area/engine/engineering)
 "pze" = (
 /obj/machinery/slot_machine,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
-	},
+/turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "pzr" = (
 /obj/structure/cable{
@@ -90714,7 +90772,7 @@
 	},
 /area/storage/secure)
 "pVi" = (
-/obj/structure/weightmachine/stacklifter,
+/obj/structure/weightmachine/weightlifter,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -90781,15 +90839,10 @@
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
 "qtw" = (
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c50,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/machinery/slot_machine,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
 	},
 /area/maintenance/apmaint)
 "qvX" = (
@@ -90805,13 +90858,8 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "qBi" = (
-/obj/machinery/power/treadmill{
-	dir = 8
-	},
-/obj/machinery/treadmill_monitor{
-	id = "Gym 2";
-	pixel_y = -32
-	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcarpet05"
 	},
@@ -90844,7 +90892,7 @@
 	},
 /area/engine/engineering)
 "qNx" = (
-/obj/structure/girder,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "qOo" = (
@@ -91031,14 +91079,22 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/port)
-"sDt" = (
-/obj/structure/chair/stool/bar,
+"szN" = (
+/obj/structure/weightmachine/stacklifter,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
-"sFE" = (
-/obj/structure/chair/office/dark{
-	dir = 4
+"sDt" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5";
+	tag = "icon-wood-broken5"
 	},
+/area/maintenance/apmaint)
+"sFE" = (
+/obj/item/stack/spacecash/c200,
+/obj/item/stack/spacecash/c50,
+/obj/item/stack/spacecash/c50,
+/obj/structure/table/wood/fancy/black,
+/obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "sHt" = (
@@ -91087,6 +91143,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/port)
+"sSR" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "sTb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1450;
@@ -91106,8 +91166,7 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/port)
 "sVM" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
+/obj/item/chair/wood,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "sZP" = (
@@ -91151,8 +91210,11 @@
 	},
 /area/engine/engineering)
 "tkQ" = (
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating/airless,
+/obj/machinery/slot_machine,
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
 /area/maintenance/apmaint)
 "tlR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -91160,6 +91222,12 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"tmF" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "ttp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -91191,7 +91259,8 @@
 	},
 /area/engine/engineering)
 "tGZ" = (
-/obj/structure/closet/emcloset,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "tPd" = (
@@ -91229,9 +91298,7 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "tTU" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/structure/chair/stool/bar,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "ubz" = (
@@ -91290,10 +91357,11 @@
 	},
 /area/maintenance/apmaint)
 "utq" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
+/turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "uxy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -91302,12 +91370,7 @@
 /turf/space,
 /area/space/nearstation)
 "uxL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/landmark/damageturf,
+/obj/machinery/mineral/mint,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "uBJ" = (
@@ -91317,7 +91380,7 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "uCT" = (
-/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "uDK" = (
@@ -91447,8 +91510,10 @@
 /turf/space,
 /area/space/nearstation)
 "vyM" = (
-/obj/structure/chair/stool/bar,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
+	},
 /area/maintenance/apmaint)
 "vBs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -91505,11 +91570,8 @@
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "vXl" = (
-/obj/machinery/slot_machine,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/structure/chair/stool/bar,
+/turf/simulated/floor/wood,
 /area/maintenance/apmaint)
 "vXQ" = (
 /obj/structure/table,
@@ -91523,8 +91585,12 @@
 	},
 /area/engine/engineering)
 "vYH" = (
-/obj/item/chair/wood,
-/turf/simulated/floor/plating/airless,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/cobweb_right_frequent,
+/turf/simulated/floor/plasteel,
 /area/maintenance/apmaint)
 "wbr" = (
 /obj/structure/cable{
@@ -91622,12 +91688,36 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
+"xba" = (
+/obj/machinery/power/treadmill{
+	dir = 8
+	},
+/obj/machinery/treadmill_monitor{
+	id = "Gym 2";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/maintenance/apmaint)
 "xcB" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"xeV" = (
+/obj/machinery/power/treadmill{
+	dir = 8
+	},
+/obj/machinery/treadmill_monitor{
+	id = "Gym 1";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/maintenance/apmaint)
 "xfQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -91692,8 +91782,16 @@
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
 "xyk" = (
-/obj/effect/spawner/window/reinforced,
-/turf/space,
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c50,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
+	},
 /area/maintenance/apmaint)
 "xyo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -105316,17 +105414,17 @@ doE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cgQ
+xJw
+cgQ
+cgQ
+xJw
+cgQ
+cgQ
+cgQ
+xJw
+xJw
+cgQ
 aaa
 aaa
 aaa
@@ -105574,15 +105672,15 @@ aaa
 aaa
 aaa
 cgQ
-xJw
+eWX
 cgQ
+jcP
+jrs
 cgQ
-cgQ
-cgQ
-cgQ
-cgQ
-xJw
-cgQ
+pze
+tkQ
+wnt
+xyk
 cgQ
 aaa
 aaa
@@ -105830,12 +105928,12 @@ cgQ
 cgQ
 xJw
 xJw
-cgQ
+ekW
 tGZ
-cgQ
+iVA
 iAC
 oXH
-cgQ
+nLN
 osd
 vXl
 wnt
@@ -106089,13 +106187,13 @@ qAp
 qAp
 wnt
 hHC
-cgQ
+see
 sFE
 moM
 see
 ktg
 vyM
-wnt
+tTU
 pze
 cgQ
 aaa
@@ -106346,18 +106444,18 @@ kjq
 kjq
 vjh
 hAO
-see
-iHu
-ekW
+cgQ
+cgQ
+cgQ
 cgQ
 fyY
 hMa
 sDt
-osd
+oXH
+see
+xJw
+ruk
 cgQ
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -106601,21 +106699,21 @@ cgQ
 sTb
 inM
 ueA
-xmy
+nVJ
 qNx
-cgQ
-cgQ
-cgQ
-cgQ
+hAO
+lFA
+liw
+nkM
 sVM
 hvk
 utq
+wnt
+tmF
+usb
+xeV
 cgQ
 see
-xJw
-ruk
-cgQ
-aaa
 aaa
 aaa
 aaa
@@ -106846,7 +106944,7 @@ bqr
 bBa
 bCj
 bJt
-bKf
+bCs
 bKV
 bLO
 blQ
@@ -106857,22 +106955,22 @@ sUC
 cgQ
 lhJ
 xJw
-cgQ
-nVJ
-oEJ
-jrs
-lFA
-uCT
-tkQ
-vYH
-iVA
-nWf
-tTU
-usb
-dTF
-nxr
-cgQ
 see
+nVJ
+wnt
+wnt
+wnt
+uCT
+cgQ
+cgQ
+cgQ
+cgQ
+cgQ
+cgQ
+wnt
+wnt
+xba
+cgQ
 aaa
 aaa
 aaa
@@ -107105,7 +107203,7 @@ blQ
 bIP
 bES
 bGS
-bKy
+bKf
 bKv
 puG
 pKu
@@ -107116,17 +107214,17 @@ hIF
 xJw
 cgQ
 moE
+iHu
 kjq
 kjq
 kjq
+vjh
+ekW
+cgQ
 uxL
+sSR
 cgQ
-cgQ
-cgQ
-cgQ
-cgQ
-wnt
-wnt
+szN
 wnt
 qBi
 cgQ
@@ -107362,7 +107460,7 @@ blQ
 bIP
 bET
 bGT
-bKy
+dTF
 blQ
 blQ
 blQ
@@ -107377,15 +107475,15 @@ cgQ
 cgQ
 cgQ
 ewI
-vjh
-cgQ
-nLN
-eWX
-cgQ
+nVJ
 wnt
+nLN
+wnt
+jbo
+see
 wnt
 usb
-liw
+usb
 xJw
 cxX
 aaa
@@ -107634,15 +107732,15 @@ aaa
 aaa
 cgQ
 cgQ
-nVJ
-tTU
+nxr
 wnt
-jbo
-see
-wnt
+cgQ
+vYH
+nWT
+cgQ
 pVi
+wnt
 usb
-dTF
 ruk
 cxY
 aaa
@@ -107891,15 +107989,15 @@ aaa
 aaa
 aaa
 cgQ
-nVJ
+nWf
+wnt
 cgQ
-nkM
-jcP
-cgQ
-tTU
+see
 cgQ
 cgQ
 cgQ
+cgQ
+tmF
 cgQ
 cxY
 czE
@@ -108148,11 +108246,11 @@ aaa
 aaa
 aaa
 xJw
-nVJ
-cgQ
-see
-cgQ
-qNx
+oEJ
+wnt
+uCT
+wnt
+wnt
 wnt
 wnt
 wnt
@@ -108918,7 +109016,7 @@ aaa
 aaa
 aaa
 aaa
-xyk
+xJw
 nTK
 ybu
 jbo
@@ -109175,7 +109273,7 @@ aaa
 aaa
 aaa
 aaa
-xyk
+xJw
 nCz
 xoC
 ukR
@@ -109689,7 +109787,7 @@ bKB
 aaa
 aaa
 aaa
-xyk
+xJw
 umF
 nVw
 cgQ
@@ -109946,7 +110044,7 @@ bKB
 aaa
 aaa
 aaa
-xyk
+xJw
 wHv
 jbo
 kfy
@@ -110468,7 +110566,7 @@ aaa
 aaa
 aaa
 cgQ
-ctN
+mqB
 cvn
 cwx
 cye
@@ -110725,7 +110823,7 @@ aaa
 aaa
 aaa
 cgQ
-coL
+ctU
 coL
 cwy
 cyf
@@ -110982,7 +111080,7 @@ aaa
 aaa
 aab
 cng
-coL
+ctU
 coL
 cwx
 cwy
@@ -111239,7 +111337,7 @@ aaa
 aaa
 aab
 cng
-coS
+kYW
 csu
 csu
 csu

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -89493,6 +89493,15 @@
 	tag = "icon-wood-broken6"
 	},
 /area/maintenance/apmaint)
+"hNQ" = (
+/obj/machinery/door/airlock/mining{
+	name = "Old Warehouse";
+	req_access_txt = "50"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint{
+	name = "Cargo Warehouse"
+	})
 "hNT" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -89874,10 +89883,11 @@
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
 "kfy" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "50"
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/apmaint)
 "kiu" = (
@@ -90077,7 +90087,6 @@
 "liw" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light/small,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "lkw" = (
@@ -90652,6 +90661,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"pKu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "pMd" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/cable{
@@ -91545,14 +91565,15 @@
 	},
 /area/engine/engineering)
 "wyJ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
+	},
+/obj/machinery/door/airlock/mining{
+	name = "Old Warehouse";
+	req_access_txt = "50"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -107087,7 +107108,7 @@ bGS
 bKy
 bKv
 puG
-puG
+pKu
 sxZ
 uoW
 cgQ
@@ -109161,7 +109182,7 @@ ukR
 jbo
 jbo
 gIC
-cqF
+hNQ
 ctU
 cvk
 cwx

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -15,6 +15,17 @@
 	},
 /turf/space,
 /area/space)
+"abc" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1450;
+	icon_state = "door_locked";
+	id_tag = "disposals_maint_outer";
+	locked = 1;
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "abp" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -31335,8 +31346,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -31386,8 +31397,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -43007,11 +43018,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKv" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
-"bKw" = (
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
 /area/maintenance/port)
 "bKx" = (
 /obj/machinery/r_n_d/protolathe,
@@ -43083,10 +43098,9 @@
 "bKF" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/maintenance/port)
 "bKG" = (
 /obj/structure/disposalpipe/segment{
@@ -44810,8 +44824,7 @@
 "bNF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -44940,8 +44953,7 @@
 /area/maintenance/port)
 "bNQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -45099,16 +45111,14 @@
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -24;
-	pixel_y = -8;
-	req_access_txt = "0"
+	pixel_y = -8
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -24;
-	pixel_y = 8;
-	req_access_txt = "0"
+	pixel_y = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -46118,8 +46128,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -60330,10 +60339,6 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
-"coK" = (
-/obj/structure/bed,
-/turf/simulated/floor/plating,
-/area/maintenance/apmaint)
 "coL" = (
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -62608,10 +62613,6 @@
 	icon_state = "white"
 	},
 /area/toxins/mixing)
-"csj" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
 "csk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -63593,6 +63594,11 @@
 /area/toxins/mixing)
 "ctM" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "ctN" = (
@@ -66176,7 +66182,6 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -88843,6 +88848,11 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"dxD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "dEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88885,6 +88895,12 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
+"dTF" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/maintenance/apmaint)
 "dVs" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -88924,6 +88940,34 @@
 "ejU" = (
 /turf/space,
 /area/space/nearstation)
+"ekW" = (
+/obj/item/stack/spacecash/c10,
+/obj/structure/table/wood/fancy/black,
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
+"elO" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1450;
+	id_tag = "disposals_pump"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1450;
+	id_tag = "cargo_maint";
+	pixel_y = -25;
+	req_access_txt = "13";
+	tag_airpump = "disposals_pump";
+	tag_chamber_sensor = "disposals_sensor";
+	tag_exterior_door = "disposals_maint_outer";
+	tag_interior_door = "disposals_maint_inner"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1450;
+	id_tag = "disposals_sensor";
+	pixel_y = 25
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "ema" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -88960,6 +89004,28 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
+"ewI" = (
+/obj/effect/spawner/random_spawners/cobweb_right_rare,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"eBK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "eDs" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
@@ -88975,6 +89041,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/supermatter)
+"eIN" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1450;
+	master_tag = "disposals_maint";
+	name = "exterior access button";
+	pixel_x = 25;
+	pixel_y = -25;
+	req_access_txt = "13"
+	},
+/turf/space,
+/area/space/nearstation)
 "eJr" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
@@ -89044,6 +89123,10 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
+"eWX" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "eYG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -89094,6 +89177,12 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
+"fyY" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "fAw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/tcomms/core/station,
@@ -89119,6 +89208,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"fLn" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "fPU" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -89241,6 +89339,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"gIC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "gLY" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -89289,6 +89391,27 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"hbX" = (
+/obj/effect/spawner/random_spawners/oil_maybe,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"hkl" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/spawner/random_spawners/cobweb_right_frequent,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "hsy" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -89310,6 +89433,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"hvk" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
+	},
+/area/maintenance/apmaint)
 "hxf" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room";
@@ -89335,6 +89467,32 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
+"hAO" = (
+/obj/effect/spawner/random_spawners/dirt_rare,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"hHC" = (
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"hIF" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1450;
+	icon_state = "door_locked";
+	id_tag = "cargo_maint_outer";
+	locked = 1;
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"hMa" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6";
+	tag = "icon-wood-broken6"
+	},
+/area/maintenance/apmaint)
 "hNT" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -89357,6 +89515,9 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"hWB" = (
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "idF" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/trinary/filter/flipped{
@@ -89392,6 +89553,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"inM" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "ioM" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -89429,6 +89595,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
+"iAC" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
 "iBS" = (
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -89443,6 +89613,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"iHc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
+"iHu" = (
+/obj/item/stack/spacecash/c200,
+/obj/item/stack/spacecash/c50,
+/obj/item/stack/spacecash/c50,
+/obj/structure/table/wood/fancy/black,
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
 "iJf" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/door/poddoor{
@@ -89462,6 +89652,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"iLt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "iNz" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -89479,6 +89678,12 @@
 "iUc" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
+"iVA" = (
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/maintenance/apmaint)
 "iXI" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -89499,6 +89704,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
+"jbo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "jbt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89511,6 +89720,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"jcP" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "jeb" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -89518,6 +89734,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"jhl" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1450;
+	master_tag = "disposals_maint";
+	name = "interior access button";
+	pixel_x = -25;
+	pixel_y = -25;
+	req_access_txt = "13"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	initialize_directions = 10
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "jnm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89531,6 +89768,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"jrs" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "jsQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89632,6 +89873,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
+"kfy" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "kiu" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards,
@@ -89640,6 +89888,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
+"kjq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "kjI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -89650,6 +89906,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"ktg" = (
+/obj/item/chair/stool/bar,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken7";
+	tag = "icon-wood-broken7"
+	},
+/area/maintenance/apmaint)
 "kwt" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -89660,8 +89923,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -89672,6 +89935,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
+"kwF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/stack/sheet/cardboard,
+/obj/item/stock_parts/cell{
+	maxcharge = 2000
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
+"kzh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "kIR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -89753,6 +90040,46 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"lgC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"lhJ" = (
+/obj/machinery/airlock_sensor{
+	frequency = 1450;
+	id_tag = "cargo_sensor";
+	pixel_y = 25
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1450;
+	id_tag = "cargo_maint";
+	pixel_y = -25;
+	req_access_txt = "13";
+	tag_airpump = "cargo_pump";
+	tag_chamber_sensor = "cargo_sensor";
+	tag_exterior_door = "cargo_maint_outer";
+	tag_interior_door = "cargo_maint_inner"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1450;
+	id_tag = "cargo_pump"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"liw" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "lkw" = (
 /obj/machinery/light{
 	dir = 8
@@ -89815,6 +90142,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"lFA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "lKP" = (
 /obj/structure/reflector/single{
 	anchored = 1;
@@ -89863,6 +90196,20 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"mdm" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1450;
+	icon_state = "door_locked";
+	id_tag = "cargo_maint_inner";
+	locked = 1;
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "mkE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -89871,6 +90218,17 @@
 /obj/machinery/light,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
+"moE" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"moM" = (
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
 "mrw" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -89925,6 +90283,16 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/storage)
+"mVz" = (
+/obj/effect/spawner/random_spawners/grille_maybe,
+/obj/machinery/portable_atmospherics/canister/air{
+	filled = 0.1
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "mWa" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/binary/pump{
@@ -89957,6 +90325,13 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/engine/supermatter)
+"nkM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "nqX" = (
 /obj/structure/table,
 /obj/item/paper{
@@ -89977,6 +90352,26 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"nxr" = (
+/obj/machinery/power/treadmill{
+	dir = 8
+	},
+/obj/machinery/treadmill_monitor{
+	id = "Gym 1";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"nCz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "nCT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -90012,6 +90407,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"nLN" = (
+/obj/machinery/mineral/mint,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "nLT" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
@@ -90056,6 +90455,34 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"nTK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
+"nVw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/soft,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
+"nVJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"nWf" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
 "nXr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/status_display{
@@ -90068,6 +90495,16 @@
 "omz" = (
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"ond" = (
+/obj/machinery/light/small,
+/obj/effect/landmark/damageturf,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"osd" = (
+/obj/machinery/slot_machine,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "oyv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -90090,6 +90527,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"oEJ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "oOZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/wall/r_wall,
@@ -90133,6 +90574,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"oXH" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 8;
+	name = "8maintenance loot spawner"
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
 "paA" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/engine,
@@ -90157,6 +90605,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/supermatter)
+"puG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "pwU" = (
 /obj/effect/landmark/battle_mob_point,
 /turf/simulated/floor/engine,
@@ -90169,6 +90625,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
+"pze" = (
+/obj/machinery/slot_machine,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3";
+	tag = "icon-wood-broken3"
+	},
+/area/maintenance/apmaint)
 "pzr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90230,6 +90693,12 @@
 	icon_state = "dark"
 	},
 /area/storage/secure)
+"pVi" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/maintenance/apmaint)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -90291,12 +90760,42 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
+"qtw" = (
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c50,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken";
+	tag = "icon-wood-broken"
+	},
+/area/maintenance/apmaint)
 "qvX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
+"qAp" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"qBi" = (
+/obj/machinery/power/treadmill{
+	dir = 8
+	},
+/obj/machinery/treadmill_monitor{
+	id = "Gym 2";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/maintenance/apmaint)
 "qCB" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
@@ -90324,6 +90823,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"qNx" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "qOo" = (
 /obj/structure/chair{
 	dir = 4
@@ -90370,6 +90873,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"ruk" = (
+/obj/effect/spawner/random_spawners/wall_rusted_probably,
+/turf/simulated/wall,
+/area/maintenance/apmaint)
 "rzU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90383,6 +90890,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"rzY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "rFd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -90445,6 +90962,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"see" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/maintenance/apmaint)
 "shz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90459,6 +90980,19 @@
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"siF" = (
+/obj/effect/spawner/random_spawners/oil_maybe,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "sud" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -90469,6 +91003,24 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"sxZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
+"sDt" = (
+/obj/structure/chair/stool/bar,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"sFE" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
 "sHt" = (
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
@@ -90507,6 +91059,37 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"sQg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
+"sTb" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1450;
+	icon_state = "door_locked";
+	id_tag = "cargo_maint_inner";
+	locked = 1;
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"sUC" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
+"sVM" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "sZP" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -90547,6 +91130,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"tkQ" = (
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "tlR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -90560,12 +91147,33 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
+"tCy" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1450;
+	master_tag = "dorms_maint";
+	name = "interior access button";
+	pixel_x = 25;
+	pixel_y = -25;
+	req_access_txt = "13"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "tDn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"tGZ" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "tPd" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1379;
@@ -90600,6 +91208,12 @@
 /obj/item/geiger_counter,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"tTU" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "ubz" = (
 /obj/structure/table,
 /obj/item/rpd,
@@ -90607,6 +91221,15 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"ueA" = (
+/obj/machinery/portable_atmospherics/canister/air{
+	filled = 0.1
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "ufc" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -90614,6 +91237,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"ukR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
+"umF" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
+"unJ" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
+"uoW" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/port)
 "uqo" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -90622,18 +91264,42 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"usb" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/maintenance/apmaint)
+"utq" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5";
+	tag = "icon-wood-broken5"
+	},
+/area/maintenance/apmaint)
 "uxy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
 /turf/space,
 /area/space/nearstation)
+"uxL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "uBJ" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"uCT" = (
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "uDK" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
@@ -90642,6 +91308,13 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"uRh" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/simulated/wall,
+/area/maintenance/apmaint)
 "uTu" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -90723,6 +91396,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"vjh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "vmA" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
@@ -90745,6 +91426,10 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"vyM" = (
+/obj/structure/chair/stool/bar,
+/turf/simulated/floor/wood,
+/area/maintenance/apmaint)
 "vBs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10;
@@ -90799,6 +91484,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"vXl" = (
+/obj/machinery/slot_machine,
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/maintenance/apmaint)
 "vXQ" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -90810,6 +91502,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"vYH" = (
+/obj/item/chair/wood,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "wbr" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -90835,6 +91531,9 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"wnt" = (
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "wnU" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -90845,6 +91544,18 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"wyJ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "wEY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90872,6 +91583,11 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"wHv" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "wQr" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating,
@@ -90921,6 +91637,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"xmy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
+"xoC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/folder/yellow,
+/obj/structure/table,
+/obj/item/book/manual/sop_supply,
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "xuG" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -90938,6 +91670,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
+"xyk" = (
+/obj/effect/spawner/window/reinforced,
+/turf/space,
+/area/maintenance/apmaint)
 "xyo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -90955,6 +91691,18 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"xES" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light_construct/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/apmaint)
 "xGn" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/structure/cable{
@@ -90964,6 +91712,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"xJw" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/maintenance/apmaint)
 "xOn" = (
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -90995,6 +91747,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"ybu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/light_construct/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "ykt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -104526,10 +105288,10 @@ bCf
 bIB
 bCf
 bIB
-bIB
-aaa
-aaa
-aaa
+bCf
+eIN
+doE
+doE
 aaa
 aaa
 aaa
@@ -104783,24 +105545,24 @@ bHe
 bII
 bKD
 bNS
-bIB
+bCf
+abc
+blQ
+doE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cgQ
+xJw
+cgQ
+cgQ
+cgQ
+cgQ
+cgQ
+cgQ
+xJw
+cgQ
+cgQ
 aaa
 aaa
 aaa
@@ -105040,24 +105802,24 @@ bIH
 bID
 bKs
 bPw
-bIB
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bCf
+elO
+blQ
+cgQ
+cgQ
+xJw
+xJw
+cgQ
+tGZ
+cgQ
+iAC
+oXH
+cgQ
+osd
+vXl
+wnt
+qtw
+cgQ
 aaa
 aaa
 aaa
@@ -105298,23 +106060,23 @@ bLJ
 bNF
 bPH
 bCf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mdm
+blQ
+mVz
+lFA
+qAp
+qAp
+wnt
+hHC
+cgQ
+sFE
+moM
+see
+ktg
+vyM
+wnt
+pze
+cgQ
 aaa
 aaa
 aaa
@@ -105555,23 +106317,23 @@ bLH
 bNB
 bPC
 bCf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jhl
+siF
+lgC
+tCy
+kjq
+kjq
+vjh
+hAO
+see
+iHu
+ekW
+cgQ
+fyY
+hMa
+sDt
+osd
+cgQ
 aaa
 aaa
 aaa
@@ -105812,26 +106574,26 @@ bSA
 bCf
 bCf
 bCf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sQg
+blQ
+cgQ
+sTb
+inM
+ueA
+xmy
+qNx
+cgQ
+cgQ
+cgQ
+cgQ
+sVM
+hvk
+utq
+cgQ
+see
+xJw
+ruk
+cgQ
 aaa
 aaa
 aaa
@@ -106067,29 +106829,29 @@ bKf
 bKV
 bLO
 blQ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aaa
-aaa
-aaa
+unJ
+hWB
+sQg
+sUC
+cgQ
+lhJ
+xJw
+cgQ
+nVJ
+oEJ
+jrs
+lFA
+uCT
+tkQ
+vYH
+iVA
+nWf
+tTU
+usb
+dTF
+nxr
+cgQ
+see
 aaa
 aaa
 aaa
@@ -106324,29 +107086,29 @@ bES
 bGS
 bKy
 bKv
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-csj
-aaa
-aaa
-aaa
+puG
+puG
+sxZ
+uoW
+cgQ
+hIF
+xJw
+cgQ
+moE
+kjq
+kjq
+kjq
+uxL
+cgQ
+cgQ
+cgQ
+cgQ
+cgQ
+wnt
+wnt
+wnt
+qBi
+cgQ
 aaa
 aaa
 aaa
@@ -106580,30 +107342,30 @@ bIP
 bET
 bGT
 bKy
-bKv
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-afO
-aaa
-aaa
-aaa
+blQ
+blQ
+blQ
+bKF
+blQ
+cgQ
+avM
+doE
+cgQ
+uRh
+cgQ
+cgQ
+cgQ
+ewI
+vjh
+cgQ
+nLN
+eWX
+cgQ
+wnt
+wnt
+usb
+liw
+xJw
 cxX
 aaa
 aaa
@@ -106837,7 +107599,7 @@ bJw
 bET
 bGV
 bMf
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -106849,18 +107611,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aaa
-aaa
-aab
-aaa
-aab
-aaa
+cgQ
+cgQ
+nVJ
+tTU
+wnt
+jbo
+see
+wnt
+pVi
+usb
+dTF
+ruk
 cxY
 aaa
 aaa
@@ -107107,17 +107869,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aab
-afO
-aMr
-aaa
-afO
-aaa
+cgQ
+nVJ
+cgQ
+nkM
+jcP
+cgQ
+tTU
+cgQ
+cgQ
+cgQ
+cgQ
 cxY
 czE
 aaa
@@ -107351,7 +108113,7 @@ bvs
 bvs
 bGW
 bDQ
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -107364,17 +108126,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aaa
-aaa
-aMr
-aab
-aab
-aaa
+xJw
+nVJ
+cgQ
+see
+cgQ
+qNx
+wnt
+wnt
+wnt
+ond
+cgQ
 cxY
 czF
 cBi
@@ -107608,7 +108370,7 @@ bvs
 bwP
 bGW
 bDQ
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -107621,17 +108383,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-afO
-aaa
-afO
-afO
-afO
-aab
-aaa
+uRh
+hkl
+kjq
+iLt
+kjq
+hbX
+kjq
+fLn
+vjh
+wnt
+see
 cxY
 czF
 cBg
@@ -107865,11 +108627,7 @@ bvs
 bEW
 bGW
 bDQ
-bKw
-aaa
-aaa
-aaa
-aaa
+blQ
 aaa
 aaa
 aaa
@@ -107886,9 +108644,13 @@ cgQ
 cgQ
 cgQ
 cgQ
-afO
-afO
-aab
+cgQ
+cgQ
+cgQ
+cgQ
+xmy
+coL
+cgQ
 cxY
 czF
 cAX
@@ -108135,16 +108897,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-cng
-coK
-cqz
+xyk
+nTK
+ybu
+jbo
+gIC
+ukR
+kzh
 cgQ
-cng
-cng
+ctU
+ctN
 cgQ
 cxY
 czF
@@ -108379,7 +109141,7 @@ bJx
 bKq
 bGW
 bDQ
-bKw
+blQ
 aaa
 aaa
 aaa
@@ -108392,15 +109154,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-cng
-coL
-coL
+xyk
+nCz
+xoC
+ukR
+jbo
+jbo
+gIC
 cqF
-coL
+ctU
 cvk
 cwx
 cyo
@@ -108649,15 +109411,15 @@ bPT
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 cgQ
 cgQ
 cgQ
 cgQ
-coL
+xES
+rzY
+rzY
+wyJ
+eBK
 cvl
 cwx
 cyn
@@ -108906,15 +109668,15 @@ bKB
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-cng
-coK
-cqz
+xyk
+umF
+nVw
 cgQ
-coL
+iHc
+jbo
+kwF
+cgQ
+ctU
 cvm
 cwx
 cyb
@@ -109163,15 +109925,15 @@ bKB
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-cng
-coL
-coL
-cqF
-coL
+xyk
+wHv
+jbo
+kfy
+jbo
+jbo
+dxD
+cgQ
+ctU
 coL
 cwx
 cyc
@@ -109420,10 +110182,10 @@ bxb
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cgQ
+cgQ
+cgQ
+cgQ
 cgQ
 cgQ
 cgQ

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -105754,7 +105754,7 @@ blQ
 doE
 aaa
 aaa
-aaa
+cgQ
 cgQ
 eWX
 cgQ
@@ -106009,9 +106009,9 @@ bCf
 elO
 blQ
 cgQ
+xJw
+xJw
 cgQ
-xJw
-xJw
 ekW
 tGZ
 iVA
@@ -106266,9 +106266,9 @@ bCf
 mdm
 blQ
 mVz
+qAp
+qAp
 lFA
-qAp
-qAp
 wnt
 hHC
 see

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -43026,14 +43026,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKv" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/grille,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/port)
 "bKx" = (
@@ -59480,21 +59473,10 @@
 /area/quartermaster/miningdock)
 "cnp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cnq" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -60260,22 +60242,17 @@
 	})
 "coE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "coF" = (
@@ -60373,10 +60350,16 @@
 	},
 /area/maintenance/apmaint)
 "coR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -60386,6 +60369,12 @@
 	d2 = 4;
 	icon_state = "2-4";
 	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -61480,12 +61469,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -61493,21 +61476,18 @@
 /area/maintenance/apmaint)
 "cqs" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4";
+	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -61699,6 +61679,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "cqI" = (
@@ -63612,6 +63594,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "ctN" = (
@@ -63729,6 +63717,12 @@
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "ctW" = (
@@ -89042,6 +89036,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "eDs" = (
@@ -89417,6 +89417,20 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
+"hiy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "hkl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -89515,6 +89529,7 @@
 	name = "Old Warehouse";
 	req_access_txt = "50"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint{
 	name = "Cargo Warehouse"
@@ -89974,6 +89989,10 @@
 /obj/item/stock_parts/cell{
 	maxcharge = 2000
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/apmaint)
 "kzh" = (
@@ -90080,6 +90099,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -90284,6 +90309,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "mrw" = (
@@ -90386,6 +90417,20 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
+"npO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "nqX" = (
 /obj/structure/table,
 /obj/item/paper{
@@ -90436,6 +90481,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"nEY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "nFa" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -90966,6 +91025,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/maintenance/apmaint)
 "rFd" = (
@@ -91162,7 +91222,7 @@
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
 "sUC" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/port)
 "sVM" = (
@@ -91263,6 +91323,17 @@
 /obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/apmaint)
+"tOe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "tPd" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1379;
@@ -91336,7 +91407,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/apmaint)
 "unJ" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/port)
 "uoW" = (
@@ -91547,6 +91618,17 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"vNX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/apmaint)
 "vOB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
@@ -91641,6 +91723,7 @@
 	name = "Old Warehouse";
 	req_access_txt = "50"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "wEY" = (
@@ -91820,6 +91903,7 @@
 /obj/machinery/light_construct/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/maintenance/apmaint)
 "xGn" = (
@@ -106947,7 +107031,7 @@ bJt
 bCs
 bKV
 bLO
-blQ
+bKv
 unJ
 hWB
 sQg
@@ -107204,7 +107288,7 @@ bIP
 bES
 bGS
 bKf
-bKv
+puG
 puG
 pKu
 sxZ
@@ -109279,9 +109363,9 @@ xoC
 ukR
 jbo
 jbo
-gIC
+cnp
 hNQ
-ctU
+vNX
 cvk
 cwx
 cyo
@@ -109795,7 +109879,7 @@ iHc
 jbo
 kwF
 cgQ
-ctU
+npO
 cvm
 cwx
 cyb
@@ -110052,7 +110136,7 @@ jbo
 jbo
 dxD
 cgQ
-ctU
+npO
 coL
 cwx
 cyc
@@ -110823,7 +110907,7 @@ aaa
 aaa
 aaa
 cgQ
-ctU
+npO
 coL
 cwy
 cyf
@@ -111080,7 +111164,7 @@ aaa
 aaa
 aab
 cng
-ctU
+npO
 coL
 cwx
 cwy
@@ -111594,7 +111678,7 @@ aaa
 aaa
 aab
 cng
-ctU
+npO
 cgQ
 cwz
 cyg
@@ -111851,7 +111935,7 @@ aaa
 aaa
 aab
 cgQ
-ctU
+npO
 cgQ
 cgQ
 cgQ
@@ -112365,7 +112449,7 @@ bYP
 aaa
 aab
 cgQ
-ctU
+npO
 cgQ
 cwA
 coL
@@ -112622,7 +112706,7 @@ bYP
 aab
 aab
 cgQ
-ctU
+npO
 cgQ
 cwB
 cwB
@@ -112879,7 +112963,7 @@ bYP
 aaa
 aab
 cgQ
-ctU
+npO
 cgQ
 cwC
 coL
@@ -113136,7 +113220,7 @@ cam
 cam
 aab
 cgQ
-ctU
+npO
 cqF
 coL
 coL
@@ -113393,7 +113477,7 @@ cnm
 cam
 cgQ
 cgQ
-ctU
+npO
 cgQ
 cwC
 coL
@@ -113650,7 +113734,7 @@ cnl
 cam
 coL
 coL
-ctU
+npO
 cgQ
 cwD
 cwD
@@ -113907,7 +113991,7 @@ cno
 cam
 cqA
 csk
-ctU
+npO
 cgQ
 cwE
 cqB
@@ -114164,7 +114248,7 @@ cno
 cam
 cqB
 csl
-ctU
+npO
 cgQ
 cwB
 cwB
@@ -114421,7 +114505,7 @@ cno
 cam
 cgQ
 cgQ
-ctU
+npO
 cvo
 cvo
 cvo
@@ -114678,7 +114762,7 @@ cam
 cam
 cqE
 csm
-ctU
+npO
 cvo
 cwF
 cwF
@@ -114935,7 +115019,7 @@ cam
 coP
 cqG
 cgQ
-ctU
+npO
 cvo
 cwF
 cyi
@@ -115192,7 +115276,7 @@ cgQ
 cgQ
 cgQ
 cgQ
-ctU
+nEY
 cvo
 cvo
 cwI
@@ -115448,8 +115532,8 @@ cnX
 cnn
 coS
 cqH
-csu
-coR
+tOe
+hiy
 cvo
 cwG
 cwI
@@ -115702,7 +115786,7 @@ ckG
 cix
 bYM
 cnX
-cnp
+gIC
 coR
 cgQ
 cgQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR expands cargo maint and locker room maint.
Features included:

- Connected cargo and locker room maints. Uses somewhat lit corridors, but dark side rooms
- Abandoned gym and gambling den, with a "secret" back office room (bolted door, false wall opposite to it)
- Coin press room with a bolted door
- Abandoned cargo warehouse, with cargo only door access
- Two airlocks to space, one out of the station and one into the cargo shuttle space

In terms of areas, the door between the two airlocks marks the split between locker room maintenance and cargo maintenance.
The cargo shuttle sits snugly in the remaining area. All doors are non-glass to reduce visibility.
Space is rather tight here without further remapping arrivals, so one main path was the best I could come up with thematically. There is a "second path" through the side rooms, if the barricade is destroyed or door unbolted.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We all know box is currently small for paradise pop, one of the main issues is the lack of adequate maintenance areas. This attempts to expand the smallest maints currently on box, and connecting them for easier antag movement between areas. All other maints are relatively close to another, but to get from engineering to arrivals you have to run through a very public hallway without a movement ability.
Adding more maints rooms that sec don't have access to (abandoned warehouse) gives antags more areas to hide in.
[This idea was taken from the proposals doc from last years community survey, available to view by clicking this sentence.](https://docs.google.com/document/d/1sOdTp-Q4SgeDt4OrkM5hvTdAN4MmpX1Kk3UYkcNPwD0/edit#)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![cyberiadcargomaints](https://user-images.githubusercontent.com/12197162/111871036-ffc6c280-897f-11eb-89ce-fa8f76bb7078.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: New maintenance area connecting cargo (mining) and locker room (disposals) maintenance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
