### PR TITLE
Adds sec hailer masks and space pod keys to sec belt's allowed items

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -230,7 +230,9 @@
 		/obj/item/flashlight/seclite,
 		/obj/item/holosign_creator/security,
 		/obj/item/melee/classic_baton/telescopic,
-		/obj/item/restraints/legcuffs/bola)
+		/obj/item/restraints/legcuffs/bola,
+		/obj/item/clothing/mask/gas/sechailer,
+		/obj/item/spacepod_key)
 
 /obj/item/storage/belt/security/sec/populate_contents()
 	new /obj/item/flashlight/seclite(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As the title states, it adds sec hailer masks and space pod keys as valid items to put on a sec belt.

## Why It's Good For The Game
These are both items that are small enough to conceivably fit on a belt, and sec officers often have a lot of gear already, so this gives them more options for managing it.

## Changelog
:cl:
tweak: Sec hailer masks and space pod keys now fit on sec belts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
