### PR TITLE
Makes CQC not able to be discounted

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -864,6 +864,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CQC"
 	item = /obj/item/CQC_manual
 	cost = 13
+	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/cameraflash
 	name = "Camera Flash"


### PR DESCRIPTION
## What Does This PR Do
As the title says, makes it so CQC can no longer be discounted in the traitor uplink.

## Why It's Good For The Game
CQC is already a great bang for your buck tool, letting normal traitors chose it is enough but discounted? Sheesh. Even though they aren't the same in terms of use and playstyle, both CQC and Sleeping Carp are both very useful **martial arts** yet one of the two can be discounted. I don't think that's right. 

## Changelog
:cl:
tweak: Made CQC unable to be discounted in the uplink
/:cl: