### PR TITLE
Fixes buying sacred flame in spellbook, misc spellbook improvements

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -88,7 +88,7 @@
 	if(!S)
 		S = new spell_type()
 	var/dat =""
-	dat += "<b>[initial(S.name)]</b>"
+	dat += "<b>[name]</b>"
 	if(S.charge_type == "recharge")
 		dat += " Cooldown:[S.charge_max/10]"
 	dat += " Cost:[cost]<br>"
@@ -172,18 +172,6 @@
 	log_name = "IG"
 	category = "Offensive"
 
-/datum/spellbook_entry/sacred_flame
-	name = "Sacred Flame"
-	spell_type = /obj/effect/proc_holder/spell/targeted/sacred_flame
-	cost = 1
-	log_name = "SF"
-	refundable = 0 //You get fire immunity out of it, no.
-
-/datum/spellbook_entry/sacred_flame/LearnSpell(mob/living/carbon/human/user, obj/item/spellbook/book, obj/effect/proc_holder/spell/newspell)
-	..()
-	user.dna.SetSEState(GLOB.coldblock, 1)
-	singlemutcheck(user, GLOB.coldblock, MUTCHK_FORCED)
-
 //Defensive
 /datum/spellbook_entry/disabletech
 	name = "Disable Tech"
@@ -238,6 +226,25 @@
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	log_name = "TS"
 	category = "Defensive"
+
+/datum/spellbook_entry/sacred_flame
+	name = "Sacred Flame and Fire Immunity"
+	spell_type = /obj/effect/proc_holder/spell/targeted/sacred_flame
+	cost = 1
+	log_name = "SF"
+	category = "Defensive"
+
+/datum/spellbook_entry/sacred_flame/LearnSpell(mob/living/carbon/human/user, obj/item/spellbook/book, obj/effect/proc_holder/spell/newspell)
+	to_chat(user, "<span class='notice'>You feel fireproof.</span>")
+	ADD_TRAIT(user, TRAIT_RESISTHEAT, MAGIC_TRAIT)
+	ADD_TRAIT(user, TRAIT_RESISTHIGHPRESSURE, MAGIC_TRAIT)
+	. = ..()
+
+/datum/spellbook_entry/sacred_flame/Refund(mob/living/carbon/human/user, obj/item/spellbook/book)
+	to_chat(user, "<span class='warning'>You no longer feel fireproof.</span>")
+	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, MAGIC_TRAIT)
+	REMOVE_TRAIT(user, TRAIT_RESISTHIGHPRESSURE, MAGIC_TRAIT)
+	. = ..()
 
 //Mobility
 /datum/spellbook_entry/knock
@@ -431,7 +438,7 @@
 	category = "Artefacts"
 
 /datum/spellbook_entry/item/voice_of_god
-	name = "Voice of god"
+	name = "Voice of God"
 	desc = "A magical vocal cord that can be used to yell out with the voice of a god, be it to harm, help, or confuse the target."
 	item_path = /obj/item/organ/internal/vocal_cords/colossus/wizard
 	log_name = "VG"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -244,7 +244,7 @@
 	to_chat(user, "<span class='warning'>You no longer feel fireproof.</span>")
 	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, MAGIC_TRAIT)
 	REMOVE_TRAIT(user, TRAIT_RESISTHIGHPRESSURE, MAGIC_TRAIT)
-	. = ..()
+	return ..()
 
 //Mobility
 /datum/spellbook_entry/knock

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -238,7 +238,7 @@
 	to_chat(user, "<span class='notice'>You feel fireproof.</span>")
 	ADD_TRAIT(user, TRAIT_RESISTHEAT, MAGIC_TRAIT)
 	ADD_TRAIT(user, TRAIT_RESISTHIGHPRESSURE, MAGIC_TRAIT)
-	. = ..()
+	return ..()
 
 /datum/spellbook_entry/sacred_flame/Refund(mob/living/carbon/human/user, obj/item/spellbook/book)
 	to_chat(user, "<span class='warning'>You no longer feel fireproof.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

This PR should be merged after https://github.com/ParadiseSS13/Paradise/pull/15815 to avoid baiting wizards into buying fire immunity that doesn't work yet.

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Fixes https://github.com/ParadiseSS13/Paradise/issues/15813
Fixes https://github.com/ParadiseSS13/Paradise/issues/15812
Fix sacred flame being free and not properly giving the wizard fireproof.
Moved sacred flame to defensive category, as offensive already has more spells and the Fire Immunity is one of the big reason you'd buy this.
Rename the spellbook entry to 'Sacred Flame and Fire Immunity' to advertise the fire immunity feature.
Change the spellbook listing to base itself on the entry name var instead of the spell's. This only matters for Sacred Flame as all others are the same.
Fix typo (Voice of god to Voice of God)
Make sacred flame refundable, removing fireproofing on refund.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes good. Being able to refund spells when you're still in the lair is also good. Advertising features to people that don't code-dive is also good.

## Changelog
:cl:
fix: Buying Sacred Flame in the wizard spellbook now properly grants fire immunity, as it's supposed to.
fix: Fixed Sacred Flame not costing any spell points.
tweak: Renamed Sacred Flame entry in the spellbook to Sacred Flame and Fire Immunity.
tweak: Moved Sacred Flame to the defensive category in the wiz spellbook.
tweak: Sacred Flame can now be refunded (You do not keep the fire immunity either.)
fix: Fixed typo in wizard spellbook
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
