### PR TITLE
Mentor Playtime Panel Tweaks

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -94,7 +94,7 @@
 #define EXP_TYPE_SERVICE		"Service"
 #define EXP_TYPE_WHITELIST		"Whitelist"
 
-#define EXP_DEPT_TYPE_LIST		list(EXP_TYPE_SERVICE, EXP_TYPE_MEDICAL, EXP_TYPE_ENGINEERING, EXP_TYPE_SCIENCE, EXP_TYPE_SECURITY, EXP_TYPE_COMMAND, EXP_TYPE_SILICON, EXP_TYPE_SPECIAL)
+#define EXP_DEPT_TYPE_LIST		list(EXP_TYPE_SUPPLY, EXP_TYPE_SERVICE, EXP_TYPE_MEDICAL, EXP_TYPE_ENGINEERING, EXP_TYPE_SCIENCE, EXP_TYPE_SECURITY, EXP_TYPE_COMMAND, EXP_TYPE_SILICON, EXP_TYPE_SPECIAL, EXP_TYPE_GHOST)
 
 // Defines just for parallax because its levels make storing it in the regular prefs a pain in the ass
 // These dont need to be bitflags because there isnt going to be more than one at a time of these active

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2630,7 +2630,7 @@
 		fax_panel(usr)
 
 	else if(href_list["getplaytimewindow"])
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN | R_MOD | R_MENTOR))
 			return
 		var/mob/M = locateUID(href_list["getplaytimewindow"])
 		if(!istype(M, /mob))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds Supply (Cargo) and Ghost hours to the Mentor/Admin 'Check Player Playtime' panel.
Also allows Mentors to open the individual 'Experience Panel', since it being blocked looks like an oversight.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
**Playtime Panel:**
1. All of the other departments are shown here, so Supply being excluded is defintely an oversight.
2. There's no real *benefit* to showing ghost hours, but the Experience Panel shows them and they're pretty interesting to see, so why not have it here too.

**Experience Panel:**
It being unavailable for Mentors seems unintentional, considering that:
1. The proc is called `cmd_mentor_show_exp_panel()`.
2. The actual proc itself allows Mentors to view it, it's just the link that's blocked.
https://github.com/ParadiseSS13/Paradise/blob/58d7054e92a2a67adf1e78da8ad524fdba8f2504/code/modules/admin/topic.dm#L2632-L2634
https://github.com/ParadiseSS13/Paradise/blob/58d7054e92a2a67adf1e78da8ad524fdba8f2504/code/game/jobs/job_exp.dm#L88-L97
3. There's really no downside to allowing it that I can see. It's just a more concise version of the existing panel.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
**Before:**
![dreamseeker_YaKBNtW9yL](https://user-images.githubusercontent.com/57483089/116945722-4d696700-ac70-11eb-8fbb-c91645865023.png)

**After:**
![dreamseeker_CKA347zard](https://user-images.githubusercontent.com/57483089/116945729-50645780-ac70-11eb-872d-6e298b28855f.png)

**Playtime Panel:**
![dreamseeker_U7iZ5KrZot](https://user-images.githubusercontent.com/57483089/116995677-45daaa00-acd2-11eb-9e4f-ec12f9fce2da.png)
*(Only just enabled playtime tracking so numbers are low.)*

## Changelog
:cl:
tweak: Added Supply and Ghost hours to the Mentor/Admin playtime panel.
tweak: Allowed Mentors to access the individual player playtime panel, on top of the server-wide one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
