### PR TITLE
"Help Bar! Fork broken!" - Bar Sign III

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -132,6 +132,7 @@
 		S.req_access = req_access
 		S.panel_open = !panel_open
 		S.prev_sign = prev_sign
+		to_chat(user, "<span_class='notice'>You unbolt the bar sign with your wrench.</span>")
 		qdel(src)
 
 /obj/item/sign/barsign
@@ -170,7 +171,7 @@
 		S.prev_sign = prev_sign
 		S.icon_state = prev_sign.icon
 		S.sign_holder = null
-		to_chat(user, "<span_class='notice>You bolt bar sign with your wrench, closing the maintenance panel in the process.</span>")
+		to_chat(user, "<span_class='notice>You bolt the bar sign in place with your wrench, closing the maintenance panel in the process.</span>")
 		qdel(src)
 	else
 		return
@@ -182,7 +183,7 @@
 	if(broken || emagged)
 		to_chat(user, "<span class='warning'>Nothing interesting happens!</span>")
 		return
-	to_chat(user, "<span class='notice'>You emag bar sign. Takeover in progress ... </span>")
+	to_chat(user, "<span class='notice'>You emag the bar sign. Takeover in progress ... </span>")
 	addtimer(CALLBACK(src, .proc/post_emag), 100)
 
 /obj/structure/sign/barsign/proc/post_emag()

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -12,7 +12,7 @@
 	switch(damage_type)
 		if(BRUTE)
 			if(damage_amount)
-				playsound(src.loc, 'sound/weapons/slash.ogg', 80, TRUE)
+				playsound(loc, 'sound/weapons/slash.ogg', 80, TRUE)
 			else
 				playsound(loc, 'sound/weapons/tap.ogg', 50, TRUE)
 		if(BURN)
@@ -24,12 +24,12 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	to_chat(user, "You unfasten the sign with [I].")
-	var/obj/item/sign/S = new(src.loc)
+	to_chat(user, "<span class='notice'>You unfasten \the [name] sign with your screwdriver.</span>")
+	var/obj/item/sign/S = new(loc)
 	S.name = name
 	S.desc = desc
 	S.icon_state = icon_state
-	//var/icon/I = icon('icons/obj/decals.dmi', icon_state)
+	//var/icon/I = icon('icons/obj/decals.dmi', icon_state)	//This code was already commented off. I'm leaving it here for legacy. I'm happy to remove it, however.
 	//S.icon = I.Scale(24, 24)
 	S.sign_state = icon_state
 	qdel(src)
@@ -43,13 +43,19 @@
 	resistance_flags = FLAMMABLE
 	var/sign_state = ""
 
-/obj/item/sign/attackby(obj/item/tool as obj, mob/user as mob)	//construction
-	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
-		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
-		if(direction == "Cancel")
-			return
-		if(QDELETED(src))
-			return
+/obj/item/sign/attackby(obj/item/I, mob/user)
+	return ..()
+
+/obj/item/sign/screwdriver_act(mob/user)	//construction
+	if(istype(src, /obj/item/sign/barsign))
+		return	// override for barsign
+	. = TRUE
+	if(QDELETED(src))
+		return
+	var/direction = input("In which direction?", "Select direction.") as null|anything in list("North", "East", "South", "West")
+	if(!direction)
+		return
+	if(isturf(user.loc))
 		var/obj/structure/sign/S = new(user.loc)
 		switch(direction)
 			if("North")
@@ -60,15 +66,13 @@
 				S.pixel_y = -32
 			if("West")
 				S.pixel_x = -32
-			else
-				return
 		S.name = name
 		S.desc = desc
 		S.icon_state = sign_state
-		to_chat(user, "You fasten \the [S] with your [tool].")
+		to_chat(user, "<span class='notice'>You fasten \the [name] sign with your screwdriver.")
 		qdel(src)
 	else
-		return ..()
+		return
 
 /obj/structure/sign/double/map
 	name = "station map"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Submits various tweaks to the bar sign
- Apologizes for the umpteenth PR from me using the same code (I somehow broke my fork that was super out of date)
- Gives credit to Tuulipoomi for the initial PR and @dearmochi for the review.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Bar sign no longer goes invisible when you use a screwdriver on it
- Bar sign now becomes an item that you can move and "attach" elsewhere (it doesn't need a wall, but it'll look silly!) by using a screwdriver and then a wrench
- Bar sign's signage can now be changed by the Bartender or, if you're a Tator Tot, you can emag the Bar Sign and now you're in control (you know you want to be)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/69871346/114443762-11287680-9b9c-11eb-9d1c-7899f319ad1d.mp4

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Bar sign's signage can now be changed by the Bartender (use a screwdriver to open the maintenance panel and then hit the sign with your hand), Bar sign can be moved (use a screwdriver and then a wrench)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
