### PR TITLE
Window leak fix

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -28,6 +28,8 @@
 
 #define is_pen(W) (istype(W, /obj/item/pen))
 
+#define is_fulltile(W) (istype(W, /obj/structure/window/full))
+
 GLOBAL_LIST_INIT(pointed_types, typecacheof(list(
 	/obj/item/pen,
 	/obj/item/screwdriver,

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -28,7 +28,7 @@
 
 #define is_pen(W) (istype(W, /obj/item/pen))
 
-#define is_fulltile(W) (istype(W, /obj/structure/window/full))
+#define isfulltile(W) (istype(W, /obj/structure/window/full))
 
 GLOBAL_LIST_INIT(pointed_types, typecacheof(list(
 	/obj/item/pen,

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -156,16 +156,17 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	for(var/obj/structure/window/D in loc)
 		if(!D.density)
 			continue
-		if(D.fulltile)
-			return 1
+		if(is_fulltile(D))
+			return TRUE
 		if(D.dir == dir)
-			return 1
+			return TRUE
 
 	for(var/obj/machinery/door/D in loc)
-		if(!D.density)//if the door is open
+		if(!D.density)	//if the door is open
 			continue
-		else return 1	// if closed, it's a real, air blocking door
-	return 0
+		else
+			return TRUE	// if closed, it's a real, air blocking door
+	return FALSE
 
 /////////////////////////////////////////////////////////////////////////
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -156,7 +156,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	for(var/obj/structure/window/D in loc)
 		if(!D.density)
 			continue
-		if(is_fulltile(D))
+		if(isfulltile(D))
 			return TRUE
 		if(D.dir == dir)
 			return TRUE

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -258,7 +258,7 @@
 					T.ChangeTurf(/turf/simulated/wall/r_wall/rust)
 				for(var/obj/structure/window/window in T.contents)
 					window.take_damage(rand(30,80))
-					if(window && window.fulltile)
+					if(window && is_fulltile(window))
 						new/obj/effect/temp_visual/revenant/cracks(window.loc)
 				for(var/obj/structure/closet/closet in T.contents)
 					closet.open()

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -258,7 +258,7 @@
 					T.ChangeTurf(/turf/simulated/wall/r_wall/rust)
 				for(var/obj/structure/window/window in T.contents)
 					window.take_damage(rand(30,80))
-					if(window && is_fulltile(window))
+					if(window && isfulltile(window))
 						new/obj/effect/temp_visual/revenant/cracks(window.loc)
 				for(var/obj/structure/closet/closet in T.contents)
 					closet.open()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -415,7 +415,7 @@ GLOBAL_LIST_INIT(brass_recipes, list (\
 	new/datum/stack_recipe/window("brass windoor", /obj/machinery/door/window/clockwork, 2, time = 30, on_floor = TRUE, window_checks = TRUE), \
 	null,
 	new/datum/stack_recipe/window("directional brass window", /obj/structure/window/reinforced/clockwork, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe/window("fulltile brass window", /obj/structure/window/reinforced/clockwork/fulltile, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
+	new/datum/stack_recipe/window("fulltile brass window", /obj/structure/window/full/clockworkreinforced, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("brass chair", /obj/structure/chair/brass, 1, time = 0, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("brass table frame", /obj/structure/table_frame/brass, 1, time = 5, one_per_turf = TRUE, on_floor = TRUE), \
 	))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -426,11 +426,15 @@
 	move_update_air(T)
 
 /obj/structure/window/CanAtmosPass(turf/T)
-	if(!density)
+	if(!istype(T))
+		return FA;SE
+	if(!density || get_turf(loc) == T)
 		return TRUE
 	if(is_fulltile(src))	// This won't work with an override on /window/full
 		return !Secured()
-	else
+	else					// Welcome to the realm of Directional Windows
+		if(!get_dir(loc, T) in GLOB.cardinal)
+			return FALSE	// Directional windows only face NORTH, SOUTH, EAST, WEST
 		if(!Secured())
 			return TRUE
 		else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -45,13 +45,13 @@
 			. += "<span class='notice'>The window is <b>screwed</b> to the floor.</span>"
 		else
 			. += "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>"
-	if(!anchored && !is_fulltile(src))
+	if(!anchored && !isfulltile(src))
 		. += "<span class='notice'>Alt-click to rotate it.</span>"
 
 /obj/structure/window/Initialize(mapload, direct)
 	. = ..()
 
-	if(direct && !is_fulltile(src))
+	if(direct && !isfulltile(src))
 		setDir(direct)
 	if(reinf && anchored)
 		state = WINDOW_SCREWED_TO_FRAME
@@ -79,9 +79,6 @@
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct(FALSE)
-
-/obj/structure/window/setDir(direct)
-	..()
 
 /obj/structure/window/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
@@ -290,7 +287,7 @@
 /obj/structure/window/proc/check_state_and_anchored(checked_state, checked_anchored)
 	return check_state(checked_state) && check_anchored(checked_anchored)
 
-/obj/structure/window/proc/Secured()
+/obj/structure/window/proc/secured()
 	if(reinf)
 		return check_state_and_anchored(WINDOW_SCREWED_TO_FRAME, TRUE)
 	else
@@ -431,12 +428,12 @@
 		return FALSE
 	if(!density || get_turf(loc) == T)
 		return TRUE
-	if(is_fulltile(src))	// This won't work with an override on /window/full
-		return !Secured()
+	if(isfulltile(src))	// This won't work with an override on /window/full
+		return !secured()
 	else					// Welcome to the realm of Directional Windows
 		if(!(get_dir(loc, T) in GLOB.cardinal))
 			return FALSE	// Directional windows only face NORTH, SOUTH, EAST, WEST
-		if(!Secured())
+		if(!secured())
 			return TRUE
 		else
 			return (dir != get_dir(loc, T))
@@ -459,7 +456,7 @@
 	return 0
 
 /obj/structure/window/basic
-	desc = "It looks thin and flimsy. A few knocks with ... anything, really, should shatter it."
+	desc = "It looks thin and flimsy. A few knocks with... anything, really, should shatter it."
 
 /obj/structure/window/reinforced
 	name = "reinforced window"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -223,6 +223,7 @@
 				return
 			state = (state == WINDOW_IN_FRAME ? WINDOW_SCREWED_TO_FRAME : WINDOW_IN_FRAME)
 			to_chat(user, "<span class='notice'>You [state == WINDOW_IN_FRAME ? "unfasten the window from":"fasten the window to"] the frame.</span>")
+			air_update_turf(TRUE)
 
 		else if(state == WINDOW_OUT_OF_FRAME)
 			if(decon_speed)
@@ -591,6 +592,8 @@
 	return TRUE
 
 /obj/structure/window/full/CanPass(atom/movable/mover, turf/target, height=0)
+	if(istype(mover) && mover.checkpass(PASSGLASS))
+		return TRUE
 	return FALSE
 
 /obj/structure/window/full/CanAStarPass(ID, to_dir)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -588,7 +588,7 @@
 /obj/structure/window/full/can_be_reached(mob/user)
 	return TRUE
 
-/obj/structure/window/full/CanPass(atom/movable/mover, turf/target, height=0)
+/obj/structure/window/full/CanPass(atom/movable/mover, turf/target, height = 0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return TRUE
 	return FALSE
@@ -613,7 +613,7 @@
 		cut_overlay(crack_overlay)
 		if(ratio > 75)
 			return
-		crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer+0.1))
+		crack_overlay = mutable_appearance('icons/obj/structures.dmi', "damage[ratio]", -(layer + 0.1))
 		add_overlay(crack_overlay)
 
 /obj/structure/window/full/spawnDebris(location)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -427,13 +427,13 @@
 
 /obj/structure/window/CanAtmosPass(turf/T)
 	if(!istype(T))
-		return FA;SE
+		return FALSE
 	if(!density || get_turf(loc) == T)
 		return TRUE
 	if(is_fulltile(src))	// This won't work with an override on /window/full
 		return !Secured()
 	else					// Welcome to the realm of Directional Windows
-		if(!get_dir(loc, T) in GLOB.cardinal)
+		if(!(get_dir(loc, T) in GLOB.cardinal))
 			return FALSE	// Directional windows only face NORTH, SOUTH, EAST, WEST
 		if(!Secured())
 			return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -286,11 +286,11 @@
 		var/turf_count = 0
 
 		for(var/direction in GLOB.cardinal)//Only use cardinals to cut down on lag
-			var/turf/T = get_turf(get_step(src, direction))	// Get_Turf on a Get_Step? Iunno, it threw an error saying it wasn't a turf.
-			if(!T.CanAtmosPass(src))
+			var/turf/T = get_step(src, direction)
+			if(!CanAtmosPass(T))
 				continue
 			if(istype(T, /turf/space))//Counted as no air
-				turf_count++//Considered a valid turf for air calcs
+				turf_count++ //Considered a valid turf for air calcs
 				continue
 			else if(istype(T, /turf/simulated/floor))
 				var/turf/simulated/S = T

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -271,7 +271,17 @@
 	..()
 	RemoveLattice()
 	if(!ignore_air)
+		ignore_air = WindowCheck()
+	if(!ignore_air)
 		Assimilate_Air()
+
+/turf/simulated/proc/WindowCheck()
+	if(!isfloorturf(src))
+		return FALSE
+	for(var/thing in loc.contents)
+		if(istype(thing, /obj/structure/window))
+			return TRUE
+	return FALSE
 
 //////Assimilate Air//////
 /turf/simulated/proc/Assimilate_Air()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -271,19 +271,9 @@
 	..()
 	RemoveLattice()
 	if(!ignore_air)
-		ignore_air = WindowCheck()
-	if(!ignore_air)
 		Assimilate_Air()
 
-/turf/simulated/proc/WindowCheck()
-	if(!isfloorturf(src))
-		return FALSE
-	for(var/thing in loc.contents)
-		if(istype(thing, /obj/structure/window))
-			return TRUE
-	return FALSE
-
-//////Assimilate Air//////
+////Assimilate Air////
 /turf/simulated/proc/Assimilate_Air()
 	if(air)
 		var/aoxy = 0 //Holders to assimilate air from nearby turfs
@@ -296,7 +286,9 @@
 		var/turf_count = 0
 
 		for(var/direction in GLOB.cardinal)//Only use cardinals to cut down on lag
-			var/turf/T = get_step(src, direction)
+			var/turf/T = get_turf(get_step(src, direction))	// Get_Turf on a Get_Step? Iunno, it threw an error saying it wasn't a turf.
+			if(!T.CanAtmosPass(src))
+				continue
 			if(istype(T, /turf/space))//Counted as no air
 				turf_count++//Considered a valid turf for air calcs
 				continue

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -88,7 +88,7 @@ GLOBAL_VAR_INIT(intercom_range_display_status, 0)
 			if(!(locate(/obj/structure/grille,T)))
 				var/window_check = 0
 				for(var/obj/structure/window/W in T)
-					if(W.dir == turn(C1.dir,180) || W.fulltile)
+					if(W.dir == turn(C1.dir,180) || is_fulltile(W))
 						window_check = 1
 						break
 				if(!window_check)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -88,7 +88,7 @@ GLOBAL_VAR_INIT(intercom_range_display_status, 0)
 			if(!(locate(/obj/structure/grille,T)))
 				var/window_check = 0
 				for(var/obj/structure/window/W in T)
-					if(W.dir == turn(C1.dir,180) || is_fulltile(W))
+					if(W.dir == turn(C1.dir,180) || isfulltile(W))
 						window_check = 1
 						break
 				if(!window_check)

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -1,64 +1,55 @@
 /turf/proc/CanAtmosPass(turf/T)
-	if(!istype(T))	return 0
-	var/R
+	if(!istype(T))
+		return FALSE
+	var/R = TRUE	// return
 	if(blocks_air || T.blocks_air)
-		R = 1
+		R = FALSE
 
-	for(var/obj/O in contents)
-		if(!O.CanAtmosPass(T))
-			R = 1
-			if(O.BlockSuperconductivity()) 	//the direction and open/closed are already checked on CanAtmosPass() so there are no arguments
-				var/D = get_dir(src, T)
-				atmos_supeconductivity |= D
-				D = get_dir(T, src)
-				T.atmos_supeconductivity |= D
-				return 0						//no need to keep going, we got all we asked
-
-	for(var/obj/O in T.contents)
-		if(!O.CanAtmosPass(src))
-			R = 1
+	for(var/obj/O in (contents + T.contents))
+		if(!O.CanAtmosPass(src) || !O.CanAtmosPass(T))
+			R = FALSE
 			if(O.BlockSuperconductivity())
 				var/D = get_dir(src, T)
-				atmos_supeconductivity |= D
+				atmos_superconductivity |= D
 				D = get_dir(T, src)
-				T.atmos_supeconductivity |= D
-				return 0
+				T.atmos_superconductivity |= D
+				return R
 
 	var/D = get_dir(src, T)
-	atmos_supeconductivity &= ~D
+	atmos_superconductivity &= ~D
 	D = get_dir(T, src)
-	T.atmos_supeconductivity &= ~D
+	T.atmos_superconductivity &= ~D
 
-	if(!R)
-		return 1
+	return R
 
 /atom/movable/proc/CanAtmosPass()
-	return 1
+	return TRUE
 
 /atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5)
 	return (!density || !height)
 
 /turf/CanPass(atom/movable/mover, turf/target, height=1.5)
-	if(!target) return 0
+	if(!target)
+		return FALSE
 
 	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
 		return !density
 
 	else // Now, doing more detailed checks for air movement and air group formation
 		if(target.blocks_air||blocks_air)
-			return 0
+			return FALSE
 
 		for(var/obj/obstacle in src)
 			if(!obstacle.CanPass(mover, target, height))
-				return 0
+				return FALSE
 		for(var/obj/obstacle in target)
 			if(!obstacle.CanPass(mover, src, height))
-				return 0
+				return FALSE
 
-		return 1
+		return TRUE
 
 /atom/movable/proc/BlockSuperconductivity() // objects that block air and don't let superconductivity act. Only firelocks atm.
-	return 0
+	return FALSE
 
 /turf/proc/CalculateAdjacentTurfs()
 	for(var/direction in GLOB.cardinal)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -4,7 +4,7 @@
 	var/pressure_difference = 0
 	var/pressure_direction = 0
 	var/list/atmos_adjacent_turfs = list()
-	var/atmos_supeconductivity = 0
+	var/atmos_superconductivity = 0
 
 /turf/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
 	qdel(giver)
@@ -430,7 +430,7 @@
 		//Does particate in air exchange so only consider directions not considered during process_cell()
 		for(var/direction in GLOB.cardinal)
 			var/turf/T = get_step(src, direction)
-			if(!(T in atmos_adjacent_turfs) && !(atmos_supeconductivity & direction))
+			if(!(T in atmos_adjacent_turfs) && !(atmos_superconductivity & direction))
 				conductivity_directions += direction
 
 	if(conductivity_directions > 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -180,12 +180,10 @@
 	if((AM.anchored && !push_anchored) || (force < (AM.move_resist * MOVE_FORCE_PUSH_RATIO)))
 		now_pushing = FALSE
 		return
-	if(istype(AM, /obj/structure/window))
-		var/obj/structure/window/W = AM
-		if(W.fulltile)
-			for(var/obj/structure/window/win in get_step(W,t))
-				now_pushing = FALSE
-				return
+	if(is_fulltile(AM))
+		for(var/obj/structure/window/win in get_step(W,t))
+			now_pushing = FALSE
+			return
 	if(pulling == AM)
 		stop_pulling()
 	var/current_dir

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -181,7 +181,7 @@
 		now_pushing = FALSE
 		return
 	if(is_fulltile(AM))
-		for(var/obj/structure/window/win in get_step(W,t))
+		for(var/obj/structure/window/win in get_step(AM, t))
 			now_pushing = FALSE
 			return
 	if(pulling == AM)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -180,7 +180,7 @@
 	if((AM.anchored && !push_anchored) || (force < (AM.move_resist * MOVE_FORCE_PUSH_RATIO)))
 		now_pushing = FALSE
 		return
-	if(is_fulltile(AM))
+	if(isfulltile(AM))
 		for(var/obj/structure/window/win in get_step(AM, t))
 			now_pushing = FALSE
 			return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -188,8 +188,9 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	//SPECIFIC CASES:
 	//Smash fulltile windows before grilles
 	if(istype(the_target, /obj/structure/grille))
-		for(var/obj/structure/window/rogueWindow in get_turf(the_target))
-			if(rogueWindow.fulltile) //done this way because the subtypes are weird.
+		for(var/obj/structure/window/W in get_turf(the_target))
+			if(is_fulltile(W))
+				var/obj/structure/window/full/rogueWindow = W
 				the_target = rogueWindow
 				break
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -189,7 +189,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	//Smash fulltile windows before grilles
 	if(istype(the_target, /obj/structure/grille))
 		for(var/obj/structure/window/W in get_turf(the_target))
-			if(is_fulltile(W))
+			if(isfulltile(W))
 				var/obj/structure/window/full/rogueWindow = W
 				the_target = rogueWindow
 				break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-     Finishes the windows fixes started by Kiyahitayika - credit to him for doing most of the work.
-     Fixes the window atmos leak issue when you move fulltile windows
-     Fixes the problem with atmos leaking under windows when you pry up their tile, or freshly build it. - resolves #2913 and #15768
-     Deletes the fulltile variable, replaces the very few instances where this was referenced with is_fulltile()
-     Makes window/full a proper subtype with overrides (except for CanAtmosPass(), my arch nemesis)
-     Tidies up the Clockwork window types

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Atmos blows, this makes it blow less.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Atmos permeability is now updated at screwdriver anchoring/unanchoring step of all windows. 
fix: Turf update (E.G. removing floor tile) doesn't pull gas from adjacent tiles if the adjacent tile doesn't allow atmos through.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
