### PR TITLE
Fixes 4 runtimes. Linked forum account message is now shown properly

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -611,7 +611,7 @@ so as to remain in compliance with the most up-to-date laws."
 	if(stone)
 		if(alert(usr, "Do you want to be captured by [stoner]'s soul stone? This will destroy your corpse and make it \
 		impossible for you to get back into the game as your regular character.",, "No", "Yes") ==  "Yes")
-			stone.opt_in = TRUE
+			stone?.opt_in = TRUE
 
 /obj/screen/alert/notify_soulstone/Destroy()
 	stone = null

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -197,13 +197,7 @@
 		apply_mode()
 
 /obj/machinery/alarm/New(loc, direction, building = 0)
-	. = ..()
-	GLOB.air_alarms += src
-	GLOB.air_alarms = sortAtom(GLOB.air_alarms)
-
-	wires = new(src)
-
-	if(building)
+	if(building) // Do this first since the Init uses this later on. TODO refactor to just use an Init
 		if(loc)
 			src.loc = loc
 
@@ -213,10 +207,15 @@
 		buildstage = 0
 		wiresexposed = 1
 		set_pixel_offsets_from_dir(-24, 24, -24, 24)
-		update_icon()
-		return
 
-	first_run()
+	. = ..()
+	GLOB.air_alarms += src
+	GLOB.air_alarms = sortAtom(GLOB.air_alarms)
+
+	wires = new(src)
+
+	if(!building)
+		first_run()
 
 /obj/machinery/alarm/Destroy()
 	SStgui.close_uis(wires)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -680,7 +680,7 @@
 	if(query_find_link.NextRow())
 		if(query_find_link.item[1])
 			if(!fromban)
-				to_chat(src, "Your forum account is already set. (" + query_find_link.item[1] + ")")
+				to_chat(src, "Your forum account is already set. ([query_find_link.item[1]])")
 			qdel(query_find_link)
 			return
 	qdel(query_find_link)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -78,6 +78,8 @@
 		for(var/atom/T in get_turf(D))
 			D.reagents.reaction(T)
 		sleep(3)
+		if(QDELETED(D))
+			return
 	qdel(D)
 
 


### PR DESCRIPTION
## What Does This PR Do
Fixes three purely technical runtimes and one which caused the user to not get a message about their forum account being linked.

```
Runtime in airalarm.dm,369: Cannot read null.atmosalm
   proc name: update icon (/obj/machinery/alarm/update_icon)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The plating (112,96,2) (/turf/simulated/floor/plating)
   src: the alarm (/obj/machinery/alarm)
   src.loc: the plating (112,96,2) (/turf/simulated/floor/plating)
   call stack:
   the alarm (/obj/machinery/alarm): update icon()
   the alarm (/obj/machinery/alarm): power change()
   the alarm (/obj/machinery/alarm): Initialize(0, 4, 1)
   the alarm (/obj/machinery/alarm): Initialize(0, 4, 1)
   Atoms (/datum/controller/subsystem/atoms): InitAtom(the alarm (/obj/machinery/alarm), /list (/list))
   the alarm (/obj/machinery/alarm): attempt init(0, 4, 1)
   the alarm (/obj/machinery/alarm): attempt init(the plating (112,96,2) (/turf/simulated/floor/plating), 4, 1)
   the alarm (/obj/machinery/alarm): New(the plating (112,96,2) (/turf/simulated/floor/plating), 4, 1)
   the alarm (/obj/machinery/alarm): New(the plating (112,96,2) (/turf/simulated/floor/plating), 4, 1)
   the alarm (/obj/machinery/alarm): New(the plating (112,96,2) (/turf/simulated/floor/plating), 4, 1)
   the air alarm frame (/obj/item/mounted/frame/alarm_frame): do build(the wall (111,96,2) (/turf/simulated/wall), NAME (/mob/living/carbon/human))
   the air alarm frame (/obj/item/mounted/frame/alarm_frame): afterattack(the wall (111,96,2) (/turf/simulated/wall), NAME (/mob/living/carbon/human), 1, "icon-x=23;icon-y=21;left=1;scr...")
   the air alarm frame (/obj/item/mounted/frame/alarm_frame): melee attack chain(NAME (/mob/living/carbon/human), the wall (111,96,2) (/turf/simulated/wall), "icon-x=23;icon-y=21;left=1;scr...")
   NAME (/mob/living/carbon/human): ClickOn(the wall (111,96,2) (/turf/simulated/wall), "icon-x=23;icon-y=21;left=1;scr...")
   the wall (111,96,2) (/turf/simulated/wall): Click(the wall (111,96,2) (/turf/simulated/wall), "mapwindow.map", "icon-x=23;icon-y=21;left=1;scr...")
```

```
Runtime in alert.dm,614: Cannot modify null.opt_in.
   proc name: Click (/obj/screen/alert/notify_soulstone/Click)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (184,143,2) (/turf/simulated/floor/plasteel)
   src: Soul Stone (/obj/screen/alert/notify_soulstone)
   src.loc: null
   call stack:
   Soul Stone (/obj/screen/alert/notify_soulstone): Click(null, "mapwindow.map", "icon-x=23;icon-y=20;left=1;scr...")
```

```
Runtime in client_procs.dm,683: type mismatch: "Your forum account is already ..." + FUID_HERE
   proc name: link forum account (/client/proc/link_forum_account)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The cryogenic freezer (NAME) (120,153,2) (/obj/machinery/cryopod)
   src: CKEY (/client)
   call stack:
   CKEY (/client): link forum account(null)
   CKEY (/client): Topic("src=\[0x5000034]_5442;link_for...", /list (/list), CKEY (/client))
```
   
```
Runtime in spray.dm,77: Cannot execute null.reaction().
   proc name: spray (/obj/item/reagent_containers/spray/proc/spray)
   usr: NAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (138,130,2) (/turf/simulated/floor/plasteel)
   src: the space cleaner (/obj/item/reagent_containers/spray/cleaner)
   src.loc: the security satchel (/obj/item/storage/backpack/satchel_sec)
   call stack:
   the space cleaner (/obj/item/reagent_containers/spray/cleaner): spray(the floor (138,131,2) (/turf/simulated/floor/plasteel))
   ImmediateInvokeAsync(the space cleaner (/obj/item/reagent_containers/spray/cleaner), /obj/item/reagent_containers/s... (/obj/item/reagent_containers/spray/proc/spray), the floor (138,131,2) (/turf/simulated/floor/plasteel))
```

## Why It's Good For The Game
Bugs b gone

## Changelog
:cl:
fix: The "Your forum account is already set." message now properly shows
/:cl: