### PR TITLE
Candles Typo Fix

### DIFF
--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -32,7 +32,7 @@
 	path = /obj/item/storage/box/matches
 
 /datum/gear/candlebox
-	display_name = "a box candles"
+	display_name = "a box of candles"
 	description = "For setting the mood or for occult rituals."
 	path = /obj/item/storage/fancy/candle_box/full
 


### PR DESCRIPTION
## What Does This PR Do
Fixes a typo in the loadout.

## Why It's Good For The Game
See above.

## Changelog
:cl:
spellcheck: Fixed a loadout typo
/:cl:
