### PR TITLE
Moved nullified to own proc and reduced stacking effect of nullrod/prayer beads

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -220,6 +220,10 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		/obj/effect/proc_holder/spell/vampire/targetted/enthrall = 300,
 		/datum/vampire_passive/full = 500)
 
+/datum/vampire/proc/adjust_nullification(base, extra)
+	// First hit should give full nullification, while subsequent hits increase the value slower
+	nullified = max(nullified + extra, base)
+
 /datum/vampire/New(gend = FEMALE)
 	gender = gend
 

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -500,7 +500,7 @@
 		if(holder.l_hand == src || holder.r_hand == src) // Holding this in your hand will
 			for(var/mob/living/carbon/human/H in range(5, loc))
 				if(H.mind && H.mind.vampire && !H.mind.vampire.get_ability(/datum/vampire_passive/full))
-					H.mind.vampire.adjust_nullification(5)
+					H.mind.vampire.adjust_nullification(5, 2)
 					if(prob(10))
 						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your powers!</span>")
 

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -39,7 +39,7 @@
 	if(ishuman(M) && M.mind?.vampire)
 		if(!M.mind.vampire.get_ability(/datum/vampire_passive/full))
 			to_chat(M, "<span class='warning'>The nullrod's power interferes with your own!</span>")
-			M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
+			M.mind.vampire.adjust_nullification(5, 2)
 
 /obj/item/nullrod/pickup(mob/living/user)
 	. = ..()
@@ -476,7 +476,7 @@
 					return
 
 				if(target.mind.vampire && !target.mind.vampire.get_ability(/datum/vampire_passive/full)) // Getting a full prayer off on a vampire will interrupt their powers for a large duration.
-					target.mind.vampire.nullified = max(120, target.mind.vampire.nullified + 120)
+					target.mind.vampire.adjust_nullification(120, 50)
 					to_chat(target, "<span class='userdanger'>[user]'s prayer to [SSticker.Bible_deity_name] has interfered with your power!</span>")
 					praying = FALSE
 					return
@@ -500,7 +500,7 @@
 		if(holder.l_hand == src || holder.r_hand == src) // Holding this in your hand will
 			for(var/mob/living/carbon/human/H in range(5, loc))
 				if(H.mind && H.mind.vampire && !H.mind.vampire.get_ability(/datum/vampire_passive/full))
-					H.mind.vampire.nullified = max(5, H.mind.vampire.nullified + 2)
+					H.mind.vampire.adjust_nullification(5)
 					if(prob(10))
 						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your powers!</span>")
 

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -284,7 +284,7 @@
 			update_flags |= M.adjustStaminaLoss(5, FALSE)
 			if(prob(20))
 				M.emote("scream")
-			M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
+			M.mind.vampire.adjust_nullification(5, 2)
 			M.mind.vampire.bloodusable = max(M.mind.vampire.bloodusable - 3,0)
 			if(M.mind.vampire.bloodusable)
 				V.vomit(0,1)
@@ -296,7 +296,7 @@
 			switch(current_cycle)
 				if(1 to 4)
 					to_chat(M, "<span class = 'warning'>Something sizzles in your veins!</span>")
-					M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
+					M.mind.vampire.adjust_nullification(5, 2)
 				if(5 to 12)
 					to_chat(M, "<span class = 'danger'>You feel an intense burning inside of you!</span>")
 					update_flags |= M.adjustFireLoss(1, FALSE)
@@ -304,7 +304,7 @@
 					M.Jitter(20)
 					if(prob(20))
 						M.emote("scream")
-					M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
+					M.mind.vampire.adjust_nullification(5, 2)
 				if(13 to INFINITY)
 					to_chat(M, "<span class = 'danger'>You suddenly ignite in a holy fire!</span>")
 					for(var/mob/O in viewers(M, null))
@@ -316,7 +316,7 @@
 					M.Jitter(30)
 					if(prob(40))
 						M.emote("scream")
-					M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
+					M.mind.vampire.adjust_nullification(5, 2)
 	return ..() | update_flags
 
 
@@ -333,7 +333,7 @@
 				return
 			else
 				to_chat(M, "<span class='warning'>Something holy interferes with your powers!</span>")
-				M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
+				M.mind.vampire.adjust_nullification(5, 2)
 
 
 /datum/reagent/holywater/reaction_turf(turf/simulated/T, volume)


### PR DESCRIPTION
## What Does This PR Do
This PR Closes #14136 regarding effect stacking of the prayer beads on vampires. Repeated uses of the prayer beads add 120 "pseudo-seconds", so about 240 in-game seconds to the nullified value of the vampire. This is contrary to other items that modify the nullification timer, which usually add a base value and further uses increase the value at a slower pace.

I've taken the opportunity to move the function to its own proc in vampire, but kept the mechanics essentially the same. The only exception being that I reduced additional applications of the preyer beads to only add 50 instead of 120 if the the resulting value is larger than the base value.

## Why It's Good For The Game
It troubled someone enough to make an issue out of it, and I can see how it goes against the way the other nullifying items work. It may in the end be subject to taste though.

## Changelog
:cl:
tweak: Prayer beads subsequent nullification reduced to 50 from 120
add: Created new proc in vampire to handle nullified modifications in future.
/:cl:
