### PR TITLE
SM engine APCs no longer short out during APC overload event. Again.

### DIFF
--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -46,6 +46,7 @@
 	// skip any APCs that are too critical to disable
 	var/list/skipped_areas_apc = list(
 		/area/engine/engineering,
+		/area/engine/supermatter,
 		/area/turret_protected/ai)
 	if(announce)
 		GLOB.event_announcement.Announce("Overload detected in [station_name()]'s powernet. Engineering, please repair shorted APCs.", "Systems Power Failure", new_sound = 'sound/AI/attention.ogg')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents the Supermatter APC from getting overloaded during the powernet overload event.

Fixes: #16027
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Supermatter APC was accidentally removed from the list of APCs that are exceptions for the event in PR #15199. This PR adds it again
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: APC overload event can no longer delaminate the SM.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
