### PR TITLE
Borgs can't use onclick when locked stunned, weakened or paralysed.

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -17,7 +17,7 @@
 
 	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
 		return
-	if(stat == DEAD || lockcharge || IsWeakened() || stunned || paralysis)
+	if(stat == DEAD || lockcharge || IsWeakened() || stunned || paralysis || low_power_mode)
 		return
 
 	var/list/modifiers = params2list(params)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -17,7 +17,7 @@
 
 	if(is_ventcrawling(src)) // To stop drones interacting with anything while ventcrawling
 		return
-	if(stat == DEAD)
+	if(stat == DEAD || lockcharge || IsWeakened() || stunned || paralysis)
 		return
 
 	var/list/modifiers = params2list(params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
This fixes an issue where lockeddown borgs can still interact with doors, on top of making sure stunned, weakend or paralyzed borgs can't do it either.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Per today, a lockeddown borg are not supposed to be able to interact with much outside of their radio, this fixes it

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: ppi
fix: Fixes oversight where locked down, stunned, weakened or paralysed borgs could interact with airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
