### PR TITLE
Removes Changeling Transformation Sting

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -66,60 +66,6 @@
 		add_attack_logs(user, target, "Unsuccessful sting (changeling)")
 	return 1
 
-/datum/action/changeling/sting/transformation
-	name = "Transformation Sting"
-	desc = "We silently sting a human, injecting a retrovirus that forces them to transform. Costs 50 chemicals."
-	helptext = "The victim will transform much like a changeling would. The effects will be obvious to the victim, and the process will damage our genomes."
-	button_icon_state = "sting_transform"
-	sting_icon = "sting_transform"
-	chemical_cost = 50
-	dna_cost = 3
-	genetic_damage = 100
-	var/datum/dna/selected_dna = null
-
-/datum/action/changeling/sting/transformation/Trigger()
-	var/mob/user = usr
-	var/datum/changeling/changeling = user.mind.changeling
-	if(changeling.chosen_sting)
-		unset_sting(user)
-		return
-	selected_dna = changeling.select_dna("Select the target DNA: ", "Target DNA")
-	if(!selected_dna)
-		return
-	if((NOTRANSSTING in selected_dna.species.species_traits) || selected_dna.species.is_small)
-		to_chat(user, "<span class='warning'>The selected DNA is incompatible with our sting.</span>")
-		return
-	..()
-
-/datum/action/changeling/sting/transformation/can_sting(mob/user, mob/target)
-	if(!..())
-		return
-	if(HAS_TRAIT(target, TRAIT_HUSK) || !ishuman(target) || (NOTRANSSTING in target.dna.species.species_traits))
-		to_chat(user, "<span class='warning'>Our sting appears ineffective against its DNA.</span>")
-		return FALSE
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(HAS_TRAIT(H, TRAIT_GENELESS))
-			to_chat(user, "<span class='warning'>This won't work on a creature without DNA.</span>")
-			return FALSE
-	return TRUE
-
-/datum/action/changeling/sting/transformation/sting_action(mob/user, mob/target)
-	add_attack_logs(user, target, "Transformation sting (changeling) (new identity is [selected_dna.real_name])")
-	if(issmall(target))
-		to_chat(user, "<span class='notice'>Our genes cry out as we sting [target.name]!</span>")
-
-	if(iscarbon(target) && (target.status_flags & CANWEAKEN))
-		var/mob/living/carbon/C = target
-		C.do_jitter_animation(500)
-
-	target.visible_message("<span class='danger'>[target] begins to violenty convulse!</span>","<span class='userdanger'>You feel a tiny prick and a begin to uncontrollably convulse!</span>")
-
-	spawn(10)
-		transform_dna(target,selected_dna)//target is always human so no problem here
-	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
-	return TRUE
-
 /datum/action/changeling/sting/extract_dna
 	name = "Extract DNA Sting"
 	desc = "We stealthily sting a target and extract their DNA. Costs 25 chemicals."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Removes Changeling Transformation Sting (no i dont care to improve it, this ability is literally just Grief Sting).
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
With the removal of Stable Mutagen, all this ability does is grief the people you use it on. Security rarely finds it to be anything other than a giant red flag that changelings are about, and I dont think I've seen it used for its intended purpose in my entire time of playing the game except MAYBE once.

## Changelog
:cl:
del: removes Transformation Sting from Changelings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
