### PR TITLE
Removes combat shotguns from cargo

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -391,20 +391,8 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 					/obj/item/storage/belt/bandolier,
 					/obj/item/storage/belt/bandolier,
 					/obj/item/storage/belt/bandolier)
-	cost = 50
-	containername = "riot shotgun crate"
-
-/datum/supply_packs/security/armory/ballisticauto
-	name = "Combat Shotguns Crate"
-	contains = list(/obj/item/gun/projectile/shotgun/automatic/combat,
-					/obj/item/gun/projectile/shotgun/automatic/combat,
-					/obj/item/gun/projectile/shotgun/automatic/combat,
-					/obj/item/storage/belt/bandolier,
-					/obj/item/storage/belt/bandolier,
-					/obj/item/storage/belt/bandolier)
 	cost = 80
-	containername = "combat shotgun crate"
-
+	containername = "riot shotgun crate"
 /datum/supply_packs/security/armory/buckshotammo
 	name = "Buckshot Ammo Crate"
 	contains = list(/obj/item/ammo_box/shotgun/buck,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR removes cargos ability to order combat shotguns, and increases riot shotgun crates from 50 to 80.
This PR does **not** remove combat shotguns in Gamma armoury, the only place crew will currently have access to them outside of direct admin spawning.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lets look at some weapon statistics for common weapons (and a not-so-common one).

### Combat shotgun:
7 round capacity with no cooldown, 60 damage per shot (slugs).
Potential damage per magazine: 420 (if using slugs)
~4 second mag empty
DPS: 105

### Riot shotgun:
As above, but requiring skill in timing pumps to rapidly empty the clip.
~9 second mag empty (using my poor skills)
DPS: 46

### Autorifle:
20 round magazine, forced cooldown between shots, 20dmg per shot.
Potential damage per magazine: 400 
~11 second mag empty
DPS: 36

### Laser carbine: (Red ERT and above)
20 round magazine, 2 shot burst, 20dmg per shot. 
Potential damage per magazine: 400 burn damage, no chance to break bones.
~7 second mag empty
DPS: 57

From this list, you can clearly see that the combat shotgun is horrendously unbalanced, even the most unrobust of users can empty the mag super fast doing devastating damage. It's TWICE the DPS of a red ERT weapon (a team that _should, by definition_ be better equipped than most station-side personnel.) not to mention the ERT weapon only does burn damage and cannot break bones. Burn damage currently just requires an automender to fix, a mag of slugs WILL break a bone or cause IB.

Combat shotguns, when paired with slugs, are too strong for station crew to have outside of emergencies. By keeping them to gamma armoury, this stops the horrid cheese we've seen lately where antags such as biohazards are completely destroyed.
Skilled players can still use riot shotguns for a high damage weapon, and I'm sure can push the DPS higher than I could manage.

Regarding the riot shotgun crate price increase, this is to bring it in line with the cost vs. DPS that we see on the other gun crates, plus it gets more guns per crate than the other lethal weapons cargo can order.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed combat shotgun crates from cargo
tweak: Riot shotgun crates now cost 80 points, not 50.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
