### PR TITLE
Poly can no longer grab inside disposals.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -562,8 +562,8 @@
 	if(held_item)
 		to_chat(src, "<span class='warning'>You are already holding [held_item]</span>")
 		return 1
-	if(istype(loc,/obj/machinery/disposal) || istype(loc,/obj/structure/disposalholder))
-		to_chat(src,"<span class='warning'>You are inside a disposal chute!</span>")
+	if(istype(loc, /obj/machinery/disposal) || istype(loc, /obj/structure/disposalholder))
+		to_chat(src, "<span class='warning'>You are inside a disposal chute!</span>")
 		return 1
 	for(var/obj/item/I in view(1, src))
 		//Make sure we're not already holding it and it's small enough

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -562,7 +562,9 @@
 	if(held_item)
 		to_chat(src, "<span class='warning'>You are already holding [held_item]</span>")
 		return 1
-
+	if(istype(loc,/obj/machinery/disposal) || istype(loc,/obj/structure/disposalholder))
+		to_chat(src,"<span class='warning'>You are inside a disposal chute!</span>")
+		return 1
 	for(var/obj/item/I in view(1, src))
 		//Make sure we're not already holding it and it's small enough
 		if(I.loc != src && I.w_class <= WEIGHT_CLASS_SMALL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Poly will no longer grab null items while inside disposals or being flushed. Instead a message appears telling you that you are inside a disposal chute. Fixes #16053.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So players don't have to see bugged messages, and will instead receive an accurate description of why they can't perform an action.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Iwanabeu
fix: Poly can't grab null items in a disposal chute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
