### PR TITLE
Fixes #15718 - All bottles now smash and spill their contents on impact.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -12,7 +12,7 @@
 	var/const/duration = 13 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
 	var/isGlass = 1 //Whether the 'bottle' is made of glass or not so that milk cartons dont shatter when someone gets hit by it
 
-/obj/item/reagent_containers/food/drinks/bottle/proc/smash(mob/living/target, mob/living/user, ranged = 0)
+/obj/item/reagent_containers/food/drinks/bottle/proc/smash(mob/living/target, mob/living/user, ranged = FALSE)
 
 	//Creates a shattering noise and replaces the bottle with a broken_bottle
 	var/new_location = get_turf(loc)
@@ -123,6 +123,11 @@
 		M.visible_message("<span class='danger'>The contents of \the [src] splashes all over [M]!</span>")
 		reagents.reaction(M, REAGENT_TOUCH)
 		reagents.clear_reagents()
+
+/obj/item/reagent_containers/food/drinks/bottle/throw_impact(atom/target,mob/thrower)
+	..()
+	SplashReagents(target)
+	smash(target, thrower, ranged = TRUE)
 
 /obj/item/reagent_containers/food/drinks/bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	if(!reagents.total_volume)
@@ -345,11 +350,10 @@
 			if(istype(R, A))
 				firestarter = 1
 				break
-	SplashReagents(target)
+	..()
 	if(firestarter && active)
 		target.fire_act()
 		new /obj/effect/hotspot(get_turf(target))
-	..()
 
 /obj/item/reagent_containers/food/drinks/bottle/molotov/attackby(obj/item/I, mob/user, params)
 	if(is_hot(I) && !active)


### PR DESCRIPTION
## What Does This PR Do
Fixes #15718

All bottles smash and spill their contents over what they hit when thrown, including molotov cocktails. If this is a problem the code can be modified to only smash molotovs.

## Why It's Good For The Game
Fixes some unexpected behaviors. I expect that several bottles will be accidentally smashed, but tossing around fragile containers never made much sense anyway.

## Changelog
:cl:
add: All thrown bottles and cartons now smash, spilling their contents over whatever they hit.
tweak: Molotovs now smash properly on hit and set the target on fire if they're burning.
/:cl:
