### PR TITLE
Server Update Update

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -92,7 +92,6 @@ GLOBAL_VAR(map_name) // Self explanatory
 GLOBAL_DATUM_INIT(data_core, /datum/datacore, new) // Station datacore, manifest, etc
 
 GLOBAL_VAR_INIT(panic_bunker_enabled, FALSE) // Is the panic bunker enabled
-GLOBAL_VAR_INIT(pending_server_update, FALSE)
 
 GLOBAL_LIST_EMPTY(ability_verbs) // Create-level abilities
 GLOBAL_LIST_INIT(pipe_colors, list("grey" = PIPE_COLOR_GREY, "red" = PIPE_COLOR_RED, "blue" = PIPE_COLOR_BLUE, "cyan" = PIPE_COLOR_CYAN, "green" = PIPE_COLOR_GREEN, "yellow" = PIPE_COLOR_YELLOW, "purple" = PIPE_COLOR_PURPLE))

--- a/code/datums/tgs_event_handler.dm
+++ b/code/datums/tgs_event_handler.dm
@@ -1,5 +1,15 @@
+/// Will our restart be slower?
+GLOBAL_VAR_INIT(slower_restart, FALSE)
+
+/proc/server_announce_global(announcement_text)
+	to_chat(world, "<span style='color: #ff00ff'>\[Server] [announcement_text]</span>")
+
+/proc/server_announce_adminonly(announcement_text)
+	to_chat(GLOB.admins, "<span style='color: #ff00ff'>\[Server]</span> <span class='adminsay'>\[Admin] [announcement_text]</span>")
+
 /datum/tgs_event_handler/impl
 	var/datum/timedevent/reattach_timer
+
 
 /datum/tgs_event_handler/impl/HandleEvent(event_code, ...)
 	switch(event_code)
@@ -7,33 +17,37 @@
 			var/list/reboot_mode_lookup = list ("[TGS_REBOOT_MODE_NORMAL]" = "be normal", "[TGS_REBOOT_MODE_SHUTDOWN]" = "shutdown the server", "[TGS_REBOOT_MODE_RESTART]" = "hard restart the server")
 			var/old_reboot_mode = args[2]
 			var/new_reboot_mode = args[3]
-			message_admins("\[Server]\[Info] Reboot will no longer [reboot_mode_lookup["[old_reboot_mode]"]], it will instead [reboot_mode_lookup["[new_reboot_mode]"]]")
+			if(new_reboot_mode == TGS_REBOOT_MODE_SHUTDOWN)
+				GLOB.slower_restart = TRUE
+			else
+				GLOB.slower_restart = FALSE
+			server_announce_adminonly("\[Info] Reboot will no longer [reboot_mode_lookup["[old_reboot_mode]"]], it will instead [reboot_mode_lookup["[new_reboot_mode]"]]")
 		if(TGS_EVENT_PORT_SWAP)
-			message_admins("\[Server]\[Info] Changing port from [world.port] to [args[2]]")
+			server_announce_adminonly("\[Info] Changing port from [world.port] to [args[2]]")
 		if(TGS_EVENT_INSTANCE_RENAMED)
-			message_admins("\[Server]\[Info] Instance renamed to from [world.TgsInstanceName()] to [args[2]]")
+			server_announce_adminonly("\[Info] Instance renamed to from [world.TgsInstanceName()] to [args[2]]")
 		if(TGS_EVENT_COMPILE_START)
-			message_admins("\[Server]\[Info] Code deployment started, new game version incoming next round...")
+			server_announce_adminonly("\[Info] Code deployment started, new game version incoming next round...")
 		if(TGS_EVENT_COMPILE_CANCELLED)
-			message_admins("\[Server]\[Warning] Code deployment cancelled!")
+			server_announce_adminonly("\[Warning] Code deployment cancelled! Consult a maintainer/host to see if this was intentional!")
 		if(TGS_EVENT_COMPILE_FAILURE)
-			message_admins("\[Server]\[Error] Code deployment failed! Inform a maintainer/host immediately!")
+			server_announce_adminonly("\[Error] Code deployment failed! Inform a maintainer/host immediately!")
 		if(TGS_EVENT_DEPLOYMENT_COMPLETE)
-			message_admins("\[Server]\[Info] Code deployment complete!")
-			to_chat(world, "<span class='boldannounce'>Server updated, changes will be applied on the next round...</span>")
+			server_announce_adminonly("\[Info] Code deployment complete!")
+			server_announce_global("Server update complete. Changes will be applied on the next round.")
 		if(TGS_EVENT_WATCHDOG_DETACH)
-			message_admins("\[Server]\[Info] Server manager restarting...")
+			server_announce_adminonly("\[Info] Server manager restarting...")
 			reattach_timer = addtimer(CALLBACK(src, .proc/LateOnReattach), 1 MINUTES, TIMER_STOPPABLE)
 		if(TGS_EVENT_WATCHDOG_REATTACH)
 			var/datum/tgs_version/old_version = world.TgsVersion()
 			var/datum/tgs_version/new_version = args[2]
 			if(!old_version.Equals(new_version))
-				message_admins("\[Server]\[Info] Manager back online. TGS has been updated to v[new_version.deprefixed_parameter]")
+				server_announce_adminonly("\[Info] Server manager back online. TGS has been updated to v[new_version.deprefixed_parameter]")
 			else
-				message_admins("\[Server]\[Info] Manager back online")
+				server_announce_adminonly("\[Info] Server manager back online")
 			if(reattach_timer)
 				deltimer(reattach_timer)
 				reattach_timer = null
 
 /datum/tgs_event_handler/impl/proc/LateOnReattach()
-	message_admins("\[Server]\[Warning] TGS hasn't notified us of it coming back for a full minute! Is there a problem?")
+	server_announce_adminonly("\[Warning] TGS hasn't notified us of it coming back for a full minute! Is there a problem?")

--- a/code/datums/tgs_event_handler.dm
+++ b/code/datums/tgs_event_handler.dm
@@ -5,7 +5,7 @@ GLOBAL_VAR_INIT(slower_restart, FALSE)
 	to_chat(world, "<span style='color: #ff00ff'>\[Server] [announcement_text]</span>")
 
 /proc/server_announce_adminonly(announcement_text)
-	to_chat(GLOB.admins, "<span style='color: #ff00ff'>\[Server]</span> <span class='adminsay'>\[Admin] [announcement_text]</span>")
+	to_chat(GLOB.admins, "<span style='color: #ff00ff'>\[Server] \[Admin] [announcement_text]</span>")
 
 /datum/tgs_event_handler/impl
 	var/datum/timedevent/reattach_timer

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -142,11 +142,11 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 	return
 	#endif
 
-	// If we had an update or pending TM, set a 60 second timeout
+	// If the server has been gracefully shutdown in TGS, have a 60 seconds grace period for SQL updates and stuff
 	var/secs_before_auto_reconnect = 10
-	if(GLOB.pending_server_update)
+	if(GLOB.slower_restart)
 		secs_before_auto_reconnect = 60
-		to_chat(world, "<span class='boldannounce'>Reboot will take a little longer, due to pending updates.</span>")
+		server_announce_global("Reboot will take a little longer due to pending backend changes.")
 
 	// Send the reboot banner to all players
 	for(var/client/C in GLOB.clients)

--- a/code/modules/world_topic/announce.dm
+++ b/code/modules/world_topic/announce.dm
@@ -4,8 +4,5 @@
 
 /datum/world_topic_handler/announce/execute(list/input, key_valid)
 	var/prtext = input["announce"]
-	var/pr_substring = copytext(prtext, 1, 23)
-	if(pr_substring == "Pull Request merged by")
-		GLOB.pending_server_update = TRUE
 	for(var/client/C in GLOB.clients)
 		to_chat(C, "<span class='announce'>PR: [prtext]</span>")

--- a/code/modules/world_topic/hostannounce.dm
+++ b/code/modules/world_topic/hostannounce.dm
@@ -1,7 +1,0 @@
-/datum/world_topic_handler/hostannounce
-	topic_key = "hostannounce"
-	requires_commskey = TRUE
-
-/datum/world_topic_handler/hostannounce/execute(list/input, key_valid)
-	GLOB.pending_server_update = TRUE
-	to_chat(world, "<hr><span style='color: #12A5F4'><b>Server Announcement:</b> [input["message"]]</span><hr>")

--- a/paradise.dme
+++ b/paradise.dme
@@ -2489,7 +2489,6 @@
 #include "code\modules\world_topic\_topic_base.dm"
 #include "code\modules\world_topic\adminmsg.dm"
 #include "code\modules\world_topic\announce.dm"
-#include "code\modules\world_topic\hostannounce.dm"
 #include "code\modules\world_topic\manifest.dm"
 #include "code\modules\world_topic\ping.dm"
 #include "code\modules\world_topic\players.dm"

--- a/tools/send2server.py
+++ b/tools/send2server.py
@@ -1,3 +1,6 @@
+#
+# This is now deprecated as of 2021-05-15
+#
 # Script to send world/Topic announcements to a server via automated tooling
 # Author: AffectedArc07
 # Takes a message as command line argument


### PR DESCRIPTION
## What Does This PR Do
Refactors the ingame update workflow to be more compliant with the new backend (TGS). Since updates are now seamless, we dont need the 60 seconds delay. That has now been repurposed as a timer for when we need to offline the server for SQL changes.

Also tweaks the admin and player messages to make them different 

Example how the new messages look
![image](https://user-images.githubusercontent.com/25063394/118376812-33118080-b5c2-11eb-8521-70da85abc9af.png)

## Why It's Good For The Game
Better updates

## Changelog
:cl: AffectedArc07
tweak: Server handles updating better
/:cl:
