### PR TITLE
Tajaran Sleek Veil Flashproofing

### DIFF
--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -5,39 +5,39 @@
 
 /datum/gear/racial/taj
 	display_name = "embroidered veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. Cannot be worn by non-Tajaran"
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."
 	path = /obj/item/clothing/glasses/tajblind
 	slot = slot_glasses
 
 /datum/gear/racial/taj/sec
 	display_name = "sleek veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built security HUD. Cannot be worn by non-Tajaran"
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built security HUD."
 	path = /obj/item/clothing/glasses/hud/security/tajblind
 	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Security Pod Pilot", "Internal Affairs Agent", "Magistrate")
 	cost = 2
 
 /datum/gear/racial/taj/med
 	display_name = "lightweight veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built medical HUD. Cannot be worn by non-Tajaran"
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built medical HUD."
 	path = /obj/item/clothing/glasses/hud/health/tajblind
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Brig Physician" , "Coroner")
 	cost = 2
 
 /datum/gear/racial/taj/sci
 	display_name = "hi-tech veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. Cannot be worn by non-Tajaran"
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."
 	path = /obj/item/clothing/glasses/tajblind/sci
 	cost = 2
 
 /datum/gear/racial/taj/eng
 	display_name = "industrial veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. Cannot be worn by non-Tajaran"
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."
 	path = /obj/item/clothing/glasses/tajblind/eng
 	cost = 2
 
 /datum/gear/racial/taj/cargo
 	display_name = "khaki veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. It is light and comfy! Cannot be worn by non-Tajaran"
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. It is light and comfy!"
 	path = /obj/item/clothing/glasses/tajblind/cargo
 	cost = 2
 

--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -5,42 +5,42 @@
 
 /datum/gear/racial/taj
 	display_name = "embroidered veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. Cannot be worn by non-Tajaran"
 	path = /obj/item/clothing/glasses/tajblind
 	slot = slot_glasses
 
 /datum/gear/racial/taj/sec
 	display_name = "sleek veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built security HUD."
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built security HUD. Cannot be worn by non-Tajaran"
 	path = /obj/item/clothing/glasses/hud/security/tajblind
 	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Security Pod Pilot", "Internal Affairs Agent", "Magistrate")
 	cost = 2
 
 /datum/gear/racial/taj/med
 	display_name = "lightweight veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built medical HUD."
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built medical HUD. Cannot be worn by non-Tajaran"
 	path = /obj/item/clothing/glasses/hud/health/tajblind
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Brig Physician" , "Coroner")
 	cost = 2
 
 /datum/gear/racial/taj/sci
 	display_name = "hi-tech veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. Cannot be worn by non-Tajaran"
 	path = /obj/item/clothing/glasses/tajblind/sci
 	cost = 2
 
 /datum/gear/racial/taj/eng
 	display_name = "industrial veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races."
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. Cannot be worn by non-Tajaran"
 	path = /obj/item/clothing/glasses/tajblind/eng
 	cost = 2
-	
+
 /datum/gear/racial/taj/cargo
 	display_name = "khaki veil"
-	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. It is light and comfy!"
+	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. It is light and comfy! Cannot be worn by non-Tajaran"
 	path = /obj/item/clothing/glasses/tajblind/cargo
 	cost = 2
-	
+
 /datum/gear/racial/footwraps
 	display_name = "cloth footwraps"
 	path = /obj/item/clothing/shoes/footwraps

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -487,6 +487,7 @@
 	desc = "An Ahdominian made veil that allows the user to see while obscuring their eyes."
 	icon_state = "tajblind"
 	item_state = "tajblind"
+	species_restricted = list("Tajaran")
 	flags_cover = GLASSESCOVERSEYES
 	actions_types = list(/datum/action/item_action/toggle)
 	up = 0
@@ -502,16 +503,19 @@
 	name = "industrial veil"
 	icon_state = "tajblind_engi"
 	item_state = "tajblind_engi"
+	species_restricted = list("Tajaran")
 
 /obj/item/clothing/glasses/tajblind/sci
 	name = "hi-tech veil"
 	icon_state = "tajblind_sci"
 	item_state = "tajblind_sci"
+	species_restricted = list("Tajaran")
 
 /obj/item/clothing/glasses/tajblind/cargo
 	name = "khaki veil"
 	icon_state = "tajblind_cargo"
 	item_state = "tajblind_cargo"
+	species_restricted = list("Tajaran")
 
 /obj/item/clothing/glasses/tajblind/attack_self()
 	toggle_veil()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -487,7 +487,6 @@
 	desc = "An Ahdominian made veil that allows the user to see while obscuring their eyes."
 	icon_state = "tajblind"
 	item_state = "tajblind"
-	species_restricted = list("Tajaran")
 	flags_cover = GLASSESCOVERSEYES
 	actions_types = list(/datum/action/item_action/toggle)
 	up = 0
@@ -503,19 +502,16 @@
 	name = "industrial veil"
 	icon_state = "tajblind_engi"
 	item_state = "tajblind_engi"
-	species_restricted = list("Tajaran")
 
 /obj/item/clothing/glasses/tajblind/sci
 	name = "hi-tech veil"
 	icon_state = "tajblind_sci"
 	item_state = "tajblind_sci"
-	species_restricted = list("Tajaran")
 
 /obj/item/clothing/glasses/tajblind/cargo
 	name = "khaki veil"
 	icon_state = "tajblind_cargo"
 	item_state = "tajblind_cargo"
-	species_restricted = list("Tajaran")
 
 /obj/item/clothing/glasses/tajblind/attack_self()
 	toggle_veil()

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -171,7 +171,7 @@
 	desc = "An Ahdominian made veil that allows the user to see while obscuring their eyes. This one has an in-built security HUD."
 	icon_state = "tajblind_sec"
 	item_state = "tajblind_sec"
-	flash_protect = 1
+	flash_protect = FLASH_PROTECTION_FLASH
 	flags_cover = GLASSESCOVERSEYES
 	actions_types = list(/datum/action/item_action/toggle)
 	up = 0

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -172,7 +172,6 @@
 	icon_state = "tajblind_sec"
 	item_state = "tajblind_sec"
 	flash_protect = 1
-	species_restricted = list("Tajaran")
 	flags_cover = GLASSESCOVERSEYES
 	actions_types = list(/datum/action/item_action/toggle)
 	up = 0

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -171,6 +171,8 @@
 	desc = "An Ahdominian made veil that allows the user to see while obscuring their eyes. This one has an in-built security HUD."
 	icon_state = "tajblind_sec"
 	item_state = "tajblind_sec"
+	flash_protect = 1
+	species_restricted = list("Tajaran")
 	flags_cover = GLASSESCOVERSEYES
 	actions_types = list(/datum/action/item_action/toggle)
 	up = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds flash immunity to the Sleek Veil, bringing it up to spec with the standard Security HUD sunglasses. ~~Also adds species restriction to all of the veils, so that only Tajaran can wear them~~

## Why It's Good For The Game
Tajaran sec officers shouldn't have to nerf themselves in order to flavour their character with lore-specific gear. Choosing the sleek veil over a standard set of HUD sunglasses was always a disadvantage, and shouldn't be when every officer has access to them from roundstart. ~~There is no reason why another race should be able to spawn with veils, given the stated lore on them. Gives Taj a reason to follow their lore regarding veils.~~

## Changelog
:cl:
add: Adds the flash_protect ability to the Sleek Veil
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
