### PR TITLE
Make the heat resistance trait fully fireproof

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -358,7 +358,7 @@
 		return
 	var/thermal_protection = get_thermal_protection()
 
-	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT || HAS_TRAIT(src, TRAIT_RESISTHEAT))
+	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
 		return
 	if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT)
 		bodytemperature += 11
@@ -366,6 +366,10 @@
 		bodytemperature += (BODYTEMP_HEATING_MAX + (fire_stacks * 12))
 
 /mob/living/carbon/human/proc/get_thermal_protection()
+
+	if(HAS_TRAIT(src, TRAIT_RESISTHEAT))
+		return FIRE_IMMUNITY_MAX_TEMP_PROTECT
+
 	var/thermal_protection = 0 //Simple check to estimate how protected we are against multiple temperatures
 	if(wear_suit)
 		if(wear_suit.max_heat_protection_temperature >= FIRE_SUIT_MAX_TEMP_PROTECT)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -366,7 +366,6 @@
 		bodytemperature += (BODYTEMP_HEATING_MAX + (fire_stacks * 12))
 
 /mob/living/carbon/human/proc/get_thermal_protection()
-
 	if(HAS_TRAIT(src, TRAIT_RESISTHEAT))
 		return FIRE_IMMUNITY_MAX_TEMP_PROTECT
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -358,7 +358,7 @@
 		return
 	var/thermal_protection = get_thermal_protection()
 
-	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
+	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT || HAS_TRAIT(src, TRAIT_RESISTHEAT))
 		return
 	if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT)
 		bodytemperature += 11


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Change the heat resistance trait to grant full fireproofing to whoever has it, by making the user immune to temperature raising from fire. This bug was caused by a missing check in /mob/living/carbon/human/proc/get_thermal_protection(), while this check is present in /mob/living/carbon/human/proc/get_heat_protection(temperature).

This affects the heat resistance mutation and skeletons. Skeletons used to be fireproof before the mutation into traits refactor, this was changed without documenting.

Fixes https://github.com/ParadiseSS13/Paradise/issues/15814

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

From the way it's used in the codebase, it seems that this mutation/trait is meant to make you completely fireproof. 

The opposite mutation make you completely cold proof (including from space, having the coldproof mutation make you entirely spaceproof), the DNA vault says it's supposed to make you 'fireproof', and it's a pretty useless trait/power to have if it doesnt do the one job it's supposed to do effectively.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

![image](https://user-images.githubusercontent.com/22121511/113442027-9323dd00-93ef-11eb-93a9-fd19f083c824.png)


## Changelog
:cl:
tweak: Heat resistance mutation now makes you completely fireproof.
tweak: Liches are once again completely fireproof.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
