### PR TITLE
SM Delam station wide siren

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -280,7 +280,10 @@
 	add_overlay(causality_field, TRUE)
 
 	var/speaking = "[emergency_alert] The supermatter has reached critical integrity failure. Emergency causality destabilization field has been activated."
-	SEND_SOUND(world, sound('sound/machines/engine_alert2.ogg'))
+	for(var/mob/M in GLOB.player_list) // for all players
+		var/turf/T = get_turf(M)
+		if(istype(T) && atoms_share_level(T, src)) // if the player is on the same zlevel as the SM shared
+			SEND_SOUND(M, sound('sound/machines/engine_alert2.ogg')) // then send them the sound file
 	radio.autosay(speaking, name, null, list(z))
 	for(var/i in SUPERMATTER_COUNTDOWN_TIME to 0 step -10)
 		if(damage < explosion_point) // Cutting it a bit close there engineers

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -280,6 +280,7 @@
 	add_overlay(causality_field, TRUE)
 
 	var/speaking = "[emergency_alert] The supermatter has reached critical integrity failure. Emergency causality destabilization field has been activated."
+	SEND_SOUND(world, sound('sound/machines/engine_alert2.ogg'))
 	radio.autosay(speaking, name, null, list(z))
 	for(var/i in SUPERMATTER_COUNTDOWN_TIME to 0 step -10)
 		if(damage < explosion_point) // Cutting it a bit close there engineers


### PR DESCRIPTION
## What Does This PR Do
Adds some fluff to the SM when it hits 0 integrity. Sounds a global siren signifying a "meltdown" or delam is imminent.

## Why It's Good For The Game
All of the SM alerts are either in engineering chat, or spammed in common chat. In the event telecomms are down, this siren will still alert the crew that the SM delam is imminent.

## Changelog
🆑 Vallidian
add: adds a global siren shortly before delam.
/🆑
