### PR TITLE
#15662 Fix - Makes welder bombs resistable by heat resistance

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -231,7 +231,7 @@
 			if(ishuman(L))
 				var/mob/living/carbon/human/M = L
 				var/heatBlockPercent = 1 - M.get_heat_protection(temp)
-				M.bodytemperature += (temp - M.bodytemperature) * heatBlockPercent / 2
+				M.bodytemperature += (temp - M.bodytemperature) * heatBlockPercent / 3
 			else
 				L.bodytemperature = (2 * L.bodytemperature + temp) / 3
 
@@ -299,7 +299,7 @@
 			if(ishuman(L))
 				var/mob/living/carbon/human/M = L
 				var/heatBlockPercent = 1 - M.get_heat_protection(temp)
-				M.bodytemperature += (temp - M.bodytemperature) * heatBlockPercent / 2
+				M.bodytemperature += (temp - M.bodytemperature) * heatBlockPercent / 3
 			else
 				L.bodytemperature = (2 * L.bodytemperature + temp) / 3
 

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -228,7 +228,12 @@
 		for(var/mob/living/L in T)
 			L.adjust_fire_stacks(3)
 			L.IgniteMob()
-			L.bodytemperature = max(temp / 3, L.bodytemperature)
+			if(ishuman(L))
+				var/mob/living/carbon/human/M = L
+				var/heatBlockPercent = 1 - M.get_heat_protection(temp)
+				M.bodytemperature += (temp - M.bodytemperature) * heatBlockPercent / 2
+			else
+				L.bodytemperature = (2 * L.bodytemperature + temp) / 3
 
 /proc/fireflash_s(atom/center, radius, temp, falloff)
 	if(temp < T0C + 60)
@@ -291,7 +296,12 @@
 		for(var/mob/living/L in T)
 			L.adjust_fire_stacks(3)
 			L.IgniteMob()
-			L.bodytemperature = (2 * L.bodytemperature + temp) / 3
+			if(ishuman(L))
+				var/mob/living/carbon/human/M = L
+				var/heatBlockPercent = 1 - M.get_heat_protection(temp)
+				M.bodytemperature += (temp - M.bodytemperature) * heatBlockPercent / 2
+			else
+				L.bodytemperature = (2 * L.bodytemperature + temp) / 3
 
 		if(T.density)
 			continue


### PR DESCRIPTION
## What Does This PR Do
Fireballs from the fireflash and fireflash_s procs now have the body temperature increase resisted by heat resistance. This most notably applies to welderbombs, but also applies to oil fires and other "fireball" type explosions (but ironically not wizard fireball). In the case of welderbombs, a fire-immune target still takes the brute damage from the explosion and may be knocked prone.

Fixes #15662

## Why It's Good For The Game
Consistency: It is to be expected that fire immunity protects you from fuel explosions as well. Also makes fuel explosions somewhat less devastating to people with the correct gear, allowing for some counterplay.

## Changelog
:cl:
balance: The internal temperature increase from fireflash effects (i.e oil explosions, welder tanks but NOT the wizard spell) is now resisted by the target's heat resistance.
/:cl:
