### PR TITLE
Cuffs now block arm implant use

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -62,8 +62,13 @@
 		Retract()
 	..()
 
+/obj/item/organ/internal/cyberimp/arm/proc/CheckCuffs()
+	if(owner.handcuffed)
+		to_chat(owner, "<span class='warning'>The handcuffs interfere with [src]!</span>")
+		return TRUE
+
 /obj/item/organ/internal/cyberimp/arm/proc/Retract()
-	if(!holder || (holder in src))
+	if(!holder || (holder in src) || CheckCuffs())
 		return
 
 	owner.visible_message("<span class='notice'>[owner] retracts [holder] back into [owner.p_their()] [parent_organ == "r_arm" ? "right" : "left"] arm.</span>",
@@ -80,9 +85,8 @@
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, 1)
 
 /obj/item/organ/internal/cyberimp/arm/proc/Extend(obj/item/item)
-	if(!(item in src))
+	if(!(item in src) || CheckCuffs())
 		return
-
 
 	holder = item
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -62,13 +62,13 @@
 		Retract()
 	..()
 
-/obj/item/organ/internal/cyberimp/arm/proc/CheckCuffs()
+/obj/item/organ/internal/cyberimp/arm/proc/check_cuffs()
 	if(owner.handcuffed)
 		to_chat(owner, "<span class='warning'>The handcuffs interfere with [src]!</span>")
 		return TRUE
 
 /obj/item/organ/internal/cyberimp/arm/proc/Retract()
-	if(!holder || (holder in src) || CheckCuffs())
+	if(!holder || (holder in src) || check_cuffs())
 		return
 
 	owner.visible_message("<span class='notice'>[owner] retracts [holder] back into [owner.p_their()] [parent_organ == "r_arm" ? "right" : "left"] arm.</span>",
@@ -85,7 +85,7 @@
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, 1)
 
 /obj/item/organ/internal/cyberimp/arm/proc/Extend(obj/item/item)
-	if(!(item in src) || CheckCuffs())
+	if(!(item in src) || check_cuffs())
 		return
 
 	holder = item


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR stops you from being able to summon invisible tools/weapons while cuffed with an arm implant.
It will now display the message:
`The handcuffs interfere with the [implant]!`
When trying to extend or retract items while handcuffed.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Phantom items that sometimes have to be admin-removed are bad, this is unintended behaviour.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Cuffs now block the use of toolset implants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
