### PR TITLE
Adds hardened versions of thermal and x ray eyes and replaces old ones bought by nuke ops

### DIFF
--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -93,7 +93,7 @@
 		/obj/item/implant/dust
 	)
 	cybernetic_implants = list(
-		/obj/item/organ/internal/eyes/cybernetic/xray,
+		/obj/item/organ/internal/eyes/cybernetic/xray/hardened,
 		/obj/item/organ/internal/cyberimp/brain/anti_stun/hardened,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/arm/combat/centcom

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -89,10 +89,10 @@
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/gun/laser
 
 /obj/item/autosurgeon/organ/syndicate/thermal_eyes
-	starting_organ = /obj/item/organ/internal/eyes/cybernetic/thermals
+	starting_organ = /obj/item/organ/internal/eyes/cybernetic/thermals/hardened
 
 /obj/item/autosurgeon/organ/syndicate/xray_eyes
-	starting_organ = /obj/item/organ/internal/eyes/cybernetic/xray
+	starting_organ = /obj/item/organ/internal/eyes/cybernetic/xray/hardened
 
 /obj/item/autosurgeon/organ/syndicate/anti_stun
 	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_stun/hardened

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -155,7 +155,7 @@
 
 /obj/item/organ/internal/eyes/cybernetic/thermals/hardened
 	name = "hardened thermal eyes"
-	desc = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included.This pair has been hardened for special opertaions personnel"
+	desc = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included. This pair has been hardened for special operations personnel."
 	emp_proof = TRUE
 	origin_tech = "materials=6;programming=5;biotech=6;magnets=6;syndicate=3"
 

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -137,6 +137,12 @@
 	vision_flags = SEE_MOBS | SEE_OBJS | SEE_TURFS
 	origin_tech = "materials=4;programming=4;biotech=7;magnets=4"
 
+/obj/item/organ/internal/eyes/cybernetic/xray/hardened
+	name = "hardened X-ray eyes"
+	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile.This pair has been hardened for special operations personnel"
+	emp_proof = TRUE
+	origin_tech = "materials=6;programming=5;biotech=7;magnets=6;syndicate=3"
+
 /obj/item/organ/internal/eyes/cybernetic/thermals
 	name = "thermal eyes"
 	desc = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included."
@@ -146,6 +152,12 @@
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 	see_in_dark = 8
 	origin_tech = "materials=5;programming=4;biotech=4;magnets=4;syndicate=1"
+
+/obj/item/organ/internal/eyes/cybernetic/thermals/hardened
+	name = "hardened thermal eyes"
+	desc = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included.This pair has been hardened for special opertaions personnel"
+	emp_proof = TRUE
+	origin_tech = "materials=6;programming=5;biotech=6;magnets=6;syndicate=3"
 
 /obj/item/organ/internal/eyes/cybernetic/flashlight
 	name = "flashlight eyes"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -139,7 +139,7 @@
 
 /obj/item/organ/internal/eyes/cybernetic/xray/hardened
 	name = "hardened X-ray eyes"
-	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile.This pair has been hardened for special operations personnel"
+	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile. This pair has been hardened for special operations personnel."
 	emp_proof = TRUE
 	origin_tech = "materials=6;programming=5;biotech=7;magnets=6;syndicate=3"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds EMP proof versions of thermal and x ray eyes and adds them to the autosurgeon kit of their respective type for nukies
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Since eyes if nukies spent TC on thermals or X ray it would render them vulnerable to EMPs making it so a single one can permanently and fully blind them, people caught onto this and began Ioning nukies on purpose and it has lead to many nuke op rounds being ruined for the operatives who didn't know that the eyes would make them go blind if EMPed. Before the eye change they were EMP immune and since it was not the intended goal of that change this once again allows nukies to have thermal and X-rays without it being detrimental to them, it also stops a players round from being ruined and the fight with the operatives being quick and underwhelming. This does not remove the orignal EMP vulnerable ones and the new hardened ones are not available to be printed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Changelog
:cl:
add: Hardened thermal eyes and Hardened X ray eyes
tweak: changed the X ray eyes on SOOs to Hardened ones, X-ray and thermal autoimplanter kits available to nuke ops now contain hardened version of their respective eyes instead of the previous EMP vulnerable ones
del: Normal X-Ray and normal thermal eyes from nuke ops autosurgeon kits

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
