### PR TITLE
Refactors and tweaks reactive armours

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -318,7 +318,9 @@
 	if(prob(hit_reaction_chance))
 		if(istype(hitby, /obj/item/projectile))
 			var/obj/item/projectile/P = hitby
-			if(!P.nodamage)
+			if(istype(P, /obj/item/projectile/ion))
+				return FALSE
+			if(!P.nodamage || P.stun)
 				return TRUE
 		else
 			return TRUE
@@ -357,7 +359,9 @@
 
 /obj/item/clothing/suit/armor/reactive/fire
 	name = "reactive incendiary armor"
-	desc = "This armor uses the power of a pyro anomaly core to shoot protective jets of fire."
+	desc = "This armor uses the power of a pyro anomaly core to shoot protective jets of fire, in addition to absorbing all damage from fire."
+	heat_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS | HEAD
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
@@ -368,7 +372,6 @@
 			if(C != owner)
 				C.fire_stacks += 8
 				C.IgniteMob()
-		owner.fire_stacks = -20
 		return TRUE
 	return FALSE
 
@@ -387,9 +390,11 @@
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.alpha = 0
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		spawn(40)
-			owner.alpha = initial(owner.alpha)
+		addtimer(CALLBACK(src, .proc/remove_invisible, owner), 4 SECONDS)
 		return TRUE
+
+/obj/item/clothing/suit/armor/reactive/stealth/proc/remove_invisible(mob/living/carbon/human/owner)
+	owner.alpha = initial(owner.alpha)
 
 /obj/item/clothing/suit/armor/reactive/tesla
 	name = "reactive tesla armor"
@@ -416,37 +421,42 @@
 	var/repulse_power = 3
 	/// How far away are we finding things to throw
 	var/repulse_range = 5
+	/// What the sparkles looks like
+	var/sparkle_path = /obj/effect/temp_visual/gravpush
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
 	if(reaction_check(hitby))
 		owner.visible_message("<span class='danger'>[src] blocks [attack_text], converting the attack into a wave of force!</span>")
-		var/list/thrownatoms = list()
+		var/list/thrown_atoms = list()
 		for(var/turf/T in range(repulse_range, owner)) //Done this way so things don't get thrown all around hilariously.
 			for(var/atom/movable/AM in T)
-				thrownatoms += AM
+				thrown_atoms += AM
 
-		for(var/am in thrownatoms)
+		for(var/am in thrown_atoms)
 			var/atom/movable/AM = am
 			if(AM == owner || AM.anchored)
 				continue
 
-			var/throwtarget = get_edge_target_turf(owner, get_dir(owner, get_step_away(AM, owner)))
-			var/distfromuser = get_dist(owner, AM)
-			if(distfromuser == 0)
+			var/throw_target = get_edge_target_turf(owner, get_dir(owner, get_step_away(AM, owner)))
+			var/dist_from_user = get_dist(owner, AM)
+			if(dist_from_user == 0)
 				if(isliving(AM))
 					var/mob/living/M = AM
 					M.Weaken(3)
 					to_chat(M, "<span class='userdanger'>You're slammed into the floor by [owner]'s reactive armor!</span>")
 			else
+				new sparkle_path(get_turf(AM), get_dir(owner, AM))
 				if(isliving(AM))
 					var/mob/living/M = AM
 					to_chat(M, "<span class='userdanger'>You're thrown back by the [owner]'s reactive armor!</span>")
-				spawn(0)
-					AM.throw_at(throwtarget, ((clamp((repulse_power - (clamp(distfromuser - 2, 0, distfromuser))), 3, repulse_power))), 1)//So stuff gets tossed around at the same time.
+				INVOKE_ASYNC(src, .proc/repulse, AM, throw_target, repulse_power, dist_from_user)//So stuff gets tossed around at the same time.
 		disable(rand(2, 5))
 		return TRUE
+
+/obj/item/clothing/suit/armor/reactive/repulse/proc/repulse(atom/movable/AM, throw_target, repulse_power, dist_from_user)
+	AM.throw_at(throw_target, ((clamp((repulse_power - (clamp(dist_from_user - 2, 0, dist_from_user))), 3, repulse_power))), 1)
 
 //All of the armor below is mostly unused
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -390,11 +390,11 @@
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.alpha = 0
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
-		addtimer(CALLBACK(src, .proc/remove_invisible, owner), 4 SECONDS)
+		addtimer(CALLBACK(owner, /mob/living/.proc/reset_alpha), 4 SECONDS)
 		return TRUE
 
-/obj/item/clothing/suit/armor/reactive/stealth/proc/remove_invisible(mob/living/carbon/human/owner)
-	owner.alpha = initial(owner.alpha)
+/mob/living/proc/reset_alpha(mob/living/carbon/human/owner)
+	alpha = initial(alpha)
 
 /obj/item/clothing/suit/armor/reactive/tesla
 	name = "reactive tesla armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -451,12 +451,9 @@
 				if(isliving(AM))
 					var/mob/living/M = AM
 					to_chat(M, "<span class='userdanger'>You're thrown back by the [owner]'s reactive armor!</span>")
-				INVOKE_ASYNC(src, .proc/repulse, AM, throw_target, repulse_power, dist_from_user)//So stuff gets tossed around at the same time.
+				INVOKE_ASYNC(AM, /atom/movable/.proc/throw_at, throw_target, ((clamp((repulse_power - (clamp(dist_from_user - 2, 0, dist_from_user))), 3, repulse_power))), 1) //So stuff gets tossed around at the same time.
 		disable(rand(2, 5))
 		return TRUE
-
-/obj/item/clothing/suit/armor/reactive/repulse/proc/repulse(atom/movable/AM, throw_target, repulse_power, dist_from_user)
-	AM.throw_at(throw_target, ((clamp((repulse_power - (clamp(dist_from_user - 2, 0, dist_from_user))), 3, repulse_power))), 1)
 
 //All of the armor below is mostly unused
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reactive armours no longer block or get activated by ion shots.
Reactive armours now block tasers.
Pyro armour is now fully fire proof instead of giving you negative fire stacks when it hits.
Repulse armour makes sparkly pulses when it activates.
Removes a couple of spawns from the code.

## Why It's Good For The Game

Ions currently have the habit of disabling the armour, but then the armour procs teleporting them away/stunning/damaging you, so you cannot follow up on it, affectively neutralising this weakness 50% of the time if you hit them directly. 

Tasers should be blocked, they are dangerous to the user and doesn't make much sense for them not to be blocked.

Pyro armour is already *sorta* fire proof, but the way it is done is very janky. negative fire stacks is very clunky in my opinion, and just making the wearer immune to fire is a much better solution.

Repulse armour making sparkles is cool, and fits in with the theme of a force wave pushing you back.

Spawns are generally bad and should be removed

## Changelog
:cl:
add: reactive repulse armour now makes sparkles
tweak: Reactive armours now block tasers. They now don't block/get triggered by Ions.
tweak: incendiary armour is properly fireproof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
