### PR TITLE
Adds Vox Specific Tourettes

### DIFF
--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -85,7 +85,10 @@
 			if(1)
 				H.emote("twitch")
 			if(2 to 3)
-				H.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
+				if(isvox(H))
+					H.say("[prob(50) ? ";" : ""][pick("SKREK", "DUSTLUNG SKREKS", "TREELESS SKREKS")]")
+				else
+					H.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
 		var/x_offset_old = H.pixel_x
 		var/y_offset_old = H.pixel_y
 		var/x_offset = H.pixel_x + rand(-2, 2)

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -86,7 +86,7 @@
 				H.emote("twitch")
 			if(2 to 3)
 				if(isvox(H))
-					H.say("[prob(50) ? ";" : ""][pick("SKREK", "DUSTLUNG SKREKS", "TREELESS SKREKS")]")
+					H.say("[prob(50) ? ";" : ""][pick("SKREK", "DUSTLUNG SKREKS", "TREELESS SKREKS", "STUPID MEATS", "IS BADS!", "SKREKKING MEATS", "SKREK OFFS")]")
 				else
 					H.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
 		var/x_offset_old = H.pixel_x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the Tourettes disability so that Vox actually swear like Vox, using a simple species check and choosing the appropriate list. Currently there is only three options for the Vox to say, but I can easily alter that list and add/remove if need be before any merging occurs. (Comment if you have any ideas!)

Also first PR, so _highly_ likely I've messed up the commit or branch or fork or whatever cutlery Github uses.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A minor change to keep Vox more in line with their lore based epithets and slurs. Mainly for added flavour than anything actually game changing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl: Joniroq
add: Added Vox specific swears for Tourettes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
