### PR TITLE
Fixes the maploader incorrectly loading list values. Fixing the AI upload turret control

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -374,45 +374,51 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 		if(equal_position) // associative var, so do the association
 			var/trim_right = trim_text(copytext(text, equal_position + 1, position)) // the content of the variable
 
-			// Check for string
-			// Make it read to the next delimiter, instead of the quote
-			if(findtext(trim_right, quote, 1, 2))
-				var/endquote = findtext(trim_right, quote, -1)
-				if(!endquote)
-					log_runtime(EXCEPTION("Terminating quote not found!"), src)
-				// Our map writer escapes quotes and curly brackets to avoid
-				// letting our simple parser choke on meanly-crafted names/etc
-				// - so we decode it here so it's back to good ol' legibility
-				trim_right = dmm_decode(copytext(trim_right, 2, endquote))
-
-			// Check for number
-			else if(isnum(text2num(trim_right)))
-				trim_right = text2num(trim_right)
-
-			// Check for null
-			else if(trim_right == "null")
-				trim_right = null
-
-			// Check for list
-			else if(copytext(trim_right, 1, 5) == "list")
-				trim_right = readlist(copytext(trim_right, 6, length(trim_right)))
-
-			// Check for file
-			else if(copytext(trim_right, 1, 2) == "'")
-				trim_right = file(copytext(trim_right, 2, length(trim_right)))
-
-			// Check for path
-			else if(ispath(text2path(trim_right)))
-				trim_right = text2path(trim_right)
-
-			to_return[trim_left] = trim_right
+			to_return[trim_left] = parse_value(trim_right)
 
 		else// simple var
-			to_return[trim_left] = null
+			to_return += parse_value(trim_left)
 
 	while(position != 0)
 
 	return to_return
+/**
+ * Tries to parse the given value_text. Will fallback on the value_text as a string if it fails
+ */
+/datum/dmm_suite/proc/parse_value(value_text)
+	// Check for string
+	// Make it read to the next delimiter, instead of the quote
+	if(findtext(value_text, quote, 1, 2))
+		var/endquote = findtext(value_text, quote, -1)
+		if(!endquote)
+			log_runtime(EXCEPTION("Terminating quote not found!"), src)
+		// Our map writer escapes quotes and curly brackets to avoid
+		// letting our simple parser choke on meanly-crafted names/etc
+		// - so we decode it here so it's back to good ol' legibility
+		. = dmm_decode(copytext(value_text, 2, endquote))
+
+	// Check for number
+	else if(isnum(text2num(value_text)))
+		. = text2num(value_text)
+
+	// Check for null
+	else if(value_text == "null")
+		. = null
+
+	// Check for list
+	else if(copytext(value_text, 1, 5) == "list")
+		. = readlist(copytext(value_text, 6, length(value_text)))
+
+	// Check for file
+	else if(copytext(value_text, 1, 2) == "'")
+		. = file(copytext(value_text, 2, length(value_text)))
+
+	// Check for path
+	else if(ispath(text2path(value_text)))
+		. = text2path(value_text)
+
+	else
+		. = value_text // Assume it is a string without quotes
 
 /datum/dmm_suite/Destroy()
 	..()

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -391,7 +391,7 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 	if(findtext(value_text, quote, 1, 2))
 		var/endquote = findtext(value_text, quote, -1)
 		if(!endquote)
-			log_runtime(EXCEPTION("Terminating quote not found!"), src)
+			stack_trace("Terminating quote not found!")
 		// Our map writer escapes quotes and curly brackets to avoid
 		// letting our simple parser choke on meanly-crafted names/etc
 		// - so we decode it here so it's back to good ol' legibility


### PR DESCRIPTION
## What Does This PR Do
Makes it so that list values actually get parsed instead of just added to the list as strings.
Fixes the ai upload turret console not being swipeable. (and maybe other things)

Also improves the logging when a terminating quote is not found. It now just uses `stack_trace` which should have everything your heart desires

Fixes #16090

It was caused due to the DME having this as declaration
```
/obj/machinery/turretid/stun{
	control_area = "\improper AI Upload Chamber";
	name = "AI Upload Turret Control";
	pixel_x = 0;
	pixel_y = -24;
	req_access = list(75)
	},
```
Other things use `req_access_txt`. However, just changing this instance will still leave the list value bug for other (more) valid cases.

## Why It's Good For The Game
Bug b gone

## Changelog
:cl:
fix: Fixes lists being incorrectly filled when dynamically loading a map. Fixing the AI upload turret console and maybe more things.
/:cl: