### PR TITLE
Evidence bag items now call pickup proc

### DIFF
--- a/code/modules/detective_work/evidence.dm
+++ b/code/modules/detective_work/evidence.dm
@@ -76,6 +76,7 @@
 		"<span class='notice'>You hear someone rustle around in a plastic bag, and remove something.</span>")
 		overlays.Cut()	//remove the overlays
 		user.put_in_hands(I)
+		I.pickup(user)
 		w_class = WEIGHT_CLASS_TINY
 		icon_state = "evidenceobj"
 		desc = "An empty evidence bag."
@@ -83,4 +84,3 @@
 	else
 		to_chat(user, "[src] is empty.")
 		icon_state = "evidenceobj"
-


### PR DESCRIPTION
## What Does This PR Do
PR fixes #15774 . Removing an object from an evidencebag just put the item in your hands without calling the item's pickup proc.

After adding it, it seems to have worked without issues in tests.

## Why It's Good For The Game
Fixes unexpected behaviour as picking up cult items regardless out of which storage item should have the negative effect on the player if they are not a cultist.

## Images of changes
![grafik](https://user-images.githubusercontent.com/29854606/113410528-eb3cee00-93b3-11eb-85f2-fe297b597e75.png)

## Changelog
:cl:
add: Added pickup(user) to /obj/item/evidencebag/attack_self
fix: Fixed item behaviour taken out of evidencebags
/:cl:
