### PR TITLE
Allows anchoring of fueltanks/watertanks/etc

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -3,8 +3,8 @@
 	desc = "..."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
-	density = 1
-	anchored = 0
+	density = TRUE
+	anchored = TRUE
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	container_type = DRAINABLE | AMOUNT_VISIBLE
 	max_integrity = 300
@@ -27,6 +27,12 @@
 	. = ..()
 	create_reagents(tank_volume)
 	reagents.add_reagent(reagent_id, tank_volume)
+
+/obj/structure/reagent_dispensers/wrench_act(mob/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	default_unfasten_wrench(user, I)
 
 /obj/structure/reagent_dispensers/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -233,12 +239,6 @@
 	var/obj/item/reagent_containers/food/drinks/sillycup/S = new(get_turf(src))
 	user.put_in_hands(S)
 	paper_cups--
-
-/obj/structure/reagent_dispensers/water_cooler/wrench_act(mob/user, obj/item/I)
-	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
-	default_unfasten_wrench(user, I, 40)
 
 /obj/structure/reagent_dispensers/beerkeg
 	name = "beer keg"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -44,7 +44,7 @@
 /obj/structure/reagent_dispensers/examine(mob/user)
 	. = ..()
 	if(can_be_unwrenched)
-		. += "<span class='notice'>You can </b>[anchored ? "unlock the wheels" : "lock it in place"] with a <b>Wrench</b>"
+		. += "<span class='notice'>The wheels look like they can be <b>[anchored ? "unlocked" : "locked in place"]</b> with a <b>wrench</b>."
 
 /obj/structure/reagent_dispensers/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -12,7 +12,7 @@
 	var/tank_volume = 1000
 	/// The ID of the reagent that the dispenser uses
 	var/reagent_id = "water"
-	/// The last person to rig this fuel tank - Stored with the object. Only the last person matter for investigation
+	/// The last person to rig this fuel tank - Stored with the object. Only the last person matters for investigation
 	var/lastrigger = ""
 	/// Can this tank be unwrenched
 	var/can_be_unwrenched = TRUE

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -8,9 +8,14 @@
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	container_type = DRAINABLE | AMOUNT_VISIBLE
 	max_integrity = 300
-	var/tank_volume = 1000 //In units, how much the dispenser can hold
-	var/reagent_id = "water" //The ID of the reagent that the dispenser uses
-	var/lastrigger = "" // The last person to rig this fuel tank - Stored with the object. Only the last person matter for investigation
+	/// How much this dispenser can hold (In units)
+	var/tank_volume = 1000
+	/// The ID of the reagent that the dispenser uses
+	var/reagent_id = "water"
+	/// The last person to rig this fuel tank - Stored with the object. Only the last person matter for investigation
+	var/lastrigger = ""
+	/// Can this tank be unwrenched
+	var/can_be_unwrenched = TRUE
 
 /obj/structure/reagent_dispensers/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
@@ -29,10 +34,17 @@
 	reagents.add_reagent(reagent_id, tank_volume)
 
 /obj/structure/reagent_dispensers/wrench_act(mob/user, obj/item/I)
+	if(!can_be_unwrenched)
+		return
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
 	default_unfasten_wrench(user, I)
+
+/obj/structure/reagent_dispensers/examine(mob/user)
+	. = ..()
+	if(can_be_unwrenched)
+		. += "<span class='notice'>You can </b>[anchored ? "unlock the wheels" : "lock it in place"] with a <b>Wrench</b>"
 
 /obj/structure/reagent_dispensers/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -212,8 +224,8 @@
 	name = "pepper spray refiller"
 	desc = "Contains condensed capsaicin for use in law \"enforcement.\""
 	icon_state = "pepper"
-	anchored = 1
-	density = 0
+	density = FALSE
+	can_be_unwrenched = FALSE
 	reagent_id = "condensedcapsaicin"
 
 /obj/structure/reagent_dispensers/water_cooler
@@ -221,7 +233,6 @@
 	desc = "A machine that dispenses liquid to drink."
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "water_cooler"
-	anchored = 1
 	tank_volume = 500
 	reagent_id = "water"
 	var/paper_cups = 25 //Paper cups left from the cooler
@@ -263,22 +274,22 @@
 	name = "virus food dispenser"
 	desc = "A dispenser of low-potency virus mutagenic."
 	icon_state = "virus_food"
-	anchored = 1
-	density = 0
+	can_be_unwrenched = FALSE
+	density = FALSE
 	reagent_id = "virusfood"
 
 /obj/structure/reagent_dispensers/spacecleanertank
 	name = "space cleaner refiller"
 	desc = "Refills space cleaner bottles."
 	icon_state = "cleaner"
-	anchored = 1
-	density = 0
+	can_be_unwrenched = FALSE
+	density = FALSE
 	tank_volume = 5000
 	reagent_id = "cleaner"
 
 /obj/structure/reagent_dispensers/fueltank/chem
 	icon_state = "fuel_chem"
-	anchored = 1
-	density = 0
-	accepts_rig = 0
+	can_be_unwrenched = FALSE
+	density = FALSE
+	accepts_rig = FALSE
 	tank_volume = 1000


### PR DESCRIPTION
## What Does This PR Do
You can now anchor and unanchor reagent dispensers (fuel tanks, water tanks, oil tanks, etc etc) with a wrench.

## Why It's Good For The Game
99% of structures like this can be wrenched in place, feels weird not to have it be consistent. Also prevents greytidery by requiring assistants to take 2 seconds to unwrench a high-capacity watertank before just running off with it.

## Changelog
:cl: AffectedArc07
add: You can now anchor and unanchor reagent dispensers (fueltanks, water tanks, etc) with a wrench
/:cl:
