### PR TITLE
Removes the early classified announcement from the blob gamemode

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -15,7 +15,6 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	recommended_enemies = 1
 	restricted_jobs = list("Cyborg", "AI")
 
-	var/declared = 0
 	var/burst = 0
 
 	var/cores_to_spawn = 1
@@ -177,12 +176,8 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 		burst_blobs()
 
-		// Stage 0
-		sleep(wait_time)
-		stage(0)
-
 		// Stage 1
-		sleep(wait_time)
+		sleep((wait_time * 2))
 		stage(1)
 
 		// Stage 2
@@ -193,13 +188,10 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /datum/game_mode/blob/proc/stage(stage)
 	switch(stage)
-		if(0)
-			send_intercept(1)
-			declared = 1
 		if(1)
 			GLOB.event_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 		if(2)
-			send_intercept(2)
+			send_intercept(1)
 
 /datum/game_mode/proc/update_blob_icons_added(datum/mind/mob_mind)
 	var/datum/atom_hud/antag/antaghud = GLOB.huds[ANTAG_HUD_BLOB]

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	log_game("[key_name(blob)] has been selected as a Blob")
 	greet_blob(blobmind)
 	to_chat(blob, "<span class='userdanger'>You feel very tired and bloated!  You don't have long before you burst!</span>")
-	addtimer(CALLBACK(src, .proc/burst_blob, blobmind), 600)
+	addtimer(CALLBACK(src, .proc/burst_blob, blobmind), 60 SECONDS)
 	return 1
 
 /datum/game_mode/blob/proc/make_blobs(count)
@@ -126,7 +126,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 				if(!warned)
 					to_chat(C, "<span class='userdanger'>You feel ready to burst, but this isn't an appropriate place!  You must return to the station!</span>")
 					message_admins("[key_name_admin(C)] was in space when the blobs burst, and will die if [C.p_they()] [C.p_do()] not return to the station.")
-					addtimer(CALLBACK(src, .proc/burst_blob, blob, 1), 300)
+					addtimer(CALLBACK(src, .proc/burst_blob, blob, 1), 30 SECONDS)
 				else
 					burst++
 					log_admin("[key_name(C)] was in space when attempting to burst as a blob.")
@@ -176,7 +176,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		addtimer(CALLBACK(src, .proc/stage, 1), (wait_time * 2))
 
 		// Stage 2
-		addtimer(CALLBACK(src, .proc/stage, 2), 30000)
+		addtimer(CALLBACK(src, .proc/stage, 2), 50 MINUTES)
 
 	return ..()
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -74,8 +74,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	log_game("[key_name(blob)] has been selected as a Blob")
 	greet_blob(blobmind)
 	to_chat(blob, "<span class='userdanger'>You feel very tired and bloated!  You don't have long before you burst!</span>")
-	spawn(600)
-		burst_blob(blobmind)
+	addtimer(CALLBACK(src, .proc/burst_blob, blobmind), 600)
 	return 1
 
 /datum/game_mode/blob/proc/make_blobs(count)
@@ -127,8 +126,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 				if(!warned)
 					to_chat(C, "<span class='userdanger'>You feel ready to burst, but this isn't an appropriate place!  You must return to the station!</span>")
 					message_admins("[key_name_admin(C)] was in space when the blobs burst, and will die if [C.p_they()] [C.p_do()] not return to the station.")
-					spawn(300)
-						burst_blob(blob, 1)
+					addtimer(CALLBACK(src, .proc/burst_blob, blob, 1), 300)
 				else
 					burst++
 					log_admin("[key_name(C)] was in space when attempting to burst as a blob.")
@@ -172,17 +170,13 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 		show_message("<span class='userdanger'>You feel like you are about to burst.</span>")
 
-		sleep(wait_time / 2)
-
-		burst_blobs()
+		addtimer(CALLBACK(src, .proc/burst_blobs), (wait_time * 2))
 
 		// Stage 1
-		sleep((wait_time * 2))
-		stage(1)
+		addtimer(CALLBACK(src, .proc/stage, 1), (wait_time * 2))
 
 		// Stage 2
-		sleep(30000)
-		stage(2)
+		addtimer(CALLBACK(src, .proc/stage, 2), 30000)
 
 	return ..()
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -170,10 +170,10 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 		show_message("<span class='userdanger'>You feel like you are about to burst.</span>")
 
-		addtimer(CALLBACK(src, .proc/burst_blobs), (wait_time * 2))
+		addtimer(CALLBACK(src, .proc/burst_blobs), (wait_time / 2))
 
 		// Stage 1
-		addtimer(CALLBACK(src, .proc/stage, 1), (wait_time * 2))
+		addtimer(CALLBACK(src, .proc/stage, 1), (wait_time * 2 + wait_time / 2))
 
 		// Stage 2
 		addtimer(CALLBACK(src, .proc/stage, 2), 50 MINUTES)

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -26,7 +26,6 @@
 		to_chat(world, "<FONT size = 3><B>The staff has won!</B></FONT>")
 		to_chat(world, "<B>The alien organism has been eradicated from the station</B>")
 		log_game("Blob mode completed with a crew victory.")
-		to_chat(world, "<span class='notice'>Rebooting in 30s</span>")
 	..()
 	return 1
 

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -5,19 +5,6 @@
 		if(0)
 			return
 		if(1)
-			interceptname = "Level 5-6 Biohazard Response Procedures"
-			intercepttext += "<FONT size = 3><B>Nanotrasen Update</B>: Biohazard Alert.</FONT><HR>"
-			intercepttext += "Reports indicate the probable transfer of a biohazardous agent onto [station_name()] during the last crew deployment cycle.<BR>"
-			intercepttext += "Preliminary analysis of the organism classifies it as a level 5 biohazard. Its origin is unknown.<BR>"
-			intercepttext += "Nanotrasen has issued a directive 7-10 for [station_name()]. The station is to be considered quarantined.<BR>"
-			intercepttext += "Orders for all [station_name()] personnel follows:<BR>"
-			intercepttext += " 1. Do not leave the quarantine area.<BR>"
-			intercepttext += " 2. Locate any outbreaks of the organism on the station.<BR>"
-			intercepttext += " 3. If found, use any neccesary means to contain the organism.<BR>"
-			intercepttext += " 4. Avoid damage to the capital infrastructure of the station.<BR>"
-			intercepttext += "<BR>Note in the event of a quarantine breach or uncontrolled spread of the biohazard, the directive 7-10 may be upgraded to a directive 7-12.<BR>"
-			intercepttext += "Message ends."
-		if(2)
 			var/nukecode = rand(10000, 99999)
 			for(var/obj/machinery/nuclearbomb/bomb in GLOB.machines)
 				if(bomb && bomb.r_code)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
##This does _not_ remove the level 5 bio hazard announcement.

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

Removes the classified announcement sent before the level 5 biohazard warning on blob rounds, and the paper that goes with it.
Also removes the declared variable, which does nothing.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Roundstart blob often has it hard, but often it is spotted quite fast. When it is not spotted fast, it has a larger issue.

![image](https://user-images.githubusercontent.com/52090703/118717628-4dcb3b80-b7f4-11eb-979b-b61394629acd.png)

This message will play. Without fail, even before anyone reads the paper, some crew will scream out blob, even if they do not see the paper and what it says. or the blob. This is silly, that crew instantly presume this message is a blob announcement. 
And of course, barring meta, this announcement can come really fast on a blob round.
Thus, this PR removes this announcement.

## Changelog
:cl:
tweak: Removes the early biohazard warning on blob rounds, but not the level 5 biohazard warning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
