### PR TITLE
Adds a [station] pencode macro to display the current map name

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -514,6 +514,7 @@
 		text = replacetext(text, "\[logo\]",	"&ZeroWidthSpace;<img src = ntlogo.png>")
 		text = replacetext(text, "\[time\]",	"[station_time_timestamp()]") // TO DO
 		text = replacetext(text, "\[date\]",	"[GLOB.current_date_string]")
+		text = replacetext(text, "\[station\]", "[SSmapping.map_datum.fluff_name]")
 		if(!no_font)
 			if(P)
 				text = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[text]</font>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a `[station]` pencode macro, similar to `[sign]` or `[logo]`, which is replaced with the current station name as defined by `SSmapping.map_datum.fluff_name`.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Map Rotation has been merged now, and a whole lotta paperwork still just says "NSS Cyberiad" on it. Having this will allow for paperwork templates to work between maps.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
<details>
<summary><b>Examples:</b></summary>

**Pencode:**
![station 0](https://user-images.githubusercontent.com/57483089/119401986-2c76bd80-bcd4-11eb-9f75-617c3a61ac4a.png)

**Box:**
![station 1](https://user-images.githubusercontent.com/57483089/119402005-326c9e80-bcd4-11eb-95fb-f25964f4f470.png)

**Delta:**
![station 2](https://user-images.githubusercontent.com/57483089/119402186-811a3880-bcd4-11eb-91cc-7666c11c46fc.png)

**Meta:**
![station 3](https://user-images.githubusercontent.com/57483089/119402200-84adbf80-bcd4-11eb-907f-81fae080d84d.png)

</details>

## Changelog
:cl:
add: Adds a [station] pencode macro for paperwork, which displays the full name of the current station. (NSS Cyberiad, NSS Kerberos, NSS Cerebron, etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
