### PR TITLE
No more multitool mutilation

### DIFF
--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -12,7 +12,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "multitool"
 	flags = CONDUCT
-	force = 5.0
+	force = 0
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 0
 	throw_range = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sets multitool force from 5 to 0 so it no longer does any damage on attack.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lightly tapping someone with a small piece of electrical equipment shouldn't hurt that much. 

_Even if it is really funny to break someone's bones with it._
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Multitool no longer does any damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
