### PR TITLE
Improves deathsquad naming structure

### DIFF
--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -136,15 +136,14 @@ GLOBAL_VAR_INIT(sent_strike_team, 0)
 /client/proc/create_death_commando(obj/spawn_location, is_leader = FALSE)
 	var/mob/living/carbon/human/new_commando = new(spawn_location.loc)
 	var/commando_leader_rank = pick("Lieutenant", "Captain", "Major")
-	var/commando_rank = pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant 1st Class", "Master Sergeant", "Sergeant Major")
-	var/commando_name = pick(GLOB.last_names)
+	var/commando_name = pick(GLOB.commando_names)
 
 	var/datum/preferences/A = new()//Randomize appearance for the commando.
 	if(is_leader)
 		A.age = rand(35,45)
 		A.real_name = "[commando_leader_rank] [commando_name]"
 	else
-		A.real_name = "[commando_rank] [commando_name]"
+		A.real_name = "[commando_name]"
 	A.copy_to(new_commando)
 
 


### PR DESCRIPTION
Yes, this is an april fools PR

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR makes deathsquads use the naming system from /config/names/death_commando.txt , which was already in the code.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Why use names similar to ERT, when we have a perfectly good death_commando.txt to get GREAT deathsquad names.

Examples of some possible names:

Killiam Shakespeare

AMERICA

THAT DAMN TRAITOR GEORGE MELONS

A whole bunch of spiders in a SWAT suit

Killing McKillingalot

Hank Chesthair

And more!

## Changelog
:cl:
experiment: Someone merged this, deathsquads now have a +1 to their naming system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
