### PR TITLE
Removes duplicate code from handle_status_effects

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -590,26 +590,7 @@
 				to_chat(src, "<span class='notice'>You no longer feel vigorous.</span>")
 			metabolism_efficiency = 1
 
-	if(drowsyness)
-		AdjustDrowsy(-1)
-		EyeBlurry(2)
-		if(prob(5))
-			AdjustSleeping(1)
-			Paralyse(5)
 
-	if(confused)
-		AdjustConfused(-1)
-	// decrement dizziness counter, clamped to 0
-	if(resting)
-		if(dizziness)
-			AdjustDizzy(-15)
-		if(jitteriness)
-			AdjustJitter(-15)
-	else
-		if(dizziness)
-			AdjustDizzy(-3)
-		if(jitteriness)
-			AdjustJitter(-3)
 
 	if(NO_INTORGANS in dna.species.species_traits)
 		return

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -314,12 +314,6 @@
 		do_jitter_animation(jitteriness)
 		AdjustJitter(-restingpwr)
 
-
-
-	//Jitteryness
-	if(jitteriness)
-		do_jitter_animation(jitteriness)
-
 	if(hallucination)
 		spawn handle_hallucinations()
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -263,7 +263,6 @@
 			setStaminaLoss(0, FALSE)
 			update_health_hud()
 
-	var/restingpwr = 1 + 4 * resting
 
 	//Dizziness
 	if(dizziness)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -297,22 +297,12 @@
 						C.pixel_x -= pixel_x_diff
 						C.pixel_y -= pixel_y_diff
 			src = oldsrc
-		AdjustDizzy(-restingpwr)
 
-	if(drowsyness)
-		AdjustDrowsy(-restingpwr)
-		EyeBlurry(2)
-		if(prob(5))
-			AdjustSleeping(1)
-			Paralyse(5)
 
-	if(confused)
-		AdjustConfused(-1)
 
 	//Jitteryness
 	if(jitteriness)
 		do_jitter_animation(jitteriness)
-		AdjustJitter(-restingpwr)
 
 	if(hallucination)
 		spawn handle_hallucinations()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -263,6 +263,7 @@
 			setStaminaLoss(0, FALSE)
 			update_health_hud()
 
+	var/restingpwr = 1 + 4 * resting
 
 	//Dizziness
 	if(dizziness)
@@ -296,6 +297,22 @@
 						C.pixel_x -= pixel_x_diff
 						C.pixel_y -= pixel_y_diff
 			src = oldsrc
+		AdjustDizzy(-restingpwr)
+
+	if(drowsyness)
+		AdjustDrowsy(-restingpwr)
+		EyeBlurry(2)
+		if(prob(5))
+			AdjustSleeping(1)
+			Paralyse(5)
+
+	if(confused)
+		AdjustConfused(-1)
+
+	//Jitteryness
+	if(jitteriness)
+		do_jitter_animation(jitteriness)
+		AdjustJitter(-restingpwr)
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #15916, removes duplicate code for dizziness, drowsiness, and jitteriness lowering from the handle_status_effects function. The same functionality seems to be already present in carbon/human/life/handle_chemicals_in_body.

## Why It's Good For The Game
Hopefully stops these status effects going down faster than they should.

## Changelog
:cl:Iwanabeu
fix: Drowsiness, Dizziness, Confusion, and Jitteriness time is decreased properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
