### PR TITLE
Fixes self surgery with beds

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -25,11 +25,6 @@
 	buckle_offset = -6
 	var/comfort = 2 // default comfort
 
-/obj/structure/bed/post_buckle_mob(mob/living/M)
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.drop_l_hand()
-		C.drop_r_hand() // no self surgery
 
 /obj/structure/bed/psych
 	name = "psych bed"
@@ -90,7 +85,6 @@
 		return ..()
 
 /obj/structure/bed/roller/post_buckle_mob(mob/living/M)
-	..()
 	density = TRUE
 	icon_state = "up"
 	M.pixel_y = initial(M.pixel_y)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -25,6 +25,12 @@
 	buckle_offset = -6
 	var/comfort = 2 // default comfort
 
+/obj/structure/bed/post_buckle_mob(mob/living/M)
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		C.drop_l_hand()
+		C.drop_r_hand() // no self surgery
+
 /obj/structure/bed/psych
 	name = "psych bed"
 	desc = "For prime comfort during psychiatric evaluations."
@@ -84,6 +90,7 @@
 		return ..()
 
 /obj/structure/bed/roller/post_buckle_mob(mob/living/M)
+	..()
 	density = TRUE
 	icon_state = "up"
 	M.pixel_y = initial(M.pixel_y)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -25,7 +25,6 @@
 	buckle_offset = -6
 	var/comfort = 2 // default comfort
 
-
 /obj/structure/bed/psych
 	name = "psych bed"
 	desc = "For prime comfort during psychiatric evaluations."

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -86,7 +86,7 @@
 /mob/living/update_canmove(delay_action_updates = 0)
 	var/fall_over = !can_stand()
 	var/buckle_lying = !(buckled && !buckled.buckle_lying)
-	if(fall_over || resting || stunned)
+	if(fall_over || resting || stunned || (buckled && buckle_lying != 0))
 		drop_r_hand()
 		drop_l_hand()
 	else

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -11,6 +11,9 @@
 								/obj/item/weldingtool = 30
 								)
 
+		if(M == user)
+			return // no self surgery
+
 		if(istype(M, /mob/living/carbon/human))
 			H = M
 			affecting = H.get_organ(check_zone(selected_zone))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You now drop items when you get buckled to beds so it is more consistent with resting.


## Why It's Good For The Game
You shouldn't be able to hold things if you cannot pick things up and you can exploit this to find where/if you have internal bleeding.



## Changelog
:cl:
fix: you can no longer start a  surgery on yourself with beds.
fix: buckling on a bed drops what you are holding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
