### PR TITLE
Combat mode for ERT hardsuits

### DIFF
--- a/code/modules/clothing/spacesuits/combat.dm
+++ b/code/modules/clothing/spacesuits/combat.dm
@@ -1,0 +1,113 @@
+//Generic combat hardsuit helmet - should never get used
+/obj/item/clothing/head/helmet/space/hardsuit/combat
+	name = "combat hardsuit helmet"
+	desc = "A dual-mode generic combat helmet designed for work in special operations. It is in EVA mode. Not the property of Gorlex Marauders."
+	alt_desc = "A dual-mode generic combat helmet designed for work in special operations. It is in combat mode. Not the property of Gorlex Marauders."
+	icon_state = "hardsuit1-syndi"
+	item_state = "syndie_helm"
+	item_color = "syndi"
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 35, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)
+	on = TRUE
+	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
+
+/obj/item/clothing/head/helmet/space/hardsuit/combat/update_icon()
+	icon_state = "hardsuit[on]-[item_color]"
+
+/obj/item/clothing/head/helmet/space/hardsuit/combat/New()
+	..()
+	if(istype(loc, /obj/item/clothing/suit/space/hardsuit))
+		suit = loc
+
+/obj/item/clothing/head/helmet/space/hardsuit/combat/attack_self(mob/user) //Toggle Helmet
+	if(!isturf(user.loc))
+		to_chat(user, "<span class='warning'>You cannot toggle your helmet while in this [user.loc]!</span>" )
+		return
+	on = !on
+	if(on)
+		to_chat(user, "<span class='notice'>You switch your hardsuit to EVA mode, sacrificing speed for space protection.</span>")
+		name = initial(name)
+		desc = initial(desc)
+		set_light(brightness_on)
+		flags |= visor_flags
+		flags_cover |= HEADCOVERSEYES | HEADCOVERSMOUTH
+		flags_inv |= visor_flags_inv
+		cold_protection |= HEAD
+	else
+		to_chat(user, "<span class='notice'>You switch your hardsuit to combat mode and can now run at full speed.</span>")
+		name = "[initial(name)] (combat)"
+		desc = alt_desc
+		set_light(0)
+		flags &= ~visor_flags
+		flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+		flags_inv &= ~visor_flags_inv
+		cold_protection &= ~HEAD
+	update_icon()
+	playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
+	toggle_hardsuit_mode(user)
+	user.update_inv_head()
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		C.head_update(src, forced = 1)
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
+
+/obj/item/clothing/head/helmet/space/hardsuit/combat/proc/toggle_hardsuit_mode(mob/user) //Helmet Toggles Suit Mode
+	if(suit)
+		if(on)
+			suit.name = initial(suit.name)
+			suit.desc= initial(suit.desc)
+			suit.slowdown = 1
+			suit.flags |= STOPSPRESSUREDMAGE
+			suit.cold_protection |= UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+		else
+			suit.name = "[initial(suit.name)] (combat)"
+			suit.desc = suit.alt_desc
+			suit.slowdown = 0
+			suit.flags &= ~STOPSPRESSUREDMAGE
+			suit.cold_protection &= ~(UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS)
+
+		suit.update_icon()
+		user.update_inv_wear_suit()
+		user.update_inv_w_uniform()
+
+//Syndicate hardsuits helmets
+/obj/item/clothing/head/helmet/space/hardsuit/combat/syndi
+	name = "blood-red hardsuit helmet"
+	desc = "A dual-mode advanced helmet designed for work in special operations. It is in EVA mode. Property of Gorlex Marauders."
+	alt_desc = "A dual-mode advanced helmet designed for work in special operations. It is in combat mode. Property of Gorlex Marauders."
+	icon_state = "hardsuit1-syndi"
+	item_state = "syndie_helm"
+	item_color = "syndi"
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 35, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)
+	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDETAIL
+	visor_flags = STOPSPRESSUREDMAGE
+
+//Elite Syndicate hardsuit helmets
+/obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/elite
+	name = "elite syndicate hardsuit helmet"
+	desc = "An dual-mode elite version of the syndicate helmet, with improved armour and fire shielding. It is in EVA mode. Property of Gorlex Marauders."
+	alt_desc = "An elite version of the syndicate helmet, with improved armour and fire shielding. It is in combat mode. Property of Gorlex Marauders."
+	icon_state = "hardsuit0-syndielite"
+	item_color = "syndielite"
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 25, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
+	heat_protection = HEAD
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+
+//Syndicate Strike Team hardsuits
+/obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/elite/sst
+	armor = list(melee = 70, bullet = 70, laser = 50, energy = 40, bomb = 80, bio = 100, rad = 100, fire = 100, acid = 100) //Almost as good as DS gear, but unlike DS can switch to combat for mobility
+	icon_state = "hardsuit0-sst"
+	item_color = "sst"
+
+/obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/freedom
+	name = "eagle helmet"
+	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle. It is in EVA mode."
+	alt_desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle. It is in combat mode."
+	icon_state = "griffinhat"
+	item_state = "griffinhat"
+	sprite_sheets = null
+
+/obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/freedom/update_icon()
+	return

--- a/code/modules/clothing/spacesuits/combat.dm
+++ b/code/modules/clothing/spacesuits/combat.dm
@@ -86,8 +86,8 @@
 //Elite Syndicate hardsuit helmets
 /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/elite
 	name = "elite syndicate hardsuit helmet"
-	desc = "An dual-mode elite version of the syndicate helmet, with improved armour and fire shielding. It is in EVA mode. Property of Gorlex Marauders."
-	alt_desc = "An elite version of the syndicate helmet, with improved armour and fire shielding. It is in combat mode. Property of Gorlex Marauders."
+	desc = "A dual-mode elite version of the syndicate helmet, with improved armor and fireproofing. It is in EVA mode. Property of Gorlex Marauders."
+	alt_desc = "A dual-mode elite version of the syndicate helmet, with improved armour and fireproofing. It is in combat mode. Property of Gorlex Marauders."
 	icon_state = "hardsuit0-syndielite"
 	item_color = "syndielite"
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 25, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
@@ -103,8 +103,8 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/freedom
 	name = "eagle helmet"
-	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle. It is in EVA mode."
-	alt_desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle. It is in combat mode."
+	desc = "An advanced, space-proof helmet. It appears to be modelled after an old-world eagle. It is in EVA mode."
+	alt_desc = "An advanced, space-proof helmet. It appears to be modelled after an old-world eagle. It is in combat mode."
 	icon_state = "griffinhat"
 	item_state = "griffinhat"
 	sprite_sheets = null

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -1,8 +1,8 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert
 	name = "emergency response team helmet"
-	desc = "A dual-mode advanced combat hardsuit helmet worn by members of the Nanotrasen Emergency Response Team. Armoured and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by members of the Nanotrasen Emergency Response Team. Armoured and space ready. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by members of Nanotrasen Emergency Response Teams. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by members of Nanotrasen Emergency Response Teams. Armored and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_commander"
 	item_state = "helm-command"
 	item_color = "ert_commander"
@@ -46,8 +46,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert
 	name = "emergency response team suit"
-	desc = "A dual-mode advanced combat hardsuit worn by members of the Nanotrasen Emergency Response Team. Armoured, space ready, and fire resistant. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by members of the Nanotrasen Emergency Response Team. Armoured, space ready, and fire resistant. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by members of Nanotrasen Emergency Response Teams. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by members of Nanotrasen Emergency Response Teams. Armored, space ready, and fireproof. It is in combat mode."
 	icon_state = "ert_commander"
 	item_state = "suit-command"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -69,8 +69,8 @@
 //Commander
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander
 	name = "emergency response team commander helmet"
-	desc = "A dual-mode advanced combat hardsuit helmet worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured and space ready. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_commander"
 	item_state = "helm-command"
 	item_color = "ert_commander"
@@ -83,8 +83,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/commander
 	name = "emergency response team commander suit"
-	desc = "A dual-mode advanced combat hardsuit worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured, space ready, and fire resistant. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in combat mode."
 	icon_state = "ert_commander"
 	item_state = "suit-command"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander
@@ -98,8 +98,8 @@
 //Security
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security
 	name = "emergency response team security helmet"
-	desc = "A dual-mode advanced combat hardsuit helmet worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured and space ready. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_security"
 	item_state = "syndicate-helm-black-red"
 	item_color = "ert_security"
@@ -112,8 +112,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/security
 	name = "emergency response team security suit"
-	desc = "A dual-mode advanced combat hardsuit worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured, space ready, and fire resistant. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in combat mode."
 	icon_state = "ert_security"
 	item_state = "syndicate-black-red"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security
@@ -127,8 +127,8 @@
 //Engineer
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer
 	name = "emergency response team engineer helmet"
-	desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored and space ready."
 	icon_state = "hardsuit0-ert_engineer"
 	item_state = "helm-orange"
 	item_color = "ert_engineer"
@@ -142,8 +142,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	name = "emergency response team engineer suit"
-	desc = "A dual-mode advanced combat hardsuit worn by the engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by the engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured, space ready, and fire resistant. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in combat mode."
 	icon_state = "ert_engineer"
 	item_state = "suit-orange"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer
@@ -157,8 +157,8 @@
 //Medical
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical
 	name = "emergency response team medical helmet"
-	desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_medical"
 	item_color = "ert_medical"
 
@@ -170,8 +170,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/medical
 	name = "emergency response team medical suit"
-	desc = "A dual-mode advanced combat hardsuit worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored and space ready. It is in combat mode."
 	icon_state = "ert_medical"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical
 
@@ -184,8 +184,8 @@
 //Janitor
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor
 	name = "emergency response team janitor helmet"
-	desc = "A dual-mode advanced combat hardsuit helmet worn by janitorial members of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by janitorial members of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured and space ready. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_janitor"
 	item_color = "ert_janitor"
 
@@ -197,8 +197,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/janitor
 	name = "emergency response team janitor suit"
-	desc = "A dual-mode advanced combat hardsuit worn by the janitorial of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by the janitorial of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured, space ready, and fire resistant. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in combat mode."
 	icon_state = "ert_janitor"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor
 
@@ -227,9 +227,9 @@
 		)
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal
-	name = "paranormal response team suit"
-	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats. It is in EVA mode."
-	alt_desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats. It is in combat mode."
+	name = "paranormal response Teams suit"
+	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner ofparanormal threats. It is in EVA mode."
+	alt_desc = "Powerful wards are built into this hardsuit, protecting the user from all manner ofparanormal threats. It is in combat mode."
 	icon_state = "hardsuit-paranormal"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal
@@ -261,7 +261,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal/berserker
 	name = "champion's helmet"
-	desc = "Peering into the eyes of the helmet is enough to seal damnation."
+	desc = "Peering into the eyes ofthe helmet is enough to seal damnation."
 	icon_state = "hardsuit0-berserker"
 	item_color = "berserker"
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 100, rad = 100, fire = 80, acid = 80)

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -46,8 +46,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert
 	name = "emergency response team suit"
-	desc = "A dual-mode advanced combat hardsuit worn by members of Nanotrasen Emergency Response Teams. Armored, space ready, and fireproof. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by members of Nanotrasen Emergency Response Teams. Armored, space ready, and fireproof. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by members of Nanotrasen Emergency Response Teams. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by members of Nanotrasen Emergency Response Teams. Armored and space ready. It is in combat mode."
 	icon_state = "ert_commander"
 	item_state = "suit-command"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -230,7 +230,7 @@
 
 //Paranormal
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal
-	name = "paranormal response unit helmet"
+	name = "paranormal paranormal response team suit helmet"
 	desc = "A dual-mode advanced combat hardsuit helmet worn by those who deal with paranormal threats for a living."
 	icon_state = "hardsuit0-ert_paranormal"
 	item_color = "ert_paranormal"
@@ -247,9 +247,9 @@
 		)
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal
-	name = "paranormal response Teams suit"
-	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner ofparanormal threats. It is in EVA mode."
-	alt_desc = "Powerful wards are built into this hardsuit, protecting the user from all manner ofparanormal threats. It is in combat mode."
+	name = "paranormal response team suit"
+	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats. It is in EVA mode."
+	alt_desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats. It is in combat mode."
 	icon_state = "hardsuit-paranormal"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal
@@ -281,7 +281,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal/berserker
 	name = "champion's helmet"
-	desc = "Peering into the eyes ofthe helmet is enough to seal damnation."
+	desc = "Peering into the eyes of the helmet is enough to seal damnation."
 	icon_state = "hardsuit0-berserker"
 	item_color = "berserker"
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 100, rad = 100, fire = 80, acid = 80)

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -140,6 +140,7 @@
 	icon_state = "hardsuit0-ert_engineer"
 	item_state = "helm-orange"
 	item_color = "ert_engineer"
+	actions_types = list(/datum/action/item_action/toggle_helmet_mode, /datum/action/item_action/toggle_geiger_counter)
 
 //Engineer
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer/gamma

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -77,20 +77,24 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander/gamma
 	name = "elite emergency response team commander helmet"
+	desc = "A dual-mode advanced combat hardsuit helmet worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammacommander"
 	item_color = "gammacommander"
 
 /obj/item/clothing/suit/space/hardsuit/ert/commander
 	name = "emergency response team commander suit"
-	desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored and space ready. It is in combat mode."
 	icon_state = "ert_commander"
 	item_state = "suit-command"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander
 
 /obj/item/clothing/suit/space/hardsuit/ert/commander/gamma
 	name = "elite emergency response team commander suit"
+	desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the commanders of Nanotrasen Emergency Response Teams. Has blue highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gcommander"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander/gamma
@@ -106,20 +110,24 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security/gamma
 	name = "elite emergency response team security helmet"
+	desc = "A dual-mode advanced combat hardsuit helmet worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammasecurity"
 	item_color = "gammasecurity"
 
 /obj/item/clothing/suit/space/hardsuit/ert/security
 	name = "emergency response team security suit"
-	desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored and space ready. It is in combat mode."
 	icon_state = "ert_security"
 	item_state = "syndicate-black-red"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security
 
 /obj/item/clothing/suit/space/hardsuit/ert/security/gamma
 	name = "elite emergency response team security suit"
+	desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by security members of Nanotrasen Emergency Response Teams. Has red highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gsecurity"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security/gamma
@@ -128,7 +136,7 @@
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer
 	name = "emergency response team engineer helmet"
 	desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored and space ready. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored and space ready."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_engineer"
 	item_state = "helm-orange"
 	item_color = "ert_engineer"
@@ -136,20 +144,24 @@
 //Engineer
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer/gamma
 	name = "elite emergency response team engineer helmet"
+	desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammaengineer"
 	item_color = "gammaengineer"
 
 /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	name = "emergency response team engineer suit"
-	desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored and space ready. It is in combat mode."
 	icon_state = "ert_engineer"
 	item_state = "suit-orange"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer
 
 /obj/item/clothing/suit/space/hardsuit/ert/engineer/gamma
 	name = "elite emergency response team engineer suit"
+	desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the engineers of Nanotrasen Emergency Response Teams. Has yellow highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gengineer"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer/gamma
@@ -164,6 +176,8 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical/gamma
 	name = "elite emergency response team medical helmet"
+	desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammamedical"
 	item_color = "gammamedical"
@@ -177,6 +191,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/medical/gamma
 	name = "elite emergency response team medical suit"
+	desc = "A dual-mode advanced combat hardsuit worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by medical members of Nanotrasen Emergency Response Teams. Has white highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gmedical"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical/gamma
@@ -191,19 +207,23 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor/gamma
 	name = "elite emergency response team janitor helmet"
+	desc = "A dual-mode advanced combat hardsuit helmet worn by janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammajanitor"
 	item_color = "gammajanitor"
 
 /obj/item/clothing/suit/space/hardsuit/ert/janitor
 	name = "emergency response team janitor suit"
-	desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in EVA mode."
-	alt_desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in combat mode."
+	desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored and space ready. It is in combat mode."
 	icon_state = "ert_janitor"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor
 
 /obj/item/clothing/suit/space/hardsuit/ert/janitor/gamma
 	name = "elite emergency response team janitor suit"
+	desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the janitors of Nanotrasen Emergency Response Teams. Has purple highlights. Armored, space ready, and fireproof. It is in combat mode."
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gjanitor"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor/gamma

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -1,7 +1,8 @@
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert
 	name = "emergency response team helmet"
-	desc = "A helmet worn by members of the Nanotrasen Emergency Response Team. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by members of the Nanotrasen Emergency Response Team. Armoured and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by members of the Nanotrasen Emergency Response Team. Armoured and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_commander"
 	item_state = "helm-command"
 	item_color = "ert_commander"
@@ -16,20 +17,20 @@
 		"Vox" = 'icons/mob/species/vox/helmet.dmi'
 		)
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/Initialize()
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/Initialize()
 	if(loc)
 		var/mob/living/carbon/human/wearer = loc.loc	//loc is the hardsuit, so its loc is the wearer
 		if(ishuman(wearer))
 			register_camera(wearer)
 	..()
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/attack_self(mob/user)
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/attack_self(mob/user)
 	if(camera || !has_camera)
 		..(user)
 	else
 		register_camera(user)
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/proc/register_camera(mob/wearer)
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/proc/register_camera(mob/wearer)
 	if(camera || !has_camera)
 		return
 	camera = new /obj/machinery/camera(src)
@@ -38,24 +39,26 @@
 	camera.c_tag = wearer.name
 	to_chat(wearer, "<span class='notice'>User scanned as [camera.c_tag]. Camera activated.</span>")
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/examine(mob/user)
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) && has_camera)
-		. += "This helmet has a built-in camera. It's [camera ? "" : "in"]active."
+		. += "<span class='notice'>This helmet has a built-in camera. It's [camera ? "" : "in"]active.</span>"
 
 /obj/item/clothing/suit/space/hardsuit/ert
 	name = "emergency response team suit"
-	desc = "A suit worn by members of the Nanotrasen Emergency Response Team. Armoured, space ready, and fire resistant."
+	desc = "A dual-mode advanced combat hardsuit worn by members of the Nanotrasen Emergency Response Team. Armoured, space ready, and fire resistant. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by members of the Nanotrasen Emergency Response Team. Armoured, space ready, and fire resistant. It is in combat mode."
 	icon_state = "ert_commander"
 	item_state = "suit-command"
 	w_class = WEIGHT_CLASS_NORMAL
+	var/on = TRUE
 	allowed = list(/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/saber,/obj/item/restraints/handcuffs,/obj/item/tank/internals)
 	armor = list(melee = 45, bullet = 25, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 50, fire = 80, acid = 80)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner, /obj/item/rcd, /obj/item/crowbar, \
 	/obj/item/screwdriver, /obj/item/weldingtool, /obj/item/wirecutters, /obj/item/wrench, /obj/item/multitool, \
 	/obj/item/radio, /obj/item/analyzer, /obj/item/gun, /obj/item/melee/baton, /obj/item/reagent_containers/spray/pepper, \
 	/obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/restraints/handcuffs)
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert
 	strip_delay = 130
 	resistance_flags = FIRE_PROOF
 	sprite_sheets = list(
@@ -64,14 +67,15 @@
 		)
 
 //Commander
-/obj/item/clothing/head/helmet/space/hardsuit/ert/commander
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander
 	name = "emergency response team commander helmet"
-	desc = "A helmet worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_commander"
 	item_state = "helm-command"
 	item_color = "ert_commander"
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/commander/gamma
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander/gamma
 	name = "elite emergency response team commander helmet"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammacommander"
@@ -79,26 +83,28 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/commander
 	name = "emergency response team commander suit"
-	desc = "A suit worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured, space ready, and fire resistant."
+	desc = "A dual-mode advanced combat hardsuit worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the commander of a Nanotrasen Emergency Response Team. Has blue highlights. Armoured, space ready, and fire resistant. It is in combat mode."
 	icon_state = "ert_commander"
 	item_state = "suit-command"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/commander
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander
 
 /obj/item/clothing/suit/space/hardsuit/ert/commander/gamma
 	name = "elite emergency response team commander suit"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gcommander"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/commander/gamma
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/commander/gamma
 
 //Security
-/obj/item/clothing/head/helmet/space/hardsuit/ert/security
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security
 	name = "emergency response team security helmet"
-	desc = "A helmet worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_security"
 	item_state = "syndicate-helm-black-red"
 	item_color = "ert_security"
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/security/gamma
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security/gamma
 	name = "elite emergency response team security helmet"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammasecurity"
@@ -106,27 +112,29 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/security
 	name = "emergency response team security suit"
-	desc = "A suit worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured, space ready, and fire resistant."
+	desc = "A dual-mode advanced combat hardsuit worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by security members of a Nanotrasen Emergency Response Team. Has red highlights. Armoured, space ready, and fire resistant. It is in combat mode."
 	icon_state = "ert_security"
 	item_state = "syndicate-black-red"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/security
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security
 
 /obj/item/clothing/suit/space/hardsuit/ert/security/gamma
 	name = "elite emergency response team security suit"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gsecurity"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/security/gamma
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/security/gamma
 
 //Engineer
-/obj/item/clothing/head/helmet/space/hardsuit/ert/engineer
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer
 	name = "emergency response team engineer helmet"
-	desc = "A helmet worn by engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured and space ready."
 	icon_state = "hardsuit0-ert_engineer"
 	item_state = "helm-orange"
 	item_color = "ert_engineer"
 
 //Engineer
-/obj/item/clothing/head/helmet/space/hardsuit/ert/engineer/gamma
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer/gamma
 	name = "elite emergency response team engineer helmet"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammaengineer"
@@ -134,25 +142,27 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	name = "emergency response team engineer suit"
-	desc = "A suit worn by the engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured, space ready, and fire resistant."
+	desc = "A dual-mode advanced combat hardsuit worn by the engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the engineers of a Nanotrasen Emergency Response Team. Has yellow highlights. Armoured, space ready, and fire resistant. It is in combat mode."
 	icon_state = "ert_engineer"
 	item_state = "suit-orange"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer
 
 /obj/item/clothing/suit/space/hardsuit/ert/engineer/gamma
 	name = "elite emergency response team engineer suit"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gengineer"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer/gamma
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/engineer/gamma
 
 //Medical
-/obj/item/clothing/head/helmet/space/hardsuit/ert/medical
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical
 	name = "emergency response team medical helmet"
-	desc = "A helmet worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_medical"
 	item_color = "ert_medical"
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/medical/gamma
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical/gamma
 	name = "elite emergency response team medical helmet"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammamedical"
@@ -160,24 +170,26 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/medical
 	name = "emergency response team medical suit"
-	desc = "A suit worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by medical members of a Nanotrasen Emergency Response Team. Has white highlights. Armoured and space ready. It is in combat mode."
 	icon_state = "ert_medical"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/medical
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical
 
 /obj/item/clothing/suit/space/hardsuit/ert/medical/gamma
 	name = "elite emergency response team medical suit"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gmedical"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/medical/gamma
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/medical/gamma
 
 //Janitor
-/obj/item/clothing/head/helmet/space/hardsuit/ert/janitor
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor
 	name = "emergency response team janitor helmet"
-	desc = "A helmet worn by janitorial members of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured and space ready."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by janitorial members of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured and space ready. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit helmet worn by janitorial members of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured and space ready. It is in combat mode."
 	icon_state = "hardsuit0-ert_janitor"
 	item_color = "ert_janitor"
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/janitor/gamma
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor/gamma
 	name = "elite emergency response team janitor helmet"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "hardsuit0-gammajanitor"
@@ -185,20 +197,21 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/janitor
 	name = "emergency response team janitor suit"
-	desc = "A suit worn by the janitorial of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured, space ready, and fire resistant."
+	desc = "A dual-mode advanced combat hardsuit worn by the janitorial of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured, space ready, and fire resistant. It is in EVA mode."
+	alt_desc = "A dual-mode advanced combat hardsuit worn by the janitorial of a Nanotrasen Emergency Response Team. Has purple highlights. Armoured, space ready, and fire resistant. It is in combat mode."
 	icon_state = "ert_janitor"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/janitor
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor
 
 /obj/item/clothing/suit/space/hardsuit/ert/janitor/gamma
 	name = "elite emergency response team janitor suit"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	icon_state = "ert_gjanitor"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/janitor/gamma
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/janitor/gamma
 
 //Paranormal
-/obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal
 	name = "paranormal response unit helmet"
-	desc = "A helmet worn by those who deal with paranormal threats for a living."
+	desc = "A dual-mode advanced combat hardsuit helmet worn by those who deal with paranormal threats for a living."
 	icon_state = "hardsuit0-ert_paranormal"
 	item_color = "ert_paranormal"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -215,10 +228,11 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal
 	name = "paranormal response team suit"
-	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats."
+	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats. It is in EVA mode."
+	alt_desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats. It is in combat mode."
 	icon_state = "hardsuit-paranormal"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal
 	resistance_flags = FIRE_PROOF
 	sprite_sheets = list(
 		"Tajaran" = 'icons/mob/species/tajaran/suit.dmi',
@@ -232,7 +246,7 @@
 	..()
 	new /obj/item/nullrod(src)
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal/inquisitor
 	name = "inquisitor's helmet"
 	icon_state = "hardsuit0-inquisitor"
 	item_color = "inquisitor"
@@ -241,11 +255,11 @@
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
 	name = "inquisitor's hardsuit"
 	icon_state = "hardsuit-inquisitor"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal/inquisitor
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 100, rad = 100, fire = 80, acid = 80)
 	slowdown = 0
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/berserker
+/obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal/berserker
 	name = "champion's helmet"
 	desc = "Peering into the eyes of the helmet is enough to seal damnation."
 	icon_state = "hardsuit0-berserker"
@@ -256,6 +270,6 @@
 	name = "champion's hardsuit"
 	desc = "Voices echo from the hardsuit, driving the user insane."
 	icon_state = "hardsuit-berserker"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/berserker
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/ert/paranormal/berserker
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 100, rad = 100, fire = 80, acid = 80)
 	slowdown = 0

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -344,8 +344,8 @@
 //Elite Syndie suit
 /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	name = "elite syndicate hardsuit"
-	desc = "An elite version of the syndicate hardsuit, with improved armour and fire shielding. It is in EVA mode."
-	alt_desc = "An elite version of the syndicate hardsuit, with improved armour and fire shielding. It is in combat mode."
+	desc = "A elite version of the syndicate hardsuit, with improved armor and fireproofing. It is in EVA mode."
+	alt_desc = "A elite version of the syndicate hardsuit, with improved armor and fireproofing. It is in combat mode."
 	icon_state = "hardsuit0-syndielite"
 	item_color = "syndielite"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/elite
@@ -363,8 +363,8 @@
 
 /obj/item/clothing/suit/space/hardsuit/syndi/freedom
 	name = "eagle suit"
-	desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit. It is in EVA mode."
-	alt_desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit. It is in combat mode."
+	desc = "An advanced and light suit, fabricated from a mixture of synthetic feathers and space-resistant materials. A gun holster appears to be integrated into the suit. It is in EVA mode."
+	alt_desc = "An advanced and light suit, fabricated from a mixture of synthetic feathers and space-resistant materials. A gun holster appears to be integrated into the suit. It is in combat mode."
 	icon_state = "freedom"
 	item_state = "freedom"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/freedom

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -321,151 +321,57 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 
+////Helmets for Syndicate hardsuits are in combat.dm////
 //Syndicate hardsuit
-/obj/item/clothing/head/helmet/space/hardsuit/syndi
-	name = "blood-red hardsuit helmet"
-	desc = "A dual-mode advanced helmet designed for work in special operations. It is in travel mode. Property of Gorlex Marauders."
-	alt_desc = "A dual-mode advanced helmet designed for work in special operations. It is in combat mode. Property of Gorlex Marauders."
-	icon_state = "hardsuit1-syndi"
-	item_state = "syndie_helm"
-	item_color = "syndi"
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 35, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)
-	on = 1
-	var/obj/item/clothing/suit/space/hardsuit/syndi/linkedsuit = null
-	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
-	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDETAIL
-	visor_flags = STOPSPRESSUREDMAGE
-
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()
-	icon_state = "hardsuit[on]-[item_color]"
-
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/New()
-	..()
-	if(istype(loc, /obj/item/clothing/suit/space/hardsuit/syndi))
-		linkedsuit = loc
-
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/attack_self(mob/user) //Toggle Helmet
-	if(!isturf(user.loc))
-		to_chat(user, "<span class='warning'>You cannot toggle your helmet while in this [user.loc]!</span>" )
-		return
-	on = !on
-	if(on)
-		to_chat(user, "<span class='notice'>You switch your hardsuit to EVA mode, sacrificing speed for space protection.</span>")
-		name = initial(name)
-		desc = initial(desc)
-		set_light(brightness_on)
-		flags |= visor_flags
-		flags_cover |= HEADCOVERSEYES | HEADCOVERSMOUTH
-		flags_inv |= visor_flags_inv
-		cold_protection |= HEAD
-	else
-		to_chat(user, "<span class='notice'>You switch your hardsuit to combat mode and can now run at full speed.</span>")
-		name += " (combat)"
-		desc = alt_desc
-		set_light(0)
-		flags &= ~visor_flags
-		flags_cover &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
-		flags_inv &= ~visor_flags_inv
-		cold_protection &= ~HEAD
-	update_icon()
-	playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
-	toggle_hardsuit_mode(user)
-	user.update_inv_head()
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		C.head_update(src, forced = 1)
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.UpdateButtonIcon()
-
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/proc/toggle_hardsuit_mode(mob/user) //Helmet Toggles Suit Mode
-	if(linkedsuit)
-		if(on)
-			linkedsuit.name = initial(linkedsuit.name)
-			linkedsuit.desc = initial(linkedsuit.desc)
-			linkedsuit.slowdown = 1
-			linkedsuit.flags |= STOPSPRESSUREDMAGE
-			linkedsuit.cold_protection |= UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-		else
-			linkedsuit.name += " (combat)"
-			linkedsuit.desc = linkedsuit.alt_desc
-			linkedsuit.slowdown = 0
-			linkedsuit.flags &= ~STOPSPRESSUREDMAGE
-			linkedsuit.cold_protection &= ~(UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS)
-
-		linkedsuit.update_icon()
-		user.update_inv_wear_suit()
-		user.update_inv_w_uniform()
-
 /obj/item/clothing/suit/space/hardsuit/syndi
 	name = "blood-red hardsuit"
-	desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in travel mode. Property of Gorlex Marauders."
+	desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in EVA mode. Property of Gorlex Marauders."
 	alt_desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in combat mode. Property of Gorlex Marauders."
 	icon_state = "hardsuit1-syndi"
 	item_state = "syndie_hardsuit"
 	item_color = "syndi"
 	w_class = WEIGHT_CLASS_NORMAL
-	var/on = 1
+	var/on = TRUE
 	actions_types = list(/datum/action/item_action/toggle_hardsuit_mode)
 	armor = list("melee" = 40, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 35, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 90)
 	allowed = list(/obj/item/gun, /obj/item/ammo_box,/obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi
 	jetpack = /obj/item/tank/jetpack/suit
 
 /obj/item/clothing/suit/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
 
 //Elite Syndie suit
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
-	name = "elite syndicate hardsuit helmet"
-	desc = "An elite version of the syndicate helmet, with improved armour and fire shielding. It is in travel mode. Property of Gorlex Marauders."
-	icon_state = "hardsuit0-syndielite"
-	item_color = "syndielite"
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 25, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
-	heat_protection = HEAD
-	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-
 /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	name = "elite syndicate hardsuit"
-	desc = "An elite version of the syndicate hardsuit, with improved armour and fire shielding. It is in travel mode."
+	desc = "An elite version of the syndicate hardsuit, with improved armour and fire shielding. It is in EVA mode."
+	alt_desc = "An elite version of the syndicate hardsuit, with improved armour and fire shielding. It is in combat mode."
 	icon_state = "hardsuit0-syndielite"
 	item_color = "syndielite"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/elite
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 50, "energy" = 25, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 //Strike team hardsuits
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/elite/sst
-	armor = list(melee = 70, bullet = 70, laser = 50, energy = 40, bomb = 80, bio = 100, rad = 100, fire = 100, acid = 100) //Almost as good as DS gear, but unlike DS can switch to combat for mobility
-	icon_state = "hardsuit0-sst"
-	item_color = "sst"
-
 /obj/item/clothing/suit/space/hardsuit/syndi/elite/sst
 	armor = list(melee = 70, bullet = 70, laser = 50, energy = 40, bomb = 80, bio = 100, rad = 100, fire = 100, acid = 100)
 	icon_state = "hardsuit0-sst"
 	item_color = "sst"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite/sst
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/elite/sst
 
 /obj/item/clothing/suit/space/hardsuit/syndi/freedom
 	name = "eagle suit"
-	desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit."
+	desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit. It is in EVA mode."
+	alt_desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit. It is in combat mode."
 	icon_state = "freedom"
 	item_state = "freedom"
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/freedom
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/combat/syndi/freedom
 	sprite_sheets = null
 
 /obj/item/clothing/suit/space/hardsuit/syndi/freedom/update_icon()
 	return
-
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/freedom
-	name = "eagle helmet"
-	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle."
-	icon_state = "griffinhat"
-	item_state = "griffinhat"
-	sprite_sheets = null
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/freedom/update_icon()
 	return
@@ -611,7 +517,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/shielded
 	name = "shielded hardsuit"
-	desc = "A hardsuit with built in energy shielding. Will rapidly recharge when not under fire."
+	desc = "A dual-mode advanced hardsuit with built in energy shielding. Will rapidly recharge when not under fire."
 	icon_state = "hardsuit-hos"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded
 	allowed = list(/obj/item/flashlight,/obj/item/tank/internals, /obj/item/gun,/obj/item/reagent_containers/spray/pepper,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/restraints/handcuffs)
@@ -668,6 +574,7 @@
 	item_state = "sec_helm"
 	item_color = "sec"
 	armor = list("melee" = 30, "bullet" = 15, "laser" = 30, "energy" = 10, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
+	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -1395,6 +1395,7 @@
 #include "code\modules\clothing\shoes\miscellaneous.dm"
 #include "code\modules\clothing\spacesuits\alien.dm"
 #include "code\modules\clothing\spacesuits\chronosuit.dm"
+#include "code\modules\clothing\spacesuits\combat.dm"
 #include "code\modules\clothing\spacesuits\ert.dm"
 #include "code\modules\clothing\spacesuits\hardsuit.dm"
 #include "code\modules\clothing\spacesuits\miscellaneous.dm"


### PR DESCRIPTION
_This was tedious to make._
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a mechanic that was previously only available to Syndicate hardsuits to the ERT ones. For the ones that dont know what it is, it adds an option of changing the hardsuit to EVA mode to be spaceproof but slow, or combat mode to not have any slowdown but you lose spaceproofness.
Adds a new file for combat mode hardsuit helmets and refractors the code a tiny bit.
Removes the geiger counter from non-engineer ERT and Syndicate hardsuits to lessen the upper toolbar bloat.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
ERTs are slow... really slow, their hardsuits have the generic slowdown, having the speed of the engineering hardsuit. That is not ideal, they have to either:
1. Carry their hardsuits in their hands to get around quickly (which looks funky)
2. Beeline to RnD/xenobio hoping that they have red potions
3. Suffer the fate of being slow and getting outran by everything in existance

With this PR ERT members NOT going on the now almost required journey to RnD will not cripple them that much, making them able to respond to threats faster.


## Changelog
:cl:
add: Added a combat mode to ERT hardsuits.
add: Added better descriptions to elite ERT hardsuits.
tweak: Non-engineer ERT and Syndicate hardsuits no longer have an inbuilt geiger counter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
