### PR TITLE
Nerf the Silencio Wizard Loadout

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -55,7 +55,7 @@
 
 /obj/effect/proc_holder/spell/targeted/mime/speak/cast(list/targets,mob/user = usr)
 	for(var/mob/living/carbon/human/H in targets)
-		H.mind.miming=!H.mind.miming
+		H.mind.miming = !H.mind.miming
 		if(H.mind.miming)
 			to_chat(H, "<span class='notice'>You make a vow of silence.</span>")
 		else

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -37,20 +37,25 @@
 /datum/spellbook_entry/loadout/mimewiz
 	name = "Silencio"
 	desc = "...<br><br> \
-		</i>Provides Finger Gun and Invisible Greater Wall manuals, Mime Robes, a Cane and Duct Tape, Ethereal Jaunt, Blink, Teleport, Mime Malaise, Knock, and Stop Time.<i>"
+		</i>Provides Finger Gun and Invisible Greater Wall, Mime Robes, a Cane and Duct Tape, Ethereal Jaunt, Teleport, Mime Malaise and Knock.<i>"
 	log_name = "SHH"
-	items_path = list(/obj/item/spellbook/oneuse/mime/fingergun, /obj/item/spellbook/oneuse/mime/greaterwall, /obj/item/clothing/suit/wizrobe/mime, /obj/item/clothing/head/wizard/mime, \
+	items_path = list(/obj/item/clothing/suit/wizrobe/mime, /obj/item/clothing/head/wizard/mime, \
 		/obj/item/clothing/mask/gas/mime/wizard, /obj/item/clothing/shoes/sandal/marisa, /obj/item/cane, /obj/item/stack/tape_roll)
-	spells_path = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt, /obj/effect/proc_holder/spell/targeted/turf_teleport/blink, /obj/effect/proc_holder/spell/targeted/area_teleport/teleport, \
-		/obj/effect/proc_holder/spell/targeted/touch/mime_malaise, /obj/effect/proc_holder/spell/aoe_turf/knock, /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop)
+	spells_path = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt, /obj/effect/proc_holder/spell/targeted/area_teleport/teleport, \
+		/obj/effect/proc_holder/spell/targeted/touch/mime_malaise, /obj/effect/proc_holder/spell/aoe_turf/knock, \
+		/obj/effect/proc_holder/spell/targeted/mime/speak/wizard, /obj/effect/proc_holder/spell/targeted/forcewall/mime, \
+		/obj/effect/proc_holder/spell/targeted/mime/fingergun)
 	category = "Unique"
 	destroy_spellbook = TRUE
 
 /datum/spellbook_entry/loadout/mimewiz/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	if(user.mind)
-		user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak(null))
 		user.mind.miming = TRUE
+		to_chat(usr, "<span class='notice'>You make a vow of silence.</span>")
 	..()
+
+/obj/effect/proc_holder/spell/targeted/mime/speak/wizard() //Low cooldown on vow of silence for mime wizard
+	charge_max = 100
 
 /datum/spellbook_entry/loadout/gunreaper
 	name = "Gunslinging Reaper"

--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -54,7 +54,7 @@
 		to_chat(usr, "<span class='notice'>You make a vow of silence.</span>")
 	..()
 
-/obj/effect/proc_holder/spell/targeted/mime/speak/wizard() //Low cooldown on vow of silence for mime wizard
+/obj/effect/proc_holder/spell/targeted/mime/speak/wizard //Low cooldown on vow of silence for mime wizard
 	charge_max = 100
 
 /datum/spellbook_entry/loadout/gunreaper


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes blink and time stop from the Silencio loadout. Tweaks how it gives spells to make it less annoying, delivering the mime spells immediately on buy instead of giving manuals, and informing the wizard they've made a vow of silence when bought. Wizard vow of silence now has a 10 second cooldown instead of 300 seconds.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
After getting to test the loadout when I rolled wizard it seems I significantly overtuned it. You get more spellpoints worth of spells than any other possible wiz build, without even counting the mime spells provided. Removing blink and time stop will make the wizard easier to get and kill by reducing the amount of escape tools available, which are still plenty (finger gun stun, invisible blockade, jaunt, teleport, stun with mime malaise...)

I've also tweaked how the loadout is delivered to make it more intuitive to use. The lower cooldown of vow of silence is because obviously a Wizard would have mastered the art of entering and leaving miming... and make it less of a pain if you accidentally unvow. It's not like a wizard can really abuse this in any way.

## Changelog
:cl:
del: Removed time stop and blink from the Mime Wizard loadout.
tweak: Lowered the cooldown of Mime Wizard vow of silence to 10 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
