### PR TITLE
Fixes Gloves of the North Star exploit.

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -166,7 +166,7 @@
 	var/mob/living/M = loc
 
 	if(M.a_intent in accepted_intents)
-		if(M.mind.martial_art, /datum/martial_art) || HAS_TRAIT(M, TRAIT_HULK))
+		if(M.mind.martial_art) || HAS_TRAIT(M, TRAIT_HULK))
 			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
 		else
 			M.changeNext_move(click_speed_modifier)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -166,7 +166,7 @@
 	var/mob/living/M = loc
 
 	if(M.a_intent in accepted_intents)
-		if(M.mind.martial_art) || HAS_TRAIT(M, TRAIT_HULK))
+		if(M.mind.martial_art || HAS_TRAIT(M, TRAIT_HULK))
 			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
 		else
 			M.changeNext_move(click_speed_modifier)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -166,7 +166,8 @@
 	var/mob/living/M = loc
 
 	if(M.a_intent in accepted_intents)
-		if(istype(M.mind.martial_art, /datum/martial_art/cqc))
+		if(istype(M.mind.martial_art, /datum/martial_art))
+      if(HAS_TRAIT(user, TRAIT_HULK))
 			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
 		else
 			M.changeNext_move(click_speed_modifier)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -166,8 +166,7 @@
 	var/mob/living/M = loc
 
 	if(M.a_intent in accepted_intents)
-		if(istype(M.mind.martial_art, /datum/martial_art))
-			if(HAS_TRAIT(user, HULK_TRAIT))
+		if(M.mind.martial_art, /datum/martial_art) || HAS_TRAIT(M, TRAIT_HULK))
 			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
 		else
 			M.changeNext_move(click_speed_modifier)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -167,7 +167,7 @@
 
 	if(M.a_intent in accepted_intents)
 		if(istype(M.mind.martial_art, /datum/martial_art))
-		if(HAS_TRAIT(user, HULK_TRAIT))
+			if(HAS_TRAIT(user, HULK_TRAIT))
 			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
 		else
 			M.changeNext_move(click_speed_modifier)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -167,7 +167,7 @@
 
 	if(M.a_intent in accepted_intents)
 		if(istype(M.mind.martial_art, /datum/martial_art))
-      if(HAS_TRAIT(user, TRAIT_HULK))
+		if(HAS_TRAIT(user, HULK_TRAIT))
 			M.changeNext_move(CLICK_CD_MELEE)//normal attack speed for hulk, CQC and Carp.
 		else
 			M.changeNext_move(click_speed_modifier)


### PR DESCRIPTION
## What Does This PR Do
This PR aims to fix the exploit likely caused by a code oversight which allows for the Gloves of the North Star to be stacked with Carp-Fu and the Hulk Mutations.

## Why It's Good For The Game
This is good for the game because it prevents a frankly overpowered strategy from being used and abused. "Carp-Star" as it has been dubbed, is an unfair strategy which is incredibly unfun to be on the receiving end of. 

## Changelog
:cl:
fix: Defines hulk and "martial art" as originally intended so it is unable to be stacked. 
/:cl:
