### PR TITLE
Removes the Transformation Sting ability

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -74,7 +74,6 @@
 
 //Species traits.
 #define NO_BLOOD		"no_blood"
-#define NOTRANSSTING	"no_trans_sting"
 #define IS_WHITELISTED 	"whitelisted"
 #define LIPS			"lips"
 #define EXOTIC_COLOR	"exotic_blood_color"

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -66,60 +66,6 @@
 		add_attack_logs(user, target, "Unsuccessful sting (changeling)")
 	return 1
 
-/datum/action/changeling/sting/transformation
-	name = "Transformation Sting"
-	desc = "We silently sting a human, injecting a retrovirus that forces them to transform. Costs 50 chemicals."
-	helptext = "The victim will transform much like a changeling would. The effects will be obvious to the victim, and the process will damage our genomes."
-	button_icon_state = "sting_transform"
-	sting_icon = "sting_transform"
-	chemical_cost = 50
-	dna_cost = 3
-	genetic_damage = 100
-	var/datum/dna/selected_dna = null
-
-/datum/action/changeling/sting/transformation/Trigger()
-	var/mob/user = usr
-	var/datum/changeling/changeling = user.mind.changeling
-	if(changeling.chosen_sting)
-		unset_sting(user)
-		return
-	selected_dna = changeling.select_dna("Select the target DNA: ", "Target DNA")
-	if(!selected_dna)
-		return
-	if((NOTRANSSTING in selected_dna.species.species_traits) || selected_dna.species.is_small)
-		to_chat(user, "<span class='warning'>The selected DNA is incompatible with our sting.</span>")
-		return
-	..()
-
-/datum/action/changeling/sting/transformation/can_sting(mob/user, mob/target)
-	if(!..())
-		return
-	if(HAS_TRAIT(target, TRAIT_HUSK) || !ishuman(target) || (NOTRANSSTING in target.dna.species.species_traits))
-		to_chat(user, "<span class='warning'>Our sting appears ineffective against its DNA.</span>")
-		return FALSE
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(HAS_TRAIT(H, TRAIT_GENELESS))
-			to_chat(user, "<span class='warning'>This won't work on a creature without DNA.</span>")
-			return FALSE
-	return TRUE
-
-/datum/action/changeling/sting/transformation/sting_action(mob/user, mob/target)
-	add_attack_logs(user, target, "Transformation sting (changeling) (new identity is [selected_dna.real_name])")
-	if(issmall(target))
-		to_chat(user, "<span class='notice'>Our genes cry out as we sting [target.name]!</span>")
-
-	if(iscarbon(target) && (target.status_flags & CANWEAKEN))
-		var/mob/living/carbon/C = target
-		C.do_jitter_animation(500)
-
-	target.visible_message("<span class='danger'>[target] begins to violenty convulse!</span>","<span class='userdanger'>You feel a tiny prick and a begin to uncontrollably convulse!</span>")
-
-	spawn(10)
-		transform_dna(target,selected_dna)//target is always human so no problem here
-	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
-	return TRUE
-
 /datum/action/changeling/sting/extract_dna
 	name = "Extract DNA Sting"
 	desc = "We stealthily sting a target and extract their DNA. Costs 25 chemicals."

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -21,7 +21,7 @@
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."
 	death_sounds = list('sound/voice/borg_deathsound.ogg') //I've made this a list in the event we add more sounds for dead robots.
 
-	species_traits = list(IS_WHITELISTED, NO_BLOOD, NO_CLONESCAN, NO_INTORGANS, NOTRANSSTING)
+	species_traits = list(IS_WHITELISTED, NO_BLOOD, NO_CLONESCAN, NO_INTORGANS)
 	inherent_traits = list(TRAIT_VIRUSIMMUNE, TRAIT_NOBREATH, TRAIT_RADIMMUNE, TRAIT_NOGERMS, TRAIT_NODECAY, TRAIT_NOPAIN, TRAIT_GENELESS) //Computers that don't decay? What a lie!
 	inherent_biotypes = MOB_ROBOTIC | MOB_HUMANOID
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -5,7 +5,7 @@
 	dangerous_existence = TRUE //So so much
 	//language = "Clatter"
 
-	species_traits = list(IS_WHITELISTED, NO_BLOOD, NOTRANSSTING, NO_HAIR)
+	species_traits = list(IS_WHITELISTED, NO_BLOOD, NO_HAIR)
 	inherent_traits = list(TRAIT_RADIMMUNE, TRAIT_NOHUNGER)
 	inherent_biotypes = MOB_HUMANOID | MOB_MINERAL
 	forced_heartattack = TRUE // Plasmamen have no blood, but they should still get heart-attacks

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -22,7 +22,7 @@
 
 	eyes = "vox_eyes_s"
 
-	species_traits = list(NO_CLONESCAN, IS_WHITELISTED, NOTRANSSTING)
+	species_traits = list(NO_CLONESCAN, IS_WHITELISTED)
 	inherent_traits = list(TRAIT_NOGERMS, TRAIT_NODECAY)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS //Species-fitted 'em all.
 	dietflags = DIET_OMNI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes the Transformation Sting ability, and the `NOTRANSSTING` trait.

Pretty much the same thing as in #14589, but I figured that since that's been open for six months now with no change, and that the only way to reverse the sting was removed (#15821), it'd be best to do this separately.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
To be honest, the reason for removing this should be pretty obvious to anyone who's played more than two Changeling rounds.

While someone could in theory use the transformation sting to frame someone else, I've never seen that happen once in 1100 hours.
There's even advanced rules specifically because of it being abused so often:
> Murderboning so you can absorb is seen as excessive. Your abilities should be used to further your goals or to prevent apprehension if you are found out. Example: Transformation Sting.
Randomly transforming crew for no other purpose than to cause chaos runs counter to this, however using it to create copies of yourself to throw off pursuit of Security is acceptable.

And even despite that, it still happens to some extent almost every cling round.

## Changelog
:cl:
del: Removed the Transformation Sting ability.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
