### PR TITLE
Axes Ratvar_Act() from the code

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -941,9 +941,6 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 /atom/proc/narsie_act()
 	return
 
-/atom/proc/ratvar_act()
-	return
-
 /**
  * Respond to an electric bolt action on our item
  *

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -195,11 +195,6 @@
 /obj/machinery/door/window/narsie_act()
 	color = NARSIE_WINDOW_COLOUR
 
-/obj/machinery/door/window/ratvar_act()
-	var/obj/machinery/door/window/clockwork/C = new(loc, dir)
-	C.name = name
-	qdel(src)
-
 /obj/machinery/door/window/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
 	if(exposed_temperature > T0C + (reinf ? 1600 : 800))
@@ -332,44 +327,6 @@
 	name = "cell door"
 	desc = "For keeping in criminal scum."
 	req_access = list(ACCESS_BRIG)
-
-/obj/machinery/door/window/clockwork
-	name = "brass windoor"
-	desc = "A thin door with translucent brass paneling."
-	icon_state = "clockwork"
-	base_state = "clockwork"
-	shards = 0
-	rods = 0
-	resistance_flags = ACID_PROOF | FIRE_PROOF
-	var/made_glow = FALSE
-
-/obj/machinery/door/window/clockwork/spawnDebris(location)
-	. = ..()
-	. = new /obj/item/stack/tile/brass(location, 2)
-
-/obj/machinery/door/window/clockwork/setDir(direct)
-	if(!made_glow)
-		var/obj/effect/E = new /obj/effect/temp_visual/ratvar/door/window(get_turf(src))
-		E.setDir(direct)
-		made_glow = TRUE
-	..()
-
-/obj/machinery/door/window/clockwork/emp_act(severity)
-	if(prob(80/severity))
-		open()
-
-/obj/machinery/door/window/clockwork/ratvar_act()
-	obj_integrity = max_integrity
-
-/obj/machinery/door/window/clockwork/hasPower()
-	return TRUE //yup that's power all right
-
-/obj/machinery/door/window/clockwork/narsie_act()
-	take_damage(rand(30, 60), BRUTE)
-	if(src)
-		var/previouscolor = color
-		color = "#960000"
-		animate(src, color = previouscolor, time = 8)
 
 /obj/machinery/door/window/northleft
 	dir = NORTH

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -328,6 +328,41 @@
 	desc = "For keeping in criminal scum."
 	req_access = list(ACCESS_BRIG)
 
+/obj/machinery/door/window/clockwork
+	name = "brass windoor"
+	desc = "A thin door with translucent brass paneling."
+	icon_state = "clockwork"
+	base_state = "clockwork"
+	shards = 0
+	rods = 0
+	resistance_flags = ACID_PROOF | FIRE_PROOF
+	var/made_glow = FALSE
+
+/obj/machinery/door/window/clockwork/spawnDebris(location)
+	. = ..()
+	. = new /obj/item/stack/tile/brass(location, 2)
+
+/obj/machinery/door/window/clockwork/setDir(direct)
+	if(!made_glow)
+		var/obj/effect/E = new /obj/effect/temp_visual/ratvar/door/window(get_turf(src))
+		E.setDir(direct)
+		made_glow = TRUE
+	..()
+
+/obj/machinery/door/window/clockwork/emp_act(severity)
+	if(prob(80/severity))
+		open()
+
+/obj/machinery/door/window/clockwork/hasPower()
+	return TRUE //yup that's power all right
+
+/obj/machinery/door/window/clockwork/narsie_act()
+	take_damage(rand(30, 60), BRUTE)
+	if(src)
+		var/previouscolor = color
+		color = "#960000"
+		animate(src, color = previouscolor, time = 8)
+
 /obj/machinery/door/window/northleft
 	dir = NORTH
 

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -120,10 +120,6 @@
 			name = "Unknown"
 			desc = "A cardboard cutout of a cultist."
 			icon_state = "cutout_cultist"
-		//if("Clockwork Cultist")
-		//	name = "[random_name(pick(MALE,FEMALE))]"
-		//	desc = "A cardboard cutout of a servant of Ratvar."
-		//	icon_state = "cutout_servant"
 		if("Revolutionary")
 			name = "Unknown"
 			desc = "A cardboard cutout of a revolutionary."

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -404,10 +404,6 @@ GLOBAL_LIST_INIT(cult_recipes, list ( \
 GLOBAL_LIST_INIT(brass_recipes, list (\
 	new/datum/stack_recipe("wall gear", /obj/structure/clockwork/wall_gear, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	null,
-	new/datum/stack_recipe/window("brass windoor", /obj/machinery/door/window/clockwork, 2, time = 30, on_floor = TRUE, window_checks = TRUE), \
-	null,
-	new/datum/stack_recipe/window("directional brass window", /obj/structure/window/reinforced/clockwork, time = 0, on_floor = TRUE, window_checks = TRUE), \
-	new/datum/stack_recipe/window("fulltile brass window", /obj/structure/window/reinforced/clockwork/fulltile, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("brass chair", /obj/structure/chair/brass, 1, time = 0, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("brass table frame", /obj/structure/table_frame/brass, 1, time = 5, one_per_turf = TRUE, on_floor = TRUE), \
 	))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -404,6 +404,10 @@ GLOBAL_LIST_INIT(cult_recipes, list ( \
 GLOBAL_LIST_INIT(brass_recipes, list (\
 	new/datum/stack_recipe("wall gear", /obj/structure/clockwork/wall_gear, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	null,
+	new/datum/stack_recipe/window("brass windoor", /obj/machinery/door/window/clockwork, 2, time = 30, on_floor = TRUE, window_checks = TRUE), \
+	null,
+	new/datum/stack_recipe/window("directional brass window", /obj/structure/window/reinforced/clockwork, time = 0, on_floor = TRUE, window_checks = TRUE), \
+	new/datum/stack_recipe/window("fulltile brass window", /obj/structure/window/reinforced/clockwork/fulltile, 2, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("brass chair", /obj/structure/chair/brass, 1, time = 0, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("brass table frame", /obj/structure/table_frame/brass, 1, time = 5, one_per_turf = TRUE, on_floor = TRUE), \
 	))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -115,10 +115,6 @@ GLOBAL_LIST_INIT(metal_recipes, list(
 /obj/item/stack/sheet/metal/fifty
 	amount = 50
 
-/obj/item/stack/sheet/metal/ratvar_act()
-	new /obj/item/stack/tile/brass(loc, amount)
-	qdel(src)
-
 /obj/item/stack/sheet/metal/narsie_act()
 	new /obj/item/stack/sheet/runed_metal(loc, amount)
 	qdel(src)
@@ -371,10 +367,6 @@ GLOBAL_LIST_INIT(cult_recipes, list ( \
 /obj/item/stack/sheet/runed_metal/New()
 	. = ..()
 	icon_state = SSticker.cultdat?.runed_metal_icon_state
-
-/obj/item/stack/sheet/runed_metal/ratvar_act()
-	new /obj/item/stack/tile/brass(loc, amount)
-	qdel(src)
 
 /obj/item/stack/sheet/runed_metal/attack_self(mob/living/user)
 	if(!iscultist(user))

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -51,10 +51,6 @@
 		if(0 to 40)
 			return "<span class='danger'>It looks heavily damaged.</span>"
 
-/obj/structure/falsewall/ratvar_act()
-	new /obj/structure/falsewall/brass(loc)
-	qdel(src)
-
 /obj/structure/falsewall/Destroy()
 	density = 0
 	air_update_turf(1)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -260,3 +260,34 @@
 	rods_broken = 0
 	grille_type = /obj/structure/grille
 	broken_type = null
+
+/obj/structure/grille/ratvar
+	icon_state = "ratvargrille"
+	name = "cog grille"
+	desc = "A strangely-shaped grille."
+	broken_type = /obj/structure/grille/ratvar/broken
+
+/obj/structure/grille/ratvar/Initialize(mapload)
+	. = ..()
+	if(broken)
+		new /obj/effect/temp_visual/ratvar/grille/broken(get_turf(src))
+	else
+		new /obj/effect/temp_visual/ratvar/grille(get_turf(src))
+		new /obj/effect/temp_visual/ratvar/beam/grille(get_turf(src))
+
+/obj/structure/grille/ratvar/narsie_act()
+	take_damage(rand(1, 3), BRUTE)
+	if(src)
+		var/previouscolor = color
+		color = "#960000"
+		animate(src, color = previouscolor, time = 8)
+
+/obj/structure/grille/ratvar/broken
+	icon_state = "brokenratvargrille"
+	density = FALSE
+	obj_integrity = 20
+	broken = TRUE
+	rods_amount = 1
+	rods_broken = 0
+	grille_type = /obj/structure/grille/ratvar
+	broken_type = null

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -55,13 +55,6 @@
 	if(!anchored)
 		. += "<span class='notice'>The anchoring screws are <i>unscrewed</i>. The rods look like they could be <b>cut</b> through.</span>"
 
-/obj/structure/grille/ratvar_act()
-	if(broken)
-		new /obj/structure/grille/ratvar/broken(loc)
-	else
-		new /obj/structure/grille/ratvar(loc)
-	qdel(src)
-
 /obj/structure/grille/Bumped(atom/user)
 	if(ismob(user))
 		if(!(shockcooldown <= world.time))
@@ -266,38 +259,4 @@
 	rods_amount = 1
 	rods_broken = 0
 	grille_type = /obj/structure/grille
-	broken_type = null
-
-/obj/structure/grille/ratvar
-	icon_state = "ratvargrille"
-	name = "cog grille"
-	desc = "A strangely-shaped grille."
-	broken_type = /obj/structure/grille/ratvar/broken
-
-/obj/structure/grille/ratvar/Initialize(mapload)
-	. = ..()
-	if(broken)
-		new /obj/effect/temp_visual/ratvar/grille/broken(get_turf(src))
-	else
-		new /obj/effect/temp_visual/ratvar/grille(get_turf(src))
-		new /obj/effect/temp_visual/ratvar/beam/grille(get_turf(src))
-
-/obj/structure/grille/ratvar/narsie_act()
-	take_damage(rand(1, 3), BRUTE)
-	if(src)
-		var/previouscolor = color
-		color = "#960000"
-		animate(src, color = previouscolor, time = 8)
-
-/obj/structure/grille/ratvar/ratvar_act()
-	return
-
-/obj/structure/grille/ratvar/broken
-	icon_state = "brokenratvargrille"
-	density = FALSE
-	obj_integrity = 20
-	broken = TRUE
-	rods_amount = 1
-	rods_broken = 0
-	grille_type = /obj/structure/grille/ratvar
 	broken_type = null

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -61,7 +61,6 @@
 
 /obj/structure/lattice/clockwork/Initialize(mapload)
 	. = ..()
-	ratvar_act()
 
 /obj/structure/lattice/catwalk
 	name = "catwalk"
@@ -98,7 +97,6 @@
 
 /obj/structure/lattice/catwalk/clockwork/Initialize(mapload)
 	. = ..()
-	ratvar_act()
 	if(!mapload)
 		new /obj/effect/temp_visual/ratvar/floor/catwalk(loc)
 		new /obj/effect/temp_visual/ratvar/beam/catwalk(loc)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -54,6 +54,15 @@
 	if(current_size >= STAGE_FOUR)
 		deconstruct()
 
+/obj/structure/lattice/clockwork
+	name = "cog lattice"
+	desc = "A lightweight support lattice. These hold the Justicar's station together."
+	icon = 'icons/obj/smooth_structures/lattice_clockwork.dmi'
+
+/obj/structure/lattice/clockwork/Initialize(mapload)
+	. = ..()
+	ratvar_act()
+
 /obj/structure/lattice/catwalk
 	name = "catwalk"
 	desc = "A catwalk for easier EVA maneuvering and cable placement."
@@ -77,3 +86,19 @@
 	for(var/obj/structure/cable/C in T)
 		C.deconstruct()
 	..()
+
+/obj/structure/lattice/catwalk/clockwork
+	name = "clockwork catwalk"
+	icon = 'icons/obj/smooth_structures/catwalk_clockwork.dmi'
+	canSmoothWith = list(/obj/structure/lattice,
+	/turf/simulated/floor,
+	/turf/simulated/wall,
+	/obj/structure/falsewall)
+	smooth = SMOOTH_MORE
+
+/obj/structure/lattice/catwalk/clockwork/Initialize(mapload)
+	. = ..()
+	ratvar_act()
+	if(!mapload)
+		new /obj/effect/temp_visual/ratvar/floor/catwalk(loc)
+		new /obj/effect/temp_visual/ratvar/beam/catwalk(loc)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -54,26 +54,6 @@
 	if(current_size >= STAGE_FOUR)
 		deconstruct()
 
-/obj/structure/lattice/clockwork
-	name = "cog lattice"
-	desc = "A lightweight support lattice. These hold the Justicar's station together."
-	icon = 'icons/obj/smooth_structures/lattice_clockwork.dmi'
-
-/obj/structure/lattice/clockwork/Initialize(mapload)
-	. = ..()
-	ratvar_act()
-
-/obj/structure/lattice/clockwork/ratvar_act()
-	if((x + y) % 2 != 0)
-		icon = 'icons/obj/smooth_structures/lattice_clockwork_large.dmi'
-		pixel_x = -9
-		pixel_y = -9
-	else
-		icon = 'icons/obj/smooth_structures/lattice_clockwork.dmi'
-		pixel_x = 0
-		pixel_y = 0
-	return TRUE
-
 /obj/structure/lattice/catwalk
 	name = "catwalk"
 	desc = "A catwalk for easier EVA maneuvering and cable placement."
@@ -97,30 +77,3 @@
 	for(var/obj/structure/cable/C in T)
 		C.deconstruct()
 	..()
-
-/obj/structure/lattice/catwalk/clockwork
-	name = "clockwork catwalk"
-	icon = 'icons/obj/smooth_structures/catwalk_clockwork.dmi'
-	canSmoothWith = list(/obj/structure/lattice,
-	/turf/simulated/floor,
-	/turf/simulated/wall,
-	/obj/structure/falsewall)
-	smooth = SMOOTH_MORE
-
-/obj/structure/lattice/catwalk/clockwork/Initialize(mapload)
-	. = ..()
-	ratvar_act()
-	if(!mapload)
-		new /obj/effect/temp_visual/ratvar/floor/catwalk(loc)
-		new /obj/effect/temp_visual/ratvar/beam/catwalk(loc)
-
-/obj/structure/lattice/catwalk/clockwork/ratvar_act()
-	if((x + y) % 2 != 0)
-		icon = 'icons/obj/smooth_structures/catwalk_clockwork_large.dmi'
-		pixel_x = -9
-		pixel_y = -9
-	else
-		icon = 'icons/obj/smooth_structures/catwalk_clockwork.dmi'
-		pixel_x = 0
-		pixel_y = 0
-	return TRUE

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -24,11 +24,6 @@
 		W.setDir(dir)
 		qdel(src)
 
-/obj/structure/chair/ratvar_act()
-	var/obj/structure/chair/brass/B = new(get_turf(src))
-	B.setDir(dir)
-	qdel(src)
-
 /obj/structure/chair/Move(atom/newloc, direct)
 	..()
 	handle_rotation()
@@ -440,9 +435,6 @@
 	turns++
 	if(turns >= 8)
 		STOP_PROCESSING(SSfastprocess, src)
-
-/obj/structure/chair/brass/ratvar_act()
-	return
 
 /obj/structure/chair/brass/AltClick(mob/living/user)
 	turns = 0

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -91,10 +91,6 @@
 	new /obj/structure/table_frame/wood(loc)
 	qdel(src)
 
-/obj/structure/table_frame/ratvar_act()
-	new /obj/structure/table_frame/brass(loc)
-	qdel(src)
-
 /*
  * Wooden Frames
  */

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -84,10 +84,6 @@
 	new /obj/structure/table/wood(loc)
 	qdel(src)
 
-/obj/structure/table/ratvar_act()
-	new /obj/structure/table/reinforced/brass(loc)
-	qdel(src)
-
 /obj/structure/table/do_climb(mob/living/user)
 	. = ..()
 	item_placed(user)
@@ -571,9 +567,6 @@
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
 
-/obj/structure/table/reinforced/brass/ratvar_act()
-	obj_integrity = max_integrity
-
 /obj/structure/table/tray
 	name = "surgical tray"
 	desc = "A small metal tray with wheels."
@@ -635,9 +628,6 @@
 	return 0
 
 /obj/structure/table/tray/narsie_act()
-	return 0
-
-/obj/structure/table/tray/ratvar_act()
 	return 0
 
 /*

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -72,13 +72,6 @@
 /obj/structure/window/narsie_act()
 	color = NARSIE_WINDOW_COLOUR
 
-/obj/structure/window/ratvar_act()
-	if(!fulltile)
-		new/obj/structure/window/reinforced/clockwork(get_turf(src), dir)
-	else
-		new/obj/structure/window/reinforced/clockwork/fulltile(get_turf(src))
-	qdel(src)
-
 /obj/structure/window/rpd_act()
 	return
 
@@ -724,10 +717,6 @@
 		E.setDir(direct)
 		made_glow = TRUE
 	..()
-
-/obj/structure/window/reinforced/clockwork/ratvar_act()
-	obj_integrity = max_integrity
-	update_nearby_icons()
 
 /obj/structure/window/reinforced/clockwork/narsie_act()
 	take_damage(rand(25, 75), BRUTE)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -234,11 +234,6 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	if(prob(20))
 		ChangeTurf(/turf/simulated/floor/engine/cult)
 
-/turf/simulated/floor/ratvar_act(force, ignore_mobs)
-	. = ..()
-	if(.)
-		ChangeTurf(/turf/simulated/floor/clockwork)
-
 /turf/simulated/floor/acid_melt()
 	ChangeTurf(baseturf)
 

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -15,9 +15,6 @@
 /turf/simulated/floor/indestructible/narsie_act()
 	return
 
-/turf/simulated/floor/indestructible/ratvar_act(force, ignore_mobs)
-	return
-
 /turf/simulated/floor/indestructible/burn_down()
 	return
 

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -176,11 +176,6 @@
 		QDEL_NULL(realappearence)
 	return ..()
 
-/turf/simulated/floor/clockwork/ReplaceWithLattice()
-	. = ..()
-	for(var/obj/structure/lattice/L in src)
-		L.ratvar_act()
-
 /turf/simulated/floor/clockwork/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -176,9 +176,6 @@
 		QDEL_NULL(realappearence)
 	return ..()
 
-/turf/simulated/floor/clockwork/ReplaceWithLattice()
-	. = ..()
-
 /turf/simulated/floor/clockwork/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -176,6 +176,9 @@
 		QDEL_NULL(realappearence)
 	return ..()
 
+/turf/simulated/floor/clockwork/ReplaceWithLattice()
+	. = ..()
+
 /turf/simulated/floor/clockwork/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -187,13 +187,6 @@
 /turf/simulated/floor/engine/cult/narsie_act()
 	return
 
-/turf/simulated/floor/engine/cult/ratvar_act()
-	. = ..()
-	if(istype(src, /turf/simulated/floor/engine/cult)) //if we haven't changed type
-		var/previouscolor = color
-		color = "#FAE48C"
-		animate(src, color = previouscolor, time = 8)
-
 //air filled floors; used in atmos pressure chambers
 
 /turf/simulated/floor/engine/n20

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -27,9 +27,6 @@
 /turf/simulated/wall/indestructible/narsie_act()
 	return
 
-/turf/simulated/wall/indestructible/ratvar_act(force, ignore_mobs)
-	return
-
 /turf/simulated/wall/indestructible/burn_down()
 	return
 

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -69,19 +69,6 @@
 	QDEL_NULL(realappearance)
 	return ..()
 
-/turf/simulated/wall/clockwork/ReplaceWithLattice()
-	..()
-	for(var/obj/structure/lattice/L in src)
-		L.ratvar_act()
-
-/turf/simulated/wall/clockwork/narsie_act()
-	..()
-	if(istype(src, /turf/simulated/wall/clockwork)) //if we haven't changed type
-		var/previouscolor = color
-		color = "#960000"
-		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
-
 /turf/simulated/wall/clockwork/dismantle_wall(devastated=0, explode=0)
 	if(devastated)
 		devastate_wall()
@@ -122,19 +109,3 @@
 		to_chat(M.occupant, "<span class='userdanger'>The wall's intense heat completely reflects your [M.name]'s attack!</span>")
 		M.take_damage(20, BURN)
 
-/turf/simulated/wall/clockwork/proc/turn_up_the_heat()
-	if(!heated)
-		name = "superheated [name]"
-		visible_message("<span class='warning'>[src] sizzles with heat!</span>")
-		playsound(src, 'sound/machines/fryer/deep_fryer_emerge.ogg', 50, TRUE)
-		heated = TRUE
-		hardness = -100 //Lower numbers are tougher, so this makes the wall essentially impervious to smashing
-		slicing_duration = 150
-		animate(realappearance, color = "#FFC3C3", time = 5)
-	else
-		name = initial(name)
-		visible_message("<span class='notice'>[src] cools down.</span>")
-		heated = FALSE
-		hardness = initial(hardness)
-		slicing_duration = initial(slicing_duration)
-		animate(realappearance, color = initial(realappearance.color), time = 25)

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -69,9 +69,6 @@
 	QDEL_NULL(realappearance)
 	return ..()
 
-/turf/simulated/wall/clockwork/ReplaceWithLattice()
-	..()
-
 /turf/simulated/wall/clockwork/narsie_act()
 	..()
 	if(istype(src, /turf/simulated/wall/clockwork)) //if we haven't changed type

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -69,6 +69,17 @@
 	QDEL_NULL(realappearance)
 	return ..()
 
+/turf/simulated/wall/clockwork/ReplaceWithLattice()
+	..()
+
+/turf/simulated/wall/clockwork/narsie_act()
+	..()
+	if(istype(src, /turf/simulated/wall/clockwork)) //if we haven't changed type
+		var/previouscolor = color
+		color = "#960000"
+		animate(src, color = previouscolor, time = 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
+
 /turf/simulated/wall/clockwork/dismantle_wall(devastated=0, explode=0)
 	if(devastated)
 		devastate_wall()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -508,15 +508,6 @@
 /turf/proc/can_lay_cable()
 	return can_have_cabling() & !intact
 
-/turf/ratvar_act(force, ignore_mobs, probability = 40)
-	. = (prob(probability) || force)
-	for(var/I in src)
-		var/atom/A = I
-		if(ignore_mobs && ismob(A))
-			continue
-		if(ismob(A) || .)
-			A.ratvar_act()
-
 /turf/proc/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	underlay_appearance.icon = icon
 	underlay_appearance.icon_state = icon_state


### PR DESCRIPTION
## What Does This PR Do
removes `ratvar_act()` from multiple files

this DOES NOT remove brass from the game and still allows the construction of brass buildings. Dead god ruin(ratvar) is still there and still works.

## Why It's Good For The Game
Clockwork cult is never getting added to this codebase. It's just bloat code and brass rarely ever gets used except in events or when a miner occasionally takes the brass from the dead god ruin. However I recognize the fun/aesthetic of brass objects and left most of them in.

## Changelog
:cl:
del: strips ratvars powers even further
/:cl: