### PR TITLE
Fixes the bridge being the staff meeting room and other area related issues

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(cell_logs, list())
 GLOBAL_LIST_INIT(navigation_computers, list())
 
 GLOBAL_LIST_INIT(all_areas, list())
+GLOBAL_LIST_INIT(all_unique_areas, list()) // List of all unique areas. AKA areas with there_can_be_many = FALSE
 GLOBAL_LIST_INIT(machines, list())
 GLOBAL_LIST_INIT(rcd_list, list()) //list of Rapid Construction Devices.
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -75,6 +75,12 @@
 	///Used to decide what the maximum time between ambience is
 	var/max_ambience_cooldown = 90 SECONDS
 
+/area/New(loc, ...)
+	if(!there_can_be_many) // Has to be done in New else the maploader will fuck up and find subtypes for the parent
+		GLOB.all_unique_areas[type] = src
+	..()
+
+
 /area/Initialize(mapload)
 	GLOB.all_areas += src
 	icon_state = ""

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -475,7 +475,9 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 		if(initial(A.there_can_be_many))
 			area_list[A] = new A
 		else
-			area_list[A] = locate(A)
+			if(!GLOB.all_unique_areas[A])
+				GLOB.all_unique_areas[A] = new A // No locate here else it will find a subtype of the one we're looking for
+			area_list[A] = GLOB.all_unique_areas[A]
 
 	return area_list[A]
 


### PR DESCRIPTION
## What Does This PR Do
Makes it so that dynamically loaded unique rooms are used correctly. `/area/bridge` was required. But `/area/bridge/meeting` was already there so the `locate` returned that.
Fixes #16091

## Why It's Good For The Game
No more breaks in the bridge

## Changelog
:cl:
fix: Fixes dynamically loaded unique areas becoming the wrong area. Bridge turning into the break room
/:cl:
