### PR TITLE
Combat shotgun and shell rebalance

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -417,7 +417,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	containername = "buckshot ammo crate"
 
 /datum/supply_packs/security/armory/slugammo
-	name = "Slug Ammo Crate"
+	name = "AP Slug Ammo Crate"
 	contains = list(/obj/item/ammo_box/shotgun,
 					/obj/item/storage/box/slug,
 					/obj/item/storage/box/slug,

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -736,7 +736,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/ammo/bulldog_XLmagsbag
 	name = "Bulldog - 12g XL Magazine Duffel Bag"
-	desc = "A duffel bag containing three 16 round drum magazines(Military Slug, Buckshot, Dragon's Breath)."
+	desc = "A duffel bag containing three 16 round drum magazines (Military Slug, Buckshot, Dragon's Breath)."
 	reference = "12XLDB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
 	cost = 12 // normally 18

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -689,7 +689,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 
 /datum/uplink_item/ammo/bullslug
-	name = "Bulldog - 12g Military Slug Magazine"
+	name = "Bulldog - 12g Magnum Slug Magazine"
 	desc = "An additional 8-round slug magazine for use in the Bulldog shotgun. Now 8 times less likely to shoot your pals."
 	reference = "12BSG"
 	item = /obj/item/ammo_box/magazine/m12g
@@ -736,7 +736,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/ammo/bulldog_XLmagsbag
 	name = "Bulldog - 12g XL Magazine Duffel Bag"
-	desc = "A duffel bag containing three 16 round drum magazines (Military Slug, Buckshot, Dragon's Breath)."
+	desc = "A duffel bag containing three 16 round drum magazines (Magnum Slug, Buckshot, Dragon's Breath)."
 	reference = "12XLDB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
 	cost = 12 // normally 18

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -689,12 +689,18 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 
 /datum/uplink_item/ammo/bullslug
-	name = "Bulldog - 12g Slug Magazine"
+	name = "Bulldog - 12g Syndicate Slug Magazine"
 	desc = "An additional 8-round slug magazine for use in the Bulldog shotgun. Now 8 times less likely to shoot your pals."
 	reference = "12BSG"
 	item = /obj/item/ammo_box/magazine/m12g
 	cost = 2
 	gamemodes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/bullslug/ap
+	name = "Bulldog - 12g AP Slug Magazine"
+	desc = "An additional 8-round slug magazine for use in the Bulldog shotgun. Sacrificing raw stopping power for armor penetration."
+	reference = "12BSGAP"
+	item = /obj/item/ammo_box/magazine/m12g/ap
 
 /datum/uplink_item/ammo/bullbuck
 	name = "Bulldog - 12g Buckshot Magazine"
@@ -730,7 +736,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/ammo/bulldog_XLmagsbag
 	name = "Bulldog - 12g XL Magazine Duffel Bag"
-	desc = "A duffel bag containing three 16 round drum magazines(Slug, Buckshot, Dragon's Breath)."
+	desc = "A duffel bag containing three 16 round drum magazines(Syndicate Slug, Buckshot, Dragon's Breath)."
 	reference = "12XLDB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
 	cost = 12 // normally 18

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -689,7 +689,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 
 /datum/uplink_item/ammo/bullslug
-	name = "Bulldog - 12g Syndicate Slug Magazine"
+	name = "Bulldog - 12g Military Slug Magazine"
 	desc = "An additional 8-round slug magazine for use in the Bulldog shotgun. Now 8 times less likely to shoot your pals."
 	reference = "12BSG"
 	item = /obj/item/ammo_box/magazine/m12g
@@ -736,7 +736,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/ammo/bulldog_XLmagsbag
 	name = "Bulldog - 12g XL Magazine Duffel Bag"
-	desc = "A duffel bag containing three 16 round drum magazines(Syndicate Slug, Buckshot, Dragon's Breath)."
+	desc = "A duffel bag containing three 16 round drum magazines(Military Slug, Buckshot, Dragon's Breath)."
 	reference = "12XLDB"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
 	cost = 12 // normally 18

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -157,7 +157,7 @@
 		new /obj/item/dnainjector/h2m(src)
 
 /obj/item/storage/box/slug
-	name = "Ammunition Box (AP Slug)"
+	name = "ammunition box (AP Slug)"
 	desc = "A small box capable of holding seven shotgun shells."
 	icon_state = "slugbox"
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -157,7 +157,7 @@
 		new /obj/item/dnainjector/h2m(src)
 
 /obj/item/storage/box/slug
-	name = "Ammunition Box (Slug)"
+	name = "Ammunition Box (AP Slug)"
 	desc = "A small box capable of holding seven shotgun shells."
 	icon_state = "slugbox"
 

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -141,11 +141,10 @@
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
-/obj/item/ammo_casing/shotgun/syndicate
-	name = "syndicate shotgun slug"
-	desc = "A modified 12 gauge lead slug commonly used by syndicate nuclear operatives. Sacrifices armor penetration for stopping power."
+/obj/item/ammo_casing/shotgun/military
+	name = "military shotgun slug"
+	desc = "A modified 12 gauge lead slug commonly used by military operatives. Sacrifices armor penetration for stopping power."
 	projectile_type = /obj/item/projectile/bullet
-	materials = null
 
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "buckshot shell"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -131,16 +131,21 @@
 	muzzle_flash_color = null
 
 /obj/item/ammo_casing/shotgun
-	name = "shotgun slug"
-	desc = "A 12 gauge lead slug."
+	name = "armor piercing shotgun slug"
+	desc = "A 12 gauge lead slug, effective at penetrating armor."
 	icon_state = "blshell"
 	caliber = "shotgun"
 	casing_drop_sound = 'sound/weapons/gun_interactions/shotgun_fall.ogg'
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/shotgun/slug
 	materials = list(MAT_METAL=4000)
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
+/obj/item/ammo_casing/shotgun/syndicate
+	name = "syndicate shotgun slug"
+	desc = "A modified 12 gauge lead slug commonly used by syndicate nuclear operatives. Sacrifices armor penetration for stopping power."
+	projectile_type = /obj/item/projectile/bullet
+	materials = null
 
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "buckshot shell"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -141,8 +141,8 @@
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
-/obj/item/ammo_casing/shotgun/military
-	name = "military shotgun slug"
+/obj/item/ammo_casing/shotgun/magnum
+	name = "magnum shotgun slug"
 	desc = "A modified 12 gauge lead slug commonly used by military operatives. Sacrifices armor penetration for stopping power."
 	projectile_type = /obj/item/projectile/bullet
 

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -376,14 +376,19 @@
 	multiple_sprites = 2
 
 /obj/item/ammo_box/magazine/m12g
-	name = "shotgun magazine (12g slugs)"
+	name = "shotgun magazine (12g syndicate slugs)"
 	desc = "A drum magazine."
 	icon_state = "m12gb"
-	ammo_type = /obj/item/ammo_casing/shotgun
+	ammo_type = /obj/item/ammo_casing/shotgun/syndicate
 	origin_tech = "combat=3;syndicate=1"
 	caliber = "shotgun"
 	max_ammo = 8
 	multiple_sprites = 2
+
+/obj/item/ammo_box/magazine/m12g/ap
+	name = "shotgun magazine (12g AP slugs)"
+	icon_state = "m12gb"
+	ammo_type = /obj/item/ammo_casing/shotgun
 
 /obj/item/ammo_box/magazine/m12g/buckshot
 	name = "shotgun magazine (12g buckshot slugs)"
@@ -416,7 +421,7 @@
 	desc = "An extra large drum magazine."
 	icon_state = "m12gXlSl"
 	w_class = WEIGHT_CLASS_NORMAL
-	ammo_type = /obj/item/ammo_casing/shotgun
+	ammo_type = /obj/item/ammo_casing/shotgun/syndicate
 	max_ammo = 16
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg/buckshot

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -376,10 +376,10 @@
 	multiple_sprites = 2
 
 /obj/item/ammo_box/magazine/m12g
-	name = "shotgun magazine (12g syndicate slugs)"
+	name = "shotgun magazine (12g military slugs)"
 	desc = "A drum magazine."
 	icon_state = "m12gb"
-	ammo_type = /obj/item/ammo_casing/shotgun/syndicate
+	ammo_type = /obj/item/ammo_casing/shotgun/military
 	origin_tech = "combat=3;syndicate=1"
 	caliber = "shotgun"
 	max_ammo = 8
@@ -417,12 +417,17 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/breaching
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg
-	name = "\improper XL shotgun magazine (12g slugs)"
+	name = "\improper XL shotgun magazine (12g military slugs)"
 	desc = "An extra large drum magazine."
 	icon_state = "m12gXlSl"
 	w_class = WEIGHT_CLASS_NORMAL
-	ammo_type = /obj/item/ammo_casing/shotgun/syndicate
+	ammo_type = /obj/item/ammo_casing/shotgun/military
 	max_ammo = 16
+
+/obj/item/ammo_box/magazine/m12g/XtrLrg/ap
+	name = "\improper XL shotgun magazine (12g AP slugs)"
+	ammo_type = /obj/item/ammo_casing/shotgun
+
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg/buckshot
 	name = "\improper XL shotgun magazine (12g buckshot)"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -376,10 +376,10 @@
 	multiple_sprites = 2
 
 /obj/item/ammo_box/magazine/m12g
-	name = "shotgun magazine (12g military slugs)"
+	name = "shotgun magazine (12g magnum slugs)"
 	desc = "A drum magazine."
 	icon_state = "m12gb"
-	ammo_type = /obj/item/ammo_casing/shotgun/military
+	ammo_type = /obj/item/ammo_casing/shotgun/magnum
 	origin_tech = "combat=3;syndicate=1"
 	caliber = "shotgun"
 	max_ammo = 8
@@ -417,11 +417,11 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/breaching
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg
-	name = "\improper XL shotgun magazine (12g military slugs)"
+	name = "\improper XL shotgun magazine (12g magnum slugs)"
 	desc = "An extra large drum magazine."
 	icon_state = "m12gXlSl"
 	w_class = WEIGHT_CLASS_NORMAL
-	ammo_type = /obj/item/ammo_casing/shotgun/military
+	ammo_type = /obj/item/ammo_casing/shotgun/magnum
 	max_ammo = 16
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg/ap

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -308,7 +308,7 @@
 	origin_tech = "combat=6"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
-	fire_delay = 8
+	fire_delay = 0.8 SECONDS
 
 //Dual Feed Shotgun
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -308,6 +308,7 @@
 	origin_tech = "combat=6"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
+	fire_delay = 8
 
 //Dual Feed Shotgun
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -7,10 +7,15 @@
 	hitsound_wall = "ricochet"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 
+/obj/item/projectile/bullet/shotgun/slug
+	name = "12 gauge AP slug"
+	damage = 35
+	armour_penetration = 25
+
 /obj/item/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	name = "beanbag slug"
 	damage = 5
-	stamina = 80
+	stamina = 60
 
 /obj/item/projectile/bullet/weakbullet/booze
 
@@ -82,15 +87,15 @@
 
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
-	damage = 12.5
+	damage = 10
 	tile_dropoff = 0.75
 	tile_dropoff_s = 1.25
-	armour_penetration = -30
+	armour_penetration = -27
 
 /obj/item/projectile/bullet/pellet/rubber
 	name = "rubber pellet"
 	damage = 3
-	stamina = 25
+	stamina = 13.3
 	icon_state = "bullet-r"
 
 /obj/item/projectile/bullet/pellet/weak

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -729,7 +729,7 @@
 	category = list("hacked", "Security")
 
 /datum/design/shotgun_slug
-	name = "Shotgun Slug"
+	name = "Shotgun AP Slug"
 	id = "shotgun_slug"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 4000)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR attempts to address some of the glaring issues with combat shotguns and their prevalent use as antag-enders.
Note: Balancing weapons is a difficult thing to get right as large scale data collection tools are not available. This PR is mainly based around common issues people have voiced, and takes player experience of using these weapons into consideration. This is an alternative to #15987 since people asked for a balance pass.

Changes made:

- Combat shotguns now have a fire delay of 0.8, as opposed to 0. This means it is now not possible to mag-dump all 7 shells within 5 seconds.
- Slugs have been renamed to Magnum Slugs, and are only available to nuclear operatives.
- AP Slugs added, these replace regular slugs in all station-related instances: Cargo, autolathes, etc. They have 35 instead of 60 damage, but have 25 armour penetration. Making them more suited for use against armoured targets.
- Buckshot has a slightly reduced damage, from 12.5 to 10 per pellet, armour penetration has been slightly buffed to compensate. This is to reduce their effectiveness against simple mobs (terrors, blob, xenobio, etc.) that don't use armour values, while still leaving them at nearly double the potential raw damage vs slugs.
- Rubber shot has been reduced to 13.3 stamina damage per pellet, leading to 80 potential per shot (down from 150).
- Beanbag slugs have been reduced to 60 stamina damage per shot from 80.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, combat shotguns are arguably the strongest weapons available to crew. They require no real skill to use, and absolutely obliterate simple mobs such as biohazards.
This attempts to improve their balance while not massively gimping them.
They have higher potential DPS than any station-side weapon still, but not like previously where they were over twice as good on paper.
The fire delay means you can still do a lot of burst damage but not nearly as much. This keeps their niche while making weapons such as the autorifle feasible for their niche (longer-lasting engagements due to ammo conservation.)
This also leaves the riot shotgun as an option for skilled players to rival combat shotguns, as if you are robust at the pump timing you can nearly match combat shotgun fire rates.

Slugs needed balancing since they were also part of the issue, it was not really much of a choice between slugs and buckshot previously due to slugs always doing max damage on hit, whereas buckshot has falloff and spread. Slugs now serve a niche role instead of a generalist one, armour piercing. Buckshot is useless vs armoured targets, so slugs with their armour penetration are still viable, while nerfing their use against non-armoured targets. For those, buckshot is still supreme, and still destroys simple mobs and unarmoured targets.

Regarding non-lethal ammunition. They were very strong on the off chance they got used for their purpose, doing 120 stam damage (instant stam crit) is incredibly strong currently, the only reason they are not used is due to lethal ammunition always being a better choice. By reducing their values slightly but not as much as the lethal ammunition was reduced, they remain a viable alternative that is still very strong in capable hands.

Ideally, this should be playtested a bit before introduction, paper balance changes can sound good but are sometimes off the mark. I'm not claiming to fix combat shotguns entirely, but this is certainly a much needed nerf, making other weapons more viable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: AP shotgun slugs, doing less overall damage but more effective against armour
tweak: Regular shotgun slugs are now called Magnum shotgun slugs
tweak: Combat shotguns now have a fire delay
tweak: Slightly reduced damage on buckshot, increased armour penetration slightly
tweak: Rubber and beanbag shot now do less stamina damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
