### PR TITLE
Changes default DMI behaviour within VSC

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+	"workbench.editorAssociations": [
+		{
+			"filenamePattern": "*.dmi",
+			"viewType": "imagePreview.previewEditor"
+		}
+	]
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Currently, DMI files try to open in the text editor, despite being basically PNG files with extra header data.
This default config option would mean it opens them as an image preview within VSC.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quick image previews from within VSC are good. Other repos do this and it works well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![image](https://user-images.githubusercontent.com/12197162/115954793-ce936200-a4ea-11eb-87df-f63075e29ebd.png)


![image](https://user-images.githubusercontent.com/12197162/115954779-bc192880-a4ea-11eb-943b-7a251c9cff47.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->