### PR TITLE
Fix summoning multiple guardians exploit 

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -250,8 +250,7 @@
 	var/name_list = list("Aries", "Leo", "Sagittarius", "Taurus", "Virgo", "Capricorn", "Gemini", "Libra", "Aquarius", "Cancer", "Scorpio", "Pisces")
 
 /obj/item/guardiancreator/attack_self(mob/living/user)
-	for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.alive_mob_list)
-		if(G.summoner == user)
+	if(has_guardian(user))
 			to_chat(user, "You already have a [mob_name]!")
 			return
 	if(user.mind && (user.mind.changeling || user.mind.vampire))
@@ -285,6 +284,9 @@
 
 	if(candidates.len)
 		theghost = pick(candidates)
+		if(has_guardian(user))
+			to_chat(user, "You already have a [mob_name]!")
+			return
 		spawn_guardian(user, theghost.key, guardian_type)
 	else
 		to_chat(user, "[failure_message]")
@@ -294,6 +296,13 @@
 	. = ..()
 	if(used)
 		. += "<span class='notice'>[used_message]</span>"
+
+/obj/item/guardiancreator/proc/has_guardian(mob/living/user)
+	for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.alive_mob_list)
+		if(G.summoner == user)
+			return TRUE
+	return FALSE
+
 
 /obj/item/guardiancreator/proc/spawn_guardian(mob/living/user, key, guardian_type)
 	var/pickedtype = /mob/living/simple_animal/hostile/guardian/punch

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -251,8 +251,8 @@
 
 /obj/item/guardiancreator/attack_self(mob/living/user)
 	if(has_guardian(user))
-			to_chat(user, "You already have a [mob_name]!")
-			return
+		to_chat(user, "You already have a [mob_name]!")
+		return
 	if(user.mind && (user.mind.changeling || user.mind.vampire))
 		to_chat(user, "[ling_failure]")
 		return

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -286,6 +286,7 @@
 		theghost = pick(candidates)
 		if(has_guardian(user))
 			to_chat(user, "You already have a [mob_name]!")
+			used = FALSE
 			return
 		spawn_guardian(user, theghost.key, guardian_type)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Fixes #8236 

## What Does This PR Do
Check for existing guardian again after observer is picked, in case the user had used multiple guardian summoning items at the same time.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players aren't supposed to have more than one guardian, this fixes an exploit to get around that restriction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/4008584/114487663-3d102000-9bcd-11eb-95b3-7c010c24b8bb.png)

## Changelog
:cl:
fix: Prevent players from summoning multiple guardians at the same time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
