### PR TITLE
Removes security borg as a selectable module

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -7,19 +7,72 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade"
 	origin_tech = "programming=2"
-	var/locked = 0
-	var/installed = 0
+	/// Whether or not the cyborg needs to have a chosen module before they can recieve this upgrade.
 	var/require_module = FALSE
+	/// The type of module this upgrade is compatible with: Engineering, Medical, etc.
 	var/module_type = null
+	/// A list of items, and their replacements that this upgrade should replace on installation, in the format of `item_type_to_replace = replacement_item_type`.
+	var/list/items_to_replace = list()
+	/// A list of replacement items will need to be placed into a cyborg module's `special_rechargable` list after this upgrade is installed.
+	var/list/special_rechargables = list()
 
+/**
+ * Called when someone clicks on a borg with an upgrade in their hand.
+ *
+ * Arguments:
+ * * R - the cyborg that was clicked on with an upgrade.
+ */
 /obj/item/borg/upgrade/proc/action(mob/living/silicon/robot/R)
+	if(!pre_install_checks(R))
+		return
+	if(!do_install(R))
+		return
+	after_install(R)
+	return TRUE
+
+/**
+ * Checks if the upgrade is able to be applied to the cyborg, before actually applying it.
+ *
+ * Arguments:
+ * * R - the cyborg that was clicked on with an upgrade.
+ */
+/obj/item/borg/upgrade/proc/pre_install_checks(mob/living/silicon/robot/R)
 	if(R.stat == DEAD)
-		to_chat(usr, "<span class='notice'>[src] will not function on a deceased cyborg.</span>")
-		return TRUE
+		to_chat(usr, "<span class='warning'>[src] will not function on a deceased cyborg.</span>")
+		return FALSE
 	if(module_type && !istype(R.module, module_type))
-		to_chat(R, "Upgrade mounting error!  No suitable hardpoint detected!")
-		to_chat(usr, "There's no mounting point for the module!")
-		return TRUE
+		to_chat(R, "<span class='warning'>Upgrade mounting error!  No suitable hardpoint detected!</span>")
+		to_chat(usr, "<span class='warning'>There's no mounting point for the module!</span>")
+		return FALSE
+	return TRUE
+
+/**
+ * Executes code that will modify the cyborg or its module.
+ *
+ * Arguments:
+ * * R - the cyborg we're applying the upgrade to.
+ */
+/obj/item/borg/upgrade/proc/do_install(mob/living/silicon/robot/R)
+	return TRUE
+
+/**
+ * Executes code after the module has been installed and the cyborg has been modified in some way.
+ *
+ * Arguments:
+ * * R - the cyborg that we've applied the upgrade to.
+ */
+/obj/item/borg/upgrade/proc/after_install(mob/living/silicon/robot/R)
+	for(var/item in items_to_replace)
+		var/replacement_type = items_to_replace[item]
+		var/obj/item/replacement = new replacement_type(R.module)
+		R.module.remove_item_from_lists(item)
+		R.module.basic_modules += replacement
+
+		if(replacement_type in special_rechargables)
+			R.module.special_rechargables += replacement
+
+	R.module.rebuild_modules()
+	return TRUE
 
 /obj/item/borg/upgrade/reset
 	name = "cyborg module reset board"
@@ -27,13 +80,12 @@
 	icon_state = "cyborg_upgrade1"
 	require_module = TRUE
 
-/obj/item/borg/upgrade/reset/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
+/obj/item/borg/upgrade/reset/do_install(mob/living/silicon/robot/R)
 	R.reset_module()
-
 	return TRUE
+
+/obj/item/borg/upgrade/reset/after_install(mob/living/silicon/robot/R)
+	return // We don't need to give them replacement items, or rebuild their module list. It's going to be a blank borg.
 
 /obj/item/borg/upgrade/rename
 	name = "cyborg reclassification board"
@@ -44,9 +96,7 @@
 /obj/item/borg/upgrade/rename/attack_self(mob/user)
 	heldname = stripped_input(user, "Enter new robot name", "Cyborg Reclassification", heldname, MAX_NAME_LEN)
 
-/obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)
-	if(..())
-		return
+/obj/item/borg/upgrade/rename/do_install(mob/living/silicon/robot/R)
 	if(!R.allow_rename)
 		to_chat(R, "<span class='warning'>Internal diagnostic error: incompatible upgrade module detected.</span>")
 		return 0
@@ -63,7 +113,7 @@
 	desc = "Used to force a reboot of a disabled-but-repaired cyborg, bringing it back online."
 	icon_state = "cyborg_upgrade1"
 
-/obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/restart/do_install(mob/living/silicon/robot/R)
 	if(R.health < 0)
 		to_chat(usr, "<span class='warning'>You have to repair the cyborg before using this module!</span>")
 		return 0
@@ -88,9 +138,7 @@
 	require_module = TRUE
 	origin_tech = "engineering=4;materials=5;programming=4"
 
-/obj/item/borg/upgrade/vtec/action(mob/living/silicon/robot/R)
-	if(..())
-		return
+/obj/item/borg/upgrade/vtec/do_install(mob/living/silicon/robot/R)
 	if(R.speed < 0)
 		to_chat(R, "<span class='notice'>A VTEC unit is already installed!</span>")
 		to_chat(usr, "<span class='notice'>There's no room for another VTEC unit!</span>")
@@ -100,16 +148,35 @@
 
 	return TRUE
 
+/obj/item/borg/upgrade/disablercooler
+	name = "cyborg rapid disabler cooling module"
+	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."
+	icon_state = "cyborg_upgrade3"
+	origin_tech = "engineering=4;powerstorage=4;combat=4"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/security
+
+/obj/item/borg/upgrade/disablercooler/do_install(mob/living/silicon/robot/R)
+	var/obj/item/gun/energy/disabler/cyborg/T = locate() in R.module.modules
+	if(!T)
+		to_chat(usr, "<span class='notice'>There's no disabler in this unit!</span>")
+		return
+	if(T.charge_delay <= 2)
+		to_chat(R, "<span class='notice'>A cooling unit is already installed!</span>")
+		to_chat(usr, "<span class='notice'>There's no room for another cooling unit!</span>")
+		return
+
+	T.charge_delay = max(2 , T.charge_delay - 4)
+
+	return TRUE
+
 /obj/item/borg/upgrade/thrusters
 	name = "ion thruster upgrade"
 	desc = "A energy-operated thruster system for cyborgs."
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "engineering=4;powerstorage=4"
 
-/obj/item/borg/upgrade/thrusters/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
+/obj/item/borg/upgrade/thrusters/do_install(mob/living/silicon/robot/R)
 	if(R.ionpulse)
 		to_chat(usr, "<span class='notice'>This unit already has ion thrusters installed!</span>")
 		return
@@ -124,20 +191,9 @@
 	origin_tech = "engineering=4;materials=5"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/miner
-
-/obj/item/borg/upgrade/ddrill/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
-	for(var/obj/item/pickaxe/drill/cyborg/D in R.module.modules)
-		qdel(D)
-	for(var/obj/item/shovel/S in R.module.modules)
-		qdel(S)
-
-	R.module.modules += new /obj/item/pickaxe/drill/cyborg/diamond(R.module)
-	R.module.rebuild()
-
-	return TRUE
+	items_to_replace = list(
+		/obj/item/pickaxe/drill/cyborg = /obj/item/pickaxe/drill/cyborg/diamond
+	)
 
 /obj/item/borg/upgrade/soh
 	name = "mining cyborg satchel of holding"
@@ -146,18 +202,9 @@
 	origin_tech = "engineering=4;materials=4;bluespace=4"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/miner
-
-/obj/item/borg/upgrade/soh/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
-	for(var/obj/item/storage/bag/ore/cyborg/S in R.module.modules)
-		qdel(S)
-
-	R.module.modules += new /obj/item/storage/bag/ore/holding(R.module)
-	R.module.rebuild()
-
-	return TRUE
+	items_to_replace = list(
+		/obj/item/storage/bag/ore/cyborg = /obj/item/storage/bag/ore/holding
+	)
 
 /obj/item/borg/upgrade/abductor_engi
 	name = "engineering cyborg abductor upgrade"
@@ -166,33 +213,17 @@
 	origin_tech = "engineering=6;materials=6;abductor=3"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/engineering
-
-/obj/item/borg/upgrade/abductor_engi/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
-	for(var/obj/item/weldingtool/largetank/cyborg/W in R.module.modules)
-		qdel(W)
-	for(var/obj/item/screwdriver/cyborg/S in R.module.modules)
-		qdel(S)
-	for(var/obj/item/wrench/cyborg/E in R.module.modules)
-		qdel(E)
-	for(var/obj/item/crowbar/cyborg/C in R.module.modules)
-		qdel(C)
-	for(var/obj/item/wirecutters/cyborg/I in R.module.modules)
-		qdel(I)
-	for(var/obj/item/multitool/cyborg/M in R.module.modules)
-		qdel(M)
-
-	R.module.modules += new /obj/item/weldingtool/abductor(R.module)
-	R.module.modules += new /obj/item/wrench/abductor(R.module)
-	R.module.modules += new /obj/item/screwdriver/abductor(R.module)
-	R.module.modules += new /obj/item/crowbar/abductor(R.module)
-	R.module.modules += new /obj/item/wirecutters/abductor(R.module)
-	R.module.modules += new /obj/item/multitool/abductor(R.module)
-	R.module.rebuild()
-
-	return TRUE
+	items_to_replace = list(
+		/obj/item/weldingtool = /obj/item/weldingtool/abductor,
+		/obj/item/wrench = /obj/item/wrench/abductor,
+		/obj/item/screwdriver = /obj/item/screwdriver/abductor,
+		/obj/item/crowbar = /obj/item/crowbar/abductor,
+		/obj/item/wirecutters = /obj/item/wirecutters/abductor,
+		/obj/item/multitool = /obj/item/multitool/abductor
+	)
+	special_rechargables = list(
+		/obj/item/weldingtool/abductor
+	)
 
 /obj/item/borg/upgrade/abductor_medi
 	name = "medical cyborg abductor upgrade"
@@ -201,39 +232,16 @@
 	origin_tech = "biotech=6;materials=6;abductor=3"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/medical
-
-/obj/item/borg/upgrade/abductor_medi/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
-	for(var/obj/item/scalpel/laser/laser1/L in R.module.modules)
-		qdel(L)
-	for(var/obj/item/hemostat/H in R.module.modules)
-		qdel(H)
-	for(var/obj/item/retractor/E in R.module.modules)
-		qdel(E)
-	for(var/obj/item/bonegel/B in R.module.modules)
-		qdel(B)
-	for(var/obj/item/FixOVein/F in R.module.modules)
-		qdel(F)
-	for(var/obj/item/bonesetter/S in R.module.modules)
-		qdel(S)
-	for(var/obj/item/circular_saw/C in R.module.modules)
-		qdel(C)
-	for(var/obj/item/surgicaldrill/D in R.module.modules)
-		qdel(D)
-
-	R.module.modules += new /obj/item/scalpel/laser/laser3(R.module) //no abductor laser scalpel, so next best thing.
-	R.module.modules += new /obj/item/hemostat/alien(R.module)
-	R.module.modules += new /obj/item/retractor/alien(R.module)
-	R.module.modules += new /obj/item/bonegel/alien(R.module)
-	R.module.modules += new /obj/item/FixOVein/alien(R.module)
-	R.module.modules += new /obj/item/bonesetter/alien(R.module)
-	R.module.modules += new /obj/item/circular_saw/alien(R.module)
-	R.module.modules += new /obj/item/surgicaldrill/alien(R.module)
-	R.module.rebuild()
-
-	return TRUE
+	items_to_replace = list(
+		/obj/item/scalpel/laser/laser1 = /obj/item/scalpel/laser/laser3, // No abductor laser scalpel, so next best thing.
+		/obj/item/hemostat = /obj/item/hemostat/alien,
+		/obj/item/retractor = /obj/item/retractor/alien,
+		/obj/item/bonegel = /obj/item/bonegel/alien,
+		/obj/item/FixOVein = /obj/item/FixOVein/alien,
+		/obj/item/bonesetter = /obj/item/bonesetter/alien,
+		/obj/item/circular_saw = /obj/item/circular_saw/alien,
+		/obj/item/surgicaldrill = /obj/item/surgicaldrill/alien
+	)
 
 /obj/item/borg/upgrade/syndicate
 	name = "safety override module"
@@ -242,13 +250,11 @@
 	origin_tech = "combat=6;materials=6"
 	require_module = TRUE
 
-/obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R)
-	if(..())
-		return
+/obj/item/borg/upgrade/syndicate/do_install(mob/living/silicon/robot/R)
 	if(R.weapons_unlock)
-		to_chat(R, "<span class='warning'>Warning: Safety Overide Protocols have be disabled.</span>")
-		return
-	R.weapons_unlock = 1
+		return // They already had the safety override upgrade, or they're a cyborg type which has this by default.
+	R.weapons_unlock = TRUE
+	to_chat(R, "<span class='warning'>Warning: Safety Overide Protocols have be disabled.</span>")
 	return TRUE
 
 /obj/item/borg/upgrade/lavaproof
@@ -259,9 +265,7 @@
 	require_module = TRUE
 	module_type = /obj/item/robot_module/miner
 
-/obj/item/borg/upgrade/lavaproof/action(mob/living/silicon/robot/R)
-	if(..())
-		return
+/obj/item/borg/upgrade/lavaproof/do_install(mob/living/silicon/robot/R)
 	if(istype(R))
 		R.weather_immunities += "lava"
 	return TRUE
@@ -278,10 +282,7 @@
 	var/powercost = 10
 	var/mob/living/silicon/robot/cyborg
 
-/obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
+/obj/item/borg/upgrade/selfrepair/do_install(mob/living/silicon/robot/R)
 	var/obj/item/borg/upgrade/selfrepair/U = locate() in R
 	if(U)
 		to_chat(usr, "<span class='warning'>This unit is already equipped with a self-repair module.</span>")

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -148,28 +148,6 @@
 
 	return TRUE
 
-/obj/item/borg/upgrade/disablercooler
-	name = "cyborg rapid disabler cooling module"
-	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."
-	icon_state = "cyborg_upgrade3"
-	origin_tech = "engineering=4;powerstorage=4;combat=4"
-	require_module = TRUE
-	module_type = /obj/item/robot_module/security
-
-/obj/item/borg/upgrade/disablercooler/do_install(mob/living/silicon/robot/R)
-	var/obj/item/gun/energy/disabler/cyborg/T = locate() in R.module.modules
-	if(!T)
-		to_chat(usr, "<span class='notice'>There's no disabler in this unit!</span>")
-		return
-	if(T.charge_delay <= 2)
-		to_chat(R, "<span class='notice'>A cooling unit is already installed!</span>")
-		to_chat(usr, "<span class='notice'>There's no room for another cooling unit!</span>")
-		return
-
-	T.charge_delay = max(2 , T.charge_delay - 4)
-
-	return TRUE
-
 /obj/item/borg/upgrade/thrusters
 	name = "ion thruster upgrade"
 	desc = "A energy-operated thruster system for cyborgs."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -100,31 +100,6 @@
 
 	return TRUE
 
-/obj/item/borg/upgrade/disablercooler
-	name = "cyborg rapid disabler cooling module"
-	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."
-	icon_state = "cyborg_upgrade3"
-	origin_tech = "engineering=4;powerstorage=4;combat=4"
-	require_module = TRUE
-	module_type = /obj/item/robot_module/security
-
-/obj/item/borg/upgrade/disablercooler/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
-	var/obj/item/gun/energy/disabler/cyborg/T = locate() in R.module.modules
-	if(!T)
-		to_chat(usr, "<span class='notice'>There's no disabler in this unit!</span>")
-		return
-	if(T.charge_delay <= 2)
-		to_chat(R, "<span class='notice'>A cooling unit is already installed!</span>")
-		to_chat(usr, "<span class='notice'>There's no room for another cooling unit!</span>")
-		return
-
-	T.charge_delay = max(2 , T.charge_delay - 4)
-
-	return TRUE
-
 /obj/item/borg/upgrade/thrusters
 	name = "ion thruster upgrade"
 	desc = "A energy-operated thruster system for cyborgs."

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -311,7 +311,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 /mob/living/silicon/robot/proc/pick_module()
 	if(module)
 		return
-	var/list/modules = list("Generalist", "Engineering", "Medical", "Miner", "Janitor", "Service", "Security")
+	var/list/modules = list("Generalist", "Engineering", "Medical", "Miner", "Janitor", "Service")
 	if(islist(force_modules) && force_modules.len)
 		modules = force_modules.Copy()
 	if(mmi != null && mmi.alien)
@@ -376,17 +376,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			see_reagents = TRUE
 
 		if("Security")
-			if(!weapons_unlock)
-				var/count_secborgs = 0
-				for(var/mob/living/silicon/robot/R in GLOB.alive_mob_list)
-					if(R && R.stat != DEAD && R.module && istype(R.module, /obj/item/robot_module/security))
-						count_secborgs++
-				var/max_secborgs = 2
-				if(GLOB.security_level == SEC_LEVEL_GREEN)
-					max_secborgs = 1
-				if(count_secborgs >= max_secborgs)
-					to_chat(src, "<span class='warning'>There are too many Security cyborgs active. Please choose another module.</span>")
-					return
 			module = new /obj/item/robot_module/security(src)
 			module.channels = list("Security" = 1)
 			module_sprites["Basic"] = "secborg"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1051,16 +1051,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_disablercooler
-	name = "Cyborg Upgrade Module (Rapid Disabler Cooling)"
-	id = "borg_upgrade_disablercooler"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/disablercooler
-	req_tech = list("combat" = 7, "powerstorage" = 7, "engineering" = 7)
-	materials = list(MAT_METAL=80000 , MAT_GLASS=6000 , MAT_GOLD= 2000, MAT_DIAMOND = 500)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 /datum/design/borg_upgrade_diamonddrill
 	name = "Cyborg Upgrade (Diamond Drill)"
 	id = "borg_upgrade_diamonddrill"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This removes the security module as a module that can be picked on station, and removes the Rapid Disabler Cooling from research since it's worthless

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Security Cyborgs have been a contended issue on Paradise for quite a while.
They got all access that they easily can share with an officer dragging em around, allowing them to check every possible antag location, making it beyond difficult for antags to have hiding spots for buying surplus outside of using a space ruin. Which is also not funny since space ruins are generally unassailable.
They are immune to all common forms of stun, they can't be pushed, they can't be slipped, throwing a body at them does not even slow them down
Near Unlimited range attack, a sec borg got far more disabler shots then your ordinary sec officer can ever dream of, combine it with rapid taser cooler, and unless you are stun immune, there is little you can do, as two shots in you will be so slowed there is nothing you can do
No hard counters, like I said, you can't slip a borg, push a borg, table a borg, stun baton a borg, you can't lock em in a room to trap em, you can't cuff them, their only 'weakness' is their speed which is countered by the very accessible VTEC, plus it can easily tank several shots of many guns and still disable you to fall down
No Loot, sec officers, head of staff, blueshield, they are walking loot piñatas, you beat em up and you can nice amount of access, and a cool amount of gear which is of good use, sec borgs give you nothing, in fact, they give you negatives, as you need to spend resources to take them down, in return get nothing.
One Button Bolt or One Button Shock, this is on a ranged mouse bind
Infinity shields, this one is a fair bit rare, but both antags, and non-antags, can and have used sec borgs are a permanent shield, they do not fall down, ever, they do not break or get destroyed, so it's like a perm shield.

Secborgs are strong to even disable a borg with damage it needs to hit -50 health or lower to disable all modules, but again this take time or weapons one most of the time should not need unless one is going loud, and not everyone can output that amount of damage before they them selves are taken down with disabler shots and a stunbaton.
The flash is a second tool for taking down sec borgs, but again that is melee, and is only really good if you got stealth initially or can overrun the borg, but if you at range, it will disable you as well as retreat to prevent that, as well as flashes behing limited to bridge personnel, robotics, security and anyone with access to tech storage, while stealthy, it's not as easy to get as a stun.
Laser Pointer is probably the best 'weapon' that is both stealth and somewhat available, as the librarian, iaa, ntrep, magistrate starts with one and mining can buy ones for you, but again, it's not something you can make yourself or just find, ontop of that, there is not a guarantee for it to work in the first place unless you upgrade to a better micro-laser, and even you need to click on them, instead of just aiming behind them.
Ion Rifle and Ion Carbines, you need to break into armor for one, or armory or an emag for the other, so not the most accessible of items.
EMP in general are somewhat easier to get, but, again with the but, you either need to pay for it, or need a special type of access to even build it, unlike a stunprod, which anyone can build, not to talk about collateral damage, many people to have cybernetic limbs and organs, and accidently killing other just to deal with two sec borgs is not the best to do.

There are several points of contentions, and there have been many changes, and while the other borg modules are strong in their regard, none of them have any ranged stun outside of the janitor borg, and even then, they need to step in it.

For the long and the short of it, both as an antag, and non-antag, dealing with sec borgs is hard, and it's a pain, and you need to dedicate a tool that works on them.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: ppi
del: Removed Security Borg Module as an station option
del: cyborg rapid disabler cooling module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
