### PR TITLE
Fixes infinite charge stunbaton and stunprod exploit

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -182,6 +182,10 @@
 		add_attack_logs(user, L, "stunned")
 	playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
 	deductcharge(hitcost)
+	if(cell.rigged)
+		cell = null
+		turned_on = FALSE
+		update_icon()
 
 
 /obj/item/melee/baton/emp_act(severity)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -76,6 +76,10 @@
 	if(!cell)
 		return
 	cell.use(amount)
+	if(cell.rigged)
+		cell = null
+		turned_on = FALSE
+		update_icon()
 	if(cell.charge < (hitcost)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
 		turned_on = FALSE
 		update_icon()
@@ -182,10 +186,6 @@
 		add_attack_logs(user, L, "stunned")
 	playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
 	deductcharge(hitcost)
-	if(cell.rigged)
-		cell = null
-		turned_on = FALSE
-		update_icon()
 
 
 /obj/item/melee/baton/emp_act(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This fixes an exploit involving plasma injected cells (rigged cells) when used in stunbatons and stunprods that let you use them infinitely without worrying about charge.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exploit bad.
Thanks to discord user UwU (Dj Philly Cheesesteak) for letting me know about this one and providing the video of it in use:

https://user-images.githubusercontent.com/12197162/117790911-b5581880-b241-11eb-9f5b-7da6d832a757.mp4


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed an exploit with stunbatons and rigged cells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
