### PR TITLE
CQC Leg Sweep Tweaks

### DIFF
--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -50,8 +50,9 @@
 		D.visible_message("<span class='warning'>[A] leg sweeps [D]!", \
 							"<span class='userdanger'>[A] leg sweeps you!</span>")
 		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
-		D.apply_damage(10, BRUTE)
-		D.Weaken(3)
+		D.apply_damage(5, BRUTE)
+		D.Weaken(1)
+		D.adjustStaminaLoss(40)
 		add_attack_logs(A, D, "Melee attacked with martial-art [src] : Leg sweep", ATKLOG_ALL)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Changes CQC's Leg Sweep into a 1 cycle (1-2 second) Weaken instead of a 3 cycle Weaken, practically making it a trip rather than a full knockdown stun. It replaces the 2 cycles of Weaken with 40 Stamina Damage (minor slowdown for a few seconds), which will allow it to be a good tool for escape and evasion rather than a MASSIVELY strong opener. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having what amounts to an instant, one-button insta-stun is a tad nuts in the realm of our current Combat System. This should reduce the Leg Sweep > Sleeper Hold combo's effectiveness by giving the victim a small window to resist out of the grab if theyre fast enough.

## Changelog
:cl:
tweak: Leg Sweep weaken reduced to 1 cycle (2ish seconds) as well as dealing minor stamina damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
