### PR TITLE
Issue 15937 Fix - Containment fields can no longer be contaminated with radiation.

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -7,6 +7,7 @@
 		opacity = FALSE
 		anchored = 1
 		resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+		flags_2 = RAD_NO_CONTAMINATE_2
 		max_integrity = 200
 
 /obj/machinery/shield/New()

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -7,6 +7,7 @@
 	density = 0
 	move_resist = INFINITY
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	flags_2 = RAD_NO_CONTAMINATE_2
 	use_power = NO_POWER_USE
 	light_range = 4
 	layer = OBJ_LAYER + 0.1


### PR DESCRIPTION
## What Does This PR Do
Fixes #15937 by setting flags_2 = RAD_NO_CONTAMINATE_2 on containment fields (also shields).

## Changelog
:cl:
tweak: Energy shields (the construct, not the item), cult barriers and containment fields can no longer be radiation contaminated and will not start glowing when exposed to radiation.
/:cl:
