### PR TITLE
Removes the ability to play as a human

### DIFF
--- a/code/modules/mob/living/carbon/human/species/human.dm
+++ b/code/modules/mob/living/carbon/human/species/human.dm
@@ -2,6 +2,7 @@
 	name = "Human"
 	name_plural = "Humans"
 	icobase = 'icons/mob/human_races/r_human.dmi'
+	blacklisted = TRUE
 	primitive_form = /datum/species/monkey
 	language = "Sol Common"
 	species_traits = list(LIPS)


### PR DESCRIPTION
## What Does This PR Do
After intense staff discussion, we have decided to remove the ability for players to choose the human race to play as. This wasn't an easy decision to make, however we have decided it is in the best interests of the player-base to do so.

## Why It's Good For The Game
A new direction for the server to take that will foster a community we'd like to have here. :3

## Changelog
:cl:
del: Removed the ability to play as a human.
/:cl: