### PR TITLE
Removes Stable Mutagen

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -94,7 +94,7 @@
 /datum/action/changeling/sting/transformation/can_sting(mob/user, mob/target)
 	if(!..())
 		return
-	if(HAS_TRAIT(target, TRAIT_HUSK) || (!ishuman(target)))
+	if(HAS_TRAIT(target, TRAIT_HUSK) || !ishuman(target) || (NOTRANSSTING in target.dna.species.species_traits))
 		to_chat(user, "<span class='warning'>Our sting appears ineffective against its DNA.</span>")
 		return FALSE
 	if(ishuman(target))

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -203,6 +203,7 @@
 	reagent_state = LIQUID
 	color = "#7DFF00"
 	taste_description = "slime"
+	can_synth = FALSE
 
 /datum/reagent/stable_mutagen/on_new(data)
 	..()

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -154,19 +154,6 @@
 	result_amount = 3
 	mix_message = "The substance turns neon green and bubbles unnervingly."
 
-/datum/chemical_reaction/stable_mutagen
-	name = "Stable mutagen"
-	id = "stable_mutagen"
-	result = "stable_mutagen"
-	required_reagents = list("mutagen" = 1, "lithium" = 1, "acetone" = 1, "bromine" = 1)
-	result_amount = 3
-	mix_message = "The substance turns a drab green and begins to bubble."
-
-/datum/chemical_reaction/stable_mutagen/stable_mutagen2
-	id = "stable_mutagen2"
-	required_reagents = list("mutadone" = 3, "lithium" = 1)
-	result_amount = 4
-
 /datum/chemical_reaction/rotatium
 	name = "Rotatium"
 	id = "Rotatium"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes both chemistry recipes for Stable Mutagen, and makes it unable to be synthesised by botany. (Still admin spawnable)
Also makes any species with the `NOTRANSSTING` trait (Vox and Plasmamen) immune to the Changeling Transformation Sting in order to balance it out.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Stable Mutagen currently has two uses:

### 1. Vox Cloning:
For this use, not only does it pretty much invalidate the 'Cannot be cloned' malus, it also doesn't make any sense lore wise.
Cloning a Vox with SM also clones their Cortical Stack, which is a bio-mechanical implant. You can't copy robotic limbs and organs with SM, so there's no reason for this to be an exception.
And of course there's also this section on the Vox wiki page:
> So far, attempts at lab-grown samples have produced no results with such efforts often producing highly acidic compounds capable of burning through most lab equipment.

As it is that statement makes no sense, since anyone with medbay access and a bit of lithium can clone a perfectly functional Vox with no issues.

Removing Stable Mutagen *will* force gibbed Vox to play as another species for the remainder of the round, but considering that Slime People (The only other non-clonable species) have to do this already, I can't see this as too much of a downside.

### 2. Forcefully transforming half the crew into yourself:
I don't think I need to go into too much detail as to why this is bad, but suffice it to say that non-antags really shouldn't have access to a DIY Transformation Sting. Especially considering how controversial the sting itself already is.

## Changelog
:cl:
del: Removed the recipe for Stable Mutagen.
tweak: Made Vox and Plasmamen immune to the Changeling Transformation Sting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
