### PR TITLE
Removes public snack vendors from every map

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -20,8 +20,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -31,8 +30,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -43,8 +41,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -155,8 +152,7 @@
 	master_tag = "tradedock";
 	name = "exterior access button";
 	pixel_x = 24;
-	pixel_y = 4;
-	req_access_txt = "0"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -194,23 +190,18 @@
 /area/space)
 "acO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	frequency = 1331;
 	id_tag = "tradedock_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "tradedock";
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	tag_airpump = "tradedock_pump";
 	tag_chamber_sensor = "tradedock_sensor";
 	tag_exterior_door = "tradedock_outer";
 	tag_interior_door = "tradedock_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "tradedock_sensor";
 	pixel_x = 25;
 	pixel_y = 5
@@ -246,8 +237,7 @@
 /area/shuttle/pod_2)
 "adt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -263,8 +253,7 @@
 "adv" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -274,14 +263,11 @@
 /area/hallway/secondary/entry)
 "adx" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -290,14 +276,11 @@
 /area/shuttle/pod_1)
 "adz" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -321,7 +304,6 @@
 "adO" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -332,7 +314,6 @@
 "adP" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -396,7 +377,6 @@
 "aee" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -433,8 +413,7 @@
 /area/hallway/secondary/entry)
 "aeA" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -520,8 +499,7 @@
 	name = "Aux Construction Site"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -554,8 +532,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -570,8 +547,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -586,15 +562,13 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
 /obj/machinery/door/airlock/engineering{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Fore Starboard Solar Access";
 	req_access_txt = "10"
 	},
@@ -610,8 +584,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -634,8 +607,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -683,9 +655,7 @@
 	id_tag = "solar_chapel_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_chapel_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "13";
 	tag_airpump = "solar_chapel_pump";
@@ -694,9 +664,7 @@
 	tag_interior_door = "solar_chapel_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_chapel_sensor";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -733,13 +701,11 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Arrivals Storage";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -785,8 +751,7 @@
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Fore Starboard Solar Control";
-	track = 0
+	name = "Fore Starboard Solar Control"
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
@@ -794,8 +759,7 @@
 "afJ" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -803,8 +767,7 @@
 "afK" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -833,8 +796,7 @@
 /area/maintenance/disposal)
 "afP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -850,8 +812,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -869,8 +830,7 @@
 /area/hallway/secondary/entry)
 "agd" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -890,13 +850,11 @@
 	dir = 10
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -904,12 +862,10 @@
 "agg" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -917,17 +873,14 @@
 "agh" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Center Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -936,7 +889,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater";
 	tag = "icon-heater (NORTH)"
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -944,32 +896,27 @@
 /area/shuttle/arrival/station)
 "agm" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Fore Starboard";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "agn" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/east,
@@ -993,7 +940,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/secondary/entry)
@@ -1058,8 +1004,7 @@
 "agL" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/mechanic_workshop/hanger)
@@ -1108,8 +1053,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -1141,8 +1085,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1154,7 +1097,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -1169,7 +1111,6 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /obj/item/stock_parts/cell/high{
@@ -1207,8 +1148,7 @@
 /area/engine/mechanic_workshop/hanger)
 "ahf" = (
 /obj/machinery/camera{
-	c_tag = "Hanger North";
-	network = list("SS13")
+	c_tag = "Hanger North"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/engine,
@@ -1228,9 +1168,7 @@
 	desc = "A remote control-switch for the pod doors.";
 	id = "secpodbay";
 	name = "Pod Door Control";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access_txt = "0"
+	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/engine,
@@ -1241,7 +1179,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/engine,
@@ -1267,7 +1204,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "65;12"
 	},
 /turf/simulated/floor/plasteel,
@@ -1348,8 +1284,7 @@
 "ahI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1386,8 +1321,7 @@
 "ahT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -1396,8 +1330,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1537,8 +1470,7 @@
 "air" = (
 /obj/effect/decal/warning_stripes/red/partial,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/engine{
 	icon_state = "stage_stairs";
@@ -1549,8 +1481,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/snack,
 /obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "ait" = (
@@ -1574,23 +1506,20 @@
 /area/security/podbay)
 "aiu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/security/podbay)
 "aiv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
 "aiw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
@@ -1598,8 +1527,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
@@ -1608,9 +1536,7 @@
 	luminosity = 3
 	},
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id_tag = "secpodbay";
-	layer = 3.1;
-	req_access_txt = "0"
+	id_tag = "secpodbay"
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
@@ -1629,8 +1555,7 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/effect/decal/warning_stripes/south,
@@ -1643,8 +1568,7 @@
 	},
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/effect/decal/warning_stripes/south,
@@ -1688,8 +1612,7 @@
 /area/hallway/secondary/entry)
 "aiJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1704,8 +1627,7 @@
 "aiL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -1734,8 +1656,7 @@
 /area/engine/mechanic_workshop/hanger)
 "aiT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/east,
@@ -1762,8 +1683,7 @@
 "aiW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/rack{
 	dir = 1
@@ -1800,8 +1720,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/engine,
 /area/security/podbay)
@@ -1819,8 +1738,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/effect/decal/warning_stripes/east,
@@ -1969,13 +1887,11 @@
 "akb" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -2000,8 +1916,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Mechanic's Office";
-	network = list("SS13")
+	c_tag = "Mechanic's Office"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -2027,8 +1942,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -2037,7 +1951,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -2047,14 +1960,12 @@
 "akf" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Mechanic Workshop";
-	req_access_txt = "70";
-	req_one_access_txt = "0"
+	req_access_txt = "70"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop)
@@ -2062,8 +1973,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
@@ -2084,8 +1994,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/camera{
 	c_tag = "Hanger South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
@@ -2133,8 +2042,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2146,8 +2054,7 @@
 /obj/item/stack/rods,
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2156,8 +2063,7 @@
 "akF" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/mechanic_workshop)
@@ -2165,21 +2071,18 @@
 /obj/machinery/mecha_part_fabricator/spacepod,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
 "akH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
@@ -2190,8 +2093,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop/hanger)
@@ -2210,8 +2112,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Mechanic Workshop";
-	req_access_txt = "70";
-	req_one_access_txt = "0"
+	req_access_txt = "70"
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -2236,8 +2137,7 @@
 /obj/machinery/door/window/westright{
 	name = "Mechanic's Desk";
 	req_access = null;
-	req_access_txt = "70";
-	req_one_access_txt = "0"
+	req_access_txt = "70"
 	},
 /obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel{
@@ -2246,8 +2146,7 @@
 /area/engine/mechanic_workshop)
 "ald" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/chair/office/light{
 	dir = 8
@@ -2267,8 +2166,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2286,8 +2184,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2312,7 +2209,6 @@
 /obj/machinery/door_control{
 	id = "mechpod";
 	name = "Mechanic's Inner Door Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "70"
 	},
@@ -2335,7 +2231,6 @@
 "alj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -2375,17 +2270,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -2404,8 +2296,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -2417,17 +2308,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Center Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -2451,7 +2339,6 @@
 /area/engine/mechanic_workshop)
 "alE" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 2;
 	height = 12;
 	id = "ferry_home";
@@ -2464,8 +2351,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -2473,7 +2359,6 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Aft Starboard";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -2494,12 +2379,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -2533,7 +2416,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "alO" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2679,8 +2562,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -2705,8 +2587,7 @@
 /area/hallway/secondary/entry)
 "amC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -2714,8 +2595,7 @@
 /area/maintenance/fsmaint)
 "amD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/candy,
@@ -2732,8 +2612,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2745,8 +2624,7 @@
 /area/maintenance/fsmaint)
 "amF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -2754,8 +2632,7 @@
 /area/maintenance/fsmaint)
 "amG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -2764,8 +2641,7 @@
 /area/maintenance/fsmaint)
 "amH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -2778,8 +2654,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -2882,8 +2757,7 @@
 "ank" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -2892,8 +2766,7 @@
 /area/hallway/secondary/entry)
 "anl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2902,8 +2775,7 @@
 /area/hallway/secondary/entry)
 "anm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -2913,8 +2785,7 @@
 /area/hallway/secondary/entry)
 "ann" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -2926,8 +2797,7 @@
 /area/hallway/secondary/entry)
 "ano" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2940,19 +2810,15 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Arrivals Hall Center";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Arrivals Hall Center"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2974,8 +2840,7 @@
 /area/hallway/secondary/entry)
 "anr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -2985,8 +2850,7 @@
 /area/hallway/secondary/entry)
 "ans" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -3063,7 +2927,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -3077,11 +2940,9 @@
 /area/hallway/secondary/entry)
 "anI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3091,7 +2952,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3100,7 +2960,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3108,22 +2967,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
 "anM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3136,7 +2991,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3152,22 +3006,19 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
 "anP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
 "anQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3215,8 +3066,7 @@
 "anV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -3232,7 +3082,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3245,11 +3094,9 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3259,11 +3106,9 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -3305,8 +3150,7 @@
 /obj/structure/table,
 /obj/random/toolbox,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -3314,15 +3158,13 @@
 "aof" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/maintenance/fsmaint)
 "aog" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -3342,7 +3184,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/maintenance/fsmaint)
@@ -3354,7 +3195,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/maintenance/fsmaint)
@@ -3427,7 +3267,6 @@
 "aow" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -3447,7 +3286,6 @@
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
@@ -3455,7 +3293,6 @@
 /obj/machinery/vending/clothing,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
@@ -3487,8 +3324,7 @@
 "aoE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3499,7 +3335,6 @@
 /obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
@@ -3511,8 +3346,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -3522,26 +3356,22 @@
 /area/maintenance/fsmaint)
 "aoH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aoI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/maintenance/fsmaint)
 "aoJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -3551,15 +3381,13 @@
 "aoK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/maintenance/fsmaint)
 "aoL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
@@ -3569,13 +3397,11 @@
 /area/maintenance/fsmaint)
 "aoM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -3584,12 +3410,10 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -3706,7 +3530,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/vacantoffice)
@@ -3715,7 +3538,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/vacantoffice)
@@ -3768,8 +3590,7 @@
 /area/bridge)
 "aph" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3843,8 +3664,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -3860,8 +3680,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -3880,8 +3699,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -3894,8 +3712,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -3972,8 +3789,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -3996,8 +3812,7 @@
 "apJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4068,18 +3883,15 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/vacantoffice)
 "apT" = (
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/vacantoffice)
@@ -4104,8 +3916,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4116,8 +3927,7 @@
 /obj/structure/table,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/kitchen_machine/microwave,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -4154,8 +3964,7 @@
 "apZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4166,9 +3975,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/camera{
-	c_tag = "Arrivals Lobby";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Arrivals Lobby"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -4204,8 +4011,7 @@
 "aqf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -4298,7 +4104,6 @@
 	name = "2maintenance loot spawner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -4308,7 +4113,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -4461,8 +4265,7 @@
 /area/maintenance/fsmaint)
 "aqI" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -4505,7 +4308,6 @@
 /area/security/vacantoffice)
 "aqP" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/vacantoffice)
@@ -4515,7 +4317,6 @@
 	},
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/vacantoffice)
@@ -4589,8 +4390,7 @@
 "aqZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -4619,12 +4419,10 @@
 "arc" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Checkpoint";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/computer/prisoner,
 /turf/simulated/floor/plasteel{
@@ -4657,7 +4455,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -4801,8 +4598,7 @@
 "arA" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -4881,8 +4677,7 @@
 "arI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4893,16 +4688,13 @@
 /obj/machinery/camera{
 	c_tag = "Customs Desk";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/computer/card,
 /turf/simulated/floor/plasteel{
@@ -5043,18 +4835,14 @@
 /area/security/checkpoint2)
 "arT" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -5155,8 +4943,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -5175,8 +4962,7 @@
 /area/maintenance/electrical_shop)
 "asj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5187,8 +4973,7 @@
 /area/maintenance/electrical_shop)
 "ask" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -5196,8 +4981,7 @@
 /area/maintenance/electrical_shop)
 "asl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -5209,8 +4993,7 @@
 /area/maintenance/electrical_shop)
 "asm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -5220,8 +5003,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -5296,8 +5078,7 @@
 /area/maintenance/fsmaint)
 "asw" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
@@ -5345,8 +5126,7 @@
 "asB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -5355,8 +5135,7 @@
 /area/hallway/secondary/entry)
 "asC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -5369,8 +5148,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry)
@@ -5515,16 +5293,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"asU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/maintenance/auxsolarport)
 "asV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -5717,8 +5485,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/computerframe,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -5727,7 +5494,6 @@
 "ato" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -5786,7 +5552,6 @@
 "atv" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -5825,7 +5590,6 @@
 /obj/item/storage/secure/briefcase,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -5849,8 +5613,7 @@
 "atB" = (
 /obj/structure/filingcabinet,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -5860,7 +5623,6 @@
 "atC" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/chair/comfy/brown{
@@ -5926,7 +5688,6 @@
 "atI" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/secure_closet/security,
@@ -5938,8 +5699,7 @@
 "atJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -5980,8 +5740,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5989,19 +5748,6 @@
 	icon_state = "dark";
 	tag = "icon-vault (NORTHEAST)"
 	},
-/area/maintenance/fsmaint)
-"atN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "atO" = (
 /obj/structure/cable{
@@ -6011,8 +5757,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -6030,8 +5775,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -6208,8 +5952,7 @@
 /obj/structure/table/wood,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/item/circuitboard/microwave,
 /obj/item/stack/sheet/glass{
@@ -6298,7 +6041,6 @@
 /obj/structure/cable,
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -6310,8 +6052,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/folder/red,
 /obj/item/lighter/zippo,
@@ -6334,7 +6075,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -6401,7 +6141,6 @@
 /obj/item/toy/AI,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -6420,8 +6159,7 @@
 	id = "garbage"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
@@ -6632,8 +6370,7 @@
 "auZ" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -6655,8 +6392,7 @@
 "avb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6684,8 +6420,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -6701,8 +6436,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -6734,11 +6468,9 @@
 "avh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -6876,8 +6608,7 @@
 /area/engine/controlroom)
 "avy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -6889,8 +6620,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -6915,8 +6645,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -6928,16 +6657,14 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "avC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -6952,8 +6679,7 @@
 /area/engine/controlroom)
 "avE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -6969,8 +6695,7 @@
 /area/engine/controlroom)
 "avG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6979,8 +6704,7 @@
 /area/engine/controlroom)
 "avH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/northwest,
@@ -6988,8 +6712,7 @@
 /area/engine/controlroom)
 "avI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -7055,7 +6778,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -7067,8 +6789,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -7080,8 +6801,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -7093,11 +6813,9 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -7109,8 +6827,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -7123,8 +6840,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7140,8 +6856,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -7155,7 +6870,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -7173,25 +6887,21 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "avX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
 "avY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -7202,16 +6912,14 @@
 /area/maintenance/fsmaint)
 "avZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "awa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -7226,8 +6934,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -7244,8 +6951,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -7255,12 +6961,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -7275,7 +6979,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -7290,8 +6993,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -7315,8 +7017,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -7345,8 +7046,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7359,8 +7059,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7372,8 +7071,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall1";
@@ -7389,8 +7087,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7412,12 +7109,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -7426,8 +7121,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -7440,8 +7134,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -7460,8 +7153,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7477,8 +7169,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7501,8 +7192,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7706,8 +7396,7 @@
 /area/engine/controlroom)
 "awO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7796,8 +7485,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
@@ -7839,7 +7527,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -7861,8 +7548,7 @@
 /area/crew_quarters/toilet)
 "axf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -7899,7 +7585,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -7927,7 +7612,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -7935,7 +7619,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -7982,7 +7665,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -8003,8 +7685,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -8020,12 +7701,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -8040,12 +7719,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -8060,8 +7737,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -8078,8 +7754,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
@@ -8096,11 +7771,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -8115,15 +7788,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/disposal)
@@ -8138,8 +7809,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -8154,8 +7824,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -8185,12 +7854,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/maintenance/disposal)
@@ -8205,8 +7872,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -8228,11 +7894,9 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/maintenance/disposal)
@@ -8246,14 +7910,12 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -8327,7 +7989,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -8411,8 +8072,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -8527,8 +8187,7 @@
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -8551,7 +8210,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/closet/jcloset,
@@ -8560,9 +8218,7 @@
 /area/janitor)
 "aym" = (
 /obj/machinery/camera{
-	c_tag = "Janitor's Closet";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Janitor's Closet"
 	},
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/requests_console{
@@ -8633,7 +8289,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/toilet)
 "ayu" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -8642,11 +8298,9 @@
 /area/hallway/secondary/entry)
 "ayv" = (
 /obj/structure/sign/directions/engineering{
-	dir = 2;
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/science{
-	dir = 2;
 	pixel_y = 1
 	},
 /obj/structure/sign/directions/evac{
@@ -8665,8 +8319,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -8677,8 +8330,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8691,7 +8343,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -8699,11 +8350,8 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical{
-	dir = 2
-	},
+/obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/security{
-	dir = 2;
 	pixel_y = 8
 	},
 /turf/simulated/wall,
@@ -8817,8 +8465,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -8839,8 +8486,7 @@
 /area/maintenance/fsmaint)
 "ayT" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -8901,15 +8547,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/maintenance/fsmaint)
 "azb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -8932,8 +8576,7 @@
 /area/maintenance/fsmaint)
 "aze" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -8962,8 +8605,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9037,8 +8679,7 @@
 "azm" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -9058,7 +8699,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -9126,13 +8766,11 @@
 "azw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Hallway North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9182,8 +8820,7 @@
 /area/quartermaster/sorting)
 "azC" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Backroom";
-	network = list("SS13")
+	c_tag = "Cargo Backroom"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9410,8 +9047,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
@@ -9481,8 +9117,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -9527,7 +9162,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/maintenance/fsmaint)
@@ -9549,7 +9183,6 @@
 /area/maintenance/fsmaint)
 "aAq" = (
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9567,8 +9200,7 @@
 /obj/item/lightreplacer,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -9636,14 +9268,12 @@
 /area/crew_quarters/toilet)
 "aAB" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/crew_quarters/toilet)
 "aAC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/crew_quarters/toilet)
@@ -9653,7 +9283,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -9668,7 +9297,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9712,13 +9340,11 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9733,8 +9359,7 @@
 	tag = ""
 	},
 /obj/machinery/door/airlock{
-	name = "Auxillary Restrooms";
-	req_access_txt = "0"
+	name = "Auxillary Restrooms"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/toilet)
@@ -9773,8 +9398,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -9783,8 +9407,7 @@
 /area/quartermaster/sorting)
 "aAN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/closet/crate,
@@ -9794,8 +9417,7 @@
 /area/quartermaster/sorting)
 "aAO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/warning_stripes/yellow,
@@ -9803,8 +9425,7 @@
 /area/quartermaster/sorting)
 "aAP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet/cardboard,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -9812,8 +9433,7 @@
 /area/quartermaster/sorting)
 "aAQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
@@ -9821,8 +9441,7 @@
 /area/quartermaster/sorting)
 "aAR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -9832,8 +9451,7 @@
 /area/quartermaster/sorting)
 "aAS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -9844,8 +9462,7 @@
 /area/quartermaster/sorting)
 "aAT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/northwest,
@@ -9853,8 +9470,7 @@
 /area/quartermaster/storage)
 "aAU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/north,
@@ -9862,8 +9478,7 @@
 /area/quartermaster/storage)
 "aAV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -9872,8 +9487,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -9929,8 +9543,7 @@
 /area/engine/supermatter)
 "aBg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -10005,12 +9618,10 @@
 /area/engine/controlroom)
 "aBn" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10028,13 +9639,11 @@
 "aBp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -10052,7 +9661,6 @@
 /obj/effect/landmark/costume/random,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/maintenance/fsmaint)
@@ -10072,11 +9680,9 @@
 	pixel_y = 1
 	},
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/maintenance/fsmaint)
@@ -10095,7 +9701,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -10127,7 +9732,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -10144,7 +9748,6 @@
 	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -10153,7 +9756,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple";
 	tag = "icon-whitepurple (WEST)"
 	},
@@ -10178,8 +9780,7 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -10244,7 +9845,6 @@
 "aBG" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -10274,8 +9874,7 @@
 "aBJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -10345,8 +9944,7 @@
 "aBR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel{
@@ -10398,9 +9996,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "aBX" = (
-/obj/machinery/power/supermatter_crystal{
-	anchored = 1
-	},
+/obj/machinery/power/supermatter_crystal,
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "aBY" = (
@@ -10548,7 +10144,6 @@
 	id = "janitorshutters";
 	name = "Janitor Shutters Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "26"
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -10559,15 +10154,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
 "aCu" = (
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/toilet{
 	dir = 8
@@ -10586,8 +10179,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -10596,8 +10188,7 @@
 /area/quartermaster/sorting)
 "aCw" = (
 /obj/machinery/door/airlock{
-	name = "Private Restroom";
-	req_access_txt = "0"
+	name = "Private Restroom"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/toilet)
@@ -10654,8 +10245,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10665,8 +10255,7 @@
 "aCD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
@@ -10735,12 +10324,10 @@
 	layer = 2.9
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -10759,8 +10346,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -10814,8 +10400,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -10973,8 +10558,7 @@
 	dir = 10
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -11083,8 +10667,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -11102,8 +10685,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11122,15 +10704,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -11145,14 +10725,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -11189,8 +10767,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11210,8 +10787,7 @@
 	tag = "icon-pipe-j1 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -11234,8 +10810,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11286,8 +10861,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11300,8 +10874,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11319,8 +10892,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11346,8 +10918,7 @@
 "aDJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -11379,8 +10950,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
@@ -11405,8 +10975,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
@@ -11498,12 +11067,10 @@
 "aDW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -11586,9 +11153,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -11681,8 +11246,7 @@
 "aEt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hydroponics/abandoned_garden)
@@ -11708,8 +11272,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11730,7 +11293,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -11743,7 +11305,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -11755,8 +11316,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -11769,8 +11329,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -11783,15 +11342,13 @@
 /area/crew_quarters/toilet)
 "aEC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "Custodial Junction";
 	sortType = 11
 	},
@@ -11809,8 +11366,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -11832,8 +11388,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -11843,8 +11398,7 @@
 "aEF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -11862,8 +11416,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -11888,13 +11441,11 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	sortType = 21;
 	tag = "icon-pipe-j1s (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -11935,8 +11486,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -11965,8 +11515,7 @@
 	},
 /obj/structure/disposaloutlet,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11976,8 +11525,7 @@
 /area/quartermaster/office)
 "aEN" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11991,8 +11539,7 @@
 "aEO" = (
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/toilet{
 	dir = 8
@@ -12027,8 +11574,7 @@
 "aER" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -12158,9 +11704,7 @@
 	},
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8;
-	filter_type = "n2";
-	name = "gas filter";
-	on = 0
+	filter_type = "n2"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -12323,8 +11867,7 @@
 "aFB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12334,8 +11877,7 @@
 "aFC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -12345,7 +11887,6 @@
 "aFD" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
@@ -12364,7 +11905,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
@@ -12374,7 +11914,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
@@ -12394,13 +11933,11 @@
 "aFJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
 "aFK" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/sorting)
@@ -12448,8 +11985,7 @@
 "aFQ" = (
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/toilet{
 	dir = 8
@@ -12466,9 +12002,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "aFS" = (
-/obj/machinery/status_display/supply_display{
-	pixel_y = 0
-	},
+/obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
 /area/quartermaster/storage)
 "aFV" = (
@@ -12519,7 +12053,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -12592,14 +12125,12 @@
 /area/engine/controlroom)
 "aGd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/item/tank/internals/plasma,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -12608,7 +12139,6 @@
 "aGe" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -12711,8 +12241,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -12737,8 +12266,7 @@
 /area/crew_quarters/sleep)
 "aGr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -12746,8 +12274,7 @@
 /area/crew_quarters/sleep)
 "aGs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "25"
@@ -12759,8 +12286,7 @@
 "aGt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
@@ -12781,8 +12307,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -12814,7 +12339,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light/small{
@@ -12833,9 +12357,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Bar Backroom";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bar Backroom"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -12861,7 +12383,6 @@
 /obj/structure/table/wood,
 /obj/item/ammo_box/shotgun/beanbag,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light_switch{
@@ -12915,7 +12436,6 @@
 	department = "Bar";
 	departmentType = 2;
 	name = "Bar Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/book/manual/barman_recipes,
@@ -12978,8 +12498,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -13008,8 +12527,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -13054,12 +12572,10 @@
 "aGQ" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -13110,9 +12626,7 @@
 "aHb" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 9;
-	pixel_y = 0
+	pixel_x = 9
 	},
 /obj/structure/sign/botany{
 	pixel_x = 32
@@ -13166,8 +12680,7 @@
 "aHi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -13256,7 +12769,6 @@
 /obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -13557,8 +13069,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -13584,8 +13095,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -13618,8 +13128,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -13632,8 +13141,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -13737,21 +13245,18 @@
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = 24;
-	pixel_y = 8;
-	req_access_txt = "0"
+	pixel_y = 8
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = 24;
-	pixel_y = -8;
-	req_access_txt = "0"
+	pixel_y = -8
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -13860,8 +13365,7 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/seeds/tower,
@@ -13973,8 +13477,7 @@
 /area/maintenance/incinerator)
 "aIy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14014,8 +13517,7 @@
 /area/maintenance/incinerator)
 "aIB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/southwest,
@@ -14029,8 +13531,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -14043,8 +13544,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -14057,8 +13557,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -14078,8 +13577,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -14096,8 +13594,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/southwestcorner,
@@ -14117,8 +13614,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -14130,8 +13626,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
@@ -14183,8 +13678,7 @@
 /area/hydroponics/abandoned_garden)
 "aIN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -14220,7 +13714,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -14230,12 +13723,10 @@
 /obj/machinery/camera{
 	c_tag = "Service Hall North";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14334,8 +13825,7 @@
 /area/crew_quarters/bar)
 "aJb" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -14430,8 +13920,7 @@
 /area/security/checkpoint/supply)
 "aJl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -14448,8 +13937,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -14461,8 +13949,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -14474,8 +13961,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -14490,8 +13976,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -14541,8 +14026,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -14630,13 +14114,11 @@
 /area/quartermaster/storage)
 "aJF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/southwest,
@@ -14669,8 +14151,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -14713,9 +14194,7 @@
 	id_tag = "solar_tool_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_tool_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "32";
 	tag_airpump = "solar_tool_pump";
@@ -14724,9 +14203,7 @@
 	tag_interior_door = "solar_tool_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_tool_sensor";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -14777,9 +14254,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
-	name = "Gas to Turbine";
-	on = 0
+	name = "Gas to Turbine"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -14818,8 +14293,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -14836,7 +14310,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -14846,9 +14319,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/controlroom)
@@ -14890,9 +14361,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/controlroom)
@@ -15004,8 +14473,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -15053,12 +14521,10 @@
 "aKm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -15110,7 +14576,6 @@
 /obj/machinery/camera{
 	c_tag = "Bar";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -15130,13 +14595,11 @@
 "aKt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Hallway North";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15169,8 +14632,7 @@
 	on = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -15196,8 +14658,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -15239,7 +14700,6 @@
 	},
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -15304,8 +14764,7 @@
 "aKH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -15400,8 +14859,7 @@
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
 	id = "portsolar";
-	name = "Aft Port Solar Control";
-	track = 0
+	name = "Aft Port Solar Control"
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
@@ -15431,7 +14889,6 @@
 "aLc" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -15478,9 +14935,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
-	name = "Mix to Turbine";
-	on = 0
+	name = "Mix to Turbine"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -15521,8 +14976,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -15557,8 +15011,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -15580,8 +15033,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
@@ -15599,8 +15051,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -15613,8 +15064,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -15636,7 +15086,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Fore Port Solar Access";
 	req_access_txt = "32"
 	},
@@ -15645,8 +15094,7 @@
 "aLs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -15705,7 +15153,6 @@
 	name = "2maintenance loot spawner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -15716,14 +15163,12 @@
 "aLz" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
 "aLA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -15731,7 +15176,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -15739,7 +15183,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -15761,8 +15204,7 @@
 "aLE" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -15787,8 +15229,7 @@
 /area/crew_quarters/sleep)
 "aLH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -15796,8 +15237,7 @@
 /area/crew_quarters/sleep)
 "aLI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "25"
@@ -15808,8 +15248,7 @@
 /area/crew_quarters/sleep)
 "aLJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -15826,8 +15265,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -15841,12 +15279,10 @@
 /obj/machinery/disposal,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor/plasteel{
@@ -15995,8 +15431,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -16071,8 +15506,7 @@
 "aMh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -16083,8 +15517,7 @@
 "aMi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -16093,8 +15526,7 @@
 /area/quartermaster/storage)
 "aMj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -16103,8 +15535,7 @@
 /area/quartermaster/storage)
 "aMk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -16116,8 +15547,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -16186,8 +15616,7 @@
 /area/security/execution)
 "aMw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -16204,8 +15633,7 @@
 	},
 /obj/machinery/power/terminal,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -16227,8 +15655,7 @@
 /area/maintenance/incinerator)
 "aMB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
@@ -16265,8 +15692,7 @@
 "aMG" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Port to Turbine";
-	on = 0
+	name = "Port to Turbine"
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
@@ -16284,9 +15710,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/incinerator)
 "aMJ" = (
-/obj/structure/sign/vacuum{
-	pixel_y = 0
-	},
+/obj/structure/sign/vacuum,
 /turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "aMK" = (
@@ -16312,8 +15736,7 @@
 /area/engine/controlroom)
 "aMN" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 22;
-	pixel_y = 0
+	pixel_x = 22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -16348,8 +15771,7 @@
 "aMR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southeast,
@@ -16385,9 +15807,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light/small,
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /turf/simulated/floor/greengrid,
 /area/engine/controlroom)
 "aMU" = (
@@ -16395,16 +15815,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
@@ -16485,12 +15901,10 @@
 "aNf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -16507,7 +15921,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -16517,12 +15930,10 @@
 /area/crew_quarters/sleep)
 "aNh" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -16535,13 +15946,11 @@
 /area/crew_quarters/bar/atrium)
 "aNj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -16609,8 +16018,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/door_timer{
 	id = "Cargo Cell";
@@ -16646,19 +16054,16 @@
 /area/security/checkpoint/supply)
 "aNs" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -16750,8 +16155,7 @@
 	},
 /obj/item/soap/nanotrasen,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -16915,8 +16319,7 @@
 /area/security/prison)
 "aNP" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
@@ -16945,8 +16348,7 @@
 /area/security/execution)
 "aNS" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -16972,9 +16374,7 @@
 /area/maintenance/incinerator)
 "aNW" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "gas pump";
-	on = 0
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -17016,8 +16416,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -17080,9 +16479,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/atmos)
@@ -17166,7 +16563,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/wood{
@@ -17243,16 +16639,13 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Theatre";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Theatre"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -17300,7 +16693,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -17379,7 +16771,6 @@
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -17413,8 +16804,7 @@
 /area/quartermaster/storage)
 "aOT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -17434,8 +16824,7 @@
 /area/space/nearstation)
 "aOV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
@@ -17458,8 +16847,7 @@
 /area/security/prison)
 "aOY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table,
@@ -17474,8 +16862,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/paper,
@@ -17489,8 +16876,7 @@
 /area/security/prison)
 "aPb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
@@ -17499,8 +16885,7 @@
 /area/security/prison)
 "aPc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -17509,8 +16894,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -17524,8 +16908,7 @@
 "aPf" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -17673,8 +17056,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -17689,8 +17071,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -17705,8 +17086,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/binary/valve,
@@ -17719,15 +17099,13 @@
 "aPu" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "aPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -17737,8 +17115,7 @@
 /area/atmos)
 "aPw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -17747,8 +17124,7 @@
 /area/atmos)
 "aPx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
@@ -17758,8 +17134,7 @@
 /area/atmos)
 "aPy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -17797,8 +17172,7 @@
 /area/atmos)
 "aPB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/warning_stripes/south,
@@ -17825,8 +17199,7 @@
 "aPD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -17914,8 +17287,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -17935,12 +17307,10 @@
 "aPP" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
@@ -17954,9 +17324,7 @@
 	},
 /obj/item/storage/fancy/crayons,
 /obj/machinery/camera{
-	c_tag = "Theatre Backstage";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Theatre Backstage"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
@@ -17973,7 +17341,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/vending/autodrobe,
@@ -17992,8 +17359,7 @@
 "aPT" = (
 /obj/structure/table/wood,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -18090,8 +17456,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
@@ -18133,8 +17498,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -18150,8 +17514,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -18280,8 +17643,7 @@
 /area/quartermaster/storage)
 "aQs" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/conveyor/northeast/ccw{
 	id = "QMLoad"
@@ -18290,8 +17652,7 @@
 /area/quartermaster/storage)
 "aQt" = (
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
@@ -18305,7 +17666,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
@@ -18313,12 +17673,10 @@
 /area/quartermaster/storage)
 "aQv" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -18345,8 +17703,7 @@
 "aQy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prison)
@@ -18358,8 +17715,7 @@
 /area/security/prison)
 "aQA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -18442,9 +17798,7 @@
 /area/maintenance/incinerator)
 "aQO" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "gas pump";
-	on = 0
+	dir = 8
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
@@ -18500,7 +17854,6 @@
 /obj/item/folder/yellow,
 /obj/item/reagent_containers/food/pill/patch/silver_sulf,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/maintenance/incinerator)
@@ -18521,8 +17874,7 @@
 /area/maintenance/incinerator)
 "aQS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18613,8 +17965,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/tank/internals/emergency_oxygen,
@@ -18634,8 +17985,7 @@
 /area/atmos)
 "aRa" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/wardrobe/atmospherics_yellow,
@@ -18857,8 +18207,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -18918,8 +18267,7 @@
 /area/crew_quarters/bar/atrium)
 "aRB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -18928,8 +18276,7 @@
 /area/crew_quarters/bar/atrium)
 "aRC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/cheesiehonkers,
@@ -18939,8 +18286,7 @@
 /area/crew_quarters/bar/atrium)
 "aRD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
@@ -18949,8 +18295,7 @@
 /area/crew_quarters/bar/atrium)
 "aRE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/item/deck/cards,
@@ -18960,8 +18305,7 @@
 /area/crew_quarters/bar/atrium)
 "aRF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -18970,8 +18314,7 @@
 /area/crew_quarters/bar/atrium)
 "aRG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -18988,8 +18331,7 @@
 /area/hallway/primary/fore)
 "aRI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -19006,8 +18348,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -19017,12 +18358,10 @@
 "aRK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -19046,8 +18385,7 @@
 	},
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -19059,7 +18397,6 @@
 /obj/item/folder/yellow,
 /obj/item/destTagger,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -19072,7 +18409,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -19081,8 +18417,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -19190,9 +18525,7 @@
 	},
 /area/quartermaster/storage)
 "aRZ" = (
-/obj/machinery/status_display/supply_display{
-	pixel_y = 0
-	},
+/obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
 /area/quartermaster/qm)
 "aSa" = (
@@ -19395,8 +18728,7 @@
 "aSA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -19409,8 +18741,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -19422,24 +18753,21 @@
 /area/atmos)
 "aSC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aSD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aSE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/warning_stripes/north,
@@ -19447,8 +18775,7 @@
 /area/atmos)
 "aSF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/effect/decal/warning_stripes/north,
@@ -19457,8 +18784,7 @@
 "aSG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -19471,8 +18797,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -19480,24 +18805,21 @@
 "aSI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aSJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aSK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -19507,8 +18829,7 @@
 "aSL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10;
-	initialize_directions = 10;
-	level = 2
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -19564,8 +18885,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
@@ -19584,8 +18904,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -19605,8 +18924,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -19626,8 +18944,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -19667,8 +18984,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -19683,8 +18999,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -19700,8 +19015,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -19750,8 +19064,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -19767,8 +19080,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -19784,8 +19096,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -19816,8 +19127,7 @@
 /area/crew_quarters/bar/atrium)
 "aTi" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals North";
@@ -19996,7 +19306,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -20024,15 +19333,13 @@
 /area/quartermaster/qm)
 "aTE" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -20101,8 +19408,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/bottle/morphine,
@@ -20136,7 +19442,6 @@
 	},
 /obj/machinery/flasher_button{
 	id = "Execution";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/simulated/floor/plasteel{
@@ -20157,8 +19462,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -20174,8 +19478,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
@@ -20196,8 +19499,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor/plasteel{
@@ -20267,8 +19569,7 @@
 /area/space/nearstation)
 "aTV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
@@ -20296,16 +19597,14 @@
 /area/atmos)
 "aTY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aTZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20314,13 +19613,11 @@
 /area/atmos)
 "aUa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Port to Turbine";
-	on = 0
+	name = "Port to Turbine"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20329,13 +19626,11 @@
 /area/atmos)
 "aUb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Port to Filter";
-	on = 0
+	name = "Port to Filter"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20345,8 +19640,7 @@
 "aUc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20361,8 +19655,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20372,8 +19665,7 @@
 "aUe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20382,8 +19674,7 @@
 /area/atmos)
 "aUf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	level = 2
+	dir = 1
 	},
 /obj/machinery/meter,
 /obj/effect/decal/warning_stripes/east,
@@ -20399,7 +19690,6 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
 	name = "Air to Pure";
-	on = 0;
 	target_pressure = 101
 	},
 /turf/simulated/floor/plasteel{
@@ -20417,16 +19707,14 @@
 "aUi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "aUj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/south,
@@ -20435,8 +19723,7 @@
 "aUk" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/wall/r_wall,
@@ -20485,8 +19772,7 @@
 /area/maintenance/gambling_den)
 "aUr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
@@ -20498,8 +19784,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood{
@@ -20515,8 +19800,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
@@ -20528,8 +19812,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -20551,8 +19834,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -20560,8 +19842,7 @@
 "aUw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/wall,
 /area/crew_quarters/theatre)
@@ -20572,7 +19853,6 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -20584,7 +19864,6 @@
 	name = "Mime"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -20593,7 +19872,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -20611,7 +19889,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -20722,8 +19999,7 @@
 /obj/item/paper_bin,
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -20781,14 +20057,12 @@
 "aUS" = (
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Medbay Lobby East";
-	network = list("SS13")
+	c_tag = "Medbay Lobby East"
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Cargo Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/storage/firstaid/regular,
@@ -20806,7 +20080,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/item/paper_bin,
@@ -20835,13 +20108,11 @@
 /area/quartermaster/office)
 "aUW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -20859,8 +20130,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20913,15 +20183,13 @@
 "aVc" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/qm)
 "aVd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20930,8 +20198,7 @@
 /area/quartermaster/qm)
 "aVe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20940,8 +20207,7 @@
 /area/quartermaster/qm)
 "aVf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -21111,15 +20377,13 @@
 "aVu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/radio/electropack,
 /obj/item/assembly/signaler,
 /obj/item/clothing/head/helmet,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -21144,8 +20408,7 @@
 "aVw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -21187,13 +20450,11 @@
 /area/security/execution)
 "aVA" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -21240,16 +20501,14 @@
 "aVE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aVF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -21259,8 +20518,7 @@
 "aVG" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -21269,8 +20527,7 @@
 /area/atmos)
 "aVH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
@@ -21280,18 +20537,15 @@
 /area/atmos)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
 "aVJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -21303,31 +20557,26 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
 "aVK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
 "aVL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -21338,11 +20587,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -21355,8 +20602,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -21371,8 +20617,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -21382,8 +20627,7 @@
 "aVP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -21448,7 +20692,6 @@
 "aVY" = (
 /obj/structure/table/wood,
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/item/lipstick/random{
@@ -21467,11 +20710,9 @@
 	department = "Clown & Mime Office";
 	departmentType = 2;
 	name = "Clown and Mime Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -21479,7 +20720,6 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/baguette,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -21491,7 +20731,6 @@
 	},
 /obj/machinery/vending/autodrobe,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -21500,14 +20739,12 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/mime,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
 "aWc" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/theatre)
@@ -21579,7 +20816,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Quartermaster Junction";
 	sortType = 13
 	},
@@ -21643,8 +20879,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -21770,8 +21005,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21789,8 +21023,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -21814,8 +21047,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21846,8 +21078,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -22016,8 +21247,7 @@
 /area/security/prison)
 "aWO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/table,
 /obj/item/paper,
@@ -22065,7 +21295,6 @@
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -22082,11 +21311,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/execution)
@@ -22094,8 +21321,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm{
@@ -22103,7 +21329,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/execution)
@@ -22115,14 +21340,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/execution)
 "aWW" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -22137,8 +21360,7 @@
 "aWX" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Justice gas pump";
-	on = 0
+	name = "Justice gas pump"
 	},
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor/plasteel{
@@ -22165,10 +21387,8 @@
 	dir = 8
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "perma_airlock";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "63";
 	tag_airpump = "perma_pump";
 	tag_chamber_sensor = "perma_sensor";
@@ -22176,12 +21396,10 @@
 	tag_interior_door = "perma_inner"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	frequency = 1331;
 	id_tag = "perma_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "perma_sensor";
 	pixel_x = 25;
 	pixel_y = 8
@@ -22220,8 +21438,7 @@
 "aXd" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/wall/r_wall,
@@ -22231,19 +21448,10 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
 /area/maintenance/gambling_den)
-"aXf" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/atmos)
 "aXg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -22260,8 +21468,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
-	name = "CO2 to Pure";
-	on = 0
+	name = "CO2 to Pure"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -22307,8 +21514,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -22363,8 +21569,7 @@
 "aXt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -22373,8 +21578,7 @@
 /area/atmos)
 "aXu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/warning_stripes/east,
@@ -22386,8 +21590,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
@@ -22397,8 +21600,7 @@
 /area/atmos)
 "aXw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -22437,8 +21639,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -22460,8 +21661,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -22471,8 +21671,7 @@
 "aXB" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/twohanded/staff/broom,
 /obj/item/clothing/head/witchwig,
@@ -22509,7 +21708,6 @@
 	},
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor/plasteel{
@@ -22526,7 +21724,6 @@
 "aXH" = (
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28;
 	pixel_y = -28
 	},
@@ -22551,7 +21748,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Cargo Junction";
 	sortType = 13
 	},
@@ -22635,8 +21831,7 @@
 /area/quartermaster/office)
 "aXR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
@@ -22794,8 +21989,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -22842,7 +22036,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
 	name = "Brig Medical Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -23040,8 +22233,7 @@
 "aYG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -23053,8 +22245,7 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -23087,8 +22278,7 @@
 /area/atmos)
 "aYL" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8;
-	level = 2
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -23097,7 +22287,6 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
 	name = "O2 to Pure";
-	on = 0;
 	target_pressure = 101
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -23111,8 +22300,7 @@
 	dir = 10
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
@@ -23162,8 +22350,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -23182,8 +22369,7 @@
 	sortType = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -23216,12 +22402,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -23244,7 +22428,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -23303,13 +22486,11 @@
 /area/crew_quarters/kitchen)
 "aZb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Atrium";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -23317,8 +22498,7 @@
 /area/crew_quarters/bar/atrium)
 "aZc" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -23332,8 +22512,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera{
 	c_tag = "Fore Hallway South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -23371,8 +22550,7 @@
 "aZh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -23443,11 +22621,9 @@
 "aZo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
@@ -23457,7 +22633,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/quartermaster/storage)
@@ -23465,7 +22640,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
@@ -23498,13 +22672,11 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Office SouthWest";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -23514,7 +22686,6 @@
 "aZu" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
@@ -23558,7 +22729,6 @@
 /obj/structure/table,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -23567,11 +22737,9 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -23588,13 +22756,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
 "aZB" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -23606,14 +22772,12 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
 "aZD" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/bed/dogbed,
 /turf/simulated/floor/plasteel{
@@ -23624,7 +22788,6 @@
 "aZE" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23636,7 +22799,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23646,7 +22808,6 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23665,7 +22826,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23683,7 +22843,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23701,14 +22860,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/sign/greencross{
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23723,7 +22880,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23739,7 +22895,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23753,7 +22908,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23769,11 +22923,9 @@
 	},
 /obj/machinery/flasher_button{
 	id = "Cell 1";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23795,7 +22947,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23816,7 +22967,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23837,7 +22987,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23863,7 +23012,6 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23879,7 +23027,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23903,7 +23050,6 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23918,7 +23064,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -23979,7 +23124,6 @@
 "aZZ" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/chair/stool/bar,
@@ -24032,8 +23176,7 @@
 "bah" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/wall/r_wall,
@@ -24058,16 +23201,14 @@
 "baj" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "bak" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24137,8 +23278,7 @@
 "bar" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -24153,8 +23293,7 @@
 "bau" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -24171,8 +23310,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -24250,14 +23388,12 @@
 "baC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/fsmaint)
 "baD" = (
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -24289,8 +23425,7 @@
 "baI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/wall,
 /area/hydroponics)
@@ -24303,13 +23438,11 @@
 "baK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/door/firedoor,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -24334,8 +23467,7 @@
 /area/crew_quarters/kitchen)
 "baN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -24372,8 +23504,7 @@
 /area/crew_quarters/kitchen)
 "baR" = (
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -24383,8 +23514,7 @@
 "baS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -24404,12 +23534,10 @@
 "baU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24443,21 +23571,18 @@
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "baX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "baY" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -24466,21 +23591,18 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/cargotech,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "bba" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "bbb" = (
 /obj/machinery/computer/supplycomp,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -24490,15 +23612,13 @@
 	name = "Cargo Technician"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
 "bbd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/stamp/granted{
 	pixel_x = 3;
@@ -24510,12 +23630,10 @@
 	},
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -24651,8 +23769,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24667,8 +23784,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -24707,8 +23823,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24717,8 +23832,7 @@
 /area/security/prison)
 "bbt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -24728,8 +23842,7 @@
 /area/security/prison)
 "bbu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24745,8 +23858,7 @@
 /area/security/prison)
 "bbw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -24764,8 +23876,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -24778,11 +23889,9 @@
 "bby" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -24793,8 +23902,7 @@
 /area/security/prison)
 "bbz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -24809,8 +23917,7 @@
 /area/security/prison)
 "bbA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/sign/pods{
@@ -24825,19 +23932,16 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
 "bbC" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24846,8 +23950,7 @@
 /area/hallway/primary/fore)
 "bbD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small,
 /obj/structure/sign/securearea{
@@ -24858,16 +23961,14 @@
 /area/security/prison)
 "bbE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/security/prison)
 "bbF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -24877,8 +23978,7 @@
 /area/security/prison)
 "bbH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -24897,9 +23997,6 @@
 /area/shuttle/pod_3)
 "bbJ" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -24909,9 +24006,7 @@
 /area/shuttle/pod_3)
 "bbK" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light,
@@ -24969,9 +24064,7 @@
 "bbQ" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 1;
-	filter_type = "";
-	name = "gas filter";
-	on = 0
+	filter_type = ""
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -25089,8 +24182,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -25100,8 +24192,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -6;
@@ -25157,22 +24248,18 @@
 "bcl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Service Hall South";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
@@ -25201,8 +24288,7 @@
 "bco" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -25237,9 +24323,7 @@
 /area/crew_quarters/kitchen)
 "bct" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen Backroom";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Kitchen Backroom"
 	},
 /obj/structure/sink/kitchen{
 	pixel_y = 30
@@ -25255,8 +24339,7 @@
 "bcv" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -25334,7 +24417,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -25394,7 +24476,6 @@
 /obj/structure/closet/secure_closet/cargotech,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/quartermaster/storage)
@@ -25408,7 +24489,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
@@ -25423,12 +24503,10 @@
 /obj/machinery/light,
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/quartermaster/storage)
@@ -25651,8 +24729,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
-	name = "Plasma to Pure";
-	on = 0
+	name = "Plasma to Pure"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -25713,8 +24790,7 @@
 /area/atmos)
 "bdu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25773,8 +24849,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25789,8 +24864,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -25812,8 +24886,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25828,8 +24901,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25844,8 +24916,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25860,8 +24931,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -25874,8 +24944,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
@@ -25897,8 +24966,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -25925,8 +24993,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/freezer{
 	req_access_txt = "28"
@@ -25941,8 +25008,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/yellow,
@@ -25956,8 +25022,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -25971,8 +25036,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/landmark/start{
 	name = "Chef"
@@ -25991,8 +25055,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -26001,7 +25064,6 @@
 "bdN" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/rack,
@@ -26017,8 +25079,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -26027,7 +25088,6 @@
 /area/crew_quarters/kitchen)
 "bdP" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -26042,7 +25102,6 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -26050,7 +25109,6 @@
 "bdS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -26079,7 +25137,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -26112,8 +25169,7 @@
 /area/hallway/primary/fore)
 "bdZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -26131,16 +25187,13 @@
 /area/hallway/primary/fore)
 "beb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -26150,8 +25203,7 @@
 "bec" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -26177,8 +25229,7 @@
 "bef" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -26288,8 +25339,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
@@ -26439,8 +25489,7 @@
 /area/atmos)
 "beN" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -26467,7 +25516,6 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
 	name = "N2 to Pure";
-	on = 0;
 	target_pressure = 101
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -26481,8 +25529,7 @@
 	dir = 10
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -26507,7 +25554,6 @@
 /area/hydroponics)
 "beU" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greenblue"
 	},
 /area/hydroponics)
@@ -26516,7 +25562,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greenblue"
 	},
 /area/hydroponics)
@@ -26528,35 +25573,29 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greenblue"
 	},
 /area/hydroponics)
 "beX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Backroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greenblue"
 	},
 /area/hydroponics)
 "beY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greenblue"
 	},
 /area/hydroponics)
@@ -26566,7 +25605,6 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greenblue"
 	},
 /area/hydroponics)
@@ -26621,7 +25659,6 @@
 "bfh" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -26635,13 +25672,11 @@
 /area/crew_quarters/kitchen)
 "bfj" = (
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -26649,7 +25684,6 @@
 "bfk" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -26668,7 +25702,6 @@
 "bfm" = (
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -26817,8 +25850,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -26827,8 +25859,7 @@
 /area/quartermaster/miningdock)
 "bfG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
@@ -26842,8 +25873,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
@@ -26904,13 +25934,11 @@
 "bfR" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
@@ -26934,7 +25962,6 @@
 /area/security/prison)
 "bfT" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/closet/secure_closet/brig,
@@ -26967,8 +25994,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -26981,8 +26007,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -26995,8 +26020,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/north,
@@ -27010,8 +26034,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Closet";
@@ -27060,8 +26083,7 @@
 "bgc" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Port Mix to Port Ports";
-	on = 0
+	name = "Port Mix to Port Ports"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27071,12 +26093,10 @@
 "bgd" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Port Mix to Starboard Ports";
-	on = 0
+	name = "Port Mix to Starboard Ports"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27103,8 +26123,7 @@
 /area/atmos)
 "bgg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5;
-	level = 2
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27113,8 +26132,7 @@
 /area/atmos)
 "bgh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -27208,8 +26226,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
-	name = "Service Hall";
-	req_access_txt = "0"
+	name = "Service Hall"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
@@ -27264,8 +26281,7 @@
 /area/hallway/primary/fore)
 "bgy" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/effect/decal/warning_stripes/yellow,
@@ -27300,7 +26316,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -27310,8 +26325,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27324,8 +26338,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -27336,8 +26349,7 @@
 "bgE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -27358,8 +26370,7 @@
 /area/hallway/primary/fore)
 "bgG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27380,9 +26391,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
@@ -27392,15 +26401,13 @@
 "bgJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/miningdock)
 "bgK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -27410,8 +26417,7 @@
 /area/quartermaster/miningdock)
 "bgL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -27427,16 +26433,14 @@
 /area/quartermaster/miningdock)
 "bgN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bgO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
@@ -27447,8 +26451,7 @@
 /area/quartermaster/miningdock)
 "bgP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27457,8 +26460,7 @@
 /area/quartermaster/miningdock)
 "bgQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -27476,8 +26478,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -27512,8 +26513,7 @@
 /area/quartermaster/miningdock)
 "bgX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -27583,8 +26583,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -27648,7 +26647,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -27786,7 +26784,6 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/botanist,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -27849,7 +26846,6 @@
 "bhJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -27865,7 +26861,6 @@
 "bhL" = (
 /mob/living/carbon/human/monkey/punpun,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -27888,8 +26883,7 @@
 "bhO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -27917,7 +26911,6 @@
 /obj/item/reagent_containers/food/snacks/dough,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -27977,8 +26970,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -27987,12 +26979,10 @@
 /area/hallway/primary/fore)
 "bhZ" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28015,8 +27005,7 @@
 "bic" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -28029,8 +27018,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -28051,12 +27039,10 @@
 /area/quartermaster/miningdock)
 "bif" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28275,8 +27261,7 @@
 "biw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -28286,8 +27271,7 @@
 "bix" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -28485,8 +27469,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
-	name = "n2o to Pure";
-	on = 0
+	name = "n2o to Pure"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -28496,8 +27479,7 @@
 "biO" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Pure to Ports";
-	on = 0
+	name = "Pure to Ports"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28507,8 +27489,7 @@
 "biP" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Mix to Ports";
-	on = 0
+	name = "Mix to Ports"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28518,8 +27499,7 @@
 "biQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Air to Ports";
-	on = 0
+	name = "Air to Ports"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28540,8 +27520,7 @@
 "biS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28597,8 +27576,7 @@
 "biX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28631,8 +27609,7 @@
 "bja" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28673,13 +27650,11 @@
 "bje" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -28705,8 +27680,7 @@
 "bjh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -28816,7 +27790,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -28841,7 +27814,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -28859,7 +27831,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -28875,7 +27846,6 @@
 	name = "Chef"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -28886,7 +27856,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -28905,8 +27874,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -29014,7 +27982,6 @@
 /area/quartermaster/miningdock)
 "bjL" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/quartermaster/miningdock)
@@ -29037,7 +28004,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
@@ -29053,7 +28019,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/quartermaster/miningdock)
@@ -29070,11 +28035,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Atmospherics South-East";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
@@ -29090,7 +28053,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/quartermaster/miningdock)
@@ -29102,7 +28064,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
@@ -29118,7 +28079,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/quartermaster/miningdock)
@@ -29212,8 +28172,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -29238,13 +28197,11 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
 	name = "Brig Medical Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
@@ -29266,8 +28223,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -29317,7 +28273,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -29482,16 +28437,14 @@
 /area/atmos)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bkB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
@@ -29500,8 +28453,7 @@
 /area/atmos)
 "bkC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/meter,
@@ -29510,8 +28462,7 @@
 /area/atmos)
 "bkD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -29523,8 +28474,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -29552,8 +28502,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -29569,8 +28518,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -29586,8 +28534,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
@@ -29610,8 +28557,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -29627,8 +28573,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
@@ -29661,8 +28606,7 @@
 "bkP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -29699,8 +28643,7 @@
 /area/hydroponics)
 "bkV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/warning_stripes/yellow,
@@ -29711,8 +28654,7 @@
 /area/hydroponics)
 "bkW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hydroponics/constructable,
@@ -29724,8 +28666,7 @@
 /area/hydroponics)
 "bkX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -29734,8 +28675,7 @@
 /area/hydroponics)
 "bkY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -29744,15 +28684,13 @@
 /area/hydroponics)
 "bkZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "bla" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -29761,7 +28699,6 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/door/window/eastleft{
-	dir = 4;
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
 	},
@@ -29770,8 +28707,7 @@
 /area/hydroponics)
 "blb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -29786,8 +28722,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -29809,23 +28744,19 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/flasher_button{
 	id = "Cell 2";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
 "blf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -29836,8 +28767,7 @@
 /area/crew_quarters/kitchen)
 "blg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/foodcart,
 /obj/effect/decal/warning_stripes/yellow,
@@ -29862,15 +28792,13 @@
 /obj/item/storage/box/papersack,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/crew_quarters/kitchen)
 "blj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/icemachine,
 /obj/effect/decal/warning_stripes/yellow,
@@ -29878,8 +28806,7 @@
 /area/crew_quarters/kitchen)
 "blk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/storage/box/donkpockets,
@@ -29890,8 +28817,7 @@
 /area/crew_quarters/kitchen)
 "bll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -29901,8 +28827,7 @@
 /area/crew_quarters/kitchen)
 "blm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -29911,22 +28836,19 @@
 /area/crew_quarters/kitchen)
 "bln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/machinery/processor,
 /obj/machinery/camera{
 	c_tag = "Kitchen";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "blo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -29975,20 +28897,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/fore)
 "blu" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/fore)
 "blv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/fore)
@@ -29996,14 +28915,12 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/fore)
 "blx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/fore)
@@ -30015,7 +28932,6 @@
 	name = "Civilian"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/fore)
@@ -30026,7 +28942,6 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/fore)
@@ -30141,12 +29056,10 @@
 "blN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -30268,7 +29181,6 @@
 /obj/item/folder/red,
 /obj/item/clothing/mask/gas/sechailer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -30277,7 +29189,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -30464,8 +29375,7 @@
 /area/atmos)
 "bmw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	level = 2
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -30485,24 +29395,21 @@
 "bmz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bmA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bmB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -30520,8 +29427,7 @@
 /area/atmos)
 "bmD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -30531,8 +29437,7 @@
 "bmE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10;
-	initialize_directions = 10;
-	level = 2
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -30669,8 +29574,7 @@
 "bmQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -30710,13 +29614,11 @@
 "bmV" = (
 /obj/machinery/plantgenes,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -30735,8 +29637,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
-	name = "Service Foyer";
-	req_access_txt = "0"
+	name = "Service Foyer"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
@@ -30771,9 +29672,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
@@ -30782,8 +29681,7 @@
 /area/crew_quarters/kitchen)
 "bnc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/chef,
@@ -30829,19 +29727,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bni" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -30918,8 +29813,7 @@
 "bnp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -30934,8 +29828,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -30944,8 +29837,7 @@
 /area/security/brig)
 "bnr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -30955,8 +29847,7 @@
 /area/security/brig)
 "bns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/security/main)
@@ -30967,14 +29858,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -30995,8 +29884,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -31011,22 +29899,19 @@
 /area/security/main)
 "bnv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/main)
 "bnw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -31035,8 +29920,7 @@
 /area/security/main)
 "bnx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31059,8 +29943,7 @@
 /area/security/main)
 "bnz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -31070,8 +29953,7 @@
 /area/security/main)
 "bnA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31080,8 +29962,7 @@
 /area/security/main)
 "bnB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -31100,15 +29981,13 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
 "bnD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /mob/living/simple_animal/hostile/retaliate/araneus,
 /turf/simulated/floor/plasteel{
@@ -31117,8 +29996,7 @@
 /area/security/hos)
 "bnE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -31143,8 +30021,7 @@
 /area/security/hos)
 "bnG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
@@ -31153,8 +30030,7 @@
 /area/security/hos)
 "bnH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -31162,8 +30038,7 @@
 /area/security/hos)
 "bnI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/computer/card/minor/hos,
 /turf/simulated/floor/plasteel{
@@ -31178,8 +30053,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
@@ -31187,8 +30061,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -31254,16 +30127,14 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "bnT" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
@@ -31271,16 +30142,14 @@
 "bnU" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/atmos)
 "bnV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/door/firedoor,
@@ -31294,8 +30163,7 @@
 "bnW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9;
-	level = 2
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
@@ -31359,16 +30227,13 @@
 "boc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -31457,8 +30322,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31467,8 +30331,7 @@
 /area/hallway/primary/central)
 "boo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31477,16 +30340,13 @@
 /area/hallway/primary/central)
 "bop" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Central Ring Hallway North";
-	dir = 2
+	c_tag = "Central Ring Hallway North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31495,8 +30355,7 @@
 /area/hallway/primary/central)
 "boq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31505,8 +30364,7 @@
 /area/hallway/primary/central)
 "bor" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -31517,8 +30375,7 @@
 /area/hallway/primary/central)
 "bos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -31535,8 +30392,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31552,8 +30408,7 @@
 /area/hallway/primary/central)
 "bov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31562,8 +30417,7 @@
 /area/hallway/primary/central)
 "bow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -31573,8 +30427,7 @@
 /area/hallway/primary/central)
 "box" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31583,8 +30436,7 @@
 /area/hallway/primary/central)
 "boy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31593,16 +30445,13 @@
 /area/hallway/primary/central)
 "boz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Central Ring Hallway North";
-	dir = 2
+	c_tag = "Central Ring Hallway North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31611,8 +30460,7 @@
 /area/hallway/primary/central)
 "boA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -31625,8 +30473,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -31645,8 +30492,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31668,8 +30514,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31712,8 +30557,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31776,7 +30620,6 @@
 "boP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/item/storage/box/prisoner,
@@ -31833,7 +30676,6 @@
 /area/security/main)
 "boV" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -32193,8 +31035,7 @@
 "bpy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -32224,9 +31065,7 @@
 /area/atmos)
 "bpB" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
-	name = "Pure to Mix";
-	on = 0
+	name = "Pure to Mix"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -32235,8 +31074,7 @@
 /area/atmos)
 "bpC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -32308,8 +31146,7 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5;
-	level = 2
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -32319,8 +31156,7 @@
 /area/atmos)
 "bpK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -32357,16 +31193,14 @@
 /area/atmos)
 "bpN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "bpO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/space_heater,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -32374,8 +31208,7 @@
 /area/atmos)
 "bpP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -32383,8 +31216,7 @@
 /area/atmos)
 "bpQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light{
@@ -32396,8 +31228,7 @@
 /area/atmos)
 "bpR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -32405,8 +31236,7 @@
 /area/atmos)
 "bpS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -32603,8 +31433,7 @@
 "bqh" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -32652,8 +31481,7 @@
 "bqm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -32833,8 +31661,7 @@
 /area/hallway/primary/central)
 "bqw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -32914,8 +31741,7 @@
 "bqI" = (
 /obj/structure/lattice,
 /obj/structure/sign/electricshock{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/space,
 /area/space/nearstation)
@@ -33079,7 +31905,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -33105,8 +31930,7 @@
 "bqZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/reinforced,
 /obj/item/book/manual/security_space_law,
@@ -33200,8 +32024,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -33368,8 +32191,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -33405,8 +32227,7 @@
 /area/atmos)
 "brD" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8;
-	level = 2
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -33431,8 +32252,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /obj/item/wrench,
 /obj/item/crowbar,
@@ -33446,8 +32266,7 @@
 "brH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -33498,16 +32317,14 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
 "brN" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -33515,8 +32332,7 @@
 "brO" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -33524,8 +32340,7 @@
 "brP" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -33533,8 +32348,7 @@
 "brQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -33542,12 +32356,10 @@
 "brR" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -33555,15 +32367,13 @@
 "brS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "brT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -33579,8 +32389,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10;
-	level = 2
+	dir = 10
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=engi3";
@@ -33629,8 +32438,7 @@
 "bsa" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -33663,7 +32471,6 @@
 /obj/item/reagent_containers/food/snacks/grown/banana,
 /obj/machinery/door/window/eastright{
 	dir = 8;
-	icon_state = "right";
 	name = "Hydroponics Desk";
 	req_access_txt = "35";
 	tag = "icon-right"
@@ -33697,7 +32504,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -33710,7 +32516,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -33722,7 +32527,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -33735,7 +32539,6 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -33752,7 +32555,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -33798,8 +32600,7 @@
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway North";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -33862,8 +32663,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -33926,7 +32726,6 @@
 /obj/structure/closet/wardrobe/miner,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -34016,7 +32815,6 @@
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -34163,7 +32961,6 @@
 /obj/item/folder/red,
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -34182,7 +32979,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -34295,8 +33091,7 @@
 "bsY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28;
@@ -34374,8 +33169,7 @@
 "btg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -34384,21 +33178,17 @@
 /area/atmos)
 "bth" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "gas pump";
-	on = 0
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bti" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	level = 2
+	dir = 1
 	},
 /obj/effect/landmark/start{
 	name = "Life Support Specialist"
@@ -34431,8 +33221,7 @@
 	on = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -34446,7 +33235,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -34504,8 +33292,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -34521,8 +33308,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -34543,8 +33329,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -34560,8 +33345,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -34579,8 +33363,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -34664,8 +33447,7 @@
 "btD" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
@@ -34696,8 +33478,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -34706,8 +33487,7 @@
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -34809,8 +33589,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -34829,8 +33608,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -34842,8 +33620,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -34860,16 +33637,14 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "bua" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -34942,8 +33717,7 @@
 /area/security/main)
 "bui" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
@@ -34953,7 +33727,6 @@
 "buj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -35020,8 +33793,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -35032,17 +33804,14 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "buq" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
-	name = "Mix to Distro";
-	on = 0
+	name = "Mix to Distro"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -35086,7 +33855,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/atmos)
@@ -35103,7 +33871,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/atmos)
@@ -35113,7 +33880,6 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/atmos)
@@ -35127,7 +33893,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/atmos)
@@ -35206,12 +33971,10 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -35245,8 +34008,7 @@
 	},
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8;
-	level = 2
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -35306,7 +34068,6 @@
 "buP" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -35328,9 +34089,7 @@
 "buS" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -35363,14 +34122,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "buX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -35488,8 +34245,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -35515,19 +34271,16 @@
 /area/security/prisonershuttle)
 "bvn" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/prisonershuttle)
 "bvo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/prisonershuttle)
@@ -35539,7 +34292,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/prisonershuttle)
@@ -35597,7 +34349,6 @@
 "bvw" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/main)
@@ -35655,8 +34406,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -35687,8 +34437,7 @@
 /area/atmos)
 "bvE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5;
-	level = 2
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -35702,7 +34451,6 @@
 	target_pressure = 101
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -35718,7 +34466,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -35726,7 +34473,6 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -35735,11 +34481,9 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
 	name = "Air to Waste";
-	on = 0;
 	target_pressure = 101
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -36011,8 +34755,7 @@
 	department = "Hydroponics";
 	departmentType = 2;
 	name = "Hydroponics Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -36143,8 +34886,7 @@
 "bwm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -36197,8 +34939,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Vault";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -36242,7 +34983,6 @@
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -36263,8 +35003,7 @@
 	network = list("SS13","Security")
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36382,8 +35121,7 @@
 /area/turret_protected/ai)
 "bwK" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -36462,8 +35200,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 22;
-	pixel_y = 0
+	pixel_x = 22
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -36480,8 +35217,7 @@
 	pixel_y = 24
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -36508,8 +35244,7 @@
 /obj/item/crowbar,
 /obj/item/analyzer,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Front Desk";
@@ -36566,8 +35301,7 @@
 "bxg" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
@@ -36593,13 +35327,11 @@
 /area/storage/tech)
 "bxk" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Secure Technical Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -36607,8 +35339,7 @@
 "bxl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -36734,7 +35465,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "65;12"
 	},
 /turf/simulated/floor/plasteel,
@@ -36758,8 +35488,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36774,8 +35503,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -36789,8 +35517,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/vault{
 	icon_state = "door_locked";
@@ -36809,8 +35536,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -36824,8 +35550,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/greengrid,
 /area/security/nuke_storage)
@@ -36935,7 +35660,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/main)
@@ -36967,8 +35691,7 @@
 "bxQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -37067,21 +35790,18 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
 "byb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -37092,15 +35812,13 @@
 /area/turret_protected/ai)
 "byc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/ai_slipper,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -37112,14 +35830,12 @@
 /area/turret_protected/ai)
 "byd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -37132,14 +35848,12 @@
 "bye" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
@@ -37189,7 +35903,6 @@
 "byk" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -37257,8 +35970,7 @@
 "byt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/plasteel{
@@ -37274,8 +35986,7 @@
 "byv" = (
 /obj/machinery/vending/cola,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -37283,9 +35994,7 @@
 /area/engine/break_room)
 "byw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/nosmoking_2{
-	pixel_y = 0
-	},
+/obj/structure/sign/nosmoking_2,
 /turf/simulated/wall/r_wall,
 /area/engine/break_room)
 "byx" = (
@@ -37381,9 +36090,7 @@
 	name = "Atmospherics Desk"
 	},
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -37406,8 +36113,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37420,8 +36126,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Hallway North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
@@ -37474,8 +36179,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -37493,8 +36197,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -37512,8 +36215,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -37525,12 +36227,10 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutral"
 	},
 /area/maintenance/fsmaint)
@@ -37552,8 +36252,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -37576,8 +36275,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37588,20 +36286,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway West";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -37610,12 +36304,10 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -37683,18 +36375,15 @@
 /obj/item/wrench,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -37718,8 +36407,7 @@
 "bza" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37764,8 +36452,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37774,8 +36461,7 @@
 /area/security/prisonershuttle)
 "bzh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37794,8 +36480,7 @@
 /area/security/prisonershuttle)
 "bzj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -37804,15 +36489,13 @@
 /area/security/prisonershuttle)
 "bzk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -37833,8 +36516,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37843,8 +36525,7 @@
 /area/security/brig)
 "bzn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -37858,8 +36539,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -37964,9 +36644,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -37974,8 +36652,7 @@
 /area/turret_protected/ai)
 "bzy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -37987,8 +36664,7 @@
 /area/turret_protected/ai)
 "bzz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -37997,8 +36673,7 @@
 "bzA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38006,8 +36681,7 @@
 /area/turret_protected/ai)
 "bzB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -38051,8 +36725,7 @@
 "bzG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/electricshock{
 	pixel_y = 32
@@ -38061,8 +36734,7 @@
 /area/engine/gravitygenerator)
 "bzH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -38080,13 +36752,11 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -38119,8 +36789,7 @@
 	charge = 5e+006
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 22;
-	pixel_y = 0
+	pixel_x = 22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -38135,10 +36804,8 @@
 	id_tag = "atmo_tank_vent"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "atmo_tank_airlock";
 	pixel_x = 57;
-	pixel_y = 0;
 	req_access_txt = "32";
 	tag_airpump = "atmo_tank_pump";
 	tag_chamber_sensor = "atmo_tank_sensor";
@@ -38146,7 +36813,6 @@
 	tag_interior_door = "atmo_tank_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "atmo_tank_sensor";
 	pixel_x = 57;
 	pixel_y = 8
@@ -38186,8 +36852,7 @@
 "bzR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/wall,
 /area/engine/break_room)
@@ -38199,7 +36864,6 @@
 	},
 /area/engine/break_room)
 "bzT" = (
-/obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -38272,8 +36936,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
@@ -38373,8 +37036,7 @@
 "bAm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/wall,
 /area/storage/primary)
@@ -38403,8 +37065,7 @@
 "bAq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -38505,8 +37166,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38518,7 +37178,6 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	name = "Research Monitor";
 	network = list("Research","Research Outpost","RD");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
@@ -38646,8 +37305,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -38687,8 +37345,7 @@
 "bAT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -38892,15 +37549,12 @@
 /area/engine/gravitygenerator)
 "bBq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/gravitygenerator)
@@ -38911,8 +37565,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -38933,8 +37586,7 @@
 /area/engine/gravitygenerator)
 "bBt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Gravity Generation Access";
@@ -38951,8 +37603,7 @@
 /area/engine/gravitygenerator)
 "bBu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/engine/break_room)
@@ -38963,8 +37614,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/break_room)
@@ -38976,8 +37626,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -39014,8 +37663,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -39035,8 +37683,7 @@
 /area/engine/break_room)
 "bBA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/west,
@@ -39044,8 +37691,7 @@
 /area/engine/break_room)
 "bBB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -39059,8 +37705,7 @@
 "bBC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -39069,8 +37714,7 @@
 /area/engine/break_room)
 "bBD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39079,8 +37723,7 @@
 /area/engine/break_room)
 "bBE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39093,14 +37736,12 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -39120,8 +37761,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -39143,8 +37783,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -39154,13 +37793,11 @@
 "bBI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -39182,7 +37819,6 @@
 	},
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -39193,7 +37829,6 @@
 	},
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -39202,7 +37837,6 @@
 /obj/item/folder/yellow,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/atmos)
@@ -39214,8 +37848,7 @@
 	department = "Atmospherics";
 	departmentType = 3;
 	name = "Atmospherics Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -39287,8 +37920,7 @@
 "bBU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/aicard,
 /turf/simulated/floor/plasteel{
@@ -39341,9 +37973,7 @@
 /obj/machinery/disposal,
 /obj/machinery/requests_console{
 	department = "Primary Tool Storage";
-	departmentType = 0;
 	name = "Primary Tool Storage Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -39570,8 +38200,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -39610,8 +38239,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -39665,7 +38293,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkbluecorners"
 	},
 /area/bridge)
@@ -39693,8 +38320,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/door/window/brigdoor/southright,
 /turf/simulated/floor/plasteel{
@@ -39785,8 +38411,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -39908,8 +38533,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -39948,8 +38572,7 @@
 /area/hallway/primary/central)
 "bCI" = (
 /obj/structure/sign/electricshock{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -39959,8 +38582,7 @@
 /area/security/prisonershuttle)
 "bCK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -39978,7 +38600,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "HoS Junction";
 	sortType = 18
 	},
@@ -39996,7 +38617,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/prisonershuttle)
@@ -40018,19 +38638,16 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/prisonershuttle)
 "bCP" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -40066,7 +38683,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/item/radio/intercom/private{
@@ -40074,7 +38690,6 @@
 	pixel_y = -10
 	},
 /obj/item/radio/intercom/custom{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/greengrid,
@@ -40162,7 +38777,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/item/radio/intercom/private{
@@ -40170,7 +38784,6 @@
 	pixel_y = -10
 	},
 /obj/item/radio/intercom/custom{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/greengrid,
@@ -40180,8 +38793,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -40205,15 +38817,13 @@
 /area/engine/gravitygenerator)
 "bDe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 22;
-	pixel_y = 0
+	pixel_x = 22
 	},
 /obj/structure/closet/radiation,
 /obj/effect/decal/warning_stripes/northeast,
@@ -40358,8 +38968,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -40416,8 +39025,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40464,8 +39072,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40505,15 +39112,13 @@
 /area/atmos)
 "bDA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "bDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -40530,8 +39135,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40580,7 +39184,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -40688,8 +39291,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -40721,8 +39323,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -40736,8 +39337,7 @@
 /area/bridge)
 "bDU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40746,13 +39346,11 @@
 "bDV" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "HoP Junction";
 	sortType = 13
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40770,8 +39368,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -40788,8 +39385,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40800,8 +39396,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -40822,8 +39417,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40831,8 +39425,7 @@
 /area/bridge)
 "bEa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -40847,8 +39440,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40856,8 +39448,7 @@
 /area/bridge)
 "bEc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -40874,8 +39465,7 @@
 /area/bridge)
 "bEe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -40889,8 +39479,7 @@
 /area/bridge)
 "bEf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -40906,8 +39495,7 @@
 	},
 /obj/machinery/computer/communications,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -40917,8 +39505,7 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -40926,8 +39513,7 @@
 /area/bridge)
 "bEi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -40940,8 +39526,7 @@
 /area/bridge)
 "bEj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -40951,8 +39536,7 @@
 /area/bridge)
 "bEk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -40967,8 +39551,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40982,8 +39565,7 @@
 /area/bridge)
 "bEn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40992,8 +39574,7 @@
 /area/bridge)
 "bEo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -41009,8 +39590,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -41021,8 +39601,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -41137,8 +39716,7 @@
 /area/security/warden)
 "bED" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -41155,7 +39733,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/effect/landmark/start{
@@ -41226,8 +39803,7 @@
 "bEK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -41239,9 +39815,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/gravitygenerator)
@@ -41270,8 +39844,7 @@
 "bEO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
@@ -41303,14 +39876,12 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/engine/break_room)
 "bER" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/engine/break_room)
@@ -41319,7 +39890,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/engine/break_room)
@@ -41327,8 +39897,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -41519,7 +40088,6 @@
 /obj/item/stock_parts/micro_laser,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -41591,11 +40159,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -41643,7 +40209,6 @@
 /area/bridge)
 "bFz" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -41667,8 +40232,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera{
 	c_tag = "Bridge Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -41677,7 +40241,6 @@
 "bFC" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -41777,7 +40340,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -41787,8 +40349,7 @@
 "bFO" = (
 /obj/machinery/camera{
 	c_tag = "Bridge Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -41919,8 +40480,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -41934,8 +40494,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
@@ -41965,8 +40524,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -41982,8 +40540,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -41996,8 +40553,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Storage";
@@ -42013,8 +40569,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42034,8 +40589,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42051,8 +40605,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -42139,8 +40692,7 @@
 /area/turret_protected/ai)
 "bGr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42187,8 +40739,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -42213,7 +40763,6 @@
 	pixel_x = 28
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -42287,8 +40836,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/reinforced,
@@ -42317,8 +40865,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42352,8 +40899,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42371,14 +40917,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42435,8 +40979,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -42470,8 +41013,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42547,8 +41089,7 @@
 "bGR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -42564,8 +41105,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/item/folder/yellow,
 /obj/item/airlock_electronics,
@@ -42607,21 +41147,18 @@
 "bGV" = (
 /obj/machinery/vending/assist,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/camera{
 	c_tag = "Primary Tool Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "bGW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/circuitboard/mechfab,
@@ -42638,8 +41175,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42650,7 +41186,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/stack/cable_coil/random,
@@ -42732,8 +41267,7 @@
 "bHg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42759,7 +41293,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -42840,8 +41373,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge Center";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/bridge)
@@ -42917,8 +41449,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -43032,8 +41563,7 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/detective,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43057,9 +41587,7 @@
 /obj/item/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "detectives camera";
-	pictures_left = 30;
-	pixel_x = 0;
-	pixel_y = 0
+	pictures_left = 30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43073,7 +41601,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/wood,
@@ -43108,8 +41635,7 @@
 	pixel_y = 32
 	},
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43134,8 +41660,7 @@
 /area/security/detectives_office)
 "bHS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair{
 	dir = 1
@@ -43149,8 +41674,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -43300,7 +41824,6 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/prisonershuttle)
@@ -43333,8 +41856,7 @@
 "bIh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -43357,7 +41879,6 @@
 	},
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -43372,13 +41893,11 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43392,8 +41911,7 @@
 /area/turret_protected/ai)
 "bIm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -43553,8 +42071,7 @@
 "bIB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -43580,8 +42097,7 @@
 "bID" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -43600,8 +42116,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -43677,8 +42192,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Technical Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/airalarm_electronics,
 /obj/item/apc_electronics,
@@ -43721,7 +42235,6 @@
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -43755,7 +42268,6 @@
 /area/storage/primary)
 "bIU" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/storage/primary)
@@ -43787,14 +42299,12 @@
 	req_access_txt = "1"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint/engineering)
 "bIX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -43834,8 +42344,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -43849,12 +42358,10 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -43872,8 +42379,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -43895,8 +42401,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -43905,8 +42410,7 @@
 "bJf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -43966,7 +42470,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -44025,7 +42528,6 @@
 /obj/machinery/computer/security/mining,
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -44091,8 +42593,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -44118,8 +42619,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -44133,8 +42633,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -44142,8 +42641,7 @@
 /area/security/detectives_office)
 "bJA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -44151,8 +42649,7 @@
 /area/security/detectives_office)
 "bJB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security{
 	name = "Interview Room";
@@ -44166,8 +42663,7 @@
 /area/security/detectives_office)
 "bJC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44177,13 +42673,11 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Auxiliary Docking North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44214,7 +42708,6 @@
 	},
 /obj/machinery/flasher{
 	id = "Cell 4";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -44258,8 +42751,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/requests_console{
 	department = "Security";
@@ -44327,8 +42819,7 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44350,8 +42841,7 @@
 /obj/structure/table/reinforced,
 /obj/item/robot_parts/chest,
 /obj/item/robot_parts/l_arm{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /obj/item/robot_parts/r_arm{
 	pixel_x = 6
@@ -44374,8 +42864,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
@@ -44384,8 +42873,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
@@ -44399,8 +42887,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
@@ -44418,8 +42905,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44458,7 +42944,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -44487,7 +42972,6 @@
 /obj/machinery/door_control{
 	id = "transitlock";
 	name = "Transit Tube Lockdown Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "11"
 	},
@@ -44510,14 +42994,12 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/chief)
 "bKf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -44525,8 +43007,7 @@
 /area/crew_quarters/chief)
 "bKg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -44542,8 +43023,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44591,8 +43071,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -44613,8 +43092,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44632,8 +43110,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44688,8 +43165,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44734,8 +43210,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/security/checkpoint/engineering)
@@ -44778,8 +43253,7 @@
 "bKx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44827,8 +43301,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -44916,8 +43389,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
@@ -44976,16 +43448,13 @@
 /area/turret_protected/ai_upload)
 "bKU" = (
 /obj/machinery/camera/motion{
-	c_tag = "AI Upload Chamber";
-	network = list("SS13")
+	c_tag = "AI Upload Chamber"
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bKV" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/bluegrid,
@@ -45012,7 +43481,6 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -45030,18 +43498,15 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
 /area/crew_quarters/captain)
 "bLb" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -45080,7 +43545,6 @@
 "bLg" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -45109,7 +43573,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -45202,7 +43665,6 @@
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -45212,7 +43674,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -45226,7 +43687,6 @@
 	},
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -45250,8 +43710,7 @@
 	dir = 10
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45262,8 +43721,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -45273,8 +43731,7 @@
 "bLz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -45344,9 +43801,7 @@
 /obj/item/flashlight/seclite,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -45414,8 +43869,7 @@
 /area/space/nearstation)
 "bLN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -45424,8 +43878,7 @@
 /area/turret_protected/ai)
 "bLO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -45437,14 +43890,12 @@
 /area/turret_protected/ai)
 "bLP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45480,8 +43931,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45498,8 +43948,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45514,12 +43963,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -45539,8 +43986,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -45576,7 +44022,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -45616,7 +44061,6 @@
 /obj/machinery/camera{
 	c_tag = "Primary Security Hallway North";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -45661,8 +44105,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45672,7 +44115,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -45777,7 +44219,6 @@
 /obj/item/pen,
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel{
@@ -45850,7 +44291,6 @@
 "bMA" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/structure/closet/secure_closet/brig{
@@ -45870,8 +44310,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/toolbox/electrical,
@@ -45892,8 +44331,7 @@
 "bME" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/firelock_electronics,
 /obj/item/firelock_electronics,
@@ -46063,8 +44501,7 @@
 "bMS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -46074,8 +44511,7 @@
 /area/bridge/meeting_room)
 "bMT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -46086,8 +44522,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -46095,8 +44530,7 @@
 /area/bridge/meeting_room)
 "bMV" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -46170,7 +44604,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -46183,7 +44616,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -46230,12 +44662,10 @@
 /area/crew_quarters/captain)
 "bNh" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -46247,8 +44677,7 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/multitool,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/light{
 	dir = 8
@@ -46295,8 +44724,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/camera{
 	c_tag = "Security Hallway South";
@@ -46304,7 +44732,6 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -46337,8 +44764,7 @@
 "bNq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -46364,7 +44790,6 @@
 /obj/item/folder/red,
 /obj/item/hand_labeler,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -46377,22 +44802,18 @@
 	name = "Detective"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
 "bNu" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -46447,8 +44868,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -46459,8 +44879,7 @@
 "bNA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/door_timer/cell_5{
 	dir = 8;
@@ -46548,13 +44967,11 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 4;
 	name = "Warden's Desk";
 	req_access_txt = "3"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -46566,8 +44983,7 @@
 "bNK" = (
 /obj/structure/closet/secure_closet,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -46577,8 +44993,7 @@
 "bNL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber South";
@@ -46605,8 +45020,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/flasher{
 	id = null;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -46670,8 +45084,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -46723,8 +45136,7 @@
 	department = "Chief Engineer's Desk";
 	departmentType = 7;
 	name = "Chief Engineer Requests Console";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -46760,11 +45172,9 @@
 	},
 /obj/machinery/flasher_button{
 	id = "Cell 3";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison)
@@ -46795,8 +45205,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -46841,7 +45250,6 @@
 /area/security/checkpoint/engineering)
 "bOl" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint/engineering)
@@ -46855,8 +45263,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -46882,8 +45289,7 @@
 "bOp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -47004,8 +45410,7 @@
 "bOD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -47113,8 +45518,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
@@ -47167,7 +45571,6 @@
 "bOV" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/newscaster{
@@ -47200,8 +45603,7 @@
 	},
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -47212,8 +45614,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -47222,8 +45623,7 @@
 "bOZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -47235,7 +45635,6 @@
 "bPa" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -47246,8 +45645,7 @@
 "bPb" = (
 /obj/machinery/camera{
 	c_tag = "Captain's Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -47257,8 +45655,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -47298,7 +45695,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/storage/tools)
@@ -47319,7 +45715,6 @@
 /obj/structure/morgue,
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
 /obj/effect/landmark{
@@ -47379,7 +45774,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -47388,7 +45782,6 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -47400,7 +45793,6 @@
 /obj/item/flashlight/lamp,
 /obj/item/reagent_containers/food/drinks/flask/detflask,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/security/detectives_office)
@@ -47497,7 +45889,6 @@
 	network = list("SS13","Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -47590,9 +45981,7 @@
 	tag = ""
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "station_ai_airlock";
-	pixel_x = 0;
 	pixel_y = -57;
 	req_access_txt = "10;13";
 	tag_airpump = "station_ai_pump";
@@ -47601,9 +45990,7 @@
 	tag_interior_door = "station_ai_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "station_ai_sensor";
-	pixel_x = 0;
 	pixel_y = -66
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -47632,8 +46019,7 @@
 	req_access_txt = "10;13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -47680,13 +46066,11 @@
 /area/turret_protected/aisat)
 "bPK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -47739,8 +46123,7 @@
 "bPP" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/sign/electricshock{
 	pixel_y = 32
@@ -47815,8 +46198,7 @@
 "bPZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/radio,
 /obj/item/radio,
@@ -47826,8 +46208,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -47862,13 +46243,11 @@
 /area/quartermaster/office)
 "bQc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastleft{
-	dir = 4;
 	name = "Kitchen Desk";
 	req_access_txt = "28"
 	},
@@ -47911,8 +46290,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -48028,8 +46406,7 @@
 	},
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -48073,7 +46450,6 @@
 	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -48090,8 +46466,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
 	c_tag = "Port Hallway South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -48139,7 +46514,6 @@
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/science{
-	dir = 2;
 	pixel_y = 1
 	},
 /obj/structure/sign/directions/evac{
@@ -48182,7 +46556,6 @@
 /obj/structure/bookcase,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -48199,13 +46572,11 @@
 "bQH" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/camera{
 	c_tag = "Command Meeting Room";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -48232,8 +46603,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -48242,7 +46612,6 @@
 "bQK" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/porta_turret{
@@ -48362,7 +46731,6 @@
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/science{
-	dir = 2;
 	pixel_y = 1
 	},
 /obj/structure/sign/directions/evac{
@@ -48472,7 +46840,6 @@
 	},
 /obj/machinery/flasher{
 	id = "Cell 5";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -48524,8 +46891,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -48533,8 +46899,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
 	dir = 8
@@ -48635,8 +47000,7 @@
 	layer = 2.9
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -48688,15 +47052,13 @@
 /area/construction/hallway)
 "bRw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/break_room)
 "bRx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/showcase{
 	density = 0;
@@ -48729,8 +47091,7 @@
 /area/turret_protected/aisat)
 "bRz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -48744,8 +47105,7 @@
 /area/turret_protected/aisat)
 "bRB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/ai_slipper,
 /turf/simulated/floor/plasteel{
@@ -48755,8 +47115,7 @@
 "bRC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -48765,8 +47124,7 @@
 "bRD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -48774,8 +47132,7 @@
 /area/turret_protected/aisat)
 "bRE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/showcase{
 	density = 0;
@@ -48792,8 +47149,7 @@
 /area/turret_protected/aisat)
 "bRF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/aisat)
@@ -48807,8 +47163,7 @@
 /area/space/nearstation)
 "bRH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -48817,8 +47172,7 @@
 "bRI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -48830,8 +47184,7 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -48843,8 +47196,7 @@
 "bRK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -48856,8 +47208,7 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -48869,8 +47220,7 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/vacuum{
 	pixel_y = 32
@@ -48889,8 +47239,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/structure/transit_tube{
 	icon_state = "S-NE";
@@ -49025,8 +47374,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -49051,8 +47399,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -49071,8 +47418,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -49086,8 +47432,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -49107,8 +47452,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Chief Engineer"
@@ -49183,8 +47527,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -49196,8 +47539,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -49211,13 +47553,11 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -49227,8 +47567,7 @@
 /area/security/checkpoint/engineering)
 "bSm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49245,8 +47584,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49289,8 +47627,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49300,8 +47637,7 @@
 "bSr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -49320,8 +47656,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49336,8 +47671,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49352,8 +47686,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -49387,8 +47720,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49421,8 +47753,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -49435,7 +47766,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -49447,8 +47777,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49459,8 +47788,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
 	c_tag = "Fore Hallway South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49480,8 +47808,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -49491,16 +47818,13 @@
 "bSD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway West";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -49533,7 +47857,6 @@
 "bSH" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right";
 	name = "Core Modules";
 	req_access_txt = "20"
@@ -49567,7 +47890,6 @@
 /obj/machinery/computer/aiupload,
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -21
 	},
 /turf/simulated/floor/bluegrid,
@@ -49576,7 +47898,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "south bump Important Area";
 	pixel_y = -24
 	},
@@ -49585,7 +47906,6 @@
 "bSL" = (
 /obj/machinery/computer/borgupload,
 /obj/item/radio/intercom/private{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/bluegrid,
@@ -49598,9 +47918,7 @@
 /area/turret_protected/ai_upload)
 "bSN" = (
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -49628,8 +47946,7 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/computer/card,
 /turf/simulated/floor/carpet,
@@ -49780,8 +48097,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
@@ -49789,14 +48105,11 @@
 "bTd" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/camera{
 	c_tag = "Auxiliary Tool Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
@@ -49848,8 +48161,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49895,12 +48207,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49919,8 +48229,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50009,8 +48318,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50027,8 +48335,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -50047,8 +48354,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50056,15 +48362,13 @@
 /area/turret_protected/aisat)
 "bTy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/ai_slipper,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50073,14 +48377,12 @@
 /area/turret_protected/aisat)
 "bTz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -50099,8 +48401,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50111,8 +48412,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -50123,8 +48423,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -50153,8 +48452,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -50167,8 +48465,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -50178,8 +48475,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50190,8 +48486,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -50208,8 +48503,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50223,8 +48517,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50235,8 +48528,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50250,8 +48542,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50261,8 +48552,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -50278,8 +48568,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50289,14 +48578,12 @@
 "bTO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50310,8 +48597,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50321,8 +48607,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/radio/beacon,
 /turf/simulated/floor/plasteel{
@@ -50333,8 +48618,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -50346,8 +48630,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50374,7 +48657,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/transit_tube/station{
 	dir = 8;
-	icon_state = "closed";
 	tag = "icon-closed (EAST)"
 	},
 /obj/structure/transit_tube_pod,
@@ -50392,8 +48674,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -50416,8 +48697,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -50447,8 +48727,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50501,12 +48780,10 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -50744,8 +49021,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/book/manual/security_space_law,
 /obj/item/radio,
@@ -50841,12 +49117,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -50881,11 +49155,9 @@
 "bUM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -50981,8 +49253,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Captain's Desk";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -50999,7 +49270,6 @@
 "bUY" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -51047,8 +49317,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -51152,8 +49421,7 @@
 "bVj" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Minisat Teleporter Room";
@@ -51281,16 +49549,13 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Security Junction";
 	sortType = 13
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard)
@@ -51327,13 +49592,11 @@
 /area/space/nearstation)
 "bVt" = (
 /obj/structure/sign/vacuum{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -51422,8 +49685,7 @@
 /area/security/warden)
 "bVz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/wall,
 /area/engine/break_room)
@@ -51464,8 +49726,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -51479,13 +49740,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -51537,12 +49796,10 @@
 "bVH" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51550,15 +49807,13 @@
 /area/construction/hallway)
 "bVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/aisat)
 "bVJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51566,8 +49821,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/nosmoking_2{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/showcase{
 	density = 0;
@@ -51590,8 +49844,7 @@
 /area/turret_protected/aisat)
 "bVL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51604,8 +49857,7 @@
 /area/turret_protected/aisat)
 "bVM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51614,8 +49866,7 @@
 "bVN" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51627,8 +49878,7 @@
 /area/turret_protected/aisat)
 "bVO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/showcase{
 	density = 0;
@@ -51645,8 +49895,7 @@
 /area/turret_protected/aisat)
 "bVP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -51654,8 +49903,7 @@
 /area/turret_protected/aisat)
 "bVQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -51664,8 +49912,7 @@
 /area/turret_protected/aisat)
 "bVR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51684,8 +49931,7 @@
 /area/turret_protected/aisat)
 "bVT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/showcase{
 	density = 0;
@@ -51703,8 +49949,7 @@
 "bVU" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -51717,8 +49962,7 @@
 "bVV" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -51734,8 +49978,7 @@
 "bVW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51744,7 +49987,6 @@
 "bVX" = (
 /obj/structure/window/reinforced,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -51923,7 +50165,6 @@
 "bWm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -52060,7 +50301,6 @@
 	},
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint/engineering)
@@ -52071,7 +50311,6 @@
 	},
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint/engineering)
@@ -52084,7 +50323,6 @@
 	},
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint/engineering)
@@ -52092,8 +50330,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28;
@@ -52106,8 +50343,7 @@
 /area/security/checkpoint/engineering)
 "bWz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52135,7 +50371,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port)
@@ -52160,8 +50395,7 @@
 "bWE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52196,8 +50430,7 @@
 "bWI" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/decal/warning_stripes/southwest,
@@ -52220,8 +50453,7 @@
 "bWK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -52229,8 +50461,7 @@
 "bWL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52240,7 +50471,6 @@
 "bWM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
@@ -52318,8 +50548,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -52334,8 +50563,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/vending/cart,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -52373,9 +50601,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52388,11 +50614,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -52430,11 +50654,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52443,11 +50665,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52457,7 +50677,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52472,7 +50691,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52484,8 +50702,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock{
 	name = "Internal Affairs Office";
@@ -52504,11 +50721,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52517,12 +50732,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52533,17 +50746,14 @@
 	tag = "icon-pipe-j2 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52552,11 +50762,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52571,12 +50779,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52596,8 +50802,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52620,7 +50825,6 @@
 "bXp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard)
@@ -52717,8 +50921,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark/start{
 	name = "Warden"
@@ -52739,8 +50942,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -52804,7 +51006,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/closet/secure_closet/security/engine,
@@ -52821,8 +51022,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -52875,8 +51075,6 @@
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -52934,8 +51132,7 @@
 "bXP" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -53044,9 +51241,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall,
 /area/engine/engineering)
@@ -53085,11 +51280,9 @@
 /area/hallway/primary/port)
 "bYg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port)
@@ -53116,8 +51309,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -53130,8 +51322,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -53140,11 +51331,8 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical{
-	dir = 2
-	},
+/obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/security{
-	dir = 2;
 	pixel_y = 8
 	},
 /turf/simulated/wall,
@@ -53153,7 +51341,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light/small,
@@ -53232,8 +51419,7 @@
 "bYu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/pdapainter,
 /turf/simulated/floor/plasteel{
@@ -53316,9 +51502,7 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical{
-	dir = 2
-	},
+/obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/security{
 	dir = 4;
 	pixel_y = 8
@@ -53394,8 +51578,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -53408,11 +51591,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/hallway/primary/starboard)
@@ -53422,18 +51603,15 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/starboard)
 "bYS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -53451,8 +51629,7 @@
 /area/security/brig)
 "bYU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -53464,12 +51641,10 @@
 "bYW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -53477,8 +51652,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -53486,7 +51660,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/warden)
@@ -53498,18 +51671,15 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/warden)
 "bZa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/warden,
 /turf/simulated/floor/plasteel{
@@ -53521,15 +51691,13 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/armoury)
 "bZc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
@@ -53546,15 +51714,13 @@
 /area/security/armoury)
 "bZd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/armoury)
 "bZe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel,
@@ -53569,8 +51735,7 @@
 "bZg" = (
 /obj/structure/table/reinforced,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/clothing/mask/gas/sechailer,
@@ -53592,8 +51757,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/flasher{
 	id = null;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Telecommunications";
@@ -53688,8 +51852,7 @@
 /area/engine/engineering)
 "bZr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/r_wall,
@@ -53735,8 +51898,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -53760,8 +51922,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -53807,8 +51968,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -53884,7 +52044,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/closet/crate,
@@ -53992,12 +52151,10 @@
 "bZT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -54026,7 +52183,6 @@
 	name = "lightsout"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
@@ -54037,8 +52193,7 @@
 "bZX" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -54106,11 +52261,9 @@
 /obj/machinery/dye_generator,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -54118,7 +52271,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/chair/barber{
@@ -54129,7 +52281,6 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -54143,7 +52294,6 @@
 	c_tag = "Barber Shop"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -54178,7 +52328,6 @@
 /obj/item/disk/nuclear,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -54214,8 +52363,7 @@
 /area/crew_quarters/captain/bedroom)
 "caq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -54223,8 +52371,7 @@
 /area/crew_quarters/captain/bedroom)
 "car" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -54238,8 +52385,7 @@
 /area/crew_quarters/captain/bedroom)
 "cas" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -54247,8 +52393,7 @@
 /area/crew_quarters/captain/bedroom)
 "cat" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -54259,16 +52404,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "cav" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -54298,16 +52441,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Primary Security Hallway East";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -54376,8 +52516,7 @@
 /obj/item/taperecorder,
 /obj/item/clothing/glasses/sunglasses,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -54441,7 +52580,6 @@
 	req_access_txt = "1"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -54449,8 +52587,7 @@
 "caN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -54471,8 +52608,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -54482,7 +52618,6 @@
 "caP" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -54669,9 +52804,7 @@
 /area/engine/engineering)
 "cbh" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "engineering_west_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "10;13";
 	tag_airpump = "engineering_west_pump";
@@ -54680,9 +52813,7 @@
 	tag_interior_door = "engineering_west_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engineering_west_sensor";
-	pixel_x = 0;
 	pixel_y = -34
 	},
 /obj/structure/cable/yellow{
@@ -54791,8 +52922,7 @@
 "cbr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -54802,8 +52932,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -54812,8 +52941,7 @@
 /area/engine/engineering)
 "cbt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -54844,8 +52972,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -54859,8 +52986,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -54870,16 +52996,14 @@
 	dir = 10
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -54971,8 +53095,7 @@
 "cbH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -54982,8 +53105,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -54994,8 +53116,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/camera{
 	c_tag = "Library North";
@@ -55027,8 +53148,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -55056,19 +53176,16 @@
 "cbP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
 "cbQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
@@ -55180,7 +53297,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -55192,18 +53308,15 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
 "ccc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -55218,7 +53331,6 @@
 "cce" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
@@ -55230,7 +53342,6 @@
 	name = "Blueshield"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
@@ -55357,8 +53468,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Captain"
@@ -55421,8 +53531,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -55455,8 +53564,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -55466,7 +53574,6 @@
 "ccx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -55488,8 +53595,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -55503,8 +53609,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -55548,8 +53653,7 @@
 "ccC" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/structure/filingcabinet/security,
 /turf/simulated/floor/plasteel{
@@ -55614,8 +53718,7 @@
 "ccI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -55636,8 +53739,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -55652,8 +53754,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -55672,8 +53773,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -55688,8 +53788,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -55710,8 +53809,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -55723,9 +53821,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Courtroom North";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Courtroom North"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -55733,8 +53829,7 @@
 /area/crew_quarters/courtroom)
 "ccP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -55760,7 +53855,6 @@
 "ccS" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -55774,8 +53868,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -55816,8 +53909,7 @@
 /area/engine/engineering)
 "cde" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -55855,8 +53947,7 @@
 "cdi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -55872,8 +53963,7 @@
 /area/engine/engineering)
 "cdk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
@@ -55896,8 +53986,7 @@
 /area/engine/engineering)
 "cdm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -55910,8 +53999,7 @@
 "cdn" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -55933,8 +54021,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -56031,8 +54118,7 @@
 "cdx" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -56049,8 +54135,7 @@
 "cdz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -56114,8 +54199,7 @@
 "cdH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/wood,
 /obj/machinery/light{
@@ -56129,8 +54213,7 @@
 /area/crew_quarters/heads/hop)
 "cdI" = (
 /obj/machinery/keycard_auth{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/door/window{
 	dir = 2;
@@ -56155,8 +54238,7 @@
 "cdL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -56171,7 +54253,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -56189,7 +54270,6 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -56200,15 +54280,13 @@
 	},
 /obj/item/razor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
 "cdP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -56223,7 +54301,6 @@
 /obj/item/book/manual/sop_command,
 /obj/item/paper/blueshield,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
@@ -56238,7 +54315,6 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
@@ -56249,8 +54325,7 @@
 	req_access_txt = "67"
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -56262,7 +54337,6 @@
 /obj/item/razor,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -56280,7 +54354,6 @@
 "cdV" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/item/twohanded/required/kirbyplants,
@@ -56308,8 +54381,7 @@
 "cdX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -56318,8 +54390,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -56329,7 +54400,6 @@
 /obj/structure/cable,
 /obj/structure/table/wood,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -56359,8 +54429,7 @@
 "cec" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -56368,8 +54437,7 @@
 /area/crew_quarters/courtroom)
 "ced" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair{
 	dir = 4
@@ -56382,8 +54450,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/chair{
 	dir = 4
@@ -56436,10 +54503,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/item/folder/blue{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/folder/blue,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -56473,12 +54537,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -56505,8 +54567,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -56549,8 +54610,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/clipboard,
 /obj/item/toy/figure/secofficer,
@@ -56561,8 +54621,7 @@
 /area/security/brig)
 "ces" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -56577,16 +54636,14 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel,
 /area/security/brig)
 "ceu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -56619,12 +54676,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Security Lobby";
-	req_access_txt = "0"
+	name = "Security Lobby"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -56675,11 +54730,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -56809,8 +54862,7 @@
 "ceN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/porta_turret,
 /turf/simulated/floor/bluegrid,
@@ -56825,8 +54877,7 @@
 /area/tcommsat/chamber)
 "ceQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -56834,8 +54885,7 @@
 /area/tcommsat/chamber)
 "ceT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -56939,8 +54989,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -57061,8 +55110,7 @@
 /obj/item/pen,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57198,8 +55246,7 @@
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57207,8 +55254,7 @@
 /area/crew_quarters/heads/hop)
 "cfF" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57251,7 +55297,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -57264,14 +55309,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
 "cfL" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -57283,8 +55326,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57298,24 +55340,20 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
 "cfO" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
 "cfP" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57350,22 +55388,19 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "cfT" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
 "cfU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -57374,8 +55409,7 @@
 /area/crew_quarters/courtroom)
 "cfV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -57390,8 +55424,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -57400,8 +55433,7 @@
 /area/crew_quarters/courtroom)
 "cfX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/wood,
@@ -57414,8 +55446,7 @@
 /area/crew_quarters/courtroom)
 "cfY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -57441,8 +55472,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/effect/landmark/start{
 	name = "Internal Affairs Agent"
@@ -57507,7 +55537,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
 /obj/item/paper_bin,
@@ -57523,13 +55552,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
@@ -57611,7 +55638,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/brig)
@@ -57654,7 +55680,6 @@
 "cgp" = (
 /obj/structure/closet/wardrobe/red,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -57701,7 +55726,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/door/firedoor,
@@ -57737,12 +55761,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
@@ -57850,8 +55872,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/camera{
 	c_tag = "Magistrate's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57882,8 +55903,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57899,8 +55919,7 @@
 /area/library)
 "cgY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -57914,8 +55933,7 @@
 /area/library)
 "cha" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -57934,8 +55952,7 @@
 /area/hallway/primary/port)
 "chc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -58054,7 +56071,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -58080,7 +56096,6 @@
 "chr" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bcarpet05"
 	},
 /area/blueshield)
@@ -58112,8 +56127,7 @@
 /area/teleporter)
 "chw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -58129,8 +56143,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -58160,8 +56173,7 @@
 "chA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
@@ -58169,18 +56181,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "chC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -58189,8 +56198,7 @@
 "chD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -58271,7 +56279,6 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/brig)
@@ -58280,7 +56287,6 @@
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -58293,7 +56299,6 @@
 /obj/item/pen,
 /obj/machinery/requests_console{
 	name = "Detective Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -58378,8 +56383,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -58399,8 +56403,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -58415,8 +56418,7 @@
 "chX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -58434,8 +56436,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -58628,8 +56629,7 @@
 "civ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -58677,14 +56677,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -58696,8 +56694,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -58717,7 +56714,6 @@
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /mob/living/simple_animal/pet/dog/corgi/Ian,
@@ -58758,13 +56754,11 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/camera{
 	c_tag = "NT Representative's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -58889,13 +56883,11 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/camera{
 	c_tag = "Blueshield's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -58955,8 +56947,7 @@
 "ciV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -58976,7 +56967,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -59038,8 +57028,7 @@
 "cjb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair{
 	dir = 4
@@ -59091,8 +57080,7 @@
 "cjg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/wood,
 /obj/item/radio/intercom,
@@ -59109,13 +57097,11 @@
 	},
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "blue"
 	},
 /area/crew_quarters/courtroom)
 "cji" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "blue"
 	},
 /area/crew_quarters/courtroom)
@@ -59140,8 +57126,7 @@
 /area/lawoffice)
 "cjl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/transit_tube{
 	icon_state = "D-NE";
@@ -59191,12 +57176,10 @@
 "cjs" = (
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/closet/crate,
 /obj/item/target/syndicate,
@@ -59212,16 +57195,14 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "cju" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/reinforced,
@@ -59230,8 +57211,7 @@
 /area/security/range)
 "cjv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -59240,15 +57220,13 @@
 /area/security/range)
 "cjw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
 "cjx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -59263,8 +57241,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
@@ -59440,16 +57417,14 @@
 /area/maintenance/fpmaint2)
 "cjW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint2)
 "cjX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/warning_stripes/west,
@@ -59469,8 +57444,7 @@
 /area/teleporter)
 "cjZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -59496,8 +57470,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -59510,8 +57483,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -59523,8 +57495,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -59554,8 +57525,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint2)
@@ -59567,8 +57537,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -59584,8 +57553,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -59599,8 +57567,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -59610,8 +57577,7 @@
 "cki" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -59641,7 +57607,6 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -59662,8 +57627,7 @@
 /area/crew_quarters/heads/hop)
 "ckp" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -59786,7 +57750,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,
@@ -59803,7 +57766,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table,
@@ -59830,7 +57792,6 @@
 /obj/machinery/door_control{
 	id = "teleaccessshutter";
 	name = "Teleporter Shutters Access Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "62"
 	},
@@ -59839,8 +57800,7 @@
 /area/teleporter)
 "ckE" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
@@ -59896,7 +57856,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -59914,8 +57873,7 @@
 "ckL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair{
 	dir = 4
@@ -59926,10 +57884,7 @@
 /area/crew_quarters/courtroom)
 "ckM" = (
 /obj/structure/table/wood,
-/obj/item/folder/blue{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/folder/blue,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -60026,8 +57981,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -60042,8 +57996,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -60061,8 +58014,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -60077,8 +58029,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -60096,8 +58047,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -60121,8 +58071,7 @@
 	tag = "icon-pipe-j1 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -60137,8 +58086,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -60157,8 +58105,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
@@ -60209,8 +58156,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -60310,9 +58256,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -60362,8 +58306,7 @@
 "clx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -60411,8 +58354,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -60485,8 +58427,7 @@
 /area/library)
 "clI" = (
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -60512,8 +58453,7 @@
 /area/crew_quarters/heads/hop)
 "clK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Personnel Bedroom";
@@ -60525,8 +58465,7 @@
 /area/crew_quarters/heads/hop)
 "clL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -60577,7 +58516,6 @@
 /obj/item/toy/figure/ian,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -60697,8 +58635,7 @@
 /area/teleporter)
 "clY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -60716,8 +58653,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -60739,8 +58675,7 @@
 	tag = "icon-pipe-j2 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -60766,8 +58701,7 @@
 	tag = "icon-pipe-j2 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -60803,7 +58737,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -60811,7 +58744,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -60901,8 +58833,7 @@
 /area/maintenance/starboard)
 "cmp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -60938,8 +58869,7 @@
 "cmu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
@@ -60977,8 +58907,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
@@ -61075,7 +59004,6 @@
 "cmM" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -61086,7 +59014,6 @@
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -61111,14 +59038,12 @@
 "cmP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -61246,7 +59171,6 @@
 /obj/structure/dispenser,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -61279,8 +59203,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -61333,8 +59256,7 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/library/checkout,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -61346,7 +59268,6 @@
 /obj/item/flashlight/lamp/green,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -61409,12 +59330,10 @@
 /area/crew_quarters/heads/hop)
 "cnu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -61476,8 +59395,7 @@
 "cnz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -61486,13 +59404,11 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Teleporter";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_x = -8;
@@ -61508,8 +59424,7 @@
 "cnC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -61521,7 +59436,6 @@
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
@@ -61539,8 +59453,7 @@
 /area/teleporter)
 "cnF" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
@@ -61551,8 +59464,7 @@
 /area/teleporter)
 "cnH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/transit_tube{
 	icon_state = "E-SW-NW";
@@ -61620,8 +59532,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -61775,8 +59686,7 @@
 /area/engine/engineering)
 "coi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/transit_tube{
 	icon_state = "E-W-Pass"
@@ -61801,8 +59711,7 @@
 "col" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -61821,8 +59730,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -61881,8 +59789,7 @@
 "cot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/field/generator{
 	anchored = 1
@@ -61904,8 +59811,7 @@
 "cow" = (
 /obj/structure/bookcase,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -61924,16 +59830,13 @@
 "coy" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/carpet,
 /area/library)
 "coz" = (
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/libraryscanner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -62012,7 +59915,6 @@
 	id = "teleportershutter";
 	name = "Teleporter Shutters Access Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "62"
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -62040,8 +59942,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62056,8 +59957,7 @@
 "coK" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62173,7 +60073,6 @@
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -62248,8 +60147,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -62336,9 +60234,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Singularity Engine Telescreen";
-	network = list("Singularity");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("Singularity")
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -62388,8 +60284,7 @@
 "cpu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -62471,8 +60366,7 @@
 /area/engine/engine_smes)
 "cpC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -62482,8 +60376,7 @@
 /area/engine/engine_smes)
 "cpD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -62498,15 +60391,13 @@
 /area/engine/engine_smes)
 "cpE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engine_smes)
 "cpF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -62521,8 +60412,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -62531,28 +60421,16 @@
 /area/maintenance/fpmaint2)
 "cpH" = (
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
 /area/library)
-"cpI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/library)
 "cpJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -62614,14 +60492,12 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port)
 "cpQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -62630,8 +60506,7 @@
 /area/bridge/meeting_room)
 "cpR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -62653,8 +60528,7 @@
 /area/bridge/meeting_room)
 "cpT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -62664,13 +60538,11 @@
 /area/bridge/meeting_room)
 "cpU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -62684,8 +60556,7 @@
 /area/bridge/meeting_room)
 "cpV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -62706,8 +60577,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -62716,8 +60586,7 @@
 /area/bridge/meeting_room)
 "cpX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
@@ -62729,8 +60598,7 @@
 /area/bridge/meeting_room)
 "cpY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -62743,8 +60611,7 @@
 /area/bridge/meeting_room)
 "cpZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62756,8 +60623,7 @@
 /area/bridge/meeting_room)
 "cqa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -62786,8 +60652,7 @@
 /area/bridge/meeting_room)
 "cqc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62799,8 +60664,7 @@
 /area/bridge/meeting_room)
 "cqd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -62814,8 +60678,7 @@
 /area/bridge/meeting_room)
 "cqe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
@@ -62836,8 +60699,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62849,8 +60711,7 @@
 /area/bridge/meeting_room)
 "cqg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -62882,8 +60743,7 @@
 /area/maintenance/starboard)
 "cqj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62896,8 +60756,7 @@
 /area/bridge/meeting_room)
 "cqk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
@@ -62911,8 +60770,7 @@
 /area/bridge/meeting_room)
 "cql" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -62930,14 +60788,12 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "cqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -62956,8 +60812,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62970,8 +60825,7 @@
 "cqp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -62979,7 +60833,6 @@
 	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -62995,8 +60848,7 @@
 /area/crew_quarters/courtroom)
 "cqr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -63005,8 +60857,7 @@
 /area/crew_quarters/courtroom)
 "cqs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Magistrate's Office";
@@ -63018,8 +60869,7 @@
 /area/crew_quarters/courtroom)
 "cqt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair{
 	dir = 1
@@ -63032,8 +60882,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -63048,8 +60897,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -63072,7 +60920,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -63083,8 +60930,7 @@
 "cqy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -63093,8 +60939,7 @@
 /area/crew_quarters/locker)
 "cqz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -63104,8 +60949,7 @@
 "cqA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -63141,15 +60985,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cqE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -63167,8 +61009,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -63182,8 +61023,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
@@ -63278,8 +61118,7 @@
 /area/engine/engineering)
 "cqV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/southeastcorner,
@@ -63306,8 +61145,7 @@
 "cqY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -63315,16 +61153,14 @@
 /area/engine/engineering)
 "cqZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -63338,8 +61174,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -63365,8 +61200,7 @@
 /area/engine/engineering)
 "cre" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63419,8 +61253,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/camera{
 	c_tag = "Library South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -63431,7 +61264,6 @@
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/window/reinforced{
@@ -63467,7 +61299,6 @@
 /obj/structure/table/wood,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/clipboard,
@@ -63513,7 +61344,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -63557,8 +61387,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63597,8 +61426,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway Center";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63711,8 +61539,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -63843,7 +61670,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -63859,7 +61685,6 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -63885,7 +61710,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -63900,7 +61724,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -63913,11 +61736,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -63939,7 +61760,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -63954,11 +61774,9 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway Center";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -63971,14 +61789,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
 "crQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -63999,8 +61815,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -64033,11 +61848,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -64083,8 +61896,7 @@
 "crZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -64136,7 +61948,6 @@
 "cse" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -64196,8 +62007,7 @@
 /area/construction/hallway)
 "csm" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
@@ -64236,8 +62046,7 @@
 /area/engine/engineering)
 "csr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/transit_tube,
 /obj/structure/lattice/catwalk,
@@ -64294,8 +62103,7 @@
 /area/engine/engine_smes)
 "csy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/transit_tube{
 	icon_state = "W-SE";
@@ -64325,7 +62133,6 @@
 "csB" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/clipboard,
@@ -64386,7 +62193,6 @@
 /area/library)
 "csI" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Private Study";
 	req_access_txt = "37"
 	},
@@ -64412,13 +62218,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/camera{
 	c_tag = "Captain's Office Nook";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
@@ -64448,8 +62252,7 @@
 "csO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light{
 	dir = 8
@@ -64505,28 +62308,24 @@
 /area/bridge/meeting_room)
 "csT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/bridge/meeting_room)
 "csU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -64550,7 +62349,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -64586,8 +62384,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -64597,8 +62394,7 @@
 "ctc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -64608,8 +62404,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -64631,8 +62426,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64644,8 +62438,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -64658,8 +62451,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64679,8 +62471,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64704,8 +62495,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64714,8 +62504,7 @@
 /area/crew_quarters/locker)
 "ctm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -64724,8 +62513,7 @@
 /area/crew_quarters/locker)
 "ctn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/stool,
 /obj/effect/landmark/start{
@@ -64738,8 +62526,7 @@
 /area/crew_quarters/locker)
 "cto" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -64750,8 +62537,7 @@
 /area/crew_quarters/locker)
 "ctp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/camera,
@@ -64763,8 +62549,7 @@
 "ctq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table,
 /obj/item/camera_film,
@@ -64899,20 +62684,17 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
 "ctF" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/item/tank/internals/plasma,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -64937,8 +62719,7 @@
 /area/library)
 "ctI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/transit_tube{
 	icon_state = "D-SW";
@@ -64973,8 +62754,7 @@
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65010,12 +62790,10 @@
 "ctQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -65050,8 +62828,7 @@
 /area/maintenance/fpmaint2)
 "ctU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -65064,8 +62841,7 @@
 "ctV" = (
 /obj/machinery/camera{
 	c_tag = "Courtroom East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -65095,7 +62871,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "E.V.A.";
-	req_access_txt = "0";
 	req_one_access_txt = "18"
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -65153,7 +62928,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/bridge/meeting_room)
@@ -65171,7 +62945,6 @@
 	name = "Civilian"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/bridge/meeting_room)
@@ -65188,7 +62961,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/bridge/meeting_room)
@@ -65203,7 +62975,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/bridge/meeting_room)
@@ -65216,7 +62987,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/bridge/meeting_room)
@@ -65229,7 +62999,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -65270,7 +63039,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -65294,8 +63062,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -65314,7 +63081,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "E.V.A.";
-	req_access_txt = "0";
 	req_one_access_txt = "18"
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -65350,8 +63116,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Firing Range";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
@@ -65407,8 +63172,7 @@
 /area/crew_quarters/locker)
 "cuA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/table,
 /obj/item/deck/cards,
@@ -65428,8 +63192,7 @@
 "cuC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -65443,7 +63206,6 @@
 	},
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -65462,8 +63224,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -65478,8 +63239,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -65495,8 +63255,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
@@ -65511,8 +63270,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -65541,8 +63299,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -65576,8 +63333,7 @@
 /area/crew_quarters/fitness)
 "cuN" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/closet/athletic_mixed,
 /turf/simulated/floor/plasteel{
@@ -65655,8 +63411,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -65664,8 +63419,7 @@
 "cuW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/storage/toolbox/electrical,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -65699,7 +63453,6 @@
 /obj/machinery/suit_storage_unit/engine,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -65807,8 +63560,7 @@
 "cvi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
@@ -65860,8 +63612,7 @@
 "cvo" = (
 /obj/structure/cult/archives,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65887,14 +63638,11 @@
 /area/library)
 "cvr" = (
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65904,8 +63652,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -65937,8 +63684,7 @@
 /obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Courtroom West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65968,7 +63714,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -66039,14 +63784,12 @@
 /area/bridge/meeting_room)
 "cvG" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
 "cvH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room)
@@ -66113,8 +63856,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -66168,7 +63910,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -66178,7 +63919,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -66212,7 +63952,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -66249,8 +63988,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
@@ -66264,8 +64002,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -66290,8 +64027,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -66318,14 +64054,12 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
 "cwg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -66390,8 +64124,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -66419,8 +64152,7 @@
 "cwq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -66430,8 +64162,7 @@
 "cwr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -66541,13 +64272,11 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Library Backroom";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -66621,8 +64350,7 @@
 "cwL" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -66631,7 +64359,6 @@
 "cwM" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/filingcabinet,
@@ -66656,7 +64383,6 @@
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/item/folder,
@@ -66716,8 +64442,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -66731,8 +64456,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -66780,8 +64504,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -66814,7 +64537,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Corporate Lounge";
-	req_access_txt = "0";
 	req_one_access_txt = "19"
 	},
 /turf/simulated/floor/plasteel{
@@ -66826,7 +64548,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Corporate Lounge";
-	req_access_txt = "0";
 	req_one_access_txt = "19"
 	},
 /turf/simulated/floor/plasteel{
@@ -66875,8 +64596,7 @@
 "cxg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -66935,8 +64655,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -66948,8 +64667,7 @@
 /area/crew_quarters/locker/locker_toilet)
 "cxo" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -67027,7 +64745,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/closet/wardrobe/green,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -67041,8 +64758,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -67052,8 +64768,7 @@
 /area/crew_quarters/fitness)
 "cxy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67062,8 +64777,7 @@
 /area/crew_quarters/fitness)
 "cxz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -67071,8 +64785,7 @@
 /area/crew_quarters/fitness)
 "cxA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -67080,8 +64793,7 @@
 /area/crew_quarters/fitness)
 "cxB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -67131,8 +64843,7 @@
 "cxI" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
@@ -67199,8 +64910,7 @@
 /area/engine/engine_smes)
 "cxO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -67226,8 +64936,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/clothing/shoes/magboots{
 	pixel_x = 4;
@@ -67286,7 +64995,6 @@
 /obj/structure/table/wood,
 /obj/item/deck/cards,
 /obj/item/deck/cards{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
@@ -67310,8 +65018,7 @@
 "cyb" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -67360,8 +65067,7 @@
 	tag = ""
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/showcase,
@@ -67412,7 +65118,6 @@
 /area/assembly/showroom)
 "cym" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "vault"
 	},
 /area/assembly/showroom)
@@ -67456,8 +65161,7 @@
 /obj/structure/rack,
 /obj/machinery/camera{
 	c_tag = "Gateway Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/closet/medical_wall{
 	pixel_x = -32
@@ -67535,8 +65239,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -67546,7 +65249,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -67561,14 +65263,12 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "cyB" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -67588,13 +65288,10 @@
 /area/crew_quarters/locker/locker_toilet)
 "cyD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
 	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -67603,23 +65300,20 @@
 /area/crew_quarters/locker/locker_toilet)
 "cyE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
 "cyF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "cyG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -67629,13 +65323,11 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
@@ -67650,7 +65342,6 @@
 /obj/structure/dispenser/oxygen,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -67658,8 +65349,7 @@
 /area/gateway)
 "cyJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/urinal{
 	pixel_y = 28
@@ -67679,8 +65369,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plasteel{
@@ -67696,8 +65385,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67712,8 +65400,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -67729,8 +65416,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/folder,
@@ -67748,8 +65434,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/paicard,
@@ -67766,8 +65451,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -67789,8 +65473,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair/stool,
@@ -67811,8 +65494,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67826,8 +65508,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -67836,7 +65517,6 @@
 	},
 /obj/structure/closet/wardrobe/pink,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -67849,7 +65529,6 @@
 "cyU" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -67883,7 +65562,6 @@
 /obj/item/paper_bin,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/pen,
@@ -68002,8 +65680,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -68068,7 +65745,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/effect/decal/cleanable/cobweb2,
@@ -68121,8 +65797,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -68182,8 +65857,7 @@
 "czy" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/newspaper,
 /obj/item/newspaper,
@@ -68193,8 +65867,7 @@
 /area/library)
 "czz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -68247,8 +65920,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -68300,8 +65972,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -68346,8 +66017,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -68470,7 +66140,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -68479,8 +66148,7 @@
 /area/assembly/showroom)
 "czU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/urinal{
 	pixel_y = 28
@@ -68556,23 +66224,20 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/gateway)
 "czZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "cAa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -68587,8 +66252,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -68609,8 +66273,7 @@
 /area/crew_quarters/locker/locker_toilet)
 "cAe" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -68637,7 +66300,6 @@
 "cAj" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -68672,7 +66334,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/closet/wardrobe/mixed,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -68686,8 +66347,7 @@
 "cAo" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/folder,
 /obj/item/razor,
@@ -68753,15 +66413,13 @@
 "cAx" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
 "cAy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/crew_quarters/fitness)
@@ -68783,8 +66441,7 @@
 "cAB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -68799,8 +66456,7 @@
 /area/engine/engineering)
 "cAD" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -68824,8 +66480,7 @@
 "cAG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -68850,8 +66505,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/engine_smes)
@@ -68867,8 +66521,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -68909,8 +66562,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/east,
@@ -68923,8 +66575,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -68944,8 +66595,7 @@
 /area/maintenance/fpmaint2)
 "cAQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -68983,8 +66633,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -68992,7 +66641,6 @@
 /obj/structure/table/wood,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/item/storage/fancy/donut_box,
@@ -69002,13 +66650,11 @@
 /area/library)
 "cAU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -69017,8 +66663,7 @@
 /area/library)
 "cAV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -69034,7 +66679,6 @@
 /obj/item/dice/d10,
 /obj/item/dice/d20,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -69048,8 +66692,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel{
@@ -69061,8 +66704,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -69154,8 +66796,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -69187,13 +66828,11 @@
 /obj/machinery/requests_console{
 	department = "EVA";
 	name = "EVA Requests Console";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/camera{
 	c_tag = "EVA Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -69210,7 +66849,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/stack/rods{
@@ -69311,8 +66949,7 @@
 "cBx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
@@ -69513,8 +67150,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -69558,7 +67194,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -69571,11 +67206,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -69585,7 +67218,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -69606,8 +67238,7 @@
 "cBV" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -69629,8 +67260,7 @@
 "cBY" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -69675,8 +67305,7 @@
 "cCe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
@@ -69711,8 +67340,7 @@
 /area/engine/engineering)
 "cCi" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow,
@@ -69720,9 +67348,7 @@
 /area/maintenance/fpmaint2)
 "cCj" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "engineering_east_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "10;13";
 	tag_airpump = "engineering_east_pump";
@@ -69731,9 +67357,7 @@
 	tag_interior_door = "engineering_east_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engineering_east_sensor";
-	pixel_x = 0;
 	pixel_y = 33
 	},
 /obj/structure/cable/yellow{
@@ -69809,8 +67433,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69831,8 +67454,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -69840,8 +67462,7 @@
 /area/engine/engineering)
 "cCq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -69853,8 +67474,7 @@
 /area/engine/engine_smes)
 "cCs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance{
@@ -69918,7 +67538,6 @@
 /area/maintenance/fpmaint2)
 "cCA" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/maintenance/fpmaint2)
@@ -69955,8 +67574,7 @@
 "cCF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -69968,8 +67586,7 @@
 "cCH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -69978,8 +67595,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -70080,7 +67696,6 @@
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/item/folder/red,
@@ -70091,12 +67706,10 @@
 "cCU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -70187,8 +67800,7 @@
 /area/crew_quarters/locker/locker_toilet)
 "cDh" = (
 /obj/machinery/door/airlock{
-	name = "Toilet";
-	req_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
@@ -70250,10 +67862,7 @@
 /area/crew_quarters/locker)
 "cDq" = (
 /obj/structure/table/wood,
-/obj/item/folder/blue{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/folder/blue,
 /obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -70268,8 +67877,7 @@
 "cDs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
@@ -70353,8 +67961,7 @@
 "cDA" = (
 /obj/structure/sign/vacuum,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -70369,8 +67976,7 @@
 "cDC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/stack/sheet/plasteel{
 	amount = 25
@@ -70409,8 +68015,7 @@
 /area/engine/engineering)
 "cDF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -70467,8 +68072,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -70635,8 +68239,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/assembly/showroom)
@@ -70675,7 +68278,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -70697,7 +68299,6 @@
 	id = "stationawaygate";
 	name = "Gateway Shutters Access Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "62"
 	},
 /obj/machinery/door/poddoor/shutters{
@@ -70870,7 +68471,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -70880,8 +68480,7 @@
 /area/maintenance/fpmaint2)
 "cEJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/maintenance/fpmaint2)
@@ -70893,8 +68492,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -70913,12 +68511,10 @@
 /area/hallway/primary/central)
 "cEM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -70975,8 +68571,7 @@
 /area/ai_monitored/storage/eva)
 "cES" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -70989,8 +68584,7 @@
 /area/hallway/primary/central)
 "cET" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -71002,11 +68596,9 @@
 /area/hallway/primary/central)
 "cEU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -71022,8 +68614,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -71033,8 +68624,7 @@
 /area/hallway/primary/central)
 "cEW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -71050,11 +68640,9 @@
 /area/hallway/primary/central)
 "cEY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -71064,8 +68652,7 @@
 /area/hallway/primary/central)
 "cEZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -71102,15 +68689,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway East";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -71127,8 +68712,7 @@
 /area/crew_quarters/locker/locker_toilet)
 "cFf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
@@ -71164,7 +68748,6 @@
 /obj/machinery/camera{
 	c_tag = "Laundry Room";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -71215,8 +68798,7 @@
 /area/crew_quarters/sleep)
 "cFp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -71233,8 +68815,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -71255,8 +68836,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -71271,8 +68851,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -71287,8 +68866,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -71303,8 +68881,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Dorm Hallway Starboard"
@@ -71322,8 +68899,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -71338,8 +68914,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Cabin"
@@ -71354,8 +68929,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -71378,8 +68952,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -71406,8 +68979,7 @@
 /area/crew_quarters/fitness)
 "cFB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -71425,8 +68997,7 @@
 /area/crew_quarters/fitness)
 "cFD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -71436,8 +69007,7 @@
 /area/crew_quarters/fitness)
 "cFE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -71446,8 +69016,7 @@
 /area/crew_quarters/fitness)
 "cFF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -71455,8 +69024,7 @@
 /area/crew_quarters/fitness)
 "cFG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -71465,8 +69033,7 @@
 /area/crew_quarters/fitness)
 "cFH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -71475,8 +69042,7 @@
 /area/crew_quarters/fitness)
 "cFI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -71484,12 +69050,10 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -71509,8 +69073,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -71520,20 +69083,15 @@
 /area/library)
 "cFN" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "sw_maint_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	tag_airpump = "sw_maint_pump";
 	tag_chamber_sensor = "sw_maint_sensor";
 	tag_exterior_door = "sw_maint_outer";
 	tag_interior_door = "sw_maint_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "sw_maint_sensor";
-	pixel_x = 0;
 	pixel_y = 33
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -71546,8 +69104,7 @@
 /area/maintenance/fpmaint2)
 "cFO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -71561,8 +69118,7 @@
 	master_tag = "sw_maint_airlock";
 	name = "interior access button";
 	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "0"
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -71644,8 +69200,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -71713,8 +69268,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -71755,8 +69309,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -71771,8 +69324,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -71791,8 +69343,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -71820,8 +69371,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -71837,8 +69387,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -71854,8 +69403,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -71878,8 +69426,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -71895,8 +69442,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -71914,8 +69460,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
@@ -71951,8 +69496,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -71965,8 +69509,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint2)
@@ -71978,8 +69521,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -72004,8 +69546,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -72022,8 +69563,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72047,8 +69587,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -72064,8 +69603,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -72077,8 +69615,7 @@
 	id_tag = "sw_maint_outer";
 	locked = 1;
 	name = "West Maintenance External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint2)
@@ -72095,8 +69632,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72188,8 +69724,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72229,16 +69764,13 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Medbay Junction";
 	sortType = 13
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -72253,8 +69785,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -72270,8 +69801,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -72280,8 +69810,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -72290,8 +69819,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -72301,16 +69829,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cGK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -72320,8 +69846,7 @@
 /area/hallway/primary/central)
 "cGL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -72343,15 +69868,13 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "cGN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -72442,7 +69965,6 @@
 /obj/machinery/camera{
 	c_tag = "Rec Room Center";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -72452,8 +69974,7 @@
 /area/crew_quarters/fitness)
 "cGY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway South"
@@ -72510,23 +70031,20 @@
 /area/maintenance/fpmaint2)
 "cHf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "cHg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "cHh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -72549,16 +70067,14 @@
 /area/maintenance/electrical)
 "cHj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "cHk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -72581,8 +70097,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -72592,8 +70107,7 @@
 /area/maintenance/fpmaint2)
 "cHm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -72603,16 +70117,14 @@
 /area/maintenance/fpmaint2)
 "cHn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "cHo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -72625,8 +70137,7 @@
 /area/maintenance/fpmaint2)
 "cHp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
@@ -72643,8 +70154,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72654,8 +70164,7 @@
 "cHr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -72735,8 +70244,7 @@
 "cHz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -72760,7 +70268,6 @@
 "cHC" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -72773,8 +70280,7 @@
 /area/hallway/primary/central)
 "cHD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/north,
@@ -72812,7 +70318,6 @@
 "cHG" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "Research Junction";
 	sortType = 20;
 	tag = "icon-pipe-j1s (EAST)"
@@ -72833,8 +70338,7 @@
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72848,8 +70352,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -72872,7 +70375,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
@@ -72885,7 +70387,6 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
@@ -72897,7 +70398,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
@@ -72907,14 +70407,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
 "cHO" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "CMO's Junction";
 	sortType = 20;
 	tag = "icon-pipe-j1s (EAST)"
@@ -72923,19 +70421,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/central)
 "cHP" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -72948,7 +70443,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -73029,8 +70523,7 @@
 "cHY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -73051,8 +70544,7 @@
 /area/crew_quarters/sleep)
 "cIc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73077,14 +70569,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
 "cIf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -73128,14 +70618,12 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Dorm Hallway Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73161,7 +70649,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -73174,7 +70661,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -73278,8 +70764,7 @@
 	req_access_txt = "10;13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -73335,8 +70820,7 @@
 /area/maintenance/electrical)
 "cIE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -73344,8 +70828,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -73451,8 +70934,7 @@
 /area/hallway/primary/central)
 "cIU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
@@ -73607,13 +71089,11 @@
 "cJr" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/medical/medbay2)
 "cJs" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/medical3,
@@ -73624,7 +71104,6 @@
 "cJt" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/closet/secure_closet/medical3,
@@ -73634,7 +71113,6 @@
 /area/medical/medbay2)
 "cJu" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/closet/wardrobe/medical_white,
@@ -73666,8 +71144,7 @@
 "cJx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -73710,11 +71187,9 @@
 "cJD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
@@ -73791,16 +71266,14 @@
 "cJN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "cJO" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -73817,8 +71290,7 @@
 /area/maintenance/fpmaint2)
 "cJQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -73912,8 +71384,7 @@
 "cKd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -74006,8 +71477,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
@@ -74188,7 +71658,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
@@ -74295,7 +71764,6 @@
 /obj/structure/table,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/item/storage/firstaid/regular,
@@ -74334,8 +71802,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage Room";
@@ -74455,8 +71922,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -74469,8 +71935,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -74487,8 +71952,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -74506,8 +71970,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -74577,7 +72040,6 @@
 "cLv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
@@ -74600,8 +72062,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -74776,8 +72237,7 @@
 /area/toxins/xenobiology)
 "cLT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark";
@@ -74788,8 +72248,7 @@
 /area/toxins/xenobiology)
 "cLU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark";
@@ -74856,7 +72315,6 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /obj/machinery/light{
@@ -75049,8 +72507,7 @@
 "cMA" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -75096,24 +72553,21 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "cMF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plasteel,
 /area/medical/medbay2)
 "cMG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -75124,8 +72578,7 @@
 "cMH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -75158,8 +72611,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75181,8 +72633,7 @@
 "cMN" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/storage/briefcase,
 /obj/item/cane,
@@ -75196,8 +72647,7 @@
 /area/crew_quarters/sleep)
 "cMP" = (
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/cryopod/right,
 /turf/simulated/floor/plasteel{
@@ -75205,7 +72655,7 @@
 	},
 /area/crew_quarters/sleep)
 "cMQ" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75218,7 +72668,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
@@ -75239,8 +72688,7 @@
 /obj/machinery/atmospherics/binary/valve,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -75249,8 +72697,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75265,8 +72712,7 @@
 "cMX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -75288,8 +72734,7 @@
 /area/maintenance/electrical)
 "cNb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75304,8 +72749,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75314,8 +72758,7 @@
 /area/maintenance/electrical)
 "cNd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75572,7 +73015,6 @@
 /obj/machinery/door/airlock/research/glass{
 	autoclose = 0;
 	frequency = null;
-	glass = 1;
 	icon_state = "door_locked";
 	id_tag = "tox_airlock_exterior";
 	locked = 1;
@@ -75657,7 +73099,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -75670,59 +73111,49 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "cNG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "cNH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "lightsout"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "cNI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "cNJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "cNK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -75730,8 +73161,7 @@
 /area/medical/research)
 "cNL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -75740,8 +73170,7 @@
 /area/medical/research)
 "cNM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/west,
@@ -75750,8 +73179,7 @@
 "cNN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -75761,8 +73189,7 @@
 /area/hallway/primary/aft)
 "cNO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75773,14 +73200,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
 "cNQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/east,
@@ -75788,8 +73213,7 @@
 /area/medical/medbay)
 "cNR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -75799,8 +73223,7 @@
 /area/medical/medbay)
 "cNS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -75808,23 +73231,19 @@
 /area/medical/medbay)
 "cNT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "cNU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -75832,19 +73251,16 @@
 "cNV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "cNW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -75854,8 +73270,7 @@
 /area/medical/medbay)
 "cNX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -75871,8 +73286,7 @@
 /area/medical/medbay)
 "cNY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -75919,7 +73333,6 @@
 /obj/machinery/recharger,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -75965,7 +73378,6 @@
 /obj/structure/table,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/item/storage/box/gloves{
@@ -76030,12 +73442,10 @@
 "cOk" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/storage/firstaid/toxin{
@@ -76071,8 +73481,7 @@
 /area/space/nearstation)
 "cOn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -76091,8 +73500,7 @@
 "cOp" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -76145,8 +73553,7 @@
 "cOw" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -76170,8 +73577,7 @@
 "cOz" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -76261,9 +73667,7 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -76318,8 +73722,6 @@
 /obj/machinery/door_control{
 	id = "xeno6";
 	name = "Containment Control";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /obj/structure/window/reinforced{
@@ -76344,8 +73746,7 @@
 "cOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -76417,8 +73818,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -76426,8 +73826,7 @@
 "cPd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/west,
@@ -76444,8 +73843,7 @@
 "cPf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -76459,8 +73857,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -76474,8 +73871,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -76496,8 +73892,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76531,7 +73926,6 @@
 	},
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -76634,7 +74028,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -76669,7 +74062,6 @@
 "cPz" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Chemistry Junction";
 	sortType = 13
 	},
@@ -76678,7 +74070,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
@@ -76805,7 +74196,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -76853,8 +74243,7 @@
 "cPN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -76915,8 +74304,7 @@
 "cPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -76960,9 +74348,7 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay Requests Console";
-	pixel_x = 30;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = 30
 	},
 /obj/item/storage/firstaid/o2{
 	pixel_x = 6;
@@ -76998,8 +74384,7 @@
 	master_tag = "sw_maint_airlock";
 	name = "exterior access button";
 	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "0"
+	pixel_y = 24
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -77044,7 +74429,6 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/landmark{
@@ -77108,8 +74492,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cryodorms Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -77156,19 +74539,16 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
 "cQp" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
@@ -77204,8 +74584,7 @@
 "cQu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -77237,8 +74616,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -77325,8 +74703,6 @@
 /obj/machinery/door_control{
 	id = "xeno4";
 	name = "Containment Control";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /obj/structure/window/reinforced{
@@ -77353,8 +74729,7 @@
 "cQH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
@@ -77372,15 +74747,13 @@
 "cQJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -77416,8 +74789,6 @@
 /obj/machinery/door_control{
 	id = "xeno5";
 	name = "Containment Control";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /obj/structure/window/reinforced{
@@ -77428,11 +74799,9 @@
 /area/toxins/xenobiology)
 "cQM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
@@ -77444,11 +74813,9 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
@@ -77459,21 +74826,17 @@
 	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
 "cQP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
@@ -77491,8 +74854,7 @@
 /area/toxins/xenobiology)
 "cQR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -77507,8 +74869,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -77547,8 +74908,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -77557,8 +74917,7 @@
 "cQX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -77630,7 +74989,6 @@
 "cRg" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -77640,7 +74998,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/aft)
@@ -77683,7 +75040,6 @@
 "cRm" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -77834,14 +75190,12 @@
 /area/medical/medbay2)
 "cRx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
-	name = "Medbay Toilet";
-	req_access_txt = "0"
+	name = "Medbay Toilet"
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/medbay3)
@@ -77872,8 +75226,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -77917,8 +75270,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -78023,7 +75375,6 @@
 /obj/machinery/door_control{
 	id = "xenosecure";
 	name = "Containment Control";
-	pixel_x = 0;
 	pixel_y = -3;
 	req_access_txt = "55"
 	},
@@ -78056,8 +75407,7 @@
 "cRT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -78065,8 +75415,7 @@
 "cRU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
@@ -78074,8 +75423,7 @@
 /area/toxins/xenobiology)
 "cRV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -78153,9 +75501,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -78224,8 +75570,7 @@
 "cSh" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/greengrid,
 /area/toxins/xenobiology)
@@ -78252,8 +75597,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/door_timer{
 	dir = 10;
@@ -78280,7 +75624,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint/science)
@@ -78351,7 +75694,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -78361,20 +75703,17 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "cSt" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "cSu" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -78388,7 +75727,6 @@
 	},
 /obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -78396,7 +75734,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -78481,14 +75818,12 @@
 	network = list("Medical","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "cSF" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -78498,7 +75833,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -78539,8 +75873,7 @@
 /area/security/checkpoint/medical)
 "cSK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -78551,15 +75884,13 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/checkpoint/medical)
 "cSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -78606,8 +75937,7 @@
 /area/medical/medbay2)
 "cSR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/urinal{
 	pixel_y = 28
@@ -78622,8 +75952,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -78633,9 +75962,7 @@
 "cST" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -78843,8 +76170,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -78857,7 +76183,6 @@
 	tag = ""
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 4;
 	id = null;
 	name = "Creature Pen";
 	req_access_txt = "47"
@@ -79020,8 +76345,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -79052,8 +76376,6 @@
 /obj/machinery/door_control{
 	id = "xeno2";
 	name = "Containment Control";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /obj/structure/window/reinforced{
@@ -79067,8 +76389,6 @@
 /obj/machinery/door_control{
 	id = "xeno3";
 	name = "Containment Control";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /obj/structure/window/reinforced{
@@ -79080,8 +76400,7 @@
 "cTI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -79120,7 +76439,6 @@
 	req_access_txt = "150"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -79197,8 +76515,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_x = -32
@@ -79215,7 +76532,6 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -79306,12 +76622,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -79344,8 +76658,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Security Checkpoint";
@@ -79372,8 +76685,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -79387,12 +76699,10 @@
 "cUi" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -79403,8 +76713,7 @@
 "cUj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -79504,8 +76813,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -79527,8 +76835,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79546,8 +76853,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79567,8 +76873,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79587,8 +76892,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79607,8 +76911,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79629,8 +76932,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79648,13 +76950,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -79669,8 +76969,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79688,8 +76987,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79711,8 +77009,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79729,12 +77026,10 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79763,8 +77058,7 @@
 /area/crew_quarters/fitness)
 "cUG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/chair/stool,
@@ -79775,8 +77069,7 @@
 /area/crew_quarters/fitness)
 "cUH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79789,8 +77082,7 @@
 /area/crew_quarters/fitness)
 "cUI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79805,8 +77097,7 @@
 /area/crew_quarters/fitness)
 "cUJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79831,8 +77122,7 @@
 /area/crew_quarters/fitness)
 "cUL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79847,7 +77137,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
@@ -79932,8 +77221,7 @@
 /area/toxins/xenobiology)
 "cUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
@@ -79962,8 +77250,7 @@
 "cVa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -79980,8 +77267,7 @@
 "cVc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -80099,8 +77385,7 @@
 "cVm" = (
 /obj/machinery/smartfridge/secure/extract,
 /obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -80127,8 +77412,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/folder/white,
 /obj/item/pen,
@@ -80159,8 +77443,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -80232,7 +77515,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "shutter0";
 	id_tag = "researchdesk2";
 	name = "Research Desk Shutters";
@@ -80262,11 +77544,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangecorner"
 	},
 /area/hallway/primary/aft)
@@ -80433,7 +77713,6 @@
 	req_access_txt = "150"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -80490,8 +77769,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80501,8 +77779,7 @@
 "cVX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
@@ -80571,7 +77848,6 @@
 /area/crew_quarters/fitness)
 "cWh" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
@@ -80610,8 +77886,7 @@
 /area/maintenance/fpmaint2)
 "cWn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80620,8 +77895,7 @@
 /area/maintenance/fpmaint2)
 "cWo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -80641,8 +77915,7 @@
 /area/maintenance/fpmaint2)
 "cWq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -80652,8 +77925,7 @@
 /area/maintenance/fpmaint2)
 "cWr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -80670,13 +77942,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -80690,8 +77960,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80702,8 +77971,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/camera{
 	c_tag = "Research Security Checkpoint";
@@ -80711,8 +77979,7 @@
 	network = list("Research","SS13","Security")
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -80727,8 +77994,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80737,8 +78003,7 @@
 /area/maintenance/fpmaint2)
 "cWw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -80751,8 +78016,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -80915,11 +78179,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
@@ -80934,7 +78196,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
@@ -80948,11 +78209,9 @@
 /obj/machinery/camera{
 	c_tag = "Research Lobby";
 	dir = 1;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
@@ -80960,8 +78219,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/item/stock_parts/matter_bin{
 	pixel_x = 3;
@@ -80989,7 +78247,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint/science)
@@ -81014,8 +78271,7 @@
 	},
 /obj/machinery/r_n_d/protolathe,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -81028,8 +78284,7 @@
 /obj/item/storage/bag/bio,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -81111,7 +78366,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangecorner"
 	},
 /area/hallway/primary/aft)
@@ -81155,7 +78409,6 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/southwest,
@@ -81187,7 +78440,6 @@
 /obj/machinery/computer/crew,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -81346,8 +78598,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -81358,8 +78609,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -81420,8 +78670,7 @@
 "cXG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redbluefull"
@@ -81468,8 +78717,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Rec Room Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -81478,7 +78726,6 @@
 "cXO" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness)
@@ -81511,8 +78758,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -81537,8 +78783,7 @@
 /area/maintenance/fpmaint2)
 "cXW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -81647,8 +78892,7 @@
 "cYg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -81662,11 +78906,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/closet/wardrobe/yellow{
-	icon_state = "yellow"
-	},
+/obj/structure/closet/wardrobe/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -81681,8 +78922,7 @@
 /area/toxins/xenobiology)
 "cYj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/south,
@@ -81692,8 +78932,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -81707,7 +78946,6 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/item/stack/cable_coil/random,
@@ -81846,7 +79084,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangecorner"
 	},
 /area/hallway/primary/aft)
@@ -81931,7 +79168,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -81939,8 +79175,7 @@
 "cYN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -82016,8 +79251,7 @@
 "cYU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -82040,7 +79274,6 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -82079,7 +79312,6 @@
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/medical/medbay3)
@@ -82089,8 +79321,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
@@ -82230,8 +79461,7 @@
 "cZo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -82275,8 +79505,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/item/folder/white,
 /obj/item/stock_parts/cell/high,
@@ -82291,8 +79520,7 @@
 /area/medical/research)
 "cZu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/west,
@@ -82304,16 +79532,12 @@
 /area/medical/research)
 "cZv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/folder,
 /obj/item/pen,
-/obj/machinery/door/window/westleft{
-	name = "interior door";
-	req_access_txt = "0"
-	},
+/obj/machinery/door/window/westleft,
 /obj/machinery/door/window/eastleft{
 	name = "Research Lab Desk";
 	req_access_txt = "7"
@@ -82394,8 +79618,7 @@
 	department = "Xenobiology";
 	departmentType = 2;
 	name = "Xenobiology Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/reagentgrinder,
 /obj/effect/decal/warning_stripes/yellow,
@@ -82403,8 +79626,7 @@
 /area/toxins/xenobiology)
 "cZD" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/door_control{
 	id = "chemdesk2";
@@ -82429,7 +79651,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -82557,7 +79778,6 @@
 /area/medical/medbay3)
 "cZR" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -82566,7 +79786,6 @@
 /obj/machinery/sleeper,
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -82586,8 +79805,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -82611,7 +79829,6 @@
 /area/medical/medbay3)
 "cZW" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/medical/medbay3)
@@ -82620,7 +79837,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/medical/medbay3)
@@ -82688,7 +79904,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/wood,
@@ -82752,8 +79967,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -82765,8 +79979,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -82780,8 +79993,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -82819,8 +80031,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -82843,8 +80054,7 @@
 /area/medical/research)
 "daw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -82855,8 +80065,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -82864,8 +80073,7 @@
 /area/medical/chemistry)
 "day" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -82881,8 +80089,7 @@
 /area/medical/research)
 "daA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -82890,8 +80097,7 @@
 /area/medical/research)
 "daB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster/official/nanotrasen_logo{
@@ -82905,8 +80111,7 @@
 /area/medical/research)
 "daC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -82919,8 +80124,7 @@
 "daE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -82930,8 +80134,7 @@
 /area/medical/research)
 "daF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -82960,8 +80163,7 @@
 /area/toxins/lab)
 "daI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -82970,8 +80172,7 @@
 /area/toxins/lab)
 "daJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -83014,7 +80215,6 @@
 "daM" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/lab)
@@ -83035,7 +80235,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangecorner"
 	},
 /area/hallway/primary/aft)
@@ -83046,7 +80245,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangefull"
 	},
 /area/hallway/primary/aft)
@@ -83086,8 +80284,7 @@
 /area/medical/chemistry)
 "daU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -83114,7 +80311,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/chemistry)
@@ -83223,8 +80419,7 @@
 "dbg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -83269,8 +80464,7 @@
 "dbl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -83306,8 +80500,7 @@
 "dbp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -83404,15 +80597,13 @@
 /area/medical/surgery1)
 "dbB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
 "dbC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -83431,8 +80622,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
@@ -83444,8 +80634,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -83454,8 +80643,7 @@
 "dbF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/item/surgicaldrill,
 /obj/item/circular_saw,
@@ -83491,8 +80679,7 @@
 "dbJ" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/sign/poster/contraband/random{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
@@ -83520,8 +80707,7 @@
 /area/maintenance/fpmaint2)
 "dbO" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -83582,7 +80768,6 @@
 /obj/item/pen,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "shutter0";
 	id_tag = "researchdesk2";
 	name = "Research Desk Shutters";
@@ -83665,7 +80850,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/lab)
@@ -83687,7 +80871,6 @@
 /area/hallway/primary/aft)
 "dcf" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangefull"
 	},
 /area/hallway/primary/aft)
@@ -83734,7 +80917,6 @@
 /area/medical/chemistry)
 "dck" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/chemistry)
@@ -83958,8 +81140,7 @@
 "dcA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -83999,8 +81180,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "";
 	name = "Staff Room";
-	req_access_txt = "5";
-	req_one_access_txt = "0"
+	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/medbay3)
@@ -84019,14 +81199,12 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	icon_state = "door_locked";
 	locked = 1;
-	name = "Maintenance Access";
-	req_access_txt = "0"
+	name = "Maintenance Access"
 	},
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plasteel,
@@ -84039,8 +81217,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -84051,8 +81228,7 @@
 /area/medical/surgery1)
 "dcH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -84060,8 +81236,7 @@
 /area/medical/surgery1)
 "dcI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -84178,8 +81353,7 @@
 "dcV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/structure/table/wood/poker,
 /turf/simulated/floor/plating,
@@ -84257,8 +81431,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -84274,8 +81447,7 @@
 "ddh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint2)
@@ -84306,7 +81478,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -84373,11 +81544,9 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Research Request Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/lab)
@@ -84398,7 +81567,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
@@ -84408,7 +81576,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -84418,7 +81585,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research)
@@ -84460,7 +81626,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -84487,7 +81652,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/item/storage/toolbox/mechanical,
@@ -84500,7 +81664,6 @@
 "ddF" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/folder/white,
@@ -84522,7 +81685,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/lab)
@@ -84563,7 +81725,6 @@
 "ddK" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "orangefull"
 	},
 /area/hallway/primary/aft)
@@ -84615,7 +81776,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/chemistry)
@@ -84626,8 +81786,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 1;
@@ -84639,11 +81798,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/chemistry)
@@ -84655,15 +81812,13 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = 4;
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/chemistry)
@@ -84671,8 +81826,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/surgery1)
@@ -84683,8 +81837,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -84701,8 +81854,7 @@
 /area/medical/medbay)
 "ddU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -84713,8 +81865,7 @@
 "ddV" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry";
@@ -84732,14 +81883,12 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/chemistry)
 "ddW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -84757,8 +81906,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -84768,7 +81916,6 @@
 "ddY" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -84776,7 +81923,6 @@
 "ddZ" = (
 /obj/machinery/chem_master,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/sign/nosmoking_2{
@@ -84790,8 +81936,7 @@
 /area/medical/chemistry)
 "dea" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue";
@@ -84833,8 +81978,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -84843,38 +81987,32 @@
 /area/medical/medbay)
 "dee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "def" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "deg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -84882,33 +82020,28 @@
 "deh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "dei" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "dej" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/medical/medbay)
 "dek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/rack,
@@ -84928,8 +82061,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -84960,8 +82092,7 @@
 /obj/machinery/door/airlock/maintenance{
 	icon_state = "door_locked";
 	locked = 1;
-	name = "Maintenance Access";
-	req_access_txt = "0"
+	name = "Maintenance Access"
 	},
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plasteel,
@@ -84974,8 +82105,7 @@
 	tag = ""
 	},
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -84995,16 +82125,14 @@
 /area/maintenance/starboard)
 "deu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "dev" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -85013,8 +82141,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -85063,8 +82190,7 @@
 	layer = 2.9
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -85142,8 +82268,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -85159,8 +82284,7 @@
 "deG" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -85180,7 +82304,6 @@
 "deK" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -85206,8 +82329,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint2)
@@ -85244,8 +82366,7 @@
 /obj/item/crowbar,
 /obj/item/clothing/mask/gas,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -85450,7 +82571,6 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -85470,9 +82590,7 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Chemistry Requests Console";
-	pixel_x = 0;
-	pixel_y = -30;
-	pixel_z = 0
+	pixel_y = -30
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
@@ -85481,18 +82599,15 @@
 /area/medical/chemistry)
 "dfr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -85507,8 +82622,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
@@ -85536,8 +82650,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -85580,8 +82693,7 @@
 /area/medical/surgery)
 "dfE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -85664,8 +82776,7 @@
 /obj/structure/cable,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
@@ -85706,8 +82817,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -85722,8 +82832,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -85847,8 +82956,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -85856,8 +82964,7 @@
 "dgm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -85865,8 +82972,7 @@
 "dgn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -85891,8 +82997,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -85935,13 +83040,11 @@
 "dgs" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/table/reinforced,
 /obj/item/paicard,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -85982,7 +83085,6 @@
 "dgv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -85996,7 +83098,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -86029,15 +83130,13 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "dgA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -86061,8 +83160,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86108,8 +83206,7 @@
 "dgH" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -86117,7 +83214,6 @@
 	pixel_x = 24
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -86201,7 +83297,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
@@ -86240,11 +83335,9 @@
 "dgR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -86290,8 +83383,7 @@
 "dgW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86309,8 +83401,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -86319,7 +83410,6 @@
 "dgY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -86368,8 +83458,7 @@
 /area/medical/surgery)
 "dhf" = (
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -86472,8 +83561,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -86487,8 +83575,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -86521,7 +83608,6 @@
 /obj/item/stock_parts/scanning_module,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -86548,8 +83634,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Experimentor Maintenance";
@@ -86577,8 +83662,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -86593,9 +83677,7 @@
 /obj/machinery/door_control{
 	id = "maintrobotics";
 	name = "Decrepit Control";
-	pixel_x = 26;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 26
 	},
 /turf/simulated/floor/plating,
 /area/medical/research)
@@ -86612,8 +83694,7 @@
 "dhG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -86631,8 +83712,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -86649,8 +83729,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -86667,8 +83746,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -86688,8 +83766,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86707,8 +83784,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86741,11 +83817,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/explab)
@@ -86759,15 +83833,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
@@ -86801,7 +83873,6 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/explab)
@@ -86810,8 +83881,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -86819,7 +83889,6 @@
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/explab)
@@ -86828,8 +83897,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -86839,8 +83907,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -86858,8 +83925,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/west,
@@ -86870,8 +83936,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -86904,8 +83969,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -86923,8 +83987,7 @@
 	tag = "icon-pipe-j2 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -86975,8 +84038,7 @@
 "dih" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86986,7 +84048,6 @@
 "dii" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Robotics Junction";
 	sortType = 13
 	},
@@ -87001,19 +84062,16 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "dik" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
@@ -87028,18 +84086,15 @@
 "dim" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
@@ -87097,7 +84152,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/northeast,
@@ -87108,8 +84162,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
@@ -87121,13 +84174,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Brig Security Equipment Lockers";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -87136,8 +84187,7 @@
 /area/hallway/primary/aft)
 "div" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -87147,27 +84197,23 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
 "dix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Paramedic Office";
-	req_access_txt = "66";
-	req_one_access_txt = "0"
+	req_access_txt = "66"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87176,8 +84222,7 @@
 /area/hallway/primary/aft)
 "diy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -87206,8 +84251,7 @@
 	pixel_x = -27
 	},
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/machinery/door/window/eastleft,
 /turf/simulated/floor/plasteel{
@@ -87229,8 +84273,7 @@
 "diD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -87238,8 +84281,7 @@
 /area/medical/genetics_cloning)
 "diE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -87252,8 +84294,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -87275,8 +84316,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -87304,8 +84344,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -87320,8 +84359,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -87355,7 +84393,6 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -87363,8 +84400,7 @@
 "diN" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Recovery Ward";
-	req_access_txt = "0"
+	name = "Recovery Ward"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -87372,8 +84408,7 @@
 /area/medical/surgery)
 "diO" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -87426,7 +84461,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -87498,8 +84532,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
@@ -87514,8 +84547,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/girder,
 /obj/structure/grille,
@@ -87542,8 +84574,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -87556,24 +84587,21 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/medical/research)
 "djh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/medical/research)
 "dji" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
@@ -87590,8 +84618,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -87612,8 +84639,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -87634,8 +84660,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -87643,8 +84668,7 @@
 "djn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table,
 /obj/item/stack/medical/bruise_pack,
@@ -87664,8 +84688,7 @@
 "djq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -87782,13 +84805,11 @@
 "djE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light_switch{
@@ -87873,8 +84894,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -87931,8 +84951,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -87953,8 +84972,7 @@
 	tag = "icon-pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -87964,11 +84982,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -87980,8 +84996,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Cyborg"
@@ -87993,8 +85008,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/landmark/start{
@@ -88035,14 +85049,12 @@
 /area/hallway/primary/aft)
 "djV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -88055,8 +85067,7 @@
 "djW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -88108,8 +85119,7 @@
 "dkc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -88120,7 +85130,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -88137,8 +85146,7 @@
 "dkf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -88161,7 +85169,6 @@
 "dkh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -88189,8 +85196,7 @@
 /area/medical/medbay)
 "dkk" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -88200,8 +85206,7 @@
 "dkl" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Recovery Ward";
-	req_access_txt = "0"
+	name = "Recovery Ward"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -88272,8 +85277,7 @@
 /obj/structure/cable,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -88288,8 +85292,7 @@
 "dkv" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -88299,7 +85302,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/stock_parts/matter_bin,
@@ -88341,7 +85343,6 @@
 "dkB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -88357,9 +85358,7 @@
 /obj/machinery/door_control{
 	id = "experimentor";
 	name = "Experimentor Control";
-	pixel_x = -26;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -26
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -88423,7 +85422,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/structure/cable{
@@ -88473,8 +85471,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -88523,8 +85520,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -88537,8 +85533,7 @@
 "dkV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -88561,19 +85556,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "dkY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -88621,8 +85613,7 @@
 "dlc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -88639,11 +85630,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -88662,7 +85651,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -88671,8 +85659,7 @@
 /area/medical/genetics_cloning)
 "dlh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -88712,7 +85699,6 @@
 "dll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -88721,12 +85707,10 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay Psych Office Corridor East";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics_cloning)
@@ -88758,8 +85742,7 @@
 	id = "medbayfoyer";
 	name = "Medbay Front Doors";
 	normaldoorcontrol = 1;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -88808,11 +85791,9 @@
 "dlu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -88851,8 +85832,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -88890,8 +85870,7 @@
 /area/medical/surgery1)
 "dlC" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel{
@@ -88937,8 +85916,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -89043,8 +86021,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -89055,8 +86032,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -89077,8 +86053,7 @@
 "dlY" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/structure/closet/bombcloset,
 /obj/effect/decal/warning_stripes/southeast,
@@ -89174,11 +86149,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -89202,11 +86175,9 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -89244,8 +86215,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -89260,11 +86230,9 @@
 "dmr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -89283,8 +86251,7 @@
 "dmv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -89325,8 +86292,7 @@
 /area/medical/surgery)
 "dmA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -89347,7 +86313,6 @@
 "dmC" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -89372,8 +86337,7 @@
 /area/maintenance/starboard)
 "dmE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -89384,15 +86348,13 @@
 /area/maintenance/starboard)
 "dmG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/construction)
 "dmH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -89401,16 +86363,14 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/construction)
 "dmJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -89424,8 +86384,7 @@
 /area/hallway/secondary/construction)
 "dmL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/construction)
@@ -89475,8 +86434,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -89570,8 +86528,7 @@
 /area/maintenance/fpmaint2)
 "dnb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -89607,8 +86564,7 @@
 /area/toxins/explab)
 "dng" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -89618,8 +86574,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -89656,8 +86611,7 @@
 "dnl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -89668,8 +86622,7 @@
 "dnm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/misc_lab)
@@ -89705,8 +86658,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/computer/aifixer,
 /turf/simulated/floor/plasteel{
@@ -89729,14 +86681,12 @@
 	name = "Research Director"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
 "dnr" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -89761,47 +86711,27 @@
 "dnt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
-"dnu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
 "dnv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "dnw" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
@@ -89832,15 +86762,12 @@
 /area/assembly/chargebay)
 "dnB" = (
 /obj/machinery/door/poddoor/shutters{
-	dir = 4;
 	id_tag = "roboticsshutters";
 	name = "Mech Bay Shutters"
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "roboticsshutters";
 	name = "Mech Bay Door Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "29"
 	},
@@ -89852,8 +86779,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -89867,7 +86793,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -89875,14 +86800,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "dnG" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -89908,8 +86831,7 @@
 "dnJ" = (
 /obj/effect/decal/warning_stripes/northwestsouth,
 /obj/vehicle/ambulance{
-	dir = 8;
-	icon_state = "docwagon2"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Paramedic's Office";
@@ -89930,7 +86852,6 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /obj/item/storage/box/disks{
@@ -90001,9 +86922,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90099,8 +87018,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -90125,8 +87043,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -90141,8 +87058,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90158,8 +87074,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -90176,8 +87091,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90193,13 +87107,11 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Recovery Ward";
-	req_access_txt = "0"
+	name = "Recovery Ward"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90215,8 +87127,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -90236,8 +87147,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/computer/operating,
 /turf/simulated/floor/plasteel{
@@ -90258,8 +87168,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/optable,
 /turf/simulated/floor/plasteel{
@@ -90275,8 +87184,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -90291,11 +87199,9 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -90308,8 +87214,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -90323,8 +87228,7 @@
 "don" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90358,8 +87262,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -90449,8 +87352,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90498,8 +87400,7 @@
 /area/toxins/mixing)
 "doH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90568,14 +87469,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/crew_quarters/hor)
 "doN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
@@ -90611,7 +87510,6 @@
 /area/toxins/xenobiology)
 "doR" = (
 /obj/machinery/door/poddoor/shutters{
-	dir = 4;
 	id_tag = "roboticsshutters";
 	name = "Mech Bay Shutters"
 	},
@@ -90634,8 +87532,7 @@
 /area/assembly/chargebay)
 "doU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -90649,8 +87546,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Cyborg"
@@ -90682,8 +87578,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90702,7 +87597,6 @@
 "dpa" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Genetics Junction";
 	sortType = 13
 	},
@@ -90711,7 +87605,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -90727,8 +87620,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -90757,8 +87649,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -90767,8 +87658,7 @@
 "dpf" = (
 /obj/effect/decal/warning_stripes/northeastsouth,
 /obj/structure/bed/amb_trolley{
-	dir = 4;
-	icon_state = "ambulance"
+	dir = 4
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -90783,7 +87673,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -90862,8 +87751,7 @@
 "dpn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90897,8 +87785,7 @@
 "dpq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90920,8 +87807,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -90936,11 +87822,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -90953,8 +87837,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -90970,8 +87853,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/cmo)
@@ -91031,8 +87913,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/cmo)
@@ -91059,8 +87940,7 @@
 	req_access_txt = "40"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/cmo)
@@ -91073,8 +87953,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -91108,11 +87987,9 @@
 "dpC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -91136,11 +88013,9 @@
 /area/medical/surgery)
 "dpF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -91148,7 +88023,6 @@
 "dpG" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -91180,23 +88054,19 @@
 /area/medical/surgery)
 "dpJ" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/surgery)
 "dpK" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -91235,8 +88105,7 @@
 /area/hallway/secondary/construction)
 "dpO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -91265,7 +88134,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28;
 	pixel_y = -28
 	},
@@ -91318,8 +88186,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/sign/nosmoking_2{
@@ -91359,8 +88226,7 @@
 "dqc" = (
 /obj/machinery/light,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/computer/robotics,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -91384,8 +88250,7 @@
 /area/crew_quarters/hor)
 "dqg" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -91426,8 +88291,7 @@
 "dqj" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -91480,8 +88344,7 @@
 /area/assembly/robotics)
 "dqq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Research West Hallway";
@@ -91496,12 +88359,10 @@
 /obj/structure/table/glass,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Genetics Office";
@@ -91566,8 +88427,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Medical Officer";
@@ -91586,8 +88446,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -91604,8 +88463,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -91624,8 +88482,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -91642,8 +88499,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -91659,8 +88515,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/start{
@@ -91722,8 +88577,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -91787,8 +88641,7 @@
 "dqK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -91813,7 +88666,6 @@
 "dqM" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/computer/med_data,
@@ -91824,12 +88676,10 @@
 /area/medical/surgery)
 "dqN" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -91864,7 +88714,6 @@
 /area/engine/engineering)
 "dqR" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -91875,9 +88724,7 @@
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
@@ -91909,7 +88756,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -91932,8 +88778,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/yellow,
@@ -91998,7 +88843,6 @@
 "drf" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
@@ -92029,8 +88873,7 @@
 /area/medical/research)
 "drj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -92063,8 +88906,7 @@
 "drn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -92075,8 +88917,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -92114,8 +88955,7 @@
 /area/toxins/mixing)
 "drs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille{
@@ -92127,8 +88967,7 @@
 "drt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -92238,8 +89077,7 @@
 /area/assembly/chargebay)
 "drF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/firealarm{
@@ -92290,7 +89128,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "shutter0";
 	id_tag = "robodesk";
 	name = "Robotics Desk Shutters";
@@ -92326,7 +89163,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -92365,8 +89201,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -92384,7 +89219,6 @@
 "drR" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
@@ -92489,20 +89323,17 @@
 	network = list("Medical","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/medbay)
 "dsd" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/bed/dogbed{
 	name = "kitty basket"
@@ -92557,8 +89388,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Medical Officer's Office";
@@ -92571,11 +89401,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -92609,8 +89437,7 @@
 "dsm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -92622,8 +89449,7 @@
 /area/medical/research)
 "dso" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -92637,16 +89463,14 @@
 /area/medical/research)
 "dsq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "dsr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -92655,8 +89479,7 @@
 /area/maintenance/fpmaint2)
 "dss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -92684,7 +89507,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -92755,8 +89577,7 @@
 /area/toxins/misc_lab)
 "dsD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -92770,8 +89591,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/landmark/start{
 	name = "Research Director"
@@ -92790,14 +89610,12 @@
 /area/crew_quarters/hor)
 "dsG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -92825,7 +89643,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -92947,13 +89764,11 @@
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
 "dsR" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
@@ -92967,9 +89782,7 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Genetics Requests Console";
-	pixel_x = 0;
-	pixel_y = -30;
-	pixel_z = 0
+	pixel_y = -30
 	},
 /obj/item/storage/box/bodybags,
 /turf/simulated/floor/plasteel{
@@ -92987,8 +89800,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -93009,7 +89821,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -93045,7 +89856,6 @@
 "dsZ" = (
 /obj/machinery/dna_scannernew,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/decal/warning_stripes/northeast,
@@ -93095,7 +89905,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -93108,8 +89917,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/gateway)
@@ -93133,8 +89941,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -93156,8 +89963,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -93180,8 +89986,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -93242,8 +90047,7 @@
 /obj/structure/table,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -93418,8 +90222,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Aft Starboard Solar Access";
@@ -93436,8 +90239,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -93520,7 +90322,6 @@
 /obj/item/clothing/mask/gas,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
@@ -93559,8 +90360,7 @@
 /area/toxins/mixing)
 "dtS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Research Hallway";
@@ -93581,8 +90381,7 @@
 /area/toxins/mixing)
 "dtU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/grille{
 	density = 0;
@@ -93606,8 +90405,7 @@
 /area/toxins/mixing)
 "dtW" = (
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -93619,7 +90417,6 @@
 /area/toxins/misc_lab)
 "dtY" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
@@ -93630,11 +90427,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
@@ -93646,7 +90441,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
@@ -93657,12 +90451,10 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
@@ -93670,19 +90462,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
 "dud" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
@@ -93716,8 +90505,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -93754,8 +90542,7 @@
 "duj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -93785,8 +90572,7 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -93823,8 +90609,7 @@
 "dur" = (
 /obj/structure/table/glass,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/clipboard,
 /obj/item/toy/figure/cmo,
@@ -93833,8 +90618,7 @@
 "dus" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -93879,8 +90663,7 @@
 "duw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Mini Satellite Access";
@@ -93901,8 +90684,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -93914,8 +90696,7 @@
 /area/medical/surgery1)
 "duz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -93924,8 +90705,7 @@
 /area/medical/medbay)
 "duA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -93937,8 +90717,7 @@
 /area/medical/medbay)
 "duB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -93952,21 +90731,16 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -93987,8 +90761,7 @@
 /area/maintenance/starboard)
 "duE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet/crate,
 /obj/item/flashlight,
@@ -93999,16 +90772,14 @@
 /area/maintenance/starboard)
 "duF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "duG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -94025,8 +90796,7 @@
 /area/maintenance/starboard)
 "duI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -94034,8 +90804,7 @@
 /area/maintenance/starboard)
 "duJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -94045,8 +90814,7 @@
 /area/maintenance/starboard)
 "duK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -94061,15 +90829,13 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
 "duM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -94082,8 +90848,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -94103,8 +90868,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
@@ -94112,8 +90876,7 @@
 "duP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Engine Room South";
@@ -94162,7 +90925,6 @@
 /obj/machinery/light/small,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
@@ -94228,11 +90990,9 @@
 /area/toxins/mixing)
 "dvb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/mixing)
@@ -94247,8 +91007,7 @@
 /area/toxins/misc_lab)
 "dve" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -94274,16 +91033,13 @@
 "dvh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -94316,7 +91072,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -94361,8 +91116,7 @@
 "dvo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -94503,13 +91257,10 @@
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32;
-	req_access_txt = "0"
+	pixel_y = -32
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Chief Medical Officer's Office"
@@ -94557,8 +91308,7 @@
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
 	name = "Chief Medical Officer Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/cmo)
@@ -94584,7 +91334,6 @@
 	dir = 8
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -94610,8 +91359,7 @@
 "dvP" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -94686,8 +91434,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -94748,7 +91495,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/mixing)
@@ -94775,8 +91521,7 @@
 /area/toxins/misc_lab)
 "dwe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -94786,8 +91531,7 @@
 "dwf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/chair/office/light{
 	dir = 8
@@ -94821,7 +91565,6 @@
 /obj/structure/table,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/clipboard,
@@ -94842,9 +91585,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server{
-	on = 1
-	},
+/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94871,7 +91612,6 @@
 /obj/machinery/door/window/eastleft,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "shutter0";
 	id_tag = "robodesk";
 	name = "Robotics Desk Shutters";
@@ -94884,8 +91624,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Recovery Ward";
-	req_access_txt = "0"
+	name = "Recovery Ward"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -94893,8 +91632,7 @@
 /area/medical/surgery)
 "dwq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/random,
@@ -94915,8 +91653,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -94945,15 +91682,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock External";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -95080,12 +91815,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -95129,7 +91862,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -95149,11 +91881,8 @@
 /area/crew_quarters/theatre)
 "dwR" = (
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
-	name = "Abandoned Theater";
-	req_access_txt = "0"
+	name = "Abandoned Theater"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -95210,7 +91939,6 @@
 /area/security/detectives_office)
 "dwY" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating,
@@ -95229,9 +91957,7 @@
 /obj/item/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "detectives camera";
-	pictures_left = 30;
-	pixel_x = 0;
-	pixel_y = 0
+	pictures_left = 30
 	},
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -95260,7 +91986,6 @@
 /obj/item/clothing/mask/gas,
 /obj/machinery/camera{
 	c_tag = "Research Outpost Temporary Storage";
-	dir = 2;
 	network = list("Research Outpost")
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -95287,11 +92012,9 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/southeast,
@@ -95344,9 +92067,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("Toxins")
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -95357,7 +92078,6 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/mixing)
@@ -95373,7 +92093,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -95411,7 +92130,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
@@ -95429,8 +92147,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/computer/rdservercontrol,
 /turf/simulated/floor/plasteel{
@@ -95466,8 +92183,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
@@ -95482,8 +92198,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -95502,8 +92217,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -95526,8 +92240,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -95536,11 +92249,9 @@
 "dxy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -95553,8 +92264,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Recovery Ward";
-	req_access_txt = "0"
+	name = "Recovery Ward"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -95603,8 +92313,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Research Secure Entrance";
@@ -95620,11 +92329,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -95653,8 +92360,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -95662,8 +92368,7 @@
 /area/medical/morgue)
 "dxI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/medical/morgue)
@@ -95680,8 +92385,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -95697,8 +92401,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -95714,8 +92417,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -95751,8 +92453,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -95760,13 +92461,11 @@
 /area/medical/morgue)
 "dxP" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -95779,8 +92478,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/morgue)
@@ -95792,8 +92490,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -95809,8 +92506,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -95831,8 +92527,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -95896,8 +92591,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -95963,8 +92657,7 @@
 "dyi" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -96104,7 +92797,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/mixing)
@@ -96128,8 +92820,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -96199,8 +92890,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/toxins/server)
@@ -96312,8 +93002,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -96352,8 +93041,7 @@
 "dza" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -96401,8 +93089,7 @@
 "dzf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/medical/morgue)
@@ -96469,12 +93156,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/landmark/start{
 	name = "Chief Medical Officer"
@@ -96542,8 +93227,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
@@ -96577,24 +93261,21 @@
 /area/toxins/test_area)
 "dzw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "dzx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "dzy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/research{
 	name = "Toxin Test Firing Range";
@@ -96625,8 +93306,7 @@
 /area/toxins/mixing)
 "dzA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -96641,8 +93321,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/research{
 	name = "Toxin Mixing";
@@ -96659,8 +93338,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -96676,8 +93354,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = -26;
@@ -96705,8 +93382,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -96745,11 +93421,9 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/mixing)
@@ -96768,8 +93442,7 @@
 "dzJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/southwestcorner,
@@ -96797,8 +93470,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -96811,8 +93483,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -96834,8 +93505,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -96940,7 +93610,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -96956,8 +93625,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -97003,7 +93671,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/assembly/robotics)
@@ -97038,7 +93705,6 @@
 "dAe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -97074,7 +93740,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
@@ -97120,8 +93785,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -97137,7 +93801,6 @@
 "dAp" = (
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/computer/med_data/laptop,
@@ -97150,7 +93813,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light,
@@ -97214,8 +93876,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -97230,8 +93891,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
@@ -97247,8 +93907,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -97261,8 +93920,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -97270,8 +93928,7 @@
 /area/crew_quarters/theatre)
 "dAz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -97279,8 +93936,7 @@
 /area/crew_quarters/theatre)
 "dAA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/wood{
 	dir = 4
@@ -97291,8 +93947,7 @@
 /area/crew_quarters/theatre)
 "dAB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -97303,8 +93958,7 @@
 /area/crew_quarters/theatre)
 "dAC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -97314,8 +93968,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -97422,8 +94075,7 @@
 "dAP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/southeast,
@@ -97452,12 +94104,10 @@
 /area/toxins/mixing)
 "dAS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/rack,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/clothing/suit/fire/firefighter,
@@ -97475,8 +94125,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -97489,8 +94138,7 @@
 	},
 /obj/machinery/door/window/southright{
 	name = "Toxins Launcher";
-	req_access_txt = "7";
-	req_one_access_txt = "0"
+	req_access_txt = "7"
 	},
 /obj/effect/decal/warning_stripes/arrow,
 /obj/effect/decal/warning_stripes/yellow/partial,
@@ -97579,8 +94227,7 @@
 "dBd" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit";
@@ -97604,8 +94251,7 @@
 "dBf" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit";
@@ -97667,7 +94313,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -97767,7 +94412,6 @@
 /obj/structure/table/wood,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/clothing/gloves/color/black,
@@ -97905,8 +94549,7 @@
 "dBM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -97920,8 +94563,7 @@
 "dBO" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/item/reagent_containers/glass/beaker/sulphuric,
@@ -97962,7 +94604,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -97980,8 +94621,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -97991,8 +94631,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -98013,8 +94652,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -98213,8 +94851,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -98283,8 +94920,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -98324,8 +94960,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -98508,7 +95143,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -98557,8 +95191,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -98570,8 +95203,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -98584,8 +95216,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes/yellow,
@@ -98599,8 +95230,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -98608,12 +95238,10 @@
 "dCZ" = (
 /obj/structure/rack,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
@@ -98625,8 +95253,7 @@
 /area/assembly/robotics)
 "dDa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light/small,
 /obj/structure/closet/firecloset,
@@ -98642,8 +95269,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -98658,8 +95284,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -98670,7 +95295,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -98692,38 +95316,33 @@
 /area/bridge)
 "dDf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/hallway/primary/aft)
 "dDg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
 "dDh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dDi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dDj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -98731,8 +95350,7 @@
 /area/maintenance/aft)
 "dDk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -98741,11 +95359,9 @@
 "dDl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -98753,8 +95369,7 @@
 /area/maintenance/aft)
 "dDm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -98768,8 +95383,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -98783,8 +95397,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -98795,8 +95408,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -98813,8 +95425,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -98827,8 +95438,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/aft)
@@ -98840,8 +95450,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -98884,8 +95493,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -98902,8 +95510,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -98920,8 +95527,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -98935,8 +95541,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -98949,8 +95554,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -98962,8 +95566,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -98977,8 +95580,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -99009,7 +95611,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -99109,8 +95710,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -99153,8 +95753,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -99217,8 +95816,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -99301,8 +95899,7 @@
 "dEr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -99365,8 +95962,7 @@
 	id_tag = "sw_maint2_outer";
 	locked = 1;
 	name = "West Maintenance External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -99378,20 +95974,15 @@
 	id_tag = "sw_maint2_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "sw_maint2_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	tag_airpump = "sw_maint2_pump";
 	tag_chamber_sensor = "sw_maint2_sensor";
 	tag_exterior_door = "sw_maint2_outer";
 	tag_interior_door = "sw_maint2_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "sw_maint2_sensor";
-	pixel_x = 0;
 	pixel_y = 33
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -99438,8 +96029,7 @@
 	master_tag = "sw_maint2_airlock";
 	name = "interior access button";
 	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "0"
+	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -99452,12 +96042,10 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -99508,8 +96096,7 @@
 /area/toxins/test_area)
 "dEL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -99519,7 +96106,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -99527,15 +96113,13 @@
 /area/medical/research)
 "dEM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/medical/research)
 "dEN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -99551,8 +96135,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -99561,8 +96144,7 @@
 /area/medical/research)
 "dEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/start{
@@ -99574,8 +96156,7 @@
 /area/medical/research)
 "dEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -99605,17 +96186,14 @@
 "dET" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -99696,8 +96274,7 @@
 /obj/structure/table,
 /obj/item/pen,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
 	dir = 4
@@ -99725,7 +96302,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -99830,8 +96406,7 @@
 "dFs" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/clipboard,
 /obj/item/folder,
@@ -99900,8 +96475,7 @@
 "dFy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = 32
@@ -100085,7 +96659,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -100112,8 +96685,7 @@
 "dFZ" = (
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/toilet{
 	dir = 8
@@ -100132,8 +96704,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/medical/cmo)
@@ -100201,8 +96772,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/computer/card,
 /turf/simulated/floor/plasteel{
@@ -100331,8 +96901,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -100381,9 +96950,7 @@
 	id_tag = "solar_xeno_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_xeno_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "13";
 	tag_airpump = "solar_xeno_pump";
@@ -100392,9 +96959,7 @@
 	tag_interior_door = "solar_xeno_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_xeno_sensor";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -100433,8 +96998,7 @@
 "dGx" = (
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -100514,7 +97078,6 @@
 /obj/structure/table/wood,
 /obj/item/paicard,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/library/abandoned)
@@ -100522,7 +97085,6 @@
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/library/abandoned)
@@ -100573,8 +97135,7 @@
 /area/maintenance/fpmaint2)
 "dGN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plasteel{
@@ -100652,7 +97213,6 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -100677,15 +97237,13 @@
 /area/maintenance/auxsolarstarboard)
 "dGY" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Science Toilet";
-	req_access_txt = "0"
+	name = "Science Toilet"
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/research)
 "dGZ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -100713,7 +97271,6 @@
 	frequency = 1379;
 	master_tag = "viro_lab_airlock_control";
 	name = "Virology Lab Access Button";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "39"
 	},
@@ -100879,8 +97436,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -100944,7 +97500,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/computer/med_data/laptop,
@@ -100976,11 +97531,9 @@
 /obj/structure/table/wood,
 /obj/item/deck/cards,
 /obj/item/deck/cards{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/library/abandoned)
@@ -100989,7 +97542,6 @@
 /obj/item/clipboard,
 /obj/item/folder/red,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/library/abandoned)
@@ -100999,8 +97551,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/library/abandoned)
@@ -101018,8 +97569,7 @@
 "dHy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -101040,12 +97590,10 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -101058,8 +97606,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101084,13 +97631,11 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -101102,8 +97647,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101120,8 +97664,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101137,8 +97680,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -101197,8 +97739,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -101242,8 +97783,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/fpmaint2)
@@ -101268,8 +97808,7 @@
 /obj/item/radio,
 /obj/item/crowbar,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -101301,8 +97840,7 @@
 /area/bridge)
 "dHQ" = (
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/closet/secure_closet,
 /obj/item/storage/secure/briefcase,
@@ -101332,7 +97870,6 @@
 	tag = "icon-pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/primary/aft)
@@ -101341,7 +97878,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/primary/aft)
@@ -101351,7 +97887,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/primary/aft)
@@ -101378,7 +97913,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -101396,8 +97930,7 @@
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
 	id = "starboardsolar";
-	name = "Aft Starboard Solar Control";
-	track = 0
+	name = "Aft Starboard Solar Control"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -101448,8 +97981,7 @@
 /area/medical/virology)
 "dIf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plasteel{
@@ -101492,7 +98024,6 @@
 	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research)
@@ -101574,12 +98105,10 @@
 /area/medical/virology)
 "dIo" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -101612,8 +98141,7 @@
 /area/library/abandoned)
 "dIs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -101628,8 +98156,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -101673,8 +98200,7 @@
 /area/maintenance/fpmaint2)
 "dIB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -101694,8 +98220,7 @@
 /area/medical/research)
 "dID" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -101704,16 +98229,14 @@
 /area/maintenance/fpmaint2)
 "dIE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "dIF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
@@ -101727,8 +98250,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/warning_stripes/south,
@@ -101852,8 +98374,7 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology)
@@ -101865,8 +98386,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -101895,8 +98415,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -101933,15 +98452,13 @@
 /area/medical/virology)
 "dJg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/medical/virology)
 "dJh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = -26;
@@ -101990,8 +98507,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -102137,7 +98653,6 @@
 /area/hallway/secondary/exit)
 "dJC" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -102325,8 +98840,7 @@
 "dKd" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -102336,8 +98850,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -102409,7 +98922,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -102530,9 +99042,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -102546,8 +99056,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -102590,8 +99099,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -102601,8 +99109,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -102704,8 +99211,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -102755,7 +99261,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -102782,8 +99287,6 @@
 	},
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
 	tag = "icon-shower (WEST)"
 	},
 /obj/effect/decal/warning_stripes/southwest,
@@ -102795,7 +99298,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -102831,7 +99333,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/camera{
@@ -102919,7 +99420,6 @@
 /obj/structure/table,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -102958,8 +99458,7 @@
 /area/chapel/main)
 "dLt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -102974,8 +99473,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -102987,8 +99485,7 @@
 "dLv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -103155,7 +99652,6 @@
 "dLP" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -103219,8 +99715,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -103256,8 +99751,7 @@
 "dLW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -103309,7 +99803,6 @@
 "dMc" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -103346,8 +99839,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera{
 	c_tag = "Chapel Backroom";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -103398,8 +99890,7 @@
 "dMo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -103567,8 +100058,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -103588,8 +100078,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -103613,8 +100102,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -103627,8 +100115,7 @@
 "dME" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -103655,7 +100142,6 @@
 	department = "Virology";
 	departmentType = 3;
 	name = "Virology Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -103694,8 +100180,7 @@
 /area/library/abandoned)
 "dML" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -103706,8 +100191,7 @@
 /area/library/abandoned)
 "dMM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -103715,8 +100199,7 @@
 /area/library/abandoned)
 "dMN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -103725,11 +100208,9 @@
 /area/library/abandoned)
 "dMO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Occult Study"
 	},
 /turf/simulated/floor/plasteel{
@@ -103738,8 +100219,7 @@
 /area/library/abandoned)
 "dMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
@@ -103775,17 +100255,14 @@
 "dMS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -103919,7 +100396,6 @@
 /area/medical/virology)
 "dNl" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -103946,8 +100422,7 @@
 "dNo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -103983,7 +100458,6 @@
 "dNs" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -104013,8 +100487,7 @@
 /area/medical/virology)
 "dNv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -104033,7 +100506,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -104121,8 +100593,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -104207,7 +100678,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -104238,7 +100708,6 @@
 "dOb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -104285,8 +100754,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -104301,8 +100769,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Virology";
@@ -104324,8 +100791,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -104358,8 +100824,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -104453,8 +100918,7 @@
 "dOq" = (
 /obj/structure/chair/wood,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -104476,12 +100940,10 @@
 "dOt" = (
 /obj/structure/chair/wood,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
@@ -104501,8 +100963,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -104562,12 +101023,10 @@
 "dOG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -104607,12 +101066,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -104641,7 +101098,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -104665,14 +101121,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock External";
@@ -104692,8 +101146,7 @@
 /area/maintenance/fpmaint2)
 "dOP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -104709,8 +101162,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -104751,8 +101203,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -104797,8 +101248,7 @@
 "dOZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -104824,8 +101274,7 @@
 /area/hallway/secondary/exit)
 "dPc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -104840,8 +101289,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -104850,8 +101298,7 @@
 /area/hallway/secondary/exit)
 "dPe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -104860,8 +101307,7 @@
 /area/hallway/secondary/exit)
 "dPf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -104878,8 +101324,7 @@
 /area/medical/virology)
 "dPj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -104896,8 +101341,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/structure/table,
 /obj/item/crowbar,
@@ -104905,7 +101349,6 @@
 /obj/item/restraints/handcuffs/cable,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -104931,8 +101374,7 @@
 "dPn" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -105104,12 +101546,10 @@
 /area/maintenance/fpmaint2)
 "dPD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -105126,8 +101566,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 100;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/crema_switch{
@@ -105180,8 +101619,7 @@
 "dPK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -105198,8 +101636,7 @@
 "dPM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -105307,8 +101744,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Coroner"
@@ -105352,7 +101788,6 @@
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/command/glass{
 	name = "Auxiliary E.V.A.";
-	req_access_txt = "0";
 	req_one_access_txt = "18"
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -105362,7 +101797,6 @@
 /obj/structure/morgue,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -105378,13 +101812,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Cremator";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -105422,7 +101854,6 @@
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/command/glass{
 	name = "Auxiliary E.V.A.";
-	req_access_txt = "0";
 	req_one_access_txt = "18"
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -105430,7 +101861,7 @@
 /area/maintenance/fpmaint2)
 "dQo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -105472,11 +101903,9 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -105531,8 +101960,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -105624,7 +102052,6 @@
 /obj/effect/decal/warning_stripes/yellow,
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -105641,8 +102068,7 @@
 /obj/item/reagent_containers/dropper,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -105663,8 +102089,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/landmark{
 	name = "blobstart"
@@ -105703,9 +102128,7 @@
 	id_tag = "robotics_solar_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "13";
 	tag_airpump = "robotics_solar_pump";
@@ -105714,7 +102137,6 @@
 	tag_interior_door = "robotics_solar_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "robotics_solar_sensor";
 	pixel_x = 12;
 	pixel_y = -25
@@ -105729,8 +102151,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -105784,8 +102205,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -105836,8 +102256,7 @@
 /area/chapel/office)
 "dQV" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -105884,8 +102303,7 @@
 "dRa" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
@@ -105922,8 +102340,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Aft Port Solar Access";
@@ -106001,7 +102418,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/stack/cable_coil/random,
@@ -106022,8 +102438,7 @@
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
 	id = "portsolar";
-	name = "Aft Port Solar Control";
-	track = 0
+	name = "Aft Port Solar Control"
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
@@ -106039,7 +102454,6 @@
 "dRq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -106056,8 +102470,7 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/clothing/mask/breath,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -106108,8 +102521,7 @@
 /area/maintenance/auxsolarstarboard)
 "dRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -106120,8 +102532,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -106168,8 +102579,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -106229,7 +102639,6 @@
 	tag = ""
 	},
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Chapel Morgue";
 	req_access_txt = "22"
 	},
@@ -106239,7 +102648,6 @@
 /area/chapel/office)
 "dRN" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Confession Booth"
 	},
 /turf/simulated/floor/plasteel{
@@ -106289,8 +102697,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -106309,8 +102716,7 @@
 "dRU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -106381,8 +102787,7 @@
 /area/maintenance/fpmaint2)
 "dSd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
@@ -106411,7 +102816,6 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -106424,7 +102828,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -106433,7 +102836,6 @@
 /area/chapel/office)
 "dSh" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Confession Booth (Chaplain)";
 	req_access_txt = "22"
 	},
@@ -106448,8 +102850,7 @@
 /area/chapel/office)
 "dSj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -106503,8 +102904,7 @@
 /area/maintenance/fpmaint2)
 "dSo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -106534,16 +102934,14 @@
 /area/chapel/office)
 "dSs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "dSt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -106556,8 +102954,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/south,
@@ -106577,8 +102974,7 @@
 /area/maintenance/fpmaint2)
 "dSB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -106591,20 +102987,16 @@
 /obj/machinery/vending/wallmed{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/surgery1)
 "dSD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/south,
@@ -106665,9 +103057,7 @@
 "dSJ" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -106834,8 +103224,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass{
@@ -106892,8 +103281,7 @@
 /area/security/checkpoint)
 "dTj" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -106932,7 +103320,6 @@
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -106961,7 +103348,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -106971,8 +103357,7 @@
 "dTp" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/camera{
-	c_tag = "Chaplain's Quarters";
-	network = list("SS13")
+	c_tag = "Chaplain's Quarters"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -107084,7 +103469,6 @@
 	master_tag = "viro_lab_airlock_control";
 	name = "Virology Lab Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "39"
 	},
 /turf/simulated/floor/plasteel{
@@ -107135,7 +103519,6 @@
 	},
 /obj/item/folder/red,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -107206,8 +103589,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -107248,8 +103630,7 @@
 /area/chapel/office)
 "dUb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -107257,8 +103638,7 @@
 /area/chapel/office)
 "dUc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -107266,8 +103646,7 @@
 /area/chapel/office)
 "dUd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/centcom{
 	name = "Chapel Office";
@@ -107280,8 +103659,7 @@
 /area/chapel/office)
 "dUe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -107305,8 +103683,7 @@
 /area/chapel/office)
 "dUh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/item/paper_bin,
 /obj/structure/table/wood,
@@ -107331,14 +103708,12 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/item/crowbar,
 /obj/item/wrench,
@@ -107617,7 +103992,6 @@
 "dUN" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light_switch{
@@ -107653,12 +104027,10 @@
 "dUQ" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/storage/fancy/candle_box{
 	pixel_x = 2;
@@ -107669,8 +104041,7 @@
 /area/chapel/office)
 "dUR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -107683,8 +104054,7 @@
 "dUS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -107709,7 +104079,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint)
@@ -107745,7 +104114,6 @@
 	},
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -107796,7 +104164,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint)
@@ -107821,7 +104188,6 @@
 /obj/item/restraints/handcuffs,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint)
@@ -107842,7 +104208,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/security/checkpoint)
@@ -107894,8 +104259,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
@@ -107930,8 +104294,7 @@
 /area/security/checkpoint)
 "dVv" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -108037,8 +104400,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/yellow,
@@ -108073,8 +104435,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass{
@@ -108113,8 +104474,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 101;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -108179,8 +104539,6 @@
 /obj/machinery/door_control{
 	id = "xeno1";
 	name = "Containment Control";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /obj/structure/window/reinforced{
@@ -108214,7 +104572,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -108245,8 +104602,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
@@ -108278,8 +104634,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -108295,8 +104650,7 @@
 	id_tag = "arrival_south_inner";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -108328,21 +104682,16 @@
 	id_tag = "arrival_south_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "arrival_south_airlock";
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	tag_airpump = "arrival_south_pump";
 	tag_chamber_sensor = "arrival_south_sensor";
 	tag_exterior_door = "arrival_south_outer";
 	tag_interior_door = "arrival_south_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engineering_west_sensor";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/light/small{
 	dir = 4;
@@ -108358,8 +104707,7 @@
 	id_tag = "arrival_south_outer";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -108404,7 +104752,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -108421,7 +104768,7 @@
 /area/hallway/primary/central)
 "dWQ" = (
 /obj/machinery/light,
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -108503,8 +104850,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/plating/airless,
 /area/medical/virology)
@@ -108544,8 +104890,7 @@
 /area/medical/virology)
 "dXc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -108574,7 +104919,6 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -108601,8 +104945,7 @@
 /area/medical/virology)
 "dXi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -108623,8 +104966,7 @@
 	on = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -108671,8 +105013,7 @@
 /area/maintenance/fpmaint2)
 "dXp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway East";
@@ -108680,7 +105021,6 @@
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -108701,8 +105041,7 @@
 "dXr" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/noticeboard{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
@@ -108724,8 +105063,7 @@
 /area/maintenance/fpmaint2)
 "dXu" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -108758,7 +105096,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light,
@@ -108777,7 +105114,6 @@
 /obj/machinery/camera{
 	c_tag = "Chapel West";
 	dir = 4;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -108787,8 +105123,7 @@
 /area/chapel/main)
 "dXy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -108804,7 +105139,6 @@
 "dXz" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/camera{
@@ -108833,7 +105167,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
@@ -108895,14 +105228,12 @@
 /area/maintenance/portsolar)
 "dXI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Chapel South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -108911,8 +105242,7 @@
 /area/chapel/main)
 "dXJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -108932,8 +105262,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
@@ -108961,7 +105290,6 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -108977,7 +105305,6 @@
 "dXS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -109041,8 +105368,7 @@
 	master_tag = "sw_maint2_airlock";
 	name = "exterior access button";
 	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "0"
+	pixel_y = 24
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -109168,8 +105494,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -109314,12 +105639,10 @@
 	req_access_txt = "39"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -109471,8 +105794,7 @@
 "dYR" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -109481,8 +105803,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -109495,8 +105816,7 @@
 /obj/item/storage/fancy/crayons,
 /obj/machinery/camera{
 	c_tag = "Chaplain's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -109542,7 +105862,6 @@
 	req_access_txt = "3"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -109579,7 +105898,6 @@
 "dZP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -109619,7 +105937,6 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -109646,8 +105963,7 @@
 /area/hallway/secondary/entry)
 "fBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -109657,7 +105973,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -109678,17 +105993,13 @@
 	id_tag = "sol_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "sol_sensor";
 	pixel_x = 12;
 	pixel_y = -25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "sol_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	tag_airpump = "sol_pump";
 	tag_chamber_sensor = "sol_sensor";
 	tag_exterior_door = "sol_outer";
@@ -109735,8 +106046,7 @@
 	id_tag = "sol_inner";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -109758,18 +106068,15 @@
 	id_tag = "sol_outer";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
-	layer = 3.3;
 	master_tag = "sol_airlock";
 	name = "exterior access button";
 	pixel_x = -13;
-	pixel_y = -23;
-	req_access_txt = "0"
+	pixel_y = -23
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -109794,12 +106101,10 @@
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
-	layer = 3.3;
 	master_tag = "sol_airlock";
 	name = "interior access button";
 	pixel_x = -25;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -109813,15 +106118,13 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "vzz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -109837,8 +106140,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -129704,9 +126005,9 @@ aaa
 abi
 abj
 apF
-asU
-asU
-asU
+aEc
+aEc
+aEc
 atc
 atZ
 atZ
@@ -132816,21 +129117,21 @@ aOb
 aOg
 aOg
 aOg
-aXf
+bmN
 aOb
 baj
 aYO
-aXf
+bmN
 aOb
 baj
 aYO
-aXf
+bmN
 aOb
 baj
 aOg
 baj
 aOb
-aXf
+bmN
 aOg
 aOg
 bwP
@@ -138215,11 +134516,11 @@ aUi
 aOb
 aUi
 aYO
-aXf
+bmN
 aOb
 baj
 aYO
-aXf
+bmN
 aOb
 baj
 aOg
@@ -141597,7 +137898,7 @@ cki
 bZM
 bZM
 bZM
-cpI
+ciw
 bZM
 csG
 bZM
@@ -142303,7 +138604,7 @@ apH
 apG
 apG
 apG
-atN
+aKd
 alI
 alI
 aqp
@@ -143588,7 +139889,7 @@ asq
 atp
 alI
 auR
-atN
+aKd
 alI
 ayh
 aze
@@ -144102,7 +140403,7 @@ asr
 aoT
 aoo
 alZ
-atN
+aKd
 awZ
 awZ
 aoH
@@ -144142,7 +140443,7 @@ btD
 buS
 bwb
 baF
-atN
+aKd
 bAn
 bCg
 bDS
@@ -146258,7 +142559,7 @@ dii
 djM
 dkW
 dme
-dnu
+dvi
 doP
 drN
 doP
@@ -147194,7 +143495,7 @@ aBu
 aCw
 aCu
 aDH
-atN
+aKd
 aFA
 aGA
 aHN
@@ -147451,7 +143752,7 @@ aAA
 axe
 axe
 aDH
-atN
+aKd
 aFA
 aGB
 aHN
@@ -153094,7 +149395,7 @@ aqn
 are
 arW
 asJ
-atN
+aKd
 aux
 arW
 alI

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -420,7 +420,6 @@
 /obj/item/plant_analyzer,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/hydroponics/constructable,
@@ -449,7 +448,6 @@
 /area/security/permabrig)
 "acI" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32
 	},
@@ -492,11 +490,9 @@
 /area/security/permabrig)
 "acO" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	icon_state = "pdoor1";
 	id_tag = "SecJusticeChamber";
-	name = "Justice Vent";
-	opacity = 1
+	name = "Justice Vent"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -592,7 +588,6 @@
 	network = list("SS13","Prison")
 	},
 /obj/item/radio/intercom/locked/prison{
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24
 	},
@@ -651,7 +646,6 @@
 /area/security/permabrig)
 "adb" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -662,7 +656,6 @@
 /area/security/permabrig)
 "adc" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -761,8 +754,7 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -869,7 +861,6 @@
 	dir = 8
 	},
 /obj/machinery/sparker{
-	dir = 2;
 	id = "executionburn";
 	pixel_x = -25
 	},
@@ -904,8 +895,7 @@
 /area/security/permabrig)
 "adA" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom";
-	req_access_txt = "0"
+	name = "Unisex Restroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -944,7 +934,6 @@
 /area/security/permabrig)
 "adE" = (
 /obj/item/radio/intercom/locked/prison{
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = -28
 	},
@@ -984,8 +973,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1117,7 +1105,6 @@
 /area/security/permabrig)
 "aeb" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 2;
 	name = "justice injector"
 	},
 /turf/simulated/floor/plasteel{
@@ -1132,7 +1119,6 @@
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "warndark";
 	tag = "icon-warndark"
 	},
@@ -1242,7 +1228,6 @@
 "aev" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -1263,7 +1248,6 @@
 	density = 0;
 	icon_state = "open";
 	id_tag = "executionfireblast";
-	name = "blast door";
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
@@ -1298,7 +1282,6 @@
 	density = 0;
 	icon_state = "open";
 	id_tag = "executionfireblast";
-	name = "blast door";
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
@@ -1316,7 +1299,6 @@
 	density = 0;
 	icon_state = "open";
 	id_tag = "executionfireblast";
-	name = "blast door";
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
@@ -1421,9 +1403,7 @@
 	},
 /area/security/permabrig)
 "aeS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -1499,7 +1479,6 @@
 /obj/machinery/alarm{
 	desc = "This particular atmos control unit appears to have no access restrictions.";
 	dir = 4;
-	icon_state = "alarm0";
 	locked = 0;
 	name = "all-access air alarm";
 	pixel_x = -24;
@@ -1507,7 +1486,6 @@
 	req_one_access = "0"
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "SecJusticeChamber";
 	layer = 4;
 	name = "Justice Vent Control";
@@ -1564,7 +1542,6 @@
 /area/security/permabrig)
 "aeZ" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Prisoner Education Chamber APC";
 	pixel_y = 24
@@ -1593,9 +1570,7 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1639,7 +1614,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -1713,7 +1687,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1757,7 +1730,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -1765,9 +1737,7 @@
 	},
 /area/security/permabrig)
 "afB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1857,7 +1827,6 @@
 /area/shuttle/pod_3)
 "afO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -1908,7 +1877,6 @@
 	pixel_x = 5
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -1962,7 +1930,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -2029,8 +1996,7 @@
 "agc" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -2232,7 +2198,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitered"
 	},
 /area/security/permabrig)
@@ -2245,7 +2210,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitered"
 	},
 /area/security/permabrig)
@@ -2262,7 +2226,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitered"
 	},
 /area/security/permabrig)
@@ -2374,8 +2337,7 @@
 	base_state = "right";
 	dir = 1;
 	icon_state = "right";
-	name = "gas ports";
-	req_access_txt = "0"
+	name = "gas ports"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2387,11 +2349,8 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 1;
-	icon_state = "left";
-	name = "gas ports";
-	req_access_txt = "0"
+	name = "gas ports"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2523,9 +2482,7 @@
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2579,7 +2536,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2671,7 +2627,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2719,11 +2674,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2742,7 +2695,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2768,7 +2720,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2781,7 +2732,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2795,7 +2745,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2827,7 +2776,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2845,7 +2793,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2862,7 +2809,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2871,7 +2817,6 @@
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -2901,7 +2846,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2914,7 +2858,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2939,11 +2882,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hallway Starboard";
-	dir = 2;
 	network = list("SS13","Prison")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2966,11 +2907,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -2987,7 +2926,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -3028,7 +2966,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/permabrig)
@@ -3051,7 +2988,6 @@
 /area/security/armoury)
 "ahV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/machinery/light/small{
@@ -3073,11 +3009,9 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29;
 	pixel_y = 23
@@ -3088,7 +3022,6 @@
 /area/security/hos)
 "ahX" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32;
 	pixel_y = 32
@@ -3121,7 +3054,6 @@
 /area/security/hos)
 "aib" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32;
 	pixel_y = 32
@@ -3141,7 +3073,6 @@
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -3166,7 +3097,6 @@
 "aig" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/machinery/door/window/eastright{
@@ -3304,7 +3234,6 @@
 	pixel_y = -3
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 30
 	},
@@ -3386,7 +3315,6 @@
 "aiC" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
 	pixel_y = -22
 	},
@@ -3442,7 +3370,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -3487,7 +3414,6 @@
 "aiL" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/chair/comfy/black{
@@ -3563,9 +3489,7 @@
 /turf/space,
 /area/solar/auxport)
 "aiS" = (
-/obj/structure/closet/secure_closet/brig{
-	anchored = 1
-	},
+/obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -3693,11 +3617,8 @@
 /turf/simulated/floor/plating,
 /area/security/hos)
 "ajd" = (
-/obj/structure/closet/secure_closet/brig{
-	anchored = 1
-	},
+/obj/structure/closet/secure_closet/brig,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -30
 	},
@@ -3707,9 +3628,7 @@
 	},
 /area/security/permabrig)
 "aje" = (
-/obj/structure/closet/secure_closet/brig{
-	anchored = 1
-	},
+/obj/structure/closet/secure_closet/brig,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -3906,8 +3825,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -3929,8 +3847,7 @@
 "ajC" = (
 /obj/machinery/power/solar_control{
 	id = "foreport";
-	name = "Fore Port Solar Control";
-	track = 0
+	name = "Fore Port Solar Control"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -3940,7 +3857,6 @@
 /area/maintenance/auxsolarport)
 "ajD" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -4226,7 +4142,6 @@
 "akg" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "Armory APC";
 	pixel_x = 1;
 	pixel_y = -24
@@ -4234,8 +4149,7 @@
 /obj/machinery/light,
 /obj/machinery/camera/motion{
 	c_tag = "Armory - Internal";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -4256,7 +4170,6 @@
 	})
 "aki" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness{
@@ -4265,7 +4178,6 @@
 "akj" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness{
@@ -4358,8 +4270,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -4371,7 +4282,6 @@
 	tag = "90Curve"
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/effect/landmark{
@@ -4390,7 +4300,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -4441,8 +4350,7 @@
 "akC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/clothing/head/beret/sec,
 /obj/item/clothing/suit/jacket/pilot,
@@ -4477,8 +4385,7 @@
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Security - EVA Storage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4596,9 +4503,7 @@
 /area/security/podbay)
 "akP" = (
 /obj/machinery/camera{
-	c_tag = "Engineering - Storage";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Engineering - Storage"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/suit_storage_unit/engine/secure,
@@ -4696,8 +4601,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Secure Gear Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/flasher/portable,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -4740,7 +4644,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -4771,9 +4674,7 @@
 	dir = 1
 	},
 /obj/machinery/door/window/eastright{
-	base_state = "right";
 	dir = 8;
-	icon_state = "right";
 	name = "Fitness Ring"
 	},
 /turf/simulated/floor/plasteel{
@@ -5051,8 +4952,7 @@
 "alD" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Control Room";
-	network = list("SS13")
+	c_tag = "Atmospherics - Control Room"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -5060,7 +4960,6 @@
 /area/security/main)
 "alE" = (
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
 	pixel_y = -22
 	},
@@ -5252,7 +5151,6 @@
 	name = "referee suit"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness{
@@ -5374,7 +5272,6 @@
 /area/maintenance/fore)
 "amp" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plating,
@@ -5399,7 +5296,6 @@
 "amr" = (
 /obj/machinery/door/airlock/engineering{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Fore Port Solar Access";
 	req_access_txt = "10"
 	},
@@ -5414,7 +5310,6 @@
 "ams" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -5423,7 +5318,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/mirror{
@@ -5472,7 +5366,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room";
-	req_access_txt = "0";
 	req_one_access_txt = "1;4"
 	},
 /turf/simulated/floor/plasteel,
@@ -5672,8 +5565,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5719,10 +5611,7 @@
 /area/security/main)
 "amP" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
@@ -5752,9 +5641,7 @@
 	},
 /area/security/main)
 "amT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -6054,7 +5941,6 @@
 "anG" = (
 /obj/item/vending_refill/cola,
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plating,
@@ -6150,8 +6036,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -6283,7 +6168,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room";
-	req_access_txt = "0";
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6323,8 +6207,7 @@
 "aog" = (
 /obj/machinery/camera{
 	c_tag = "Security - Office - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6431,8 +6314,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Infirmary";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6509,7 +6391,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -6525,9 +6406,7 @@
 	},
 /area/security/main)
 "aoy" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "vault"
@@ -6556,7 +6435,6 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -6588,8 +6466,7 @@
 /area/security/main)
 "aoI" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6655,7 +6532,6 @@
 	},
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right";
 	layer = 3
 	},
@@ -6688,7 +6564,6 @@
 "aoW" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -6816,9 +6691,7 @@
 	},
 /area/security/brig)
 "apk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6868,9 +6741,7 @@
 	},
 /area/security/warden)
 "app" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7011,8 +6882,7 @@
 "apG" = (
 /obj/machinery/camera{
 	c_tag = "Security - Office - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7052,8 +6922,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7079,9 +6948,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7120,8 +6987,7 @@
 	req_access_txt = "63"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 1;
-	icon_state = "airlock_unres_helper"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7130,8 +6996,7 @@
 /area/security/brig)
 "apQ" = (
 /obj/machinery/sleeper{
-	dir = 4;
-	icon_state = "sleeper-open"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7176,7 +7041,6 @@
 	})
 "apV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -7215,7 +7079,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness{
@@ -7228,7 +7091,6 @@
 /area/security/brig)
 "aqc" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "maintenance access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7313,7 +7175,6 @@
 "aqs" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
-	dir = 4;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
@@ -7379,8 +7240,7 @@
 	base_state = "right";
 	dir = 2;
 	icon_state = "right";
-	name = "windoor";
-	req_access_txt = "0"
+	name = "windoor"
 	},
 /obj/item/book/manual/engineering_hacking,
 /obj/item/tape/random,
@@ -7499,13 +7359,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7547,8 +7405,7 @@
 	})
 "aqP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7556,8 +7413,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7585,8 +7441,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7600,7 +7455,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -7615,8 +7469,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Gear Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7722,8 +7575,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7746,12 +7598,10 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7761,8 +7611,7 @@
 /area/security/evidence)
 "arh" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7798,9 +7647,7 @@
 	},
 /area/security/brig)
 "arl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
@@ -7916,7 +7763,6 @@
 /area/maintenance/disposal)
 "arF" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/machinery/conveyor/east{
@@ -7927,7 +7773,6 @@
 /area/maintenance/disposal)
 "arG" = (
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
@@ -7989,11 +7834,8 @@
 	})
 "arM" = (
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
-	name = "Infirmary";
-	req_access_txt = "0"
+	name = "Infirmary"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -8011,7 +7853,6 @@
 	})
 "arO" = (
 /obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
 	machinedir = 8;
 	pixel_x = 32
 	},
@@ -8088,7 +7929,6 @@
 	pixel_x = -1
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plating,
@@ -8197,7 +8037,6 @@
 	name = "Evidence Closet"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -8303,8 +8142,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -8378,7 +8216,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	sortType = 21;
 	tag = "icon-pipe-j1s (EAST)"
 	},
@@ -8413,7 +8250,6 @@
 /area/security/main)
 "asu" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "1;4;38;12"
 	},
 /turf/simulated/floor/plating,
@@ -8453,7 +8289,6 @@
 /area/security/main)
 "asx" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -8513,7 +8348,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8560,9 +8394,7 @@
 	name = "\improper Recreation Area"
 	})
 "asE" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness{
 	name = "\improper Arcade"
@@ -8572,7 +8404,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness{
@@ -8588,8 +8419,7 @@
 "asK" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8616,8 +8446,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -8653,12 +8482,10 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Infirmary";
-	req_access_txt = "0"
+	name = "Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -8688,8 +8515,7 @@
 "asU" = (
 /obj/machinery/power/solar_control{
 	id = "forestarboard";
-	name = "Fore Starboard Solar Control";
-	track = 0
+	name = "Fore Starboard Solar Control"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -8699,8 +8525,7 @@
 /area/maintenance/auxsolarstarboard)
 "asV" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -8757,7 +8582,6 @@
 /area/maintenance/disposal)
 "atd" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Disposal APC";
 	pixel_y = -24
 	},
@@ -8878,7 +8702,6 @@
 "atp" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -8944,8 +8767,7 @@
 "atw" = (
 /obj/machinery/camera{
 	c_tag = "Security - Gear Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -8957,8 +8779,7 @@
 /area/security/brig)
 "atx" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom";
-	req_access_txt = "0"
+	name = "Unisex Restroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8968,7 +8789,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = "0";
 	req_one_access_txt = "1;4"
 	},
 /turf/simulated/floor/plasteel,
@@ -8978,7 +8798,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = "0";
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9069,7 +8888,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12;
 	pixel_y = 2
 	},
@@ -9148,7 +8966,7 @@
 	name = "\improper Recreation Area"
 	})
 "atS" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness{
 	name = "\improper Arcade"
@@ -9159,7 +8977,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/fitness{
@@ -9255,9 +9072,7 @@
 	dir = 1;
 	location = "Disposals"
 	},
-/obj/structure/plasticflaps{
-	opacity = 0
-	},
+/obj/structure/plasticflaps,
 /obj/machinery/door/window/northright{
 	dir = 2;
 	name = "delivery door";
@@ -9290,8 +9105,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -9303,7 +9117,6 @@
 	tag = "90Curve"
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/effect/landmark{
@@ -9322,7 +9135,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -9492,7 +9304,6 @@
 "auH" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -9566,8 +9377,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -9669,12 +9479,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -9692,8 +9500,7 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Outer Window";
-	req_access_txt = "0"
+	name = "Outer Window"
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -9728,8 +9535,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -9787,8 +9593,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -9796,8 +9601,7 @@
 /area/security/brig)
 "avf" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom";
-	req_access_txt = "0"
+	name = "Unisex Restroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -9831,8 +9635,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -9841,7 +9644,6 @@
 "avj" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -9853,7 +9655,6 @@
 /obj/machinery/door/airlock/security{
 	name = "Interrogation Monitoring";
 	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "1;4"
 	},
 /turf/simulated/floor/plasteel{
@@ -9911,23 +9712,12 @@
 "avp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom";
-	req_access_txt = "0"
+	name = "Unisex Restroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/security/brig)
-"avq" = (
-/obj/machinery/cryopod/right,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/sleep)
 "avr" = (
 /turf/simulated/wall,
 /area/crew_quarters/mrchangs)
@@ -10003,7 +9793,6 @@
 /area/crew_quarters/courtroom)
 "avC" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/effect/landmark{
@@ -10063,7 +9852,6 @@
 "avI" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/hologram/holopad,
@@ -10074,8 +9862,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -10102,7 +9889,6 @@
 	pixel_y = 23
 	},
 /obj/machinery/status_display{
-	density = 0;
 	pixel_y = 32
 	},
 /obj/machinery/conveyor/north{
@@ -10218,9 +10004,7 @@
 /area/engine/gravitygenerator)
 "avW" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Supply Bay Bridge Access";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "Supply Bay Bridge Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10266,8 +10050,7 @@
 /area/crew_quarters/sleep)
 "awb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/conveyor/north{
 	id = "QMLoad2"
@@ -10277,9 +10060,7 @@
 "awc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Supply Bay Bridge Access";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "Supply Bay Bridge Access"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
@@ -10321,7 +10102,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance{
 	name = "Brig Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "63;12"
 	},
 /obj/structure/disposalpipe/segment,
@@ -10353,8 +10133,7 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Labor Camp Desk";
-	req_access_txt = "0"
+	name = "Labor Camp Desk"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -10565,7 +10344,6 @@
 /area/security/brig)
 "awD" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -10701,8 +10479,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -10717,7 +10494,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -10750,9 +10526,7 @@
 /obj/machinery/door_control{
 	id = "supplybridge";
 	name = "Shuttle Bay Space Bridge Control";
-	pixel_y = 27;
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	pixel_y = 27
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
@@ -10787,15 +10561,6 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"axa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
 "axb" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -10824,7 +10589,6 @@
 "axd" = (
 /obj/machinery/door/airlock/engineering{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Fore Starboard Solar Access";
 	req_access_txt = "10"
 	},
@@ -10844,8 +10608,7 @@
 /obj/machinery/door_control{
 	id = "supplybridge";
 	name = "Shuttle Bay Space Bridge Control";
-	pixel_y = 27;
-	req_access_txt = "0"
+	pixel_y = 27
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
@@ -10855,9 +10618,7 @@
 "axf" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10885,18 +10646,15 @@
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Cell Window Control";
-	normaldoorcontrol = 0;
 	pixel_x = -5;
 	pixel_y = -3;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/door_control{
 	id = "briglockdown";
 	name = "Brig Lockdown Control";
 	pixel_x = 5;
-	pixel_y = -3;
-	req_access_txt = "0"
+	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -10955,9 +10713,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -11022,7 +10778,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	sortType = 2
 	},
 /turf/simulated/floor/plating,
@@ -11075,7 +10830,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;63"
 	},
 /turf/simulated/floor/plating,
@@ -11181,9 +10935,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	frequency = 1424;
-	listening = 1;
 	name = "Interrogation Intercom";
 	pixel_y = -31
 	},
@@ -11272,12 +11024,9 @@
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
@@ -11339,7 +11088,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -11427,7 +11175,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -11440,8 +11187,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
@@ -11523,8 +11269,7 @@
 	base_state = "right";
 	dir = 2;
 	icon_state = "right";
-	name = "Reception Window";
-	req_access_txt = "0"
+	name = "Reception Window"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -11593,7 +11338,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room";
-	req_access_txt = "0";
 	req_one_access_txt = "1;4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -11759,7 +11503,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/northeast,
@@ -11818,9 +11561,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Warden's Office";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Warden's Office"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -11839,8 +11580,7 @@
 	id = "armoryshutter";
 	name = "Armory Shutter";
 	pixel_x = 5;
-	pixel_y = -3;
-	req_access_txt = "0"
+	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -11871,8 +11611,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -11882,8 +11621,7 @@
 "azb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -11909,8 +11647,7 @@
 /area/security/brig)
 "azd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
@@ -11934,9 +11671,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "azg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
 "azh" = (
@@ -12070,9 +11805,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "azx" = (
@@ -12161,9 +11894,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -12295,7 +12026,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;50"
 	},
 /turf/simulated/floor/plating,
@@ -12309,7 +12039,6 @@
 "azR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12434,8 +12163,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -12447,7 +12175,6 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -12550,8 +12277,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -12579,8 +12305,7 @@
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -12713,7 +12438,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -12890,7 +12614,6 @@
 "aBh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -12898,8 +12621,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/door_timer{
 	id = "Cell 1";
@@ -12940,7 +12662,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -12988,7 +12709,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
@@ -12997,7 +12717,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -13024,7 +12743,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -13073,12 +12791,9 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
 "aBG" = (
@@ -13130,7 +12845,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -13294,9 +13008,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13451,11 +13163,9 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -13565,9 +13275,7 @@
 "aCA" = (
 /obj/structure/table,
 /obj/item/folder/red,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/item/radio/intercom{
 	broadcasting = 1;
 	frequency = 1424;
@@ -13585,7 +13293,6 @@
 "aCB" = (
 /obj/structure/table/reinforced,
 /obj/structure/closet/fireaxecabinet{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -13732,8 +13439,7 @@
 	req_access_txt = "63"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 1;
-	icon_state = "airlock_unres_helper"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -13758,8 +13464,7 @@
 	req_access_txt = "63"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 1;
-	icon_state = "airlock_unres_helper"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -13909,7 +13614,6 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -13963,9 +13667,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "aDf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -14246,9 +13948,7 @@
 "aDO" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -14528,8 +14228,7 @@
 "aEn" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14593,7 +14292,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -14720,8 +14418,7 @@
 /obj/machinery/door/window/southright{
 	dir = 4;
 	name = "Engineering Deliveries";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -14877,8 +14574,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock{
@@ -14919,13 +14615,10 @@
 	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
-	name = "Outer Window";
-	req_access_txt = "0"
+	name = "Outer Window"
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 4;
 	name = "Security Desk";
 	req_access_txt = "1"
 	},
@@ -15056,8 +14749,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Dock";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/flasher{
 	id = "PRelease";
@@ -15158,9 +14850,7 @@
 "aFr" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -15176,8 +14866,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Detective's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -15219,7 +14908,6 @@
 "aFx" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/computer/secure_data,
@@ -15233,7 +14921,6 @@
 /area/maintenance/fore)
 "aFz" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -15284,7 +14971,6 @@
 "aFE" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/status_display{
-	density = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -15375,7 +15061,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
@@ -15447,12 +15132,10 @@
 	req_access_txt = "48"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -15489,9 +15172,7 @@
 	},
 /area/security/brig)
 "aFY" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15504,14 +15185,11 @@
 /area/engine/engineering)
 "aGb" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering - Fore";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Engineering - Fore"
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -15519,7 +15197,6 @@
 "aGc" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/northwest,
@@ -15551,8 +15228,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
@@ -15674,8 +15350,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -15733,8 +15408,7 @@
 	req_access_txt = "63"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 1;
-	icon_state = "airlock_unres_helper"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15859,8 +15533,7 @@
 	})
 "aGL" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15926,8 +15599,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
@@ -15945,8 +15617,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/tranquillite,
 /turf/simulated/floor/mineral/tranquillite,
@@ -15991,8 +15662,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -16015,9 +15685,7 @@
 	name = "Storage Wing"
 	})
 "aHc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "aHf" = (
@@ -16128,7 +15796,6 @@
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -16144,8 +15811,7 @@
 	req_access_txt = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -16279,7 +15945,6 @@
 /area/security/brig)
 "aHM" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore)
@@ -16348,18 +16013,15 @@
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Cell Window Control";
-	normaldoorcontrol = 0;
 	pixel_x = 5;
 	pixel_y = 27;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/door_control{
 	id = "briglockdown";
 	name = "Brig Lockdown Control";
 	pixel_x = 5;
-	pixel_y = 37;
-	req_access_txt = "0"
+	pixel_y = 37
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -16402,9 +16064,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/machinery/flasher_button{
 	id = "holdingflash";
@@ -16415,11 +16075,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Desk";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29;
 	pixel_y = -2
@@ -16591,8 +16249,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -16842,7 +16499,6 @@
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -16904,8 +16560,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -16998,7 +16653,6 @@
 "aJa" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel,
@@ -17101,8 +16755,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -17178,7 +16831,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light/small{
@@ -17233,8 +16885,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Restrooms";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -17284,11 +16935,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -17318,8 +16967,7 @@
 "aJB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17384,7 +17032,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -17392,9 +17039,7 @@
 /area/engine/equipmentstorage)
 "aJJ" = (
 /obj/effect/spawner/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aJK" = (
@@ -17479,12 +17124,10 @@
 	req_access_txt = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -17508,8 +17151,7 @@
 "aJU" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -17549,8 +17191,7 @@
 "aJZ" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17586,7 +17227,6 @@
 	pixel_x = -5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock{
@@ -17604,7 +17244,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock{
@@ -17641,7 +17280,6 @@
 	})
 "aKi" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;63;48;50"
 	},
 /obj/structure/disposalpipe/segment,
@@ -17738,8 +17376,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -17921,9 +17558,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Fore Primary Hallway Cells";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Fore Primary Hallway Cells"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -17973,14 +17608,12 @@
 /area/hallway/primary/fore)
 "aKI" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
 "aKK" = (
 /obj/item/radio/beacon,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
@@ -17989,7 +17622,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -18049,7 +17681,6 @@
 "aKS" = (
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -18097,7 +17728,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start{
@@ -18143,7 +17773,6 @@
 "aLc" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/newscaster{
@@ -18194,7 +17823,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -18202,7 +17830,6 @@
 /obj/machinery/light/small,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18212,7 +17839,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -18223,7 +17849,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -18536,8 +18161,7 @@
 /area/quartermaster/storage)
 "aLU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -18577,8 +18201,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -18594,7 +18217,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -18612,13 +18234,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -18673,8 +18293,7 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -18714,7 +18333,6 @@
 	req_access_txt = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
@@ -18893,8 +18511,7 @@
 "aMC" = (
 /obj/structure/statue/bananium/clown,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
@@ -18966,9 +18583,7 @@
 	name = "Storage Wing"
 	})
 "aMI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -18980,8 +18595,7 @@
 "aMJ" = (
 /obj/machinery/door/window{
 	dir = 1;
-	name = "glass door";
-	req_access_txt = "0"
+	name = "glass door"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -18990,7 +18604,6 @@
 "aMK" = (
 /obj/machinery/light/small,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Restrooms APC";
 	pixel_y = -26
 	},
@@ -19147,9 +18760,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Bay - Fore";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Cargo Bay - Fore"
 	},
 /obj/structure/sign/double/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -19185,7 +18796,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -19199,9 +18809,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
@@ -19283,7 +18891,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Mining";
-	departmentType = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -19328,8 +18935,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -19348,8 +18954,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/construction/Storage{
@@ -19371,8 +18976,7 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -19447,7 +19051,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
@@ -19468,8 +19071,6 @@
 /area/crew_quarters/courtroom)
 "aNw" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -19499,8 +19100,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Storage Wing - Security Access Door";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -19558,7 +19158,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19619,7 +19218,6 @@
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "Fore Primary Hallway APC";
 	pixel_y = -27
 	},
@@ -19648,7 +19246,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -19688,7 +19285,6 @@
 "aNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -19713,14 +19309,12 @@
 "aNS" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/field/generator{
-	anchored = 0;
 	state = 2
 	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "aNT" = (
 /obj/machinery/field/generator{
-	anchored = 0;
 	state = 2
 	},
 /turf/simulated/floor/plating,
@@ -19731,9 +19325,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering - Secure Storage";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Engineering - Secure Storage"
 	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
@@ -19744,8 +19336,7 @@
 "aNX" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Storage Wing Entrance";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -19773,12 +19364,9 @@
 "aOa" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aOb" = (
@@ -19877,7 +19465,6 @@
 "aOk" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel,
@@ -19928,7 +19515,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -19947,7 +19533,6 @@
 	},
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -19968,7 +19553,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;63;48;50"
 	},
 /turf/simulated/floor/plating,
@@ -19982,7 +19566,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;63;48;50"
 	},
 /turf/simulated/floor/plating,
@@ -20004,7 +19587,6 @@
 	name = "Primary Tool Storage"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
@@ -20061,9 +19643,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -20160,15 +19740,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
 "aOZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -20179,8 +19757,7 @@
 "aPa" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -20200,7 +19777,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
@@ -20283,9 +19859,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Brig - Hallway - Entrance";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig - Hallway - Entrance"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -20324,7 +19898,6 @@
 "aPr" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -20334,8 +19907,7 @@
 "aPs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -20367,12 +19939,10 @@
 	cell_type = 25000;
 	dir = 1;
 	name = "Engineering Engine Super APC";
-	pixel_x = 0;
 	pixel_y = 24;
 	shock_proof = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -20402,7 +19972,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -20544,8 +20113,7 @@
 "aPL" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -20560,12 +20128,10 @@
 	pixel_y = 1
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -20625,7 +20191,6 @@
 "aPS" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -20758,7 +20323,6 @@
 "aQd" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/open/shower,
@@ -20816,7 +20380,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -20839,8 +20402,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -20867,15 +20429,13 @@
 "aQu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "aQv" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/effect/landmark/start{
@@ -20890,7 +20450,6 @@
 	})
 "aQw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/structure/cable/yellow{
@@ -20904,8 +20463,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/camera{
 	c_tag = "Law Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
@@ -20976,12 +20534,10 @@
 /area/engine/engineering)
 "aQG" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -21045,7 +20601,6 @@
 "aQM" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -21181,8 +20736,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -21203,15 +20757,12 @@
 /obj/machinery/door/airlock/engineering/glass{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
 "aRe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -21225,8 +20776,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21318,7 +20868,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/open/shower,
@@ -21337,7 +20886,6 @@
 	},
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower,
@@ -21362,7 +20910,6 @@
 /area/turret_protected/ai_upload)
 "aRB" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Storage Wing APC";
 	pixel_y = -27
 	},
@@ -21388,7 +20935,6 @@
 "aRC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -21429,14 +20975,12 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Storage Wing";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -21520,8 +21064,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -21534,7 +21077,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
@@ -21546,7 +21088,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
@@ -21583,7 +21124,6 @@
 	name = "Judge"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -21591,9 +21131,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Courtroom";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Courtroom"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21646,9 +21184,7 @@
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "aRX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -21902,7 +21438,6 @@
 	pixel_y = -5
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
@@ -21956,7 +21491,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -22000,8 +21534,7 @@
 /area/quartermaster/storage)
 "aSO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -22023,8 +21556,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -22072,9 +21604,7 @@
 	dir = 8
 	},
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 2;
-	icon_state = "left";
 	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access_txt = "16"
@@ -22154,7 +21684,6 @@
 "aTe" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/open/shower,
@@ -22192,7 +21721,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/effect/landmark/start{
@@ -22207,15 +21735,12 @@
 "aTh" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower,
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -22344,7 +21869,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -22431,8 +21955,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
-	name = "Garden";
-	req_access_txt = "0"
+	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22525,8 +22048,7 @@
 /obj/machinery/disposal,
 /obj/machinery/camera{
 	c_tag = "Garden";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -22632,8 +22154,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -22650,8 +22171,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -22669,8 +22189,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -22720,12 +22239,10 @@
 "aUd" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -22742,9 +22259,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "aUf" = (
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -22769,8 +22284,7 @@
 "aUh" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Central";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -22885,11 +22399,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
@@ -22997,7 +22509,6 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -23023,7 +22534,6 @@
 	})
 "aUH" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -23187,8 +22697,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -23226,8 +22735,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -23281,7 +22789,6 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -23312,7 +22819,6 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 30
 	},
@@ -23335,14 +22841,10 @@
 	name = "Port Maintenance"
 	})
 "aVr" = (
-/obj/machinery/disposal{
-	pixel_y = 0
-	},
+/obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
-	c_tag = "Locker Room Starboard";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Locker Room Starboard"
 	},
 /obj/structure/sign/pods{
 	pixel_y = 30
@@ -23393,13 +22895,11 @@
 /obj/structure/table,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/paper_bin{
 	pixel_x = -1;
@@ -23414,7 +22914,6 @@
 /obj/item/aiModule/freeformcore,
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right";
 	name = "Core Modules";
 	req_access_txt = "20"
@@ -23434,7 +22933,6 @@
 "aVx" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "Upload APC";
 	pixel_y = -24
 	},
@@ -23465,8 +22963,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -23488,17 +22985,14 @@
 	network = list("SS13","RD","AIUpload")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "aVA" = (
 /obj/structure/table,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -23553,8 +23047,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -23622,9 +23115,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Crew Quarters Entrance";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Crew Quarters Entrance"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23716,21 +23207,18 @@
 /obj/item/clothing/mask/balaclava,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
 "aVY" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -23823,10 +23311,7 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aWh" = (
-/obj/machinery/camera/autoname{
-	dir = 2;
-	network = list("SS13")
-	},
+/obj/machinery/camera/autoname,
 /obj/machinery/hologram/holopad,
 /obj/machinery/power/apc{
 	dir = 1;
@@ -23865,9 +23350,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "aWk" = (
 /obj/machinery/door_control{
 	id = "lawyer_blast";
@@ -23925,14 +23408,12 @@
 /area/engine/engineering)
 "aWo" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/security/brig)
 "aWp" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/closet/firecloset,
@@ -23949,7 +23430,6 @@
 	})
 "aWr" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32
 	},
@@ -23993,17 +23473,14 @@
 	},
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
 	pixel_x = 30
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Tool Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -24016,7 +23493,6 @@
 /area/maintenance/fore)
 "aWw" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -24177,13 +23653,10 @@
 	on = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -24193,7 +23666,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -24212,7 +23684,6 @@
 	gpstag = "QM0"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -24240,8 +23711,7 @@
 /area/storage/primary)
 "aWU" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -24267,14 +23737,11 @@
 	name = "Engineering Power Monitoring Console"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering - Power Monitoring";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Engineering - Power Monitoring"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -24343,9 +23810,7 @@
 "aXi" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "aXj" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -24365,7 +23830,6 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -24498,18 +23962,14 @@
 "aXB" = (
 /obj/structure/table,
 /obj/item/clipboard,
-/obj/item/stamp/qm{
-	pixel_y = 0
-	},
+/obj/item/stamp/qm,
 /obj/machinery/status_display{
-	density = 0;
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "aXC" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -24520,8 +23980,7 @@
 /obj/structure/table,
 /obj/item/aiModule/reset,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -24546,7 +24005,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32
 	},
@@ -24643,8 +24101,7 @@
 /area/engine/engineering)
 "aXR" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -24686,7 +24143,6 @@
 /area/construction)
 "aXX" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Construction Area APC";
 	pixel_y = -24
 	},
@@ -24709,8 +24165,7 @@
 /area/construction)
 "aXZ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -24763,8 +24218,7 @@
 	opened = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -24808,9 +24262,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "aYo" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad";
@@ -24908,7 +24360,6 @@
 "aYy" = (
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "AI Upload";
 	req_access_txt = "16"
 	},
@@ -25034,13 +24485,11 @@
 	location = "14.2-Central-CrewQuarters"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
 "aYK" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -25054,8 +24503,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -25064,14 +24512,12 @@
 /area/security/brig)
 "aYM" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Locker Room APC";
 	pixel_x = -1;
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -25105,7 +24551,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -25151,8 +24596,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25262,8 +24706,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -25288,7 +24731,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
@@ -25417,13 +24859,11 @@
 /area/quartermaster/storage)
 "aZu" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/conveyor/north{
 	id = "QMLoad"
@@ -25463,9 +24903,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "aZA" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -25501,14 +24939,12 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
 "aZD" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
@@ -25518,7 +24954,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
@@ -25526,7 +24961,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
@@ -25540,7 +24974,6 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
@@ -25553,7 +24986,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
@@ -25657,7 +25089,6 @@
 	name = "Fore Primary Hallway"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
@@ -25670,8 +25101,6 @@
 /area/crew_quarters/courtroom)
 "aZT" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
-	dir = 2;
 	name = "Courtroom APC";
 	pixel_x = 1;
 	pixel_y = -24
@@ -25696,8 +25125,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25714,8 +25142,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25741,7 +25168,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -25754,7 +25180,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -25873,8 +25298,7 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Crate Disposal Chute";
-	req_access_txt = "0"
+	name = "Crate Disposal Chute"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -25933,8 +25357,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -26051,7 +25474,6 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	density = 0;
 	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -26072,12 +25494,10 @@
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
-	layer = 3.3;
 	master_tag = "sol_airlock";
 	name = "interior access button";
 	pixel_x = -25;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -26098,9 +25518,7 @@
 "baK" = (
 /obj/structure/chair,
 /obj/machinery/camera{
-	c_tag = "Arrivals - Fore Arm - Far";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Arrivals - Fore Arm - Far"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -26114,8 +25532,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Courtroom - Gallery";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -26164,7 +25581,6 @@
 /area/crew_quarters/bar)
 "baO" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -26217,8 +25633,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -26228,9 +25643,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "baZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -26238,8 +25651,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -26249,9 +25661,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bba" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -26269,9 +25679,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bbb" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -26283,22 +25691,17 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bbe" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -26306,7 +25709,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
-	req_access_txt = "0";
 	req_one_access_txt = "32;19;70"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26428,9 +25830,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Fore";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Central Primary Hallway - Fore"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -26463,7 +25863,6 @@
 /area/hallway/primary/central)
 "bbt" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -26477,7 +25876,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -26486,7 +25884,6 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -26527,7 +25924,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/locker)
 "bbB" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	tag = "icon-vault"
@@ -26642,9 +26039,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bbQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -26686,8 +26081,7 @@
 "bbT" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -26695,14 +26089,11 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bbV" = (
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Tool Storage APC";
 	pixel_y = -27
 	},
@@ -26826,9 +26217,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -26888,7 +26277,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/engineering)
@@ -26914,7 +26302,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "AI Upload Access APC";
 	pixel_y = -27
 	},
@@ -26974,9 +26361,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -26991,7 +26376,6 @@
 /area/engine/engineering)
 "bcr" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC"
@@ -27084,9 +26468,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bcA" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -27094,9 +26476,7 @@
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bcB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -27126,20 +26506,16 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Break Room";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bcE" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -27184,7 +26560,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;63;48;50"
 	},
 /turf/simulated/floor/plating,
@@ -27266,9 +26641,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -27400,9 +26773,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
 "bda" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -27416,7 +26787,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -27445,9 +26815,7 @@
 	},
 /area/hallway/primary/central)
 "bde" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -27490,11 +26858,8 @@
 	},
 /area/hallway/primary/central)
 "bdh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -27658,13 +27023,11 @@
 "bdu" = (
 /obj/machinery/camera{
 	c_tag = "Mini Satellite AI Chamber North";
-	dir = 2;
 	network = list("SS13","MiniSat")
 	},
 /obj/structure/showcase{
 	density = 0;
 	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
 	name = "Cyborg Statue";
@@ -27679,9 +27042,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/cloning{
-	pixel_x = 0
-	},
+/obj/item/circuitboard/cloning,
 /obj/item/circuitboard/med_data{
 	pixel_x = 3;
 	pixel_y = -3
@@ -27702,7 +27063,6 @@
 /obj/structure/showcase{
 	density = 0;
 	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
 	name = "Cyborg Statue";
@@ -27722,7 +27082,6 @@
 /area/storage/tech)
 "bdy" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -27743,9 +27102,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Chief Engineer's Office";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Chief Engineer's Office"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -27755,7 +27112,6 @@
 "bdB" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -27782,8 +27138,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
-	req_access_txt = "56";
-	req_one_access_txt = "0"
+	req_access_txt = "56"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27795,7 +27150,6 @@
 	pixel_y = 25
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -27816,9 +27170,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Fore - AI Upload";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Central Primary Hallway - Fore - AI Upload"
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH-POWER TURRETS AHEAD'.";
@@ -27836,7 +27188,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -27919,7 +27270,6 @@
 	})
 "bdQ" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -27950,9 +27300,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)
 "bdT" = (
-/obj/machinery/status_display{
-	density = 0
-	},
+/obj/machinery/status_display,
 /turf/simulated/wall,
 /area/quartermaster/storage)
 "bdU" = (
@@ -27991,7 +27339,6 @@
 "bdX" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -28078,7 +27425,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;63;48;50"
 	},
 /turf/simulated/floor/plating,
@@ -28110,7 +27456,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
@@ -28281,8 +27626,7 @@
 	req_access_txt = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -28321,7 +27665,6 @@
 /area/storage/tech)
 "beD" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -28359,7 +27702,6 @@
 /area/storage/tech)
 "beH" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -28396,7 +27738,6 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/engine/chiefs_office)
@@ -28414,9 +27755,7 @@
 /obj/item/folder/red,
 /obj/item/folder/red,
 /obj/item/folder/red,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/item/clothing/glasses/sunglasses/big,
 /turf/simulated/floor/wood,
 /area/lawoffice)
@@ -28683,7 +28022,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;48;50;1"
 	},
 /turf/simulated/floor/plating,
@@ -28701,8 +28039,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -28735,12 +28072,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -28753,7 +28088,6 @@
 "bfo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/structure/cable/yellow{
@@ -28779,8 +28113,7 @@
 "bfq" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -28805,7 +28138,6 @@
 	},
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/effect/decal/warning_stripes/northeast,
@@ -28834,9 +28166,7 @@
 /area/quartermaster/storage)
 "bfw" = (
 /turf/simulated/wall,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bfx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28864,7 +28194,6 @@
 "bfz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/lattice,
@@ -28880,8 +28209,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -28893,14 +28221,12 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "bfD" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -28931,12 +28257,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -28950,8 +28274,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -28970,7 +28293,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -28979,7 +28301,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -28989,7 +28310,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -29011,7 +28331,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -29028,7 +28347,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -29038,13 +28356,11 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "bfS" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -29071,8 +28387,7 @@
 "bfX" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Courtroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -29113,7 +28428,6 @@
 	})
 "bgb" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -27;
 	pixel_y = -29
@@ -29129,8 +28443,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Starboard Corner";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -29180,12 +28493,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Fore Arm";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -29210,8 +28521,7 @@
 /area/maintenance/starboard)
 "bgk" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel{
@@ -29228,12 +28538,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -29261,7 +28568,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -29435,8 +28741,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -29488,7 +28793,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -29534,8 +28838,6 @@
 /area/security/brig)
 "bgK" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -29745,9 +29047,7 @@
 "bhc" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bhd" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -29764,7 +29064,6 @@
 /obj/item/flash,
 /obj/item/flash,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
@@ -29785,9 +29084,7 @@
 	dir = 1;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bhf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -29819,9 +29116,7 @@
 	dir = 1;
 	icon_state = "browncorner"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bhh" = (
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
@@ -29833,22 +29128,17 @@
 	dir = 4;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bhi" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bhj" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/warning_stripes/yellow,
@@ -29876,8 +29166,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Foyer";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -29893,7 +29182,6 @@
 	pixel_y = 32
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -29904,7 +29192,6 @@
 "bhp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -29926,8 +29213,7 @@
 	})
 "bhu" = (
 /obj/machinery/door/airlock{
-	name = "Central Emergency Storage";
-	req_access_txt = "0"
+	name = "Central Emergency Storage"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29945,9 +29231,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -30005,12 +29289,10 @@
 "bhE" = (
 /obj/machinery/camera{
 	c_tag = "Auxiliary Tool Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light/small{
@@ -30215,15 +29497,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bhY" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel{
@@ -30317,7 +29596,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -30328,8 +29606,7 @@
 /area/engine/engineering)
 "bih" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -30448,7 +29725,6 @@
 	})
 "bix" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -30471,9 +29747,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Customs Checkpoint";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Customs Checkpoint"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -30490,7 +29764,6 @@
 /area/atmos)
 "biA" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
@@ -30500,9 +29773,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "biB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -30527,9 +29798,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biE" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -30542,9 +29811,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biF" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -30552,34 +29819,25 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biG" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "packageSort2"
 	},
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biH" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "packageSort2"
 	},
-/obj/structure/plasticflaps{
-	opacity = 0
-	},
+/obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biI" = (
 /obj/structure/rack,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Cargo Bay APC";
 	pixel_x = 1;
 	pixel_y = -24
@@ -30617,35 +29875,27 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biN" = (
 /obj/machinery/computer/supplycomp,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biO" = (
 /obj/effect/landmark{
 	name = "JoinLateCryo"
@@ -30664,14 +29914,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "biR" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -30723,7 +29970,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	sortType = 22
 	},
 /turf/simulated/floor/plasteel,
@@ -30738,7 +29984,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -30841,12 +30086,9 @@
 	dir = 9;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bjg" = (
 /obj/machinery/status_display{
-	density = 0;
 	pixel_y = 32
 	},
 /obj/structure/table,
@@ -30907,8 +30149,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Port Corner";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -30965,7 +30206,6 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/storage/tools)
@@ -30973,7 +30213,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/storage/tools)
@@ -30983,7 +30222,6 @@
 /obj/item/airlock_electronics,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/storage/tools)
@@ -31068,7 +30306,6 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -31088,12 +30325,9 @@
 /area/storage/tech)
 "bjC" = (
 /obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 0
-	},
+/obj/machinery/cell_charger,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/stock_parts/cell/high{
@@ -31115,7 +30349,6 @@
 /area/hallway/primary/central)
 "bjE" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;27;37"
 	},
 /turf/simulated/floor/plating,
@@ -31125,7 +30358,6 @@
 "bjF" = (
 /obj/structure/closet/toolcloset,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
@@ -31141,8 +30373,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -31168,9 +30399,7 @@
 	},
 /area/engine/chiefs_office)
 "bjI" = (
-/obj/structure/closet/secure_closet/engineering_chief{
-	req_access_txt = "0"
-	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -31178,7 +30407,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -31207,7 +30435,6 @@
 "bjL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -31254,12 +30481,10 @@
 /area/turret_protected/ai)
 "bjU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31367,9 +30592,7 @@
 /area/shuttle/arrival/station)
 "bkh" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Shuttle";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Arrivals Shuttle"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -31536,17 +30759,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkv" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Entrance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -31579,9 +30799,7 @@
 	dir = 9;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bky" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	req_access_txt = 1
@@ -31595,7 +30813,6 @@
 "bkz" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31606,17 +30823,14 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkA" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -31624,46 +30838,35 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkB" = (
 /mob/living/simple_animal/pet/sloth/paperwork,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkC" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkD" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkE" = (
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "packageSort2"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial,
 /obj/effect/decal/warning_stripes/arrow,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31692,7 +30895,6 @@
 /area/hallway/primary/central)
 "bkK" = (
 /obj/machinery/status_display{
-	density = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -31702,9 +30904,7 @@
 	dir = 1;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bkL" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -31837,7 +31037,6 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -31866,7 +31065,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/binary/valve{
-	dir = 2;
 	name = "output gas to space"
 	},
 /turf/simulated/floor/plasteel{
@@ -31888,7 +31086,6 @@
 	},
 /obj/structure/chair/comfy/brown{
 	dir = 8;
-	icon_state = "comfychair";
 	tag = "icon-comfychair (WEST)"
 	},
 /turf/simulated/floor/carpet,
@@ -31920,8 +31117,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain{
@@ -31930,7 +31126,6 @@
 "blf" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -31974,8 +31169,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -32024,7 +31218,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "23;30"
 	},
 /obj/structure/cable/yellow{
@@ -32060,12 +31253,9 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bly" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -32093,7 +31283,6 @@
 "blD" = (
 /obj/machinery/camera/motion{
 	c_tag = "Mini Satellite AI Chamber";
-	dir = 2;
 	network = list("SS13","MiniSat");
 	start_active = 1
 	},
@@ -32150,12 +31339,10 @@
 "blI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32
 	},
@@ -32288,7 +31475,6 @@
 "blU" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater";
 	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
@@ -32306,8 +31492,7 @@
 /area/shuttle/arrival/station)
 "blW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -32324,7 +31509,6 @@
 "blX" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/closet,
@@ -32350,7 +31534,6 @@
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
 	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -32417,9 +31600,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bme" = (
 /obj/machinery/space_heater,
 /obj/structure/disposalpipe/wrapsortjunction{
@@ -32436,9 +31617,7 @@
 	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/wall,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmg" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -32454,9 +31633,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -32482,13 +31659,9 @@
 	},
 /area/hallway/primary/port)
 "bmj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -32497,25 +31670,19 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bml" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmm" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -32544,9 +31711,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmo" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/security_unit{
@@ -32561,25 +31726,20 @@
 	name = "\improper Captain's Quarters"
 	})
 "bmp" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -32598,9 +31758,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -32614,9 +31772,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bms" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start{
@@ -32634,9 +31790,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -32657,9 +31811,7 @@
 	dir = 4;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bmu" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -32735,28 +31887,24 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j1"
+	dir = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bmz" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
 "bmA" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/port)
 "bmB" = (
 /obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage";
-	req_access_txt = "0"
+	name = "Starboard Emergency Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -32875,7 +32023,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/locker)
@@ -32972,7 +32119,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mini Satellite AI Chamber South";
-	dir = 2;
 	network = list("SS13","MiniSat")
 	},
 /turf/simulated/floor/bluegrid,
@@ -33160,9 +32306,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway - Tech Storage";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Starboard Primary Hallway - Tech Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33173,9 +32317,7 @@
 	},
 /area/hallway/primary/starboard)
 "bnj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -33295,9 +32437,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bnr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33337,12 +32477,10 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -33429,7 +32567,6 @@
 /area/engine/break_room)
 "bnA" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -33466,7 +32603,6 @@
 "bnF" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -33531,7 +32667,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -33703,7 +32838,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;48;50;1"
 	},
 /turf/simulated/floor/plating,
@@ -33752,33 +32886,25 @@
 "boh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "boi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "boj" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
 	on = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bok" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bol" = (
 /obj/structure/table,
 /obj/item/destTagger{
@@ -33793,9 +32919,7 @@
 	dir = 4;
 	icon_state = "arrival"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bom" = (
 /obj/structure/rack{
 	dir = 8;
@@ -33819,9 +32943,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "boo" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -33892,7 +33014,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	aidisabled = 0;
 	cell_type = 5000;
 	dir = 1;
 	name = "AI Core APC";
@@ -34055,8 +33176,7 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/camera{
 	c_tag = "Custodial Closet";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -34097,7 +33217,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -34115,7 +33234,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34129,7 +33247,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34150,7 +33267,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34168,7 +33284,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34187,7 +33302,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34202,7 +33316,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34214,11 +33327,9 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34233,7 +33344,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34249,7 +33359,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34264,7 +33373,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34285,7 +33393,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34303,7 +33410,6 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34318,7 +33424,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -34382,9 +33487,7 @@
 "bpm" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpn" = (
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -34392,18 +33495,14 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpp" = (
 /obj/effect/landmark{
 	name = "blobstart"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpq" = (
 /obj/structure/table/reinforced,
 /obj/item/phone{
@@ -34431,9 +33530,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -34468,14 +33565,11 @@
 	pixel_y = 12
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -34515,17 +33609,13 @@
 /area/hallway/primary/port)
 "bpD" = (
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34533,7 +33623,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mailroom";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -34541,12 +33630,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpF" = (
 /obj/machinery/status_display{
-	density = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34556,9 +33642,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34599,7 +33683,6 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -34618,9 +33701,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpK" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -34629,12 +33710,9 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpL" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start{
@@ -34647,47 +33725,34 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpN" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Mailroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpO" = (
 /obj/structure/table,
 /obj/item/stack/wrapping_paper,
@@ -34731,12 +33796,9 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpP" = (
 /obj/item/storage/box,
 /obj/structure/table,
@@ -34751,13 +33813,10 @@
 	dir = 6;
 	icon_state = "arrival"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpQ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/item/reagent_containers/glass/bucket,
@@ -34774,36 +33833,26 @@
 "bpR" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpS" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bpU" = (
 /obj/effect/landmark{
 	name = "blobstart"
 	},
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 4;
 	name = "Central Maintenance APC";
 	pixel_x = 26
@@ -34841,13 +33890,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
 "bpY" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -34855,9 +33902,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Central";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bridge - Central"
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
@@ -34868,7 +33913,6 @@
 /obj/structure/table,
 /obj/item/toner,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 30
 	},
@@ -34889,7 +33933,6 @@
 "bqb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -34986,7 +34029,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/machinery/door/window/westright{
@@ -35023,10 +34065,7 @@
 /obj/structure/toilet{
 	pixel_y = 13
 	},
-/obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1"
-	},
+/obj/machinery/light,
 /obj/effect/landmark/start{
 	name = "Captain"
 	},
@@ -35101,7 +34140,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/central)
@@ -35196,8 +34234,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -35229,8 +34266,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Engineering";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -35255,7 +34291,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -35283,7 +34318,6 @@
 /area/engine/break_room)
 "bqP" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -35351,7 +34385,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
-	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -35367,9 +34400,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bqX" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
@@ -35378,7 +34409,6 @@
 /obj/item/pen/multi,
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -35412,7 +34442,6 @@
 /obj/item/pen/multi,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -35498,7 +34527,6 @@
 	})
 "brj" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 2;
 	frequency = 1443;
 	icon_state = "on";
 	id = "air_in";
@@ -35737,9 +34765,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "brH" = (
 /obj/machinery/door/window/eastleft{
 	base_state = "right";
@@ -35749,9 +34775,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "brI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
@@ -35766,26 +34790,20 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "brK" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageExternal";
 	pixel_y = 18
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "brL" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -35826,11 +34844,9 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -36108,9 +35124,7 @@
 	dir = 8;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bsl" = (
 /obj/machinery/light{
 	dir = 4
@@ -36120,7 +35134,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/central)
@@ -36172,9 +35185,7 @@
 	dir = 4;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "bst" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -36204,7 +35215,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -36249,12 +35259,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
 "bsz" = (
@@ -36415,9 +35422,7 @@
 	},
 /obj/machinery/door/window/northleft{
 	dir = 2;
-	icon_state = "left";
-	name = "Reception Window";
-	req_access_txt = "0"
+	name = "Reception Window"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
@@ -36529,8 +35534,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/pod_parts/core,
@@ -36550,7 +35554,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Mechanic Workshop APC";
 	pixel_y = -25
 	},
@@ -36734,7 +35737,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -36749,8 +35751,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -36816,9 +35817,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Port Primary Hallway - Middle";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Port Primary Hallway - Middle"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -36881,7 +35880,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -36927,9 +35925,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36991,8 +35987,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -37027,15 +36022,11 @@
 "btO" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 0
-	},
+/obj/item/storage/firstaid/regular,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Cargo Office APC";
 	pixel_x = 1;
 	pixel_y = -24
@@ -37045,9 +36036,7 @@
 	dir = 10;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "btP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -37070,9 +36059,7 @@
 	dir = 6;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "btS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -37107,7 +36094,6 @@
 	},
 /obj/item/hand_labeler,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/hallway/primary/port)
@@ -37306,8 +36292,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Starboard - Art Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37323,9 +36308,7 @@
 	},
 /area/hallway/primary/central)
 "bul" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door_control{
 	id = "turbinevent";
 	name = "Turbine Vent Control";
@@ -37423,8 +36406,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -37444,9 +36426,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "buv" = (
 /obj/item/storage/box/lights/mixed,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -37499,8 +36479,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Station Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37537,7 +36516,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -37644,7 +36622,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mini Satellite Entrance";
-	dir = 2;
 	network = list("SS13","MiniSat")
 	},
 /obj/machinery/light/small{
@@ -37722,7 +36699,6 @@
 /area/hallway/primary/starboard)
 "buW" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -37749,7 +36725,6 @@
 "buY" = (
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
 /obj/machinery/light_switch{
@@ -37808,7 +36783,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/structure/cable/yellow{
@@ -37826,7 +36800,6 @@
 /obj/structure/showcase{
 	density = 0;
 	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
 	name = "Cyborg Statue";
@@ -37846,8 +36819,7 @@
 	},
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/camera/motion{
 	c_tag = "Mini Satellite Maintenance";
@@ -37888,15 +36860,12 @@
 	})
 "bvg" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/structure/showcase{
 	density = 0;
 	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
 	name = "Cyborg Statue";
@@ -38001,7 +36970,6 @@
 	})
 "bvo" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -38056,8 +37024,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38065,7 +37032,6 @@
 /area/bridge)
 "bvs" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32
 	},
@@ -38080,8 +37046,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -38111,9 +37076,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Engineering - Transit Tube Access";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Engineering - Transit Tube Access"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38188,8 +37151,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Lounge";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
@@ -38343,7 +37305,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	sortType = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38503,7 +37464,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -38566,8 +37526,7 @@
 /obj/structure/cable/yellow,
 /obj/machinery/camera{
 	c_tag = "Bridge - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -38623,7 +37582,6 @@
 /area/storage/tools)
 "bwm" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -38657,9 +37615,7 @@
 /obj/item/stack/packageWrap,
 /obj/item/gun/projectile/revolver/doublebarrel,
 /obj/machinery/camera{
-	c_tag = "Maltese Falcon - Backroom";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Maltese Falcon - Backroom"
 	},
 /obj/item/eftpos,
 /turf/simulated/floor/wood,
@@ -38907,7 +37863,6 @@
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
@@ -38930,7 +37885,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
-	icon_state = "pipe-j1s";
 	sortType = 19
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -38967,7 +37921,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -38991,8 +37944,7 @@
 	icon_state = "W-NE-SE"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -39007,16 +37959,14 @@
 	tag = "icon-D-NE"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "bwY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -39038,8 +37988,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -39050,12 +37999,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/transit_tube/station{
 	dir = 4;
-	icon_state = "closed";
 	tag = "icon-closed (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -39090,9 +38037,6 @@
 /area/engine/break_room)
 "bxe" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -39169,7 +38113,6 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Engineering Foyer APC";
 	pixel_x = -1;
 	pixel_y = -26
@@ -39567,8 +38510,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -39598,8 +38540,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Civilian"
@@ -39609,7 +38550,7 @@
 	},
 /area/hallway/primary/port)
 "bxP" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -39630,14 +38571,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port)
 "bxS" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -39699,7 +38637,6 @@
 	req_access_txt = "57"
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -39729,8 +38666,7 @@
 "byd" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -39794,9 +38730,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
 "byj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -39837,7 +38771,6 @@
 /area/crew_quarters/heads)
 "byn" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/carpet,
@@ -39897,8 +38830,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Command Chair";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -39917,7 +38849,6 @@
 /area/bridge)
 "byu" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -39928,7 +38859,6 @@
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -39969,7 +38899,6 @@
 /area/bridge)
 "byy" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
@@ -40071,8 +39000,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
@@ -40089,7 +39017,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "20;12"
 	},
 /turf/simulated/floor/plating,
@@ -40170,7 +39097,6 @@
 /area/crew_quarters/bar)
 "byL" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/effect/landmark{
@@ -40193,7 +39119,6 @@
 "byN" = (
 /obj/structure/closet/gmcloset{
 	desc = "It's a storage unit.";
-	icon_state = "black";
 	name = "spare gear"
 	},
 /obj/item/wrench,
@@ -40213,7 +39138,6 @@
 /area/maintenance/starboard)
 "byP" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 8;
 	name = "Barber APC";
 	pixel_x = -25
@@ -40257,7 +39181,6 @@
 "byV" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Foyer Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "32;19"
 	},
 /turf/simulated/floor/plating,
@@ -40267,11 +39190,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/engine/break_room)
@@ -40282,14 +39203,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/engine/break_room)
@@ -40302,7 +39221,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -30
 	},
@@ -40331,7 +39249,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "blackcorner"
 	},
 /area/hallway/primary/starboard)
@@ -40505,8 +39422,7 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -40520,8 +39436,7 @@
 "bzn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -40554,8 +39469,7 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40569,8 +39483,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -40642,9 +39555,7 @@
 	name = "Arrivals"
 	})
 "bzz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
@@ -40686,8 +39597,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40710,8 +39620,7 @@
 /area/hallway/primary/port)
 "bzF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40736,7 +39645,6 @@
 /area/hallway/primary/port)
 "bzJ" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;27;37"
 	},
 /obj/structure/cable/yellow{
@@ -40762,7 +39670,6 @@
 	name = "Library"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpetsymbol"
 	},
 /area/library)
@@ -40776,7 +39683,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpetsymbol"
 	},
 /area/library)
@@ -40809,7 +39715,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	sortType = 15
 	},
 /obj/structure/cable/yellow{
@@ -40835,7 +39740,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -41080,8 +39984,7 @@
 "bAq" = (
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "carpet10-8";
@@ -41114,8 +40017,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -41133,7 +40035,6 @@
 "bAt" = (
 /obj/structure/transit_tube/station{
 	dir = 8;
-	icon_state = "closed";
 	tag = "icon-closed (EAST)"
 	},
 /obj/structure/window/reinforced{
@@ -41200,7 +40101,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
 /mob/living/simple_animal/bot/cleanbot{
@@ -41316,7 +40216,6 @@
 	pixel_y = -24
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 5;
 	pixel_y = -26
@@ -41340,8 +40239,7 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -41357,7 +40255,6 @@
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "MiniSat Maintenance APC";
 	pixel_y = -24
 	},
@@ -41440,11 +40337,9 @@
 "bBd" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "AI Satellite Exterior APC";
 	pixel_y = -24
 	},
@@ -41520,7 +40415,6 @@
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 5;
 	pixel_y = -26
@@ -41558,18 +40452,14 @@
 	})
 "bBl" = (
 /turf/simulated/wall/r_wall,
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bBm" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 0
-	},
+/obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -41644,7 +40534,6 @@
 	})
 "bBu" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = -32
 	},
@@ -41720,9 +40609,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -41801,7 +40688,6 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -41926,9 +40812,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/item/storage/lockbox/medal{
-	pixel_y = 0
-	},
+/obj/item/storage/lockbox/medal,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
@@ -41962,9 +40846,7 @@
 	})
 "bCh" = (
 /obj/machinery/camera{
-	c_tag = "Council Chamber";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Council Chamber"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -41973,7 +40855,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -42065,7 +40946,6 @@
 	},
 /obj/structure/chair/comfy/brown{
 	dir = 4;
-	icon_state = "comfychair";
 	tag = "icon-comfychair (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -42094,9 +40974,7 @@
 	name = "\improper Captain's Quarters"
 	})
 "bCq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -42108,7 +40986,6 @@
 	},
 /obj/structure/chair/comfy/brown{
 	dir = 8;
-	icon_state = "comfychair";
 	tag = "icon-comfychair (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -42157,14 +41034,12 @@
 	pixel_x = 29
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/engine/break_room)
@@ -42285,9 +41160,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bCG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -42313,7 +41186,6 @@
 /obj/machinery/computer/arcade,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -42335,7 +41207,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -42393,7 +41264,6 @@
 /area/atmos)
 "bCW" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "AI Satellite Teleporter APC";
 	pixel_y = -24
 	},
@@ -42407,7 +41277,6 @@
 	})
 "bCX" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkbluecorners"
 	},
 /area/turret_protected/aisat_interior{
@@ -42458,14 +41327,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bDd" = (
 /obj/structure/showcase{
 	density = 0;
 	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
 	name = "Cyborg Statue";
@@ -42474,9 +41340,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bDe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
@@ -42488,14 +41352,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bDf" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 31
 	},
@@ -42504,9 +41365,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bDg" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -42514,7 +41373,6 @@
 /obj/structure/showcase{
 	density = 0;
 	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
 	name = "Cyborg Statue";
@@ -42523,9 +41381,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bDh" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42547,20 +41403,16 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bDi" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /mob/living/simple_animal/bot/floorbot{
 	on = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkbluecorners"
 	},
 /area/turret_protected/aisat_interior{
@@ -42575,9 +41427,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bDk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -42681,8 +41531,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Port Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42712,23 +41561,19 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "bDu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry{
@@ -42747,7 +41592,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry{
@@ -42764,7 +41608,6 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -42790,7 +41633,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -42803,7 +41645,6 @@
 "bDz" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -42828,8 +41669,7 @@
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -42838,15 +41678,13 @@
 "bDB" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -42867,8 +41705,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -42890,8 +41727,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -42916,8 +41752,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Auxiliary Bathrooms";
-	req_access_txt = "0"
+	name = "Auxiliary Bathrooms"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -42925,8 +41760,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -42949,8 +41783,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -42979,7 +41812,6 @@
 /obj/machinery/vending/cigarette,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
@@ -43047,7 +41879,6 @@
 /area/library)
 "bDO" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -43057,7 +41888,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -43087,8 +41917,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -43214,8 +42043,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43223,8 +42051,7 @@
 /area/bridge)
 "bEg" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/firealarm{
@@ -43269,7 +42096,6 @@
 "bEk" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4;
-	icon_state = "comfychair";
 	tag = "icon-comfychair (EAST)"
 	},
 /turf/simulated/floor/carpet,
@@ -43286,7 +42112,6 @@
 "bEm" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8;
-	icon_state = "comfychair";
 	tag = "icon-comfychair (WEST)"
 	},
 /turf/simulated/floor/carpet,
@@ -43296,12 +42121,10 @@
 "bEn" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "carpet11-12";
@@ -43312,9 +42135,7 @@
 	})
 "bEo" = (
 /obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bar"
 	},
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -43525,7 +42346,6 @@
 	})
 "bEK" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -43560,8 +42380,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Control Room";
-	network = list("SS13")
+	c_tag = "Atmospherics - Control Room"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -43598,7 +42417,6 @@
 /area/crew_quarters/bar)
 "bEP" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -43611,9 +42429,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Club - Fore";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Club - Fore"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -43649,8 +42465,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Middle Arm";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atm{
 	pixel_y = -32
@@ -43680,7 +42495,6 @@
 /area/bridge)
 "bEU" = (
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "wloop_atm_meter";
 	name = "Waste Loop"
 	},
@@ -43708,7 +42522,6 @@
 /area/atmos)
 "bEW" = (
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "dloop_atm_meter";
 	name = "Distribution Loop"
 	},
@@ -43721,7 +42534,6 @@
 "bEX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 1;
-	icon_state = "map";
 	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
@@ -43734,8 +42546,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Distro Loop";
-	network = list("SS13")
+	c_tag = "Atmospherics - Distro Loop"
 	},
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	dir = 8;
@@ -43764,8 +42575,7 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -43800,19 +42610,15 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bFe" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Middle Arm - Far";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -43824,7 +42630,6 @@
 	name = "Grid Power Monitoring Computer"
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 5;
 	pixel_y = -26
@@ -43864,9 +42669,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bFj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43874,9 +42677,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bFk" = (
 /obj/structure/transit_tube{
 	icon_state = "E-W-Pass"
@@ -43906,9 +42707,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bFn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43936,8 +42735,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
-	name = "Port Emergency Storage";
-	req_access_txt = "0"
+	name = "Port Emergency Storage"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
@@ -43961,7 +42759,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpetsymbol"
 	},
 /area/security/vacantoffice)
@@ -44015,8 +42812,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	req_access_txt = 1
@@ -44031,22 +42827,18 @@
 /area/library)
 "bFy" = (
 /obj/machinery/door/morgue{
-	name = "Study #1";
-	req_access_txt = "0"
+	name = "Study #1"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
 /area/library)
 "bFz" = (
 /obj/machinery/door/morgue{
-	name = "Study #2";
-	req_access_txt = "0"
+	name = "Study #2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -44054,7 +42846,6 @@
 "bFA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -44063,8 +42854,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -44119,7 +42909,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = -32
 	},
@@ -44147,7 +42936,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -25
 	},
@@ -44189,7 +42977,6 @@
 "bFM" = (
 /obj/structure/chair/comfy/teal{
 	dir = 4;
-	icon_state = "comfychair";
 	tag = "icon-comfychair (EAST)"
 	},
 /obj/structure/chair/comfy/black{
@@ -44232,7 +43019,6 @@
 "bFS" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/vending/cigarette{
@@ -44293,7 +43079,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = -32
 	},
@@ -44346,7 +43131,6 @@
 /obj/item/cigbutt,
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "Port Maintenance APC";
 	pixel_y = -24
 	},
@@ -44487,7 +43271,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/clothing/head/sombrero,
@@ -44503,8 +43286,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Atmospherics";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44520,7 +43302,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -44559,7 +43340,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -44568,7 +43348,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -44580,13 +43359,11 @@
 	name = "Life Support Specialist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
 "bGz" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -44610,8 +43387,7 @@
 /area/atmos)
 "bGA" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -44653,7 +43429,6 @@
 "bGD" = (
 /obj/machinery/space_heater,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -44675,8 +43450,7 @@
 "bGH" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Mix to Distro";
-	on = 0
+	name = "Mix to Distro"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -44756,7 +43530,6 @@
 "bGQ" = (
 /obj/machinery/camera{
 	c_tag = "Toxins - Launch Area";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -44802,9 +43575,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bGU" = (
 /obj/machinery/shieldwallgen{
 	req_access = list(55)
@@ -44826,8 +43597,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Entrance";
-	network = list("SS13")
+	c_tag = "Atmospherics - Entrance"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -44882,9 +43652,7 @@
 	name = "Port Maintenance"
 	})
 "bHe" = (
-/obj/machinery/atmospherics/unary/thermomachine/heater/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/thermomachine/heater/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -44917,9 +43685,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bHj" = (
 /obj/structure/table/wood,
 /obj/item/camera_film{
@@ -45001,7 +43767,6 @@
 	})
 "bHq" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -45041,7 +43806,6 @@
 /area/library)
 "bHv" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -45051,9 +43815,7 @@
 	name = "\improper Command Hallway"
 	})
 "bHw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/library)
 "bHx" = (
@@ -45185,7 +43947,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "20;12"
 	},
 /turf/simulated/floor/plating,
@@ -45257,9 +44018,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bHT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -45327,7 +44086,6 @@
 /area/atmos)
 "bId" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -45338,18 +44096,15 @@
 	name = "External to Filter"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
 "bIf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -45444,8 +44199,7 @@
 "bIr" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Air to Mix";
-	on = 0
+	name = "Air to Mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -45529,9 +44283,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bIA" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
@@ -45540,9 +44292,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bIB" = (
 /obj/structure/filingcabinet{
 	pixel_x = 3
@@ -45550,9 +44300,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bID" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter/zippo,
@@ -45648,7 +44396,6 @@
 /obj/structure/table/wood,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/folder/red,
@@ -45677,7 +44424,6 @@
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	pixel_y = -24
 	},
@@ -45755,7 +44501,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -45913,9 +44658,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bJm" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -45936,9 +44679,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bJn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46147,7 +44888,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
@@ -46180,9 +44920,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -46233,9 +44971,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/bar)
 "bJH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -46303,14 +45039,12 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre - Stage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -46342,7 +45076,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -46361,7 +45094,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -46416,7 +45148,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plasteel,
@@ -46563,9 +45294,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bKo" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -46603,7 +45332,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/machinery/camera/motion{
@@ -46757,7 +45485,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -47017,7 +45744,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47036,7 +45762,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47054,7 +45779,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47075,7 +45799,6 @@
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47088,7 +45811,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47110,7 +45832,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47121,7 +45842,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -47152,7 +45872,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47168,7 +45887,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47191,7 +45909,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47208,7 +45925,6 @@
 	name = "Command Hallway"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -47261,7 +45977,6 @@
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -47346,9 +46061,7 @@
 	},
 /area/crew_quarters/bar)
 "bLA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -47389,8 +46102,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -47401,7 +46113,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry{
@@ -47409,7 +46120,6 @@
 	})
 "bLD" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;27"
 	},
 /obj/structure/cable/yellow{
@@ -47423,7 +46133,6 @@
 	})
 "bLF" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/wood,
@@ -47481,7 +46190,6 @@
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi';
 	name = "Theatre Stage";
-	req_access_txt = "0";
 	req_one_access_txt = "12;46"
 	},
 /obj/structure/cable/yellow{
@@ -47540,7 +46248,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -47576,7 +46283,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -47601,7 +46307,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -47614,7 +46319,6 @@
 	name = "Air to External"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -47630,7 +46334,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "blackcorner"
 	},
 /area/atmos)
@@ -47743,8 +46446,7 @@
 "bMe" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Pure to Mix";
-	on = 0
+	name = "Pure to Mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47758,8 +46460,7 @@
 	tag = "icon-intact-g (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -47851,7 +46552,6 @@
 /area/space/nearstation)
 "bMo" = (
 /obj/machinery/door/window/southleft{
-	dir = 2;
 	name = "Maximum Security Test Chamber";
 	req_access_txt = "55"
 	},
@@ -47954,9 +46654,7 @@
 	name = "\improper Secure Lab"
 	})
 "bMv" = (
-/obj/structure/disposaloutlet{
-	dir = 2
-	},
+/obj/structure/disposaloutlet,
 /turf/simulated/floor/engine,
 /area/toxins/xenobiology{
 	name = "\improper Secure Lab"
@@ -47968,8 +46666,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -48007,14 +46704,11 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/machinery/camera{
-	c_tag = "Command Hallway - Starboard";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Command Hallway - Starboard"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -48031,7 +46725,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -48089,7 +46782,6 @@
 "bML" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;37"
 	},
 /turf/simulated/floor/plating,
@@ -48148,12 +46840,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room{
@@ -48263,7 +46953,6 @@
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -48303,7 +46992,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32
 	},
@@ -48335,7 +47023,6 @@
 /area/crew_quarters/kitchen)
 "bNo" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;17"
 	},
 /obj/structure/cable/yellow{
@@ -48359,7 +47046,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -48453,8 +47139,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen - Coldroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -48544,7 +47229,6 @@
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Inner Pipe Access";
 	req_access_txt = "24"
 	},
@@ -48554,12 +47238,10 @@
 	pixel_y = 1
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48702,7 +47384,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
-	req_access_txt = "0";
 	req_one_access_txt = "17;19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -48721,7 +47402,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -48738,7 +47418,6 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock{
@@ -48769,7 +47448,6 @@
 "bOk" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/effect/decal/cleanable/blood,
@@ -48813,7 +47491,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
@@ -49008,7 +47685,6 @@
 	pixel_y = -3
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -49033,8 +47709,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command Hallway - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -49053,7 +47728,6 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/bridge/meeting_room{
@@ -49084,8 +47758,7 @@
 "bOO" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Mix";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine{
 	name = "vacuum floor";
@@ -49175,14 +47848,12 @@
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
 "bOX" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/machinery/door_control{
@@ -49190,7 +47861,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/item/soap/nanotrasen,
@@ -49216,8 +47886,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Kitchen Hatch";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -49245,7 +47914,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
@@ -49260,8 +47928,7 @@
 	base_state = "right";
 	dir = 8;
 	icon_state = "right";
-	name = "Theatre Stage";
-	req_access_txt = "0"
+	name = "Theatre Stage"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/theatre)
@@ -49320,9 +47987,7 @@
 	name = "\improper Secure Lab"
 	})
 "bPl" = (
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Secure Lab - Test Chamber";
 	dir = 1;
@@ -49375,7 +48040,6 @@
 /obj/item/flashlight,
 /obj/structure/closet/crate,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -49473,7 +48137,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -49548,9 +48211,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bPK" = (
 /obj/structure/table,
 /obj/item/assembly/igniter{
@@ -49604,7 +48265,6 @@
 	})
 "bPN" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;27;37"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49643,7 +48303,6 @@
 	})
 "bPR" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -49861,9 +48520,7 @@
 /turf/simulated/floor/plating,
 /area/gateway)
 "bQn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/blueshield)
 "bQp" = (
@@ -49881,9 +48538,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/ntrep)
 "bQx" = (
@@ -49973,7 +48628,6 @@
 /area/gateway)
 "bQE" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -50004,7 +48658,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -50089,19 +48742,19 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bQP" = (
-/obj/machinery/vending/snack,
 /obj/machinery/newscaster{
 	pixel_y = -29
 	},
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bQQ" = (
-/obj/machinery/vending/coffee,
+/obj/structure/table/wood,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bQR" = (
@@ -50110,8 +48763,7 @@
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "N2O to Pure";
-	on = 0
+	name = "N2O to Pure"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
@@ -50209,24 +48861,21 @@
 "bRd" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Air to Port";
-	on = 0
+	name = "Air to Port"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bRe" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Mix to Port";
-	on = 0
+	name = "Mix to Port"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bRf" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Pure to Port";
-	on = 0
+	name = "Pure to Port"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -50298,9 +48947,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
-/area/tcommsat/computer{
-	name = "\improper Telecoms Control Room"
-	})
+/area/tcommsat/computer)
 "bRp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -50424,8 +49071,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -50571,7 +49217,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -50645,7 +49290,6 @@
 	})
 "bRT" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -50802,14 +49446,12 @@
 "bSj" = (
 /obj/machinery/camera{
 	c_tag = "Club - Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -29
 	},
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/structure/table/wood,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bSk" = (
@@ -50985,7 +49627,6 @@
 "bSA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32
 	},
@@ -51031,7 +49672,6 @@
 "bSE" = (
 /obj/machinery/camera{
 	c_tag = "Morgue";
-	dir = 2;
 	network = list("SS13","Medbay")
 	},
 /obj/structure/window/reinforced{
@@ -51061,9 +49701,7 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/obj/item/clothing/shoes/magboots{
-	pixel_y = 0
-	},
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/shoes/magboots{
 	pixel_x = 4;
 	pixel_y = -3
@@ -51175,8 +49813,7 @@
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Disposals Chute";
-	pixel_x = -1;
-	req_access_txt = "0"
+	pixel_x = -1
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 8;
@@ -51211,14 +49848,12 @@
 /area/atmos)
 "bSW" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Starboard - Kitchen";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -51227,7 +49862,6 @@
 /area/hallway/primary/central)
 "bSX" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light/small{
@@ -51243,8 +49877,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51322,11 +49955,9 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -51341,8 +49972,7 @@
 /obj/item/radio,
 /obj/machinery/camera{
 	c_tag = "Engineering Equipment East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51553,8 +50183,7 @@
 /obj/item/folder,
 /obj/item/folder,
 /obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
@@ -51603,7 +50232,6 @@
 	},
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -51635,8 +50263,7 @@
 "bTH" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm - Far";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -51676,14 +50303,12 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
 "bTL" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -51696,7 +50321,6 @@
 "bTO" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -51716,12 +50340,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/theatre)
 "bTR" = (
-/obj/structure/closet/secure_closet/medical1{
-	pixel_x = 0
-	},
+/obj/structure/closet/secure_closet/medical1,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -51789,7 +50410,6 @@
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -51848,7 +50468,6 @@
 	},
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -51911,14 +50530,12 @@
 "bUo" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Central";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -51966,16 +50583,14 @@
 "bUu" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2O";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "bUv" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Mix to Port";
-	on = 0
+	name = "Mix to Port"
 	},
 /obj/item/crowbar,
 /turf/simulated/floor/plasteel,
@@ -51984,7 +50599,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
 	name = "Inner Pipe Access";
 	req_access_txt = "24"
 	},
@@ -52040,7 +50654,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/machinery/camera/motion{
@@ -52105,7 +50718,6 @@
 	opacity = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpetsymbol"
 	},
 /area/library)
@@ -52125,7 +50737,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "carpetsymbol"
 	},
 /area/library)
@@ -52135,7 +50746,6 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -52175,7 +50785,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -52207,8 +50816,7 @@
 	})
 "bUQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52251,8 +50859,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52281,7 +50888,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -25
 	},
@@ -52371,8 +50977,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/east,
@@ -52391,13 +50996,11 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_tele,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Teleporter Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -52411,8 +51014,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway - Atrium";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -52436,7 +51038,6 @@
 "bVi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "1;4;38;12"
 	},
 /turf/simulated/floor/plating,
@@ -52476,7 +51077,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division - Airlock";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -52512,8 +51112,7 @@
 /area/crew_quarters/sleep)
 "bVn" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -52581,7 +51180,6 @@
 	},
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -52810,8 +51408,7 @@
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Air to Port";
-	on = 0
+	name = "Air to Port"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -52846,9 +51443,7 @@
 	pixel_x = 4;
 	pixel_y = -1
 	},
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_y = 0
-	},
+/obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide{
 	pixel_x = -4;
 	pixel_y = 1
@@ -52988,7 +51583,6 @@
 "bWh" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/cable/yellow{
@@ -53013,8 +51607,7 @@
 "bWj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Vacant Office Maintenance";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /turf/simulated/floor/plating,
 /area/security/vacantoffice)
@@ -53109,7 +51702,6 @@
 "bWx" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -53130,7 +51722,6 @@
 "bWz" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -53290,7 +51881,6 @@
 	announcementConsole = 1;
 	department = "NT Representative";
 	departmentType = 5;
-	dir = 2;
 	name = "NT Rep Requests Console";
 	pixel_x = 30
 	},
@@ -53326,7 +51916,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
-	icon_state = "pipe-j1s";
 	sortType = 18
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -53478,8 +52067,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Plasma to Pure";
-	on = 0
+	name = "Plasma to Pure"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53566,8 +52154,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre - Backstage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
@@ -53649,7 +52236,6 @@
 	},
 /obj/item/clothing/under/suit_jacket/red,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -53701,7 +52287,6 @@
 	tag = "icon-plant-14"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -53769,7 +52354,6 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -53809,16 +52393,13 @@
 	},
 /area/crew_quarters/locker)
 "bXR" = (
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/item/camera,
 /obj/item/radio/intercom{
 	pixel_y = -25
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -53828,7 +52409,6 @@
 	name = "Forbidden Knowledge"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -53882,14 +52462,12 @@
 	},
 /obj/machinery/processor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bXY" = (
 /obj/machinery/computer/teleporter,
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plating,
@@ -53946,8 +52524,7 @@
 /obj/item/flashlight/lamp,
 /obj/machinery/camera{
 	c_tag = "Blueshield's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
@@ -53983,8 +52560,7 @@
 "bYg" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -54047,8 +52623,7 @@
 "bYn" = (
 /obj/machinery/camera{
 	c_tag = "NT Representative's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/machinery/newscaster/security_unit{
@@ -54069,7 +52644,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -54206,7 +52780,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -54215,7 +52788,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -54237,7 +52809,6 @@
 "bYE" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -54494,7 +53065,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -24
 	},
@@ -54502,7 +53072,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -54523,8 +53092,7 @@
 /obj/item/kitchen/rollingpin,
 /obj/machinery/camera{
 	c_tag = "Kitchen";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/door_control{
 	id = "kitchenhydro";
@@ -54533,7 +53101,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -54635,8 +53202,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -54653,7 +53219,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;17"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54667,7 +53232,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/primary/central)
@@ -54742,13 +53306,11 @@
 "bZD" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway - Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
@@ -54796,9 +53358,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bZH" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -54829,16 +53389,14 @@
 "bZL" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Port to Filter";
-	on = 0
+	name = "Port to Filter"
 	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -54852,8 +53410,7 @@
 "bZN" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Toxins";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine/plasma,
 /area/atmos)
@@ -54951,8 +53508,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/storage/pill_bottle/dice,
 /obj/structure/table/wood,
@@ -54991,7 +53547,6 @@
 "cad" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;37"
 	},
 /obj/structure/disposalpipe/segment{
@@ -55037,7 +53592,6 @@
 	},
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	name = "emergency shower";
 	tag = "icon-shower (WEST)"
 	},
@@ -55062,9 +53616,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2{
@@ -55187,7 +53739,7 @@
 	},
 /area/hallway/primary/central)
 "caA" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
@@ -55246,15 +53798,13 @@
 /obj/machinery/door/window/eastleft{
 	dir = 1;
 	name = "Kitchen Window";
-	req_access_txt = "28";
-	req_one_access_txt = "0"
+	req_access_txt = "28"
 	},
 /obj/machinery/door/firedoor,
 /obj/item/paper,
 /obj/machinery/door/window/eastleft{
 	dir = 2;
 	name = "Hydroponics Window";
-	req_access_txt = "0";
 	req_one_access_txt = "30;35"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -55282,7 +53832,6 @@
 /area/crew_quarters/locker)
 "caI" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Starboard Maintenance APC";
 	pixel_x = -1;
@@ -55330,7 +53879,6 @@
 	})
 "caL" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
@@ -55355,7 +53903,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -55366,7 +53913,6 @@
 /area/hallway/primary/central)
 "caP" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -55386,7 +53932,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -55442,8 +53987,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
-	req_access_txt = "35";
-	req_one_access_txt = "0"
+	req_access_txt = "35"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55505,18 +54049,15 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "cbb" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -55573,8 +54114,7 @@
 "cbg" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Port to Filter";
-	on = 0
+	name = "Port to Filter"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -55660,7 +54200,6 @@
 	})
 "cbr" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;25;28"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -55844,7 +54383,6 @@
 	pixel_y = -5
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -55880,7 +54418,6 @@
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Hydroponics Desk";
-	req_access_txt = "0";
 	req_one_access_txt = "30;35"
 	},
 /turf/simulated/floor/plasteel{
@@ -55964,7 +54501,6 @@
 "cca" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay";
-	dir = 2;
 	network = list("SS13","Medbay")
 	},
 /turf/simulated/floor/plasteel{
@@ -56021,8 +54557,7 @@
 "ccg" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "CO2 to Pure";
-	on = 0
+	name = "CO2 to Pure"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/window/reinforced{
@@ -56072,8 +54607,7 @@
 /area/gateway)
 "ccm" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "JoinLateGateway"
@@ -56109,8 +54643,7 @@
 /area/hallway/primary/central)
 "ccp" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -56293,7 +54826,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;37;25;28"
 	},
 /turf/simulated/floor/plating,
@@ -56327,12 +54859,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -56354,8 +54883,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Port Corner";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -56399,7 +54927,6 @@
 "ccJ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -56435,7 +54962,6 @@
 "ccM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
@@ -56457,7 +54983,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -56478,7 +55003,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -56490,11 +55014,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -56510,7 +55032,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -56526,7 +55047,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -56548,9 +55068,7 @@
 	},
 /area/atmos)
 "ccU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -56559,7 +55077,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -56571,14 +55088,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/primary/central)
 "ccW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -56610,7 +55124,6 @@
 /obj/machinery/door/window/westright{
 	dir = 4;
 	name = "Hydroponics Desk";
-	req_access_txt = "0";
 	req_one_access_txt = "30;35"
 	},
 /obj/item/folder/white,
@@ -56739,14 +55252,12 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Maintenance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "cdk" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/machinery/firealarm{
@@ -56761,12 +55272,10 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -56842,8 +55351,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -57034,8 +55542,7 @@
 "cdC" = (
 /obj/machinery/power/solar_control{
 	id = "aftport";
-	name = "Aft Port Solar Control";
-	track = 0
+	name = "Aft Port Solar Control"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -57056,22 +55563,18 @@
 	})
 "cdE" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Starboard Corner";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -57193,8 +55696,7 @@
 "cdS" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - CO2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine/co2,
 /area/atmos)
@@ -57209,8 +55711,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57232,8 +55733,7 @@
 	id_tag = "escapepodbay"
 	},
 /obj/structure/spacepoddoor{
-	dir = 4;
-	icon_state = "n_beam"
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/hallway/secondary/entry{
@@ -57263,8 +55763,7 @@
 "cdZ" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -57281,24 +55780,20 @@
 "ced" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
 "cee" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
 "cef" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
@@ -57306,7 +55801,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
@@ -57318,7 +55812,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
@@ -57333,7 +55826,6 @@
 	tag = "icon-plant-10"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
@@ -57352,7 +55844,6 @@
 /area/hallway/primary/central)
 "cek" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;7;35;8;47"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57368,8 +55859,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57391,8 +55881,7 @@
 	})
 "cen" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/hydroponics,
@@ -57477,7 +55966,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/landmark/start{
@@ -57604,8 +56092,7 @@
 /area/atmos)
 "ceL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57622,8 +56109,7 @@
 /area/medical/paramedic)
 "ceM" = (
 /obj/structure/spacepoddoor{
-	dir = 4;
-	icon_state = "n_beam"
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/hallway/secondary/entry{
@@ -57758,9 +56244,7 @@
 	dir = 5;
 	icon_state = "brown"
 	},
-/area/quartermaster/office{
-	name = "\improper Cargo Office"
-	})
+/area/quartermaster/office)
 "ceY" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -57786,7 +56270,6 @@
 	req_access_txt = 1
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;25;28"
 	},
 /turf/simulated/floor/plating,
@@ -57848,8 +56331,7 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -57938,12 +56420,10 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/table/glass,
 /obj/effect/decal/warning_stripes/west,
@@ -58012,7 +56492,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -58047,7 +56526,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -58063,7 +56541,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -58092,9 +56569,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -58140,7 +56615,6 @@
 "cfC" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -58251,7 +56725,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -58279,8 +56752,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port-Aft";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plasteel{
@@ -58360,7 +56832,6 @@
 	})
 "cgc" = (
 /obj/machinery/atmospherics/trinary/mixer{
-	dir = 2;
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
@@ -58375,8 +56846,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom";
-	req_access_txt = "35";
-	req_one_access_txt = "0"
+	req_access_txt = "35"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -58410,7 +56880,6 @@
 	})
 "cgg" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -58526,7 +56995,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
@@ -58550,7 +57018,6 @@
 	},
 /obj/item/pen/invisible,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -58566,7 +57033,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -58579,7 +57045,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division - Lobby";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /turf/simulated/floor/plasteel{
@@ -58617,7 +57082,6 @@
 /area/hallway/primary/aft)
 "cgy" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -58742,7 +57206,6 @@
 /area/hallway/primary/central)
 "cgL" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "mixingsparker";
 	pixel_x = 25
 	},
@@ -58766,7 +57229,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -58862,7 +57324,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -58985,7 +57446,6 @@
 /area/maintenance/incinerator)
 "chg" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -59000,7 +57460,6 @@
 "chh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plasteel,
@@ -59034,7 +57493,6 @@
 "chm" = (
 /obj/machinery/light,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Hydroponics APC";
 	pixel_y = -28
 	},
@@ -59207,7 +57665,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	sortType = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -59233,7 +57690,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5"
 	},
 /turf/simulated/floor/plating,
@@ -59322,9 +57778,7 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -59453,8 +57907,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59466,15 +57919,12 @@
 "chV" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
@@ -59483,7 +57933,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
@@ -59500,8 +57949,6 @@
 /area/maintenance/incinerator)
 "chY" = (
 /obj/machinery/door/window/northleft{
-	dir = 1;
-	icon_state = "left";
 	name = "Inner Pipe Access";
 	req_access_txt = "24"
 	},
@@ -59681,8 +58128,7 @@
 /obj/item/paper/hydroponics,
 /obj/machinery/camera{
 	c_tag = "Hydroponics - Foyer";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/radio/intercom{
 	pixel_y = -25
@@ -59740,8 +58186,6 @@
 	dir = 8
 	},
 /obj/machinery/door/window/northleft{
-	dir = 1;
-	icon_state = "left";
 	name = "Inner Pipe Access";
 	req_access_txt = "24"
 	},
@@ -59826,8 +58270,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/northleft{
-	dir = 1;
-	icon_state = "left";
 	name = "Inner Pipe Access";
 	req_access_txt = "24"
 	},
@@ -59900,13 +58342,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/alarm{
 	desc = "This particular atmos control unit appears to have no access restrictions.";
 	dir = 8;
-	icon_state = "alarm0";
 	locked = 0;
 	name = "all-access air alarm";
 	pixel_x = 24;
@@ -60143,13 +58583,11 @@
 "cjb" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
 	name = "glass door";
 	req_access_txt = "24"
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "glass door";
 	req_access_txt = "24"
 	},
@@ -60197,7 +58635,6 @@
 "cjh" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60222,7 +58659,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60379,14 +58815,11 @@
 "cjx" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay";
-	dir = 2;
 	network = list("SS13","Medbay")
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -60421,7 +58854,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2{
@@ -60542,7 +58974,6 @@
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -60621,11 +59052,9 @@
 "cjO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2{
@@ -60636,7 +59065,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2{
@@ -60675,8 +59103,7 @@
 "cjV" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
-	req_access_txt = "35";
-	req_one_access_txt = "0"
+	req_access_txt = "35"
 	},
 /turf/simulated/floor/plating,
 /area/hydroponics)
@@ -60751,7 +59178,6 @@
 /area/medical/reception)
 "cke" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "mixingsparker";
 	pixel_x = 25
 	},
@@ -60767,9 +59193,7 @@
 "ckf" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = -30
 	},
@@ -60777,7 +59201,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -60830,8 +59253,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -60898,7 +59320,6 @@
 	network = list("SS13","Medbay")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -61019,13 +59440,11 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -30
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61158,7 +59577,6 @@
 	name = "Medical Doctor"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -61198,7 +59616,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -61277,7 +59694,6 @@
 	maxcharge = 15000
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61291,7 +59707,6 @@
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61302,7 +59717,6 @@
 /obj/item/stock_parts/cell/potato,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61314,7 +59728,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61326,7 +59739,6 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61341,17 +59753,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61363,7 +59772,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -61384,7 +59792,6 @@
 /obj/structure/table,
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -61393,7 +59800,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -61569,7 +59975,6 @@
 	pixel_y = -3
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Medbay Storage APC";
 	pixel_y = -24
 	},
@@ -61599,9 +60004,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "clu" = (
@@ -61663,9 +60066,7 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "clB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "clC" = (
@@ -61684,9 +60085,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -61727,7 +60126,6 @@
 "clI" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/optable,
@@ -61881,7 +60279,6 @@
 "clX" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2{
@@ -61894,7 +60291,6 @@
 	},
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2{
@@ -61902,7 +60298,6 @@
 	})
 "clZ" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2{
@@ -61911,7 +60306,6 @@
 "cma" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -61947,7 +60341,6 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -61966,13 +60359,11 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62004,7 +60395,6 @@
 /area/medical/chemistry)
 "cmm" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -62047,9 +60437,7 @@
 	},
 /area/medical/reception)
 "cmt" = (
-/obj/machinery/ai_status_display{
-	pixel_y = 0
-	},
+/obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/medical/reception)
 "cmu" = (
@@ -62094,7 +60482,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -62129,8 +60516,7 @@
 "cmA" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
-	req_access_txt = "7";
-	req_one_access_txt = "0"
+	req_access_txt = "7"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	req_access_txt = 1
@@ -62157,7 +60543,6 @@
 	})
 "cmD" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/structure/table/glass,
@@ -62231,8 +60616,7 @@
 "cmI" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 25;
-	req_access_txt = "0"
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -62304,7 +60688,6 @@
 /obj/machinery/door/airlock/research{
 	id_tag = "ResearchFoyer";
 	name = "Research Division";
-	req_access_txt = "0";
 	req_one_access_txt = "47"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -62483,14 +60866,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "cng" = (
 /obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon.";
-	name = "notice board";
 	pixel_y = 31
 	},
 /turf/simulated/floor/plasteel{
@@ -62552,7 +60932,6 @@
 "cnl" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -62569,13 +60948,11 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "cnn" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -62585,7 +60962,6 @@
 	tag = "icon-plant-11"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -62651,7 +61027,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -62708,7 +61083,6 @@
 	pixel_y = 3
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "rndshuttersup";
 	name = "Shutters Control Button";
 	pixel_x = 26;
@@ -62731,7 +61105,6 @@
 /obj/machinery/door/airlock/research{
 	id_tag = "";
 	name = "Research Division";
-	req_access_txt = "0";
 	req_one_access_txt = "47"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -62767,7 +61140,6 @@
 "cnF" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -62836,7 +61208,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telescience - Test Chamber";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /obj/machinery/light{
@@ -62967,7 +61338,6 @@
 "cnW" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
@@ -62982,7 +61352,6 @@
 "cnZ" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "mair_in_meter";
 	name = "Mixed Air Tank In"
 	},
@@ -62992,7 +61361,6 @@
 "coa" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "mair_out_meter";
 	name = "Mixed Air Tank Out"
 	},
@@ -63083,8 +61451,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
@@ -63109,8 +61476,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -63182,7 +61548,6 @@
 	external_pressure_bound = 0;
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 0;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -63207,7 +61572,6 @@
 	},
 /obj/structure/morgue{
 	dir = 8;
-	icon_state = "morgue1";
 	tag = "icon-morgue1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -63238,7 +61602,6 @@
 	name = "Turbine Access Console";
 	pixel_x = 6;
 	pixel_y = -26;
-	req_access_txt = "0";
 	tag_exterior_door = "gas_turbine_exterior";
 	tag_interior_door = "gas_turbine_interior"
 	},
@@ -63319,8 +61682,7 @@
 /area/medical/surgery1)
 "coz" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63426,7 +61788,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -63436,8 +61797,7 @@
 "coL" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = -25;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63516,7 +61876,6 @@
 "coV" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/vending/cola,
@@ -63561,9 +61920,7 @@
 /turf/simulated/floor/engine,
 /area/toxins/explab)
 "cpb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -63727,9 +62084,7 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "cpq" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 2
-	},
+/obj/machinery/atmospherics/binary/pump,
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "cpr" = (
@@ -63982,8 +62337,7 @@
 /obj/structure/table,
 /obj/machinery/computer/guestpass,
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -64048,9 +62402,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -64200,7 +62552,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -64236,7 +62587,6 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -64312,7 +62662,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -64349,7 +62698,6 @@
 "cqw" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -64375,13 +62723,11 @@
 /area/toxins/explab)
 "cqB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/closet/firecloset,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -64539,8 +62885,7 @@
 "cqS" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine/n2,
 /area/atmos)
@@ -64639,9 +62984,7 @@
 	name = "Aft Maintenance"
 	})
 "crd" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/sleeper,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -64650,7 +62993,6 @@
 "crf" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "acutesep";
 	name = "Acute Separation Privacy Shutters";
@@ -64699,8 +63041,7 @@
 "crl" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - O2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine/o2,
 /area/atmos)
@@ -64717,8 +63058,7 @@
 "crq" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Air";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/engine/air,
 /area/atmos)
@@ -64865,15 +63205,13 @@
 "crI" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -64881,7 +63219,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -64937,7 +63274,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -64956,7 +63292,6 @@
 "crR" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /obj/item/assembly/infra,
@@ -64972,7 +63307,6 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
-	dir = 2;
 	location = "Research Division"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -65024,7 +63358,6 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -65189,7 +63522,6 @@
 "csh" = (
 /obj/machinery/door/airlock/maintenance{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -65336,7 +63668,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -65413,8 +63744,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -65488,8 +63818,7 @@
 	})
 "csG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -65526,7 +63855,6 @@
 "csI" = (
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "acutesep";
 	name = "Acute Separation Privacy Shutters";
@@ -65612,7 +63940,6 @@
 	})
 "csN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
@@ -65713,14 +64040,12 @@
 /area/medical/reception)
 "csT" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/science{
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -65731,8 +64056,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -65756,8 +64080,7 @@
 /obj/item/stock_parts/scanning_module,
 /obj/item/stock_parts/scanning_module,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 30
@@ -65780,12 +64103,10 @@
 /obj/machinery/door/airlock/research{
 	id_tag = "";
 	name = "Research Division";
-	req_access_txt = "0";
 	req_one_access_txt = "47"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -65802,13 +64123,11 @@
 /obj/machinery/door/airlock/research{
 	id_tag = "";
 	name = "Research Division";
-	req_access_txt = "0";
 	req_one_access_txt = "47"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/medical/research{
@@ -65828,7 +64147,6 @@
 "ctb" = (
 /obj/machinery/door/airlock{
 	name = "Research Emergency Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "47"
 	},
 /obj/structure/cable/yellow{
@@ -65848,7 +64166,6 @@
 /obj/machinery/door/airlock/research{
 	id_tag = "";
 	name = "Research Break Room";
-	req_access_txt = "0";
 	req_one_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -65976,9 +64293,7 @@
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
@@ -66025,9 +64340,7 @@
 /turf/space,
 /area/space/nearstation)
 "ctt" = (
-/obj/structure/disposaloutlet{
-	dir = 2
-	},
+/obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -66196,9 +64509,7 @@
 	},
 /area/hallway/primary/aft)
 "ctR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -66217,8 +64528,6 @@
 /obj/item/reagent_containers/iv_bag,
 /obj/item/reagent_containers/iv_bag,
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -66279,7 +64588,6 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/exam_room)
@@ -66335,8 +64643,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -66391,7 +64698,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Central";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /turf/simulated/floor/plasteel{
@@ -66414,12 +64720,8 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /obj/item/folder/white,
-/obj/item/disk/tech_disk{
-	pixel_y = 0
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 0
-	},
+/obj/item/disk/tech_disk,
+/obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /obj/item/disk/design_disk,
 /turf/simulated/floor/plasteel{
@@ -66435,7 +64737,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/research{
@@ -66451,8 +64752,6 @@
 	})
 "cut" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -66489,7 +64788,6 @@
 	tag = "icon-plant-10"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research{
@@ -66671,7 +64969,6 @@
 	external_pressure_bound = 0;
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 0;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -66690,7 +64987,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -66728,8 +65024,7 @@
 	})
 "cuW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -66757,7 +65052,6 @@
 "cva" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12;
 	pixel_y = 2
 	},
@@ -66779,7 +65073,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "acute2";
 	name = "Acute 2 Privacy Shutters";
@@ -67132,9 +65425,7 @@
 	icon_state = "pipe-j2";
 	tag = "icon-pipe-j2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -67197,14 +65488,10 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -67223,8 +65510,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -67236,9 +65522,7 @@
 	name = "Research Division"
 	})
 "cvH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -67346,7 +65630,6 @@
 /obj/structure/table,
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -67364,7 +65647,6 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -67398,7 +65680,6 @@
 "cvR" = (
 /obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -67557,9 +65838,7 @@
 	},
 /area/medical/medbay3)
 "cwk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -67567,7 +65846,6 @@
 /area/medical/medbay3)
 "cwl" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -67578,7 +65856,6 @@
 "cwm" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Fore";
-	dir = 2;
 	network = list("SS13","Medbay")
 	},
 /turf/simulated/floor/plasteel{
@@ -67589,9 +65866,7 @@
 "cwn" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -67690,7 +65965,6 @@
 /obj/item/pen,
 /obj/machinery/door/window/northleft{
 	dir = 2;
-	icon_state = "left";
 	name = "Medbay Reception";
 	req_access_txt = "5"
 	},
@@ -67741,8 +66015,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Locker Room Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -67806,9 +66079,7 @@
 "cwI" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/rack,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 0
-	},
+/obj/item/storage/firstaid/regular,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/ointment,
@@ -67822,9 +66093,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
 "cwK" = (
@@ -67834,7 +66103,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -67965,11 +66233,9 @@
 	})
 "cwV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research{
@@ -68012,7 +66278,6 @@
 	on = 1
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Experimentation Lab APC";
 	pixel_y = -24
 	},
@@ -68146,8 +66411,7 @@
 /area/medical/medbay3)
 "cxr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -68163,34 +66427,27 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
 "cxt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
 "cxu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -68213,12 +66470,9 @@
 /area/medical/medbay3)
 "cxw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitebluecorner"
@@ -68227,8 +66481,7 @@
 "cxx" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -68273,9 +66526,7 @@
 	},
 /area/medical/chemistry)
 "cxB" = (
-/obj/machinery/disposal{
-	pixel_x = 0
-	},
+/obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68308,8 +66559,6 @@
 "cxE" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -68337,8 +66586,7 @@
 "cxH" = (
 /obj/structure/bed/roller,
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -68420,13 +66668,11 @@
 	maxcharge = 15000
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Research Lab APC";
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/door_control{
-	dir = 2;
 	id = "rndshutters";
 	name = "Shutters Control Button";
 	pixel_x = -24;
@@ -68485,7 +66731,6 @@
 	name = "research and development lab shutters"
 	},
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Research and Development Desk";
 	req_access_txt = "7"
 	},
@@ -68494,8 +66739,7 @@
 "cxS" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
-	id_tag = "researchrangeshutters";
-	name = "blast door"
+	id_tag = "researchrangeshutters"
 	},
 /turf/simulated/floor/plating,
 /area/toxins/misc_lab{
@@ -68575,7 +66819,6 @@
 "cyb" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -68723,8 +66966,7 @@
 /area/medical/surgery1)
 "cyq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness{
@@ -68776,9 +67018,7 @@
 	},
 /area/medical/medbay3)
 "cyu" = (
-/obj/structure/sign/fire{
-	pixel_y = 0
-	},
+/obj/structure/sign/fire,
 /turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "cyv" = (
@@ -68786,8 +67026,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68815,8 +67054,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -68829,8 +67067,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68855,8 +67092,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68873,8 +67109,7 @@
 "cyz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -68883,8 +67118,7 @@
 /area/medical/chemistry)
 "cyA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -68938,8 +67172,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness{
@@ -68966,7 +67199,6 @@
 /area/medical/reception)
 "cyJ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -68991,7 +67223,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -69008,7 +67239,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -69017,8 +67247,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
-	name = "Aft Emergency Storage";
-	req_access_txt = "0"
+	name = "Aft Emergency Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69042,7 +67271,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "7;47;29;12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69085,7 +67313,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "7;47;29"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69098,7 +67325,6 @@
 "cyW" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -69205,8 +67431,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69256,7 +67481,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -69268,13 +67492,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/fitness{
@@ -69340,7 +67562,6 @@
 "czq" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Fore";
-	dir = 2;
 	network = list("SS13","Medbay")
 	},
 /turf/simulated/floor/plasteel{
@@ -69486,7 +67707,6 @@
 "czB" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -69535,14 +67755,11 @@
 "czH" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
 "czI" = (
-/obj/structure/sign/directions/evac{
-	pixel_y = 0
-	},
+/obj/structure/sign/directions/evac,
 /turf/simulated/wall,
 /area/maintenance/aft{
 	name = "Aft Maintenance"
@@ -69584,7 +67801,6 @@
 "czN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Testing Range Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "7;47;29"
 	},
 /turf/simulated/floor/plating,
@@ -69593,8 +67809,7 @@
 	})
 "czO" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -69734,7 +67949,6 @@
 "czY" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	sortType = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69761,7 +67975,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -69870,7 +68083,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	sortType = 23
 	},
 /turf/simulated/floor/plasteel{
@@ -69920,8 +68132,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -69958,8 +68169,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -69975,7 +68185,6 @@
 	},
 /obj/item/storage/box/bodybags,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -70003,8 +68212,7 @@
 	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70019,8 +68227,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70056,8 +68263,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70083,7 +68289,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -70143,11 +68348,9 @@
 "cAA" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -70251,7 +68454,6 @@
 	})
 "cAK" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/medical/research{
@@ -70411,9 +68613,7 @@
 	name = "Aft Maintenance"
 	})
 "cBa" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -70565,8 +68765,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Recovery Ward";
-	req_access_txt = "0"
+	name = "Recovery Ward"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -70576,8 +68775,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Office";
-	req_access_txt = "40";
-	req_one_access_txt = "0"
+	req_access_txt = "40"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70625,8 +68823,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Chief Medical Officer"
@@ -70641,8 +68838,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -70656,11 +68852,9 @@
 "cBw" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/machinery/door/window/southleft{
-	dir = 2;
 	name = "Cloning Shower"
 	},
 /obj/structure/mirror{
@@ -70674,7 +68868,6 @@
 "cBx" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Cloning Shower"
 	},
@@ -70693,7 +68886,6 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -70806,7 +68998,6 @@
 /area/toxins/storage)
 "cBM" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4
 	},
 /turf/simulated/wall,
@@ -70895,8 +69086,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
-	req_access_txt = "30";
-	req_one_access_txt = "0"
+	req_access_txt = "30"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70997,7 +69187,6 @@
 "cBY" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -71112,14 +69301,11 @@
 	},
 /obj/structure/table/glass,
 /obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon.";
-	name = "notice board";
 	pixel_x = -32;
 	pixel_y = 32
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
@@ -71145,7 +69331,6 @@
 "cCk" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -71154,7 +69339,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -71163,7 +69347,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -71173,7 +69356,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -71187,13 +69369,11 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "cCp" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -71314,8 +69494,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Recovery Ward";
-	req_access_txt = "0"
+	name = "Recovery Ward"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -71348,7 +69527,6 @@
 /area/medical/genetics)
 "cCB" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -71494,7 +69672,6 @@
 "cCN" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -71537,7 +69714,6 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -71576,7 +69752,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/radio/intercom{
@@ -71604,8 +69779,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -71652,7 +69826,6 @@
 "cDa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "airlock access";
-	req_access_txt = "0";
 	req_one_access_txt = "8;12"
 	},
 /turf/simulated/floor/plating,
@@ -71738,7 +69911,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -71767,9 +69939,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/cryo)
 "cDm" = (
-/obj/machinery/atmospherics/unary/cryo_cell{
-	layer = 3.3
-	},
+/obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/medical/cryo)
@@ -71780,8 +69950,7 @@
 "cDo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
@@ -71801,12 +69970,10 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/medbreak)
@@ -71832,8 +69999,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -71937,7 +70103,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
@@ -71986,7 +70151,6 @@
 	})
 "cDK" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "RD Office APC";
 	pixel_y = -27
 	},
@@ -72005,7 +70169,6 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/light,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = -32
 	},
@@ -72131,12 +70294,10 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "CloningDoor";
 	name = "Cloning Lab";
-	req_access_txt = "0";
 	req_one_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72186,8 +70347,7 @@
 	})
 "cEc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -72314,8 +70474,7 @@
 "cEn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -72335,7 +70494,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -72357,22 +70515,19 @@
 "cEs" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/landmark/start{
 	name = "Roboticist"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "cEt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72410,7 +70565,6 @@
 	location = "8.1-Aft-to-Escape"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -72573,8 +70727,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -72634,8 +70787,7 @@
 	name = "Medical Doctor"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -72727,13 +70879,11 @@
 /area/medical/surgery2)
 "cFb" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -72784,7 +70934,6 @@
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/medbreak)
@@ -72799,7 +70948,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/medbreak)
@@ -72811,7 +70959,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/medbreak)
@@ -72821,7 +70968,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/medbreak)
@@ -72839,7 +70985,6 @@
 /area/medical/medbay3)
 "cFl" = (
 /obj/machinery/door_control{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 26;
@@ -72847,13 +70992,11 @@
 	req_one_access_txt = "29"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
 "cFm" = (
 /obj/machinery/door_control{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = -26;
@@ -72883,8 +71026,6 @@
 "cFo" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -72897,8 +71038,7 @@
 	base_state = "right";
 	dir = 1;
 	icon_state = "right";
-	name = "door";
-	req_access_txt = "0"
+	name = "door"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -72928,8 +71068,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -72942,7 +71081,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/research{
@@ -73024,7 +71162,6 @@
 	})
 "cFD" = (
 /obj/machinery/atmospherics/trinary/filter{
-	density = 0;
 	dir = 8;
 	req_access = "0"
 	},
@@ -73060,7 +71197,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "8;12"
 	},
 /turf/simulated/floor/plating,
@@ -73164,12 +71300,9 @@
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "cFP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73199,9 +71332,7 @@
 "cFT" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/pen{
-	pixel_x = 0
-	},
+/obj/item/flashlight/pen,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
@@ -73252,9 +71383,7 @@
 /turf/simulated/floor/plating,
 /area/medical/genetics_cloning)
 "cGb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -73274,13 +71403,11 @@
 /area/medical/genetics_cloning)
 "cGe" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73323,7 +71450,6 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -73347,8 +71473,7 @@
 	in_use = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -73399,16 +71524,13 @@
 "cGm" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -73478,7 +71600,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -73486,8 +71607,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73581,7 +71701,6 @@
 	})
 "cGy" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/thermomachine/freezer,
@@ -73604,7 +71723,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Research Testing Range";
-	req_access_txt = "0";
 	req_one_access_txt = "7;47;29"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -73699,9 +71817,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -73861,7 +71977,6 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -73883,7 +71998,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -73968,8 +72082,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "";
 	name = "Staff Room";
-	req_access_txt = "5";
-	req_one_access_txt = "0"
+	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -74062,8 +72175,7 @@
 /area/medical/medbreak)
 "cHh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74077,8 +72189,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "";
 	name = "Staff Room";
-	req_access_txt = "5";
-	req_one_access_txt = "0"
+	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -74169,9 +72280,7 @@
 	},
 /area/medical/cryo)
 "cHn" = (
-/obj/structure/sign/directions/evac{
-	pixel_y = 0
-	},
+/obj/structure/sign/directions/evac,
 /turf/simulated/wall,
 /area/assembly/chargebay)
 "cHo" = (
@@ -74243,8 +72352,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/clothing/ears/earmuffs,
 /obj/effect/decal/warning_stripes/east,
@@ -74490,7 +72598,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -74750,12 +72857,10 @@
 /area/medical/surgery2)
 "cIt" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -74888,7 +72993,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -75042,17 +73146,14 @@
 "cIU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/status_display{
 	dir = 4;
 	layer = 4;
 	pixel_x = -32
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -75092,8 +73193,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
@@ -75189,7 +73289,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/genetics_cloning)
@@ -75210,7 +73309,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "robotics";
 	name = "Shutter Control";
 	pixel_x = -26;
@@ -75220,12 +73318,8 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cJk" = (
-/obj/machinery/mecha_part_fabricator{
-	dir = 2
-	},
+/obj/machinery/mecha_part_fabricator,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -75248,12 +73342,9 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cJm" = (
-/obj/machinery/mecha_part_fabricator{
-	dir = 2
-	},
+/obj/machinery/mecha_part_fabricator,
 /obj/machinery/camera{
 	c_tag = "Robotics - Fore";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -75275,8 +73366,6 @@
 /area/assembly/robotics)
 "cJo" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
@@ -75299,8 +73388,7 @@
 /area/assembly/robotics)
 "cJq" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -75323,7 +73411,6 @@
 "cJt" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower";
 	tag = "icon-shower (EAST)"
 	},
@@ -75386,12 +73473,8 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/iv_bag{
-	pixel_y = 0
-	},
-/obj/item/reagent_containers/iv_bag{
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/iv_bag,
+/obj/item/reagent_containers/iv_bag,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/dropper,
 /obj/structure/sign/biohazard{
@@ -75521,8 +73604,7 @@
 /obj/structure/chair/office/light,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = -25;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -75549,7 +73631,6 @@
 /area/medical/virology)
 "cJO" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/machinery/smartfridge/secure/chemistry/virology,
@@ -75571,8 +73652,7 @@
 /obj/structure/chair/office/light,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 25;
-	req_access_txt = "0"
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -75643,8 +73723,7 @@
 /area/hallway/primary/aft)
 "cJX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -75672,7 +73751,6 @@
 "cKb" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12;
 	pixel_y = 2
 	},
@@ -75718,7 +73796,6 @@
 "cKh" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -25
 	},
@@ -75731,7 +73808,6 @@
 "cKi" = (
 /obj/item/gun/energy/laser/practice,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Research Firing Range APC";
 	pixel_y = -28
 	},
@@ -75798,7 +73874,6 @@
 /area/assembly/robotics)
 "cKq" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
@@ -75809,8 +73884,6 @@
 /area/hallway/primary/aft)
 "cKr" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -75828,8 +73901,7 @@
 /obj/machinery/door_control{
 	id = "researchrangeshutters";
 	name = "Blast Door Control";
-	pixel_y = -24;
-	req_access_txt = "0"
+	pixel_y = -24
 	},
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/south,
@@ -75876,7 +73948,6 @@
 	dir = 4
 	},
 /obj/machinery/driver_button{
-	dir = 2;
 	id_tag = "toxinsdriver";
 	pixel_x = 24;
 	pixel_y = -24
@@ -75915,8 +73986,6 @@
 /obj/item/reagent_containers/iv_bag,
 /obj/item/reagent_containers/iv_bag,
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -76020,8 +74089,7 @@
 /obj/item/stack/medical/bruise_pack/advanced,
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery 1 South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/table/tray,
@@ -76058,8 +74126,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
@@ -76069,7 +74136,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -76127,7 +74193,6 @@
 /area/medical/patient_a)
 "cKV" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;6"
 	},
 /obj/structure/disposalpipe/segment,
@@ -76163,7 +74228,6 @@
 "cKY" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -76177,12 +74241,9 @@
 "cLa" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -76200,7 +74261,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -76242,13 +74302,11 @@
 "cLg" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Middle";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76396,8 +74454,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -76412,8 +74469,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76535,9 +74591,7 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/obj/item/assembly/timer{
-	pixel_y = 0
-	},
+/obj/item/assembly/timer,
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
@@ -76624,12 +74678,8 @@
 /obj/item/transfer_valve{
 	pixel_x = -5
 	},
-/obj/item/transfer_valve{
-	pixel_x = 0
-	},
-/obj/item/transfer_valve{
-	pixel_x = 0
-	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
 /obj/item/transfer_valve{
 	pixel_x = 5
 	},
@@ -76669,7 +74719,6 @@
 	on = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay2{
@@ -76694,8 +74743,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -76734,8 +74782,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76850,8 +74897,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/wrench,
@@ -76891,9 +74937,7 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cMl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "cMm" = (
@@ -77338,7 +75382,6 @@
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
-	frequency = 1449;
 	master_tag = "virology_airlock_control";
 	pixel_x = 10;
 	pixel_y = 25;
@@ -77355,15 +75398,13 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Office";
-	req_access_txt = "40";
-	req_one_access_txt = "0"
+	req_access_txt = "40"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77385,8 +75426,7 @@
 	sortType = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -77419,7 +75459,6 @@
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
-	frequency = 1449;
 	master_tag = "virology_airlock_control";
 	pixel_x = 10;
 	pixel_y = 25;
@@ -77463,7 +75502,6 @@
 	})
 "cMV" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -77598,12 +75636,10 @@
 "cNf" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -77680,7 +75716,6 @@
 	})
 "cNo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/wall/r_wall,
@@ -77697,7 +75732,6 @@
 	id_tag = "tox_airlock_control";
 	name = "Toxin Mixing Console";
 	pixel_x = -24;
-	req_access_txt = "0";
 	tag_airpump = "tox_airlock_apump";
 	tag_chamber_sensor = "tox_airlock_sensor";
 	tag_exterior_door = "tox_airlock_exterior";
@@ -77841,8 +75875,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77882,20 +75915,17 @@
 	network = list("SS13","Medbay")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
 "cNK" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
 "cNL" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -77904,7 +75934,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -77914,14 +75943,12 @@
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
 "cNO" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -78015,7 +76042,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;6"
 	},
 /turf/simulated/floor/plating,
@@ -78134,8 +76160,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78257,9 +76282,7 @@
 	name = "\improper Research Division Server Room"
 	})
 "cOl" = (
-/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/thermomachine/freezer/on/server,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -78286,7 +76309,6 @@
 	})
 "cOo" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	external_pressure_bound = 140;
 	on = 1;
 	pressure_checks = 0
@@ -78377,9 +76399,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
 	name = "Aft Maintenance"
@@ -78539,7 +76559,6 @@
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/reagent_dispensers/virusfood{
-	density = 0;
 	pixel_y = 30
 	},
 /obj/structure/table/glass,
@@ -78571,22 +76590,12 @@
 /area/maintenance/aft{
 	name = "Aft Maintenance"
 	})
-"cOK" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
-	on = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft{
-	name = "Aft Maintenance"
-	})
 "cOL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -78611,7 +76620,6 @@
 	})
 "cON" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/primary/aft)
@@ -78624,18 +76632,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/primary/aft)
 "cOP" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/primary/aft)
@@ -78664,7 +76669,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -78726,13 +76730,11 @@
 	})
 "cPb" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -78816,7 +76818,6 @@
 "cPi" = (
 /obj/machinery/camera{
 	c_tag = "Research Division - Server Room";
-	dir = 2;
 	network = list("SS13","RD");
 	pixel_x = 22
 	},
@@ -78934,7 +76935,6 @@
 /area/medical/virology)
 "cPv" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -78946,8 +76946,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79026,8 +77025,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical Surplus Storeroom";
-	req_access_txt = "12";
-	req_one_access_txt = "0"
+	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
@@ -79115,7 +77113,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cPM" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cola,
 /obj/structure/sign/double/map/right{
 	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
 	icon_state = "map-right-MS";
@@ -79162,7 +77160,6 @@
 	name = "Departure Lounge"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/exit{
@@ -79173,7 +77170,6 @@
 /obj/item/retractor,
 /obj/item/hemostat,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -79258,7 +77254,6 @@
 "cPX" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -79296,8 +77291,6 @@
 	})
 "cQa" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -79417,9 +77410,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -79555,7 +77546,6 @@
 /obj/item/hand_labeler,
 /obj/item/radio/headset/headset_med,
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/machinery/camera{
@@ -79570,7 +77560,6 @@
 /area/medical/virology)
 "cQu" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -79620,8 +77609,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -79631,7 +77619,6 @@
 "cQA" = (
 /obj/structure/morgue{
 	dir = 8;
-	icon_state = "morgue1";
 	tag = "icon-morgue1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -79750,8 +77737,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/computer/pandemic,
 /turf/simulated/floor/plasteel{
@@ -80056,8 +78042,7 @@
 	tag = "icon-plant-11"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -80081,7 +78066,6 @@
 	})
 "cRr" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;6"
 	},
 /turf/simulated/floor/plating,
@@ -80217,7 +78201,6 @@
 	})
 "cRC" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;7;47;29"
 	},
 /obj/structure/cable/yellow{
@@ -80246,8 +78229,7 @@
 	})
 "cRE" = (
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80276,7 +78258,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "7;12;47"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80318,9 +78299,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -80450,9 +78429,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/item/storage/box/masks{
-	pixel_y = 0
-	},
+/obj/item/storage/box/masks,
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80577,7 +78554,6 @@
 	req_access_txt = "22"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -80588,7 +78564,6 @@
 	name = "mysterious old book of "
 	},
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
-	name = "flask of holy water";
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -80598,7 +78573,6 @@
 /obj/item/organ/internal/heart,
 /obj/structure/closet/secure_closet/chaplain,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -80606,7 +78580,6 @@
 "cSi" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance Access ";
-	req_access_txt = "0";
 	req_one_access_txt = "12;27"
 	},
 /obj/structure/cable/yellow{
@@ -80733,7 +78706,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "7;12;47"
 	},
 /turf/simulated/floor/plating,
@@ -80778,8 +78750,7 @@
 /area/assembly/robotics)
 "cSy" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -80789,7 +78760,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -80819,8 +78789,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -80834,8 +78803,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -81005,8 +78973,7 @@
 	id = "chapelescapeshutters";
 	name = "Side Windows Shutter Control";
 	pixel_x = -6;
-	pixel_y = 25;
-	req_access_txt = "0"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -81026,7 +78993,6 @@
 	})
 "cSW" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -81123,7 +79089,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -81146,7 +79111,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81191,7 +79155,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/sign/double/map/right{
@@ -81261,13 +79224,11 @@
 /area/maintenance/starboardsolar)
 "cTq" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Fore";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-24";
@@ -81331,7 +79292,6 @@
 	name = "robotics lab shutters"
 	},
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Robotics Desk";
 	req_access_txt = "29"
 	},
@@ -81353,8 +79313,7 @@
 "cTz" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office - Backroom";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 4;
@@ -81561,8 +79520,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Starboard Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -81661,8 +79619,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Maintenance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
@@ -81714,7 +79671,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -81724,9 +79680,7 @@
 "cUh" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -81818,8 +79772,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81857,9 +79810,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -81940,9 +79891,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Chapel - Fore";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Chapel - Fore"
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/plasteel{
@@ -81965,7 +79914,6 @@
 	})
 "cUz" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4
 	},
 /turf/simulated/wall,
@@ -82067,9 +80015,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -82216,8 +80162,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82308,9 +80253,7 @@
 /obj/item/plant_analyzer,
 /obj/item/cultivator,
 /obj/item/reagent_containers/glass/bucket,
-/obj/structure/rack{
-	layer = 2.8
-	},
+/obj/structure/rack,
 /obj/item/seeds/corn,
 /obj/item/seeds/cabbage,
 /obj/item/seeds/ambrosia,
@@ -82339,9 +80282,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cVj" = (
-/obj/structure/rack{
-	layer = 2.8
-	},
+/obj/structure/rack,
 /obj/item/seeds/wheat,
 /obj/item/seeds/watermelon,
 /obj/item/seeds/watermelon,
@@ -82393,9 +80334,7 @@
 	name = "\improper Secure Lab"
 	})
 "cVo" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/seeds/carrot,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
@@ -82403,9 +80342,7 @@
 	name = "Aft Maintenance"
 	})
 "cVp" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/plant_analyzer,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
@@ -82413,9 +80350,7 @@
 	name = "Aft Maintenance"
 	})
 "cVq" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/seeds/glowshroom,
 /obj/item/seeds/corn,
 /obj/effect/decal/warning_stripes/south,
@@ -82476,8 +80411,7 @@
 /area/chapel/main)
 "cVA" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -82648,9 +80582,7 @@
 	name = "\improper Departure Lounge"
 	})
 "cWa" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -82702,7 +80634,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
-	dir = 2;
 	network = list("SS13","Medbay")
 	},
 /turf/simulated/floor/plasteel{
@@ -82804,8 +80735,7 @@
 	},
 /obj/item/restraints/handcuffs,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/radio/off,
 /obj/machinery/requests_console{
@@ -82838,9 +80768,7 @@
 	name = "Aft Maintenance"
 	})
 "cWr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -82918,7 +80846,6 @@
 "cWA" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -82949,12 +80876,10 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Secure Lab - Airlock";
@@ -82993,7 +80918,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -83038,7 +80962,6 @@
 "cWL" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -83048,7 +80971,6 @@
 /area/medical/virology)
 "cWM" = (
 /obj/machinery/door/window/eastleft{
-	dir = 4;
 	name = "Coffin Storage";
 	req_access_txt = "22"
 	},
@@ -83106,12 +81028,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -83158,8 +81078,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -83230,7 +81149,6 @@
 "cXg" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -83248,7 +81166,6 @@
 "cXh" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -83287,13 +81204,11 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Funeral Parlour";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -83323,19 +81238,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Fitness Room - Fore";
-	dir = 2
+	c_tag = "Fitness Room - Fore"
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -83379,9 +81291,7 @@
 	},
 /area/medical/medbay3)
 "cXs" = (
-/obj/machinery/ai_status_display{
-	pixel_y = 0
-	},
+/obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -83449,7 +81359,6 @@
 "cXw" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -83482,7 +81391,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay3)
@@ -83494,8 +81402,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Security Post";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/book/manual/security_space_law{
 	pixel_x = -4;
@@ -83505,8 +81412,6 @@
 	pixel_x = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
@@ -83530,7 +81435,6 @@
 "cXE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83540,7 +81444,6 @@
 /area/chapel/main)
 "cXF" = (
 /obj/machinery/door/window{
-	dir = 4;
 	name = "Mass Driver";
 	req_access_txt = "22"
 	},
@@ -83593,8 +81496,7 @@
 	id = "chapelspaceshutters";
 	name = "Space Window Shutter Control";
 	pixel_x = -6;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -83705,11 +81607,9 @@
 "cXU" = (
 /obj/machinery/camera{
 	c_tag = "Secure Lab - Fore";
-	dir = 2;
 	network = list("SS13","RD")
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -83791,8 +81691,7 @@
 "cYa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -83842,25 +81741,20 @@
 	name = "\improper Departure Lounge"
 	})
 "cYg" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
 /area/chapel/main)
 "cYh" = (
 /obj/machinery/door/morgue{
-	name = "Chapel Garden";
-	req_access_txt = "0"
+	name = "Chapel Garden"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -83908,9 +81802,7 @@
 	},
 /area/chapel/main)
 "cYm" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/seeds/glowshroom,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -83976,9 +81868,7 @@
 	name = "\improper Secure Lab"
 	})
 "cYw" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/seeds/ambrosia,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -84180,7 +82070,6 @@
 "cYU" = (
 /obj/machinery/monkey_recycler,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
@@ -84196,7 +82085,6 @@
 	pixel_y = -29
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
@@ -84246,8 +82134,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -84411,8 +82298,6 @@
 /area/chapel/office)
 "cZt" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	lighting = 3;
 	name = "Chapel Office APC";
 	pixel_y = -25
 	},
@@ -84448,13 +82333,11 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -84514,7 +82397,6 @@
 /area/solar/starboard)
 "cZC" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -84524,8 +82406,7 @@
 /area/chapel/main)
 "cZD" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -84569,9 +82450,7 @@
 	},
 /area/medical/medbay3)
 "cZJ" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -84607,9 +82486,7 @@
 	name = "\improper Secure Lab"
 	})
 "cZN" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/seeds/watermelon,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -84631,7 +82508,6 @@
 /area/medical/psych)
 "cZQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84684,8 +82560,7 @@
 /area/solar/starboard)
 "cZX" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -84696,9 +82571,7 @@
 	},
 /area/chapel/main)
 "cZY" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
+/obj/machinery/hydroponics/soil,
 /obj/item/seeds/berry,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
@@ -84752,8 +82625,7 @@
 "dae" = (
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/item/storage/box/PDAs{
@@ -84766,12 +82638,10 @@
 /area/crew_quarters/heads)
 "daf" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery 1 North";
-	network = list("SS13")
+	c_tag = "Medbay Surgery 1 North"
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -84791,7 +82661,6 @@
 "dak" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/secure_closet/psychiatrist,
@@ -84877,14 +82746,12 @@
 "dat" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Starboard Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -84901,12 +82768,10 @@
 "dau" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Aft";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -85101,8 +82966,7 @@
 /area/medical/psych)
 "daR" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
@@ -85219,7 +83083,6 @@
 /obj/item/crowbar,
 /obj/machinery/camera{
 	c_tag = "Medbay Cryo";
-	dir = 2;
 	network = list("SS13","Medbay")
 	},
 /obj/item/screwdriver{
@@ -85345,7 +83208,6 @@
 	})
 "dbw" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
@@ -85396,7 +83258,6 @@
 "dbz" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -85435,7 +83296,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -85586,7 +83446,6 @@
 	})
 "dbL" = (
 /obj/machinery/mass_driver{
-	dir = 2;
 	id_tag = "chapelgun"
 	},
 /obj/structure/sign/securearea{
@@ -85741,8 +83600,7 @@
 /obj/machinery/door_control{
 	id = "chapelparlourshutters";
 	name = "Window Shutter Control";
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -85902,7 +83760,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology{
@@ -85970,7 +83827,6 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/effect/decal/warning_stripes/southwest,
@@ -86092,8 +83948,7 @@
 	})
 "dcK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -86238,8 +84093,7 @@
 /area/space)
 "ddR" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -86379,7 +84233,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;6"
 	},
 /obj/structure/disposalpipe/segment{
@@ -86460,13 +84313,10 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
-	name = "Outer Window";
-	req_access_txt = "0"
+	name = "Outer Window"
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 4;
 	name = "Security Desk";
 	req_access_txt = "1"
 	},
@@ -86557,8 +84407,7 @@
 	})
 "deA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/toxins/xenobiology{
@@ -86825,9 +84674,7 @@
 	},
 /area/engine/mechanic_workshop)
 "dfh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/chair/office/light{
 	dir = 1;
 	pixel_y = 3
@@ -86898,8 +84745,7 @@
 /area/chapel/main)
 "dfq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Mechanic"
@@ -86938,8 +84784,7 @@
 "dfu" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -86969,8 +84814,7 @@
 /area/chapel/main)
 "dfx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -86979,8 +84823,7 @@
 /area/engine/mechanic_workshop)
 "dfy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop)
@@ -87005,8 +84848,7 @@
 /area/engine/break_room)
 "dfA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -87036,7 +84878,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -87045,7 +84886,6 @@
 "dfD" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/camera{
@@ -87088,8 +84928,7 @@
 	})
 "dfI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -87108,8 +84947,7 @@
 "dfJ" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -87126,8 +84964,7 @@
 /area/engine/mechanic_workshop)
 "dfK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -87157,7 +84994,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/effect/decal/warning_stripes/northwest,
@@ -87167,8 +85003,7 @@
 /area/medical/virology)
 "dfT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -87273,8 +85108,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -87282,16 +85116,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "bluecorner"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "dgb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -87306,7 +85137,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry{
@@ -87315,8 +85145,7 @@
 "dgg" = (
 /obj/machinery/camera{
 	c_tag = "Chapel - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -87439,8 +85268,7 @@
 "dgv" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
@@ -87553,12 +85381,10 @@
 /area/maintenance/starboard)
 "dgJ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/engine,
@@ -87571,8 +85397,7 @@
 /area/engine/mechanic_workshop)
 "dgL" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -87583,7 +85408,6 @@
 "dgW" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/toxins/xenobiology{
@@ -87798,8 +85622,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -87946,8 +85769,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -87964,8 +85786,7 @@
 	id_tag = "sol_inner";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -88003,16 +85824,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/construction)
 "dMG" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88043,8 +85862,7 @@
 /area/security/permabrig)
 "dPn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -88052,8 +85870,7 @@
 /area/bridge)
 "dRN" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
@@ -88102,12 +85919,8 @@
 /area/hallway/primary/central)
 "dXb" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	level = 2
-	},
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/light,
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -88186,7 +85999,6 @@
 "elv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
@@ -88214,9 +86026,7 @@
 	name = "\improper Recreation Area"
 	})
 "esj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -88234,17 +86044,13 @@
 	id_tag = "sol_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "sol_sensor";
 	pixel_x = 12;
 	pixel_y = -25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "sol_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	tag_airpump = "sol_pump";
 	tag_chamber_sensor = "sol_sensor";
 	tag_exterior_door = "sol_outer";
@@ -88289,8 +86095,7 @@
 /area/space/nearstation)
 "eSB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/courtroom)
@@ -88314,13 +86119,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
 	name = "Inner Pipe Access";
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -88476,8 +86279,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -88486,8 +86288,7 @@
 /area/security/brig)
 "fZa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -88502,8 +86303,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -88534,7 +86334,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -88558,7 +86357,6 @@
 "ged" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -88601,8 +86399,7 @@
 "gqj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/light{
 	dir = 8
@@ -88648,7 +86445,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -88660,8 +86456,7 @@
 /area/hallway/secondary/entry)
 "gGG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -88799,8 +86594,7 @@
 "hqN" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88827,7 +86621,6 @@
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -88870,8 +86663,7 @@
 /area/storage/primary)
 "hEA" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -88981,7 +86773,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -89094,8 +86885,7 @@
 "iAT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Starboard";
@@ -89113,16 +86903,13 @@
 	name = "Aft Maintenance"
 	})
 "iHk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
@@ -89132,8 +86919,7 @@
 /area/hallway/primary/starboard)
 "iHq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
@@ -89149,8 +86935,7 @@
 "iMC" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry{
@@ -89197,8 +86982,7 @@
 "iTR" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft{
@@ -89225,9 +87009,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/server)
 "iYb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -89268,8 +87050,7 @@
 	req_one_access_txt = "32;19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -89311,9 +87092,7 @@
 	name = "\improper Secure Lab"
 	})
 "jmm" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -89371,14 +87150,6 @@
 "kez" = (
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
-"kkt" = (
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/atmos)
 "kmF" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -89515,7 +87286,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/storage/primary)
@@ -89544,7 +87314,6 @@
 "kKa" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/lattice,
@@ -89654,8 +87423,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -89679,9 +87447,7 @@
 /turf/space,
 /area/space/nearstation)
 "lpU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -89775,12 +87541,10 @@
 	})
 "lWo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -89836,18 +87600,15 @@
 	id_tag = "sol_outer";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
-	layer = 3.3;
 	master_tag = "sol_airlock";
 	name = "exterior access button";
 	pixel_x = -13;
-	pixel_y = -23;
-	req_access_txt = "0"
+	pixel_y = -23
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -89937,8 +87698,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -89997,7 +87757,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/structure/cable{
@@ -90052,7 +87811,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
@@ -90066,9 +87824,7 @@
 "npj" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
@@ -90175,8 +87931,7 @@
 /area/space)
 "nKy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -90228,12 +87983,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -90277,8 +88030,7 @@
 "ogE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -90347,7 +88099,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -90366,8 +88117,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -90559,9 +88309,7 @@
 	},
 /area/engine/engineering)
 "pmh" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -90573,7 +88321,6 @@
 /area/crew_quarters/bar)
 "ptc" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
@@ -90608,7 +88355,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
@@ -90703,8 +88449,7 @@
 "pUq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
@@ -90796,7 +88541,6 @@
 "qtt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/lattice,
@@ -90808,7 +88552,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/aft)
@@ -90891,7 +88634,6 @@
 /obj/machinery/space_heater,
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "Aft Maintenance APC";
 	pixel_y = -24
 	},
@@ -90938,16 +88680,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qWn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "qYF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
@@ -91000,12 +88739,8 @@
 	name = "\improper MiniSat Exterior"
 	})
 "rlJ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	level = 2
-	},
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -91036,8 +88771,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -91071,7 +88805,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/atmos)
@@ -91136,12 +88869,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -91354,7 +89085,6 @@
 "sDC" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
-	icon_state = "pinonfar";
 	id = "whiteship_cerebron";
 	name = "North of Cerebron"
 	},
@@ -91420,7 +89150,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -91442,12 +89171,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -91461,8 +89188,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -91534,8 +89260,7 @@
 /area/engine/engineering)
 "tvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -91705,8 +89430,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -91791,9 +89515,7 @@
 	},
 /area/bridge)
 "uTZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "uWq" = (
@@ -91808,8 +89530,7 @@
 "veh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -91850,7 +89571,6 @@
 "vmT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/lattice,
@@ -91900,8 +89620,7 @@
 /area/bridge)
 "vCR" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -92020,7 +89739,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /turf/simulated/floor/wood,
@@ -92061,14 +89779,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "wuZ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -92081,15 +89797,13 @@
 	},
 /obj/machinery/power/solar_control{
 	id = "aftstarboard";
-	name = "Aft Starboard Solar Control";
-	track = 0
+	name = "Aft Starboard Solar Control"
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "wxw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 2;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -92133,8 +89847,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -92167,8 +89880,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -92221,7 +89933,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -92270,16 +89981,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
-"xyA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/atmos)
 "xyZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
@@ -92361,7 +90062,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -92394,8 +90094,7 @@
 /area/turret_protected/ai_upload)
 "xRI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -92418,8 +90117,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -92456,9 +90154,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -109086,7 +106782,7 @@ cdN
 bZU
 cNa
 cNP
-cOK
+chv
 cfc
 bZU
 aaa
@@ -113886,7 +111582,7 @@ apf
 aqB
 arU
 aEl
-axa
+aHX
 ajg
 axz
 axQ
@@ -126473,7 +124169,7 @@ abq
 anQ
 aok
 aok
-avq
+bAC
 aok
 aok
 avv
@@ -136808,7 +134504,7 @@ bNe
 bPC
 bRi
 bSU
-xyA
+bPC
 bPC
 bRi
 bSU
@@ -137065,7 +134761,7 @@ bzL
 bHG
 bzL
 bIt
-kkt
+bHG
 bHG
 bzL
 bIt

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -9,7 +9,6 @@
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
-	icon_state = "pinonfar";
 	id = "whiteship_cyberiad";
 	name = "North of Cyberiad"
 	},
@@ -31,8 +30,7 @@
 "abO" = (
 /obj/machinery/camera{
 	c_tag = "Brig Secure Armory Exterior East";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/space,
 /area/security/securearmoury)
@@ -54,7 +52,6 @@
 "aca" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/range)
@@ -158,7 +155,6 @@
 "acB" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower/security,
@@ -181,8 +177,7 @@
 /area/security/range)
 "acD" = (
 /obj/machinery/door/airlock{
-	name = "Toilet";
-	req_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -191,9 +186,7 @@
 "acE" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -239,14 +232,12 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -257,10 +248,8 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/flashbangs,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -285,9 +274,7 @@
 /obj/machinery/magnetic_controller{
 	autolink = 1;
 	name = "Firing Range Control Console";
-	path = "w;e;e;w;s;n;n;s";
-	pixel_x = 0;
-	pixel_y = 0
+	path = "w;e;e;w;s;n;n;s"
 	},
 /turf/simulated/wall,
 /area/security/range)
@@ -302,8 +289,7 @@
 /area/security/range)
 "acR" = (
 /obj/machinery/door/airlock{
-	name = "Toilet";
-	req_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -342,8 +328,7 @@
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
 /obj/machinery/camera{
-	c_tag = "Brig Labor Camp Airlock North";
-	network = list("SS13")
+	c_tag = "Brig Labor Camp Airlock North"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -417,13 +402,10 @@
 	layer = 2.9
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Secure Armory";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Secure Armory"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel{
@@ -435,12 +417,9 @@
 "adi" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/laser/practice,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
@@ -460,9 +439,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Firing Range";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Firing Range"
 	},
 /obj/machinery/syndicatebomb/training,
 /turf/simulated/floor/plasteel{
@@ -472,9 +449,7 @@
 "adm" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/laser/practice,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -491,8 +466,7 @@
 /area/security/permabrig)
 "adp" = (
 /obj/machinery/door/airlock{
-	name = "Bathroom";
-	req_access_txt = "0"
+	name = "Bathroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -507,7 +481,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -592,14 +565,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "adE" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -626,14 +597,12 @@
 "adG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -678,7 +647,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -695,7 +663,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -709,8 +676,7 @@
 "adO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -735,7 +701,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -751,7 +716,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -811,7 +775,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -828,7 +791,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -926,7 +888,6 @@
 	department = "Security";
 	departmentType = 5;
 	name = "Security Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -940,8 +901,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Security Equipment Lockers";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -956,7 +916,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -970,12 +929,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -1016,8 +973,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1027,9 +983,7 @@
 /area/security/medbay)
 "aeu" = (
 /obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -1047,8 +1001,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1067,8 +1020,7 @@
 "aez" = (
 /obj/effect/decal/warning_stripes/red/partial,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -1084,13 +1036,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -1102,8 +1052,7 @@
 "aeD" = (
 /obj/machinery/computer/secure_data,
 /obj/item/radio/intercom/department/security{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1130,8 +1079,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
@@ -1187,9 +1135,7 @@
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/camera{
-	c_tag = "Brig Medbay";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Medbay"
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
@@ -1224,8 +1170,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1248,7 +1193,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
@@ -1275,7 +1219,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -1323,14 +1266,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1398,8 +1337,6 @@
 /area/security/prisonershuttle)
 "afa" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = -27
 	},
 /obj/structure/table,
@@ -1439,7 +1376,6 @@
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
@@ -1453,9 +1389,7 @@
 /area/security/medbay)
 "afe" = (
 /obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1482,7 +1416,6 @@
 /obj/machinery/sleeper,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -1506,8 +1439,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "west bump Important Area";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -1591,14 +1523,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
 /area/security/medbay)
 "afs" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -1607,7 +1537,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -1615,8 +1544,7 @@
 "afu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1640,7 +1568,6 @@
 "afw" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -1652,7 +1579,6 @@
 	},
 /obj/item/clothing/suit/tracksuit/red,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -1711,14 +1637,11 @@
 "afS" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/camera{
-	c_tag = "Prisoner Lockers";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Prisoner Lockers"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -1756,7 +1679,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
 	name = "Brig Medical Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1776,7 +1698,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
 	name = "Brig Medical Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1828,15 +1749,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -1846,7 +1765,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1856,8 +1774,7 @@
 /area/security/prisonlockers)
 "agn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1881,8 +1798,7 @@
 "agp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -1898,8 +1814,7 @@
 /area/security/brig)
 "agq" = (
 /obj/machinery/camera{
-	c_tag = "Brig Main Hall West 2";
-	network = list("SS13")
+	c_tag = "Brig Main Hall West 2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -1964,8 +1879,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1999,7 +1913,6 @@
 /area/security/brig)
 "agO" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -2096,12 +2009,10 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Main Hall Center";
-	network = list("SS13")
+	c_tag = "Brig Main Hall Center"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2126,9 +2037,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -2156,7 +2065,6 @@
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -2167,7 +2075,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -2219,9 +2126,7 @@
 /turf/simulated/floor/carpet,
 /area/security/hos)
 "ahu" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "white"
@@ -2241,7 +2146,6 @@
 /area/security/brig)
 "ahD" = (
 /obj/item/radio/intercom/department/security{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -2276,8 +2180,6 @@
 	on = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/item/storage/box/chemimp{
@@ -2314,8 +2216,7 @@
 	pixel_y = 23
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Main Hall East 1";
-	network = list("SS13")
+	c_tag = "Brig Main Hall East 1"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -2367,13 +2268,10 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -2389,7 +2287,6 @@
 /area/security/securearmoury)
 "ahW" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/northeast,
@@ -2409,8 +2306,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2434,8 +2330,7 @@
 /area/security/podbay)
 "aib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2454,26 +2349,12 @@
 /area/security/podbay)
 "aid" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
-"aie" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2484,10 +2365,8 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -2496,8 +2375,7 @@
 /area/security/armoury)
 "aig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2568,8 +2446,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "west bump Important Area";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2623,8 +2500,7 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2636,8 +2512,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2645,8 +2520,7 @@
 /area/security/securearmoury)
 "ais" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2662,8 +2536,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -2672,13 +2545,11 @@
 /area/security/brig)
 "aiu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2692,8 +2563,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "west bump Important Area";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2701,8 +2571,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Armory";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2711,32 +2580,14 @@
 /area/security/armoury)
 "aix" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
-"aiy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
 "aiz" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -2755,8 +2606,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2771,10 +2621,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/clothing/suit/armor/laserproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/laserproof,
 /obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2784,14 +2631,11 @@
 /area/security/securearmoury)
 "aiD" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Main Hall West 1";
-	network = list("SS13")
+	c_tag = "Brig Main Hall West 1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -2811,8 +2655,7 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2836,8 +2679,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2852,13 +2694,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2869,8 +2709,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2883,8 +2722,7 @@
 "aiS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -2900,12 +2738,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2914,7 +2750,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -2922,12 +2757,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2948,12 +2781,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2975,12 +2806,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2996,13 +2825,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3027,8 +2854,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -3077,7 +2903,6 @@
 	},
 /obj/item/pen,
 /obj/item/radio/intercom/locked/prison{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -3087,9 +2912,7 @@
 "ajg" = (
 /obj/machinery/washing_machine,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -3152,7 +2975,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -3167,31 +2989,19 @@
 	tag = ""
 	},
 /obj/machinery/ai_status_display{
-	pixel_w = 0;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
 "ajq" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -3210,17 +3020,13 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/gun/advtaser{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/gun/energy/gun/advtaser,
 /obj/item/gun/energy/gun/advtaser{
 	pixel_x = 3;
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3232,7 +3038,6 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /obj/item/stock_parts/cell/high/plus,
@@ -3251,15 +3056,12 @@
 /area/security/podbay)
 "aju" = (
 /obj/machinery/camera{
-	c_tag = "Brig Podbay";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Podbay"
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the pod doors.";
 	id = "secpodbay";
 	name = "Pod Door Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "71"
 	},
@@ -3271,9 +3073,7 @@
 	on = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/engine,
@@ -3293,12 +3093,9 @@
 /area/security/podbay)
 "ajJ" = (
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -3314,8 +3111,7 @@
 	layer = 2.9
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3344,7 +3140,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
@@ -3357,7 +3152,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
@@ -3375,7 +3169,6 @@
 	tag = "90Curve"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
@@ -3391,7 +3184,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
@@ -3415,7 +3207,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
@@ -3430,7 +3221,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3457,7 +3247,6 @@
 /area/security/brig)
 "ajT" = (
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment{
@@ -3476,9 +3265,7 @@
 /area/security/brig)
 "ajU" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -3494,8 +3281,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3514,8 +3300,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3526,7 +3311,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3540,8 +3324,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3549,7 +3332,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3575,8 +3357,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3587,7 +3368,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3595,15 +3375,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3617,8 +3395,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3637,8 +3414,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3649,7 +3425,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -3661,8 +3436,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -3681,12 +3455,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -3700,8 +3472,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3730,8 +3501,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3768,8 +3538,7 @@
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -3794,14 +3563,11 @@
 /area/security/securearmoury)
 "akv" = (
 /obj/structure/table,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
 /obj/item/radio/intercom/department/security{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel,
@@ -3864,9 +3630,7 @@
 /area/security/brig)
 "akE" = (
 /obj/machinery/door/window/eastright{
-	base_state = "right";
 	dir = 1;
-	icon_state = "right";
 	name = "Security Delivery";
 	req_access_txt = "1"
 	},
@@ -3881,7 +3645,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -3912,7 +3675,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/landmark/start{
@@ -3971,7 +3733,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/poddoor{
@@ -3988,7 +3749,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -4029,8 +3789,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4042,7 +3801,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Brig HoS Office";
 	sortType = 7
 	},
@@ -4089,7 +3847,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -4129,8 +3886,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -4177,7 +3933,6 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -4244,8 +3999,7 @@
 /area/security/securearmoury)
 "alk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/light,
 /obj/machinery/door_control{
@@ -4338,7 +4092,6 @@
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
@@ -4346,8 +4099,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Briefing Room West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -4355,11 +4107,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -4402,8 +4152,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -4461,10 +4210,8 @@
 "alG" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -4485,8 +4232,7 @@
 /obj/structure/grille,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating/airless,
 /area/security/podbay)
@@ -4518,8 +4264,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -4611,9 +4356,7 @@
 /obj/structure/closet,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4772,8 +4515,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -4787,7 +4528,6 @@
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/item/radio/intercom/department/security{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4825,17 +4565,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
-"amo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/solar/auxstarboard)
 "amp" = (
 /obj/structure/chair{
 	dir = 8
@@ -4848,8 +4577,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Briefing Room East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/landmark/start{
 	name = "Security Officer"
@@ -4873,19 +4601,15 @@
 	name = "Head of Security"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/main)
 "ams" = (
 /obj/item/radio/intercom/locked/prison{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "amt" = (
@@ -4894,8 +4618,7 @@
 	department = "Head of Security's Desk";
 	departmentType = 5;
 	name = "Head of Security Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/computer/brigcells,
 /turf/simulated/floor/plasteel{
@@ -4905,8 +4628,7 @@
 "amu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/carpet,
 /area/security/hos)
@@ -4957,9 +4679,7 @@
 /area/security/warden)
 "amA" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
@@ -4968,9 +4688,7 @@
 	on = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Warden's Office";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Warden's Office"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -4991,9 +4709,7 @@
 "amC" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -5086,7 +4802,6 @@
 "amL" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/structure/curtain/open/shower,
@@ -5113,7 +4828,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -5131,8 +4845,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -5154,11 +4867,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -5169,8 +4880,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Pod Pilot's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5268,7 +4978,6 @@
 	network = list("Prison","SS13")
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -5284,7 +4993,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -5307,15 +5015,12 @@
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "anj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "ank" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -5330,8 +5035,7 @@
 	},
 /obj/machinery/flasher{
 	id = "permaflash1";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -5348,7 +5052,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -5359,8 +5062,7 @@
 "anp" = (
 /obj/structure/bed,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -5396,8 +5098,7 @@
 "ant" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -5408,11 +5109,9 @@
 	network = list("Prison","SS13")
 	},
 /obj/item/radio/intercom/locked/prison{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -5444,7 +5143,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/poddoor{
@@ -5479,8 +5177,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5491,8 +5188,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5505,8 +5201,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5562,8 +5257,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -5573,8 +5267,7 @@
 "anF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -5584,7 +5277,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -5597,7 +5289,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Brig Equipment Storage";
 	sortType = 8
 	},
@@ -5647,15 +5338,12 @@
 "anM" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
 /area/security/main)
 "anN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "anO" = (
@@ -5665,7 +5353,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -5678,8 +5365,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -5694,8 +5380,7 @@
 /area/security/permabrig)
 "anQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -5712,15 +5397,13 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "anS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -5729,8 +5412,7 @@
 /area/security/main)
 "anT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5748,8 +5430,7 @@
 /obj/item/book/manual/sop_security,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -5801,7 +5482,6 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -5813,16 +5493,13 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/light{
 	dir = 1;
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -5833,7 +5510,6 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -5841,7 +5517,6 @@
 "aoc" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
@@ -5853,7 +5528,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "lawyer";
 	name = "Internal Affairs Privacy Shutters";
@@ -5865,7 +5539,6 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -5891,8 +5564,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -5900,8 +5572,7 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5941,9 +5612,7 @@
 	},
 /area/security/lobby)
 "aol" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5957,8 +5626,7 @@
 /area/security/lobby)
 "aon" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -5973,8 +5641,7 @@
 /area/security/lobby)
 "aoo" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -5983,8 +5650,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -6024,8 +5690,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6041,8 +5706,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/start{
 	name = "Warden"
@@ -6075,8 +5739,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6094,7 +5757,6 @@
 "aow" = (
 /obj/machinery/flasher{
 	id = "Cell 1";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -6119,8 +5781,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/security/seceqstorage)
@@ -6143,13 +5804,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -6180,8 +5839,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -6213,8 +5871,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -6233,8 +5890,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6291,8 +5947,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6343,8 +5998,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6363,8 +6017,7 @@
 /area/security/main)
 "aoS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/computer/card/minor/hos,
 /turf/simulated/floor/plasteel{
@@ -6388,9 +6041,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /obj/machinery/camera{
-	c_tag = "Brig Cell 1";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Cell 1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6400,10 +6051,8 @@
 "aoV" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
@@ -6416,7 +6065,6 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -6428,17 +6076,13 @@
 "aoX" = (
 /obj/structure/bed,
 /obj/machinery/camera{
-	c_tag = "Brig Cell 3";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Cell 3"
 	},
 /obj/machinery/flasher{
 	id = "Cell 3";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -6468,9 +6112,7 @@
 /obj/item/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "Camera";
-	pictures_left = 30;
-	pixel_x = 0;
-	pixel_y = 0
+	pictures_left = 30
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -6498,7 +6140,6 @@
 /obj/structure/closet,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light/small{
@@ -6517,14 +6158,12 @@
 /obj/item/pen,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/requests_console{
 	department = "Warden";
 	departmentType = 7;
 	name = "Warden's Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/radio/intercom/department/security{
@@ -6543,7 +6182,6 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -6553,13 +6191,11 @@
 /obj/item/paper/armory,
 /obj/item/clipboard,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/warden)
 "aph" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -6568,14 +6204,12 @@
 /obj/item/folder/red,
 /obj/item/megaphone,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/warden)
 "apj" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -6688,11 +6322,8 @@
 /area/security/prison/cell_block/A)
 "apA" = (
 /obj/machinery/vending/wallmed{
-	dir = 2;
 	name = "Emergency NanoMed";
-	pixel_x = -27;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -27
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/medical/bruise_pack/advanced,
@@ -6705,8 +6336,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Security Equipment South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -6728,7 +6358,6 @@
 	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -6744,8 +6373,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -6775,7 +6403,6 @@
 "apG" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -6894,8 +6521,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -6907,7 +6533,6 @@
 "apU" = (
 /obj/structure/table/wood,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -6917,8 +6542,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Head of Security's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/folder/red,
 /obj/item/folder/red,
@@ -6931,8 +6555,7 @@
 "apV" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /obj/machinery/light,
 /obj/item/radio{
@@ -6981,7 +6604,6 @@
 /obj/structure/bed,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -7084,8 +6706,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -7098,8 +6719,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
@@ -7166,8 +6786,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -7310,7 +6929,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/poddoor{
@@ -7356,7 +6974,6 @@
 /obj/item/pen,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -7418,7 +7035,6 @@
 "aqY" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -7445,7 +7061,6 @@
 /obj/item/stamp/law,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -7544,8 +7159,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7568,7 +7182,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -7626,9 +7239,7 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -7654,7 +7265,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -7698,12 +7308,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -7737,7 +7345,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7756,8 +7363,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
@@ -7780,14 +7386,11 @@
 	pixel_x = -24;
 	pixel_y = 23
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "arC" = (
 /obj/item/radio/intercom/department/security{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -7839,8 +7442,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7876,7 +7478,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7888,8 +7489,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -7927,7 +7527,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -7961,8 +7560,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -7973,8 +7571,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7999,8 +7596,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plating,
@@ -8012,8 +7607,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plating,
@@ -8051,12 +7644,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8067,8 +7658,7 @@
 /area/security/brig)
 "ase" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8157,8 +7747,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8172,8 +7761,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -8188,8 +7776,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8203,8 +7790,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8225,8 +7811,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8260,8 +7845,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8279,8 +7863,7 @@
 	req_access_txt = "2"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -8288,8 +7871,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8302,7 +7884,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -8318,7 +7899,6 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,
@@ -8336,8 +7916,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8348,8 +7927,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -8362,7 +7939,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door_control{
@@ -8386,12 +7962,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8475,9 +8049,7 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -8492,15 +8064,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8514,12 +8084,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8529,15 +8097,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8552,8 +8118,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8564,7 +8129,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -8607,7 +8171,6 @@
 	req_access_txt = "2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -8617,20 +8180,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
 /area/lawoffice)
 "asQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8639,7 +8199,6 @@
 /area/security/lobby)
 "asR" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/lobby)
@@ -8654,7 +8213,6 @@
 /obj/structure/chair/office/dark,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28;
 	pixel_y = -28
 	},
@@ -8761,7 +8319,6 @@
 	name = "Cell 3 Locker"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -8807,8 +8364,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8840,15 +8396,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -8870,14 +8424,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -8952,9 +8504,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "atv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "atw" = (
@@ -8967,15 +8517,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/brig)
@@ -8983,8 +8531,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -9032,8 +8579,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9055,14 +8601,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -9083,8 +8626,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -9112,8 +8654,7 @@
 /area/maintenance/fsmaint)
 "atH" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/plant_analyzer,
@@ -9157,8 +8698,7 @@
 /obj/item/dice/d20,
 /obj/item/instrument/harmonica,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -9174,8 +8714,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9202,8 +8741,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -9215,7 +8753,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -9245,8 +8782,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -9287,12 +8823,9 @@
 /obj/machinery/door_timer/cell_1{
 	dir = 1;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -9312,11 +8845,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -9338,7 +8869,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -9348,13 +8878,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -9373,7 +8900,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/poddoor{
@@ -9393,7 +8919,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -9429,7 +8954,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9448,7 +8972,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -9457,7 +8980,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -9470,7 +8992,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -9489,7 +9010,6 @@
 /obj/machinery/door_timer/cell_3{
 	dir = 1;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -9503,7 +9023,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -9541,9 +9060,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
-	c_tag = "Security Pod";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Security Pod"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -9553,7 +9070,6 @@
 "aur" = (
 /obj/structure/filingcabinet/employment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -9563,7 +9079,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -9643,8 +9158,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -9709,7 +9223,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -9857,12 +9370,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Cell Block A North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -9895,8 +9406,6 @@
 /obj/machinery/camera{
 	c_tag = "Brig Prisoner Processing West";
 	dir = 4;
-	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/machinery/door_control{
@@ -9947,7 +9456,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -10041,7 +9549,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/smartfridge/drying_rack,
@@ -10052,7 +9559,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -10064,15 +9570,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -10084,7 +9588,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -10100,12 +9603,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10127,19 +9628,16 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10155,12 +9653,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -10173,7 +9669,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -10183,24 +9678,18 @@
 	tag = "90Curve"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/computer/cryopod{
-	density = 0;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "avp" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -10216,12 +9705,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10251,9 +9738,7 @@
 /area/shuttle/pod_3)
 "avu" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light,
@@ -10275,7 +9760,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "Processing Shutter";
 	name = "Processing Shutter";
@@ -10298,12 +9782,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10313,14 +9795,12 @@
 /area/security/permabrig)
 "avD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -10330,7 +9810,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -10344,7 +9823,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -10359,11 +9837,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
@@ -10375,8 +9851,7 @@
 	security_level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10389,7 +9864,6 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
@@ -10398,18 +9872,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
@@ -10419,19 +9890,16 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "avK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10440,8 +9908,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -10452,13 +9919,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
@@ -10484,18 +9949,15 @@
 "avO" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "south bump Important Area";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
@@ -10503,24 +9965,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "avQ" = (
 /obj/item/storage/secure/safe{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/machinery/camera{
 	c_tag = "Internal Affairs Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -10533,7 +9990,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -10544,12 +10000,10 @@
 /area/lawoffice)
 "avT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -10569,15 +10023,12 @@
 	req_access_txt = "38"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -10650,8 +10101,7 @@
 	req_access_txt = "63"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10663,7 +10113,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -10675,8 +10124,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10695,7 +10143,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -10704,8 +10151,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -10737,7 +10183,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "Processing Shutter";
 	name = "Processing Shutter";
@@ -10759,7 +10204,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -10772,7 +10216,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -10815,12 +10258,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -10831,15 +10272,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -10860,7 +10299,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -10882,8 +10320,6 @@
 /obj/machinery/camera{
 	c_tag = "Brig Prisoner Processing East";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -10986,8 +10422,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -11061,8 +10496,7 @@
 /area/security/permabrig)
 "awY" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -11078,8 +10512,7 @@
 "awZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -11091,7 +10524,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door_control{
@@ -11146,7 +10578,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11169,7 +10600,6 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1450;
 	id_tag = "dorms_sensor";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -11217,15 +10647,12 @@
 /obj/machinery/requests_console{
 	department = "Internal Affairs Office";
 	name = "Internal Affairs Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -11242,11 +10669,9 @@
 /area/solar/auxstarboard)
 "axr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -11267,7 +10692,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/lobby)
@@ -11276,7 +10700,6 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "Processing Shutter";
 	name = "Processing Shutter";
@@ -11319,8 +10742,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
@@ -11351,10 +10773,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Lobby East";
-	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -11365,16 +10784,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
@@ -11388,7 +10805,6 @@
 "axD" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
@@ -11398,7 +10814,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -11444,14 +10859,10 @@
 /area/security/prison/cell_block/A)
 "axH" = (
 /obj/machinery/door_timer/cell_2{
-	dir = 2;
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = -32
+	layer = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11477,27 +10888,21 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "axJ" = (
 /obj/machinery/door_timer/cell_4{
-	dir = 2;
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = -32
+	layer = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11517,7 +10922,6 @@
 "axK" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -11529,7 +10933,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -11541,8 +10944,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -11557,11 +10959,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/processing)
@@ -11580,24 +10980,9 @@
 "axQ" = (
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "redcorner"
-	},
-/area/security/processing)
-"axR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/processing)
@@ -11606,7 +10991,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -11620,15 +11004,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "axU" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -11636,14 +11018,11 @@
 	},
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -11678,9 +11057,7 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "axZ" = (
@@ -11760,7 +11137,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
@@ -11779,9 +11155,7 @@
 /area/security/processing)
 "ayq" = (
 /obj/structure/table,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "ayr" = (
@@ -11822,10 +11196,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -11843,7 +11214,6 @@
 /area/security/permabrig)
 "ayx" = (
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/table,
@@ -11888,7 +11258,6 @@
 "ayA" = (
 /obj/structure/table/wood,
 /obj/structure/noticeboard{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/paper_bin{
@@ -11912,7 +11281,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/poddoor{
@@ -11928,7 +11296,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -11939,7 +11306,6 @@
 	id = "Execution Shutter";
 	name = "Execution Shutter Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "1"
 	},
 /turf/simulated/floor/plasteel{
@@ -11978,8 +11344,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -11998,12 +11363,10 @@
 /obj/machinery/door_control{
 	id = "lawyer";
 	name = "Internal Affairs Privacy Shutters Control";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/vending/coffee/free,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -12011,15 +11374,13 @@
 "ayI" = (
 /obj/structure/chair/comfy/brown,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
 /area/lawoffice)
 "ayJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12028,20 +11389,15 @@
 /area/security/lobby)
 "ayK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Lobby West";
-	dir = 4;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12053,8 +11409,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -12064,15 +11419,13 @@
 /area/security/lobby)
 "ayM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/light,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/item/reagent_containers/food/drinks/mug/sec,
@@ -12087,8 +11440,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12110,16 +11462,13 @@
 /area/security/lobby)
 "ayP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -12160,8 +11509,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -12269,7 +11617,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12337,8 +11684,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -12374,8 +11720,7 @@
 /area/space/nearstation)
 "azp" = (
 /obj/machinery/door/airlock{
-	name = "Bathroom";
-	req_access_txt = "0"
+	name = "Bathroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -12392,7 +11737,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/closet/wardrobe/pjs,
@@ -12409,8 +11753,7 @@
 	},
 /obj/machinery/flasher{
 	id = "permaflash2";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -12422,7 +11765,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -12453,13 +11795,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12471,8 +11811,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12505,12 +11844,10 @@
 	pixel_x = 24
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -12523,12 +11860,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12543,7 +11878,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -12552,15 +11886,13 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -12572,7 +11904,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -12608,17 +11939,14 @@
 /area/magistrateoffice)
 "azG" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster/official/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -12630,7 +11958,6 @@
 	id = "brig_courtroom";
 	name = "Brig Courtroom Shutter Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12672,7 +11999,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12704,9 +12030,7 @@
 	name = "Cell 2 Locker"
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Cell 2";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Cell 2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12715,16 +12039,13 @@
 /area/security/prison/cell_block/A)
 "azO" = (
 /obj/machinery/camera{
-	c_tag = "Brig Cell 4";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Cell 4"
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 4";
 	name = "Cell 4 Locker"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -12741,14 +12062,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -12812,9 +12131,7 @@
 	name = "Cell 5 Locker"
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Cell 5";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Cell 5"
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel,
@@ -12822,8 +12139,7 @@
 "azX" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -12838,14 +12154,12 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -12924,7 +12238,6 @@
 "aAo" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/open/shower,
@@ -12964,7 +12277,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/poddoor{
@@ -13001,7 +12313,6 @@
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -13064,7 +12375,6 @@
 "aAD" = (
 /obj/structure/closet/lawcloset,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13079,27 +12389,23 @@
 	pixel_y = -5
 	},
 /obj/item/storage/briefcase{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /obj/item/storage/secure/briefcase{
 	pixel_x = 5;
 	pixel_y = -5
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13115,7 +12421,6 @@
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13127,7 +12432,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13137,12 +12441,10 @@
 /obj/item/pen,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13157,7 +12459,6 @@
 "aAK" = (
 /obj/machinery/atmospherics/binary/valve/open{
 	dir = 4;
-	icon_state = "map_valve1";
 	tag = "icon-map_valve1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -13179,24 +12480,19 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Magistrate's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aAN" = (
 /obj/structure/table/reinforced,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/item/megaphone,
 /obj/item/radio/intercom/department/security{
 	pixel_x = 28;
 	pixel_y = -7
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28;
 	pixel_y = 5
 	},
@@ -13266,12 +12562,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13304,18 +12598,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -13334,12 +12625,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -13361,12 +12650,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13379,7 +12666,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 4;
 	id = "Cell 5";
 	name = "Cell 5";
 	req_access_txt = "2"
@@ -13387,8 +12673,6 @@
 /obj/machinery/door/firedoor,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -13410,7 +12694,6 @@
 "aBd" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -13418,7 +12701,6 @@
 "aBe" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood{
@@ -13429,7 +12711,6 @@
 "aBf" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
@@ -13443,9 +12724,7 @@
 /area/maintenance/abandonedbar)
 "aBi" = (
 /obj/structure/table/reinforced,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13471,8 +12750,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13486,7 +12764,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13501,8 +12778,7 @@
 /area/maintenance/fsmaint)
 "aBr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -13511,16 +12787,14 @@
 /area/security/interrogation)
 "aBt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aBu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -13541,7 +12815,6 @@
 	master_tag = "eva_airlock";
 	name = "exterior access button";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "13"
 	},
 /obj/structure/lattice/catwalk,
@@ -13567,7 +12840,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -13595,13 +12867,11 @@
 	id_tag = "solar_tool_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_tool_sensor";
 	pixel_x = 25;
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_tool_airlock";
 	pixel_x = 25;
 	req_access_txt = "13";
@@ -13622,7 +12892,6 @@
 /obj/item/soap,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -13665,10 +12934,8 @@
 /obj/item/lighter,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13717,7 +12984,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood{
@@ -13791,7 +13057,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13802,11 +13067,9 @@
 	department = "Magistrate's Office"
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13817,18 +13080,14 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13843,7 +13102,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13868,7 +13126,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "magistrate";
 	name = "Magistrate Privacy Shutters";
@@ -13879,7 +13136,6 @@
 "aCl" = (
 /obj/structure/closet/secure_closet/magistrate,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -13891,9 +13147,7 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aCn" = (
@@ -13914,19 +13168,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
+/mob/living/simple_animal/bot/secbot/beepsky,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aCp" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
-	pass_flags = 0;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/simulated/floor/plasteel{
@@ -13958,11 +13207,9 @@
 /obj/structure/bed,
 /obj/machinery/flasher{
 	id = "Cell 4";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/prison/cell_block/A)
@@ -13971,13 +13218,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -13991,7 +13236,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -14014,7 +13258,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/flasher{
 	id = "Cell 5";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -14101,7 +13344,6 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -14112,8 +13354,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -14141,14 +13382,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -14249,8 +13488,7 @@
 "aCZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14261,8 +13499,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -14277,13 +13514,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door_control{
 	id = "brig_courtroom";
 	name = "Brig Courtroom Shutter Control";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "2"
 	},
@@ -14330,7 +13565,7 @@
 /turf/simulated/floor/plating,
 /area/magistrateoffice)
 "aDf" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "aDg" = (
@@ -14348,14 +13583,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
 /area/magistrateoffice)
 "aDi" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -14377,7 +13610,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -14394,8 +13626,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -14412,13 +13643,11 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Cell Block A South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14431,13 +13660,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14487,8 +13714,7 @@
 "aDu" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Fore Port Solar Control";
-	track = 0
+	name = "Fore Port Solar Control"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -14508,8 +13734,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -14580,15 +13805,13 @@
 /obj/item/seeds/ambrosia,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/structure/toilet{
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -14606,9 +13829,6 @@
 /area/maintenance/fpmaint)
 "aDH" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -14628,13 +13848,11 @@
 	name = "Brig Courtroom Shutters"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
 "aDJ" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/permabrig)
@@ -14691,7 +13909,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -14702,10 +13919,8 @@
 /area/maintenance/auxsolarstarboard)
 "aDT" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "eva_sensor";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -14721,7 +13936,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -14787,7 +14001,6 @@
 "aEg" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -14797,7 +14010,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
@@ -14806,10 +14018,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aEi" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -14860,7 +14069,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -14875,7 +14083,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/carpet,
@@ -14886,8 +14093,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14898,18 +14104,15 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkredcorners"
 	},
 /area/security/prison/cell_block/A)
 "aEr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -14928,8 +14131,7 @@
 /area/security/prison/cell_block/A)
 "aEs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14953,8 +14155,7 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14966,8 +14167,7 @@
 /area/maintenance/fsmaint)
 "aEu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -14980,8 +14180,7 @@
 /area/maintenance/fsmaint)
 "aEv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -15131,18 +14330,15 @@
 	tag = ""
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_chapel_sensor";
 	pixel_x = 25;
 	pixel_y = 12
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
 	frequency = 1379;
 	id_tag = "solar_chapel_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_chapel_airlock";
 	pixel_x = 25;
 	req_access_txt = "13";
@@ -15185,7 +14381,6 @@
 "aEW" = (
 /obj/item/stack/rods,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/maintenance/abandonedbar)
@@ -15235,8 +14430,7 @@
 /area/maintenance/abandonedbar)
 "aFh" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15246,8 +14440,7 @@
 /area/crew_quarters/courtroom)
 "aFj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15272,13 +14465,11 @@
 /obj/item/gavelblock,
 /obj/item/gavelhammer,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -15290,8 +14481,7 @@
 /area/security/interrogation)
 "aFo" = (
 /obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm{
@@ -15299,7 +14489,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -15312,11 +14501,9 @@
 	},
 /obj/item/pen/multi,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -15331,7 +14518,6 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -15351,7 +14537,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -15361,7 +14546,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -15372,14 +14556,12 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -15389,18 +14571,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
 "aFv" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "eva_airlock";
 	name = "EVA Airlock Console";
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	req_one_access_txt = "1;5;11;18;24";
 	tag_airpump = "eva_pump";
 	tag_chamber_sensor = "eva_sensor";
@@ -15422,7 +14600,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -15594,9 +14771,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "aFS" = (
@@ -15753,14 +14928,12 @@
 "aGq" = (
 /obj/structure/chair,
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redfull";
 	tag = "icon-redfull (NORTHWEST)"
 	},
@@ -15775,8 +14948,7 @@
 /area/crew_quarters/courtroom)
 "aGs" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -15798,7 +14970,6 @@
 "aGw" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
@@ -15846,9 +15017,7 @@
 	tag = ""
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Detective's Office";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Brig Detective's Office"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -15887,9 +15056,7 @@
 "aGE" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -15906,8 +15073,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15921,7 +15087,6 @@
 "aGH" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -15933,7 +15098,6 @@
 	},
 /obj/item/razor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -15941,16 +15105,13 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -15966,16 +15127,12 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Barber Shop";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Barber Shop"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -15983,11 +15140,9 @@
 /obj/machinery/dye_generator,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -16003,12 +15158,9 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Arcade";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Arcade"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -16048,8 +15200,7 @@
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -16059,8 +15210,7 @@
 "aGU" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Fore Starboard Solar Control";
-	track = 0
+	name = "Fore Starboard Solar Control"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -16071,7 +15221,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
@@ -16113,7 +15262,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -16136,7 +15284,6 @@
 /obj/item/toy/crayon/white,
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -16157,15 +15304,13 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/fpmaint2)
 "aHh" = (
 /obj/machinery/door/airlock/engineering{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Fore Port Solar Access";
 	req_access_txt = "10"
 	},
@@ -16223,7 +15368,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16271,10 +15415,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -16283,8 +15424,7 @@
 /area/crew_quarters/courtroom)
 "aHy" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -16300,7 +15440,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "courtroomshutters";
 	layer = 3.21;
@@ -16318,7 +15457,6 @@
 	in_use = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -16404,7 +15542,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16477,14 +15614,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
 "aHZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16494,16 +15629,13 @@
 	},
 /area/security/detectives_office)
 "aIa" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aIb" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16517,8 +15649,7 @@
 /area/clownoffice)
 "aId" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -16550,8 +15681,7 @@
 	security_level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16575,7 +15705,6 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -16586,11 +15715,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -16620,7 +15747,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -16637,7 +15763,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -16651,18 +15776,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -16760,16 +15882,13 @@
 "aIC" = (
 /obj/machinery/camera{
 	c_tag = "Fore Starboard Solars";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "aID" = (
@@ -16829,7 +15948,6 @@
 	req_access_txt = "74"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -16850,8 +15968,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -16979,13 +16096,11 @@
 	id_tag = "arrivals_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "arrivals_sensor";
 	pixel_x = 25;
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "arrivals_airlock";
 	pixel_x = 25;
 	req_access_txt = "13";
@@ -17034,7 +16149,6 @@
 /obj/item/storage/box/evidence,
 /obj/structure/table/wood,
 /obj/item/radio/intercom/department/security{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/cable{
@@ -17066,13 +16180,10 @@
 /obj/item/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "detectives camera";
-	pictures_left = 30;
-	pixel_x = 0;
-	pixel_y = 0
+	pictures_left = 30
 	},
 /obj/machinery/requests_console{
 	name = "Detective Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -17082,7 +16193,6 @@
 "aJn" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -17126,7 +16236,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -17135,14 +16244,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
 	name = "Barber"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -17151,22 +16258,19 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
 "aJu" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
 "aJv" = (
 /obj/machinery/gameboard,
 /obj/structure/sign/poster/contraband/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -17195,8 +16299,7 @@
 "aJA" = (
 /obj/structure/closet/lasertag/red,
 /obj/structure/sign/poster/official/random{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -17221,7 +16324,6 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Fore Starboard Solar Access";
 	req_access_txt = "10"
 	},
@@ -17265,8 +16367,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/auxsolarstarboard)
@@ -17376,22 +16477,11 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
-"aKe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -17404,7 +16494,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -17416,8 +16505,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -17432,8 +16520,7 @@
 "aKj" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -17475,7 +16562,6 @@
 /area/crew_quarters/courtroom)
 "aKs" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -17483,8 +16569,7 @@
 "aKt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -17515,7 +16600,6 @@
 "aKw" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -17535,7 +16619,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -17543,7 +16626,6 @@
 "aKy" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/hallway/primary/fore)
@@ -17551,8 +16633,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17588,7 +16669,6 @@
 "aKD" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -17603,7 +16683,6 @@
 "aKF" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/item/pen,
@@ -17611,7 +16690,6 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -17624,18 +16702,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -17643,8 +16718,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17699,8 +16773,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -17714,8 +16786,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
 	c_tag = "Clown's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -17747,7 +16818,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -17792,14 +16862,11 @@
 /area/maintenance/fsmaint2)
 "aLb" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -17816,14 +16883,11 @@
 /area/hallway/secondary/entry)
 "aLf" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -17912,7 +16976,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -17944,8 +17007,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 9
@@ -17993,7 +17055,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -18009,7 +17070,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18021,7 +17081,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18142,17 +17201,14 @@
 /area/maintenance/fpmaint)
 "aLN" = (
 /obj/structure/sign/poster/official/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom ";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -18173,7 +17229,6 @@
 	id = "courtroomshutters";
 	name = "Brig Courtroom Shutter Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_one_access_txt = "74;3"
 	},
 /turf/simulated/floor/carpet,
@@ -18184,15 +17239,13 @@
 /area/crew_quarters/courtroom)
 "aLS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aLT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18207,13 +17260,11 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom Lobby";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -18223,8 +17274,7 @@
 /area/crew_quarters/courtroom)
 "aLV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18241,13 +17291,11 @@
 /area/crew_quarters/courtroom)
 "aLW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18271,8 +17319,7 @@
 /area/crew_quarters/courtroom)
 "aLY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18290,8 +17337,7 @@
 /area/crew_quarters/courtroom)
 "aLZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18304,8 +17350,7 @@
 "aMa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18320,7 +17365,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18355,17 +17399,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
@@ -18390,7 +17431,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18443,7 +17483,6 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -18461,7 +17500,6 @@
 "aMp" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -18481,7 +17519,6 @@
 "aMt" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -18503,8 +17540,6 @@
 /area/maintenance/fpmaint2)
 "aMw" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18512,11 +17547,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -18540,7 +17573,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -18558,7 +17590,6 @@
 "aMD" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -18608,10 +17639,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aMJ" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cola,
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -18658,7 +17688,6 @@
 /obj/item/pen,
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -18730,8 +17759,7 @@
 /area/maintenance/fpmaint)
 "aNa" = (
 /obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -18748,9 +17776,7 @@
 "aNc" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -18787,7 +17813,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -18829,8 +17854,7 @@
 /area/maintenance/electrical)
 "aNl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18849,7 +17873,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/landmark/burnturf,
@@ -18957,7 +17980,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -19012,8 +18034,7 @@
 /area/maintenance/fpmaint2)
 "aNI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -19022,8 +18043,7 @@
 /area/maintenance/fpmaint2)
 "aNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -19044,13 +18064,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -19058,11 +18076,8 @@
 	},
 /area/hallway/primary/fore)
 "aNL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -19105,7 +18120,6 @@
 "aNQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -19114,7 +18128,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19132,7 +18145,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "courtroomshutters";
 	layer = 3.21;
@@ -19144,8 +18156,7 @@
 "aNT" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -19158,8 +18169,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -19193,14 +18203,12 @@
 "aNX" = (
 /obj/machinery/disposal,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -19210,15 +18218,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -19230,7 +18236,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -19243,8 +18248,7 @@
 /area/crew_quarters/arcade)
 "aOc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19254,8 +18258,7 @@
 "aOd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -19297,8 +18300,7 @@
 "aOh" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
@@ -19335,12 +18337,9 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
@@ -19398,8 +18397,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -19412,8 +18410,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -19494,7 +18491,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -19559,8 +18555,7 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -19570,7 +18565,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "courtroomshutters";
 	layer = 3.21;
@@ -19597,8 +18591,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -19666,8 +18659,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19703,12 +18695,10 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "barber"
 	},
 /area/civilian/barber)
@@ -19727,8 +18717,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -19763,7 +18752,6 @@
 "aPk" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -19773,7 +18761,6 @@
 "aPn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -19813,8 +18800,7 @@
 "aPx" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
@@ -19846,7 +18832,6 @@
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -19876,9 +18861,6 @@
 /area/crew_quarters/courtroom)
 "aPE" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light,
@@ -19901,7 +18883,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -19923,17 +18904,13 @@
 	id_tag = "sol_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "sol_sensor";
 	pixel_x = 12;
 	pixel_y = -25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "sol_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	tag_airpump = "sol_pump";
 	tag_chamber_sensor = "sol_sensor";
 	tag_exterior_door = "sol_outer";
@@ -19988,8 +18965,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall,
 /area/maintenance/electrical)
@@ -20033,7 +19009,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump Engineering";
-	pixel_x = 0;
 	pixel_y = 24;
 	shock_proof = 1
 	},
@@ -20041,7 +19016,6 @@
 /area/maintenance/electrical)
 "aPT" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20124,7 +19098,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -20155,10 +19128,8 @@
 /area/maintenance/fpmaint)
 "aQk" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -20190,9 +19161,6 @@
 /area/crew_quarters/dorms)
 "aQn" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 28
 	},
 /obj/structure/disposalpipe/junction{
@@ -20209,7 +19177,6 @@
 	name = "Civilian"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -20235,9 +19202,7 @@
 /area/crew_quarters/dorms)
 "aQr" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -20260,8 +19225,7 @@
 /area/hallway/primary/starboard/west)
 "aQt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -20269,8 +19233,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -20283,8 +19246,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -20341,7 +19303,7 @@
 	},
 /area/crew_quarters/dorms)
 "aQA" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /obj/machinery/light{
 	dir = 1;
 	in_use = 1
@@ -20385,22 +19347,18 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aQE" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 28;
-	req_access_txt = "0"
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -20492,15 +19450,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aQS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bluecorner"
@@ -20529,7 +19485,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
@@ -20545,12 +19500,10 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
@@ -20573,9 +19526,7 @@
 /obj/effect/landmark{
 	name = "JoinLateCryo"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
 	tag = "icon-whitebluefull"
@@ -20583,16 +19534,13 @@
 /area/crew_quarters/sleep)
 "aRa" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Arrivals Escape Pods";
-	dir = 2
+	c_tag = "Arrivals Escape Pods"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -20603,18 +19551,15 @@
 	id_tag = "sol_outer";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
-	layer = 3.3;
 	master_tag = "sol_airlock";
 	name = "exterior access button";
 	pixel_x = -13;
-	pixel_y = -23;
-	req_access_txt = "0"
+	pixel_y = -23
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -20625,8 +19570,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -20644,7 +19588,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -20652,8 +19595,7 @@
 /area/hallway/secondary/entry)
 "aRf" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -20713,8 +19655,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20732,8 +19673,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20747,8 +19687,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -20768,8 +19707,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20789,8 +19727,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -20801,8 +19738,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20820,16 +19756,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -20842,8 +19776,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -20879,8 +19812,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -20899,8 +19831,7 @@
 "aRC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -20912,12 +19843,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -20928,10 +19857,8 @@
 /area/hallway/primary/fore)
 "aRF" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -20943,7 +19870,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20960,7 +19886,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -20970,7 +19895,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21012,7 +19936,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/carpet,
@@ -21021,16 +19944,12 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/courtroom)
 "aRN" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/chair/comfy/brown{
@@ -21052,7 +19971,6 @@
 /area/crew_quarters/courtroom)
 "aRQ" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -21090,8 +20008,7 @@
 /area/shuttle/pod_2)
 "aRW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -21123,15 +20040,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
 "aSc" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -21169,8 +20084,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
@@ -21183,8 +20097,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -21194,13 +20107,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"aSk" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/dorms)
 "aSl" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -21218,7 +20124,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
@@ -21323,7 +20228,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
@@ -21401,8 +20305,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -21434,8 +20337,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -21453,7 +20355,6 @@
 /area/crew_quarters/dorms)
 "aSM" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
@@ -21463,24 +20364,15 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
-"aSO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
 "aSP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aSQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/crew_quarters/dorms)
@@ -21488,11 +20380,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -21500,8 +20390,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -21544,37 +20433,29 @@
 /area/hallway/secondary/entry)
 "aSZ" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTa" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "aTb" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "aTc" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -21585,7 +20466,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -21619,9 +20499,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aTi" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -21684,12 +20562,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -21705,7 +20580,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -21772,8 +20646,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -21810,9 +20683,7 @@
 /obj/machinery/cryopod/right,
 /obj/machinery/camera{
 	c_tag = "Cryodorms";
-	c_tag_order = 999;
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -21920,8 +20791,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical{
 	name = "Coroner";
-	req_access_txt = "5";
-	req_one_access_txt = "0"
+	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -21938,8 +20808,7 @@
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access_txt = "6";
-	req_one_access_txt = "0"
+	req_access_txt = "6"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -21961,9 +20830,7 @@
 /area/ai_monitored/storage/eva)
 "aTQ" = (
 /obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -22037,8 +20904,7 @@
 "aTX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -22109,9 +20975,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aUh" = (
@@ -22134,7 +20998,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/wall,
@@ -22144,9 +21007,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aUk" = (
@@ -22183,13 +21044,11 @@
 "aUp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
@@ -22248,7 +21107,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -22262,8 +21120,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22300,8 +21157,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
@@ -22382,7 +21238,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -22392,8 +21247,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -22410,8 +21264,7 @@
 	in_use = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Lobby West";
-	network = list("SS13")
+	c_tag = "Medbay Lobby West"
 	},
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plasteel{
@@ -22427,8 +21280,7 @@
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -5;
-	pixel_y = 30;
-	req_access_txt = "0"
+	pixel_y = 30
 	},
 /obj/structure/table,
 /obj/item/folder/white,
@@ -22443,8 +21295,7 @@
 "aUR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
@@ -22467,8 +21318,7 @@
 /area/maintenance/fsmaint2)
 "aUV" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -22515,8 +21365,7 @@
 "aVd" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22538,12 +21387,10 @@
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
-	layer = 3.3;
 	master_tag = "sol_airlock";
 	name = "interior access button";
 	pixel_x = -25;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -22573,7 +21420,6 @@
 "aVk" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -22585,7 +21431,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -22618,15 +21463,12 @@
 /area/security/nuke_storage)
 "aVn" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/table/reinforced,
 /obj/structure/closet/fireaxecabinet{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -22693,8 +21535,7 @@
 /area/crew_quarters/dorms)
 "aVt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22717,8 +21558,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -22727,16 +21567,13 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -22764,8 +21601,6 @@
 	desc = "A remote control switch for the medbay foyer.";
 	id = "imnotmakingyoulubepissoff";
 	name = "Chemistry Privacy Shutter Control";
-	normaldoorcontrol = 0;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/plasteel{
@@ -22775,8 +21610,7 @@
 /area/medical/chemistry)
 "aVz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22822,8 +21656,7 @@
 /area/crew_quarters/toilet)
 "aVD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22841,8 +21674,7 @@
 /area/maintenance/fpmaint)
 "aVE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22869,8 +21701,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22880,8 +21711,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -22891,7 +21721,6 @@
 /area/crew_quarters/bar)
 "aVH" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -22900,8 +21729,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22948,8 +21776,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22959,8 +21786,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -23065,7 +21891,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -23083,7 +21908,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -23101,14 +21925,12 @@
 	id_tag = "sol_inner";
 	locked = 1;
 	name = "Arrivals External Access";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "aWf" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/computer/security{
@@ -23148,7 +21970,6 @@
 "aWi" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/wirecutters,
@@ -23209,8 +22030,6 @@
 "aWo" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/item/assembly/signaler,
@@ -23225,7 +22044,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -23247,7 +22065,6 @@
 /obj/structure/table,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/storage/toolbox/mechanical,
@@ -23296,25 +22113,6 @@
 	icon_state = "vault"
 	},
 /area/security/nuke_storage)
-"aWy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint2)
 "aWz" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/light{
@@ -23341,8 +22139,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -23448,7 +22245,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -23462,8 +22258,7 @@
 	in_use = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Chemistry North";
-	network = list("SS13")
+	c_tag = "Medbay Chemistry North"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -23492,7 +22287,6 @@
 /obj/machinery/chem_master,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -23510,7 +22304,6 @@
 /obj/item/reagent_containers/dropper/precision,
 /obj/effect/decal/warning_stripes/northwest,
 /obj/structure/reagent_dispensers/fueltank/chem{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -23588,27 +22381,23 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aXb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aXc" = (
 /obj/machinery/crema_switch{
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23618,7 +22407,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -23635,7 +22423,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -23645,7 +22432,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -23661,14 +22447,12 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -23681,14 +22465,12 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/chapel/main)
 "aXi" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -23697,14 +22479,12 @@
 /obj/structure/morgue,
 /obj/machinery/camera{
 	c_tag = "Chapel Crematorium";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/landmark{
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -23714,7 +22494,6 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -23740,7 +22519,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -23815,9 +22593,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -23884,8 +22660,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/construction{
@@ -23901,8 +22676,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -23913,8 +22687,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -23922,12 +22695,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
-	name = "Garden";
-	req_access_txt = "0"
+	name = "Garden"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/construction{
@@ -23950,8 +22721,7 @@
 "aXO" = (
 /obj/machinery/camera{
 	c_tag = "Vault";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/closet/crate{
 	name = "Gold Crate"
@@ -23968,8 +22738,6 @@
 	pixel_y = -2
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/item/storage/belt/champion,
@@ -24034,7 +22802,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -24047,7 +22814,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -24106,8 +22872,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24187,12 +22952,10 @@
 /obj/item/scalpel,
 /obj/item/autopsy_scanner,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -24238,9 +23001,7 @@
 	},
 /area/security/armoury)
 "aYn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/storage/office)
 "aYo" = (
@@ -24248,12 +23009,10 @@
 	department = "Morgue";
 	departmentType = 5;
 	name = "Morgue Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Coroner";
-	network = list("SS13")
+	c_tag = "Medbay Coroner"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -24329,8 +23088,7 @@
 "aYu" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/window/southleft{
-	name = "EVA Equipment";
-	req_access_txt = "0"
+	name = "EVA Equipment"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -24340,8 +23098,7 @@
 "aYv" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24358,8 +23115,7 @@
 "aYw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -24380,7 +23136,6 @@
 	name = "revenantspawn"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -24388,8 +23143,7 @@
 "aYy" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/door/window/southright{
-	name = "EVA Equipment";
-	req_access_txt = "0"
+	name = "EVA Equipment"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -24398,9 +23152,7 @@
 /area/ai_monitored/storage/eva)
 "aYz" = (
 /obj/machinery/camera{
-	c_tag = "Chapel North";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Chapel North"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -24452,13 +23204,10 @@
 /area/chapel/main)
 "aYI" = (
 /obj/machinery/computer/cryopod{
-	density = 0;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -24514,7 +23263,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -24534,15 +23282,13 @@
 /area/escapepodbay)
 "aYT" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "propulsion"
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/arrival/station)
 "aYV" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "heater"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -24554,7 +23300,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -24567,7 +23312,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -24619,7 +23363,6 @@
 "aZb" = (
 /obj/item/radio,
 /obj/item/radio/intercom/department/security{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/hologram/holopad,
@@ -24631,7 +23374,6 @@
 "aZc" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -24644,7 +23386,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -24655,8 +23396,7 @@
 "aZe" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/stack/cable_coil{
 	pixel_x = 2;
@@ -24684,7 +23424,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -24738,7 +23477,6 @@
 "aZm" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/chapel/main)
@@ -24898,11 +23636,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkbluecorners"
 	},
 /area/chapel/main)
@@ -24925,7 +23661,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -24952,7 +23687,6 @@
 /obj/item/toy/crayon/mime,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -24964,7 +23698,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -24997,8 +23730,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -25026,8 +23758,7 @@
 /area/medical/morgue)
 "aZU" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer/autopsy,
 /turf/simulated/floor/plasteel{
@@ -25067,7 +23798,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -25086,7 +23816,6 @@
 "bab" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -25122,7 +23851,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25164,8 +23892,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25191,9 +23918,7 @@
 	},
 /area/gateway)
 "ban" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -25201,9 +23926,7 @@
 /area/gateway)
 "bao" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/table/wood,
@@ -25233,8 +23956,7 @@
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25245,8 +23967,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25258,8 +23979,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25282,12 +24002,10 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25341,15 +24059,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25392,15 +24108,12 @@
 /area/escapepodbay)
 "baH" = (
 /obj/machinery/camera{
-	c_tag = "Departure Lounge Podbay";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Departure Lounge Podbay"
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the pod doors.";
 	id = "escapepodbay";
 	name = "Pod Door Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "13"
 	},
@@ -25562,8 +24275,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -25575,7 +24287,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
@@ -25639,8 +24350,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25667,11 +24377,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bbi" = (
-/obj/machinery/vending/cola,
 /obj/machinery/camera{
-	c_tag = "Dormitories North-West";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Dormitories North-West"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -25745,12 +24452,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/structure/cable{
@@ -25761,8 +24466,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -25794,14 +24498,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bby" = (
 /obj/machinery/camera{
-	c_tag = "Medbay Morgue";
-	network = list("SS13")
+	c_tag = "Medbay Morgue"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -25819,7 +24521,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "Kitchen";
 	sortType = 20;
 	tag = "icon-pipe-j1s (EAST)"
@@ -25840,7 +24541,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -25848,12 +24548,10 @@
 "bbB" = (
 /obj/structure/closet/secure_closet/mime,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -25894,7 +24592,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -25966,9 +24663,7 @@
 "bbL" = (
 /obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -26007,7 +24702,6 @@
 "bbQ" = (
 /obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -26019,8 +24713,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26066,7 +24759,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -26082,8 +24774,7 @@
 "bbX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -26151,10 +24842,7 @@
 /area/maintenance/fsmaint2)
 "bcc" = (
 /obj/structure/window/reinforced,
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/crew_quarters/dorms)
 "bcd" = (
@@ -26199,9 +24887,7 @@
 "bch" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/camera{
-	c_tag = "Library North";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Library North"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -26276,9 +24962,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -26310,13 +24994,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -26334,8 +25016,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26353,9 +25034,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Chapel Chaplain's Office";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Chapel Chaplain's Office"
 	},
 /obj/structure/table/wood,
 /obj/item/lighter/zippo/black,
@@ -26387,7 +25066,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -26440,7 +25118,6 @@
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
-	pixel_y = 0;
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
@@ -26450,8 +25127,7 @@
 /area/chapel/main)
 "bcG" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Lounge";
-	dir = 2
+	c_tag = "Arrivals Lounge"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -26481,14 +25157,9 @@
 /area/shuttle/arrival/station)
 "bcO" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
 "bcP" = (
@@ -26505,14 +25176,11 @@
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/plant_analyzer,
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
 	pixel_x = -6;
 	pixel_y = -25
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -26539,13 +25207,11 @@
 	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
 	name = "Kitchen Desk";
 	req_access_txt = "28"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -26578,7 +25244,6 @@
 "bcW" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -26702,8 +25367,7 @@
 	opacity = 0
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -26731,11 +25395,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -26787,12 +25449,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mime's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -26801,12 +25461,10 @@
 /obj/structure/statue/tranquillite/mime,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -26836,7 +25494,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -26851,8 +25508,7 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -26864,8 +25520,7 @@
 "bdy" = (
 /obj/effect/decal/warning_stripes/blue/hollow,
 /obj/structure/sign/poster/official/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -26895,12 +25550,10 @@
 "bdB" = (
 /obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel{
@@ -26911,8 +25564,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26924,7 +25576,6 @@
 "bdE" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/structure/rack,
@@ -26940,8 +25591,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -26972,8 +25622,7 @@
 	name = "Dormitories"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26985,8 +25634,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/closet/chefcloset,
@@ -26999,20 +25646,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "bdL" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
@@ -27023,8 +25665,7 @@
 /area/crew_quarters/kitchen)
 "bdM" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen Freezer";
-	network = list("SS13")
+	c_tag = "Kitchen Freezer"
 	},
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
@@ -27037,19 +25678,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"bdN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/dorms)
 "bdO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -27073,8 +25701,7 @@
 	opacity = 0
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
@@ -27082,8 +25709,7 @@
 /area/bridge)
 "bdQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27095,7 +25721,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27120,7 +25745,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27129,8 +25753,7 @@
 /area/crew_quarters/kitchen)
 "bdU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
@@ -27147,8 +25770,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Hydroponics Storage";
-	network = list("SS13")
+	c_tag = "Hydroponics Storage"
 	},
 /obj/structure/closet/crate/hydroponics/prespawned,
 /turf/simulated/floor/plasteel{
@@ -27166,7 +25788,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -27225,8 +25846,7 @@
 /area/ai_monitored/storage/eva)
 "bea" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -27240,8 +25860,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -27259,8 +25878,7 @@
 /area/hydroponics)
 "bec" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27301,7 +25919,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -27312,8 +25929,7 @@
 /area/ai_monitored/storage/eva)
 "bef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27385,7 +26001,6 @@
 "beq" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
-	pixel_y = 0;
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
@@ -27401,7 +26016,6 @@
 /area/chapel/office)
 "bes" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -27432,8 +26046,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27475,8 +26088,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -27614,8 +26226,7 @@
 /area/hallway/primary/port)
 "beT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27639,13 +26250,11 @@
 /area/storage/primary)
 "beV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27657,8 +26266,7 @@
 /area/crew_quarters/dorms)
 "beW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27667,7 +26275,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27675,7 +26282,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "E.V.A.";
-	req_access_txt = "0";
 	req_one_access_txt = "18"
 	},
 /turf/simulated/floor/plasteel{
@@ -27684,8 +26290,7 @@
 /area/ai_monitored/storage/eva)
 "beY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27697,7 +26302,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27710,7 +26314,6 @@
 	tag = "icon-pipe-j2 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27722,15 +26325,13 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_plating = "plating";
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "bfb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27739,12 +26340,10 @@
 	dir = 4
 	},
 /obj/machinery/poolcontroller{
-	pixel_x = 0;
 	pixel_y = -25;
 	srange = 7
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27754,14 +26353,12 @@
 /area/hallway/primary/port)
 "bfd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -27770,7 +26367,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27805,35 +26401,28 @@
 /area/ai_monitored/storage/eva)
 "bfi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory Center";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27846,7 +26435,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27855,7 +26443,6 @@
 	department = "Bar";
 	departmentType = 2;
 	name = "Bar Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/table/reinforced,
@@ -27896,15 +26483,13 @@
 /area/maintenance/fsmaint2)
 "bfo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
@@ -27921,34 +26506,29 @@
 /area/crew_quarters/dorms)
 "bfq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -27960,7 +26540,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -27993,8 +26572,7 @@
 /area/turret_protected/aisat_interior)
 "bfv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28009,7 +26587,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -28031,26 +26608,22 @@
 /area/maintenance/fsmaint2)
 "bfx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28060,14 +26633,12 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -28077,7 +26648,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -28120,7 +26690,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -28138,7 +26707,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/closet/secure_closet/hydroponics,
@@ -28152,7 +26720,6 @@
 "bfG" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "Botany";
 	sortType = 21;
 	tag = "icon-pipe-j1s (EAST)"
@@ -28225,7 +26792,6 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/watertank,
@@ -28313,8 +26879,7 @@
 /area/chapel/main)
 "bfT" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -28351,8 +26916,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -28416,8 +26980,7 @@
 /area/chapel/office)
 "bgh" = (
 /obj/machinery/camera{
-	c_tag = "Port Hallway 2";
-	dir = 2
+	c_tag = "Port Hallway 2"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -28471,13 +27034,11 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	icon_state = "direction_evac";
 	pixel_y = 24;
 	tag = "icon-direction_evac (EAST)"
 	},
 /obj/structure/sign/directions/medical{
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_y = 32;
 	tag = "icon-direction_med (EAST)"
 	},
@@ -28487,7 +27048,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -28498,9 +27058,7 @@
 /area/hallway/primary/port)
 "bgr" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -28509,13 +27067,10 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/camera{
 	c_tag = "Office Supplies";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -28549,7 +27104,6 @@
 "bgw" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -28589,9 +27143,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bgB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bgC" = (
@@ -28626,12 +27178,10 @@
 /area/hallway/secondary/entry)
 "bgH" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -28650,7 +27200,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -28664,8 +27213,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -28718,14 +27266,12 @@
 "bgO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "E.V.A. Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "18"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28757,8 +27303,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Funeral Processing East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -28773,18 +27318,13 @@
 /area/crew_quarters/mrchangs)
 "bgU" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/north)
 "bgV" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/door/firedoor,
@@ -28825,8 +27365,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -28837,7 +27376,6 @@
 "bgZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -28867,14 +27405,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "bhf" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -28894,8 +27430,7 @@
 /obj/structure/statue/bananium/clown,
 /obj/machinery/camera{
 	c_tag = "Clown's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/clownoffice)
@@ -28975,8 +27510,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitories Toilets";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -29035,8 +27569,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -29062,7 +27595,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -29088,8 +27620,7 @@
 "bhD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -29105,7 +27636,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -29117,8 +27647,7 @@
 	},
 /obj/item/vending_refill/cola,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -29140,10 +27669,8 @@
 	pixel_y = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -29152,8 +27679,7 @@
 /area/gateway)
 "bhI" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -29165,8 +27691,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -29184,8 +27709,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -29241,8 +27765,7 @@
 	},
 /obj/item/radio,
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -29276,7 +27799,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -29318,8 +27840,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -29346,9 +27867,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -29371,7 +27890,7 @@
 	},
 /area/hydroponics)
 "bid" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cola,
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -29380,12 +27899,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -29395,7 +27911,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/closet/secure_closet/hydroponics,
@@ -29409,7 +27924,6 @@
 "bih" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
@@ -29419,10 +27933,7 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bii" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bij" = (
@@ -29438,8 +27949,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29467,8 +27977,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -29500,8 +28009,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Office Maintenance";
@@ -29547,7 +28055,6 @@
 /area/hallway/secondary/entry)
 "biw" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -29600,7 +28107,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -29634,8 +28140,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29659,8 +28164,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29699,8 +28203,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29746,12 +28249,10 @@
 	pixel_y = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/item/storage/toolbox/mechanical{
@@ -29765,8 +28266,7 @@
 "biO" = (
 /turf/simulated/floor/plasteel{
 	desc = "";
-	icon_state = "L13";
-	name = "floor"
+	icon_state = "L13"
 	},
 /area/hallway/primary/central/north)
 "biP" = (
@@ -29778,9 +28278,7 @@
 "biQ" = (
 /obj/structure/statue/chickenstatue,
 /obj/machinery/camera{
-	c_tag = "Mr. Chang's";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Mr. Chang's"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
@@ -29791,9 +28289,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "biS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -29811,7 +28307,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -29841,8 +28336,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -29868,8 +28362,7 @@
 "biX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -29892,8 +28385,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -29901,22 +28393,19 @@
 /area/crew_quarters/kitchen)
 "biZ" = (
 /obj/machinery/camera{
-	c_tag = "Bar Storage";
-	network = list("SS13")
+	c_tag = "Bar Storage"
 	},
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/dropper,
 /obj/structure/sign/poster/contraband/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bja" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -29934,17 +28423,13 @@
 	id_tag = "ai_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "ai_sensor";
 	pixel_x = 12;
 	pixel_y = 25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "ai_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	tag_airpump = "ai_pump";
 	tag_chamber_sensor = "ai_sensor";
 	tag_exterior_door = "ai_outer";
@@ -29964,7 +28449,6 @@
 "bjd" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -30015,8 +28499,6 @@
 /area/atmos)
 "bjj" = (
 /obj/structure/closet/gmcloset{
-	icon_closed = "black";
-	icon_state = "black";
 	name = "formal wardrobe"
 	},
 /obj/machinery/light/small{
@@ -30064,7 +28546,6 @@
 /area/maintenance/fsmaint2)
 "bjp" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Confession Booth (Chaplain)";
 	req_access_txt = "22"
 	},
@@ -30118,9 +28599,7 @@
 	},
 /area/hydroponics)
 "bju" = (
-/obj/machinery/bookbinder{
-	pixel_y = 0
-	},
+/obj/machinery/bookbinder,
 /turf/simulated/floor/wood,
 /area/library)
 "bjv" = (
@@ -30155,9 +28634,7 @@
 	in_use = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -30242,8 +28719,7 @@
 "bjQ" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -30264,8 +28740,7 @@
 "bjU" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Center";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -30351,7 +28826,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/disposalpipe/segment{
@@ -30402,7 +28876,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel,
@@ -30438,8 +28911,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -30469,7 +28941,6 @@
 /area/hallway/primary/port)
 "bkm" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -30489,7 +28960,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -30498,8 +28968,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -30509,7 +28978,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -30530,7 +28998,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -30547,7 +29014,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -30557,7 +29023,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -30570,7 +29035,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -30594,7 +29058,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/sign/securearea{
@@ -30613,7 +29076,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -30626,7 +29088,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -30641,7 +29102,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -30654,7 +29114,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -30688,7 +29147,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -30701,7 +29159,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -30714,7 +29171,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -30741,8 +29197,7 @@
 /area/space/nearstation)
 "bkJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -30750,8 +29205,7 @@
 	master_tag = "ai_airlock";
 	name = "interior access button";
 	pixel_x = -25;
-	pixel_y = 25;
-	req_access_txt = "0"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
@@ -30837,7 +29291,6 @@
 "bkU" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/seed_extractor,
@@ -30847,8 +29300,7 @@
 /area/hydroponics)
 "bkV" = (
 /obj/machinery/camera{
-	c_tag = "Hydroponics North";
-	network = list("SS13")
+	c_tag = "Hydroponics North"
 	},
 /obj/machinery/vending/hydroseeds,
 /turf/simulated/floor/plasteel{
@@ -30880,7 +29332,6 @@
 	name = "Forbidden Knowledge"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -30901,13 +29352,11 @@
 /obj/item/pen/invisible,
 /obj/machinery/camera{
 	c_tag = "Library Study";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/stack/tape_roll,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -30961,8 +29410,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -30981,13 +29429,11 @@
 "blh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -31016,12 +29462,9 @@
 "blm" = (
 /obj/machinery/camera{
 	c_tag = "Chapel South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -31054,12 +29497,10 @@
 /obj/structure/window/reinforced/tinted,
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -31091,10 +29532,7 @@
 	},
 /area/hallway/secondary/entry)
 "blt" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "blw" = (
@@ -31102,8 +29540,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -31138,7 +29574,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -31147,7 +29582,6 @@
 "blE" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -31165,8 +29599,7 @@
 /area/hallway/primary/port)
 "blG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -31207,7 +29640,8 @@
 	},
 /area/chapel/main)
 "blJ" = (
-/obj/machinery/vending/snack,
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -31217,8 +29651,7 @@
 /area/hallway/primary/port)
 "blL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -31283,8 +29716,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31335,18 +29767,16 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -31386,8 +29816,8 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -31425,8 +29855,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -31435,7 +29864,6 @@
 /area/hallway/primary/port)
 "bmg" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Confession Booth"
 	},
 /turf/simulated/floor/plasteel{
@@ -31448,11 +29876,9 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -31476,12 +29902,10 @@
 	dir = 1
 	},
 /obj/machinery/door/window{
-	dir = 4;
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -31499,12 +29923,10 @@
 "bml" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "E.V.A. Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "18"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31567,19 +29989,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
 "bmu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -31604,8 +30023,7 @@
 /area/hallway/primary/port)
 "bmw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31672,15 +30090,13 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/library)
 "bmE" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -31691,7 +30107,6 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -31704,7 +30119,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -31724,8 +30138,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -31743,7 +30156,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -31761,8 +30173,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31779,8 +30190,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -31797,7 +30207,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -31836,7 +30245,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -31863,8 +30271,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -31909,8 +30316,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L2"
@@ -31925,7 +30331,6 @@
 /area/hallway/primary/central/north)
 "bng" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/hologram/holopad,
@@ -31993,8 +30398,7 @@
 /area/hallway/primary/central/north)
 "bnl" = (
 /obj/machinery/camera{
-	c_tag = "Bar East";
-	network = list("SS13")
+	c_tag = "Bar East"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -32027,22 +30431,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
-"bnp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/ne)
 "bnq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32055,7 +30443,6 @@
 /area/maintenance/port)
 "bnr" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/hologram/holopad,
@@ -32118,7 +30505,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -32149,8 +30535,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/pet_store)
@@ -32330,20 +30715,16 @@
 /area/hallway/primary/central/ne)
 "boe" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "bof" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -32366,7 +30747,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -32388,7 +30768,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -32396,12 +30775,10 @@
 "boj" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -32430,17 +30807,13 @@
 /area/crew_quarters/bar)
 "bon" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen";
-	network = list("SS13")
+	c_tag = "Kitchen"
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/kitchen_machine/candy_maker,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -32452,7 +30825,6 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -32472,7 +30844,6 @@
 "boq" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -32503,12 +30874,10 @@
 /area/ai_monitored/storage/eva)
 "bos" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -32526,7 +30895,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -32559,12 +30927,10 @@
 /area/quartermaster/office)
 "boy" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Private Study";
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -32574,7 +30940,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -32596,9 +30961,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Departure Lounge Security";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Departure Lounge Security"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -32633,9 +30996,6 @@
 /area/library)
 "boH" = (
 /obj/machinery/door/window{
-	base_state = "left";
-	dir = 4;
-	icon_state = "left";
 	name = "Bar Door";
 	req_access_txt = "25"
 	},
@@ -32663,7 +31023,6 @@
 /area/chapel/main)
 "boL" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -32671,13 +31030,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -32702,7 +31059,6 @@
 "boP" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -32741,7 +31097,6 @@
 /area/crew_quarters/kitchen)
 "boT" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel,
@@ -32761,8 +31116,7 @@
 "boW" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -32799,7 +31153,6 @@
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -32807,7 +31160,6 @@
 "bpb" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/table,
@@ -32849,7 +31201,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel,
@@ -32878,7 +31229,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel,
@@ -32907,12 +31257,10 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage";
-	dir = 2
+	c_tag = "Auxiliary Tool Storage"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -32929,7 +31277,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -32945,9 +31292,7 @@
 "bpn" = (
 /obj/structure/table,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/stack/sheet/glass{
@@ -32971,7 +31316,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -33021,7 +31365,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -33069,7 +31412,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -33082,7 +31424,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -33098,7 +31439,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -33158,7 +31498,6 @@
 "bpF" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel,
@@ -33207,7 +31546,6 @@
 "bpL" = (
 /obj/structure/foodcart,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -33233,12 +31571,10 @@
 	opacity = 0
 	},
 /obj/machinery/door/window{
-	dir = 4;
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -33260,13 +31596,11 @@
 /area/chapel/main)
 "bpQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/carpet,
@@ -33286,7 +31620,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -33325,16 +31658,12 @@
 /area/hallway/secondary/entry)
 "bpY" = (
 /obj/machinery/door/window/northright{
-	base_state = "right";
 	dir = 8;
-	icon_state = "right";
 	name = "Library Desk Door";
 	req_access_txt = "37"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
@@ -33369,9 +31698,7 @@
 /area/library)
 "bqd" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/library/checkout{
-	pixel_y = 0
-	},
+/obj/machinery/computer/library/checkout,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -33395,8 +31722,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -33433,7 +31759,6 @@
 "bqk" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood,
@@ -33457,8 +31782,7 @@
 	name = "Mr. Chang's"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33467,7 +31791,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/wood,
@@ -33476,8 +31799,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -33504,7 +31826,6 @@
 	frequency = 1379;
 	master_tag = "eva_airlock";
 	name = "interior access button";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "13"
 	},
@@ -33521,8 +31842,7 @@
 /area/maintenance/fpmaint2)
 "bqu" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plasteel,
@@ -33553,13 +31873,11 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -33590,7 +31908,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -33610,9 +31927,7 @@
 "bqF" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/wood,
@@ -33631,7 +31946,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -33698,9 +32012,7 @@
 	network = list("SS13","Research Outpost","Mining Outpost","Telecomms")
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge West";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bridge West"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -33709,9 +32021,7 @@
 /area/bridge)
 "bqR" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bqS" = (
@@ -33747,7 +32057,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -33766,8 +32075,7 @@
 /area/bridge)
 "bra" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/computer/security/mining,
 /turf/simulated/floor/plasteel{
@@ -33777,17 +32085,13 @@
 /area/bridge)
 "brb" = (
 /obj/machinery/camera{
-	c_tag = "Bridge East";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bridge East"
 	},
 /obj/machinery/computer/supplycomp,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/bridge)
@@ -33825,20 +32129,17 @@
 "brf" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/camera{
 	c_tag = "Bar West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brg" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /obj/effect/landmark/start{
@@ -33849,9 +32150,7 @@
 "brh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bri" = (
@@ -33867,8 +32166,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -33903,16 +32201,13 @@
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
 "brn" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33929,15 +32224,13 @@
 "bro" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
 "brp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -33965,8 +32258,6 @@
 "brt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -34028,8 +32319,7 @@
 /area/library)
 "brC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
@@ -34046,8 +32336,7 @@
 "brE" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -34087,7 +32376,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -34167,7 +32455,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34208,7 +32495,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -34222,8 +32508,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -34232,8 +32517,7 @@
 /obj/machinery/requests_console{
 	department = "Locker Room";
 	name = "Locker Room Requests Console";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -34250,7 +32534,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -34269,7 +32552,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -34289,7 +32571,6 @@
 "bsm" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel,
@@ -34323,8 +32604,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -34493,9 +32773,7 @@
 /area/hallway/primary/central/ne)
 "bsL" = (
 /obj/machinery/camera{
-	c_tag = "Bridge East Entrance";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bridge East Entrance"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -34520,10 +32798,9 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
-/obj/machinery/vending/snack,
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bsP" = (
@@ -34533,8 +32810,6 @@
 /area/hallway/secondary/exit)
 "bsQ" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/wood,
@@ -34557,7 +32832,6 @@
 	},
 /obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -34571,7 +32845,6 @@
 /obj/structure/table,
 /obj/item/book/manual/sop_service,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34579,14 +32852,12 @@
 "bsU" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -34600,7 +32871,6 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -34620,7 +32890,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -34628,7 +32897,6 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -34645,16 +32913,12 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
 "bta" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/vending/cola,
@@ -34675,8 +32939,7 @@
 "btc" = (
 /obj/structure/chair,
 /obj/machinery/camera{
-	c_tag = "Departure Lounge North";
-	network = list("SS13")
+	c_tag = "Departure Lounge North"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -34693,7 +32956,6 @@
 "btf" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /obj/effect/landmark/start{
@@ -34804,7 +33066,6 @@
 	},
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34870,7 +33131,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34880,7 +33140,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34896,7 +33155,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34917,7 +33175,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34931,7 +33188,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34948,7 +33204,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -34983,8 +33238,7 @@
 /area/crew_quarters/locker)
 "btU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -35003,8 +33257,7 @@
 /area/library)
 "btW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -35027,8 +33280,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -35062,9 +33314,7 @@
 /area/storage/tools)
 "bue" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -35101,9 +33351,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "buh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bui" = (
@@ -35131,8 +33379,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -35152,9 +33399,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bup" = (
@@ -35164,7 +33409,6 @@
 "buq" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35174,7 +33418,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -35183,7 +33426,6 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -35197,7 +33439,6 @@
 /obj/structure/table,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -35206,14 +33447,12 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/cream,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "buv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -35228,12 +33467,10 @@
 "bux" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 1;
-	icon_state = "4"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -35253,18 +33490,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
-	pixel_y = 0;
 	step_size = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -35287,7 +33521,6 @@
 "buC" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
@@ -35306,7 +33539,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/hallway/secondary/exit)
@@ -35315,7 +33547,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35328,8 +33559,7 @@
 "buG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Chapel";
-	req_access_txt = "0"
+	name = "Chapel"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -35350,7 +33580,6 @@
 	name = "Chef"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -35362,11 +33591,9 @@
 	department = "Kitchen";
 	departmentType = 2;
 	name = "Kitchen Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -35385,14 +33612,12 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/carpet,
@@ -35409,7 +33634,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -35429,7 +33653,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/wood/wings{
 	dir = 1;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (NORTH)"
 	},
 /turf/simulated/floor/wood,
@@ -35437,7 +33660,6 @@
 "buR" = (
 /obj/structure/chair/wood/wings{
 	dir = 1;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (NORTH)"
 	},
 /turf/simulated/floor/wood,
@@ -35450,18 +33672,14 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Auxiliary Docking North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "buT" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -35470,8 +33688,7 @@
 "buU" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -35483,7 +33700,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/carpet,
@@ -35493,7 +33709,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -35522,21 +33737,18 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Chapel";
-	req_access_txt = "0"
+	name = "Chapel"
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "bva" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Chapel";
-	req_access_txt = "0"
+	name = "Chapel"
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
@@ -35573,7 +33785,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/sign/poster/random{
@@ -35600,7 +33811,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -35610,7 +33820,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -35645,8 +33854,7 @@
 /area/security/vacantoffice)
 "bvo" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood,
@@ -35758,8 +33966,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -35828,7 +34035,6 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -35852,8 +34058,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -35886,7 +34091,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -35920,19 +34124,16 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvU" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -36056,8 +34257,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -36104,7 +34304,6 @@
 /area/hallway/primary/central/ne)
 "bwk" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/hallway/secondary/exit)
@@ -36139,7 +34338,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36148,12 +34346,10 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36164,7 +34360,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36182,22 +34377,19 @@
 /obj/machinery/disposal,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
 "bws" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plasteel{
@@ -36207,8 +34399,7 @@
 "bwt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -36247,7 +34438,6 @@
 /area/storage/tools)
 "bwA" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/rack{
@@ -36261,13 +34451,11 @@
 "bwB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
@@ -36299,8 +34487,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
@@ -36424,7 +34611,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36459,18 +34645,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -36552,9 +34735,7 @@
 	dir = 4;
 	id = "packageSort2"
 	},
-/obj/structure/plasticflaps{
-	opacity = 0
-	},
+/obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "bxg" = (
@@ -36610,8 +34791,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -36653,17 +34833,14 @@
 /area/bridge)
 "bxs" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bxt" = (
 /obj/machinery/camera/motion{
-	c_tag = "AI Upload Chamber";
-	network = list("SS13")
+	c_tag = "AI Upload Chamber"
 	},
 /obj/machinery/light_switch{
 	pixel_y = 27
@@ -36701,8 +34878,7 @@
 "bxy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -36754,8 +34930,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -36765,8 +34940,7 @@
 "bxD" = (
 /obj/machinery/camera{
 	c_tag = "Bridge Central";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -36788,20 +34962,17 @@
 /area/bridge)
 "bxE" = (
 /obj/machinery/atm{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxF" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36809,7 +34980,6 @@
 "bxG" = (
 /obj/machinery/icemachine,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36832,7 +35002,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36854,7 +35023,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36876,7 +35044,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -36910,14 +35077,11 @@
 "bxN" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light_switch{
@@ -36931,7 +35095,6 @@
 /obj/machinery/turretid/stun{
 	control_area = "\improper AI Upload Chamber";
 	name = "AI Upload Turret Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access = list(75)
 	},
@@ -36988,7 +35151,6 @@
 /obj/machinery/light,
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "south bump Important Area";
 	pixel_y = -24
 	},
@@ -37017,7 +35179,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
@@ -37087,7 +35248,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -37111,8 +35271,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -37161,7 +35320,6 @@
 /area/security/vacantoffice)
 "byh" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
@@ -37169,7 +35327,6 @@
 "byi" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
@@ -37211,9 +35368,7 @@
 "byo" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -37319,7 +35474,6 @@
 "byv" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -37332,8 +35486,7 @@
 "byx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -37380,7 +35533,6 @@
 "byD" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
@@ -37390,7 +35542,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -37411,7 +35562,6 @@
 /obj/machinery/door_control{
 	id = "heads_meeting";
 	name = "Privacy Shutters Control";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
@@ -37427,15 +35577,11 @@
 /area/bridge/meeting_room)
 "byJ" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge Conference Room";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bridge Conference Room"
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
@@ -37444,7 +35590,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light_switch{
@@ -37460,7 +35605,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
@@ -37521,7 +35665,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -37547,7 +35690,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light_switch{
@@ -37563,13 +35705,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Library";
-	req_access_txt = "0"
+	name = "Library"
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -37578,11 +35718,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet,
@@ -37595,7 +35733,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/carpet,
@@ -37609,14 +35746,12 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "north bump Important Area";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "byY" = (
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -37694,9 +35829,7 @@
 /area/hallway/primary/starboard/west)
 "bzh" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 2";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Starboard Primary Hallway 2"
 	},
 /obj/structure/closet/crate/can,
 /turf/simulated/floor/plasteel{
@@ -37732,7 +35865,6 @@
 /area/hydroponics)
 "bzl" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light,
@@ -37742,8 +35874,7 @@
 /area/chapel/main)
 "bzm" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -37761,7 +35892,6 @@
 /obj/machinery/light,
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
@@ -37771,7 +35901,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37779,16 +35908,12 @@
 /area/library)
 "bzr" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bzs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bzt" = (
@@ -37835,7 +35960,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37902,7 +36026,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
@@ -37954,9 +36077,6 @@
 /obj/item/storage/box,
 /obj/item/storage/box,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -37991,10 +36111,8 @@
 /area/security/vacantoffice)
 "bzM" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -38020,8 +36138,7 @@
 /area/security/vacantoffice)
 "bzQ" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -38059,10 +36176,8 @@
 /area/turret_protected/ai_upload)
 "bzU" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -38095,7 +36210,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/vending/cigarette,
@@ -38145,8 +36259,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -38175,13 +36288,11 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -38193,7 +36304,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -38208,8 +36318,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38225,7 +36334,6 @@
 /area/hallway/primary/starboard/west)
 "bAo" = (
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -38238,7 +36346,6 @@
 /area/hallway/primary/starboard/west)
 "bAq" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -38269,8 +36376,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38306,8 +36412,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38336,8 +36441,7 @@
 "bAB" = (
 /obj/machinery/camera{
 	c_tag = "Bridge West Entrance";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -38400,7 +36504,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -38443,7 +36546,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -38465,8 +36567,7 @@
 /area/engine/engineering)
 "bAU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -38489,8 +36590,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 4";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38499,8 +36599,7 @@
 "bAX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Library";
-	req_access_txt = "0"
+	name = "Library"
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -38561,8 +36660,7 @@
 "bBf" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -38576,8 +36674,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Arrivals Auxiliary Docking South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
@@ -38604,7 +36701,6 @@
 "bBk" = (
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/cable{
@@ -38620,8 +36716,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -38678,13 +36773,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -38721,7 +36814,6 @@
 "bBy" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/porta_turret{
@@ -38764,23 +36856,19 @@
 /area/crew_quarters/captain)
 "bBE" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bBF" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -38829,12 +36917,10 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -38863,7 +36949,6 @@
 "bBO" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	pixel_x = 5;
 	tag = "icon-shower (EAST)"
 	},
@@ -38997,7 +37082,6 @@
 "bCv" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/cable{
@@ -39078,7 +37162,6 @@
 /obj/machinery/light/small,
 /obj/structure/chair/wood/wings{
 	dir = 8;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood,
@@ -39102,7 +37185,6 @@
 "bCF" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -39120,7 +37202,6 @@
 /obj/structure/table,
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right";
 	name = "Core Modules";
 	req_access_txt = "20"
@@ -39142,8 +37223,7 @@
 "bCI" = (
 /obj/machinery/camera{
 	c_tag = "Bar South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/gameboard,
 /turf/simulated/floor/wood,
@@ -39152,7 +37232,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "south bump Important Area";
 	pixel_y = -24
 	},
@@ -39162,7 +37241,6 @@
 /obj/machinery/computer/aiupload,
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -21
 	},
 /turf/simulated/floor/bluegrid,
@@ -39170,7 +37248,6 @@
 "bCL" = (
 /obj/machinery/computer/borgupload,
 /obj/item/radio/intercom/private{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/bluegrid,
@@ -39201,8 +37278,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -39249,8 +37325,7 @@
 /obj/structure/table/wood,
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/storage/lockbox/medal,
 /turf/simulated/floor/wood,
@@ -39258,8 +37333,7 @@
 "bCW" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/storage/box/cups{
 	pixel_x = 6;
@@ -39267,9 +37341,7 @@
 	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /obj/item/roller,
 /turf/simulated/floor/plasteel{
@@ -39294,8 +37366,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -39304,7 +37375,6 @@
 /area/hallway/primary/central/east)
 "bCZ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
@@ -39323,8 +37393,7 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -39335,7 +37404,6 @@
 "bDd" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/computer/mob_healer_terminal{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -39430,7 +37498,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/chem_dispenser,
@@ -39453,9 +37520,7 @@
 /area/bridge/meeting_room)
 "bDp" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -39465,14 +37530,12 @@
 /area/hallway/secondary/exit)
 "bDq" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/hallway/primary/starboard/east)
 "bDr" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/hallway/primary/starboard/east)
@@ -39487,18 +37550,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -39509,8 +37569,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -39522,9 +37581,7 @@
 "bDv" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39669,8 +37726,7 @@
 "bDR" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -39731,8 +37787,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -39852,15 +37907,13 @@
 "bEl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Chapel";
-	req_access_txt = "0"
+	name = "Chapel"
 	},
 /turf/simulated/floor/plasteel,
 /area/chapel/main)
 "bEm" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -39952,9 +38005,7 @@
 "bEz" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -39996,9 +38047,7 @@
 /area/toxins/lab)
 "bEE" = (
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Coroner";
-	req_access_txt = "0";
 	req_one_access_txt = "5;4"
 	},
 /turf/simulated/floor/plasteel{
@@ -40114,8 +38163,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -40169,8 +38217,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -40185,9 +38232,7 @@
 /area/hallway/primary/central/east)
 "bFj" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 1";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Starboard Primary Hallway 1"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
@@ -40235,14 +38280,12 @@
 "bFn" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -40258,7 +38301,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -40292,7 +38334,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -40309,7 +38350,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -40332,7 +38372,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
@@ -40342,14 +38381,12 @@
 /area/hallway/primary/starboard/east)
 "bFv" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -40359,9 +38396,7 @@
 /area/hallway/primary/starboard/east)
 "bFw" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 6";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Starboard Primary Hallway 6"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40372,8 +38407,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial,
 /obj/effect/decal/warning_stripes/arrow,
@@ -40405,7 +38439,6 @@
 "bFB" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor,
@@ -40435,7 +38468,6 @@
 /area/engine/gravitygenerator)
 "bFF" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/slot_machine,
@@ -40464,7 +38496,6 @@
 "bFI" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
@@ -40500,13 +38531,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -40525,7 +38554,6 @@
 "bFP" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -40535,7 +38563,6 @@
 "bFQ" = (
 /obj/structure/morgue{
 	dir = 8;
-	icon_state = "morgue1";
 	tag = "icon-morgue1 (WEST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -40551,9 +38578,7 @@
 "bFS" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -40568,7 +38593,6 @@
 "bFT" = (
 /obj/structure/morgue{
 	dir = 8;
-	icon_state = "morgue1";
 	tag = "icon-morgue1 (WEST)"
 	},
 /obj/effect/landmark{
@@ -40687,8 +38711,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -40701,8 +38724,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -40748,7 +38770,6 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -40782,8 +38803,7 @@
 /area/hallway/secondary/exit)
 "bGk" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -40809,8 +38829,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -40921,7 +38940,6 @@
 	},
 /obj/machinery/smartfridge/medbay,
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Chemistry Desk";
 	req_access_txt = "33"
 	},
@@ -40986,19 +39004,14 @@
 /area/assembly/robotics)
 "bGC" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/lab)
 "bGD" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/item/storage/belt/utility,
 /obj/item/clothing/gloves/color/latex,
 /turf/simulated/floor/plasteel{
@@ -41056,7 +39069,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
@@ -41182,8 +39194,7 @@
 "bGZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -41240,7 +39251,6 @@
 	base_state = "right";
 	icon_state = "right";
 	layer = 3;
-	name = "interior door";
 	req_access_txt = "50"
 	},
 /obj/machinery/disposal/deliveryChute{
@@ -41315,13 +39325,11 @@
 "bHo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/east)
@@ -41343,12 +39351,10 @@
 	opacity = 0
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -41435,8 +39441,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
@@ -41562,8 +39567,7 @@
 /area/medical/morgue)
 "bHM" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
@@ -41606,8 +39610,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -41657,8 +39660,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -41685,9 +39687,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -41709,10 +39709,8 @@
 /area/assembly/robotics)
 "bIb" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -41758,14 +39756,12 @@
 /area/maintenance/port)
 "bIf" = (
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bIg" = (
 /obj/machinery/door_control{
-	dir = 2;
 	id = "mechbay";
 	name = "Mech Bay Door Control";
 	pixel_x = 6;
@@ -41845,7 +39841,6 @@
 "bIm" = (
 /obj/machinery/camera{
 	c_tag = "Research Robotics Lab";
-	dir = 2;
 	network = list("Research","SS13")
 	},
 /obj/structure/reagent_dispensers/oil,
@@ -41894,9 +39889,7 @@
 "bIs" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -41923,7 +39916,6 @@
 	id = "rdlab";
 	name = "Research and Development Lab Shutters Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "47"
 	},
 /turf/simulated/floor/plasteel{
@@ -41967,8 +39959,6 @@
 /area/quartermaster/storage)
 "bIy" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -41996,8 +39986,7 @@
 "bIG" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -42045,9 +40034,7 @@
 "bIM" = (
 /obj/structure/table,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -42093,8 +40080,7 @@
 /area/maintenance/port)
 "bIQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -42129,7 +40115,6 @@
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Cargo Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/stamp/granted{
@@ -42159,9 +40144,7 @@
 	},
 /obj/structure/closet/secure_closet/cargotech,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -42170,9 +40153,6 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
@@ -42182,7 +40162,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -42202,12 +40181,10 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/hallway/primary/starboard/west)
@@ -42216,7 +40193,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -42229,7 +40205,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -42240,7 +40215,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/hallway/primary/starboard/west)
@@ -42264,14 +40238,12 @@
 "bJh" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 3";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -42310,7 +40282,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -42344,8 +40315,7 @@
 "bJp" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 5";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -42365,8 +40335,7 @@
 /area/hallway/secondary/exit)
 "bJs" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -42404,8 +40373,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -42427,8 +40395,7 @@
 	dir = 1;
 	icon_state = "pipe-j2s";
 	name = "Disposals Maint";
-	sortType = 1;
-	sortdir = 0
+	sortType = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -42447,8 +40414,7 @@
 "bJx" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -42477,9 +40443,7 @@
 	id = "toilet_unit1";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -42495,9 +40459,7 @@
 /obj/item/storage/box/rxglasses,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastright{
-	base_state = "right";
 	dir = 1;
-	icon_state = "right";
 	name = "Medical Reception";
 	req_access_txt = "5"
 	},
@@ -42544,7 +40506,6 @@
 "bJE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -42556,8 +40517,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -42603,8 +40563,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
@@ -42661,7 +40620,6 @@
 /area/hallway/primary/central/sw)
 "bJP" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -42693,8 +40651,7 @@
 "bJS" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Corridor East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -42741,8 +40698,7 @@
 /obj/item/storage/fancy/candle_box/eternal,
 /obj/item/storage/fancy/candle_box/eternal,
 /obj/item/storage/secure/safe{
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -42866,8 +40822,7 @@
 /area/maintenance/port)
 "bKg" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -42915,8 +40870,7 @@
 /area/toxins/lab)
 "bKk" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/table,
 /obj/item/flash/synthetic,
@@ -42940,7 +40894,6 @@
 "bKn" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -42953,9 +40906,7 @@
 "bKo" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/decal/warning_stripes/northwest,
@@ -42971,7 +40922,6 @@
 "bKq" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -43083,8 +41033,7 @@
 "bKF" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/port)
@@ -43102,8 +41051,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -43125,7 +41073,6 @@
 "bKJ" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
@@ -43208,8 +41155,7 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -43224,7 +41170,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -43236,7 +41181,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/hallway/primary/starboard/east)
@@ -43311,9 +41255,7 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bLb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43405,21 +41347,18 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bLp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43430,8 +41369,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -43450,8 +41388,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -43526,8 +41463,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -43538,8 +41474,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -43573,8 +41508,7 @@
 "bLB" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -43585,12 +41519,10 @@
 "bLC" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -43680,10 +41612,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
@@ -43713,8 +41643,7 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -43740,7 +41669,6 @@
 	in_use = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -43799,13 +41727,9 @@
 /obj/item/storage/firstaid/o2,
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -43922,8 +41846,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -43946,9 +41869,7 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "bMk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bMl" = (
@@ -43962,8 +41883,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/west)
@@ -44032,8 +41952,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -44057,15 +41976,12 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "bMD" = (
-/obj/machinery/computer/account_database{
-	anchored = 1
-	},
+/obj/machinery/computer/account_database,
 /turf/simulated/floor/plasteel,
 /area/bridge/meeting_room)
 "bME" = (
@@ -44099,8 +42015,7 @@
 	tag = ""
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44126,7 +42041,6 @@
 "bMK" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44143,13 +42057,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -44163,8 +42075,7 @@
 /area/maintenance/maintcentral)
 "bMN" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -44175,7 +42086,6 @@
 "bMO" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right";
 	name = "Captain's Desk Door";
 	req_access_txt = "20"
@@ -44184,7 +42094,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/requests_console{
@@ -44192,7 +42101,6 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44205,14 +42113,12 @@
 /area/crew_quarters/captain)
 "bMP" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44228,7 +42134,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -44274,8 +42179,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -44325,7 +42229,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -44363,9 +42266,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Medicine Storage";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Medbay Medicine Storage"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -44455,7 +42356,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -44489,8 +42389,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -44565,14 +42464,11 @@
 "bNm" = (
 /obj/machinery/camera{
 	c_tag = "Research Access";
-	dir = 2;
 	network = list("Research","SS13")
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44590,8 +42486,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -44644,8 +42539,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44678,8 +42572,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j2s";
-	name = "Cargo Disposals";
-	sortType = 0
+	name = "Cargo Disposals"
 	},
 /turf/simulated/wall,
 /area/quartermaster/office)
@@ -44711,7 +42604,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -44725,7 +42617,6 @@
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -44775,10 +42666,8 @@
 /area/maintenance/disposal)
 "bNC" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/stack/packageWrap,
 /obj/item/pen,
@@ -44810,8 +42699,7 @@
 "bNF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -44867,7 +42755,6 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/ai_status_display{
 	pixel_x = 32;
-	pixel_y = 0;
 	step_size = 0
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -44885,8 +42772,6 @@
 	icon_state = "2-4"
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44902,29 +42787,12 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/assembly/robotics)
-"bNO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
 "bNP" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -44940,8 +42808,7 @@
 /area/maintenance/port)
 "bNQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -44963,8 +42830,7 @@
 /area/quartermaster/storage)
 "bNU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Research Research and Development Lab";
@@ -44986,8 +42852,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45001,14 +42866,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32;
-	req_access_txt = "0"
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45022,12 +42884,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -45036,7 +42896,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45051,7 +42910,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -45074,9 +42932,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -45099,16 +42955,14 @@
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -24;
-	pixel_y = -8;
-	req_access_txt = "0"
+	pixel_y = -8
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -24;
-	pixel_y = 8;
-	req_access_txt = "0"
+	pixel_y = 8
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -45132,7 +42986,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -45148,7 +43001,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -45229,7 +43081,6 @@
 /area/quartermaster/office)
 "bOq" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -45244,8 +43095,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Accounts Uplink Terminal";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45264,8 +43114,6 @@
 "bOt" = (
 /obj/machinery/computer/supplycomp/public,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
@@ -45273,8 +43121,7 @@
 "bOu" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -45385,13 +43232,11 @@
 "bOB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -45402,7 +43247,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,
@@ -45423,8 +43267,7 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -45437,7 +43280,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -45448,9 +43290,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -45461,7 +43301,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -45498,8 +43337,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -45516,7 +43354,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -45538,7 +43375,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -45586,8 +43422,7 @@
 /obj/item/storage/firstaid/toxin,
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
@@ -45623,7 +43458,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
@@ -45639,7 +43473,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
@@ -45710,8 +43543,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -45806,9 +43638,7 @@
 	})
 "bPl" = (
 /obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "bPm" = (
@@ -45842,8 +43672,7 @@
 /area/hallway/secondary/exit)
 "bPr" = (
 /obj/machinery/door/airlock{
-	name = "Port Emergency Storage";
-	req_access_txt = "0"
+	name = "Port Emergency Storage"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -45867,7 +43696,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45919,8 +43747,7 @@
 	pixel_y = -5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/crowbar,
 /turf/simulated/floor/plasteel{
@@ -45945,7 +43772,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -45985,7 +43811,6 @@
 	},
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -46043,8 +43868,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -46068,7 +43892,6 @@
 	req_access_txt = "28"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -46097,12 +43920,10 @@
 /area/quartermaster/storage)
 "bPQ" = (
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -46118,8 +43939,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -46164,8 +43984,7 @@
 /area/quartermaster/office)
 "bQa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -46221,8 +44040,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -46255,23 +44073,19 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 4;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
 	req_access_txt = "57"
 	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
-	name = "Head of Personnel's Desk";
-	req_access_txt = "0"
+	name = "Head of Personnel's Desk"
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
 "bQj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -46291,8 +44105,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -46323,8 +44136,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -46360,12 +44172,10 @@
 /area/crew_quarters/heads)
 "bQq" = (
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -46400,12 +44210,10 @@
 /obj/machinery/hologram/holopad,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -46419,8 +44227,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
@@ -46440,15 +44247,13 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "bQw" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/item/storage/box/matches,
@@ -46465,12 +44270,10 @@
 	base_state = "left";
 	dir = 1;
 	icon_state = "left";
-	name = "Shower";
-	req_access_txt = "0"
+	name = "Shower"
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/item/soap/deluxe,
@@ -46484,8 +44287,7 @@
 /area/crew_quarters/captain/bedroom)
 "bQy" = (
 /obj/machinery/door/airlock{
-	name = "Private Restroom";
-	req_access_txt = "0"
+	name = "Private Restroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -46533,9 +44335,7 @@
 "bQD" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -46555,7 +44355,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
@@ -46607,7 +44406,6 @@
 	tag = ""
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -46645,8 +44443,7 @@
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access_txt = "6;29";
-	req_one_access_txt = "0"
+	req_access_txt = "6;29"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46683,8 +44480,7 @@
 "bQO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -46736,8 +44532,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby Reception";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/storage/box/pillbottles{
 	pixel_x = -5;
@@ -46775,13 +44570,11 @@
 "bQW" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Chemistry South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel,
@@ -46804,14 +44597,12 @@
 /area/medical/chemistry)
 "bQZ" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/medical/chemistry)
 "bRa" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32;
-	pixel_y = 0;
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
@@ -46844,15 +44635,11 @@
 	pixel_y = -6
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/item/gun/syringe{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/gun/syringe,
 /obj/item/gun/syringe{
 	pixel_x = 3;
 	pixel_y = -3
@@ -46866,15 +44653,13 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access_txt = "6;5";
-	req_one_access_txt = "0"
+	req_access_txt = "6;5"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -46919,7 +44704,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -46939,8 +44723,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -46964,7 +44747,6 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/table,
@@ -47039,10 +44821,7 @@
 "bRq" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/toolbox/mechanical,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -47071,8 +44850,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
@@ -47098,8 +44876,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -47127,10 +44904,7 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/stock_parts/scanning_module,
 /obj/item/stock_parts/scanning_module{
 	pixel_x = 2;
 	pixel_y = 3
@@ -47216,13 +44990,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -47240,9 +45012,7 @@
 "bRQ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -47271,8 +45041,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -47376,8 +45145,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -47398,7 +45166,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -47432,7 +45199,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
@@ -47442,7 +45208,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -47462,8 +45227,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -47476,8 +45240,7 @@
 /obj/machinery/vending/medical,
 /obj/machinery/camera{
 	c_tag = "Medbay Corridor West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -47502,13 +45265,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -47582,7 +45343,6 @@
 /area/medical/medbay2)
 "bSv" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32;
 	step_size = 0
 	},
@@ -47674,8 +45434,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Cloning";
-	network = list("SS13")
+	c_tag = "Medbay Cloning"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -47690,7 +45449,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -47714,7 +45472,6 @@
 "bSF" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -47872,16 +45629,13 @@
 /area/medical/medbay2)
 "bSS" = (
 /obj/machinery/camera{
-	c_tag = "Medbay Corridor Center";
-	network = list("SS13")
+	c_tag = "Medbay Corridor Center"
 	},
 /obj/machinery/requests_console{
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay Requests Console";
-	pixel_x = 0;
-	pixel_y = 30;
-	pixel_z = 0
+	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -47897,11 +45651,9 @@
 "bSU" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/central/sw)
@@ -47911,12 +45663,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Secondary Hallway North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -47928,7 +45678,6 @@
 	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/assembly/robotics)
@@ -47956,7 +45705,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/medical/research{
@@ -47969,7 +45717,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "robotics2";
 	name = "Robotics Lab Shutters";
@@ -47990,7 +45737,6 @@
 "bTc" = (
 /obj/structure/table,
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -48003,7 +45749,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/bed/dogbed/ian,
@@ -48016,8 +45761,7 @@
 /area/toxins/lab)
 "bTf" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -48064,7 +45808,6 @@
 	in_use = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -48078,14 +45821,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -48106,10 +45847,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "bTk" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "bTm" = (
@@ -48165,8 +45903,7 @@
 	})
 "bTx" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -48184,13 +45921,11 @@
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Cargo Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/stack/sheet/glass{
 	amount = 50;
@@ -48208,7 +45943,6 @@
 /obj/item/bedsheet/captain,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet,
@@ -48241,7 +45975,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/carpet,
@@ -48252,7 +45985,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -48334,7 +46066,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/pdapainter,
@@ -48366,8 +46097,7 @@
 /area/medical/reception)
 "bTN" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -48385,8 +46115,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -48404,16 +46133,12 @@
 /area/medical/reception)
 "bTR" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "bTS" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/closet/crate,
@@ -48428,9 +46153,7 @@
 	},
 /area/medical/chemistry)
 "bTU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull";
 	tag = "icon-whitebluefull"
@@ -48438,11 +46161,9 @@
 /area/medical/biostorage)
 "bTV" = (
 /obj/machinery/camera{
-	c_tag = "Teleporter Room";
-	network = list("SS13")
+	c_tag = "Teleporter Room"
 	},
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel,
@@ -48468,7 +46189,6 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -48491,7 +46211,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/item/radio/intercom{
@@ -48523,7 +46242,6 @@
 /area/assembly/robotics)
 "bUf" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	name = "Primate Pen";
 	req_access_txt = "9"
 	},
@@ -48569,8 +46287,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -48599,8 +46316,7 @@
 	tag = "icon-pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -48618,8 +46334,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -48680,7 +46395,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -48690,7 +46404,6 @@
 /obj/structure/table/tray,
 /obj/item/scalpel,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -48698,13 +46411,11 @@
 "bUv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -48721,7 +46432,6 @@
 "bUy" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/power/terminal,
@@ -48766,8 +46476,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -48777,12 +46486,10 @@
 "bUC" = (
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -48833,22 +46540,18 @@
 /area/assembly/robotics)
 "bUI" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
 "bUJ" = (
 /obj/structure/closet/wardrobe/genetics_white,
 /obj/machinery/camera{
-	c_tag = "Medbay Genetics";
-	network = list("SS13")
+	c_tag = "Medbay Genetics"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
@@ -48868,12 +46571,10 @@
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -48903,7 +46604,6 @@
 "bUN" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -48919,7 +46619,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Hallway Entrance";
-	dir = 2;
 	network = list("Research","SS13")
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -48984,7 +46683,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -48998,8 +46696,7 @@
 "bUV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -49028,13 +46725,11 @@
 "bUY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -49072,7 +46767,6 @@
 "bVd" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -49085,8 +46779,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
@@ -49096,7 +46789,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -49118,8 +46810,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49138,15 +46829,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bVo" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/rack,
@@ -49170,8 +46859,7 @@
 /area/quartermaster/storage)
 "bVq" = (
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -49207,8 +46895,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -49228,7 +46915,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/cable{
@@ -49247,8 +46933,6 @@
 	tag = ""
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
@@ -49284,7 +46968,6 @@
 "bVB" = (
 /obj/machinery/message_server,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/bluegrid,
@@ -49304,14 +46987,11 @@
 "bVD" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -49320,8 +47000,7 @@
 /area/assembly/robotics)
 "bVE" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -49339,7 +47018,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/research{
@@ -49380,7 +47058,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -49412,7 +47089,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/photocopier,
@@ -49456,7 +47132,6 @@
 /obj/item/radio/beacon,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -49494,8 +47169,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -49520,7 +47194,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -49528,8 +47201,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49553,7 +47225,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -49566,14 +47237,12 @@
 "bVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49593,8 +47262,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -49620,8 +47288,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -49631,8 +47298,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49652,12 +47318,10 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR: EMERGENCY ENTRANCE'.";
 	name = "KEEP CLEAR: EMERGENCY ENTRANCE";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -49668,8 +47332,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -49682,8 +47345,7 @@
 /area/medical/genetics_cloning)
 "bWe" = (
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/closet/secure_closet/roboticist,
 /turf/simulated/floor/plasteel{
@@ -49700,7 +47362,6 @@
 "bWh" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -49716,7 +47377,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49741,13 +47401,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -49763,7 +47421,6 @@
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -49773,7 +47430,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49790,12 +47446,10 @@
 	})
 "bWo" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -49805,7 +47459,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/noticeboard{
@@ -49828,7 +47481,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49855,8 +47507,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49947,7 +47598,6 @@
 /obj/item/crowbar,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -49957,7 +47607,6 @@
 	id = "CloningDoor";
 	name = "Cloning Doors Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -36
 	},
 /turf/simulated/floor/plasteel{
@@ -49987,7 +47636,6 @@
 	dir = 1;
 	icon_state = "left";
 	name = "Cryo Tank Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "5;32"
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -50044,13 +47692,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "ramptop";
 	tag = "icon-stage_stairs"
 	},
@@ -50066,12 +47712,10 @@
 	opacity = 0
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/machinery/ticket_machine{
 	layer = 4;
@@ -50082,9 +47726,7 @@
 "bWT" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -50104,7 +47746,6 @@
 /obj/structure/table,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/storage/belt/utility,
@@ -50155,12 +47796,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
 "bXb" = (
-/obj/machinery/computer/security/mining{
-	network = list("Mining Outpost")
-	},
+/obj/machinery/computer/security/mining,
 /obj/machinery/keycard_auth{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -50193,8 +47831,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -50217,13 +47854,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -50235,7 +47870,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -50244,8 +47878,7 @@
 /area/maintenance/asmaint2)
 "bXj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -50258,8 +47891,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
@@ -50292,10 +47924,8 @@
 /area/crew_quarters/heads)
 "bXq" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50306,8 +47936,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -50321,7 +47950,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/bluegrid,
@@ -50339,8 +47967,6 @@
 /area/medical/genetics)
 "bXt" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -50352,7 +47978,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator";
-	req_access_txt = "0";
 	req_one_access_txt = "10;30"
 	},
 /obj/structure/cable{
@@ -50385,7 +48010,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/chair/stool,
@@ -50402,8 +48026,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
@@ -50412,7 +48035,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/bluespace_beacon,
@@ -50427,7 +48049,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50446,8 +48067,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR: EMERGENCY ENTRANCE'.";
 	name = "KEEP CLEAR: EMERGENCY ENTRANCE";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -50456,7 +48076,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50481,8 +48100,7 @@
 /area/medical/sleeper)
 "bXF" = (
 /obj/machinery/light_switch{
-	pixel_x = -21;
-	pixel_y = 0
+	pixel_x = -21
 	},
 /obj/machinery/sleeper{
 	dir = 4
@@ -50572,8 +48190,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel/dark,
@@ -50623,9 +48240,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50644,7 +48259,6 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -50696,12 +48310,10 @@
 /obj/item/roller,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50724,7 +48336,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50742,7 +48353,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50758,7 +48368,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -50774,13 +48383,11 @@
 "bYa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -50820,9 +48427,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bYd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitebluecorner";
@@ -50837,9 +48442,7 @@
 	},
 /area/medical/medbay2)
 "bYf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitebluecorner";
@@ -50848,9 +48451,7 @@
 /area/medical/medbay2)
 "bYg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -50861,7 +48462,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -50906,8 +48506,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50951,8 +48550,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
@@ -51012,7 +48610,6 @@
 "bYx" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -51077,7 +48674,6 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -51125,13 +48721,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/quartermaster/office)
 "bYI" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -51184,8 +48778,7 @@
 "bYO" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atm{
 	pixel_x = -24
@@ -51209,7 +48802,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/plasticflaps{
@@ -51235,8 +48827,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
@@ -51245,7 +48836,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -51279,8 +48869,7 @@
 "bYW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -51340,7 +48929,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -51363,12 +48951,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -51386,13 +48972,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/gravitygenerator)
@@ -51401,11 +48985,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -51433,9 +49015,7 @@
 "bZj" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -51456,8 +49036,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51486,7 +49065,6 @@
 "bZn" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel,
@@ -51547,8 +49125,7 @@
 	tag = ""
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -51575,16 +49152,13 @@
 /obj/machinery/computer/card/minor/cmo,
 /obj/machinery/camera{
 	c_tag = "Medbay Chief Medical Officer's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/radio/intercom/department/medbay{
 	pixel_x = -32;
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -32;
 	pixel_y = -8
 	},
@@ -51632,7 +49206,6 @@
 /area/medical/cmo)
 "bZA" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/machinery/light_switch{
@@ -51679,12 +49252,10 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -51740,7 +49311,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "Medbay Hall";
 	sortType = 9
 	},
@@ -51777,8 +49347,7 @@
 /area/medical/medbay2)
 "bZI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -51880,7 +49449,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "Med Chemistry";
 	sortType = 11
 	},
@@ -51935,8 +49503,7 @@
 /area/medical/medbay2)
 "bZP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -51955,8 +49522,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -51974,7 +49540,6 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -52007,8 +49572,7 @@
 /area/medical/reception)
 "bZS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52049,7 +49613,6 @@
 	req_access_txt = "30"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -52080,7 +49643,6 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -52107,8 +49669,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -52131,13 +49692,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -52201,12 +49760,10 @@
 "caj" = (
 /obj/machinery/camera{
 	c_tag = "Research Hallway West";
-	dir = 2;
 	network = list("Research","SS13")
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -52282,8 +49839,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -52306,10 +49862,8 @@
 "caw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -52340,12 +49894,10 @@
 	})
 "caz" = (
 /obj/structure/sign/poster/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52366,8 +49918,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -52470,7 +50021,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -52488,7 +50038,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -52510,7 +50059,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -52530,11 +50078,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -52549,7 +50095,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
@@ -52568,7 +50113,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -52590,14 +50134,12 @@
 /area/medical/cryo)
 "caO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -52646,8 +50188,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -52686,7 +50227,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -52733,7 +50273,6 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/disks,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -52771,8 +50310,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -52791,7 +50329,6 @@
 "cbe" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/bluegrid,
@@ -52805,8 +50342,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Messaging Server";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -52821,12 +50357,10 @@
 "cbh" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Foyer";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/closet/radiation,
@@ -52867,12 +50401,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "Captain's Office";
 	sortType = 18
 	},
@@ -52906,10 +50438,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -52918,7 +50448,6 @@
 /obj/item/megaphone,
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -52926,7 +50455,6 @@
 "cbq" = (
 /obj/machinery/computer/robotics,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -52994,7 +50522,6 @@
 /area/medical/medbay2)
 "cbv" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -53046,7 +50573,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -53111,7 +50637,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -53147,7 +50672,6 @@
 "cbR" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/disposalpipe/segment,
@@ -53159,14 +50683,12 @@
 /area/toxins/test_area)
 "cbT" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -53182,11 +50704,9 @@
 "cbV" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -53230,8 +50750,7 @@
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -53240,7 +50759,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -53294,7 +50812,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -53319,7 +50836,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -53340,8 +50856,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -53360,7 +50875,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light,
@@ -53381,13 +50895,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -53403,7 +50915,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -53426,7 +50937,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -53446,7 +50956,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -53476,12 +50985,10 @@
 	},
 /obj/item/stack/medical/bruise_pack/advanced,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -53530,13 +51037,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -53547,13 +51052,10 @@
 "ccq" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
-	dir = 1;
-	network = list("SS13");
-	pixel_x = 0
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -53573,7 +51075,6 @@
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -53583,7 +51084,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -53633,8 +51133,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -53650,14 +51149,12 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -5;
-	pixel_y = -30;
-	req_access_txt = "0"
+	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -53677,7 +51174,6 @@
 	dir = 1;
 	icon_state = "left";
 	name = "Cryo Tank Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "5;32"
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -53693,9 +51189,6 @@
 /obj/machinery/light,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
@@ -53716,7 +51209,6 @@
 	dir = 1;
 	icon_state = "left";
 	name = "Cryo Tank Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "5;32"
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -53807,8 +51299,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -53816,8 +51307,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump Important Area";
-	pixel_x = 24;
-	shock_proof = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -53873,7 +51363,6 @@
 /area/maintenance/asmaint2)
 "ccN" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/structure/closet/l3closet/janitor,
@@ -53882,8 +51371,6 @@
 "ccO" = (
 /obj/structure/closet/jcloset,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
@@ -53923,7 +51410,6 @@
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
@@ -53937,14 +51423,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8;
-	icon_state = "intact";
 	tag = "icon-intact (WEST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -53960,7 +51444,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
@@ -53968,7 +51451,6 @@
 "ccW" = (
 /obj/machinery/camera{
 	c_tag = "Research Server Room";
-	dir = 2;
 	network = list("Research","SS13");
 	pixel_x = 22
 	},
@@ -53981,7 +51463,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -54012,8 +51493,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/conveyor/east{
 	id = "packageExternal"
@@ -54026,8 +51506,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/conveyor/east{
 	id = "packageExternal"
@@ -54039,7 +51518,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator";
-	req_access_txt = "0";
 	req_one_access_txt = "10;30"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54052,8 +51530,6 @@
 "cdb" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on/server,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -54068,8 +51544,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Central Hallway South East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -54116,7 +51591,6 @@
 "cdg" = (
 /obj/machinery/computer/mecha,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -54129,7 +51603,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -54157,8 +51630,6 @@
 /area/medical/genetics)
 "cdk" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -54185,7 +51656,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "CloningDoor";
 	name = "Genetics Cloning";
-	req_access_txt = "0";
 	req_one_access_txt = "5;9"
 	},
 /obj/structure/cable{
@@ -54204,8 +51674,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -54228,8 +51697,7 @@
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Cargo Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -54354,8 +51822,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -54371,7 +51838,6 @@
 	name = "Research Director"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -54380,9 +51846,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "cdO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -54404,15 +51868,12 @@
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Cargo Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cdR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cdS" = (
@@ -54424,7 +51885,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -54444,7 +51904,6 @@
 /area/hallway/primary/central/sw)
 "cdV" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -54467,7 +51926,6 @@
 "cdY" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
-	icon_state = "pipe-j1";
 	tag = "icon-pipe-j1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -54518,8 +51976,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Observation Room";
-	req_access_txt = "0"
+	name = "Observation Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54537,8 +51994,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Observation Room";
-	req_access_txt = "0"
+	name = "Observation Room"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -54552,7 +52008,6 @@
 "ceh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -54567,8 +52022,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -54660,7 +52114,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -54679,8 +52132,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
@@ -54704,9 +52155,7 @@
 /area/hallway/primary/central/south)
 "cex" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
@@ -54721,8 +52170,7 @@
 "cez" = (
 /obj/machinery/alarm/server{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -54736,15 +52184,12 @@
 /area/hallway/primary/central/south)
 "ceB" = (
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway South";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Central Primary Hallway South"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
 "ceC" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel,
@@ -54766,7 +52211,6 @@
 /area/quartermaster/storage)
 "ceF" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -54869,7 +52313,6 @@
 	})
 "ceO" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -54889,11 +52332,9 @@
 "ceS" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -54903,7 +52344,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -54924,8 +52364,7 @@
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -54967,20 +52406,17 @@
 /obj/machinery/computer/security/mining,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cfg" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
@@ -54992,8 +52428,7 @@
 	location = "QM"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -55003,12 +52438,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -55027,7 +52460,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -55053,7 +52485,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -55069,12 +52500,10 @@
 /area/hallway/primary/central/sw)
 "cfn" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -55083,7 +52512,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/start{
@@ -55106,8 +52534,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -55118,8 +52545,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -55159,8 +52585,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
@@ -55179,7 +52604,6 @@
 	},
 /obj/item/surgicaldrill,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -55215,7 +52639,6 @@
 /obj/machinery/door_control{
 	id = "surgeryobs1";
 	name = "Privacy Shutters Control";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -55259,8 +52682,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery Observation";
-	network = list("SS13")
+	c_tag = "Medbay Surgery Observation"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -55301,7 +52723,6 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 4;
 	icon_state = "open";
 	id_tag = "surgeryobs2";
 	name = "Privacy Shutters";
@@ -55337,11 +52758,9 @@
 /obj/machinery/door_control{
 	id = "surgeryobs2";
 	name = "Privacy Shutters Control";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -55375,7 +52794,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/table/tray,
@@ -55448,7 +52866,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -55494,7 +52911,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -55519,14 +52935,12 @@
 /area/hallway/primary/central/sw)
 "cfU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -55551,7 +52965,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -55573,8 +52986,7 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/plasteel{
@@ -55595,9 +53007,7 @@
 "cfY" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -55626,7 +53036,6 @@
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/bluegrid/telecomms/server,
@@ -55668,8 +53077,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -55685,8 +53093,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/south)
@@ -55767,7 +53174,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -55794,7 +53200,6 @@
 "cgv" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -55809,9 +53214,7 @@
 /area/toxins/mixing)
 "cgE" = (
 /turf/simulated/wall/r_wall,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cgG" = (
 /obj/structure/closet/wardrobe/miner,
 /turf/simulated/floor/plasteel{
@@ -55836,8 +53239,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
@@ -55847,8 +53249,7 @@
 	location = "CHE"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -55888,9 +53289,7 @@
 	icon_state = "pipe-j2";
 	tag = "icon-pipe-j1 (WEST)"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -55919,12 +53318,9 @@
 /area/quartermaster/qm)
 "cgO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -55950,8 +53346,7 @@
 /area/maintenance/apmaint)
 "cgR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -55972,8 +53367,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/toxins/server_coldroom)
@@ -56045,17 +53439,14 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 4;
 	icon_state = "rightsecure";
 	name = "Server Exterior Door";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Server Interior Door";
-	req_access = null;
-	req_access_txt = "0"
+	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -56091,7 +53482,6 @@
 /obj/structure/sign/directions/engineering,
 /obj/structure/sign/directions/science{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = -7
 	},
 /obj/structure/sign/directions/medical{
@@ -56121,12 +53511,10 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "CloningDoor";
 	name = "Genetics Cloning";
-	req_access_txt = "0";
 	req_one_access_txt = "5;9"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 4;
-	icon_state = "airlock_unres_helper"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -56137,7 +53525,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -56149,8 +53536,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -56248,7 +53634,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/start{
@@ -56275,14 +53660,12 @@
 "chv" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
@@ -56295,8 +53678,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -56317,8 +53699,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -56354,7 +53735,6 @@
 /obj/item/clothing/mask/gas,
 /obj/item/storage/briefcase,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
@@ -56370,13 +53750,11 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "chC" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -56390,7 +53768,6 @@
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
 	name = "Chief Medical Officer Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
@@ -56405,14 +53782,12 @@
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "chF" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -56434,7 +53809,6 @@
 "chH" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
@@ -56461,13 +53835,11 @@
 /area/medical/surgery1)
 "chL" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -56477,7 +53849,6 @@
 "chM" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -56492,7 +53863,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -56532,19 +53902,16 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	icon_state = "pipe-j1s";
 	name = "Sci RD Office 2";
 	sortType = 13
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -56570,7 +53937,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -56580,7 +53946,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -56598,7 +53963,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -56609,7 +53973,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -56622,7 +53985,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -56654,7 +54016,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -56664,7 +54025,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -56719,9 +54079,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/camera{
 	c_tag = "Research Toxins Mixing North";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -56762,8 +54120,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -56822,8 +54179,7 @@
 	pixel_y = 7
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
@@ -56850,7 +54206,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -56869,8 +54224,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/blueshield)
@@ -56911,9 +54265,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/power/apc{
@@ -56927,8 +54279,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -56953,9 +54304,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/twohanded/required/kirbyplants,
@@ -56971,7 +54320,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -56992,7 +54340,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -57006,7 +54353,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -57015,7 +54361,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -57050,7 +54395,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -57073,11 +54417,9 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -57091,9 +54433,7 @@
 	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -57206,7 +54546,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -57246,8 +54585,7 @@
 	req_access_txt = "73"
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/ntrep)
@@ -57281,7 +54619,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57318,11 +54655,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -57347,7 +54682,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light,
@@ -57358,7 +54692,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -57426,7 +54759,6 @@
 /obj/item/clothing/under/rank/medical/green,
 /obj/item/clothing/under/rank/medical/purple,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -57454,12 +54786,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -57492,7 +54822,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -57539,7 +54868,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -57602,7 +54930,6 @@
 	id = "cmoofficedoor";
 	name = "Office Door";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -13;
 	req_access_txt = "40"
 	},
@@ -57624,9 +54951,7 @@
 "cjI" = (
 /obj/machinery/camera{
 	c_tag = "Research E.X.P.E.R.I-MENTOR Chamber";
-	dir = 2;
-	network = list("Telepad","Research","SS13");
-	pixel_x = 0
+	network = list("Telepad","Research","SS13")
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -57653,7 +54978,6 @@
 "cjK" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -57665,8 +54989,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -57696,11 +55019,9 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -57726,14 +55047,12 @@
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/hor)
 "cjQ" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -57745,7 +55064,6 @@
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -57764,7 +55082,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -57892,7 +55209,6 @@
 "cko" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
@@ -57917,13 +55233,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -57935,7 +55249,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -57984,8 +55297,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -58017,15 +55329,11 @@
 "ckA" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery East Storage";
-	dir = 1;
-	network = list("SS13");
-	pixel_x = 0
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -58056,7 +55364,6 @@
 /obj/machinery/recharger,
 /obj/item/screwdriver,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -58074,7 +55381,6 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -58084,7 +55390,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -58092,11 +55397,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Break Room";
-	network = list("SS13")
+	c_tag = "Medbay Break Room"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -58239,9 +55542,7 @@
 "ckU" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery West";
-	dir = 1;
-	network = list("SS13");
-	pixel_x = 0
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -58260,7 +55561,6 @@
 "ckW" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -58282,7 +55582,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -58296,13 +55595,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -58325,9 +55622,7 @@
 "clb" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"
@@ -58376,12 +55671,9 @@
 "clf" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery East";
-	dir = 1;
-	network = list("SS13");
-	pixel_x = 0
+	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light,
@@ -58402,8 +55694,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -58411,8 +55702,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -58430,7 +55720,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -58451,11 +55740,9 @@
 /obj/machinery/washing_machine,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -58467,7 +55754,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -58535,7 +55821,6 @@
 "clt" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/engine,
@@ -58556,8 +55841,7 @@
 "clw" = (
 /obj/machinery/atmospherics/binary/valve,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -58565,7 +55849,6 @@
 /area/toxins/mixing)
 "clx" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 2;
 	frequency = 1443;
 	icon_state = "on";
 	id = "air_in";
@@ -58598,8 +55881,7 @@
 /area/toxins/test_area)
 "clB" = (
 /obj/machinery/door/airlock/external{
-	name = "Toxins Test Chamber";
-	req_access_txt = "0"
+	name = "Toxins Test Chamber"
 	},
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
@@ -58625,8 +55907,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/wall,
 /area/quartermaster/miningdock)
@@ -58707,8 +55988,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -58718,7 +55998,6 @@
 "clU" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -58746,7 +56025,6 @@
 "clX" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light/small{
@@ -58766,8 +56044,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -58782,7 +56059,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -58881,7 +56157,6 @@
 	layer = 4;
 	name = "Singularity Engine Telescreen";
 	network = list("Singularity");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/chair/office/dark{
@@ -58894,7 +56169,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -58925,8 +56199,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Virology Lobby Hallway";
-	req_access_txt = "0"
+	name = "Virology Lobby Hallway"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -58971,7 +56244,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
@@ -58984,13 +56256,11 @@
 "cmr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -59022,7 +56292,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -59030,7 +56299,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59052,7 +56320,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59068,11 +56335,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59083,7 +56348,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59127,7 +56391,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -59146,7 +56409,6 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/britcup,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59166,8 +56428,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -59250,7 +56511,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -59274,7 +56534,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -59306,7 +56565,6 @@
 "cmW" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/reagent_dispensers/watertank,
@@ -59332,9 +56590,7 @@
 "cmY" = (
 /obj/machinery/camera{
 	c_tag = "Research Toxins Mixing West";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
@@ -59411,8 +56667,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -59432,7 +56687,6 @@
 "cnl" = (
 /obj/structure/closet/wardrobe/miner,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
@@ -59452,7 +56706,6 @@
 "cno" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
@@ -59485,7 +56738,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -59535,8 +56787,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
-	name = "Virology Lobby Hallway";
-	req_access_txt = "0"
+	name = "Virology Lobby Hallway"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -59577,7 +56828,6 @@
 	})
 "cnA" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -59587,9 +56837,6 @@
 	on = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -59609,20 +56856,17 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cnD" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Lobby";
-	network = list("SS13")
+	c_tag = "Virology Lobby"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -59674,7 +56918,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -59706,7 +56949,6 @@
 "cnL" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -59731,11 +56973,9 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59743,7 +56983,6 @@
 "cnO" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59751,7 +56990,6 @@
 "cnP" = (
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59759,7 +56997,6 @@
 "cnQ" = (
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59767,11 +57004,9 @@
 "cnR" = (
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -59788,7 +57023,6 @@
 "cnT" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "QM Office";
 	sortType = 3
 	},
@@ -59796,7 +57030,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -59820,8 +57053,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
@@ -59834,8 +57066,7 @@
 /area/maintenance/asmaint)
 "cnW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -59855,7 +57086,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -59873,8 +57103,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59891,8 +57120,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59909,7 +57137,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -59921,8 +57148,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59940,15 +57166,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -59963,12 +57186,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -59985,12 +57206,10 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60012,7 +57231,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -60077,8 +57295,7 @@
 "com" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -60119,18 +57336,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/janitor)
-"cos" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "cot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -60145,7 +57350,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -60199,8 +57403,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -60280,22 +57483,18 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins");
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/alarm{
 	pixel_y = 31
 	},
 /obj/machinery/driver_button{
-	dir = 2;
 	id_tag = "toxinsdriver";
 	pixel_y = 22;
 	range = 18
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "coH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -60323,9 +57522,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "coJ" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel/airless,
@@ -60374,7 +57571,6 @@
 "coT" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -60396,8 +57592,7 @@
 /area/ntrep)
 "coW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/carpet,
 /area/ntrep)
@@ -60417,8 +57612,7 @@
 /area/blueshield)
 "coY" = (
 /obj/machinery/keycard_auth{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/door/window{
 	dir = 1;
@@ -60429,12 +57623,10 @@
 /area/blueshield)
 "coZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60446,7 +57638,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology/lab{
@@ -60455,8 +57646,7 @@
 "cpa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60476,12 +57666,10 @@
 	})
 "cpb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60493,12 +57681,10 @@
 	tag = ""
 	},
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32;
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60507,12 +57693,10 @@
 	})
 "cpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60529,7 +57713,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60538,12 +57721,10 @@
 	})
 "cpd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60556,7 +57737,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60565,12 +57745,10 @@
 	})
 "cpe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60586,7 +57764,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60611,21 +57788,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "cph" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -60667,7 +57841,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -60682,7 +57855,6 @@
 /obj/item/folder,
 /obj/item/radio,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -60702,13 +57874,9 @@
 "cpn" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue";
@@ -60718,13 +57886,9 @@
 "cpo" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue";
@@ -60734,7 +57898,6 @@
 "cpp" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -60766,7 +57929,6 @@
 "cpr" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -60798,13 +57960,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -60836,9 +57996,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery West Storage";
-	dir = 1;
-	network = list("SS13");
-	pixel_x = 0
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -60888,9 +58046,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -60910,7 +58066,6 @@
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -60960,7 +58115,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -61075,7 +58229,6 @@
 	master_tag = "viro_lab_airlock_control";
 	name = "Virology Lab Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61103,8 +58256,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Medbay Secondary Hallway South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -61181,7 +58333,6 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -61207,7 +58358,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -61224,8 +58374,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -61293,7 +58442,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
@@ -61333,9 +58481,7 @@
 "cqj" = (
 /obj/machinery/camera{
 	c_tag = "Research Toxins Mixing East";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -61363,8 +58509,7 @@
 "cqm" = (
 /obj/structure/dispenser,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -61396,7 +58541,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/holosign/surgery{
@@ -61417,8 +58561,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -61427,16 +58570,13 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cqq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -61445,15 +58585,12 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cqr" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -61483,13 +58620,11 @@
 	dir = 5
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -61501,12 +58636,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "HoP Office";
 	sortType = 15
 	},
@@ -61540,8 +58673,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -61572,7 +58704,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/holosign/surgery{
@@ -61587,19 +58718,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cqy" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -61632,9 +58759,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cqD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -61647,7 +58772,6 @@
 "cqE" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -61664,7 +58788,6 @@
 "cqG" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor/plasteel{
@@ -61718,7 +58841,6 @@
 "cqN" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -61785,7 +58907,6 @@
 	announcementConsole = 1;
 	department = "NT Representative";
 	departmentType = 5;
-	dir = 2;
 	name = "NT Representative Requests Console";
 	pixel_x = 30
 	},
@@ -61799,8 +58920,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -61916,8 +59036,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -61950,7 +59069,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/surgery1)
@@ -61959,7 +59077,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/medical/surgery2)
@@ -61967,8 +59084,7 @@
 /obj/machinery/door_control{
 	id = "telescienceblast";
 	name = "Test Chamber Blast Doors";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -62014,8 +59130,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -62040,8 +59155,7 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
 /obj/machinery/camera{
-	c_tag = "Virology Monkey Pen";
-	network = list("SS13")
+	c_tag = "Virology Monkey Pen"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62051,8 +59165,7 @@
 /area/medical/virology)
 "crn" = (
 /obj/structure/sign/fire{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -62068,8 +59181,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -62086,7 +59198,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -62103,7 +59214,6 @@
 	department = "Virology";
 	departmentType = 3;
 	name = "Virology Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -62165,9 +59275,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "crx" = (
 /obj/structure/closet/bombcloset,
 /obj/structure/cable{
@@ -62177,8 +59285,7 @@
 	tag = ""
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62187,17 +59294,14 @@
 /area/toxins/mixing)
 "cry" = (
 /obj/machinery/camera{
-	c_tag = "Virology Airlock";
-	network = list("SS13")
+	c_tag = "Virology Airlock"
 	},
 /obj/machinery/shower{
 	pixel_y = 20
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
@@ -62257,8 +59361,7 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -62374,11 +59477,9 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "crR" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -62395,7 +59496,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -62405,17 +59505,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "crT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "crU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62426,8 +59522,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -62436,7 +59531,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -62496,7 +59590,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -62506,11 +59599,8 @@
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -62547,7 +59637,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -62560,12 +59649,9 @@
 	layer = 4;
 	name = "E.X.P.E.R.I-MENTOR Camera Screen";
 	network = list("Telepad");
-	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -62575,7 +59661,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -62590,7 +59675,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -62635,15 +59719,12 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cso" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -62666,14 +59747,11 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins");
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "csr" = (
 /obj/structure/grille,
 /obj/structure/window/plasmareinforced{
@@ -62691,9 +59769,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "css" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel/airless,
@@ -62753,11 +59829,9 @@
 /obj/item/flashlight/lamp,
 /obj/machinery/camera{
 	c_tag = "Blueshield's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
@@ -62814,15 +59888,13 @@
 "csE" = (
 /obj/machinery/camera{
 	c_tag = "NT Representative's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "NT Representative's Office"
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
@@ -62846,8 +59918,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -62859,13 +59930,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62877,7 +59946,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light,
@@ -62885,7 +59953,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
@@ -62902,11 +59969,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
@@ -62917,16 +59982,13 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "csO" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/closet/firecloset,
@@ -62943,7 +60005,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -62966,7 +60027,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/window/plasmareinforced{
@@ -62986,13 +60046,10 @@
 /obj/item/storage/box/monkeycubes/farwacubes,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63005,7 +60062,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -63030,7 +60086,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -63041,12 +60096,10 @@
 "csW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63067,12 +60120,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -63081,8 +60132,7 @@
 "csY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -63097,12 +60147,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -63110,8 +60158,7 @@
 /area/medical/virology)
 "cta" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -63121,12 +60168,10 @@
 "ctb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -63135,12 +60180,10 @@
 /area/medical/virology)
 "ctc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -63154,12 +60197,10 @@
 /area/medical/virology)
 "ctd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -63174,8 +60215,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -63209,12 +60249,10 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -63228,12 +60266,10 @@
 /area/medical/virology)
 "ctg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -63297,7 +60333,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -63307,7 +60342,6 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -63324,8 +60358,7 @@
 "ctn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63405,7 +60438,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -63423,7 +60455,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -63454,7 +60485,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -63489,7 +60519,6 @@
 "ctC" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -63540,8 +60569,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -63566,16 +60594,13 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Engineering Desk";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -63583,8 +60608,7 @@
 /area/engine/controlroom)
 "ctL" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plasteel{
@@ -63618,9 +60642,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "ctP" = (
 /obj/structure/grille,
 /obj/structure/window/plasmareinforced{
@@ -63642,14 +60664,11 @@
 	},
 /obj/item/radio/intercom,
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "ctQ" = (
 /obj/machinery/door/window/southright{
 	name = "Toxins Launcher";
-	req_access_txt = "7";
-	req_one_access_txt = "0"
+	req_access_txt = "7"
 	},
 /obj/machinery/door/window/southright{
 	dir = 1;
@@ -63664,9 +60683,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "ctR" = (
 /turf/simulated/wall/r_wall,
 /area/blueshield)
@@ -63686,9 +60703,6 @@
 /area/hallway/primary/aft)
 "ctT" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Assembly Line Delivery";
 	req_access_txt = "32"
 	},
@@ -63735,7 +60749,6 @@
 /obj/machinery/door/window/westright{
 	name = "Engineering Monitoring Station";
 	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "11;24;34"
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -63750,10 +60763,8 @@
 /area/maintenance/asmaint)
 "cua" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -63786,9 +60797,7 @@
 /obj/item/pen,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -63801,7 +60810,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -63822,7 +60830,6 @@
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28;
 	pixel_y = -28
 	},
@@ -63836,7 +60843,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -63853,7 +60859,6 @@
 /area/engine/controlroom)
 "cuj" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -63864,19 +60869,16 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cul" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/reagent_containers/syringe/antiviral,
@@ -63884,7 +60886,6 @@
 /obj/item/reagent_containers/dropper/precision,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -63909,14 +60910,12 @@
 	id_tag = "viro_lab_airlock_control";
 	name = "Virology Lab Access Console";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_one_access_txt = "39";
 	tag_exterior_door = "viro_lab_airlock_exterior";
 	tag_interior_door = "viro_lab_airlock_interior"
 	},
 /obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -63939,7 +60938,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -63960,7 +60958,6 @@
 "cur" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/closet/l3closet,
@@ -63988,9 +60985,7 @@
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Engineering Monitoring Station";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/effect/decal/warning_stripes/yellow,
@@ -64009,7 +61004,6 @@
 /area/maintenance/asmaint)
 "cuv" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -64041,7 +61035,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -64058,9 +61051,7 @@
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreen";
@@ -64073,8 +61064,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -64108,8 +61098,7 @@
 	dir = 6
 	},
 /obj/structure/sign/poster/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -64137,7 +61126,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -64145,7 +61133,6 @@
 "cuJ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/table,
@@ -64155,8 +61142,7 @@
 	},
 /obj/item/pen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -64213,7 +61199,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -64263,7 +61248,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64281,7 +61265,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/firealarm{
@@ -64347,7 +61330,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -64448,7 +61430,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/vending/plasmaresearch,
@@ -64458,7 +61439,6 @@
 /area/toxins/mixing)
 "cvf" = (
 /obj/machinery/atmospherics/trinary/mixer{
-	density = 0;
 	dir = 8;
 	req_access = null
 	},
@@ -64471,7 +61451,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -64501,9 +61480,7 @@
 	id_tag = "toxinsdriver"
 	},
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cvk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -64538,9 +61515,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "cvs" = (
 /obj/machinery/door/poddoor{
 	id_tag = "toxinsdriver";
@@ -64582,8 +61557,7 @@
 /obj/item/flash,
 /obj/item/flash,
 /obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -64592,9 +61566,7 @@
 /area/storage/tech)
 "cvy" = (
 /obj/machinery/camera{
-	c_tag = "Tech Storage";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Tech Storage"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -64620,7 +61592,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -64630,7 +61601,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
@@ -64684,8 +61654,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Hallway South";
 	dir = 1;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -64703,13 +61672,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -64735,7 +61702,6 @@
 "cvK" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -64751,16 +61717,13 @@
 /obj/machinery/disposal,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/trunk{
@@ -64819,15 +61782,13 @@
 /obj/machinery/door_control{
 	id = "psychoffice";
 	name = "Privacy Shutters Control";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "cvS" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -64841,7 +61802,6 @@
 /area/medical/surgery1)
 "cvT" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -64853,7 +61813,6 @@
 /obj/item/clothing/mask/gas,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -64890,7 +61849,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -64910,7 +61868,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
-	pixel_y = 0;
 	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
@@ -64929,16 +61886,13 @@
 /area/medical/virology)
 "cwc" = (
 /obj/machinery/camera{
-	c_tag = "Virology Break Room";
-	network = list("SS13")
+	c_tag = "Virology Break Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64949,8 +61903,7 @@
 "cwd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
@@ -64962,12 +61915,10 @@
 /area/medical/virology)
 "cwe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -64977,12 +61928,10 @@
 /area/medical/virology)
 "cwf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64992,8 +61941,7 @@
 /area/medical/virology)
 "cwg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -65012,12 +61960,10 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
@@ -65047,8 +61993,7 @@
 "cwk" = (
 /obj/machinery/disposal,
 /obj/structure/sign/poster/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -65119,7 +62064,6 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/research{
@@ -65141,15 +62085,13 @@
 /area/toxins/explab)
 "cwr" = (
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/table,
 /obj/item/storage/box/pillbottles{
 	layer = 4
 	},
 /obj/item/storage/box/bodybags{
-	layer = 3;
 	pixel_x = 5;
 	pixel_y = 5
 	},
@@ -65314,25 +62256,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"cwL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
 "cwM" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65403,8 +62331,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -65448,13 +62375,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -65466,40 +62391,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
-"cwZ" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "cxa" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -65534,7 +62436,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -65588,7 +62489,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -65597,11 +62497,9 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "";
 	name = "Staff Room";
-	req_access_txt = "5";
-	req_one_access_txt = "0"
+	req_access_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
@@ -65614,8 +62512,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65624,7 +62521,6 @@
 "cxl" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "bulb1";
 	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -65634,7 +62530,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -65679,8 +62574,7 @@
 /area/engine/controlroom)
 "cxs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
@@ -65747,8 +62641,7 @@
 /obj/item/flashlight/lamp/green,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
@@ -65805,7 +62698,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -65828,7 +62720,6 @@
 /obj/structure/bed,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -65863,13 +62754,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -65878,7 +62767,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/sign/securearea{
@@ -65914,7 +62802,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -65940,7 +62827,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -65966,7 +62852,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light/small{
@@ -65992,7 +62877,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -66008,7 +62892,6 @@
 /area/maintenance/asmaint)
 "cxU" = (
 /obj/structure/sign/poster/contraband/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -66024,14 +62907,12 @@
 /area/maintenance/asmaint2)
 "cxW" = (
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light{
@@ -66130,8 +63011,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -66176,7 +63056,6 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -66223,8 +63102,7 @@
 /area/storage/tech)
 "cys" = (
 /obj/machinery/camera{
-	c_tag = "Secure Tech Storage";
-	dir = 2
+	c_tag = "Secure Tech Storage"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -66332,7 +63210,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light{
@@ -66360,7 +63237,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
@@ -66391,7 +63267,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -66413,8 +63288,7 @@
 /area/engine/controlroom)
 "cyH" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -66425,7 +63299,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -66433,8 +63306,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -66451,7 +63323,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/carpet,
@@ -66499,7 +63370,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -66528,12 +63398,10 @@
 "cyU" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -66552,7 +63420,6 @@
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/item/reagent_containers/iv_bag/blood/random,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32;
 	step_size = 0
 	},
@@ -66573,7 +63440,6 @@
 	pixel_y = 6
 	},
 /obj/item/storage/secure/safe{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -66586,7 +63452,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -66607,7 +63472,6 @@
 /obj/structure/bed,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -66625,7 +63489,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /mob/living/simple_animal/mouse,
@@ -66646,7 +63509,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/remains/robot,
@@ -66713,7 +63575,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -66726,7 +63587,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark{
@@ -66782,7 +63642,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -66795,7 +63654,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark{
@@ -66815,7 +63673,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -66834,12 +63691,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66861,8 +63716,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -66875,7 +63729,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -66891,8 +63744,6 @@
 /area/hallway/primary/aft)
 "czB" = (
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66902,7 +63753,6 @@
 "czC" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump Engineering";
 	pixel_y = -24;
 	shock_proof = 1
@@ -66912,10 +63762,7 @@
 "czD" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Construction Area";
-	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -66943,9 +63790,7 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/incinerator)
 "czG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
@@ -66966,12 +63811,9 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Module North";
-	network = list("SS13")
+	c_tag = "Virology Module North"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreen";
@@ -67088,7 +63930,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -67098,7 +63939,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -67111,13 +63951,10 @@
 "czW" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -67172,13 +64009,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -67218,7 +64053,6 @@
 "cAf" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -67251,7 +64085,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitegreen";
 	tag = "icon-whitehall (WEST)"
 	},
@@ -67270,8 +64103,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -67279,7 +64111,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -67291,7 +64122,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -67320,9 +64150,7 @@
 	},
 /area/construction)
 "cAp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -67332,8 +64160,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -67371,14 +64198,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -67392,14 +64217,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67502,7 +64325,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -67549,7 +64371,6 @@
 /obj/machinery/requests_console{
 	department = "Tech Storage";
 	name = "Tech Storage Requests Console";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
@@ -67586,8 +64407,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67617,9 +64437,7 @@
 /area/toxins/misc_lab)
 "cAR" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -67631,9 +64449,7 @@
 "cAT" = (
 /obj/structure/table,
 /obj/item/mounted/frame/apc_frame,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cAU" = (
@@ -67670,8 +64486,7 @@
 /area/medical/virology)
 "cAZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/wall/r_wall,
 /area/toxins/misc_lab)
@@ -67706,16 +64521,6 @@
 	icon_state = "floorgrime"
 	},
 /area/maintenance/incinerator)
-"cBe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
 "cBf" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -67735,7 +64540,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/engine,
@@ -67816,8 +64620,7 @@
 /area/maintenance/incinerator)
 "cBo" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -67856,9 +64659,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/cloning{
-	pixel_x = 0
-	},
+/obj/item/circuitboard/cloning,
 /obj/item/circuitboard/med_data{
 	pixel_x = 3;
 	pixel_y = -3
@@ -67929,8 +64730,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/medical/psych)
@@ -67939,7 +64739,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -68013,7 +64812,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -68055,8 +64853,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -68123,7 +64920,6 @@
 /obj/machinery/light,
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/maintenance/asmaint)
@@ -68135,14 +64931,12 @@
 	},
 /obj/item/storage/toolbox,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/maintenance/asmaint)
 "cBX" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "caution"
 	},
 /area/maintenance/asmaint)
@@ -68199,8 +64993,7 @@
 "cCd" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68220,9 +65013,7 @@
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/camera{
 	c_tag = "Research Test Lab West";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68239,7 +65030,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -68270,9 +65060,7 @@
 	on = 1
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -68320,7 +65108,6 @@
 /obj/machinery/chem_master,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -68345,14 +65132,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -68368,7 +65153,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/wall/r_wall,
@@ -68381,7 +65165,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/closet/emcloset,
@@ -68392,7 +65175,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -68414,14 +65196,12 @@
 /area/toxins/test_area)
 "cCv" = (
 /obj/machinery/door/airlock/external{
-	name = "Toxins Test Chamber";
-	req_access_txt = "0"
+	name = "Toxins Test Chamber"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -68448,7 +65228,6 @@
 	layer = 3.1;
 	master_tag = "incinerator_access_control";
 	name = "Incinerator Airlock Control";
-	pixel_x = 0;
 	pixel_y = -23
 	},
 /turf/simulated/floor/engine,
@@ -68468,7 +65247,6 @@
 	command = "cycle_interior";
 	master_tag = "incinerator_access_control";
 	name = "Incinerator Airlock Control";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/engine,
@@ -68476,7 +65254,6 @@
 "cCz" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
@@ -68505,7 +65282,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -68555,7 +65331,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -68565,7 +65340,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -68585,7 +65359,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68607,8 +65380,7 @@
 /area/construction)
 "cCL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -68658,7 +65430,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -68678,7 +65449,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -68690,8 +65460,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
@@ -68700,7 +65469,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -68729,13 +65497,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -68746,7 +65512,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -68768,7 +65533,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -68791,7 +65555,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -68807,7 +65570,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -68835,8 +65597,7 @@
 "cDb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68847,8 +65608,7 @@
 /area/toxins/misc_lab)
 "cDc" = (
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -68909,7 +65669,6 @@
 	pixel_y = 27
 	},
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel{
@@ -68927,12 +65686,10 @@
 /area/atmos)
 "cDk" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics North-East";
-	network = list("SS13")
+	c_tag = "Atmospherics North-East"
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/binary/volume_pump/on{
@@ -68955,7 +65712,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump Engineering";
-	pixel_x = 0;
 	pixel_y = 24;
 	shock_proof = 1
 	},
@@ -68996,8 +65752,7 @@
 "cDs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69009,8 +65764,7 @@
 "cDt" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -69050,7 +65804,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -69073,20 +65826,16 @@
 "cDz" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69099,7 +65848,6 @@
 	dir = 9
 	},
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -69139,9 +65887,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32;
-	req_access_txt = "0"
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -69213,7 +65959,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -69261,8 +66006,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -69293,7 +66036,6 @@
 /obj/machinery/door_control{
 	id = "disvent";
 	name = "Incinerator Vent Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "12"
 	},
@@ -69327,7 +66069,6 @@
 /area/storage/tech)
 "cDZ" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/binary/pump{
@@ -69368,8 +66109,7 @@
 	tag = ""
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -69383,8 +66123,7 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -69444,13 +66183,11 @@
 "cEj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
@@ -69495,13 +66232,11 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -69563,9 +66298,7 @@
 "cEu" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -69580,9 +66313,7 @@
 /area/engine/mechanic_workshop)
 "cEw" = (
 /obj/machinery/camera{
-	c_tag = "Mechanic's Workshop West";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Mechanic's Workshop West"
 	},
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop)
@@ -69643,9 +66374,7 @@
 	},
 /area/toxins/xenobiology)
 "cEI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
 /area/engine/mechanic_workshop)
 "cEJ" = (
@@ -69654,7 +66383,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/mecha_part_fabricator/spacepod,
@@ -69686,13 +66414,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/camera{
-	c_tag = "Mechanic's Workshop East";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Mechanic's Workshop East"
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plasteel{
@@ -69709,7 +66434,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -69723,7 +66447,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -69733,7 +66456,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/closet/emcloset,
@@ -69747,7 +66469,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -69763,7 +66484,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -69791,7 +66511,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -69810,13 +66529,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/segment{
@@ -69835,7 +66551,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -69872,8 +66587,7 @@
 "cFd" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/mechanic_workshop)
@@ -69920,8 +66634,7 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69961,9 +66674,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 3";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Aft Primary Hallway 3"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -69989,9 +66700,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -70040,12 +66749,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -70077,8 +66784,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -70135,7 +66841,6 @@
 	master_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /obj/structure/cable{
@@ -70165,7 +66870,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -70185,7 +66889,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -70204,7 +66907,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -70229,7 +66931,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/table,
@@ -70252,7 +66953,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/firealarm{
@@ -70323,8 +67023,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70392,7 +67091,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -70452,7 +67150,6 @@
 	amount = 50
 	},
 /obj/item/stack/sheet/mineral/plasma{
-	amount = 1;
 	layer = 2.9
 	},
 /obj/item/stack/sheet/glass{
@@ -70489,8 +67186,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -70537,8 +67233,7 @@
 "cGg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70582,7 +67277,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -70590,8 +67284,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -70629,8 +67322,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -70679,8 +67371,7 @@
 /area/engine/break_room)
 "cGu" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/shower{
 	pixel_y = 8
@@ -70690,8 +67381,7 @@
 /area/engine/break_room)
 "cGv" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics Control Room";
-	network = list("SS13")
+	c_tag = "Atmospherics Control Room"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -70705,7 +67395,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump Engineering";
-	pixel_x = 0;
 	pixel_y = 24;
 	shock_proof = 1
 	},
@@ -70726,8 +67415,7 @@
 /area/medical/virology)
 "cGx" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -70741,7 +67429,6 @@
 "cGy" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32;
-	pixel_y = 0;
 	step_size = 0
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -70756,13 +67443,11 @@
 "cGz" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/effect/decal/warning_stripes/northwest,
@@ -70777,9 +67462,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Xenobiology Access";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
@@ -70796,8 +67479,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -70807,7 +67489,6 @@
 "cGC" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -70842,8 +67523,7 @@
 /obj/machinery/door/window/westright{
 	name = "Mechanic's Desk";
 	req_access = null;
-	req_access_txt = "70";
-	req_one_access_txt = "0"
+	req_access_txt = "70"
 	},
 /obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel{
@@ -70886,8 +67566,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -70904,7 +67583,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -70912,7 +67590,6 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 1;
-	icon_state = "map";
 	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/wall,
@@ -70922,14 +67599,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -70942,7 +67617,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -70951,8 +67625,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -70977,8 +67650,7 @@
 /obj/structure/table,
 /obj/item/camera,
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -70986,8 +67658,7 @@
 /area/storage/office)
 "cGT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -71011,7 +67682,6 @@
 /obj/effect/decal/warning_stripes/northeast,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -71021,7 +67691,6 @@
 "cGW" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -71047,8 +67716,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -71058,8 +67726,7 @@
 "cGZ" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -71098,24 +67765,20 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engine/chiefs_office)
 "cHb" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/computer/station_alert,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -71127,7 +67790,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -71186,7 +67848,6 @@
 "cHj" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -71224,7 +67885,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -71276,8 +67936,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/machinery/camera{
-	c_tag = "Engineering Foyer";
-	network = list("SS13")
+	c_tag = "Engineering Foyer"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 28
@@ -71335,12 +67994,10 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -71450,8 +68107,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -71491,8 +68147,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment{
@@ -71561,7 +68215,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/wall,
@@ -71572,8 +68225,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71608,7 +68260,6 @@
 	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel,
@@ -71649,8 +68300,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -71698,8 +68348,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -71753,9 +68402,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cIp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cIq" = (
@@ -71819,7 +68466,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -71864,8 +68510,7 @@
 /area/maintenance/asmaint)
 "cIA" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -71874,9 +68519,7 @@
 	tag = ""
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -71886,7 +68529,6 @@
 "cIB" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -71925,7 +68567,6 @@
 	desc = "Used for watching the horrors within the test chamber.";
 	name = "Research Monitor";
 	network = list("TestChamber");
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -71993,7 +68634,6 @@
 	desc = "A remote control-switch for the pod doors.";
 	id = "mechpodbay";
 	name = "Pod Door Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "70"
 	},
@@ -72011,7 +68651,6 @@
 	desc = "A remote control-switch for the pod doors.";
 	id = "mechpodbayouter";
 	name = "Pod Door Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "70"
 	},
@@ -72027,8 +68666,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -72037,12 +68675,10 @@
 /area/toxins/xenobiology)
 "cIO" = (
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/effect/decal/warning_stripes/west,
@@ -72055,7 +68691,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72112,7 +68747,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/trunk{
@@ -72139,8 +68773,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -72283,8 +68916,7 @@
 	icon_state = "door_locked";
 	locked = 1;
 	name = "Assembly Line (KEEP OUT)";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -72318,8 +68950,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -72368,8 +68999,7 @@
 /area/atmos/control)
 "cJq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/break_room)
@@ -72448,7 +69078,6 @@
 /obj/item/paper/pamphlet,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/stack/tape_roll,
@@ -72512,7 +69141,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -72536,7 +69164,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/hologram/holopad,
@@ -72545,16 +69172,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "cJI" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/wall,
@@ -72564,7 +69188,6 @@
 /obj/machinery/door_control{
 	id = "xenobio3";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -72575,7 +69198,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/southeast,
@@ -72593,7 +69215,6 @@
 /area/toxins/xenobiology)
 "cJM" = (
 /obj/structure/sign/atmosplaque{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -72608,7 +69229,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -72697,8 +69317,7 @@
 /obj/structure/grille,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/mechanic_workshop)
@@ -72723,8 +69342,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Mechanic Workshop";
-	req_access_txt = "70";
-	req_one_access_txt = "0"
+	req_access_txt = "70"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72758,13 +69376,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72798,7 +69414,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -72871,8 +69486,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -72880,12 +69494,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	level = 1
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -72944,7 +69556,6 @@
 /obj/machinery/door_control{
 	id = "xenobio7";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -72987,7 +69598,6 @@
 "cKv" = (
 /obj/structure/chair/wood/wings{
 	dir = 4;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (EAST)"
 	},
 /turf/simulated/floor/wood,
@@ -72995,7 +69605,6 @@
 "cKw" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood{
@@ -73008,14 +69617,11 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module North";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73030,14 +69636,12 @@
 	icon_state = "0-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -73057,8 +69661,7 @@
 	department = "Atmospherics";
 	departmentType = 3;
 	name = "Atmospherics Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -73122,8 +69725,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -73136,7 +69738,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -73161,7 +69762,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -73301,7 +69901,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/newscaster{
@@ -73334,7 +69933,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/trunk{
@@ -73379,9 +69977,7 @@
 "cLj" = (
 /obj/machinery/camera{
 	c_tag = "Research Test Chamber";
-	dir = 2;
-	network = list("TestChamber","SS13","Research");
-	pixel_x = 0
+	network = list("TestChamber","SS13","Research")
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
@@ -73421,9 +70017,7 @@
 	id = "Skynet_heavy"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/decal/warning_stripes/north,
@@ -73463,7 +70057,6 @@
 /obj/machinery/door_control{
 	id = "mechpod";
 	name = "Mechanic's Inner Door Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "70"
 	},
@@ -73484,9 +70077,7 @@
 /area/engine/mechanic_workshop)
 "cLs" = (
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -73498,7 +70089,6 @@
 "cLt" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/window/reinforced{
@@ -73511,7 +70101,6 @@
 /area/engine/mechanic_workshop)
 "cLu" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/computer/rdconsole/mechanics,
@@ -73527,7 +70116,6 @@
 /area/assembly/assembly_line)
 "cLw" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -73668,7 +70256,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -73681,7 +70268,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/light/small,
@@ -73695,7 +70281,6 @@
 /obj/machinery/door_control{
 	id = "xenobio2";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -73706,7 +70291,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -73735,8 +70319,7 @@
 "cLU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -73782,7 +70365,6 @@
 "cLZ" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
-	icon_state = "wooden_chair_wings";
 	tag = "icon-wooden_chair_wings (WEST)"
 	},
 /turf/simulated/floor/wood,
@@ -73947,7 +70529,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -73976,7 +70557,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/item/paper,
@@ -73998,7 +70578,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -74113,7 +70692,6 @@
 /obj/machinery/door_control{
 	id = "xenobio4";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -74127,7 +70705,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
 "cML" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "arrival"
@@ -74150,8 +70728,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -74184,7 +70761,6 @@
 "cMR" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -74211,9 +70787,7 @@
 	},
 /area/toxins/xenobiology)
 "cMT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "cMU" = (
@@ -74222,18 +70796,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/assembly/assembly_line)
-"cMV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
 "cMW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74327,8 +70889,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
@@ -74356,7 +70917,6 @@
 /obj/machinery/door_control{
 	id = "xenobio6";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -74393,7 +70953,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -74413,8 +70972,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -74423,7 +70981,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -74442,8 +70999,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -74546,8 +71102,7 @@
 /area/maintenance/aft)
 "cNE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10;
-	level = 2
+	dir = 10
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -74578,14 +71133,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -74621,7 +71174,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -74695,7 +71247,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -74712,7 +71263,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -74756,8 +71306,7 @@
 /area/assembly/assembly_line)
 "cOb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -74766,7 +71315,6 @@
 "cOc" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment{
@@ -74774,7 +71322,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -74839,8 +71386,7 @@
 "cOk" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/binary/valve/digital{
 	color = "";
@@ -74852,8 +71398,7 @@
 /area/atmos)
 "cOl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
@@ -74901,7 +71446,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -74921,7 +71465,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -74948,8 +71491,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74976,7 +71518,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/engine,
@@ -75012,12 +71553,10 @@
 /area/atmos/distribution)
 "cOB" = (
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 8;
-	icon_state = "3"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 8;
-	icon_state = "4"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -75031,8 +71570,7 @@
 /area/maintenance/asmaint2)
 "cOD" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
@@ -75042,12 +71580,10 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/arrow{
-	dir = 4;
-	icon_state = "4"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -75080,8 +71616,7 @@
 "cOI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Mix to Distro";
-	on = 0
+	name = "Mix to Distro"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -75092,9 +71627,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cOK" = (
@@ -75102,7 +71635,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/navbeacon{
@@ -75168,8 +71700,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Assembly Line East";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -75213,19 +71744,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/wall/r_wall,
 /area/atmos/distribution)
-"cOX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cOY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -75235,18 +71753,15 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
@@ -75303,8 +71818,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating,
@@ -75321,7 +71835,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -75411,8 +71924,7 @@
 "cPo" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Equipment West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -75427,18 +71939,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
-"cPp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
 "cPq" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -75450,8 +71950,7 @@
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/camera{
 	c_tag = "Atmospherics North-West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75479,9 +71978,7 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -75495,7 +71992,6 @@
 /obj/structure/table,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75517,7 +72013,6 @@
 /obj/item/pen,
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -75537,7 +72032,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/item/clothing/mask/gas,
@@ -75560,9 +72054,7 @@
 /turf/space,
 /area/solar/port)
 "cPD" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cPE" = (
@@ -75637,20 +72129,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
-"cPL" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
-/area/hallway/primary/aft)
 "cPM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75660,8 +72144,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -75682,12 +72165,10 @@
 "cPP" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Equipment East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/engineeringcart,
 /obj/item/radio/intercom{
@@ -75704,13 +72185,11 @@
 "cPS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -75788,8 +72267,7 @@
 /area/solar/port)
 "cQe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
@@ -75799,7 +72277,6 @@
 	dir = 1
 	},
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "wloop_atm_meter";
 	name = "Waste Loop"
 	},
@@ -75813,7 +72290,6 @@
 /area/atmos/distribution)
 "cQg" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -75823,7 +72299,6 @@
 /area/atmos/distribution)
 "cQh" = (
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "dloop_atm_meter";
 	name = "Distribution Loop"
 	},
@@ -75833,11 +72308,9 @@
 "cQi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10;
-	initialize_directions = 10;
-	level = 2
+	initialize_directions = 10
 	},
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel,
@@ -75870,8 +72343,7 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
@@ -75880,16 +72352,14 @@
 /area/medical/virology)
 "cQo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cQp" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/space,
 /area/space/nearstation)
@@ -75995,8 +72465,7 @@
 /area/toxins/xenobiology)
 "cQB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plasteel{
@@ -76018,9 +72487,7 @@
 	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32;
-	req_access_txt = "0"
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -76032,15 +72499,12 @@
 	department = "Chief Engineer's Desk";
 	departmentType = 7;
 	name = "Chief Engineer Requests Console";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -76074,8 +72538,7 @@
 /area/engine/engineering)
 "cQH" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable/yellow{
@@ -76111,7 +72574,6 @@
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "11"
 	},
@@ -76184,8 +72646,7 @@
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/item/stack/sheet/glass{
 	amount = 50
@@ -76199,9 +72660,7 @@
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cQP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
 "cQR" = (
@@ -76219,7 +72678,6 @@
 	pixel_y = 19
 	},
 /obj/item/reagent_containers/syringe/antiviral{
-	pixel_x = 0;
 	pixel_y = 13
 	},
 /obj/item/reagent_containers/syringe/antiviral{
@@ -76235,7 +72693,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -76243,8 +72700,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -76260,8 +72716,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -76289,19 +72744,16 @@
 /area/engine/engineering)
 "cQW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76313,7 +72765,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -76334,8 +72785,7 @@
 "cRa" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
@@ -76359,15 +72809,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10;
-	initialize_directions = 10;
-	level = 2
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cRd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -76400,8 +72848,7 @@
 "cRf" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
@@ -76426,8 +72873,7 @@
 /area/engine/engineering)
 "cRh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -76440,14 +72886,12 @@
 "cRj" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Pure to Mix";
-	on = 0
+	name = "Pure to Mix"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -76464,7 +72908,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -76536,14 +72979,12 @@
 "cRr" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -76578,8 +73019,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
@@ -76641,8 +73081,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -76654,7 +73093,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76693,7 +73131,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -76707,8 +73144,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -76734,8 +73170,7 @@
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Assembly Line West";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -76746,8 +73181,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76759,8 +73193,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76775,7 +73208,6 @@
 /obj/item/multitool,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -76791,8 +73223,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -76864,7 +73295,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/stack/rods{
@@ -76875,8 +73305,7 @@
 "cRV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -76902,14 +73331,12 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module South";
 	dir = 4;
-	network = list("Research","SS13");
-	pixel_x = 0
+	network = list("Research","SS13")
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	id = "xenobio1";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -76920,7 +73347,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/east,
@@ -76948,13 +73374,10 @@
 /area/toxins/xenobiology)
 "cSa" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Equipment North";
-	network = list("SS13")
+	c_tag = "Engineering Equipment North"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/vending/engivend,
@@ -76984,8 +73407,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -77025,8 +73447,7 @@
 /area/engine/engineering)
 "cSm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	level = 2
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -77040,20 +73461,16 @@
 /area/atmos)
 "cSo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Air to Mix";
-	on = 0
+	name = "Air to Mix"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cSp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cSq" = (
@@ -77066,18 +73483,14 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cSr" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plasteel{
@@ -77087,8 +73500,7 @@
 /area/atmos/distribution)
 "cSs" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics Waste Tank";
-	network = list("SS13")
+	c_tag = "Atmospherics Waste Tank"
 	},
 /turf/simulated/floor/engine{
 	name = "vacuum floor";
@@ -77128,8 +73540,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
@@ -77145,8 +73556,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -77154,8 +73564,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
@@ -77252,8 +73661,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77280,7 +73688,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -77293,7 +73700,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/sign/poster/official/random{
@@ -77323,8 +73729,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -77344,9 +73749,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "cSU" = (
@@ -77354,7 +73757,6 @@
 /area/engine/engineering)
 "cSV" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/carpet,
@@ -77382,7 +73784,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -77395,7 +73796,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/computer/atmos_alert,
@@ -77432,7 +73832,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -77442,7 +73841,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -77463,7 +73861,6 @@
 /area/engine/equipmentstorage)
 "cTf" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
@@ -77504,7 +73901,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -77517,7 +73913,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -77528,7 +73923,6 @@
 "cTl" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -77546,12 +73940,9 @@
 	},
 /area/engine/engineering)
 "cTn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -77593,9 +73984,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cTs" = (
@@ -77689,8 +74078,7 @@
 "cTE" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -77713,8 +74101,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77788,8 +74175,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -77806,8 +74192,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/equipmentstorage)
@@ -77828,7 +74213,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -77869,7 +74253,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/table,
@@ -77912,13 +74295,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10;
-	level = 2
+	dir = 10
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77937,9 +74318,7 @@
 	id_tag = "robotics_solar_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "13";
 	tag_airpump = "robotics_solar_pump";
@@ -77948,7 +74327,6 @@
 	tag_interior_door = "robotics_solar_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "robotics_solar_sensor";
 	pixel_x = 12;
 	pixel_y = -25
@@ -77987,8 +74365,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -78068,7 +74445,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -78099,15 +74475,12 @@
 	},
 /obj/item/book/manual/engineering_singularity_safety,
 /obj/machinery/camera{
-	c_tag = "Engineering North-West";
-	network = list("SS13")
+	c_tag = "Engineering North-West"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cUk" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/table,
@@ -78123,8 +74496,7 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /obj/machinery/light{
@@ -78165,7 +74537,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78185,7 +74556,6 @@
 /area/engine/equipmentstorage)
 "cUu" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/reinforced,
@@ -78240,8 +74610,7 @@
 /area/engine/chiefs_office)
 "cUz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78269,8 +74638,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -78282,8 +74650,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -78298,13 +74665,11 @@
 /area/engine/engineering)
 "cUN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "Unfiltered to Mix";
-	on = 0
+	name = "Unfiltered to Mix"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -78322,7 +74687,6 @@
 /obj/machinery/door_control{
 	id = "xenobio5";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -78385,8 +74749,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -78413,7 +74776,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -78509,7 +74871,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -78517,8 +74878,7 @@
 "cVl" = (
 /obj/machinery/power/solar_control{
 	id = "portsolar";
-	name = "Aft Port Solar Control";
-	track = 0
+	name = "Aft Port Solar Control"
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -78526,12 +74886,10 @@
 "cVm" = (
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Control";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump Engineering";
 	pixel_y = -24;
 	shock_proof = 1
@@ -78542,8 +74900,7 @@
 /obj/structure/closet/wardrobe/black,
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Access";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -78553,7 +74910,6 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
@@ -78563,7 +74919,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -78581,8 +74936,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78593,8 +74947,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -78647,9 +75000,7 @@
 "cVv" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -78661,8 +75012,7 @@
 "cVw" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/engine,
@@ -78681,7 +75031,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -78689,8 +75038,7 @@
 "cVy" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/meter,
 /obj/machinery/light,
@@ -78703,9 +75051,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
@@ -78715,8 +75061,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -78734,8 +75079,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/disposal,
 /obj/structure/sign/deathsposal{
@@ -78768,8 +75112,7 @@
 "cVK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/plating,
@@ -78778,16 +75121,14 @@
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -78805,15 +75146,12 @@
 "cVO" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
 "cVP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4;
 	level = 2
@@ -78823,8 +75161,7 @@
 /area/atmos/distribution)
 "cVQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -78840,8 +75177,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/atmos/distribution)
@@ -78855,7 +75191,6 @@
 	cell_type = 25000;
 	dir = 1;
 	name = "Engineering Engine Super APC";
-	pixel_x = 0;
 	pixel_y = 24;
 	shock_proof = 1
 	},
@@ -78903,8 +75238,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/chiefs_office)
@@ -79021,7 +75355,6 @@
 /area/maintenance/asmaint)
 "cWr" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/simulated/floor/plasteel{
@@ -79045,8 +75378,7 @@
 /obj/item/toy/plushie/octopus,
 /obj/machinery/camera{
 	c_tag = "Departure Lounge East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -79083,16 +75415,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWz" = (
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
@@ -79108,7 +75437,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -79119,15 +75447,12 @@
 /area/engine/equipmentstorage)
 "cWC" = (
 /obj/structure/sign/poster/official/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWD" = (
-/obj/structure/closet/secure_closet/engineering_chief{
-	req_access_txt = "0"
-	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"
@@ -79139,9 +75464,7 @@
 /area/hallway/secondary/exit)
 "cWG" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25";
 	tag = "icon-left (WEST)"
@@ -79168,7 +75491,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -79202,7 +75524,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -79220,21 +75541,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cWN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -79254,9 +75571,7 @@
 /turf/simulated/floor/beach/sand,
 /area/hallway/secondary/exit)
 "cWR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -79274,7 +75589,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/binary/volume_pump/on{
@@ -79304,11 +75618,9 @@
 "cWV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
@@ -79316,28 +75628,22 @@
 "cWW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWX" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cWY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
@@ -79346,20 +75652,16 @@
 /turf/simulated/floor/engine/n20,
 /area/atmos)
 "cXa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "N2O to Pure";
-	on = 0
+	name = "N2O to Pure"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	level = 2
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -79373,12 +75675,9 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos)
 "cXd" = (
@@ -79410,7 +75709,6 @@
 "cXf" = (
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
@@ -79421,7 +75719,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/hallway/secondary/exit)
@@ -79448,7 +75745,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/southeastcorner,
@@ -79456,8 +75752,7 @@
 /area/hallway/secondary/exit)
 "cXm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -79465,8 +75760,7 @@
 "cXn" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -79479,7 +75773,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -79518,9 +75811,7 @@
 /area/maintenance/asmaint)
 "cXs" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -79558,7 +75849,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -79595,7 +75885,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
@@ -79617,7 +75906,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -79652,13 +75940,10 @@
 "cXG" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Chief Engineer's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "station intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -79702,8 +75987,7 @@
 "cXM" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "SMES Room";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -79716,8 +76000,7 @@
 /area/engine/engineering)
 "cXO" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -79739,8 +76022,7 @@
 /area/atmos)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plasteel,
@@ -79748,15 +76030,13 @@
 "cXS" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "56"
 	},
 /obj/structure/cable{
@@ -79768,15 +76048,11 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXT" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXV" = (
@@ -79787,31 +76063,27 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9;
-	level = 2
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXX" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Mix to Port";
-	on = 0
+	name = "Mix to Port"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cXY" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Air to Port";
-	on = 0
+	name = "Air to Port"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -79824,8 +76096,7 @@
 "cYa" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Pure to Port";
-	on = 0
+	name = "Pure to Port"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -79838,9 +76109,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos)
 "cYc" = (
@@ -79909,8 +76178,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -79973,8 +76241,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80043,8 +76310,7 @@
 	pixel_y = -8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -80064,15 +76330,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "cYD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -80084,7 +76348,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /obj/item/radio/intercom{
 	dir = 0;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -80137,7 +76400,6 @@
 /obj/effect/decal/warning_stripes/white/hollow,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light,
@@ -80160,8 +76422,7 @@
 "cYP" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -80193,8 +76454,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80230,8 +76490,7 @@
 "cYY" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -80244,7 +76503,6 @@
 /obj/machinery/door_control{
 	id = "stationawaygate";
 	name = "Gateway Shutters Access Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "62"
 	},
@@ -80262,14 +76520,12 @@
 "cZc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cZd" = (
 /obj/machinery/atmospherics/trinary/filter{
-	density = 0;
 	dir = 1;
 	filter_type = 4;
 	name = "Gas filter (N2O tank)";
@@ -80287,18 +76543,14 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/atmos)
 "cZg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -80308,8 +76560,7 @@
 "cZh" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/space,
 /area/space/nearstation)
@@ -80326,8 +76577,7 @@
 /area/atmos)
 "cZj" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -80553,12 +76803,11 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cZK" = (
-/obj/machinery/vending/snack,
 /obj/machinery/ai_status_display{
 	pixel_x = 32;
-	pixel_y = 0;
 	step_size = 0
 	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "cZL" = (
@@ -80578,8 +76827,7 @@
 /area/engine/engineering)
 "cZP" = (
 /obj/machinery/camera{
-	c_tag = "Engineering East";
-	network = list("SS13")
+	c_tag = "Engineering East"
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "A telescreen that connects to the engine's camera network.";
@@ -80587,7 +76835,6 @@
 	layer = 4;
 	name = "Engine Monitor";
 	network = list("engine");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,
@@ -80602,8 +76849,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -80625,10 +76871,7 @@
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "cZT" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
@@ -80646,15 +76889,13 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -80676,9 +76917,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cZZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
 	name = "Mix to Engine"
@@ -80689,13 +76928,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -80727,8 +76962,7 @@
 "dad" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10;
-	level = 2
+	dir = 10
 	},
 /turf/space,
 /area/space/nearstation)
@@ -80743,14 +76977,12 @@
 /obj/machinery/requests_console{
 	department = "EVA";
 	name = "EVA Requests Console";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80764,12 +76996,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dah" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -80784,8 +77013,7 @@
 "dak" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -80803,7 +77031,6 @@
 /area/engine/engineering)
 "dam" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel,
@@ -80826,14 +77053,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "EVA";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80845,12 +77070,10 @@
 /area/escapepodbay)
 "dau" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -80892,8 +77115,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80926,8 +77148,7 @@
 /obj/structure/grille,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating/airless,
 /area/escapepodbay)
@@ -80935,8 +77156,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81083,8 +77303,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81099,8 +77318,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -81114,13 +77332,10 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "daW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Plasma to Pure";
-	on = 0
+	name = "Plasma to Pure"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -81131,8 +77346,7 @@
 /area/maintenance/asmaint)
 "daY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8;
-	level = 2
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -81151,8 +77365,7 @@
 "dba" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/space,
@@ -81180,8 +77393,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -81252,8 +77464,7 @@
 /area/maintenance/genetics)
 "dbo" = (
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
@@ -81293,8 +77504,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage North";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/field/generator,
 /turf/simulated/floor/plating,
@@ -81308,8 +77518,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81323,7 +77532,6 @@
 /area/maintenance/genetics)
 "dbx" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -81359,8 +77567,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -81370,8 +77577,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -81407,12 +77613,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -81426,8 +77630,7 @@
 /area/escapepodbay)
 "dbJ" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -81440,8 +77643,7 @@
 "dbK" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/warning_stripes/yellow/partial,
@@ -81465,8 +77667,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -81575,8 +77776,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81592,12 +77792,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -81621,8 +77819,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -81657,7 +77854,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -81670,8 +77866,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10;
-	level = 2
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
@@ -81692,8 +77887,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -81757,8 +77951,7 @@
 /area/maintenance/turbine)
 "dcx" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -81766,8 +77959,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -81789,8 +77981,7 @@
 "dcA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -81838,8 +78029,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -81855,8 +78045,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -81897,7 +78086,6 @@
 /area/storage/secure)
 "dcO" = (
 /obj/machinery/atmospherics/trinary/filter{
-	density = 0;
 	dir = 1;
 	name = "Gas filter (Toxins tank)";
 	on = 1
@@ -81930,8 +78118,7 @@
 "dcS" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/space,
@@ -82068,8 +78255,7 @@
 "ddl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /obj/machinery/light{
@@ -82130,8 +78316,7 @@
 "ddt" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
-	name = "Port to Filter";
-	on = 0
+	name = "Port to Filter"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82177,8 +78362,7 @@
 "ddx" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Central";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82226,7 +78410,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -82256,7 +78439,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -82295,8 +78477,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -82320,8 +78501,7 @@
 /area/solar/starboard)
 "ddO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -82359,7 +78539,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -82377,8 +78556,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -82413,7 +78591,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -82453,8 +78630,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -82464,8 +78640,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -82500,7 +78675,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/lattice/catwalk,
@@ -82551,13 +78725,10 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dej" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "CO2 to Pure";
-	on = 0
+	name = "CO2 to Pure"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82629,8 +78800,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -82639,8 +78809,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
@@ -82724,8 +78893,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -82756,8 +78924,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82765,8 +78932,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboardsolar)
@@ -82781,7 +78947,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -82818,16 +78983,13 @@
 	opacity = 0
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -82889,16 +79051,14 @@
 "deQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "deR" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
-	name = "N2 to Pure";
-	on = 0
+	name = "N2 to Pure"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -82971,9 +79131,7 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "deZ" = (
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -82993,8 +79151,7 @@
 /obj/structure/chair/stool,
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Control";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
@@ -83008,8 +79165,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -83042,8 +79198,7 @@
 /area/maintenance/asmaint2)
 "dfj" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -83077,16 +79232,13 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "dfm" = (
 /obj/machinery/door/airlock/external{
-	aiControlDisabled = 0;
 	frequency = 1379;
-	hackProof = 0;
 	icon_state = "door_locked";
 	id_tag = "atmospherics_south_outer";
 	locked = 1;
@@ -83098,8 +79250,7 @@
 "dfn" = (
 /obj/machinery/power/solar_control{
 	id = "starboardsolar";
-	name = "Aft Starboard Solar Control";
-	track = 0
+	name = "Aft Starboard Solar Control"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -83123,7 +79274,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -83140,14 +79290,12 @@
 /obj/machinery/door/airlock/engineering/glass{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
@@ -83181,7 +79329,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/external{
@@ -83201,11 +79348,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_xeno_airlock";
 	pixel_x = 25;
 	req_access_txt = "13";
@@ -83215,7 +79360,6 @@
 	tag_interior_door = "solar_xeno_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_xeno_sensor";
 	pixel_x = 25;
 	pixel_y = 12
@@ -83237,7 +79381,6 @@
 /area/atmos)
 "dfA" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/transit_tube{
@@ -83249,15 +79392,12 @@
 	},
 /area/maintenance/storage)
 "dfB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfC" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
@@ -83272,9 +79412,7 @@
 /area/maintenance/storage)
 "dfE" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/transit_tube/station,
@@ -83287,28 +79425,24 @@
 /area/maintenance/storage)
 "dfF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	name = "O2 to Pure";
-	on = 0
+	name = "O2 to Pure"
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -83319,15 +79453,12 @@
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	target_pressure = 4500
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dfJ" = (
 /obj/machinery/atmospherics/trinary/filter{
-	density = 0;
 	dir = 1;
 	filter_type = 3;
 	name = "Gas filter (CO2 tank)";
@@ -83338,8 +79469,7 @@
 "dfK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10;
-	initialize_directions = 10;
-	level = 2
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -83356,8 +79486,7 @@
 /area/maintenance/asmaint)
 "dfN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -83381,9 +79510,7 @@
 /area/maintenance/asmaint2)
 "dfQ" = (
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -83404,7 +79531,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/external{
@@ -83428,7 +79554,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted{
@@ -83436,7 +79561,6 @@
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted,
@@ -83478,9 +79602,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dgg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgi" = (
@@ -83500,7 +79622,6 @@
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1450;
 	id_tag = "dorms_maint";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "13";
 	tag_airpump = "dorms_pump";
@@ -83519,9 +79640,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "dgm" = (
@@ -83549,8 +79668,7 @@
 "dgr" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics South-West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -83574,8 +79692,7 @@
 "dgt" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plasteel,
@@ -83620,7 +79737,6 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -83639,15 +79755,13 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Port";
 	dir = 4;
-	network = list("SS13","engine");
-	pixel_x = 0
+	network = list("SS13","engine")
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "dgM" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -83657,7 +79771,6 @@
 /area/atmos)
 "dgN" = (
 /obj/machinery/atmospherics/trinary/filter{
-	density = 0;
 	dir = 4;
 	filter_type = 2;
 	name = "Gas filter (N2 tank)";
@@ -83667,24 +79780,19 @@
 /area/atmos)
 "dgP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dgR" = (
 /obj/machinery/atmospherics/trinary/filter{
-	density = 0;
 	dir = 4;
 	filter_type = 1;
 	name = "Gas filter (O2 tank)";
@@ -83711,8 +79819,7 @@
 /area/maintenance/port)
 "dgV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9;
-	level = 2
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -83726,8 +79833,7 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9;
-	level = 2
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/atmos)
@@ -83761,7 +79867,6 @@
 "dhf" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/lattice,
@@ -83769,9 +79874,7 @@
 /area/space/nearstation)
 "dhj" = (
 /obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "dhk" = (
@@ -83787,7 +79890,6 @@
 "dho" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8;
-	icon_state = "intact";
 	tag = "icon-intact (WEST)"
 	},
 /turf/simulated/wall/r_wall,
@@ -83806,9 +79908,6 @@
 "dhq" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/chair/wood{
@@ -83832,8 +79931,7 @@
 /area/crew_quarters/dorms)
 "dhs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -83842,7 +79940,6 @@
 /area/crew_quarters/dorms)
 "dht" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -83860,8 +79957,7 @@
 "dhu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -83887,8 +79983,7 @@
 /area/engine/engineering)
 "dhw" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -83928,9 +80023,7 @@
 	output_tag = "n2_out";
 	sensors = list("n2_sensor" = "Tank")
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -83964,9 +80057,7 @@
 	},
 /area/atmos)
 "dhE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "blue"
@@ -83995,9 +80086,7 @@
 	},
 /area/atmos)
 "dhH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "arrival"
@@ -84017,8 +80106,7 @@
 "dhJ" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics South-East";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/binary/valve/digital/open{
 	name = "Mixed Air Outlet Valve"
@@ -84030,9 +80118,6 @@
 /area/atmos)
 "dhK" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -84041,8 +80126,7 @@
 /area/crew_quarters/toilet)
 "dhL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/turbine)
@@ -84056,7 +80140,6 @@
 "dhN" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -84069,9 +80152,7 @@
 	id = "toilet_unitb";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -84127,8 +80208,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -84173,8 +80253,7 @@
 /area/maintenance/fsmaint2)
 "dii" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84214,8 +80293,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84246,9 +80324,7 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/atmos)
 "diq" = (
@@ -84276,15 +80352,12 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
 /area/atmos)
 "diu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6;
-	level = 2
+	dir = 6
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -84300,8 +80373,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -84310,12 +80382,9 @@
 "diw" = (
 /obj/item/flag/nt,
 /obj/machinery/camera{
-	c_tag = "Central Hallway North";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Central Hallway North"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
@@ -84344,8 +80413,7 @@
 	network = list("SS13","MiniSat")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
@@ -84360,8 +80428,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -84373,8 +80440,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -84412,8 +80478,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/effect/landmark/start{
 	name = "Cyborg"
@@ -84456,13 +80521,10 @@
 	desc = "A remote control-switch for the engineering security doors.";
 	id = "teledoor";
 	name = "AI Satellite Teleport Shutters Control";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "17;75"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "dark";
@@ -84547,23 +80609,12 @@
 /area/turret_protected/aisat_interior)
 "diU" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	level = 2
-	},
-/turf/space,
-/area/space/nearstation)
-"diV" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/space,
 /area/space/nearstation)
 "dja" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	level = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/space,
 /area/space/nearstation)
 "djb" = (
@@ -84597,8 +80648,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -84617,14 +80667,12 @@
 /area/crew_quarters/dorms)
 "djh" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
 /obj/item/book/manual/sop_service,
 /obj/item/pen/blue{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/book/manual/barman_recipes,
@@ -84638,9 +80686,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Bar North";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Bar North"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/soda,
@@ -84656,7 +80702,6 @@
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/clothing/head/that{
@@ -84742,7 +80787,6 @@
 "djt" = (
 /obj/machinery/door/window/eastright{
 	dir = 2;
-	icon_state = "right";
 	name = "Hydroponics Delivery";
 	req_access_txt = "35";
 	tag = "icon-right"
@@ -84766,7 +80810,6 @@
 "djv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8;
-	icon_state = "intact";
 	tag = "icon-intact (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -84780,8 +80823,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/camera{
-	c_tag = "Hydroponics Pasture";
-	network = list("SS13")
+	c_tag = "Hydroponics Pasture"
 	},
 /obj/machinery/hydroponics/soil,
 /obj/structure/disposalpipe/segment{
@@ -84793,7 +80835,6 @@
 "djx" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/grass,
@@ -84811,7 +80852,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted{
@@ -84819,7 +80859,6 @@
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	tag = ""
 	},
 /obj/structure/window/reinforced/tinted,
@@ -84846,15 +80885,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
 	name = "Cyborg"
@@ -84878,8 +80915,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -84908,7 +80944,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -84992,7 +81027,6 @@
 /obj/machinery/turretid/stun{
 	control_area = "\improper AI Satellite Antechamber";
 	name = "AI Antechamber Turret Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "75"
 	},
@@ -85011,7 +81045,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "mair_in_meter";
 	name = "Mixed Air Tank In"
 	},
@@ -85027,7 +81060,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/grille,
 /obj/machinery/meter{
-	frequency = 1443;
 	id = "mair_out_meter";
 	name = "Mixed Air Tank Out"
 	},
@@ -85037,7 +81069,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -85049,9 +81080,7 @@
 /area/hallway/primary/central/nw)
 "djW" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway North-West";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Central Hallway North-West"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -85126,15 +81155,13 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "station intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -85153,13 +81180,11 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -85179,7 +81204,6 @@
 	control_area = "\improper AI Satellite Atmospherics";
 	name = "AI Satellite Atmospherics Turret Control";
 	pixel_x = -28;
-	pixel_y = 0;
 	req_access_txt = "75"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -85241,18 +81265,13 @@
 /area/atmos)
 "dkl" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/north)
 "dkm" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
@@ -85272,7 +81291,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel{
@@ -85373,9 +81391,7 @@
 /area/atmos)
 "dky" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway North-East";
-	dir = 2;
-	network = list("SS13")
+	c_tag = "Central Hallway North-East"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -85441,7 +81457,6 @@
 	control_area = "\improper AI Satellite Service";
 	name = "AI Satellite Service Bay Turret Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "75"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -85476,7 +81491,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "station intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/computer/cryopod/robot{
@@ -85524,7 +81538,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/ai_slipper{
@@ -85532,8 +81545,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -85574,7 +81586,6 @@
 "dkR" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light/small{
@@ -85601,15 +81612,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -85636,7 +81645,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -85658,7 +81666,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -85711,16 +81718,14 @@
 /area/turret_protected/aisat_interior)
 "dkZ" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "gas pump"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "dla" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -85729,7 +81734,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -85754,7 +81758,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -85776,7 +81779,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -85793,8 +81795,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -85852,7 +81853,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -85884,7 +81884,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -85959,8 +81958,7 @@
 	dir = 1
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
@@ -86291,8 +82289,7 @@
 /area/maintenance/asmaint)
 "dmk" = (
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -86409,8 +82406,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
@@ -86428,7 +82424,6 @@
 	external_pressure_bound = 0;
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 0;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -86490,8 +82485,7 @@
 	tag = ""
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -86574,8 +82568,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/bluegrid,
 /area/aisat{
@@ -86589,8 +82582,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/aisat{
@@ -86605,7 +82597,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -86618,9 +82609,7 @@
 "dmS" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Satellite Hallway";
@@ -86757,8 +82746,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -86810,8 +82798,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -86821,8 +82808,7 @@
 /area/turret_protected/ai)
 "dnk" = (
 /obj/machinery/atm{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -86928,8 +82914,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -86952,7 +82937,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -87031,7 +83015,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -87080,7 +83063,6 @@
 	department = "Hydroponics";
 	departmentType = 2;
 	name = "Hydroponics Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/plantgenes,
@@ -87128,13 +83110,11 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1450;
 	id_tag = "south_sensor";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1450;
 	id_tag = "south_maint";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "13";
 	tag_airpump = "south_pump";
@@ -87146,19 +83126,14 @@
 /area/maintenance/asmaint)
 "dnM" = (
 /obj/structure/table/wood,
-/obj/item/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/taperecorder,
 /obj/item/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "Camera";
-	pictures_left = 30;
-	pixel_x = 0;
-	pixel_y = 0
+	pictures_left = 30
 	},
 /obj/item/book/codex_gigas,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cult";
 	tag = "icon-cult"
 	},
@@ -87236,15 +83211,13 @@
 "dnT" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "dnU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
@@ -87254,20 +83227,17 @@
 "dnV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "dnW" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
@@ -87299,13 +83269,10 @@
 "dnY" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87327,12 +83294,10 @@
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
@@ -87351,7 +83316,6 @@
 "doe" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -87390,7 +83354,6 @@
 /obj/machinery/computer/card,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/light{
@@ -87420,15 +83383,12 @@
 	id_tag = "atmospherics_south_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "atmospherics_south_sensor";
 	pixel_x = -8;
 	pixel_y = -30
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "atmospherics_south";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = null;
 	tag_airpump = "atmospherics_south_pump";
@@ -87464,9 +83424,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	aiControlDisabled = 0;
 	frequency = 1379;
-	hackProof = 0;
 	icon_state = "door_locked";
 	id_tag = "atmospherics_south_inner";
 	locked = 1;
@@ -87498,7 +83456,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -87511,8 +83468,7 @@
 /area/maintenance/storage)
 "dos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
@@ -87551,7 +83507,6 @@
 /obj/structure/table/wood,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/camera,
@@ -87567,9 +83522,7 @@
 /area/space/nearstation)
 "doF" = (
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "doG" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -87586,9 +83539,6 @@
 /area/turret_protected/aisat_interior)
 "doI" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -87599,9 +83549,7 @@
 "doK" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "doL" = (
 /obj/docking_port/mobile/pod{
 	dir = 4;
@@ -87616,9 +83564,7 @@
 /area/shuttle/pod_4)
 "doM" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light,
@@ -87631,7 +83577,6 @@
 /obj/machinery/computer/station_alert,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -87645,12 +83590,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87666,12 +83609,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87758,7 +83699,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -87771,7 +83711,6 @@
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -87784,7 +83723,6 @@
 /obj/structure/table,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -87810,7 +83748,6 @@
 	})
 "dpD" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
 	name = "Air Out"
 	},
 /turf/simulated/floor/plating,
@@ -87819,7 +83756,6 @@
 	})
 "dpE" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
 	name = "Mix to MiniSat"
 	},
 /turf/simulated/floor/plating,
@@ -87882,7 +83818,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/space_heater,
@@ -87925,7 +83860,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/rack,
@@ -87933,10 +83867,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /obj/machinery/camera{
 	c_tag = "AI Satellite Service Bay";
@@ -87956,8 +83887,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/aisat/entrance{
@@ -88027,8 +83957,7 @@
 	pixel_y = -29
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -88072,8 +84001,7 @@
 /area/aisat)
 "dqM" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/porta_turret{
 	dir = 4;
@@ -88086,8 +84014,7 @@
 	})
 "dqO" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/porta_turret{
 	dir = 8;
@@ -88192,8 +84119,7 @@
 /area/turret_protected/ai)
 "drA" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
@@ -88219,14 +84145,11 @@
 /area/turret_protected/ai)
 "drG" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -88239,8 +84162,7 @@
 "drK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
-	initialize_directions = 10;
-	level = 1
+	initialize_directions = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -88259,14 +84181,11 @@
 /area/turret_protected/ai)
 "drO" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -88325,7 +84244,6 @@
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
 	name = "south bump Important Area";
 	pixel_y = -24
 	},
@@ -88357,7 +84275,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/requests_console{
@@ -88437,15 +84354,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/simulated/wall,
 /area/turret_protected/ai)
 "dse" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -88455,7 +84370,6 @@
 "dsg" = (
 /obj/machinery/camera/motion{
 	c_tag = "AI Core South";
-	dir = 2;
 	network = list("SS13","MiniSat")
 	},
 /turf/simulated/floor/bluegrid,
@@ -88486,7 +84400,6 @@
 "dsj" = (
 /obj/machinery/camera{
 	c_tag = "AI Satellite Exterior South";
-	dir = 2;
 	network = list("SS13","MiniSat")
 	},
 /turf/space,
@@ -88574,7 +84487,6 @@
 	cell_type = 25000;
 	dir = 1;
 	name = "Engineering Engine Super APC";
-	pixel_x = 0;
 	pixel_y = 24;
 	shock_proof = 1
 	},
@@ -88595,7 +84507,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "station intercom (General)";
 	pixel_y = 25
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -88633,8 +84544,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -88710,7 +84620,6 @@
 "dtk" = (
 /obj/item/pipe_painter,
 /obj/item/clothing/ears/earmuffs{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/clothing/ears/earmuffs{
@@ -88749,7 +84658,6 @@
 "dtq" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/table,
@@ -88761,7 +84669,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump Engineering";
-	pixel_x = 0;
 	pixel_y = 24;
 	shock_proof = 1
 	},
@@ -88779,7 +84686,6 @@
 	layer = 2.9
 	},
 /obj/machinery/alarm{
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/south,
@@ -88869,8 +84775,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
@@ -88888,25 +84793,19 @@
 "dVs" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
 "edp" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering SMES";
-	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -88943,8 +84842,7 @@
 "esG" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9;
-	level = 2
+	dir = 9
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -88989,8 +84887,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8;
-	initialize_directions = 11;
-	level = 2
+	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
@@ -89005,8 +84902,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -89039,9 +84935,7 @@
 /turf/simulated/floor/plating,
 /area/engine/supermatter)
 "eTE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
 "eYG" = (
@@ -89083,8 +84977,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
-	initialize_directions = 6;
-	level = 2
+	initialize_directions = 6
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -89099,8 +84992,7 @@
 /obj/machinery/tcomms/core/station,
 /obj/machinery/camera{
 	c_tag = "Telecommunications Core";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/tcommsat/chamber)
@@ -89149,8 +85041,7 @@
 "gei" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -89159,8 +85050,7 @@
 /area/engine/engineering)
 "ggO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -89209,8 +85099,7 @@
 "gDJ" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -89232,7 +85121,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
-	dir = 2;
 	network = list("engine");
 	pixel_x = 23
 	},
@@ -89313,8 +85201,7 @@
 "hxf" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room";
-	req_access_txt = "10";
-	req_one_access_txt = "0"
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -89326,7 +85213,6 @@
 "hyv" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -89467,9 +85353,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
-	})
+/area/toxins/launch)
 "iRc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -89503,8 +85387,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -89546,8 +85429,7 @@
 "jve" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
@@ -89604,7 +85486,6 @@
 	anchored = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -89627,8 +85508,7 @@
 /area/engine/engineering)
 "kcS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	level = 1
+	dir = 9
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -89636,7 +85516,6 @@
 /obj/structure/table/wood,
 /obj/item/deck/cards,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -89660,14 +85539,13 @@
 	},
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -89680,8 +85558,7 @@
 "kLx" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -89709,15 +85586,13 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "kNZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/crew_quarters/dorms)
@@ -89745,8 +85620,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
@@ -89789,7 +85663,6 @@
 	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -89827,12 +85700,10 @@
 "lLC" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 1;
-	icon_state = "3"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -89886,8 +85757,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -89895,8 +85765,7 @@
 /area/engine/engineering)
 "mtr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -89913,15 +85782,12 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "mAG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "mTX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/storage)
@@ -89980,8 +85846,7 @@
 "nCT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	level = 1
+	dir = 6
 	},
 /obj/machinery/light{
 	dir = 8
@@ -89991,12 +85856,10 @@
 "nFa" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Aft";
-	dir = 2;
 	network = list("SS13","engine");
 	pixel_x = 23
 	},
@@ -90025,8 +85888,7 @@
 "nPw" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -90043,7 +85905,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
 	name = "Cooling Loop Bypass"
 	},
 /turf/simulated/floor/engine,
@@ -90060,8 +85921,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -90071,7 +85931,6 @@
 "oyv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
@@ -90104,15 +85963,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -90174,7 +86031,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -90195,7 +86051,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/simulated/floor/plasteel,
@@ -90240,8 +86095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -90252,8 +86106,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 11;
-	level = 1
+	initialize_directions = 11
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -90357,7 +86210,6 @@
 "rlX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/lattice,
@@ -90378,8 +86230,7 @@
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/yellow/partial{
-	dir = 4;
-	icon_state = "3"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -90449,8 +86300,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
@@ -90474,8 +86324,7 @@
 /area/holodeck/alphadeck)
 "sIy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -90529,8 +86378,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -90568,7 +86416,6 @@
 /area/engine/engineering)
 "tPd" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
 	id_tag = "engineering_east_airlock";
 	pixel_x = -25;
 	req_access_txt = "10;13";
@@ -90578,7 +86425,6 @@
 	tag_interior_door = "engineering_east_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engineering_east_sensor";
 	pixel_x = -25;
 	pixel_y = 12
@@ -90637,7 +86483,6 @@
 "uDK" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/space,
@@ -90717,7 +86562,6 @@
 	dir = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 0;
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -90747,8 +86591,7 @@
 /area/space/nearstation)
 "vBs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10;
-	level = 2
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -90770,7 +86613,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -90817,8 +86659,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -90838,7 +86679,6 @@
 "wnU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plasteel{
@@ -90849,8 +86689,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -90933,8 +86772,7 @@
 /area/engine/engineering)
 "xwz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -90972,14 +86810,12 @@
 "xVt" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/dorms)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/space,
@@ -90990,8 +86826,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Starboard";
 	dir = 8;
-	network = list("SS13","engine");
-	pixel_x = 0
+	network = list("SS13","engine")
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -91009,8 +86844,7 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
@@ -91021,8 +86855,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4;
-	level = 2
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
@@ -105790,9 +101623,9 @@ aTu
 aTu
 bcM
 bhN
-bgv
-biv
 bkd
+biv
+bgv
 blJ
 brk
 aSf
@@ -107829,7 +103662,7 @@ aGn
 aHn
 aLn
 aGn
-aKe
+aLx
 aLq
 aMx
 aNE
@@ -108086,7 +103919,7 @@ aHS
 aHS
 aHl
 aHl
-aKe
+aLx
 aLp
 aGn
 aNF
@@ -108343,7 +104176,7 @@ aEL
 aEL
 aHS
 aHl
-aKe
+aLx
 aGn
 aGn
 aNH
@@ -108600,7 +104433,7 @@ aGn
 aGn
 aGn
 aGn
-aKe
+aLx
 aHS
 aHS
 aHS
@@ -109887,7 +105720,7 @@ aGn
 aGn
 aGn
 aHS
-aKe
+aLx
 aGn
 aPc
 aGn
@@ -113776,7 +109609,7 @@ bzJ
 byB
 bAF
 bDX
-bNO
+bOp
 bDX
 bSK
 bPV
@@ -116386,7 +112219,7 @@ cJx
 cNZ
 cLd
 cKb
-cOX
+cPj
 cSU
 cSU
 cSU
@@ -116643,7 +112476,7 @@ cME
 cMx
 cLf
 cKb
-cOX
+cPj
 cSU
 cUk
 cVh
@@ -116804,7 +112637,7 @@ ahu
 afr
 aeg
 aqW
-aie
+aib
 ajM
 alc
 aob
@@ -116900,7 +112733,7 @@ cJx
 cJx
 cLn
 cKb
-cOX
+cPj
 cSU
 cUj
 cVi
@@ -117157,7 +112990,7 @@ cNG
 cNG
 cLf
 cKb
-cOX
+cPj
 cSU
 dsI
 pxP
@@ -117414,7 +113247,7 @@ cNG
 cOG
 cOE
 cKb
-cOX
+cPj
 cSU
 dsH
 dsP
@@ -117928,7 +113761,7 @@ cJx
 cJx
 cLD
 cKb
-cOX
+cPj
 cSU
 dsK
 cVj
@@ -118185,7 +114018,7 @@ cJx
 cJx
 cPv
 cKb
-cOX
+cPj
 cSU
 dsL
 cVj
@@ -118442,7 +114275,7 @@ cJx
 cJx
 cNG
 cKb
-cOX
+cPj
 cSU
 dsK
 cVj
@@ -119211,9 +115044,9 @@ cLL
 cJl
 cMG
 cMG
-cPL
+cMG
 cJZ
-cOX
+cPj
 cRR
 cUu
 cRM
@@ -119631,7 +115464,7 @@ afl
 apj
 aqx
 ago
-aiy
+ase
 akd
 alN
 aop
@@ -119725,7 +115558,7 @@ cHJ
 cHI
 cHD
 cHD
-cwL
+cqy
 cJZ
 cRR
 cRR
@@ -120224,7 +116057,7 @@ crV
 ctl
 cue
 cvK
-cwL
+cqy
 crV
 cnA
 cHD
@@ -120238,7 +116071,7 @@ cHO
 cHD
 cHD
 cnA
-cMV
+cqy
 cOc
 cJZ
 cRR
@@ -120946,7 +116779,7 @@ aLP
 aLP
 aLP
 aRx
-bdN
+aUw
 bgT
 biP
 boU
@@ -121203,7 +117036,7 @@ aWz
 aYs
 aLP
 bbZ
-bdN
+aUw
 bgT
 biT
 bpT
@@ -121460,7 +117293,7 @@ aQZ
 aYp
 aSl
 aRx
-bdN
+aUw
 bgT
 biR
 bpR
@@ -122496,7 +118329,7 @@ aRx
 dhr
 djf
 dko
-bnp
+bnN
 dnC
 bmi
 aaa
@@ -122787,7 +118620,7 @@ cjn
 ckT
 clS
 cPd
-cos
+cPd
 cPd
 cqY
 cmt
@@ -122996,7 +118829,7 @@ axe
 aNU
 aOI
 aQk
-aSk
+aTD
 aTD
 aWB
 aZs
@@ -123237,7 +119070,7 @@ avB
 avB
 aAF
 awj
-axR
+axO
 ayY
 azW
 aBb
@@ -124372,7 +120205,7 @@ dgg
 dgP
 dhC
 dip
-diV
+djE
 djB
 dkk
 dkO
@@ -125400,7 +121233,7 @@ dgt
 dgP
 dhF
 dip
-diV
+djE
 djB
 dks
 dkT
@@ -128136,7 +123969,7 @@ aFJ
 aFJ
 aOI
 aQG
-aSO
+qFg
 aVq
 aVq
 aZE
@@ -130504,7 +126337,7 @@ ckC
 cxj
 ckC
 ciY
-cwZ
+czY
 cqM
 crE
 cvX
@@ -132218,8 +128051,8 @@ aaa
 alv
 aab
 alD
-amo
-amo
+axq
+axq
 ann
 aoK
 apn
@@ -134825,7 +130658,7 @@ aGX
 aUe
 aGY
 aGX
-aWy
+bbh
 bau
 bau
 bch
@@ -135082,7 +130915,7 @@ aIE
 aGY
 aGY
 aGX
-aWy
+bbh
 bau
 bav
 bci
@@ -135339,7 +131172,7 @@ aGX
 aMz
 aMz
 aQL
-aWy
+bbh
 bau
 bao
 bcs
@@ -135596,7 +131429,7 @@ aKX
 aIE
 aUW
 aUW
-aWy
+bbh
 bau
 bax
 bcj
@@ -135853,7 +131686,7 @@ aUU
 aIE
 aGY
 aGY
-aWy
+bbh
 aGX
 aGX
 aGX
@@ -138228,7 +134061,7 @@ cKZ
 cJK
 cNy
 cKV
-cPp
+cNo
 cEH
 cEH
 cSH
@@ -142071,7 +137904,7 @@ cuZ
 cgs
 cxV
 czL
-cBe
+cac
 cCo
 cjY
 bGG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes every non-bridge snack vendor.
Also removes all default-set variable instances because I forgot to toggle that off in StrongDMM oops.

## Why It's Good For The Game
This forces a funnel and reliance on an (always occupied) job. This also means if the chef's food is poisoned, it is an _actual_ concern.


## Changelog
:cl:FreeStylaLT
del:Snack vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
