### PR TITLE
Fixes dream text

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -18,13 +18,13 @@
 /mob/living/carbon/proc/custom_dreams(list/dreamlist, mob/user)
 	var/list/newlist = dreamlist.Copy()
 	for(var/i in 1 to newlist.len)
-		newlist[i] = replacetext(newlist[i], "\[DREAMER\]", "[user.name]")
+		newlist[i] = replacetext(newlist[i], "DREAMER", "[user.name]")
 	return newlist
 
 
 //NIGHTMARES
 /mob/living/carbon/proc/nightmare()
-	var/list/nightmares = GLOB.nightmare_strings.Copy()
+	var/list/nightmares = custom_dreams(GLOB.nightmare_strings, src)
 
 	for(var/obj/item/bedsheet/sheet in loc)
 		nightmares += sheet.nightmare_messages

--- a/config/names/dreams.txt
+++ b/config/names/dreams.txt
@@ -109,4 +109,4 @@ the AI core
 the mining station
 the research station
 a beaker of strange liquid
-Captain [DREAMER]
+Captain DREAMER

--- a/config/names/nightmares.txt
+++ b/config/names/nightmares.txt
@@ -25,4 +25,4 @@ aaaAAAaaaaAAAAAAaa
 pApErWork
 we SEE yoU
 the ceiling
-we have been waiting for you [DREAMER]
+we have been waiting for you DREAMER


### PR DESCRIPTION

## What Does This PR Do
The previous [DREAMER] text during dreams and nightmares is replaced with the character's name.

## Why It's Good For The Game
More immersion during sleep

## Images of changes
Before
![image](https://user-images.githubusercontent.com/47925856/113219730-5c678e80-9258-11eb-8ff4-9d1ab9646f29.png)


After
![image](https://user-images.githubusercontent.com/47925856/113213208-3937e180-924e-11eb-9a08-3a50e66c044f.png)

## Changelog
:cl:

fix: Replaces the [DREAMER] word with the character's name during dreams and nightmares
/:cl:

