### PR TITLE
Enable MMI/posibrain speakers by default.

### DIFF
--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -234,7 +234,7 @@
 	searching_icon = "posibrain-searching"
 	occupied_icon = "posibrain-occupied"
 	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."
-	silenced = TRUE
+	silenced = FALSE
 	requires_master = FALSE
 	ejected_flavor_text = "metal cube"
 	dead_icon = "posibrain"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR enables the speaker for MMIs/IPCs by default.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Posibrains are fairly indestructible and survive dismemberment of the host chassis, leaving the player alive but—by default—unable to speak or do anything. By enabling the speaker by default, free posibrains can alert other players to their plight and hopefully get them back into a chassis quicker.


## Changelog
:cl:
tweak: MMIs and posibrains now have their speakers enabled by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
