### PR TITLE
Removes the construct shell from the beach gateway

### DIFF
--- a/_maps/map_files/RandomZLevels/beach.dmm
+++ b/_maps/map_files/RandomZLevels/beach.dmm
@@ -18,9 +18,6 @@
 	},
 /turf/simulated/floor/beach/away/water/deep/sand_floor,
 /area/awaymission/undersea)
-"af" = (
-/turf/simulated/floor/beach/away/water/deep/wood_floor,
-/area/awaymission/undersea)
 "ag" = (
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/beach/away/water/deep/wood_floor,
@@ -46311,7 +46308,7 @@ ad
 ad
 ad
 ah
-af
+ah
 ah
 ah
 ar
@@ -46822,7 +46819,7 @@ av
 av
 ad
 ad
-af
+ah
 ah
 ah
 ah
@@ -48107,7 +48104,7 @@ av
 av
 ad
 ad
-af
+ah
 ah
 ah
 ah
@@ -48624,7 +48621,7 @@ ad
 ad
 ad
 ah
-af
+ah
 ah
 ah
 ah

--- a/_maps/map_files/RandomZLevels/beach.dmm
+++ b/_maps/map_files/RandomZLevels/beach.dmm
@@ -19,7 +19,6 @@
 /turf/simulated/floor/beach/away/water/deep/sand_floor,
 /area/awaymission/undersea)
 "af" = (
-/obj/structure/constructshell,
 /turf/simulated/floor/beach/away/water/deep/wood_floor,
 /area/awaymission/undersea)
 "ag" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This PR removes the construct shell from the beach gateway.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This one might be a bit contriversal.
The chaplain has a holy soul stone, as most people know, that lets them turn 1 person into a shade, if they are willing. This has no issue. The main issue, is when a chaplain gets ahold of a construct shell, and makes an artificer. Suddenly, the chaplain can now create endless holy constructs that are loyal to chaplain, and are just as strong as normal constructs, with the same sprite, so long as there are willing bodies. Generaly, there are quite a few of them. While one holy construct is fine, an army of them can become quite a mess. Often, one of a few situations happen.

The chaplain gets an army of constructs, and it turns out to be a cult round. This leads to confusion on crew and cult side, of which constructs are loyal, and often leads to one side (usualy cult) being suddenly attacked by a construct they did not expect to be hostile, and ahelps to be made. It often also leads to validhunting jaunting constructs that find bases with ease, or juggernaughts smashing down doors everywhere.

The constructs see a crewmember attacking a artificer for building cult stuff in their bar / library / office / bridge, and then attack the crewmember. Other crewmemebers see this, start attacking constructs, constructs attack back, becomes a huge mess.

The constructs are used by a traitor chaplain, and crew gets confused when the "holy" constructs attack security, as they think they are loyal to the crew. This often again leads to a mess as both sides attack each other.

To avoid this issue, I propose removing the spawn in the beach gateway, leading to construct shells only being avalible to the chaplain if they get a shell from the cult, a wizard, or the admins, instead of showing up every time the beach gateway exists, potentialy screwing over modes like cult before they even really get started.

## Changelog
:cl:
del: Removed the construct shell from the beach gateway.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
