### PR TITLE
Updates the proximity monitor component

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -268,7 +268,8 @@
 
 ///called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"
-
+///called when the movable is removed from a disposal holder object: /obj/structure/disposalpipe/proc/expel(): (obj/structure/disposalholder/H, turf/T, direction)
+#define COMSIG_MOVABLE_EXIT_DISPOSALS "movable_exit_disposals"
 
 // /datum/mind signals
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1966,27 +1966,6 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		return TRUE
 	return FALSE
 
-/**
- * Proc which gets all adjacent turfs to `src`, including the turf that `src` is on.
- *
- * This is similar to doing `for(var/turf/T in range(1, src))`. However it is slightly more performant.
- * Additionally, the above proc becomes more costly the more atoms there are nearby. This proc does not care about that.
- */
-/atom/proc/get_all_adjacent_turfs()
-	var/turf/src_turf = get_turf(src)
-	var/list/_list = list(
-		src_turf,
-		get_step(src_turf, NORTH),
-		get_step(src_turf, NORTHEAST),
-		get_step(src_turf, NORTHWEST),
-		get_step(src_turf, SOUTH),
-		get_step(src_turf, SOUTHEAST),
-		get_step(src_turf, SOUTHWEST),
-		get_step(src_turf, EAST),
-		get_step(src_turf, WEST)
-	)
-	return _list
-
 // Check if the source atom contains another atom
 /atom/proc/contains(atom/location)
 	if(!location)

--- a/code/controllers/subsystem/processing/fields.dm
+++ b/code/controllers/subsystem/processing/fields.dm
@@ -1,0 +1,6 @@
+PROCESSING_SUBSYSTEM_DEF(fields)
+	name = "Fields"
+	wait = 2
+	priority = FIRE_PRIORITY_FIELDS
+	flags = SS_KEEP_TIMING | SS_NO_INIT
+	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -531,6 +531,28 @@
 			target.TakeComponent(comps)
 
 /**
+  * Transfer a single component from the source datum, to the target.
+  *
+  * Arguments:
+  * * datum/target - the target to move the component to
+  * * component_instance_or_typepath - either an already created component, or a component typepath
+  */
+/datum/proc/TransferComponent(datum/target, component_instance_or_typepath)
+	if(!datum_components)
+		return
+	// If the proc was fed a typepath.
+	var/datum/component/comp = datum_components[component_instance_or_typepath]
+	if(comp?.can_transfer)
+		target.TakeComponent(comp)
+		return
+	// if the proc was fed a component instance.
+	for(var/component in datum_components)
+		var/datum/component/C = datum_components[component]
+		if(istype(C, component_instance_or_typepath) && C.can_transfer)
+			target.TakeComponent(C)
+			return
+
+/**
   * Return the object that is the host of any UI's that this component has
   */
 /datum/component/ui_host(mob/user)

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -98,8 +98,9 @@
 	// The receiver moved inside of another atom, set the host to that atom so we can track its movement.
 	else if(always_active)
 		toggle_checkers(TRUE)
-		host = get_atom_on_turf(hasprox_receiver)
-		if(ismovable(host) && host != old_loc)
+		var/atom/new_host = get_atom_on_turf(hasprox_receiver)
+		if(ismovable(new_host) && host != new_host && host != old_loc)
+			host = new_host
 			RegisterSignal(host, COMSIG_MOVABLE_MOVED, .proc/handle_move)
 	// Deactivate the field, leave it where it is, and stop listening for movement.
 	else
@@ -181,6 +182,8 @@
  */
 /datum/component/proximity_monitor/proc/recenter_prox_checkers()
 	var/turf/parent_turf = get_turf(parent)
+	if(!parent_turf)
+		return // Need a sanity check here for certain situations like objects moving into disposal holders. Their turf will be null in these cases.
 	var/index = 1
 	for(var/T in RANGE_TURFS(radius, parent_turf))
 		var/obj/checker = proximity_checkers[index++]

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -1,139 +1,474 @@
 /**
- * # Proximity monitor component
+ * # Basic Proximity Monitor
  *
- * Attaching this component to an atom means that the atom will be able to detect mobs/objs moving within a 1 tile of it.
+ * Attaching this component to an atom means that the atom will be able to detect mobs or objects moving within a specified radius of it.
  *
- * The component creates several `obj/effect/abstract/proximity_checker` objects, which follow the parent atom around, always making sure it's at the center.
- * When something crosses one of these `proximiy_checker`s, the parent has the `HasProximity()` proc called on it, with the crossing mob/obj as the argument.
+ * The component creates several [/obj/effect/abstract/proximity_checker] objects, which follow the parent (or host) atom around, always making sure it's at the center.
+ * When something crosses one of these proximiy checkers, the `hasprox_receiver` will have the `HasProximity()` proc called on it, with the crossing mob/obj as the argument.
  */
 /datum/component/proximity_monitor
-	var/atom/owner
-	/// A list of currently created `/obj/effect/abstract/proximity_checker`s in use with this component.
+	can_transfer = TRUE
+	var/name = "Proximity detection field"
+	/// The primary atom the component is attached to and that will be receiving `HasProximity()` calls. Usually the `parent`.
+	var/atom/hasprox_receiver
+	/**
+	 * The atom that the component is listening to for movement. Null by default, but this can change.
+	 * For example, if the receiver gets put into a humans's pocket, the host will become the human.
+	 */
+	var/atom/host
+	/// The radius of the field, in tiles.
+	var/radius
+	/// A list of currently created [/obj/effect/abstract/proximity_checker] in use with this component.
 	var/list/proximity_checkers
+	/// The type of checker object that should be used for the main field.
+	var/field_checker_type = /obj/effect/abstract/proximity_checker
+	/// Should the parent always detect proximity and update the field on movement, even if it's not on a turf?
+	var/always_active
 
-/datum/component/proximity_monitor/Initialize()
+/datum/component/proximity_monitor/Initialize(_radius = 1, _always_active = FALSE)
 	. = ..()
-	if(!isatom(parent))
+	if(!ismovable(parent) && !isturf(parent)) // No areas or datums allowed.
 		return COMPONENT_INCOMPATIBLE
-	owner = parent
+	ASSERT(_radius >= 1)
+	hasprox_receiver = parent
+	radius = _radius
+	always_active = _always_active
 	create_prox_checkers()
 
+	if(isturf(hasprox_receiver.loc))
+		return
+	if(!always_active)
+		toggle_checkers(FALSE)
+		return
+	// We only want a host to track if we're `always_active`.
+	host = get_atom_on_turf(host)
+
 /datum/component/proximity_monitor/Destroy(force, silent)
+	hasprox_receiver = null
+	host = null
 	QDEL_LIST(proximity_checkers)
-	owner = null
 	return ..()
 
 /datum/component/proximity_monitor/RegisterWithParent()
 	. = ..()
-	if(ismovable(parent))
-		RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/HandleMove)
+	// Override vars are set to TRUE here to allow for component transfering.
+	if(ismovable(hasprox_receiver))
+		RegisterSignal(hasprox_receiver, COMSIG_MOVABLE_MOVED, .proc/handle_move, TRUE)
+	if(host && ismovable(host))
+		RegisterSignal(host, COMSIG_MOVABLE_MOVED, .proc/handle_move, TRUE)
 
 /datum/component/proximity_monitor/UnregisterFromParent()
 	. = ..()
-	if(ismovable(parent))
-		UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
+	if(ismovable(hasprox_receiver))
+		UnregisterSignal(hasprox_receiver, COMSIG_MOVABLE_MOVED)
+	if(host && ismovable(host))
+		UnregisterSignal(host, COMSIG_MOVABLE_MOVED)
+
+/datum/component/proximity_monitor/PostTransfer()
+	if(!ismovable(parent) && !isturf(parent))
+		return COMPONENT_INCOMPATIBLE
+	host = null
+	hasprox_receiver = parent
+	if(!isturf(hasprox_receiver.loc))
+		host = get_atom_on_turf(host)
+	recenter_prox_checkers()
 
 /**
- * Called when the `parent` receives the `COMSIG_MOVABLE_MOVED` signal, which occurs when it `Move()`s
- *
- * Code is only ran when there is no `Dir`, which occurs when the parent is teleported, gets placed into a storage item, dropped, or picked up.
- * Normal movement, for example moving 1 tile to the west, is handled by the `proximity_checker` objects.
+ * Called when the `hasprox_receiver` moves. If a `host` exists, its movement will also call this proc.
  *
  * Arguments:
- * * source - this will be the `parent`
- * * OldLoc - the location the parent just moved from
+ * * datum/source - this will be the `parent`
+ * * atom/OldLoc - the location the parent just moved from
  * * Dir - the direction the parent just moved in
  * * forced - if we were forced to move
  */
-/datum/component/proximity_monitor/proc/HandleMove(datum/source, atom/OldLoc, Dir, forced)
-	if(!Dir) // No dir means the parent teleported, or moved in a non-standard way like getting placed into disposals, onto a table, dropped, picked up, etc.
-		recenter_prox_checkers()
+/datum/component/proximity_monitor/proc/handle_move(datum/source, atom/OldLoc, Dir, forced)
+	SIGNAL_HANDLER
+
+	if(Dir)
+		move_prox_checkers(Dir)
+		return // It was just a normal tile-based move, return.
+
+	// The field is always active while the receiver is on a turf.
+	if(isturf(hasprox_receiver.loc))
+		toggle_checkers(TRUE)
+		if(host && ismovable(host))
+			UnregisterSignal(host, COMSIG_MOVABLE_MOVED)
+			host = null
+	// The receiver moved inside of another atom, set the host to that atom so we can track its movement.
+	else if(always_active)
+		toggle_checkers(TRUE)
+		host = get_atom_on_turf(hasprox_receiver)
+		if(ismovable(host) && host != OldLoc)
+			RegisterSignal(host, COMSIG_MOVABLE_MOVED, .proc/handle_move)
+	// Deactivate the field, leave it where it is, and stop listening for movement.
+	else
+		toggle_checkers(FALSE)
+
+	recenter_prox_checkers()
 
 /**
- * Called in Initialize(). Generates a set of `/obj/effect/abstract/proximity_checker` objects around the parent, and registers signals to them.
+ * Relays basic directional movement from the `hasprox_receiver` or `host`, to all objects in the `proximity_checkers` list.
+ *
+ * Arguments:
+ * * move_dir - the direction the checkers should move in
  */
-/datum/component/proximity_monitor/proc/create_prox_checkers()
-	proximity_checkers = list()
-	for(var/turf/T in range(1, get_turf(parent)))
-		var/obj/effect/abstract/proximity_checker/P = new(T, parent)
-		proximity_checkers += P
-		// Basic movement for the proximity_checker objects. The objects will move 1 tile in the direction the parent just moved.
-		P.RegisterSignal(parent, COMSIG_MOVABLE_MOVED, /obj/effect/abstract/proximity_checker/.proc/HandleMove)
-
-/**
- * Re-centers all of the parent's `proximity_checker`s around its current location.
- */
-/datum/component/proximity_monitor/proc/recenter_prox_checkers()
-	var/list/prox_checkers = owner.get_all_adjacent_turfs()
+/datum/component/proximity_monitor/proc/move_prox_checkers(move_dir)
 	for(var/checker in proximity_checkers)
 		var/obj/effect/abstract/proximity_checker/P = checker
-		P.loc = pick_n_take(prox_checkers)
+		P.loc = get_step(P, move_dir)
 
 /**
- * # Proximity checker abstract object
+ * Update all of the component's proximity checker's to either become active or not active.
  *
- * Inteded for use with the proximity checker component (/datum/component/proximity_monitor).
+ * Arguments:
+ * * new_active - the value to be assigned to the proximity checker's `active` variable
+ */
+/datum/component/proximity_monitor/proc/toggle_checkers(new_active)
+	for(var/checker in proximity_checkers)
+		var/obj/effect/abstract/proximity_checker/P = checker
+		P.active = new_active
+
+/**
+ * Specifies a new radius for the field. Creates or deletes proximity_checkers accordingly.
+ *
+ * This proc *can* have a high cost due to the `new`s and `qdel`s of the proximity checkers, depending on the number of calls you need to make to it.
+ *
+ * Arguments:
+ * new_raidus - the new value that `proximity_raidus` should be set to.
+ */
+/datum/component/proximity_monitor/proc/set_radius(new_radius)
+	ASSERT(new_radius >= 1)
+
+	var/new_field_size = (1 + new_radius * 2) ** 2
+	var/old_field_size = length(proximity_checkers)
+	radius = new_radius
+
+	// Radius is decreasing.
+	if(new_field_size < old_field_size)
+		for(var/i in 1 to (old_field_size - new_field_size))
+			qdel(proximity_checkers[length(proximity_checkers)]) // Pop the last entry.
+	// Radius is increasing.
+	else
+		var/turf/parent_turf = get_turf(parent)
+		for(var/i in 1 to (new_field_size - old_field_size))
+			create_single_prox_checker(parent_turf)
+	recenter_prox_checkers()
+
+/**
+ * Creates a single proximity checker object, at the given location and of the given type. Adds it to the proximity checkers list.
+ *
+ * Arguments:
+ * * turf/T - the turf the checker should be created on
+ * * checker_type - the type of [/obj/item/abstract/proximity_checker] to create
+ */
+/datum/component/proximity_monitor/proc/create_single_prox_checker(turf/T, checker_type = field_checker_type)
+	var/obj/effect/abstract/proximity_checker/P = new checker_type(T, parent, src)
+	proximity_checkers += P
+	return P
+
+/**
+ * Called in Initialize(). Generates a set of [/obj/effect/abstract/proximity_checker] objects around the parent, and registers signals to them.
+ */
+/datum/component/proximity_monitor/proc/create_prox_checkers()
+	LAZYINITLIST(proximity_checkers)
+	var/turf/parent_turf = get_turf(parent)
+	for(var/T in RANGE_TURFS(radius, parent_turf))
+		create_single_prox_checker(T)
+
+/**
+ * Re-centers all of the `proximity_checker`s around the parent's current location.
+ */
+/datum/component/proximity_monitor/proc/recenter_prox_checkers()
+	var/turf/parent_turf = get_turf(parent)
+	var/index = 1
+	for(var/T in RANGE_TURFS(radius, parent_turf))
+		var/obj/checker = proximity_checkers[index++]
+		checker.loc = T
+
+
+/**
+ * # Advanced Proximity Monitor
+ *
+ * This component functions similar to the basic version, however it has some extra features:
+ *
+ * First of all, if the field radius is more than 1 tile, you have the option to make a distinction between inner proximity checkers, versus ones along the edge.
+ * You can specifiy which type of [/obj/effect/abstract/proximity_checker] objects you want to use for both inner, and edge checkers.
+ *
+ * Secondly, the advanced proximity monitor has the ability to use processing (the `process` proc). This is optional however.
+ * Each proximity checker object can process itself or other things on it's turf as needed. It's up to you on how you want to use it.
+ * Inner and edge checkers can process thing seperately. You can turn off processing for field checkers and have only edge checkers process, and vice versa.
+ */
+/datum/component/proximity_monitor/advanced
+	name = "Advanced energy field"
+	field_checker_type = /obj/effect/abstract/proximity_checker/advanced/inner_field
+	/// The type of checker object that should be used for the field edges.
+	var/edge_checker_type = /obj/effect/abstract/proximity_checker/advanced/edge_field
+	/// Make a distinction between edge checkers and field checkers seperately.
+	var/uses_edge_checkers = FALSE
+	/// Do any of the proximity_checker objects need to process things sitting on their tile?
+	var/requires_processing = FALSE
+	/// Should the main field checkers process things on their tile?
+	var/process_field_checkers = FALSE
+	/// Should the edge field checkers process things on their tile?
+	var/process_edge_checkers = FALSE
+	/// A list of proximity_checkers in the inner field. Excludes checkers on the edge of the field.
+	var/list/field_checkers
+	/// A list of proximity_checkers on the edge of the field.
+	var/list/edge_checkers
+
+/datum/component/proximity_monitor/advanced/Initialize(_radius = 1, _always_active = FALSE)
+	. = ..()
+	if(requires_processing)
+		START_PROCESSING(SSfields, src)
+
+/datum/component/proximity_monitor/advanced/Destroy(force, silent)
+	STOP_PROCESSING(SSfields, src)
+	QDEL_NULL(field_checkers)
+	QDEL_NULL(edge_checkers)
+	return ..()
+
+/datum/component/proximity_monitor/advanced/create_prox_checkers()
+	if(!uses_edge_checkers)
+		..() // We don't need to make a distinction between field and edge checkers, use the parent.
+		if(process_field_checkers)
+			field_checkers = proximity_checkers.Copy() // Still allows for field checkers to use processing.
+		return
+
+	LAZYINITLIST(proximity_checkers)
+	LAZYINITLIST(field_checkers)
+	LAZYINITLIST(edge_checkers)
+
+	var/turf/parent_turf = get_turf(parent)
+	for(var/T in RANGE_TURFS(radius, parent_turf))
+		if(get_dist(T, parent_turf) == radius)
+			edge_checkers += create_single_prox_checker(T, edge_checker_type)
+			continue
+		field_checkers += create_single_prox_checker(T)
+
+/datum/component/proximity_monitor/advanced/recenter_prox_checkers()
+	if(!uses_edge_checkers)
+		return ..() // We don't need to make a distinction between field and edge checkers, use the parent.
+
+	var/turf/parent_turf = get_turf(parent)
+	var/inner_index = 1
+	var/edge_index = 1
+
+	for(var/T in RANGE_TURFS(radius, parent_turf))
+		var/obj/checker
+		if(get_dist(T, parent_turf) == radius) // If it's at this distance, it's on the edge of the field.
+			checker = edge_checkers[edge_index++]
+			checker.loc = T
+			continue
+		checker = field_checkers[inner_index++]
+		checker.loc = T
+
+/datum/component/proximity_monitor/advanced/process()
+	if(process_field_checkers)
+		for(var/checker in field_checkers)
+			var/obj/effect/abstract/proximity_checker/advanced/inner_field/F = checker
+			process_inner_checker(F)
+	if(process_edge_checkers)
+		for(var/checker in field_checkers)
+			var/obj/effect/abstract/proximity_checker/advanced/edge_field/F = checker
+			process_edge_checker(F)
+
+/**
+ * Base proc. All processing-related actions associated with inner proximity checkers should go here.
+ *
+ * Arguments:
+ * * obj/effect/abstract/proximity_checker/advanced/inner_field/F - the proximity checker to process
+ */
+/datum/component/proximity_monitor/advanced/proc/process_inner_checker(obj/effect/abstract/proximity_checker/advanced/inner_field/F)
+	return
+
+/**
+ * Base proc. All processing-related actions associated with edge proximity checkers should go here.
+ *
+ * Arguments:
+ * * obj/effect/abstract/proximity_checker/advanced/edge_field/F - the proximity checker to process
+ */
+/datum/component/proximity_monitor/advanced/proc/process_edge_checker(obj/effect/abstract/proximity_checker/advanced/edge_field/F)
+	return
+
+/**
+ * Base proc. Checks if `AM` can pass the inner field checker.
+ *
+ * Arguments:
+ * * atom/movable/AM - the atom trying to pass the inner field checker object
+ * * obj/effect/abstract/proximity_checker/advanced/inner_field/F - the proximity checker object `AM` is trying to pass
+ * * turf/entering - the turf `AM` is entering from
+ */
+/datum/component/proximity_monitor/advanced/proc/inner_field_canpass(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/inner_field/F, turf/entering)
+	return TRUE
+
+/**
+ * Base proc. Called when something crosses an inner field checker.
+ *
+ * Arguments:
+ * * atom/movable/AM - the atom crossing the inner field checker object
+ * * obj/effect/abstract/proximity_checker/advanced/inner_field/F - the proximity checker object `AM` getting crossed
+ */
+/datum/component/proximity_monitor/advanced/proc/inner_field_crossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/inner_field/F)
+	return TRUE
+
+/**
+ * Base proc. Called when something uncrosses an inner field checker.
+ *
+ * Arguments:
+ * * atom/movable/AM - the atom uncrossing the inner field checker object
+ * * obj/effect/abstract/proximity_checker/advanced/inner_field/F - the proximity checker object `AM` getting uncrossed
+ */
+/datum/component/proximity_monitor/advanced/proc/inner_field_uncrossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/inner_field/F)
+	return TRUE
+
+/**
+ * Base proc. Checks if `AM` can pass the edge field checker.
+ *
+ * Arguments:
+ * * atom/movable/AM - the atom trying to pass the edge field checker object
+ * * obj/effect/abstract/proximity_checker/advanced/edge_field/F - the proximity checker object `AM` is trying to pass
+ * * turf/entering - the turf `AM` is entering from
+ */
+/datum/component/proximity_monitor/advanced/proc/edge_field_canpass(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/edge_field/F, turf/entering)
+	return TRUE
+
+/**
+ * Base proc. Called when something crosses an edge field checker.
+ *
+ * Arguments:
+ * * atom/movable/AM - the atom crossing the edge field checker object
+ * * obj/effect/abstract/proximity_checker/advanced/edge_field/F - the proximity checker object `AM` getting crossed
+ */
+/datum/component/proximity_monitor/advanced/proc/edge_field_crossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/edge_field/F)
+	return TRUE
+
+/**
+ * Base proc. Called when something uncrosses an edge field checker.
+ *
+ * Arguments:
+ * * atom/movable/AM - the atom uncrossing the edge field checker object
+ * * obj/effect/abstract/proximity_checker/advanced/edge_field/F - the proximity checker object `AM` getting uncrossed
+ */
+/datum/component/proximity_monitor/advanced/proc/edge_field_uncrossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/edge_field/F)
+	return TRUE
+
+
+/**
+ * # Basic Proximity Checker
+ *
+ * Inteded for use with the proximity checker component [/datum/component/proximity_monitor].
  * Whenever a movable atom crosses this object, it calls `HasProximity()` on the object which is listening for proximity (`hasprox_receiver`).
  */
 /obj/effect/abstract/proximity_checker
-	name = "Proximity checker"
+	name = "proximity checker"
+	/// The component that this object is in use with, and that will receive `HasProximity()` calls.
+	var/datum/component/proximity_monitor/monitor
 	/// Whether or not the proximity checker is listening for things crossing it.
 	var/active
-	/// The linked atom which has the proximity_monitor component, and will recieve the `HasProximity()` calls.
-	var/atom/hasprox_receiver
 
 // If this object is initialized without a `_hasprox_receiver` arg, it is qdel'd.
-/obj/effect/abstract/proximity_checker/Initialize(mapload, atom/_hasprox_receiver)
-	if(_hasprox_receiver)
-		hasprox_receiver = _hasprox_receiver
-		RegisterSignal(hasprox_receiver, COMSIG_PARENT_QDELETING, .proc/OnParentDeletion)
-		if(isturf(hasprox_receiver.loc)) // if the reciever is inside a locker/crate/etc, they don't detect proximity
-			active = TRUE
-	else
-		stack_trace("/obj/effect/abstract/proximity_checker created without a receiver")
+/obj/effect/abstract/proximity_checker/Initialize(mapload, atom/_hasprox_receiver, datum/component/proximity_monitor/P)
+	if(!_hasprox_receiver)
+		stack_trace("[src] created without a receiver")
 		return INITIALIZE_HINT_QDEL
-	return ..()
+	. = ..()
+	monitor = P
+	RegisterSignal(monitor, COMSIG_PARENT_QDELETING, .proc/on_receiver_deletion)
 
 /obj/effect/abstract/proximity_checker/Destroy()
-	hasprox_receiver = null
+	monitor.proximity_checkers -= src
+	monitor = null
 	return ..()
 
 /**
  * Called when the `hasprox_receiver` receives the `COMSIG_PARENT_QDELETING` signal. When the receiver is deleted, so is this object.
  *
  * Arugments:
- * * source - this will be the `hasprox_receiver`
+ * * datum/source - this will be the `hasprox_receiver`
  * * force - the force flag taken from the qdel proc currently running on `hasprox_receiver`
  */
-/obj/effect/abstract/proximity_checker/proc/OnParentDeletion(datum/source, force = FALSE)
+/obj/effect/abstract/proximity_checker/proc/on_receiver_deletion(datum/source, force = FALSE)
+	SIGNAL_HANDLER
+
 	qdel(src)
 
 /**
- * Something crossed over the proximity_checker. Notify the `hasprox_receiver` it has proximity with something. Only fires if the checker is `active`.
+ * Called when something crossed over the proximity_checker. Notifies the `hasprox_receiver` it has proximity with something.
+ *
+ * Arguments:
+ * * atom/movable/AM - the atom crossing the proximity checker
+ * * oldloc - the location `AM` used to be at
  */
 /obj/effect/abstract/proximity_checker/Crossed(atom/movable/AM, oldloc)
 	set waitfor = FALSE
-	if(active)
-		hasprox_receiver.HasProximity(AM)
+	. = ..()
+	if(active && AM != monitor.host && AM != monitor.hasprox_receiver)
+		monitor.hasprox_receiver.HasProximity(AM)
 
 /**
- * Moves the proximity_checker 1 tile in the `Dir` direction.
+ * # Advanced Proximity Checker
  *
- * If `Dir` is null it will be recentered around the receiver via the `recenter_prox_checkers()` proc.
- * If the new location of the receiver is NOT a turf, set `active` to FALSE, so that it does not receive proximity calls.
- * If the new location of the receiver IS a turf, set `active` to TRUE, so that it can receive proximity calls again.
- *
- * Arguments:
- * * source - this will be the `hasprox_receiver`
- * * OldLoc - the location the `hasprox_receiver` just moved from
- * * Dir - the direction the `hasprox_receiver` just moved in
- * * forced - if we were forced to move
+ * Like basic proximity checkers, these objects can also detect proximity.
+ * However these are meant for when you need to have some additional (more advanced) behavior on top of what basic proximity checkers can do.
  */
-/obj/effect/abstract/proximity_checker/proc/HandleMove(datum/source, atom/OldLoc, Dir, forced)
-	if(Dir)
-		loc = get_step(src, Dir) // Basic movement 1 tile in some direction.
-		return
-	if(!isturf(hasprox_receiver.loc))
-		active = FALSE // Receiver shouldn't detect proximity while picked up, in a backpack, closet, etc.
-	else
-		active = TRUE // Receiver can detect proximity again because it's on a turf.
+/obj/effect/abstract/proximity_checker/advanced
+	name = "advanced proximity phecker"
+	/// `hasprox_receivers`s advanced proximity monitor component.
+	var/datum/component/proximity_monitor/advanced/advanced_monitor
+
+/obj/effect/abstract/proximity_checker/advanced/Initialize(mapload, atom/_hasprox_receiver, datum/component/proximity_monitor/advanced/P, _always_active)
+	if(!P)
+		stack_trace("[src] created without a component argument")
+		return INITIALIZE_HINT_QDEL
+	advanced_monitor = P
+	return ..()
+
+
+/**
+ * # Inner Field Proximity Checker
+ *
+ * An advanced proximity checker object which sits on the the inner tiles of a field.
+ */
+/obj/effect/abstract/proximity_checker/advanced/inner_field
+	name = "inner field"
+
+/obj/effect/abstract/proximity_checker/advanced/inner_field/Destroy()
+	advanced_monitor.field_checkers -= src
+	return ..()
+
+/obj/effect/abstract/proximity_checker/advanced/inner_field/Crossed(atom/movable/AM, oldloc)
+	. = ..()
+	return advanced_monitor.inner_field_crossed(AM, src)
+
+/obj/effect/abstract/proximity_checker/advanced/inner_field/Uncrossed(atom/movable/AM, oldloc)
+	. = ..()
+	return advanced_monitor.inner_field_uncrossed(AM, src)
+
+/obj/effect/abstract/proximity_checker/advanced/inner_field/CanPass(atom/movable/mover, turf/target, height)
+	. = ..()
+	return advanced_monitor.inner_field_canpass(mover, src, target)
+
+/**
+ * # Edge Field Proximity Checker
+ *
+ * An advanced proximity checker object which sits on the outer edge tiles of a field.
+ */
+/obj/effect/abstract/proximity_checker/advanced/edge_field
+	name = "edge field"
+
+/obj/effect/abstract/proximity_checker/advanced/edge_field/Destroy()
+	advanced_monitor.edge_checkers -= src
+	return ..()
+
+/obj/effect/abstract/proximity_checker/advanced/edge_field/Crossed(atom/movable/AM, oldloc)
+	. = ..()
+	return advanced_monitor.edge_field_crossed(AM, src)
+
+/obj/effect/abstract/proximity_checker/advanced/edge_field/Uncrossed(atom/movable/AM)
+	. = ..()
+	return advanced_monitor.edge_field_uncrossed(AM, src)
+
+/obj/effect/abstract/proximity_checker/advanced/edge_field/CanPass(atom/movable/mover, turf/target, height)
+	. = ..()
+	return advanced_monitor.edge_field_canpass(mover, src, target)

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -78,15 +78,15 @@
  *
  * Arguments:
  * * datum/source - this will be the `parent`
- * * atom/OldLoc - the location the parent just moved from
- * * Dir - the direction the parent just moved in
+ * * atom/old_loc - the location the parent just moved from
+ * * dir - the direction the parent just moved in
  * * forced - if we were forced to move
  */
-/datum/component/proximity_monitor/proc/handle_move(datum/source, atom/OldLoc, Dir, forced)
+/datum/component/proximity_monitor/proc/handle_move(datum/source, atom/old_loc, dir, forced)
 	SIGNAL_HANDLER
 
-	if(Dir)
-		move_prox_checkers(Dir)
+	if(dir)
+		move_prox_checkers(dir)
 		return // It was just a normal tile-based move, return.
 
 	// The field is always active while the receiver is on a turf.
@@ -99,7 +99,7 @@
 	else if(always_active)
 		toggle_checkers(TRUE)
 		host = get_atom_on_turf(hasprox_receiver)
-		if(ismovable(host) && host != OldLoc)
+		if(ismovable(host) && host != old_loc)
 			RegisterSignal(host, COMSIG_MOVABLE_MOVED, .proc/handle_move)
 	// Deactivate the field, leave it where it is, and stop listening for movement.
 	else
@@ -135,7 +135,7 @@
  * This proc *can* have a high cost due to the `new`s and `qdel`s of the proximity checkers, depending on the number of calls you need to make to it.
  *
  * Arguments:
- * new_raidus - the new value that `proximity_raidus` should be set to.
+ * new_radius - the new value that `proximity_radius` should be set to.
  */
 /datum/component/proximity_monitor/proc/set_radius(new_radius)
 	ASSERT(new_radius >= 1)
@@ -266,12 +266,10 @@
 /datum/component/proximity_monitor/advanced/process()
 	if(process_field_checkers)
 		for(var/checker in field_checkers)
-			var/obj/effect/abstract/proximity_checker/advanced/inner_field/F = checker
-			process_inner_checker(F)
+			process_inner_checker(checker)
 	if(process_edge_checkers)
 		for(var/checker in field_checkers)
-			var/obj/effect/abstract/proximity_checker/advanced/edge_field/F = checker
-			process_edge_checker(F)
+			process_edge_checker(checker)
 
 /**
  * Base proc. All processing-related actions associated with inner proximity checkers should go here.
@@ -413,7 +411,7 @@
  * However these are meant for when you need to have some additional (more advanced) behavior on top of what basic proximity checkers can do.
  */
 /obj/effect/abstract/proximity_checker/advanced
-	name = "advanced proximity phecker"
+	name = "advanced proximity checker"
 	/// `hasprox_receivers`s advanced proximity monitor component.
 	var/datum/component/proximity_monitor/advanced/advanced_monitor
 

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -36,10 +36,10 @@
 	create_prox_checkers()
 
 	if(isturf(hasprox_receiver.loc))
+		toggle_checkers(TRUE)
 		return
-	if(!always_active)
-		toggle_checkers(FALSE)
-		return
+	else if(always_active)
+		toggle_checkers(TRUE)
 	// We only want a host to track if we're `always_active`.
 	host = get_atom_on_turf(host)
 
@@ -169,11 +169,18 @@
 	return P
 
 /**
- * Called in Initialize(). Generates a set of [/obj/effect/abstract/proximity_checker] objects around the parent, and registers signals to them.
+ * Called in Initialize(). Generates a set of [proximity checker][/obj/effect/abstract/proximity_checker] objects around the parent.
  */
 /datum/component/proximity_monitor/proc/create_prox_checkers()
 	LAZYINITLIST(proximity_checkers)
 	var/turf/parent_turf = get_turf(parent)
+	// For whatever reason their turf is null. Create the checkers in nullspace for now. When the parent moves to a valid turf, they can be recenetered.
+	if(!parent_turf)
+		// Since we can't use `in range` in nullspace, we need to calculate the number of checkers to create with the below formula.
+		var/checker_amount = (1 + radius * 2) ** 2
+		for(var/i in 1 to checker_amount)
+			create_single_prox_checker(null)
+		return
 	for(var/T in RANGE_TURFS(radius, parent_turf))
 		create_single_prox_checker(T)
 

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -110,6 +110,10 @@
 		move_prox_checkers(dir)
 		return
 
+	// Moving onto a turf.
+	if(!isturf(old_loc) && isturf(moved_atom.loc))
+		toggle_checkers(TRUE)
+
 	map_nested_locs()
 	recenter_prox_checkers()
 
@@ -237,6 +241,7 @@
 /datum/component/proximity_monitor/proc/recenter_prox_checkers()
 	var/turf/parent_turf = get_turf(parent)
 	if(!parent_turf)
+		toggle_checkers(FALSE)
 		return // Need a sanity check here for certain situations like objects moving into disposal holders. Their turf will be null in these cases.
 	var/index = 1
 	for(var/T in RANGE_TURFS(radius, parent_turf))
@@ -281,8 +286,8 @@
 
 /datum/component/proximity_monitor/advanced/Destroy(force, silent)
 	STOP_PROCESSING(SSfields, src)
-	QDEL_NULL(field_checkers)
-	QDEL_NULL(edge_checkers)
+	QDEL_LIST(field_checkers)
+	QDEL_LIST(edge_checkers)
 	return ..()
 
 /datum/component/proximity_monitor/advanced/create_prox_checkers()

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -372,24 +372,11 @@
 		return INITIALIZE_HINT_QDEL
 	. = ..()
 	monitor = P
-	RegisterSignal(monitor, COMSIG_PARENT_QDELETING, .proc/on_receiver_deletion)
 
 /obj/effect/abstract/proximity_checker/Destroy()
 	monitor.proximity_checkers -= src
 	monitor = null
 	return ..()
-
-/**
- * Called when the `hasprox_receiver` receives the `COMSIG_PARENT_QDELETING` signal. When the receiver is deleted, so is this object.
- *
- * Arugments:
- * * datum/source - this will be the `hasprox_receiver`
- * * force - the force flag taken from the qdel proc currently running on `hasprox_receiver`
- */
-/obj/effect/abstract/proximity_checker/proc/on_receiver_deletion(datum/source, force = FALSE)
-	SIGNAL_HANDLER
-
-	qdel(src)
 
 /**
  * Called when something crossed over the proximity_checker. Notifies the `hasprox_receiver` it has proximity with something.
@@ -422,6 +409,9 @@
 	advanced_monitor = P
 	return ..()
 
+/obj/effect/abstract/proximity_checker/advanced/Destroy()
+	advanced_monitor = null
+	return ..()
 
 /**
  * # Inner Field Proximity Checker

--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -419,6 +419,10 @@
  *
  * Inteded for use with the proximity checker component [/datum/component/proximity_monitor].
  * Whenever a movable atom crosses this object, it calls `HasProximity()` on the object which is listening for proximity (`hasprox_receiver`).
+ *
+ * Because these objects try to make the smallest footprint possible, when these objects move **they should use direct `loc` setting only, and not `forceMove`!**
+ * The overhead for forceMove is very unnecessary, because for example turfs and areas don't need to know when these have entered or exited them, etc.
+ * These are invisible objects who's sole purpose is to simply inform the receiver that something has moved within X tiles of the it.
  */
 /obj/effect/abstract/proximity_checker
 	name = "proximity checker"

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -61,6 +61,7 @@
 	density = FALSE
 	icon = null
 	icon_state = null
+	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 100, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 
 // Most of these overrides procs below are overkill, but better safe than sorry.
 /obj/effect/abstract/swarmer_act()
@@ -79,6 +80,15 @@
 	return
 
 /obj/effect/abstract/ex_act(severity)
+	return
+
+/obj/effect/abstract/blob_act()
+	return
+
+/obj/effect/abstract/acid_act()
+	return
+
+/obj/effect/abstract/fire_act()
 	return
 
 /obj/effect/decal

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -62,8 +62,7 @@
 		to_chat(user, "<span class='notice'>You attach [A] to the valve controls and secure it.</span>")
 		A.holder = src
 		A.toggle_secure()	//this calls update_icon(), which calls update_icon() on the holder (i.e. the bomb).
-		if(istype(attached_device, /obj/item/assembly/prox_sensor))
-			AddComponent(/datum/component/proximity_monitor)
+		A.on_attach()
 
 		investigate_log("[key_name(user)] attached a [A] to a transfer valve.", INVESTIGATE_BOMB)
 		add_attack_logs(user, src, "attached [A] to a transfer valve", ATKLOG_FEW)
@@ -136,10 +135,8 @@
 				attached_device.attack_self(usr)
 		if("remove_device")
 			if(attached_device)
-				attached_device.forceMove(get_turf(src))
-				attached_device.holder = null
+				attached_device.on_detach()
 				attached_device = null
-				qdel(GetComponent(/datum/component/proximity_monitor))
 				update_icon()
 		else
 			. = FALSE

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -62,7 +62,6 @@
 		to_chat(user, "<span class='notice'>You attach [A] to the valve controls and secure it.</span>")
 		A.holder = src
 		A.toggle_secure()	//this calls update_icon(), which calls update_icon() on the holder (i.e. the bomb).
-		A.on_attach()
 
 		investigate_log("[key_name(user)] attached a [A] to a transfer valve.", INVESTIGATE_BOMB)
 		add_attack_logs(user, src, "attached [A] to a transfer valve", ATKLOG_FEW)
@@ -135,7 +134,8 @@
 				attached_device.attack_self(usr)
 		if("remove_device")
 			if(attached_device)
-				attached_device.on_detach()
+				attached_device.forceMove(get_turf(src))
+				attached_device.holder = null
 				attached_device = null
 				update_icon()
 		else

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -190,8 +190,7 @@
 
 		user.drop_item()
 		nadeassembly = A
-		if(nadeassembly.has_prox_sensors())
-			AddComponent(/datum/component/proximity_monitor)
+		A.on_attach(src)
 		A.master = src
 		A.loc = src
 		assemblyattacher = user.ckey
@@ -220,8 +219,8 @@
 		if(nadeassembly)
 			nadeassembly.loc = get_turf(src)
 			nadeassembly.master = null
+			nadeassembly.on_detach(src)
 			nadeassembly = null
-			qdel(GetComponent(/datum/component/proximity_monitor))
 		if(beakers.len)
 			for(var/obj/O in beakers)
 				O.loc = get_turf(src)
@@ -307,8 +306,6 @@
 /obj/item/grenade/chem_grenade/proc/CreateDefaultTrigger(typekey)
 	if(ispath(typekey,/obj/item/assembly))
 		nadeassembly = new(src)
-		if(nadeassembly.has_prox_sensors())
-			AddComponent(/datum/component/proximity_monitor)
 		nadeassembly.a_left = new /obj/item/assembly/igniter(nadeassembly)
 		nadeassembly.a_left.holder = nadeassembly
 		nadeassembly.a_left.secured = 1
@@ -317,8 +314,10 @@
 			nadeassembly.a_right.toggle_secure() // necessary because fuxing prock_sensors
 		nadeassembly.a_right.holder = nadeassembly
 		nadeassembly.secured = 1
+		nadeassembly.a_right.on_attach()
 		nadeassembly.master = src
 		nadeassembly.update_icon()
+		nadeassembly.on_attach(src)
 		stage = READY
 		update_icon()
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -176,7 +176,7 @@
 			if(I.reagents.total_volume)
 				to_chat(user, "<span class='notice'>You add [I] to the assembly.</span>")
 				user.drop_item()
-				I.loc = src
+				I.forceMove(src)
 				beakers += I
 			else
 				to_chat(user, "<span class='notice'>[I] is empty.</span>")
@@ -190,9 +190,8 @@
 
 		user.drop_item()
 		nadeassembly = A
-		A.on_attach(src)
 		A.master = src
-		A.loc = src
+		A.forceMove(src)
 		assemblyattacher = user.ckey
 		stage = WIRED
 		to_chat(user, "<span class='notice'>You add [A] to [src]!</span>")
@@ -217,13 +216,12 @@
 		payload_name = null
 		label = null
 		if(nadeassembly)
-			nadeassembly.loc = get_turf(src)
+			nadeassembly.forceMove(get_turf(src))
 			nadeassembly.master = null
-			nadeassembly.on_detach(src)
 			nadeassembly = null
 		if(beakers.len)
 			for(var/obj/O in beakers)
-				O.loc = get_turf(src)
+				O.forceMove(get_turf(src))
 			beakers = list()
 		update_icon()
 
@@ -314,10 +312,8 @@
 			nadeassembly.a_right.toggle_secure() // necessary because fuxing prock_sensors
 		nadeassembly.a_right.holder = nadeassembly
 		nadeassembly.secured = 1
-		nadeassembly.a_right.on_attach()
 		nadeassembly.master = src
 		nadeassembly.update_icon()
-		nadeassembly.on_attach(src)
 		stage = READY
 		update_icon()
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -42,7 +42,7 @@
 
 /obj/structure/janitorialcart/proc/put_in_cart(obj/item/I, mob/user)
 	user.drop_item()
-	I.loc = src
+	I.forceMove(src)
 	updateUsrDialog()
 	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 	return

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -71,6 +71,17 @@
 		holder = null
 	return ..()
 
+/obj/item/assembly/proc/on_attach()
+	return
+
+//Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
+/obj/item/assembly/proc/on_detach()
+	if(!holder)
+		return FALSE
+	forceMove(holder.drop_location())
+	holder = null
+	return TRUE
+
 /obj/item/assembly/pulsed(radio = FALSE)
 	if(holder && (wires & WIRE_RECEIVE))
 		activate()

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -71,17 +71,6 @@
 		holder = null
 	return ..()
 
-/obj/item/assembly/proc/on_attach()
-	return
-
-//Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
-/obj/item/assembly/proc/on_detach()
-	if(!holder)
-		return FALSE
-	forceMove(holder.drop_location())
-	holder = null
-	return TRUE
-
 /obj/item/assembly/pulsed(radio = FALSE)
 	if(holder && (wires & WIRE_RECEIVE))
 		activate()

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -37,11 +37,10 @@
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	to_chat(user, "<span class='notice'>You disassemble [src].</span>")
-	bombassembly.loc = user.loc
+	bombassembly.forceMove(user.loc)
 	bombassembly.master = null
-	bombassembly.on_detach(src)
 	bombassembly = null
-	bombtank.loc = user.loc
+	bombtank.forceMove(user.loc)
 	bombtank.master = null
 	bombtank = null
 	qdel(src)
@@ -115,13 +114,12 @@
 	M.put_in_hands(R)		//Equips the bomb if possible, or puts it on the floor.
 
 	R.bombassembly = S	//Tell the bomb about its assembly part
-	S.on_attach(R)
 	S.master = R		//Tell the assembly about its new owner
-	S.loc = R			//Move the assembly out of the fucking way
+	S.forceMove(R)			//Move the assembly out of the fucking way
 
 	R.bombtank = src	//Same for tank
 	master = R
-	loc = R
+	forceMove(R)
 	R.update_icon()
 	return
 

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -12,10 +12,6 @@
 	var/obj/item/tank/bombtank = null //the second part of the bomb is a plasma tank
 	origin_tech = "materials=1;engineering=1"
 
-/obj/item/onetankbomb/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/proximity_monitor)
-
 /obj/item/onetankbomb/examine(mob/user)
 	. = ..()
 	. += bombtank.examine(user)
@@ -43,6 +39,7 @@
 	to_chat(user, "<span class='notice'>You disassemble [src].</span>")
 	bombassembly.loc = user.loc
 	bombassembly.master = null
+	bombassembly.on_detach(src)
 	bombassembly = null
 	bombtank.loc = user.loc
 	bombtank.master = null
@@ -118,6 +115,7 @@
 	M.put_in_hands(R)		//Equips the bomb if possible, or puts it on the floor.
 
 	R.bombassembly = S	//Tell the bomb about its assembly part
+	S.on_attach(R)
 	S.master = R		//Tell the assembly about its new owner
 	S.loc = R			//Move the assembly out of the fucking way
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -29,6 +29,14 @@
 		a_right.holder = null
 	return ..()
 
+/obj/item/assembly_holder/proc/on_attach(atom/A)
+	if(has_prox_sensors())
+		TransferComponent(A, /datum/component/proximity_monitor)
+
+/obj/item/assembly_holder/proc/on_detach(atom/A)
+	if(has_prox_sensors())
+		A.TransferComponent(src, /datum/component/proximity_monitor)
+
 /obj/item/assembly_holder/attach(obj/item/D, obj/item/D2, mob/user)
 	if(!D || !D2)
 		return FALSE
@@ -47,11 +55,11 @@
 			user.remove_from_mob(A2)
 		A2.forceMove(src)
 	A1.holder = src
+	A1.on_attach()
 	A2.holder = src
+	A2.on_attach()
 	a_left = A1
 	a_right = A2
-	if(has_prox_sensors())
-		AddComponent(/datum/component/proximity_monitor)
 	name = "[A1.name]-[A2.name] assembly"
 	update_icon()
 	return TRUE
@@ -182,11 +190,9 @@
 		if(!T)
 			return FALSE
 		if(a_left)
-			a_left.holder = null
-			a_left.loc = T
+			a_left.on_detach()
 		if(a_right)
-			a_right.holder = null
-			a_right.loc = T
+			a_right.on_detach()
 		qdel(src)
 
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -29,14 +29,6 @@
 		a_right.holder = null
 	return ..()
 
-/obj/item/assembly_holder/proc/on_attach(atom/A)
-	if(has_prox_sensors())
-		TransferComponent(A, /datum/component/proximity_monitor)
-
-/obj/item/assembly_holder/proc/on_detach(atom/A)
-	if(has_prox_sensors())
-		A.TransferComponent(src, /datum/component/proximity_monitor)
-
 /obj/item/assembly_holder/attach(obj/item/D, obj/item/D2, mob/user)
 	if(!D || !D2)
 		return FALSE
@@ -55,9 +47,7 @@
 			user.remove_from_mob(A2)
 		A2.forceMove(src)
 	A1.holder = src
-	A1.on_attach()
 	A2.holder = src
-	A2.on_attach()
 	a_left = A1
 	a_right = A2
 	name = "[A1.name]-[A2.name] assembly"
@@ -190,9 +180,11 @@
 		if(!T)
 			return FALSE
 		if(a_left)
-			a_left.on_detach()
+			a_left.holder = null
+			a_left.forceMove(T)
 		if(a_right)
-			a_right.on_detach()
+			a_right.holder = null
+			a_right.forceMove(T)
 		qdel(src)
 
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -15,7 +15,7 @@
 
 /obj/item/assembly/prox_sensor/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/proximity_monitor)
+	AddComponent(/datum/component/proximity_monitor, _always_active = TRUE)
 
 /obj/item/assembly/prox_sensor/on_attach()
 	. = ..()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -17,6 +17,15 @@
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor)
 
+/obj/item/assembly/prox_sensor/on_attach()
+	. = ..()
+	TransferComponent(holder, /datum/component/proximity_monitor)
+
+//Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
+/obj/item/assembly/prox_sensor/on_detach()
+	holder.TransferComponent(src, /datum/component/proximity_monitor)
+	return ..()
+
 /obj/item/assembly/prox_sensor/describe()
 	if(timing)
 		return "<span class='notice'>The proximity sensor is arming.</span>"

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -17,15 +17,6 @@
 	. = ..()
 	AddComponent(/datum/component/proximity_monitor, _always_active = TRUE)
 
-/obj/item/assembly/prox_sensor/on_attach()
-	. = ..()
-	TransferComponent(holder, /datum/component/proximity_monitor)
-
-//Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
-/obj/item/assembly/prox_sensor/on_detach()
-	holder.TransferComponent(src, /datum/component/proximity_monitor)
-	return ..()
-
 /obj/item/assembly/prox_sensor/describe()
 	if(timing)
 		return "<span class='notice'>The proximity sensor is arming.</span>"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -146,7 +146,6 @@
 		trigger.forceMove(src)
 		trigger.master = src
 		trigger.holder = src
-		AddComponent(/datum/component/proximity_monitor)
 		to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
 		return TRUE
 	else if(istype(W, /obj/item/assembly))
@@ -166,7 +165,6 @@
 	trigger.master = null
 	trigger.holder = null
 	trigger = null
-	qdel(GetComponent(/datum/component/proximity_monitor))
 
 /obj/item/clothing/mask/muzzle/safety/shock/proc/can_shock(obj/item/clothing/C)
 	if(istype(C))
@@ -187,10 +185,6 @@
 		M.Stuttering(1)
 		M.Jitter(20)
 	return
-
-/obj/item/clothing/mask/muzzle/safety/shock/HasProximity(atom/movable/AM)
-	if(trigger)
-		trigger.HasProximity(AM)
 
 
 /obj/item/clothing/mask/muzzle/safety/shock/hear_talk(mob/living/M as mob, list/message_pieces)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -168,7 +168,6 @@
 	if(assembly)
 		to_chat(usr, "<span class='notice'>You detach [assembly] from [src]</span>")
 		usr.put_in_hands(assembly)
-		assembly.on_detach(src)
 		assembly = null
 		update_icon()
 	else
@@ -183,11 +182,9 @@
 		if(assembly)
 			to_chat(usr, "<span class='warning'>[src] already has an assembly.</span>")
 			return ..()
-		var/obj/item/assembly_holder/holder = W
-		assembly = holder
+		assembly = W
 		user.drop_item()
-		holder.forceMove(src)
-		holder.on_attach(src)
+		W.forceMove(src)
 		overlays += "assembly"
 	else
 		..()

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -168,8 +168,8 @@
 	if(assembly)
 		to_chat(usr, "<span class='notice'>You detach [assembly] from [src]</span>")
 		usr.put_in_hands(assembly)
+		assembly.on_detach(src)
 		assembly = null
-		qdel(GetComponent(/datum/component/proximity_monitor))
 		update_icon()
 	else
 		to_chat(usr, "<span class='notice'>There is no assembly to remove.</span>")
@@ -183,11 +183,11 @@
 		if(assembly)
 			to_chat(usr, "<span class='warning'>[src] already has an assembly.</span>")
 			return ..()
-		assembly = W
+		var/obj/item/assembly_holder/holder = W
+		assembly = holder
 		user.drop_item()
-		W.forceMove(src)
-		if(assembly.has_prox_sensors())
-			AddComponent(/datum/component/proximity_monitor)
+		holder.forceMove(src)
+		holder.on_attach(src)
 		overlays += "assembly"
 	else
 		..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -152,7 +152,6 @@
 		if(do_after(usr, 20, target = src))
 			usr.visible_message("<span class='notice'>[usr] detaches [rig] from [src].</span>", "<span class='notice'>You detach [rig] from [src].</span>")
 			rig.forceMove(get_turf(usr))
-			rig.on_detach(src)
 			rig = null
 			lastrigger = null
 			overlays.Cut()
@@ -176,7 +175,6 @@
 				rig = H
 				user.drop_item()
 				H.forceMove(src)
-				H.on_attach(src)
 				var/icon/test = getFlatIcon(H)
 				test.Shift(NORTH, 1)
 				test.Shift(EAST, 6)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -152,8 +152,8 @@
 		if(do_after(usr, 20, target = src))
 			usr.visible_message("<span class='notice'>[usr] detaches [rig] from [src].</span>", "<span class='notice'>You detach [rig] from [src].</span>")
 			rig.forceMove(get_turf(usr))
+			rig.on_detach(src)
 			rig = null
-			qdel(GetComponent(/datum/component/proximity_monitor))
 			lastrigger = null
 			overlays.Cut()
 
@@ -176,8 +176,7 @@
 				rig = H
 				user.drop_item()
 				H.forceMove(src)
-				if(rig.has_prox_sensors())
-					AddComponent(/datum/component/proximity_monitor)
+				H.on_attach(src)
 				var/icon/test = getFlatIcon(H)
 				test.Shift(NORTH, 1)
 				test.Shift(EAST, 6)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -803,6 +803,8 @@
 			for(var/atom/movable/AM in H)
 				AM.forceMove(T)
 				AM.pipe_eject(direction)
+				SEND_SIGNAL(AM, COMSIG_MOVABLE_EXIT_DISPOSALS)
+
 				spawn(1)
 					if(AM)
 						AM.throw_at(target, 100, 1)
@@ -818,6 +820,8 @@
 
 				AM.forceMove(T)
 				AM.pipe_eject(0)
+				SEND_SIGNAL(AM, COMSIG_MOVABLE_EXIT_DISPOSALS)
+
 				spawn(1)
 					if(AM)
 						AM.throw_at(target, 5, 1)

--- a/paradise.dme
+++ b/paradise.dme
@@ -276,6 +276,7 @@
 #include "code\controllers\subsystem\weather.dm"
 #include "code\controllers\subsystem\processing\dcs.dm"
 #include "code\controllers\subsystem\processing\fastprocess.dm"
+#include "code\controllers\subsystem\processing\fields.dm"
 #include "code\controllers\subsystem\processing\instruments.dm"
 #include "code\controllers\subsystem\processing\obj.dm"
 #include "code\controllers\subsystem\processing\processing.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Requested by @Fox-McCloud

This updates the proximity monitor component and introduces framework for an "advanced" subtype component that has some additional functionality. Following the original PR which added this component, the code is influenced by TG's 
`/datum/proximity_monitor/advanced` datum, but it's not really a "port" per se, and has been heavily modified.

**Changes:**
- Slightly optimizes and simplifies the existing proximity monitor component code.
- Adds a new subsystem, `SSfields` for use with the advanced proximity monitor component. Which processes every 0.2 seconds.
- Creates an "advanced" proximity monitor component which can take advantage of `process()`, make a distinction between inner and edge parts of it's field, check if objects can pass it's field tiles, and more.
- Documents all code related to the proximity monitor component.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The ~~Game~~ Codebase
Gives developers additional tools to utilize. Optimizes some code.

Fixes #16219
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 
fix: Fixes a bug where proximity sensors were only detecting motion while on turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
