### PR TITLE
Fixes statues making invisible atmos blocking walls

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -46,9 +46,6 @@
 	user.visible_message("[user] rubs some dust off from the [name]'s surface.", \
 						 "<span class='notice'>You rub some dust off from the [name]'s surface.</span>")
 
-/obj/structure/statue/CanAtmosPass()
-	return !density
-
 /obj/structure/statue/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))
 		if(material_drop_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops statues creating magic atmos blocking space tiles.
Stops statues blocking atmos in general because that makes very little sense, a statue isn't airtight.

## Why It's Good For The Game
Realism and bug fixes.

Space should NOT be airtight.

## Images of changes
![how does this work](https://user-images.githubusercontent.com/69320440/115118565-b5932a00-9f9b-11eb-9a96-aaf7674baa8b.png)


Stops this being airtight.


## Changelog
:cl:
Fix: you can no longer make airtight space with statues.
Tweak: statues no longer block atmos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
