### PR TITLE
Update suggested client version to 513.1542

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -8,8 +8,8 @@
 #define UPLOAD_LIMIT		10485760	//Restricts client uploads to the server to 10MB //Boosted this thing. What's the worst that can happen?
 #define MIN_CLIENT_VERSION	513		// Minimum byond major version required to play.
 									//I would just like the code ready should it ever need to be used.
-#define SUGGESTED_CLIENT_VERSION	513		// only integers (e.g: 513, 514) are useful here. This is the part BEFORE the ".", IE 513 out of 513.1536
-#define SUGGESTED_CLIENT_BUILD	1536		// only integers (e.g: 1536, 1539) are useful here. This is the part AFTER the ".", IE 1536 out of 513.1536
+#define SUGGESTED_CLIENT_VERSION	513		// only integers (e.g: 513, 514) are useful here. This is the part BEFORE the ".", IE 513 out of 513.1542
+#define SUGGESTED_CLIENT_BUILD	1542		// only integers (e.g: 1542, 1543) are useful here. This is the part AFTER the ".", IE 1542 out of 513.1542
 
 #define SSD_WARNING_TIMER 30 // cycles, not seconds, so 30=60s
 


### PR DESCRIPTION
## What Does This PR Do
Causes players still using 513.1536 to 513.1541 to get a notice prompting them to update to the latest stable release of byond 513.1542.

## Why It's Good For The Game
We still have players using 513.1537 and similar versions that have outstanding bugs, which sometimes show up in helpchat. While we can tell those players to update their byond, an automated notice encouraging them to do so is better.

## Changelog
:cl:
tweak: Players on byond versions under 513.1542 now get encouraged to update.
/:cl:
