### PR TITLE
Fixes loadout errors appearing on every round

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -84,13 +84,13 @@
 			continue
 
 		if(!use_name)
-			error("Loadout - Missing display name: [G]")
+			stack_trace("Loadout - Missing display name: [G]")
 			continue
 		if(!initial(G.cost))
-			error("Loadout - Missing cost: [G]")
+			stack_trace("Loadout - Missing cost: [G]")
 			continue
 		if(!initial(G.path))
-			error("Loadout - Missing path definition: [G]")
+			stack_trace("Loadout - Missing path definition: [G]")
 			continue
 
 		if(!GLOB.loadout_categories[use_category])

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -4,7 +4,7 @@
 	slot = slot_w_uniform
 	sort_category = "Uniforms and Casual Dress"
 
-/datum/gear/uniform/suits
+/datum/gear/uniform/suit
 	subtype_path = /datum/gear/uniform/suit
 
 //there's a lot more colors than I thought there were @_@


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes this appearing on *every* round at startup ever since #12873 was merged:
`WORLD: ## ERROR: Loadout - Missing display name: /datum/gear/uniform/suits`
`WORLD: ## ERROR: Loadout - Missing display name: /datum/gear/uniform/suit`

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It causes two error messages in `game.log` every round. (At least it does on my test server, can't verify live.)

## Changelog
:cl:
N/A
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
