### PR TITLE
Fixed a grammar mistake in the coroners cap description.

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -195,6 +195,6 @@
 	dog_fashion = /datum/dog_fashion/head/surgery
 
 /obj/item/clothing/head/surgery/black
-	desc = "A cap coroners wear during autopsies. Keeps their hair from falling into the cadavers.  It is as dark than the coroner's humor."
+	desc = "A cap coroners wear during autopsies. Keeps their hair from falling into the cadavers.  It is as dark as the coroners humor."
 	icon_state = "surgcap_black"
 	dog_fashion = /datum/dog_fashion/head/surgery

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -195,6 +195,6 @@
 	dog_fashion = /datum/dog_fashion/head/surgery
 
 /obj/item/clothing/head/surgery/black
-	desc = "A cap coroners wear during autopsies. Keeps their hair from falling into the cadavers.  It is as dark as the coroners humor."
+	desc = "A cap coroners wear during autopsies. Keeps their hair from falling into the cadavers.  It is as dark as the coroner's humor."
 	icon_state = "surgcap_black"
 	dog_fashion = /datum/dog_fashion/head/surgery


### PR DESCRIPTION
## What Does This PR Do
Fix #15895, a grammar mistake in the coroners cap and takes it away from @S34NW.

## Why It's Good For The Game
Good grammar good.

## Changelog
:cl:
spellcheck: fixed the description of the coroners cap
/:cl: