### PR TITLE
Removes flight when wielded broomstick is dropped by a wizard

### DIFF
--- a/code/game/objects/items/weapons/staff.dm
+++ b/code/game/objects/items/weapons/staff.dm
@@ -52,6 +52,11 @@
 		return
 	..()
 
+/obj/item/twohanded/staff/broom/dropped(mob/user)
+	if((user.mind in SSticker.mode.wizards) && user.flying)
+		user.flying = FALSE
+	..()
+
 /obj/item/twohanded/staff/broom/horsebroom
 	name = "broomstick horse"
 	desc = "Saddle up!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently, if a wizard wields a broomstick twohanded, it will grant them flight. If the broomstick is then dropped, the flight will remain permanent. This PR makes it so that the flight effect is removed when the wielded broomstick is dropped

fixes: #15463
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Wizard wielded broomstick flying is removed when the broomstick is dropped now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
