### PR TITLE
Make RND machines check for upgraded parts when checking if an item is constructable

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -63,10 +63,10 @@ Note: Must be placed west/left of and R&D console to function.
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
 	materials.max_amount = T * 75000
-	T = 1.2
+	T = 12
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		T -= M.rating/10
-	efficiency_coeff = min(max(0, T), 1)
+		T -= M.rating
+	efficiency_coeff = min(max(0, T / 10), 1)
 
 /obj/machinery/r_n_d/protolathe/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material
 	var/A = materials.amount(M)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -72,9 +72,9 @@ Note: Must be placed west/left of and R&D console to function.
 	var/A = materials.amount(M)
 	if(!A)
 		A = reagents.get_reagent_amount(M)
-		A = A / max(1, (being_built.reagents_list[M]))
+		A = A / max(1, (being_built.reagents_list[M] * efficiency_coeff))
 	else
-		A = A / max(1, (being_built.materials[M]))
+		A = A / max(1, (being_built.materials[M] * efficiency_coeff))
 	return A
 
 /obj/machinery/r_n_d/protolathe/attackby(obj/item/O as obj, mob/user as mob, params)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -427,7 +427,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	var/enough_materials = TRUE
 
-	if(!machine.materials.has_materials(efficient_mats, amount))
+	if(!machine.materials.has_materials(being_built.materials, coeff))
 		atom_say("Not enough materials to complete prototype.")
 		enough_materials = FALSE
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Makes the check for the amount of times you can construct an item in the protolathe take into account the improved efficiency from components, meaning that if you have the required materials in the protolathe, the item is printable. Previously, it did not check for this efficiency, so you actually needed the amount of materials that the print would take without any improved parts to start the print. (EG. Item takes 1000 metal to print without an upgraded protolathe, 400 to print with an upgraded protolathe, but you require 1000 metal available to print the item, which then only subtracts 400 metal from the protolathe's materials.)
- Fixes a minor point rounding error that would prevent printing when the exact amount of materials for an item have been input

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You should not need to have more materials than is required to print something to start the print.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Protolathe printing now checks for upgraded parts when checking if an item is constructable
fix: Removes a rounding error in protolathe efficiency that would prevent items from being printed when the exact amount of materials is available.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
