### PR TITLE
Player terror spiders now have their own orbit category

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -114,6 +114,12 @@
 						antag_serialized["antag"] = antag_name
 						antagonists += list(antag_serialized)
 
+				// Player terror spiders have their own category to help see how much there are.
+				// Not in the above block because terrors can be known whether AHUD is on or not.
+				if(isterrorspider(M))
+					var/antag_serialized = serialized.Copy()
+					antag_serialized["antag"] = "Terror Spider"
+					antagonists += list(antag_serialized)
 		else
 			misc += list(serialized)
 

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -117,7 +117,7 @@
 				// Player terror spiders have their own category to help see how much there are.
 				// Not in the above block because terrors can be known whether AHUD is on or not.
 				if(isterrorspider(M))
-					var/antag_serialized = serialized.Copy()
+					var/list/antag_serialized = serialized.Copy()
 					antag_serialized["antag"] = "Terror Spider"
 					antagonists += list(antag_serialized)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
- Adds a Terror Spider antagonist category in the Orbit menu. Unlike other antagonists, this category always shows regardless of AHUD.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- Helps distinguish how many player terror spiders there are alive.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/1496804/118844069-f1871b00-b8ca-11eb-95f4-75475838ed92.png)

## Changelog
:cl:
add: Terror spider category in the orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
