### PR TITLE
Makes all nuclear operatives remember the nuke code

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -108,18 +108,23 @@
 	var/agent_number = 1
 	var/spawnpos = 1
 
+	var/obj/machinery/nuclearbomb/syndicate/the_bomb
+	if(nuke_spawn && synd_spawn.len > 0)
+		the_bomb = new /obj/machinery/nuclearbomb/syndicate(nuke_spawn.loc)
+		the_bomb.r_code = nuke_code
+
 	for(var/datum/mind/synd_mind in syndicates)
 		if(spawnpos > synd_spawn.len)
 			spawnpos = 2
 		synd_mind.current.loc = synd_spawn[spawnpos]
 		synd_mind.offstation_role = TRUE
 		forge_syndicate_objectives(synd_mind)
-		create_syndicate(synd_mind)
+		create_syndicate(synd_mind, the_bomb)
 		greet_syndicate(synd_mind)
 		equip_syndicate(synd_mind.current)
 
 		if(!leader_selected)
-			prepare_syndicate_leader(synd_mind, nuke_code)
+			prepare_syndicate_leader(synd_mind, the_bomb)
 			leader_selected = 1
 		else
 			synd_mind.current.real_name = "[syndicate_name()] Operative #[agent_number]"
@@ -131,9 +136,6 @@
 
 	scale_telecrystals()
 	share_telecrystals()
-	if(nuke_spawn && synd_spawn.len > 0)
-		var/obj/machinery/nuclearbomb/syndicate/the_bomb = new /obj/machinery/nuclearbomb/syndicate(nuke_spawn.loc)
-		the_bomb.r_code = nuke_code
 
 	return ..()
 
@@ -160,7 +162,7 @@
 			U.hidden_uplink.uses++
 			remainder--
 
-/datum/game_mode/proc/create_syndicate(datum/mind/synd_mind) // So we don't have inferior species as ops - randomize a human
+/datum/game_mode/proc/create_syndicate(datum/mind/synd_mind, var/obj/machinery/nuclearbomb/syndicate/the_bomb) // So we don't have inferior species as ops - randomize a human
 	var/mob/living/carbon/human/M = synd_mind.current
 
 	M.set_species(/datum/species/human, TRUE)
@@ -186,7 +188,11 @@
 	M.regenerate_icons()
 	M.update_body()
 
-/datum/game_mode/proc/prepare_syndicate_leader(datum/mind/synd_mind, nuke_code)
+	if(the_bomb)
+		synd_mind.store_memory("<B>Syndicate [the_bomb.name] Code</B>: [the_bomb.r_code]", 0, 0)
+		to_chat(synd_mind.current, "The [the_bomb.name] code is: <B>[the_bomb.r_code]</B>")
+
+/datum/game_mode/proc/prepare_syndicate_leader(datum/mind/synd_mind, var/obj/machinery/nuclearbomb/syndicate/the_bomb)
 	var/leader_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord")
 	synd_mind.current.real_name = "[syndicate_name()] Team [leader_title]"
 	to_chat(synd_mind.current, "<B>You are the Syndicate leader for this mission. You are responsible for the distribution of telecrystals and your ID is the only one who can open the launch bay doors.</B>")
@@ -198,11 +204,9 @@
 
 	update_syndicate_id(synd_mind, leader_title, TRUE)
 
-	if(nuke_code)
-		synd_mind.store_memory("<B>Syndicate Nuclear Bomb Code</B>: [nuke_code]", 0, 0)
-		to_chat(synd_mind.current, "The nuclear authorization code is: <B>[nuke_code]</B>")
+	if(the_bomb)
 		var/obj/item/paper/P = new
-		P.info = "The nuclear authorization code is: <b>[nuke_code]</b>"
+		P.info = "The [the_bomb.name] code is: <B>[the_bomb.r_code]</B>"
 		P.name = "nuclear bomb code"
 		var/obj/item/stamp/syndicate/stamp = new
 		P.stamp(stamp)
@@ -216,8 +220,6 @@
 			H.equip_to_slot_or_del(P, slot_r_store, 0)
 			H.update_icons()
 
-	else
-		nuke_code = "code will be provided later"
 
 /datum/game_mode/proc/update_syndicate_id(datum/mind/synd_mind, is_leader = FALSE)
 	var/list/found_ids = synd_mind.current.search_contents_for(/obj/item/card/id)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -109,7 +109,7 @@
 	var/spawnpos = 1
 
 	var/obj/machinery/nuclearbomb/syndicate/the_bomb
-	if(nuke_spawn && synd_spawn.len > 0)
+	if(nuke_spawn && length(synd_spawn))
 		the_bomb = new /obj/machinery/nuclearbomb/syndicate(nuke_spawn.loc)
 		the_bomb.r_code = nuke_code
 
@@ -189,7 +189,7 @@
 	M.update_body()
 
 	if(the_bomb)
-		synd_mind.store_memory("<B>Syndicate [the_bomb.name] Code</B>: [the_bomb.r_code]", 0, 0)
+		synd_mind.store_memory("<B>Syndicate [the_bomb.name] Code</B>: [the_bomb.r_code]")
 		to_chat(synd_mind.current, "The code for \the [the_bomb.name] is: <B>[the_bomb.r_code]</B>")
 
 /datum/game_mode/proc/prepare_syndicate_leader(datum/mind/synd_mind, obj/machinery/nuclearbomb/syndicate/the_bomb)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -162,7 +162,7 @@
 			U.hidden_uplink.uses++
 			remainder--
 
-/datum/game_mode/proc/create_syndicate(datum/mind/synd_mind, var/obj/machinery/nuclearbomb/syndicate/the_bomb) // So we don't have inferior species as ops - randomize a human
+/datum/game_mode/proc/create_syndicate(datum/mind/synd_mind, obj/machinery/nuclearbomb/syndicate/the_bomb) // So we don't have inferior species as ops - randomize a human
 	var/mob/living/carbon/human/M = synd_mind.current
 
 	M.set_species(/datum/species/human, TRUE)
@@ -190,9 +190,9 @@
 
 	if(the_bomb)
 		synd_mind.store_memory("<B>Syndicate [the_bomb.name] Code</B>: [the_bomb.r_code]", 0, 0)
-		to_chat(synd_mind.current, "The [the_bomb.name] code is: <B>[the_bomb.r_code]</B>")
+		to_chat(synd_mind.current, "The code for \the [the_bomb.name] is: <B>[the_bomb.r_code]</B>")
 
-/datum/game_mode/proc/prepare_syndicate_leader(datum/mind/synd_mind, var/obj/machinery/nuclearbomb/syndicate/the_bomb)
+/datum/game_mode/proc/prepare_syndicate_leader(datum/mind/synd_mind, obj/machinery/nuclearbomb/syndicate/the_bomb)
 	var/leader_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord")
 	synd_mind.current.real_name = "[syndicate_name()] Team [leader_title]"
 	to_chat(synd_mind.current, "<B>You are the Syndicate leader for this mission. You are responsible for the distribution of telecrystals and your ID is the only one who can open the launch bay doors.</B>")
@@ -206,7 +206,7 @@
 
 	if(the_bomb)
 		var/obj/item/paper/P = new
-		P.info = "The [the_bomb.name] code is: <B>[the_bomb.r_code]</B>"
+		P.info = "The code for \the [the_bomb.name] is: <B>[the_bomb.r_code]</B>"
 		P.name = "nuclear bomb code"
 		var/obj/item/stamp/syndicate/stamp = new
 		P.stamp(stamp)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Places the nuke code into the memories of all operatives at round start, not the just leader. Also informs them all in chat, not just the leader.

## Why It's Good For The Game
For far too long nuke ops have been left cluelessly standing over a nuke, disk in hand, the crew hot on their trail with the only man who knew the code splattered across the captain's office. Their only recourse in this scenario was to plead to the gods for this oh-so-important information before they are blown to smithereens! No more!

In all seriousness, the leader dying and not sharing the code is a problem, since it usually falls on the admins to remind the surviving nukies the codes, an annoyance for nukies and admins both.

## Changelog
:cl:
tweak: All nuclear operatives are told and made to remember the nuke code at round start, not just the leader.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
