### PR TITLE
Optimizes handle_mutations_and_radiation. No more looping 55 times per human to do nothing

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_INIT(assigned_mutation_blocks, new(DNA_SE_LENGTH))
 // Used to determine what each block means (admin hax and species stuff on /vg/, mostly)
 GLOBAL_LIST_INIT(assigned_blocks, new(DNA_SE_LENGTH))
 
+/// Assoc list. Key = type of the mutation, value = the mutation
 GLOBAL_LIST_EMPTY(dna_mutations)
 
 GLOBAL_LIST_EMPTY(good_blocks)

--- a/code/game/dna/dna2_domutcheck.dm
+++ b/code/game/dna/dna2_domutcheck.dm
@@ -32,7 +32,7 @@
 	var/mutation_active = M.dna.GetSEState(mutation.block)
 
 	// Sanity checks, don't skip.
-	if(!mutation.can_activate(M, flags) && mutation_active)
+	if(mutation_active && !mutation.can_activate(M, flags))
 		//testing("[M] - Failed to activate [gene.name] (can_activate fail).")
 		return FALSE
 
@@ -46,11 +46,7 @@
 		if(mutation_active)
 			//testing("[gene.name] activated!")
 			mutation.activate(M)
-			if(M)
-				M.active_mutations |= mutation.type
 		// If Gene is NOT active:
 		else
 			//testing("[gene.name] deactivated!")
 			mutation.deactivate(M)
-			if(M)
-				M.active_mutations -= mutation.type

--- a/code/game/dna/mutations/_mutations.dm
+++ b/code/game/dna/mutations/_mutations.dm
@@ -32,6 +32,7 @@
 // Called when the gene activates.  Do your magic here.
 /datum/mutation/proc/activate(mob/living/M)
 	M.gene_stability -= instability
+	M.active_mutations |= type // |= is probably not required but just in case
 	for(var/thing in traits_to_add)
 		ADD_TRAIT(M, thing, GENETIC_MUTATION)
 	if(length(activation_messages))
@@ -43,6 +44,7 @@
 // Only called when the block is deactivated.
 /datum/mutation/proc/deactivate(mob/living/M)
 	M.gene_stability += instability
+	M.active_mutations -= type
 	for(var/thing in traits_to_add)
 		REMOVE_TRAIT(M, thing, GENETIC_MUTATION)
 	if(length(deactivation_messages))

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -114,18 +114,21 @@
 		if(G.block)
 			if(G.block in blocks_assigned)
 				warning("DNA2: Gene [G.name] trying to use already-assigned block [G.block] (used by [english_list(blocks_assigned[G.block])])")
-			GLOB.dna_mutations.Add(G)
+			GLOB.dna_mutations[mutation_type] = G
 			var/list/assignedToBlock[0]
 			if(blocks_assigned[G.block])
-				assignedToBlock=blocks_assigned[G.block]
+				assignedToBlock = blocks_assigned[G.block]
 			assignedToBlock.Add(G.name)
-			blocks_assigned[G.block]=assignedToBlock
+			blocks_assigned[G.block] = assignedToBlock
 			//testing("DNA2: Gene [G.name] assigned to block [G.block].")
+		else
+			qdel(G)
 
 	// I WILL HAVE A LIST OF MUTATIONS THAT MATCHES THE RANDOMIZED BLOCKS GODDAMNIT!
 	for(var/block in 1 to DNA_SE_LENGTH)
 		var/name = GLOB.assigned_blocks[block]
-		for(var/datum/mutation/mutation in GLOB.dna_mutations)
+		for(var/mutation_type in GLOB.dna_mutations)
+			var/datum/mutation/mutation = GLOB.dna_mutations[mutation_type]
 			if(mutation.name == name || mutation.block == block)
 				if(mutation.block in GLOB.assigned_mutation_blocks)
 					warning("DNA2: Mutation [mutation.name] trying to add to already assigned gene block list (used by [english_list(GLOB.assigned_mutation_blocks[block])])")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -170,11 +170,10 @@
 					emote("drool")
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
-	for(var/datum/mutation/mutation in GLOB.dna_mutations)
-		if(!mutation.block)
-			continue
-		if(mutation.is_active(src))
-			mutation.on_life(src)
+	for(var/mutation_type in active_mutations)
+		var/datum/mutation/mutation = GLOB.dna_mutations[mutation_type]
+		mutation.on_life(src)
+
 	if(!ignore_gene_stability && gene_stability < GENETIC_DAMAGE_STAGE_1)
 		var/instability = DEFAULT_GENE_STABILITY - gene_stability
 		if(prob(instability * 0.1))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -152,11 +152,9 @@
 				verb = pick("whinnies", "neighs", "says")
 
 		if(dna)
-			for(var/datum/mutation/mutation in GLOB.dna_mutations)
-				if(!mutation.block)
-					continue
-				if(mutation.is_active(src))
-					S.message = mutation.on_say(src, S.message)
+			for(var/mutation_type in active_mutations)
+				var/datum/mutation/mutation = GLOB.dna_mutations[mutation_type]
+				S.message = mutation.on_say(src, S.message)
 
 		var/braindam = getBrainLoss()
 		if(braindam >= 60)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -450,14 +450,13 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(gender == FEMALE)
 		g = "f"
 	// DNA2 - Drawing underlays.
-	for(var/datum/mutation/mutation in GLOB.dna_mutations)
-		if(!mutation.block)
-			continue
-		if(mutation.is_active(src))
-			var/underlay = mutation.on_draw_underlays(src, g)
-			if(underlay)
-				standing.underlays += underlay
-				add_image = 1
+	for(var/mutation_type in active_mutations)
+		var/datum/mutation/mutation = GLOB.dna_mutations[mutation_type]
+		var/underlay = mutation.on_draw_underlays(src, g)
+		if(underlay)
+			standing.underlays += underlay
+			add_image = TRUE
+
 	if(HAS_TRAIT(src, TRAIT_LASEREYES))
 		standing.overlays += "lasereyes_s"
 		add_image = 1

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -174,6 +174,7 @@
 
 	var/stance_damage = 0 //Whether this mob's ability to stand has been affected
 
+	/// List of the active mutation types
 	var/list/active_mutations = list()
 
 	var/last_movement = -100 // Last world.time the mob actually moved of its own accord.


### PR DESCRIPTION
## What Does This PR Do
Optimizes `handle_mutations_and_radiation` so it only loops over gene mutations that are actually active instead of looping over all possible gene mutations.

Test case involved gibbing all carbons first using `CALL gib() ON /mob/living/carbon`. Then spawning 101 unathis.
Profiler stats:
```
Proc Name                                                   Self CPU    Total CPU    Real Time     Overtime      Calls
Old
/mob/living/carbon/human/handle_mutations_and_radiation      0.140        0.192        0.190        0.000         1717
New
/mob/living/carbon/human/handle_mutations_and_radiation      0.009        0.012        0.012        0.000         2100
```
In this test case it saved a fuckton of self CPU and total CPU (it calls some procs in there) usage. Which was the goal here.

Profiler data from the live server:
```
Proc Name                                                  Self CPU    Total CPU    Real Time     Overtime        Calls
/mob/living/carbon/human/Life                              4.797        228.773        229.34        0.001        688526
/mob/living/carbon/human/handle_mutations_and_radiation    13.211        21.164        21.221        0.009        461744
```
Best case the total CPU cost will lower to about 2-3. This will mean about a 7% decrease in Life total CPU usage (rough estimates)

## Why It's Good For The Game
Saves the CPU some load without sacrificing features.

## Changelog
Purely technical