### PR TITLE
Remove unsafe areas from wizard teleport list

### DIFF
--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -593,12 +593,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/atmos/control
 	name = "Atmospherics Control Room"
 	icon_state = "atmos"
-	no_teleportlocs = TRUE
+	no_teleportlocs = FALSE
 
 /area/atmos/distribution
 	name = "Atmospherics Distribution Loop"
 	icon_state = "atmos"
-	no_teleportlocs = TRUE
+	no_teleportlocs = FALSE
 
 //Maintenance
 /area/maintenance

--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -43,6 +43,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	outdoors = TRUE
 	ambientsounds = SPACE_SOUNDS
 	sound_environment = SOUND_AREA_SPACE
+	no_teleportlocs = TRUE
 
 /area/space/nearstation
 	icon_state = "space_near"
@@ -585,16 +586,19 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //STATION13
 
 /area/atmos
- 	name = "Atmospherics"
- 	icon_state = "atmos"
+	name = "Atmospherics"
+	icon_state = "atmos"
+	no_teleportlocs = TRUE
 
 /area/atmos/control
- 	name = "Atmospherics Control Room"
- 	icon_state = "atmos"
+	name = "Atmospherics Control Room"
+	icon_state = "atmos"
+	no_teleportlocs = TRUE
 
 /area/atmos/distribution
- 	name = "Atmospherics Distribution Loop"
- 	icon_state = "atmos"
+	name = "Atmospherics Distribution Loop"
+	icon_state = "atmos"
+	no_teleportlocs = TRUE
 
 //Maintenance
 /area/maintenance
@@ -661,10 +665,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance/incinerator
 	name = "\improper Incinerator"
 	icon_state = "disposal"
+	no_teleportlocs = TRUE
 
 /area/maintenance/turbine
 	name = "\improper Turbine"
 	icon_state = "disposal"
+	no_teleportlocs = TRUE
 
 /area/maintenance/disposal
 	name = "Waste Disposal"
@@ -673,7 +679,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance/genetics
 	name = "Genetics Maintenance"
 	icon_state = "asmaint"
-
 
 /area/maintenance/electrical
 	name = "Electrical Maintenance"
@@ -1140,6 +1145,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Supermatter Engine"
 	icon_state = "engine"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	no_teleportlocs = TRUE
 
 //Solars
 
@@ -1149,6 +1155,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	dynamic_lighting = DYNAMIC_LIGHTING_IFSTARLIGHT
 	ambientsounds = ENGINEERING_SOUNDS
 	sound_environment = SOUND_AREA_SPACE
+	no_teleportlocs = TRUE
 
 /area/solar/auxport
 	name = "\improper Fore Port Solar Array"
@@ -1643,6 +1650,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/toxins/supermatter
 	name = "\improper Supermatter Lab"
 	icon_state = "toxlab"
+	no_teleportlocs = TRUE
 
 /area/toxins/xenobiology
 	name = "\improper Xenobiology Lab"
@@ -1665,10 +1673,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Toxins Test Area"
 	icon_state = "toxtest"
 	valid_territory = FALSE
+	no_teleportlocs = TRUE
 
 /area/toxins/mixing
 	name = "\improper Toxins Mixing Room"
 	icon_state = "toxmix"
+	no_teleportlocs = TRUE
 
 /area/toxins/launch
 	name = "Toxins Launch Room"
@@ -1681,6 +1691,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/toxins/test_chamber
 	name = "\improper Research Testing Chamber"
 	icon_state = "toxtest"
+	no_teleportlocs = TRUE
 
 /area/toxins/server
 	name = "\improper Server Room"
@@ -1689,6 +1700,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/toxins/server_coldroom
 	name = "\improper Server Coldroom"
 	icon_state = "servercold"
+	no_teleportlocs = TRUE
 
 /area/toxins/explab
 	name = "\improper Experimentation Lab"
@@ -1991,6 +2003,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/turret_protected/
 	ambientsounds = list('sound/ambience/ambimalf.ogg', 'sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
+	no_teleportlocs = TRUE
 
 /area/turret_protected/ai_upload
 	name = "\improper AI Upload Chamber"
@@ -2014,6 +2027,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/aisat
 	name = "\improper AI Satellite Exterior"
 	icon_state = "yellow"
+	no_teleportlocs = TRUE
 
 /area/aisat/entrance
 	name = "\improper AI Satellite Entrance"
@@ -2058,6 +2072,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/tcommsat
 	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg', 'sound/ambience/ambitech.ogg',\
 											'sound/ambience/ambitech2.ogg', 'sound/ambience/ambitech3.ogg', 'sound/ambience/ambimystery.ogg')
+	no_teleportlocs = TRUE
 
 /area/tcommsat/chamber
 	name = "\improper Telecoms Central Compartment"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR removes areas from the wizard teleport list that are usually unsafe and/or clogs the list. 
This also affects as a side effect the area selector for the Nuke Ops Assault Pod, and which areas you can be randomly teleported to if you're a non-abductor using the abductor teleporter. IMO, none of those areas will be really missed for these cases.

This does not affect any other cases of teleportation such as admin/ghost area teleporting, teleporting machinery, random teleportation by teleporter error, etc.

Areas removed from the teleport list : 

- Space, Solars and Toxins Test Site (No atmos, you can still teleport to solar control rooms)
- Turbine, Toxins Mixing, Incinerator (Can teleport you in the middle of a plasma fire)
- Atmospherics (Can teleport you in the middle of plasma/sleeping gas/etc, the distribution loop and control rooms are still accessible)
- All AI sats rooms (Usually guarded by turrets, and clogs the list right at the top with a bunch of rooms you arent usually interested to go for. I decided to lock out the entire sat for consistency and because it makes sense... it's not technically part of the station)
- AI upload (Guarded by turrets)
- Supermatter room (Unsafe atmos and there's an instant death machine in there)
- Scichem test chamber (Usually safe but it's often not, and you can just select scichem instead so not needed)
- Server coldroom (Unsafe atmos, you can still teleport to the safe side of the server room)

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The teleport scroll/teleport wiz spell is quite clunky to use. 
Removing unsafe areas will both prevent unexperienced wizards from dying one minute in and also make it less annoying to use by having less irrelevant areas in the list, especially the AI satellite areas right at the top of the list.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/22121511/115549346-d663c400-a2a8-11eb-875b-850d1bbe65d7.png)

## Changelog
:cl:
tweak: Removed usually unsafe areas from the list of areas wizards can teleport to, such as space or turret protected areas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
