### PR TITLE
Allows crowbars to be recycled in autolathes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -288,6 +288,8 @@
 	return ..()
 
 /obj/machinery/autolathe/crowbar_act(mob/user, obj/item/I)
+	if(!panel_open)
+		return
 	if(!I.use_tool(src, user, 0, volume = 0))
 		return
 	. = TRUE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -164,9 +164,9 @@
 	to_chat(user, "You [mode ? "unfasten": "fasten"] the screws around the power connection.")
 
 /obj/machinery/disposal/welder_act(mob/user, obj/item/I)
-	. = TRUE
 	if(mode != required_mode_to_deconstruct)
 		return
+	. = TRUE
 	if(contents.len > 0)
 		to_chat(user, "Eject the items first!")
 		return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -164,9 +164,9 @@
 	to_chat(user, "You [mode ? "unfasten": "fasten"] the screws around the power connection.")
 
 /obj/machinery/disposal/welder_act(mob/user, obj/item/I)
+	. = TRUE
 	if(mode != required_mode_to_deconstruct)
 		return
-	. = TRUE
 	if(contents.len > 0)
 		to_chat(user, "Eject the items first!")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes you able to recycle crowbars in autolathes like most other items/tools
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No reason why you shouldn't be able to deconstruct a crowbar
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Makes crowbars recyclable in the autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
