### PR TITLE
Fixes bike dismanting

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -156,3 +156,6 @@
 
 		else
 			. = 1
+
+/obj/structure/chair/wheelchair/bike/wrench_act(mob/user, obj/item/I)
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
you can no longer dismantle the arcade bicycle

## Why It's Good For The Game
likely an oversight, you probably shouldn't be able to destroy 10k tickets worth of work with a single click of a wrench.

## Changelog
:cl:
Fix: you can no longer dismantle the arcade bicycle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
