### PR TITLE
Adds a timer to robots and ai for hotkey bolting and shocking doors

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -188,17 +188,21 @@
 /obj/machinery/door/airlock/AIAltShiftClick(mob/user)  // Sets/Unsets Emergency Access Override
 	if(!ai_control_check(user))
 		return
-	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/toggle_emergency_status, user), 5 SECONDS)
+	toggle_emergency_status(user)
 
 /obj/machinery/door/airlock/AIShiftClick(mob/user)  // Opens and closes doors!
 	if(!ai_control_check(user))
 		return
-	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/open_close, user), 5 SECONDS)
+	open_close(user)
 
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/toggle_bolt, user), 5 SECONDS)
+	if(src.locked )
+		toggle_bolt(user)
+	else
+		addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/toggle_bolt, user), 5 SECONDS)
+		to_chat(user, "You send a signal to raise the door bolts of [src].")
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
 	if(!ai_control_check(user))
@@ -206,15 +210,16 @@
 	if(wires.is_cut(WIRE_ELECTRIFY))
 		to_chat(user, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
 	if(isElectrified())
-		addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/electrify, 0, user), 5 SECONDS)
+		electrify(0, user, TRUE) // un-shock
 	else
 		addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/electrify, -1, user), 5 SECONDS)
+		to_chat(user, "You send a signal to shock [src].")
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.
 	if(!ai_control_check(user))
 		return
-	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/toggle_light, user), 5 SECONDS)
+	toggle_light(user)
 
 // AI-CONTROLLED SLIP GENERATOR IN AI CORE
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -188,17 +188,17 @@
 /obj/machinery/door/airlock/AIAltShiftClick(mob/user)  // Sets/Unsets Emergency Access Override
 	if(!ai_control_check(user))
 		return
-	toggle_emergency_status(user)
+	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/toggle_emergency_status, user), 5 SECONDS)
 
 /obj/machinery/door/airlock/AIShiftClick(mob/user)  // Opens and closes doors!
 	if(!ai_control_check(user))
 		return
-	open_close(user)
+	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/open_close, user), 5 SECONDS)
 
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-	toggle_bolt(user)
+	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/toggle_bolt, user), 5 SECONDS)
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
 	if(!ai_control_check(user))
@@ -206,15 +206,15 @@
 	if(wires.is_cut(WIRE_ELECTRIFY))
 		to_chat(user, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
 	if(isElectrified())
-		electrify(0, user, TRUE) // un-shock
+		addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/electrify, 0, user), 5 SECONDS)
 	else
-		electrify(-1, user, TRUE) // permanent shock
+		addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/electrify, -1, user), 5 SECONDS)
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.
 	if(!ai_control_check(user))
 		return
-	toggle_light(user)
+	addtimer(CALLBACK(src, /obj/machinery/door/airlock/.proc/toggle_light, user), 5 SECONDS)
 
 // AI-CONTROLLED SLIP GENERATOR IN AI CORE
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -17,7 +17,7 @@
 
 	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
 		return
-	if(stat == DEAD)
+	if(stat == DEAD || lockcharge || IsWeakened() || stunned || paralysis)
 		return
 
 	var/list/modifiers = params2list(params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This simply adds a 5 second timer on bolting, and shocking doors.
It also makes it so that cyborgs that are locked, down stunned, paralyzed or weakened, can't use click hotkeys.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
One thing that does suck the fun outta things, is ai shocking doors right before you open it, or bolting a door in your face, and will slow this down, this here will make it a bit harder as they need to pre-emptively click a door.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: ppi
add: Adds a 5 second delay to cyborgs and ai bolting and shocking doors via hotkey
removes: Cyborgs can no longer use keyboard+mouse hotkeys while locked down, stunned, weakened or paralyzed 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
