### PR TITLE
Allows (D)eswords to cut through walls like a welder

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -211,6 +211,7 @@
 	brightness_on = 0
 	sharp_when_wielded = FALSE // It's a toy
 	needs_permit = FALSE
+	toy = TRUE
 
 /obj/item/twohanded/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -18,6 +18,8 @@
 	light_power = 2
 	var/brightness_on = 2
 	var/colormap = list(red=LIGHT_COLOR_RED, blue=LIGHT_COLOR_LIGHTBLUE, green=LIGHT_COLOR_GREEN, purple=LIGHT_COLOR_PURPLE, rainbow=LIGHT_COLOR_WHITE)
+	///Is the energy weapon able to cut down walls?
+	var/can_cut_walls = TRUE
 
 /obj/item/melee/energy/attack(mob/living/target, mob/living/carbon/human/user)
 	var/nemesis_faction = FALSE
@@ -269,6 +271,7 @@
 	sharp = TRUE
 	faction_bonus_force = 30
 	nemesis_factions = list("mining", "boss")
+	can_cut_walls = FALSE //not really an energy weapon
 	var/transform_cooldown
 	var/swiping = FALSE
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -280,7 +280,6 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
-	toolspeed = 1
 	light_power = 2
 	needs_permit = TRUE
 	var/brightness_on = 2

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -280,6 +280,7 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
+	toolspeed = 1
 	light_power = 2
 	needs_permit = TRUE
 	var/brightness_on = 2

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -284,6 +284,7 @@
 	needs_permit = TRUE
 	var/brightness_on = 2
 	var/colormap = list(red=LIGHT_COLOR_RED, blue=LIGHT_COLOR_LIGHTBLUE, green=LIGHT_COLOR_GREEN, purple=LIGHT_COLOR_PURPLE, rainbow=LIGHT_COLOR_WHITE)
+	var/toy = FALSE //Is this a toy?
 
 /obj/item/twohanded/dualsaber/New()
 	..()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -371,28 +371,25 @@
 	return FALSE
 
 /turf/simulated/wall/proc/try_decon(obj/item/I, mob/user, params)
+	var/cutting = FALSE
+	var/speed = 10 //Time to cut down the wall, plasmacutter is faster
 	if(istype(I, /obj/item/gun/energy/plasmacutter))
-		to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
-		playsound(src, I.usesound, 100, 1)
-		if(do_after(user, I.toolspeed * 6 SECONDS, target = src))
-			cut_down(I, user)
-			return TRUE
-	if(istype(I, /obj/item/melee/energy))
+		cutting = TRUE
+		speed = 6
+	else if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/O = I
-		if(O.can_cut_walls && O.active)
-			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
-			playsound(src, 'sound/items/welder.ogg', 100, TRUE)
-			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
-				cut_down(I, user)
-				return TRUE
-	if(istype(I, /obj/item/twohanded/dualsaber))
+		cutting = O.can_cut_walls && O.active
+	else if(istype(I, /obj/item/twohanded/dualsaber))
 		var/obj/item/twohanded/dualsaber/O = I
-		if(O.wielded && !O.toy)
-			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
-			playsound(src, 'sound/items/welder.ogg', 100, 1)
-			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
-				cut_down(I, user)
-				return TRUE
+		cutting = O.wielded && !O.toy
+	if(!cutting)
+		return FALSE
+
+	to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
+	playsound(src, 'sound/items/welder.ogg', 100, TRUE)
+	if(do_after(user, I.toolspeed * speed SECONDS, target = src))
+		cut_down(I, user)
+		return TRUE
 	return FALSE
 
 /turf/simulated/wall/proc/cut_down(obj/item/I, mob/living/user, params)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -370,7 +370,7 @@
 		return TRUE
 	return FALSE
 
-/turf/simulated/wall/proc/try_decon(obj/item/I, mob/living/user, params)
+/turf/simulated/wall/proc/try_decon(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/gun/energy/plasmacutter))
 		to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
 		playsound(src, I.usesound, 100, 1)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -370,15 +370,36 @@
 		return TRUE
 	return FALSE
 
-/turf/simulated/wall/proc/try_decon(obj/item/I, mob/user, params)
+/turf/simulated/wall/proc/try_decon(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/gun/energy/plasmacutter))
 		to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
 		playsound(src, I.usesound, 100, 1)
-
 		if(do_after(user, istype(sheet_type, /obj/item/stack/sheet/mineral/diamond) ? 120 * I.toolspeed : 60 * I.toolspeed, target = src))
 			to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
 			dismantle_wall()
-			visible_message("<span class='warning'>[user] slices apart [src]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
+			visible_message("<span class='warning'>[user] slices apart [src] with [I]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
+			return TRUE
+	if(istype(I, /obj/item/melee/energy))
+		var/obj/item/melee/energy/O = I
+		if(O.can_cut_walls && O.active)
+			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
+			playsound(src, 'sound/items/welder.ogg', 100, 1)
+			user.flash_eyes(2) // This isn't a precision tool like a plasmacutter, this is gonna hurt
+			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
+				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
+				dismantle_wall()
+				visible_message("<span class='warning'>[user] slices apart [src] with [O]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
+				return TRUE
+	if(istype(I, /obj/item/twohanded/dualsaber))
+		var/obj/item/twohanded/dualsaber/O = I
+		if(O.wielded && !(istype(O, /obj/item/twohanded/dualsaber/toy)))
+			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
+			playsound(src, 'sound/items/welder.ogg', 100, 1)
+			user.flash_eyes(2) // This isn't a precision tool like a plasmacutter, this is gonna hurt
+			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
+				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
+				dismantle_wall()
+				visible_message("<span class='warning'>[user] slices apart [src] with [O]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
 			return TRUE
 
 	return FALSE

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -383,7 +383,7 @@
 		var/obj/item/melee/energy/O = I
 		if(O.can_cut_walls && O.active)
 			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
-			playsound(src, 'sound/items/welder.ogg', 100, 1)
+			playsound(src, 'sound/items/welder.ogg', 100, TRUE)
 			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
 				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
 				dismantle_wall()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -374,10 +374,8 @@
 	if(istype(I, /obj/item/gun/energy/plasmacutter))
 		to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
 		playsound(src, I.usesound, 100, 1)
-		if(do_after(user, istype(sheet_type, /obj/item/stack/sheet/mineral/diamond) ? 120 * I.toolspeed : 60 * I.toolspeed, target = src))
-			to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
-			dismantle_wall()
-			visible_message("<span class='warning'>[user] slices apart [src] with [I]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
+		if(do_after(user, I.toolspeed * 6 SECONDS, target = src))
+			cut_down(I, user)
 			return TRUE
 	if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/O = I
@@ -385,22 +383,22 @@
 			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
 			playsound(src, 'sound/items/welder.ogg', 100, TRUE)
 			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
-				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
-				dismantle_wall()
-				visible_message("<span class='warning'>[user] slices apart [src] with [O]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
+				cut_down(I, user)
 				return TRUE
 	if(istype(I, /obj/item/twohanded/dualsaber))
 		var/obj/item/twohanded/dualsaber/O = I
-		if(O.wielded && !(istype(O, /obj/item/twohanded/dualsaber/toy)))
+		if(O.wielded && !O.toy)
 			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
 			playsound(src, 'sound/items/welder.ogg', 100, 1)
 			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
-				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
-				dismantle_wall()
-				visible_message("<span class='warning'>[user] slices apart [src] with [O]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
-			return TRUE
-
+				cut_down(I, user)
+				return TRUE
 	return FALSE
+
+/turf/simulated/wall/proc/cut_down(obj/item/I, mob/living/user, params)
+	to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
+	dismantle_wall()
+	visible_message("<span class='warning'>[user] slices apart [src] with [I]!</span>", "<span class='warning'>You hear metal being sliced apart.</span>")
 
 /turf/simulated/wall/proc/try_destroy(obj/item/I, mob/user, params)
 	var/isdiamond = istype(sheet_type, /obj/item/stack/sheet/mineral/diamond) // snowflake bullshit

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -384,7 +384,6 @@
 		if(O.can_cut_walls && O.active)
 			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
 			playsound(src, 'sound/items/welder.ogg', 100, 1)
-			user.flash_eyes(2) // This isn't a precision tool like a plasmacutter, this is gonna hurt
 			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
 				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
 				dismantle_wall()
@@ -395,7 +394,6 @@
 		if(O.wielded && !(istype(O, /obj/item/twohanded/dualsaber/toy)))
 			to_chat(user, "<span class='notice'>You begin slicing through the outer plating.</span>")
 			playsound(src, 'sound/items/welder.ogg', 100, 1)
-			user.flash_eyes(2) // This isn't a precision tool like a plasmacutter, this is gonna hurt
 			if(do_after(user, O.toolspeed * 10 SECONDS, target = src))
 				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
 				dismantle_wall()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Allows energy and dual swords to cut through walls like a welder. Does not work on reinforced walls.
Changes the message slightly for plasmacutters and esword wall welding to mention what was used to cut the wall down.
Adds a toolspeed of 1 to dual eswords
Adds a can_cut_walls variable to energy melee weapons,  mainly used on the cleaving saw to be false.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Mainly because it is cool, and everyone wants to summon their inner Darth Vader to slice down a wall with their esword.

This doesn't really have any major balence issues either, welding tools already were small, and could be carried just as easy as an esword, not to mention you can find them everywhere. The esword takes just as long as a welder, it is no more effective than a welder, and can not be used to unweld or weld doors, or repair stuff like a welder. Plus, if you are welding down a wall with an esword, 50/50 someone is going to come up to you and disarm you anyway.

## Changelog
:cl:
tweak: You can now weld down walls with an energy sword or dual energy sword.
tweak: Plasmacutters no longer take extra time to deconstruct diamond walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
