### PR TITLE
Fixes a minor runtime when double opening observe

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -198,7 +198,8 @@
 			QDEL_NULL(mind)
 			GLOB.respawnable_list += observer
 			qdel(src)
-			return 1
+			return TRUE
+		return FALSE
 	if(href_list["tos"])
 		privacy_consent()
 		return FALSE


### PR DESCRIPTION
## What Does This PR Do
Small runtime I found while testing
Fixes:
```
 Runtime in new_player.dm,25: /list {len = 1}a/chatDebug.lo7
   verb name: new player panel (/mob/new_player/verb/new_player_panel)
   usr: Farie82 () (/mob/new_player)
   src: Farie82 (/mob/new_player)
   src.loc: null
   call stack:
   Farie82 (/mob/new_player): new player panel()
   Farie82 (/mob/new_player): Topic("src=\[0x3000030]_88;observe=1", /list (/list))
   Farie82 (/client): Topic("src=\[0x3000030]_88;observe=1", /list (/list), Farie82 (/mob/new_player))
```

## Why It's Good For The Game
Gone b bug

## Changelog
None
