### PR TITLE
Adds wiki links to antag greeting messages

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -103,6 +103,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	to_chat(blob.current, "<b>Find a good location to spawn the core and then take control and overwhelm the station!</b>")
 	to_chat(blob.current, "<b>When you have found a location, wait until you spawn; this will happen automatically and you cannot speed up the process.</b>")
 	to_chat(blob.current, "<b>If you go outside of the station level, or in space, then you will die; make sure your location has lots of ground to cover.</b>")
+	to_chat(blob.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Blob)</span>")
 	SEND_SOUND(blob.current, sound('sound/magic/mutate.ogg'))
 	return
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	to_chat(blob.current, "<b>Find a good location to spawn the core and then take control and overwhelm the station!</b>")
 	to_chat(blob.current, "<b>When you have found a location, wait until you spawn; this will happen automatically and you cannot speed up the process.</b>")
 	to_chat(blob.current, "<b>If you go outside of the station level, or in space, then you will die; make sure your location has lots of ground to cover.</b>")
-	to_chat(blob.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Blob)</span>")
+	to_chat(blob.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Blob)</span>")
 	SEND_SOUND(blob.current, sound('sound/magic/mutate.ogg'))
 	return
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -147,6 +147,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	for(var/datum/objective/objective in changeling.objectives)
 		to_chat(changeling.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
+	to_chat(changeling.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Changeling)</span>")
 	return
 
 /datum/game_mode/proc/remove_changeling(datum/mind/changeling_mind)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -147,7 +147,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	for(var/datum/objective/objective in changeling.objectives)
 		to_chat(changeling.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
-	to_chat(changeling.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Changeling)</span>")
+	to_chat(changeling.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Changeling)</span>")
 	return
 
 /datum/game_mode/proc/remove_changeling(datum/mind/changeling_mind)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		add_cult_actions(cult_mind)
 		update_cult_icons_added(cult_mind)
 		cult_objs.study(cult_mind.current)
-		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Cultist)</span>")
+		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Cultist)</span>")
 	cult_threshold_check()
 	addtimer(CALLBACK(src, .proc/cult_threshold_check), 2 MINUTES) // Check again in 2 minutes for latejoiners
 	..()
@@ -208,7 +208,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 				ascend(cult_mind.current)
 		check_cult_size()
 		cult_objs.study(cult_mind.current)
-		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Cultist)</span>")
+		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Cultist)</span>")
 		return TRUE
 
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -96,6 +96,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		add_cult_actions(cult_mind)
 		update_cult_icons_added(cult_mind)
 		cult_objs.study(cult_mind.current)
+		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Cultist)</span>")
 	cult_threshold_check()
 	addtimer(CALLBACK(src, .proc/cult_threshold_check), 2 MINUTES) // Check again in 2 minutes for latejoiners
 	..()
@@ -207,6 +208,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 				ascend(cult_mind.current)
 		check_cult_size()
 		cult_objs.study(cult_mind.current)
+		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Cultist)</span>")
 		return TRUE
 
 

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -181,6 +181,7 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 	to_chat(raider.current, "<span class='notice'>Vox are cowardly and will flee from larger groups, but corner one or find them en masse and they are vicious.</span>")
 	to_chat(raider.current, "<span class='notice'>Use :V to voxtalk, :H to talk on your encrypted channel, and don't forget to turn on your nitrogen internals!</span>")
 	to_chat(raider.current, "<span class='notice'>Choose to accomplish your objectives by either raiding the crew and taking what you need, or by attempting to trade with them.</span>")
+	to_chat(raider.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Vox_Raider)</span>")
 	spawn(25)
 		show_objectives(raider)
 

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 	to_chat(raider.current, "<span class='notice'>Vox are cowardly and will flee from larger groups, but corner one or find them en masse and they are vicious.</span>")
 	to_chat(raider.current, "<span class='notice'>Use :V to voxtalk, :H to talk on your encrypted channel, and don't forget to turn on your nitrogen internals!</span>")
 	to_chat(raider.current, "<span class='notice'>Choose to accomplish your objectives by either raiding the crew and taking what you need, or by attempting to trade with them.</span>")
-	to_chat(raider.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Vox_Raider)</span>")
+	to_chat(raider.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Vox_Raider)</span>")
 	spawn(25)
 		show_objectives(raider)
 

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -158,7 +158,7 @@
 	to_chat(abductor.current, "<span class='notice'>You are an agent of [team_name]!</span>")
 	to_chat(abductor.current, "<span class='notice'>With the help of your teammate, kidnap and experiment on station crew members!</span>")
 	to_chat(abductor.current, "<span class='notice'>Use your stealth technology and equipment to incapacitate humans for your scientist to retrieve.</span>")
-	to_chat(abductor.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Abductor)</span>")
+	to_chat(abductor.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Abductor)</span>")
 
 	abductor.announce_objectives()
 
@@ -171,7 +171,7 @@
 	to_chat(abductor.current, "<span class='notice'>You are a scientist of [team_name]!</span>")
 	to_chat(abductor.current, "<span class='notice'>With the help of your teammate, kidnap and experiment on station crew members!</span>")
 	to_chat(abductor.current, "<span class='notice'>Use your tool and ship consoles to support the agent and retrieve human specimens.</span>")
-	to_chat(abductor.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Abductor)</span>")
+	to_chat(abductor.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Abductor)</span>")
 
 	abductor.announce_objectives()
 

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -158,6 +158,7 @@
 	to_chat(abductor.current, "<span class='notice'>You are an agent of [team_name]!</span>")
 	to_chat(abductor.current, "<span class='notice'>With the help of your teammate, kidnap and experiment on station crew members!</span>")
 	to_chat(abductor.current, "<span class='notice'>Use your stealth technology and equipment to incapacitate humans for your scientist to retrieve.</span>")
+	to_chat(abductor.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Abductor)</span>")
 
 	abductor.announce_objectives()
 
@@ -170,6 +171,7 @@
 	to_chat(abductor.current, "<span class='notice'>You are a scientist of [team_name]!</span>")
 	to_chat(abductor.current, "<span class='notice'>With the help of your teammate, kidnap and experiment on station crew members!</span>")
 	to_chat(abductor.current, "<span class='notice'>Use your tool and ship consoles to support the agent and retrieve human specimens.</span>")
+	to_chat(abductor.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Abductor)</span>")
 
 	abductor.announce_objectives()
 

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -837,6 +837,7 @@
 		to_chat(src, "You are a brain slug that worms its way into the head of its victim. Use stealth, persuasion and your powers of mind control to keep you, your host and your eventual spawn safe and warm.")
 		to_chat(src, "Sugar nullifies your abilities, avoid it at all costs!")
 		to_chat(src, "You can speak to your fellow borers by prefixing your messages with ':bo'. Check out your Borer tab to see your abilities.")
+		to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Cortical_Borer)</span>")
 
 /proc/create_borer_mind(key)
 	var/datum/mind/M = new /datum/mind(key)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -837,7 +837,7 @@
 		to_chat(src, "You are a brain slug that worms its way into the head of its victim. Use stealth, persuasion and your powers of mind control to keep you, your host and your eventual spawn safe and warm.")
 		to_chat(src, "Sugar nullifies your abilities, avoid it at all costs!")
 		to_chat(src, "You can speak to your fellow borers by prefixing your messages with ':bo'. Check out your Borer tab to see your abilities.")
-		to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Cortical_Borer)</span>")
+		to_chat(src, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Cortical_Borer)</span>")
 
 /proc/create_borer_mind(key)
 	var/datum/mind/M = new /datum/mind(key)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -21,7 +21,7 @@
 	roundstart = FALSE
 	important_info = "Follow your objectives, do not make the station inhospitable or try and kill crew."
 	flavour_text = "You are a swarmer, a weapon of a long dead civilization. Until further orders from your original masters are received, you must continue to consume and replicate."
-	description = {" Your goal is to create more of yourself by consuming the station. Clicking on any object will try to consume it, either deconstructing it into its components, destroying it, or integrating any materials it has into you if successful. Ctrl-Clicking on a mob will attempt to remove it from the area and place it in a safe environment for storage.
+	description = {"Your goal is to create more of yourself by consuming the station. Clicking on any object will try to consume it, either deconstructing it into its components, destroying it, or integrating any materials it has into you if successful. Ctrl-Clicking on a mob will attempt to remove it from the area and place it in a safe environment for storage.
 	Objectives:
 	1. Consume resources and replicate until there are no more resources left.
 	2. Ensure that this location is fit for invasion at a later date; do not perform actions that would render it dangerous or inhospitable.
@@ -112,6 +112,7 @@
 	to_chat(src, "1. Consume resources and replicate until there are no more resources left.")
 	to_chat(src, "2. Ensure that the station is fit for invasion at a later date, do not perform actions that would render it dangerous or inhospitable.")
 	to_chat(src, "3. Biological and sentient resources will be harvested at a later date, do not harm them.")
+	to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Swarmer)</span>")
 
 /mob/living/simple_animal/hostile/swarmer/New()
 	..()

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -112,7 +112,7 @@
 	to_chat(src, "1. Consume resources and replicate until there are no more resources left.")
 	to_chat(src, "2. Ensure that the station is fit for invasion at a later date, do not perform actions that would render it dangerous or inhospitable.")
 	to_chat(src, "3. Biological and sentient resources will be harvested at a later date, do not harm them.")
-	to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Swarmer)</span>")
+	to_chat(src, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Swarmer)</span>")
 
 /mob/living/simple_animal/hostile/swarmer/New()
 	..()

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -343,7 +343,7 @@
 	to_chat(G, "You are capable of manifesting or recalling to your master with verbs in the Guardian tab. You will also find a verb to communicate with them privately there.")
 	to_chat(G, "While personally invincible, you will die if [user.real_name] does, and any damage dealt to you will have a portion passed on to them as you feed upon them to sustain yourself.")
 	to_chat(G, "[G.playstyle_string]")
-	to_chat(G, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Guardian)</span>")
+	to_chat(G, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Guardian)</span>")
 	G.faction = user.faction
 
 	var/color = pick(color_list)

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -343,6 +343,7 @@
 	to_chat(G, "You are capable of manifesting or recalling to your master with verbs in the Guardian tab. You will also find a verb to communicate with them privately there.")
 	to_chat(G, "While personally invincible, you will die if [user.real_name] does, and any damage dealt to you will have a portion passed on to them as you feed upon them to sustain yourself.")
 	to_chat(G, "[G.playstyle_string]")
+	to_chat(G, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Guardian)</span>")
 	G.faction = user.faction
 
 	var/color = pick(color_list)

--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -26,6 +26,7 @@
 		player_mind.special_role = SPECIAL_ROLE_MORPH
 		SSticker.mode.traitors |= player_mind
 		to_chat(S, S.playstyle_string)
+		to_chat(S, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Morph)</span>")
 		SEND_SOUND(S, sound('sound/magic/mutate.ogg'))
 		message_admins("[key_of_morph] has been made into morph by an event.")
 		log_game("[key_of_morph] was spawned as a morph by an event.")

--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -26,7 +26,7 @@
 		player_mind.special_role = SPECIAL_ROLE_MORPH
 		SSticker.mode.traitors |= player_mind
 		to_chat(S, S.playstyle_string)
-		to_chat(S, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Morph)</span>")
+		to_chat(S, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Morph)</span>")
 		SEND_SOUND(S, sound('sound/magic/mutate.ogg'))
 		message_admins("[key_of_morph] has been made into morph by an event.")
 		log_game("[key_of_morph] was spawned as a morph by an event.")

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -168,7 +168,7 @@
 			to_chat(src, "<b>You are invincible and invisible to everyone but other ghosts. Most abilities will reveal you, rendering you vulnerable.</b>")
 			to_chat(src, "<b>To function, you are to drain the life essence from humans. This essence is a resource, as well as your health, and will power all of your abilities.</b>")
 			to_chat(src, "<b><i>You do not remember anything of your past lives, nor will you remember anything about this one after your death.</i></b>")
-			to_chat(src, "<b>Be sure to read the wiki page at http://www.paradisestation.org/wiki/index.php/Revenant to learn more.</b>")
+			to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Revenant)</span>")
 			var/datum/objective/revenant/objective = new
 			objective.owner = mind
 			mind.objectives += objective

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -168,7 +168,7 @@
 			to_chat(src, "<b>You are invincible and invisible to everyone but other ghosts. Most abilities will reveal you, rendering you vulnerable.</b>")
 			to_chat(src, "<b>To function, you are to drain the life essence from humans. This essence is a resource, as well as your health, and will power all of your abilities.</b>")
 			to_chat(src, "<b><i>You do not remember anything of your past lives, nor will you remember anything about this one after your death.</i></b>")
-			to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Revenant)</span>")
+			to_chat(src, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Revenant)</span>")
 			var/datum/objective/revenant/objective = new
 			objective.owner = mind
 			mind.objectives += objective

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -92,6 +92,7 @@
 			mind.objectives += fluffObjective
 			to_chat(src, "<B>Objective #[1]</B>: [objective.explanation_text]")
 			to_chat(src, "<B>Objective #[2]</B>: [fluffObjective.explanation_text]")
+		to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Slaughter_Demon)</span>")
 
 
 /obj/effect/decal/cleanable/blood/innards

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -92,7 +92,7 @@
 			mind.objectives += fluffObjective
 			to_chat(src, "<B>Objective #[1]</B>: [objective.explanation_text]")
 			to_chat(src, "<B>Objective #[2]</B>: [fluffObjective.explanation_text]")
-		to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Slaughter_Demon)</span>")
+		to_chat(src, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Slaughter_Demon)</span>")
 
 
 /obj/effect/decal/cleanable/blood/innards

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -245,6 +245,7 @@
 	for(var/datum/objective/objective in syndicate.objectives)
 		to_chat(syndicate.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
+	to_chat(syndicate.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Nuclear_Agent)</span>")
 	return
 
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -245,7 +245,7 @@
 	for(var/datum/objective/objective in syndicate.objectives)
 		to_chat(syndicate.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
-	to_chat(syndicate.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Nuclear_Agent)</span>")
+	to_chat(syndicate.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Nuclear_Agent)</span>")
 	return
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -110,6 +110,7 @@
 		to_chat(rev_mind.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		rev_mind.special_role = SPECIAL_ROLE_HEAD_REV
 		obj_count++
+	to_chat(rev_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Revolution)</span>")
 
 /////////////////////////////////////////////////////////////////////////////////
 //This are equips the rev heads with their gear, and makes the clown not clumsy//

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -110,7 +110,7 @@
 		to_chat(rev_mind.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		rev_mind.special_role = SPECIAL_ROLE_HEAD_REV
 		obj_count++
-	to_chat(rev_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Revolution)</span>")
+	to_chat(rev_mind.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Revolution)</span>")
 
 /////////////////////////////////////////////////////////////////////////////////
 //This are equips the rev heads with their gear, and makes the clown not clumsy//

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -126,8 +126,7 @@ Made by Xhuis
 	to_chat(shadow.current, "<b>Currently, you are disguised as an employee aboard [world.name].</b>")
 	to_chat(shadow.current, "<b>In your limited state, you have two abilities: Hatch and Shadowling Hivemind (:8).</b>")
 	to_chat(shadow.current, "<b>Any other shadowlings are your allies. You must assist them as they shall assist you.</b>")
-	to_chat(shadow.current, "<b>If you are new to shadowling, or want to read about abilities, check the wiki page at https://www.paradisestation.org/wiki/index.php/Shadowling</b><br>")
-	to_chat(shadow.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Shadowling)</span>")
+	to_chat(shadow.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Shadowling)</span>")
 
 
 /datum/game_mode/proc/process_shadow_objectives(datum/mind/shadow_mind)
@@ -169,7 +168,7 @@ Made by Xhuis
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>Your body has been irreversibly altered. The attentive can see this - you may conceal it by wearing a mask.</span>")
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>Though not nearly as powerful as your masters, you possess some weak powers. These can be found in the Thrall Abilities tab.</span>")
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>You may communicate with your allies by speaking in the Shadowling Hivemind (:8).</span>")
-		to_chat(new_thrall_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Shadowling)</span>")
+		to_chat(new_thrall_mind.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Shadowling)</span>")
 		if(jobban_isbanned(new_thrall_mind.current, ROLE_SHADOWLING) || jobban_isbanned(new_thrall_mind.current, ROLE_SYNDICATE))
 			replace_jobbanned_player(new_thrall_mind.current, ROLE_SHADOWLING)
 		if(!victory_warning_announced && (length(shadowling_thralls) >= warning_threshold))//are the slings very close to winning?

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -127,7 +127,7 @@ Made by Xhuis
 	to_chat(shadow.current, "<b>In your limited state, you have two abilities: Hatch and Shadowling Hivemind (:8).</b>")
 	to_chat(shadow.current, "<b>Any other shadowlings are your allies. You must assist them as they shall assist you.</b>")
 	to_chat(shadow.current, "<b>If you are new to shadowling, or want to read about abilities, check the wiki page at https://www.paradisestation.org/wiki/index.php/Shadowling</b><br>")
-
+	to_chat(shadow.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Shadowling)</span>")
 
 
 /datum/game_mode/proc/process_shadow_objectives(datum/mind/shadow_mind)
@@ -169,6 +169,7 @@ Made by Xhuis
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>Your body has been irreversibly altered. The attentive can see this - you may conceal it by wearing a mask.</span>")
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>Though not nearly as powerful as your masters, you possess some weak powers. These can be found in the Thrall Abilities tab.</span>")
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>You may communicate with your allies by speaking in the Shadowling Hivemind (:8).</span>")
+		to_chat(new_thrall_mind.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Shadowling)</span>")
 		if(jobban_isbanned(new_thrall_mind.current, ROLE_SHADOWLING) || jobban_isbanned(new_thrall_mind.current, ROLE_SYNDICATE))
 			replace_jobbanned_player(new_thrall_mind.current, ROLE_SHADOWLING)
 		if(!victory_warning_announced && (length(shadowling_thralls) >= warning_threshold))//are the slings very close to winning?

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -193,8 +193,8 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	for(var/datum/objective/objective in vampire.objectives)
 		to_chat(vampire.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
+	to_chat(vampire.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Vampire)</span>")
 	return
-
 /datum/vampire
 	var/bloodtotal = 0 // CHANGE TO ZERO WHEN PLAYTESTING HAPPENS
 	var/bloodusable = 0 // CHANGE TO ZERO WHEN PLAYTESTING HAPPENS

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -193,7 +193,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	for(var/datum/objective/objective in vampire.objectives)
 		to_chat(vampire.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
-	to_chat(vampire.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Vampire)</span>")
+	to_chat(vampire.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Vampire)</span>")
 	return
 /datum/vampire
 	var/bloodtotal = 0 // CHANGE TO ZERO WHEN PLAYTESTING HAPPENS

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -323,7 +323,7 @@
 					var/mob/living/simple_animal/hostile/construct/C = new picked_class(shell.loc)
 					C.init_construct(shade, src, shell)
 					to_chat(C, C.playstyle_string)
-					to_chat(C, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Construct)</span>")
+					to_chat(C, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Construct)</span>")
 			else
 				to_chat(user, "<span class='danger'>Creation failed!</span>: The soul stone is empty! Go kill someone!")
 

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -323,6 +323,7 @@
 					var/mob/living/simple_animal/hostile/construct/C = new picked_class(shell.loc)
 					C.init_construct(shade, src, shell)
 					to_chat(C, C.playstyle_string)
+					to_chat(C, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Construct)</span>")
 			else
 				to_chat(user, "<span class='danger'>Creation failed!</span>: The soul stone is empty! Go kill someone!")
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -108,6 +108,7 @@
 	for(var/datum/objective/objective in wizard.objectives)
 		to_chat(wizard.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
+	to_chat(wizard.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Wizard)</span>")
 	return
 
 /*/datum/game_mode/proc/learn_basic_spells(mob/living/carbon/human/wizard_mob)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -108,7 +108,7 @@
 	for(var/datum/objective/objective in wizard.objectives)
 		to_chat(wizard.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 		obj_count++
-	to_chat(wizard.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Wizard)</span>")
+	to_chat(wizard.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Wizard)</span>")
 	return
 
 /*/datum/game_mode/proc/learn_basic_spells(mob/living/carbon/human/wizard_mob)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -248,6 +248,7 @@
 		owner.announce_objectives()
 	if(should_give_codewords)
 		give_codewords()
+	to_chat(owner.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Traitor)</span>")
 
 
 /datum/antagonist/traitor/proc/update_traitor_icons_added(datum/mind/traitor_mind)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -248,7 +248,7 @@
 		owner.announce_objectives()
 	if(should_give_codewords)
 		give_codewords()
-	to_chat(owner.current, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Traitor)</span>")
+	to_chat(owner.current, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Traitor)</span>")
 
 
 /datum/antagonist/traitor/proc/update_traitor_icons_added(datum/mind/traitor_mind)

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -30,6 +30,6 @@
 	SSticker.mode.update_blob_icons_added(B.mind)
 
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
-	to_chat(B, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Blob)</span>")
+	to_chat(B, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Blob)</span>")
 	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B)
 	successSpawn = TRUE

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -30,5 +30,6 @@
 	SSticker.mode.update_blob_icons_added(B.mind)
 
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
+	to_chat(B, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Blob)</span>")
 	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B)
 	successSpawn = TRUE

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -56,6 +56,7 @@
 		var/mob/living/simple_animal/hostile/poison/terror_spider/S = new spider_type(vent.loc)
 		var/mob/M = pick_n_take(candidates)
 		S.key = M.key
+		to_chat(S, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Terror_Spider)</span>")
 		spawncount--
 		successSpawn = TRUE
 

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -56,7 +56,7 @@
 		var/mob/living/simple_animal/hostile/poison/terror_spider/S = new spider_type(vent.loc)
 		var/mob/M = pick_n_take(candidates)
 		S.key = M.key
-		to_chat(S, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Terror_Spider)</span>")
+		to_chat(S, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Terror_Spider)</span>")
 		spawncount--
 		successSpawn = TRUE
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -99,7 +99,7 @@
 			new_xeno.mind.assigned_role = SPECIAL_ROLE_XENOMORPH
 			new_xeno.mind.special_role = SPECIAL_ROLE_XENOMORPH
 			new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)//To get the player's attention
-			to_chat(new_xeno, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Xenomorph)</span>")
+			to_chat(new_xeno, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Xenomorph)</span>")
 
 			if(gib_on_success)
 				owner.gib()

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -99,6 +99,7 @@
 			new_xeno.mind.assigned_role = SPECIAL_ROLE_XENOMORPH
 			new_xeno.mind.special_role = SPECIAL_ROLE_XENOMORPH
 			new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)//To get the player's attention
+			to_chat(new_xeno, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Xenomorph)</span>")
 
 			if(gib_on_success)
 				owner.gib()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
@@ -42,5 +42,6 @@
 		to_chat(user, "<span class='notice'>Someone else already took this spider.</span>")
 		return
 	key = user.key
+	to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Terror_Spider)</span>")
 	for(var/mob/dead/observer/G in GLOB.player_list)
 		G.show_message("<i>A ghost has taken control of <b>[src]</b>. ([ghost_follow_link(src, ghost=G)]).</i>")

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
@@ -42,6 +42,6 @@
 		to_chat(user, "<span class='notice'>Someone else already took this spider.</span>")
 		return
 	key = user.key
-	to_chat(src, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Terror_Spider)</span>")
+	to_chat(src, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Terror_Spider)</span>")
 	for(var/mob/dead/observer/G in GLOB.player_list)
 		G.show_message("<i>A ghost has taken control of <b>[src]</b>. ([ghost_follow_link(src, ghost=G)]).</i>")

--- a/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
+++ b/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
@@ -78,7 +78,7 @@
 	new_spawn.rename_character(new_spawn.real_name, new_spawn.dna.species.get_random_name(new_spawn.gender))
 
 	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
-	to_chat(new_spawn, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Ash_Walker)</span>")
+	to_chat(new_spawn, "<span class='motd'>For more information, check the wiki page: ([config.wikiurl]/index.php/Ash_Walker)</span>")
 
 /obj/effect/mob_spawn/human/ash_walker/New()
 	. = ..()

--- a/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
+++ b/code/modules/ruins/lavalandruin_code/ash_walker_den.dm
@@ -78,6 +78,7 @@
 	new_spawn.rename_character(new_spawn.real_name, new_spawn.dna.species.get_random_name(new_spawn.gender))
 
 	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
+	to_chat(new_spawn, "<span class='motd'>For more information, check the wiki page: (https://www.paradisestation.org/wiki/index.php/Ash_Walker)</span>")
 
 /obj/effect/mob_spawn/human/ash_walker/New()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Gives a wiki link to all antagonists for their associated wiki page.
Vampires get linked to https://www.paradisestation.org/wiki/index.php/Vampire,
Swarmers get linked to https://www.paradisestation.org/wiki/index.php/Swarmer,
etc.

**Currently added:**
1. Blobs
2. Changelings
3. Cultists
4. Vox Raiders
5. Abductors
6. Cortical Borers
7. Swarmers
8. Guardians/Holoparasites
9. Morphs
10. Revenants
11. Slaugher Demons
12. Nuclear Agents
13. Revolutionaries 
14. Shadowlings
15. Vampires
16. Wizards
17. Traitors
18. Ash Walkers
19. Terror Spiders
20. Constructs
21. Xenomorphs

I'm not entirely happy with the implimentation of just copying the same line over for every antag, but since they all use different procs and implimentations I can't see another way of doing it at the moment. At least until they're properly datumised.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The majority of new players have absolutely no idea what they're doing on their first antag round, and a surprisingly small number of them know to check the wiki or mentorhelp.
Having a big "Click here for help!" link should (at the very least) reduce the number of people quitting because they can't handle the stress, or cultists ignoring their objectives because they don't know what to do.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![e](https://user-images.githubusercontent.com/57483089/115935687-a1639700-a48b-11eb-95de-f837fd58e09b.PNG)

## Changelog
:cl:
experiment: Added links to the relevant wiki page in all antagonist greeting messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
