### PR TITLE
Adds a New Wizard Loudout in honor of Jordanius The Very Baldius

### DIFF
--- a/code/game/gamemodes/wizard/wizloadouts.dm
+++ b/code/game/gamemodes/wizard/wizloadouts.dm
@@ -71,3 +71,16 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(H), slot_gloves)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/syndicate(H), slot_w_uniform)
+
+/datum/spellbook_entry/loadout/jordanius
+	name = "Jordanius The Very Baldius"
+	desc = "Jordanius was mocked for being bald for such a long time, failure, after failure.<br> \
+		Now Jordanius has thrown down the gloves and will make the station pay for mocking him.<br> \
+		With this set, station will remember you, but not for your name, but for the death you leave behind you.<br> \
+		<i>With Recall, Spellblade, Blink, Etheral Jaunt, Blink, Disable Tech and a Necromantic Stone</i>"
+	log_name = "JTVB"
+	items_path = list(/obj/item/necromantic_stone, /obj/item/gun/magic/staff/spellblade)
+	spells_path = list(/obj/effect/proc_holder/spell/targeted/emplosion/disable_tech, /obj/effect/proc_holder/spell/targeted/ethereal_jaunt, \
+		/obj/effect/proc_holder/spell/targeted/summonitem, /obj/effect/proc_holder/spell/targeted/turf_teleport/blink)
+	category = "Unique"
+	destroy_spellbook = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This makes a new unique loadout in honor of Jordanius The Very Baldius.
The loadout contains Summon Item, Ethereal Jaunt, Blink, Disable Tech as the spells and Spellblade and the Necromantic Stone as support items.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Wizard is in a very weak state, considering there are routinely 100+ players online, this loadout if played correctly can be ver powerful both in effect against the crew, and create immense amounts of salt in dead chat.
Having a solid loadout that have a solid chance of causing chaos, and see rounds last beyond 20 minutes would be a huge improvement to the game, while this alone won't guarantee anything, it does give a solid amount of help.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/21987702/117733981-c6c60400-b1f2-11eb-9130-3d475f769c4a.png)

## Changelog
:cl: ppi
add: Add a new powerfull wizard loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
