### PR TITLE
Honkbot AI fixes and sad trombone

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -361,6 +361,13 @@
 				/obj/item/bikehorn)
 	category = CAT_MISC
 
+/datum/crafting_recipe/sad_trombone
+	name = "Sad trombone"
+	result = list(/obj/item/instrument/trombone/sad)
+	time = 20
+	reqs = list(/obj/item/stack/sheet/mineral/bananium = 5)
+	category = CAT_MISC
+
 /datum/crafting_recipe/blackcarpet
 	name = "Black Carpet"
 	result = list(/obj/item/stack/tile/carpet/black)

--- a/code/modules/instruments/objs/items/instruments.dm
+++ b/code/modules/instruments/objs/items/instruments.dm
@@ -135,6 +135,16 @@
 	playsound (src, 'sound/instruments/trombone/Cn4.mid', 100,1,-1)
 	..()
 
+/obj/item/instrument/trombone/sad
+	name = "sad trombone"
+	desc = "Wah. Waah. Waaah. Waaaaaaah."
+	force = 0
+	attack_verb = list("Wahed", "Waahed", "Waaahed", "Honked")
+
+/obj/item/instrument/trombone/sad/attack(mob/living/carbon/C, mob/user)
+	playsound(loc, 'sound/misc/sadtrombone.ogg', 50, 1, -1)
+	..()
+
 /obj/item/instrument/recorder
 	name = "recorder"
 	desc = "Just like in school, playing ability and all."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes a few oversights on the honkbot
- The honk bot now is prevented from stunning you with ear protection
- The honkbot properly spams its horn at long range when emagged
- The honkbot now properly retaliates when attacked with an item instead of just with a hand
- Adds a sad trombone that can be made with bananium to give an alternate way to make the honk bot. It makes sad trombone sounds when attacking instead of dealing damage.

## Why It's Good For The Game
There were a few just oversights and issues with the honkbot's AI, for example in its find target AI there was a case where it was supposed to remove its range limit on the horn, but it would never happen. Also, the sonic attack wasn't prevented by earmuffs. Further, the robot would only retaliate with attack_hand, instead of any attack. Finally, I added the new trombone mostly to give the clown another way to get honkbots, without having to order a 50 point music crate from cargo, also sad trombone is funny.

## Changelog
:cl:
add: Added a sad trombone that can be made from bananium
add: Earmuffs now protect against honkbot stun
fix: Fixed a few oversights in the honkbot's AI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
