### PR TITLE
Removes hijack objective from the pool

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -104,9 +104,8 @@
 
 
 /datum/antagonist/traitor/proc/forge_human_objectives()
-	var/is_hijacker = prob(10)
 	var/martyr_chance = prob(20)
-	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
+	var/objective_count = 0 			//Hijacking counts towards number of objectives
 	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors
 		if(!SSticker.mode.exchange_red)
 			SSticker.mode.exchange_red = owner
@@ -118,13 +117,6 @@
 
 
 	var/objective_amount = config.traitor_objectives_amount
-
-	if(is_hijacker && objective_count <= objective_amount) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount
-		if (!(locate(/datum/objective/hijack) in objectives))
-			var/datum/objective/hijack/hijack_objective = new
-			hijack_objective.owner = owner
-			add_objective(hijack_objective)
-			return
 
 	for(var/i = objective_count, i < objective_amount)
 		i += forge_single_objective()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -105,7 +105,7 @@
 
 /datum/antagonist/traitor/proc/forge_human_objectives()
 	var/martyr_chance = prob(20)
-	var/objective_count = 0 			//Hijacking counts towards number of objectives
+	var/objective_count = 0
 	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors
 		if(!SSticker.mode.exchange_red)
 			SSticker.mode.exchange_red = owner


### PR DESCRIPTION
LET THE CONTROVERSY BEGIN 

## What Does This PR Do
This PR takes hijack out of the objective pool. But why AA, why would you do that?

Well, I have a long thought about this, and came to a realisation. Hijack is the least RP-centric objective we have in the entire pool. If we look at the existing objectives, most of these have atleast some RP aspect to them.

- Destroy AI: You have several routes you can go about this, either aggressively breaking into the AI sat, enslaving the AI so it kills itself, there are several ways you can do this 
- Debrain: Again, you have multiple avenues for this. You can either kill and take it that way, or offer up the person implants or another surgery then take the brain out without them knowing
- Maroon: Again, easily doable. Either kill the person, or spend a shift having a nice conversation with them to say "Heya, when the shuttle arrives could you stay here for me? Would make life a lot easier for the both of us"
- Assassinate: Again, you can go in with an ebow and a minibomb and instagib people to permakill them, or you can be subtle, let your target actually have some time to enjoy their round before being knocked out for the entire thing
- Steal: You can take the item without them noticing, drug the holder then take it when they are unconscious, trade it away, none of these involve round removal.

Now take hijack. The entire premise of this objective is mass murderbone to make sure no one gets on the shuttle. This usually results in one or more of the following:
- Dual esword rampage
- Plasma in distro
- Engine decimation
- Carpet bombing escape

Hijack just ends in complete murderbone which is boring for everyone involved except the hijacker, who usually gets owned by security and promptly shot. For the rest of the playerbase, they usually die soon off and are then out of the round for the rest of the thing. All the while this feeds into a vicious cycle of the hijacker powergaming more to be able to survive security (Entire bloodstream of memechems anyone?), and security getting hyperguns to deal with this (Backpack full of AEGs and fuck tons of cyberimps anyone?) 

I honestly think this objective discourages RP standards and promotes obscene levels of powergaming, but hey, maybe I am just crazy.

Also note that this PR just removes the ability to random roll it. Admins can still force set it. 

## Why It's Good For The Game
See entire list of points above.

## Changelog
:cl: AffectedArc07
del: You can no longer roll hijack. 
/:cl:
