### PR TITLE
Gives PRRs qdel log ingame

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -263,6 +263,8 @@ GLOBAL_LIST_INIT(admin_verbs_ticket, list(
 			verbs += GLOB.admin_verbs_proccall
 		if(holder.rights & R_VIEWRUNTIMES)
 			verbs += /client/proc/view_runtimes
+			verbs += /client/proc/cmd_display_del_log
+			verbs += /client/proc/cmd_display_del_log_simple
 			spawn(1) // This setting exposes the profiler for people with R_VIEWRUNTIMES. They must still have it set in cfg/admin.txt
 				control_freak = 0
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -790,7 +790,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	set name = "Display del() Log"
 	set desc = "Display del's log of everything that's passed through it."
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_DEBUG|R_VIEWRUNTIMES))
 		return
 
 	var/list/dellog = list("<B>List of things that have gone through qdel this round</B><BR><BR><ol>")
@@ -822,7 +822,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	set name = "Display Simple del() Log"
 	set desc = "Display a compacted del's log."
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_DEBUG|R_VIEWRUNTIMES))
 		return
 
 	var/dat = "<B>List of things that failed to GC this round</B><BR><BR>"


### PR DESCRIPTION
## What Does This PR Do
Gives PRRs access to the qdel log ingame
![image](https://user-images.githubusercontent.com/25063394/119272992-bead9180-bc00-11eb-8ec5-2bad6e98d7d5.png)

## Why It's Good For The Game
They already have:
- Runtimes
- MC
- Profiler

It makes sense to give them this as they can use it to narrow down GC issues when a round is lagging hard.
![image](https://user-images.githubusercontent.com/25063394/119273004-d2f18e80-bc00-11eb-842f-8e38618e6eeb.png)


## Changelog
:cl: AffectedArc07
add: PR Reviewers can now see the ingame qdel log
/:cl:
