### PR TITLE
Issue #15928 - Finger gun trigger guard fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -159,6 +159,7 @@
 	fire_sound_text = null
 	lefthand_file = null
 	righthand_file = null
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 	clumsy_check = 0 //Stole your uplink! Honk!
 	needs_permit = 0 //go away beepsky
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #15928 by allowing all entities to use the finger gun made by the finger gun spell.

## Changelog
:cl:
tweak: Golems (and other entities such as ashwalkers) can now use finger guns created by the finger gun or fake finger gun spell.
/:cl:
