### PR TITLE
Adds *spin emote to humans and cyborgs, adds a 5 second cooldown to the Dog's tail chase verb

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -128,11 +128,13 @@
 			on_CD = handle_emote_CD(50) //longer cooldown
 		if("fart", "farts", "flip", "flips", "snap", "snaps")
 			on_CD = handle_emote_CD()				//proc located in code\modules\mob\emote.dm
-		if("cough", "coughs", "highfive")
+		if("cough", "coughs", "slap", "slaps", "highfive")
 			on_CD = handle_emote_CD()
 		if("gasp", "gasps")
 			on_CD = handle_emote_CD()
 		if("deathgasp", "deathgasps")
+			on_CD = handle_emote_CD(50)
+		if("spin", "spins")
 			on_CD = handle_emote_CD(50)
 		if("sneeze", "sneezes")
 			on_CD = handle_emote_CD()
@@ -442,6 +444,17 @@
 							else
 								message = "<B>[src]</B> does a flip!"
 								SpinAnimation(5,1)
+
+		if("spin", "spins")
+			if(!restrained() && !lying)
+				if(prob(5))
+					INVOKE_ASYNC(src, .proc/spin, 30, 1)
+					message = "<B>[src]</B> spins too much!"
+					Dizzy(12)
+					Confused(12)
+				else
+					INVOKE_ASYNC(src, .proc/spin, 20, 1)
+					message = "<B>[src]</B> spins!"
 
 		if("aflap", "aflaps")
 			if(!restrained())
@@ -870,7 +883,7 @@
 			var/obj/item/slapper/N = new(src)
 			if(put_in_hands(N))
 				to_chat(src, "<span class='notice'>You ready your slapping hand.</span>")
-			else
+				else
 				qdel(N)
 				to_chat(src, "<span class='warning'>You're incapable of slapping in your current state.</span>")
 
@@ -956,8 +969,7 @@
 		if("help")
 			var/emotelist = "aflap(s), airguitar, blink(s), blink(s)_r, blush(es), bow(s)-none/mob, burp(s), choke(s), chuckle(s), clap(s), collapse(s), cough(s), cry, cries, custom, dance, dap(s)-none/mob," \
 			+ " deathgasp(s), drool(s), eyebrow, fart(s), faint(s), flap(s), flip(s), frown(s), gasp(s), giggle(s), glare(s)-none/mob, grin(s), groan(s), grumble(s), grin(s)," \
-			+ " handshake-mob, hug(s)-none/mob, hem, highfive, johnny, jump, kiss(es), laugh(s), look(s)-none/mob, moan(s), mumble(s), nod(s), pale(s), point(s)-atom, quiver(s), raise(s), salute(s)-none/mob, scream(s), shake(s)," \
-			+ " shiver(s), shrug(s), sigh(s), signal(s)-#1-10, slap(s), smile(s),snap(s), sneeze(s), sniff(s), snore(s), stare(s)-none/mob, tremble(s), twitch(es), twitch(es)_s," \
+			+ " shiver(s), shrug(s), sigh(s), signal(s)-#1-10,slap(s)-none/mob, smile(s),snap(s), sneeze(s), sniff(s), snore(s), spin(s) stare(s)-none/mob, tremble(s), twitch(es), twitch(es)_s," \
 			+ " wave(s), whimper(s), wink(s), yawn(s)"
 
 			switch(dna.species.name)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -448,12 +448,12 @@
 		if("spin", "spins")
 			if(!restrained() && !lying)
 				if(prob(5))
-					spin(30, 1, spin_direction = 2)
+					spin(30, 1)
 					message = "<B>[src]</B> spins too much!"
 					Dizzy(12)
 					Confused(12)
 				else
-					spin(20, 1, spin_direction = 2)
+					spin(20, 1)
 					message = "<B>[src]</B> spins!"
 
 		if("aflap", "aflaps")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -448,12 +448,12 @@
 		if("spin", "spins")
 			if(!restrained() && !lying)
 				if(prob(5))
-					INVOKE_ASYNC(src, .proc/spin, 30, 1)
+					spin(30, 1, spin_direction = 2)
 					message = "<B>[src]</B> spins too much!"
 					Dizzy(12)
 					Confused(12)
 				else
-					INVOKE_ASYNC(src, .proc/spin, 20, 1)
+					spin(20, 1, spin_direction = 2)
 					message = "<B>[src]</B> spins!"
 
 		if("aflap", "aflaps")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -128,7 +128,7 @@
 			on_CD = handle_emote_CD(50) //longer cooldown
 		if("fart", "farts", "flip", "flips", "snap", "snaps")
 			on_CD = handle_emote_CD()				//proc located in code\modules\mob\emote.dm
-		if("cough", "coughs", "slap", "slaps", "highfive")
+		if("cough", "coughs", "highfive")
 			on_CD = handle_emote_CD()
 		if("gasp", "gasps")
 			on_CD = handle_emote_CD()
@@ -883,7 +883,7 @@
 			var/obj/item/slapper/N = new(src)
 			if(put_in_hands(N))
 				to_chat(src, "<span class='notice'>You ready your slapping hand.</span>")
-				else
+			else
 				qdel(N)
 				to_chat(src, "<span class='warning'>You're incapable of slapping in your current state.</span>")
 
@@ -969,7 +969,8 @@
 		if("help")
 			var/emotelist = "aflap(s), airguitar, blink(s), blink(s)_r, blush(es), bow(s)-none/mob, burp(s), choke(s), chuckle(s), clap(s), collapse(s), cough(s), cry, cries, custom, dance, dap(s)-none/mob," \
 			+ " deathgasp(s), drool(s), eyebrow, fart(s), faint(s), flap(s), flip(s), frown(s), gasp(s), giggle(s), glare(s)-none/mob, grin(s), groan(s), grumble(s), grin(s)," \
-			+ " shiver(s), shrug(s), sigh(s), signal(s)-#1-10,slap(s)-none/mob, smile(s),snap(s), sneeze(s), sniff(s), snore(s), spin(s) stare(s)-none/mob, tremble(s), twitch(es), twitch(es)_s," \
+			+ " handshake-mob, hug(s)-none/mob, hem, highfive, johnny, jump, kiss(es), laugh(s), look(s)-none/mob, moan(s), mumble(s), nod(s), pale(s), point(s)-atom, quiver(s), raise(s), salute(s)-none/mob, scream(s), shake(s)," \
+			+ " shiver(s), shrug(s), sigh(s), signal(s)-#1-10, slap(s), smile(s),snap(s), sneeze(s), sniff(s), snore(s), spin(s) stare(s)-none/mob, tremble(s), twitch(es), twitch(es)_s," \
 			+ " wave(s), whimper(s), wink(s), yawn(s)"
 
 			switch(dna.species.name)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -13,6 +13,8 @@
 		//Cooldown-inducing emotes
 		if("law","flip","flips","halt")		//halt is exempt because it's used to stop criminal scum //WHOEVER THOUGHT THAT WAS A GOOD IDEA IS GOING TO GET SHOT.
 			on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
+		if("spin","spins")
+			on_CD = handle_emote_CD(5 SECONDS)
 		//Everything else, including typos of the above emotes
 		else
 			on_CD = 0	//If it doesn't induce the cooldown, we won't check for the cooldown
@@ -156,6 +158,10 @@
 			m_type = 1
 			message = "<B>[src]</B> does a flip!"
 			src.SpinAnimation(5,1)
+
+		if("spin","spins")
+			INVOKE_ASYNC(src, .proc/spin, 20, 1)
+			message = "<B>[src]</B> spins!"
 
 		if("help")
 			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitches, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look,\n law, halt")

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -160,7 +160,7 @@
 			src.SpinAnimation(5,1)
 
 		if("spin","spins")
-			INVOKE_ASYNC(src, .proc/spin, 20, 1)
+			spin(20, 1, spin_direction = 2)
 			message = "<B>[src]</B> spins!"
 
 		if("help")

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -160,7 +160,7 @@
 			src.SpinAnimation(5,1)
 
 		if("spin","spins")
-			spin(20, 1, spin_direction = 2)
+			spin(20, 1)
 			message = "<B>[src]</B> spins!"
 
 		if("help")

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -164,7 +164,7 @@
 			message = "<B>[src]</B> spins!"
 
 		if("help")
-			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitches, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look,\n law, halt")
+			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitches, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look,\n law, halt, flip, spin")
 
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -21,17 +21,17 @@
 	var/yelp_sound = 'sound/creatures/dog_yelp.ogg' //Used on death.
 	var/last_eaten = 0
 	footstep_type = FOOTSTEP_MOB_CLAW
-	var/next_spin = 0
+	var/next_spin_message = 0
 
 /mob/living/simple_animal/pet/dog/verb/chasetail()
 	set name = "Chase your tail"
 	set desc = "d'awwww."
 	set category = "Dog"
 
-	if(next_spin <= world.time)
+	if(next_spin_message <= world.time)
 		visible_message("[src] [pick("dances around", "chases [p_their()] tail")].", "[pick("You dance around", "You chase your tail")].")
-		spin(20, 1)
-		next_spin = world.time + 5 SECONDS
+		next_spin_message = world.time + 5 SECONDS
+	spin(20, 1)
 
 /mob/living/simple_animal/pet/dog/death(gibbed)
 	// Only execute the below if we successfully died

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -21,14 +21,17 @@
 	var/yelp_sound = 'sound/creatures/dog_yelp.ogg' //Used on death.
 	var/last_eaten = 0
 	footstep_type = FOOTSTEP_MOB_CLAW
+	var/next_spin = 0
 
 /mob/living/simple_animal/pet/dog/verb/chasetail()
 	set name = "Chase your tail"
 	set desc = "d'awwww."
 	set category = "Dog"
 
-	visible_message("[src] [pick("dances around", "chases [p_their()] tail")].", "[pick("You dance around", "You chase your tail")].")
-	spin(20, 1)
+	if(next_spin <= world.time)
+		visible_message("[src] [pick("dances around", "chases [p_their()] tail")].", "[pick("You dance around", "You chase your tail")].")
+		spin(20, 1)
+		next_spin = world.time + 5 SECONDS
 
 /mob/living/simple_animal/pet/dog/death(gibbed)
 	// Only execute the below if we successfully died

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1343,10 +1343,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/can_resist()
 	return FALSE		//overridden in living.dm
 
-#define SPIN_DIRECTION_CLOCKWISE 0
-#define SPIN_DIRECTION_COUNTERCLOCKWISE 1
-#define SPIN_DIRECTION_RANDOM 2
-
 /mob/proc/spin(spintime, speed)
 	set waitfor = 0
 	if(!spintime || !speed || spintime > 100)
@@ -1359,10 +1355,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 			dir = turn(dir, 90)
 		else
 			dir = turn(dir, -90)
-
-#undef SPIN_DIRECTION_CLOCKWISE
-#undef SPIN_DIRECTION_COUNTERCLOCKWISE
-#undef SPIN_DIRECTION_RANDOM
 
 /mob/proc/is_literate()
 	return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1347,44 +1347,18 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 #define SPIN_DIRECTION_COUNTERCLOCKWISE 1
 #define SPIN_DIRECTION_RANDOM 2
 
-/mob/proc/spin(spintime, speed, spin_direction = SPIN_DIRECTION_CLOCKWISE)
+/mob/proc/spin(spintime, speed)
 	set waitfor = 0
 	if(!spintime || !speed || spintime > 100)
 		CRASH("Aborted attempted call of /mob/proc/spin with invalid args ([spintime],[speed]) which could have frozen the server.")
-	var/D = dir
-	var/S
-	if(spin_direction == SPIN_DIRECTION_CLOCKWISE || spin_direction == SPIN_DIRECTION_COUNTERCLOCKWISE)
-		S = spin_direction
-	else
-		S = pick(SPIN_DIRECTION_CLOCKWISE,SPIN_DIRECTION_COUNTERCLOCKWISE)
-	if(S == SPIN_DIRECTION_CLOCKWISE)
-		while(spintime >= speed)
-			sleep(speed)
-			switch(D)
-				if(NORTH)
-					D = EAST
-				if(SOUTH)
-					D = WEST
-				if(EAST)
-					D = SOUTH
-				if(WEST)
-					D = NORTH
-			setDir(D)
-			spintime -= speed
-	else
-		while(spintime >= speed)
-			sleep(speed)
-			switch(D)
-				if(NORTH)
-					D = WEST
-				if(SOUTH)
-					D = EAST
-				if(EAST)
-					D = NORTH
-				if(WEST)
-					D = SOUTH
-			setDir(D)
-			spintime -= speed
+	var/end_time = world.time + spintime
+	var/spin_dir = prob(50)
+	while(world.time <= end_time)
+		sleep(speed)
+		if(spin_dir)
+			dir = turn(dir, 90)
+		else
+			dir = turn(dir, -90)
 
 #undef SPIN_DIRECTION_CLOCKWISE
 #undef SPIN_DIRECTION_COUNTERCLOCKWISE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1343,24 +1343,52 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/can_resist()
 	return FALSE		//overridden in living.dm
 
-/mob/proc/spin(spintime, speed)
+#define SPIN_DIRECTION_CLOCKWISE 0
+#define SPIN_DIRECTION_COUNTERCLOCKWISE 1
+#define SPIN_DIRECTION_RANDOM 2
+
+/mob/proc/spin(spintime, speed, spin_direction = SPIN_DIRECTION_CLOCKWISE)
 	set waitfor = 0
 	if(!spintime || !speed || spintime > 100)
 		CRASH("Aborted attempted call of /mob/proc/spin with invalid args ([spintime],[speed]) which could have frozen the server.")
 	var/D = dir
-	while(spintime >= speed)
-		sleep(speed)
-		switch(D)
-			if(NORTH)
-				D = EAST
-			if(SOUTH)
-				D = WEST
-			if(EAST)
-				D = SOUTH
-			if(WEST)
-				D = NORTH
-		setDir(D)
-		spintime -= speed
+	var/S
+	if(spin_direction == SPIN_DIRECTION_CLOCKWISE || spin_direction == SPIN_DIRECTION_COUNTERCLOCKWISE)
+		S = spin_direction
+	else
+		S = pick(SPIN_DIRECTION_CLOCKWISE,SPIN_DIRECTION_COUNTERCLOCKWISE)
+	if(S == SPIN_DIRECTION_CLOCKWISE)
+		while(spintime >= speed)
+			sleep(speed)
+			switch(D)
+				if(NORTH)
+					D = EAST
+				if(SOUTH)
+					D = WEST
+				if(EAST)
+					D = SOUTH
+				if(WEST)
+					D = NORTH
+			setDir(D)
+			spintime -= speed
+	else
+		while(spintime >= speed)
+			sleep(speed)
+			switch(D)
+				if(NORTH)
+					D = WEST
+				if(SOUTH)
+					D = EAST
+				if(EAST)
+					D = NORTH
+				if(WEST)
+					D = SOUTH
+			setDir(D)
+			spintime -= speed
+
+#undef SPIN_DIRECTION_CLOCKWISE
+#undef SPIN_DIRECTION_COUNTERCLOCKWISE
+#undef SPIN_DIRECTION_RANDOM
 
 /mob/proc/is_literate()
 	return FALSE


### PR DESCRIPTION
## What Does This PR Do
Adds *spin and *spins to Human and Cyborg emote lists on a 5 second cooldown. Humans using *spin have a 5% chance of spinning too long and making themselves Dizzy and Confused for a short time.
Also adds a 5 second cooldown on the dog's tail chasing message to prevent text spam (the ability to actually chase one's tail is unimpeded).
Also rewrites the spin() function to spin either clockwise or counterclockwise.

## Why It's Good For The Game
Mob go spinny. Might be used as a dance move or in a similar range of cases as *flip.

## Images of changes
![spinny](https://user-images.githubusercontent.com/35320204/115385185-301dad00-a21b-11eb-8328-4e1445fbb45a.gif)


## Changelog
:cl:
add: Humanoids and Cyborgs can now use the *spin emote. Humanoids have a small chance of spinning too long and getting dizzy.
tweak: Dogs (particularly Ian) now have a 5 second cooldown on the chat message for chasing their tail.
/:cl:
