### PR TITLE
Fix diona/slimepeople limbs not augmenting fully

### DIFF
--- a/code/modules/surgery/organs/subtypes/diona.dm
+++ b/code/modules/surgery/organs/subtypes/diona.dm
@@ -5,6 +5,7 @@
 	amputation_point = "trunk"
 	encased = null
 	gendered_icon = 0
+	convertable_children = list(/obj/item/organ/external/groin/diona)
 
 /obj/item/organ/external/groin/diona
 	name = "fork"
@@ -17,24 +18,28 @@
 	max_damage = 35
 	min_broken_damage = 20
 	amputation_point = "upper left trunk"
+	convertable_children = list(/obj/item/organ/external/arm/diona)
 
 /obj/item/organ/external/arm/right/diona
 	name = "right upper tendril"
 	max_damage = 35
 	min_broken_damage = 20
 	amputation_point = "upper right trunk"
+	convertable_children = list(/obj/item/organ/external/arm/right/diona)
 
 /obj/item/organ/external/leg/diona
 	name = "left lower tendril"
 	max_damage = 35
 	min_broken_damage = 20
 	amputation_point = "lower left fork"
+	convertable_children = list(/obj/item/organ/external/leg/diona)
 
 /obj/item/organ/external/leg/right/diona
 	name = "right lower tendril"
 	max_damage = 35
 	min_broken_damage = 20
 	amputation_point = "lower right fork"
+	convertable_children = list(/obj/item/organ/external/leg/right/diona)
 
 /obj/item/organ/external/foot/diona
 	name = "left foot"

--- a/code/modules/surgery/organs/subtypes/unbreakable.dm
+++ b/code/modules/surgery/organs/subtypes/unbreakable.dm
@@ -1,21 +1,26 @@
 /obj/item/organ/external/chest/unbreakable
 	cannot_break = TRUE
 	encased = null
+	convertable_children = list(/obj/item/organ/external/groin/unbreakable)
 
 /obj/item/organ/external/groin/unbreakable
 	cannot_break = TRUE
 
 /obj/item/organ/external/arm/unbreakable
 	cannot_break = TRUE
+	convertable_children = list(/obj/item/organ/external/hand/unbreakable)
 
 /obj/item/organ/external/arm/right/unbreakable
 	cannot_break = TRUE
+	convertable_children = list(/obj/item/organ/external/hand/right/unbreakable)
 
 /obj/item/organ/external/leg/unbreakable
 	cannot_break = TRUE
+	convertable_children = list(/obj/item/organ/external/foot/right/unbreakable)
 
 /obj/item/organ/external/leg/right/unbreakable
 	cannot_break = TRUE
+	convertable_children = list(/obj/item/organ/external/foot/right/unbreakable)
 
 /obj/item/organ/external/foot/unbreakable
 	cannot_break = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where when you augment a limb on a diona/slimeperson, it would not augment connected limbs (EG. Augmenting an arm would not augment the hand.)

Fixes: #15641
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Augmenting limbs on slimepeople and diona now also augments connected limbs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
