### PR TITLE
Adds an interaction between two SMs when they collide.

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -756,8 +756,8 @@
 				power += 5000//releases A LOT of power
 				matter_power += 500000
 				damage += 180//drops the integrety by 20%
-				AM.visible_message("<span class='danger'>[AM] smacks into [src], rapidly flashes into pure energy. The energy inside [src] begins superradiance scattering!</span>", null,\
-				"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
+				AM.visible_message("<span class='danger'>[AM] smacks into [src], rapidly flashing blasts of pure energy. The energy inside [src] undergoes superradiance scattering!</span>", null,\
+				"<span class='italics'>You hear a loud crack as a wave of heat washes over you.</span>")
 		qdel(AM)
 	if(!iseffect(AM) && power_changes)
 		matter_power += 200

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -752,6 +752,12 @@
 				suspicion = "last touched by [AM.fingerprintslast]"
 			message_admins("[src] has consumed [AM], [suspicion] [ADMIN_JMP(src)].")
 			investigate_log("has consumed [AM] - [suspicion].", "supermatter")
+			if(istype(AM, /obj/machinery/power/supermatter_crystal))
+				power += 5000//releases A LOT of power
+				matter_power += 500000
+				damage += 180//drops the integrety by 20%
+				AM.visible_message("<span class='danger'>[AM] smacks into [src], rapidly flashes into pure energy. The energy inside [src] begins superradiance scattering!</span>", null,\
+				"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 		qdel(AM)
 	if(!iseffect(AM) && power_changes)
 		matter_power += 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When a supermatter shard collides with another it will deal 20% integrity damage and massively increase the EER.

## Why It's Good For The Game
A supermatter dusting another supermatter should have a massive reaction, all the energy contained with one crystal is instantly being released. 
This allows for interesting sabotages that involve throwing shards into the crystal to hyper energize it, giving engineers a challenge to fix compared to current sabotage which can be fixed with N2 and a fire extinguisher. Currently engine sabotage is barely worth a hijacker/nukies time because of engineers being able to fix it relatively easily and the minimal damage it courses. 
This also makes making more SMs slightly more dangerous because currently if a shard is delamming you can just throw it into the main crystal and it is gone.

## Images of changes
![ezgif-7-8c56b242ec98](https://user-images.githubusercontent.com/69320440/112755746-084f7680-8fda-11eb-8ad2-7487bd5ae4cc.gif)




## Changelog
:cl:
add: throwing an SM shard into another will cause one of the shards to have a massive boost in energy and a drop in integrity. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
