### PR TITLE
Prescription glasses tweaks

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -263,6 +263,7 @@
 	icon_state = "meson"
 	item_state = "meson"
 	resistance_flags = NONE
+	prescription_upgradable = TRUE
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 	sprite_sheets = list(

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -4,31 +4,33 @@
 		// Pre-upgraded upgradable glasses
 		name = "prescription [name]"
 
-/obj/item/clothing/glasses/attackby(obj/item/O as obj, mob/user as mob)
-	if(user.stat || user.restrained() || !ishuman(user))
+/obj/item/clothing/glasses/attackby(obj/item/I, mob/user)
+	if(!prescription_upgradable || user.stat || user.restrained() || !ishuman(user))
 		return ..()
 	var/mob/living/carbon/human/H = user
-	if(prescription_upgradable)
-		if(istype(O, /obj/item/clothing/glasses/regular))
-			if(prescription)
-				to_chat(H, "You can't possibly imagine how adding more lenses would improve \the [name].")
-				return
-			H.unEquip(O)
-			O.loc = src // Store the glasses for later removal
-			to_chat(H, "You fit \the [name] with lenses from \the [O].")
-			prescription = 1
-			name = "prescription [name]"
+
+	// Adding prescription glasses
+	if(istype(I, /obj/item/clothing/glasses/regular))
+		if(prescription)
+			to_chat(H, "<span class='warning'>You can't possibly imagine how adding more lenses would improve [src].</span>")
 			return
-		if(prescription && istype(O, /obj/item/screwdriver))
-			var/obj/item/clothing/glasses/regular/G = locate() in src
-			if(!G)
-				G = new(get_turf(H))
-			to_chat(H, "You salvage the prescription lenses from \the [name].")
-			prescription = 0
-			name = initial(name)
-			H.put_in_hands(G)
-			return
-	return ..()
+		H.unEquip(I)
+		I.loc = src // Store the glasses for later removal
+		to_chat(H, "<span class='notice'>You fit [src] with lenses from [I].</span>")
+		prescription = TRUE
+		name = "prescription [initial(name)]"
+
+	// Removing prescription glasses
+	else if(prescription && istype(I, /obj/item/screwdriver))
+		var/obj/item/clothing/glasses/regular/G = locate() in src
+		if(!G)
+			G = new(src)
+		to_chat(H, "<span class='notice'>You salvage the prescription lenses from [src].</span>")
+		prescription = FALSE
+		name = initial(name)
+		H.put_in_hands(G)
+
+	H.update_nearsighted_effects()
 
 /obj/item/clothing/glasses/visor_toggling()
 	..()
@@ -114,7 +116,7 @@
 	icon_state = "purple"
 	item_state = "glasses"
 	origin_tech = "magnets=2;engineering=1"
-	prescription_upgradable = 0
+	prescription_upgradable = TRUE
 	scan_reagents = 1 //You can see reagents while wearing science goggles
 	resistance_flags = ACID_PROOF
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 100)
@@ -135,6 +137,7 @@
 	icon_state = "nvpurple"
 	item_state = "glasses"
 	see_in_dark = 8
+	prescription_upgradable = FALSE
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE //don't render darkness while wearing these
 
 /obj/item/clothing/glasses/janitor
@@ -454,6 +457,7 @@
 	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS
 	see_in_dark = 8
 	scan_reagents = 1
+	prescription = TRUE
 	flags = NODROP
 	flags_cover = null
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
1. Makes Science goggles and Chameleon glasses upgradable with prescription glasses.
2. Adds a prescription to 'The Eye of God'.
3. Slightly reworks the prescription modification code to make the 'Nearsighted' effect update even if the glasses are modified while being worn.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. Consistency with other glasses.
2. 'The Eye of God' shouldn't make you half blind, since that kinda defeats the point of it.
3. Could be abused to bypass the need for special glasses.

## Changelog
:cl:
tweak: Added `prescription_upgradable` to Science goggles and Chameleon Glasses.
tweak: Added a prescription to The Eye of God.
fix: Fixed prescription glasses not updating the 'Nearsighted' effect if modified while being worn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
