### PR TITLE
Remove cat ears from the random costume landmark

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -164,10 +164,9 @@
 	new /obj/item/clothing/shoes/jackboots(src.loc)
 	qdel(src)
 
-/obj/effect/landmark/costume/nyangirl/New()
+/obj/effect/landmark/costume/schoolgirl/New()
 	. = ..()
 	new /obj/item/clothing/under/schoolgirl(src.loc)
-	new /obj/item/clothing/head/kitty(src.loc)
 	qdel(src)
 
 /obj/effect/landmark/costume/maid/New()


### PR DESCRIPTION
## What Does This PR Do
Actually removes cat ears from the costume landmark. Only Delta and Meta has costume landmarks mapped in.

## Why It's Good For The Game
Cleaning up the left over crumbs.

## Changelog
:cl:
tweak: no random cat ears
/:cl:
