### PR TITLE
Adds the current mode of door remotes to the description

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -8,7 +8,7 @@
 	item_state = "electronic"
 	icon = 'icons/obj/device.dmi'
 	name = "control wand"
-	desc = "Remotely controls airlocks. Current mode: open doors"
+	desc = "Remotely controls airlocks."
 	w_class = WEIGHT_CLASS_TINY
 	flags = NOBLUDGEON
 	var/mode = WAND_OPEN

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -32,18 +32,18 @@
 	switch(mode)
 		if(WAND_OPEN)
 			mode = WAND_BOLT
-			desc = "Remotely controls airlocks. Current mode: toggle bolts"
 		if(WAND_BOLT)
 			mode = WAND_EMERGENCY
-			desc = "Remotely controls airlocks. Current mode: toggle emergancy access"
 		if(WAND_EMERGENCY)
 			mode = WAND_SPEED
-			desc = "Remotely controls airlocks. Current mode: change door speed"
 		if(WAND_SPEED)
 			mode = WAND_OPEN
-			desc = "Remotely controls airlocks. Current mode: open doors"
 
 	to_chat(user, "<span class='notice'>Now in mode: [mode].</span>")
+
+/obj/item/door_remote/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It's current mode is: [mode]</span>"
 
 /obj/item/door_remote/afterattack(obj/machinery/door/airlock/D, mob/user)
 	if(!istype(D))

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -8,7 +8,7 @@
 	item_state = "electronic"
 	icon = 'icons/obj/device.dmi'
 	name = "control wand"
-	desc = "Remotely controls airlocks."
+	desc = "Remotely controls airlocks. Current mode: open doors"
 	w_class = WEIGHT_CLASS_TINY
 	flags = NOBLUDGEON
 	var/mode = WAND_OPEN
@@ -32,12 +32,16 @@
 	switch(mode)
 		if(WAND_OPEN)
 			mode = WAND_BOLT
+			desc = "Remotely controls airlocks. Current mode: toggle bolts"
 		if(WAND_BOLT)
 			mode = WAND_EMERGENCY
+			desc = "Remotely controls airlocks. Current mode: toggle emergancy access"
 		if(WAND_EMERGENCY)
 			mode = WAND_SPEED
+			desc = "Remotely controls airlocks. Current mode: change door speed"
 		if(WAND_SPEED)
 			mode = WAND_OPEN
+			desc = "Remotely controls airlocks. Current mode: open doors"
 
 	to_chat(user, "<span class='notice'>Now in mode: [mode].</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The description of door remotes now tell you what mode they are in

## Why It's Good For The Game
good quality of life change for command players. you no longer have to cycle through all the modes to check what mode you were on. Prevents you from accidentally opening/bolting a door when you don't want to.

## Changelog
:cl:
tweak: The description of door remotes now tell you what mode they are in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
