### PR TITLE
Update description text of tentacle, match reality

### DIFF
--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -173,8 +173,8 @@
 	name = "Tentacle"
 	desc = "We ready a tentacle to grab items or victims with. Costs 10 chemicals."
 	helptext = "We can use it once to retrieve a distant item. If used on living creatures, the effect depends on the intent: \
-	Help will simply drag them closer, Disarm will grab whatever they are holding instead of them, Grab will put the victim in our hold after catching it, \
-	and Harm will stun it, and stab it if we are also holding a sharp weapon. Cannot be used while in lesser form."
+	Help will simply drag it closer, Disarm will grab whatever the creature is holding, Grab will put the victim in our hold after catching it, \
+	and Harm will drag it closer, and stab it if we are also holding a sharp weapon. Cannot be used while in lesser form."
 	button_icon_state = "tentacle"
 	chemical_cost = 10
 	dna_cost = 2

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -173,7 +173,9 @@
 	name = "Tentacle"
 	desc = "We ready a tentacle to grab items or victims with. Costs 10 chemicals."
 	helptext = "We can use it once to retrieve a distant item. If used on living creatures, the effect depends on the intent: \
-	Help will simply drag it closer, Disarm will grab whatever the creature is holding, Grab will put the victim in our hold after catching it, \
+	Help will drag the target closer. \
+	Disarm will grab whatever the target is holding. \
+	Grab will put the target in our grip after we catch it. \
 	and Harm will drag it closer, and stab it if we are also holding a sharp weapon. Cannot be used while in lesser form."
 	button_icon_state = "tentacle"
 	chemical_cost = 10

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -176,7 +176,8 @@
 	Help will drag the target closer. \
 	Disarm will grab whatever the target is holding. \
 	Grab will put the target in our grip after we catch it. \
-	and Harm will drag it closer, and stab it if we are also holding a sharp weapon. Cannot be used while in lesser form."
+	Harm will drag the target closer and stab it. \
+	Cannot be used while in our lesser form."
 	button_icon_state = "tentacle"
 	chemical_cost = 10
 	dna_cost = 2

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -176,7 +176,7 @@
 	Help will drag the target closer. \
 	Disarm will grab whatever the target is holding. \
 	Grab will put the target in our grip after we catch it. \
-	Harm will drag the target closer and stab it. \
+	Harm will drag the target closer and stab it if we are holding a sharp weapon in our other hand. \
 	Cannot be used while in our lesser form."
 	button_icon_state = "tentacle"
 	chemical_cost = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the description of the changeling tentacle ability.

Old:
> [...] and Harm will stun it, and stab it if we are also holding a sharp weapon. Cannot be used while in lesser form.

New:
> [...] and Harm will drag it closer, and stab it if we are also holding a sharp weapon. Cannot be used while in lesser form.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes misinformation about a nonexistent stun. Misinformation? Bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nokko
del: Removed misleading changeling tentacle description that said it could stun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
