### PR TITLE
Fixes firing flamethrowers when you cannot fire guns

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -68,6 +68,8 @@
 	. = ..()
 	if(flag)
 		return // too close
+	if(!user)
+		return
 	if(user?.mind?.martial_art?.no_guns)
 		to_chat(user, "<span class='warning'>[user.mind.martial_art.no_guns_message]</span>")
 		return

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -72,7 +72,7 @@
 		to_chat(user, "<span class='warning'>[user.mind.martial_art.no_guns_message]</span>")
 		return
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
-		to_chat(user, "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>")
+		to_chat(user, "<span class='warning'>Your meaty finger is far too large for the trigger guard!</span>")
 		return
 	if(user && user.get_active_hand() == src) // Make sure our user is still holding us
 		var/turf/target_turf = get_turf(target)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -70,13 +70,13 @@
 		return // too close
 	if(!user)
 		return
-	if(user?.mind?.martial_art?.no_guns)
+	if(user.mind?.martial_art?.no_guns)
 		to_chat(user, "<span class='warning'>[user.mind.martial_art.no_guns_message]</span>")
 		return
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
 		to_chat(user, "<span class='warning'>Your meaty finger is far too large for the trigger guard!</span>")
 		return
-	if(user && user.get_active_hand() == src) // Make sure our user is still holding us
+	if(user.get_active_hand() == src) // Make sure our user is still holding us
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)
 			var/turflist = getline(user, target_turf)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -68,6 +68,12 @@
 	. = ..()
 	if(flag)
 		return // too close
+	if(user?.mind?.martial_art?.no_guns)
+		to_chat(user, "<span class='warning'>[user.mind.martial_art.no_guns_message]</span>")
+		return
+	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
+		to_chat(user, "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>")
+		return
 	if(user && user.get_active_hand() == src) // Make sure our user is still holding us
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1734,7 +1734,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
 		if(HAS_TRAIT(src, TRAIT_CHUNKYFINGERS))
-			to_chat(src, "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>")
+			to_chat(src, "<span class='warning'>Your meaty finger is far too large for the trigger guard!</span>")
 			return FALSE
 
 	if(mind && mind.martial_art && mind.martial_art.no_guns) //great dishonor to famiry


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can no longer fire flamethrowers if you cannot fire guns

Sleeping carp, golems etc.

## Why It's Good For The Game
Likely an oversight. Seems exploity to use a ranged weapon when you shouldn't be able to.

## Changelog
:cl:
Fix: flamethrowers now respect races and martial arts that cannot fire guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
