### PR TITLE
Makes Display Cases Emaggable

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -35,11 +35,12 @@
 	QDEL_NULL(showpiece)
 	return ..()
 
-/obj/structure/displaycase/emag_act(user as mob)
+/obj/structure/displaycase/emag_act(mob/user)
 	if(!emagged)
 		to_chat(user, "<span class ='warning'>You override the ID lock on the [src].</span>")
+		trigger_alarm()
 
-		emagged = 1
+		emagged = TRUE
 
 /obj/structure/displaycase/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -35,10 +35,18 @@
 	QDEL_NULL(showpiece)
 	return ..()
 
+/obj/structure/displaycase/emag_act(user as mob)
+	if(!emagged)
+		to_chat(user, "<span class ='warning'>You override the ID lock on the [src].</span>")
+
+		emagged = 1
+
 /obj/structure/displaycase/examine(mob/user)
 	. = ..()
 	if(alert)
 		. += "<span class='notice'>Hooked up with an anti-theft system.</span>"
+	if(emagged)
+		. += "<span class='warning'>The ID lock has been shorted out.</span>"
 	if(showpiece)
 		. += "<span class='notice'>There's [showpiece] inside.</span>"
 	if(trophy_message)
@@ -100,7 +108,7 @@
 
 /obj/structure/displaycase/attackby(obj/item/I, mob/user, params)
 	if(I.GetID() && !broken && openable)
-		if(allowed(user))
+		if(allowed(user) || emagged)
 			to_chat(user,  "<span class='notice'>You [open ? "close":"open"] [src].</span>")
 			toggle_lock(user)
 		else

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -37,7 +37,7 @@
 
 /obj/structure/displaycase/emag_act(mob/user)
 	if(!emagged)
-		to_chat(user, "<span class='warning'>You override the ID lock on the [src].</span>")
+		to_chat(user, "<span class='warning'>You override the ID lock on [src].</span>")
 		trigger_alarm()
 
 		emagged = TRUE

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -37,7 +37,7 @@
 
 /obj/structure/displaycase/emag_act(mob/user)
 	if(!emagged)
-		to_chat(user, "<span class ='warning'>You override the ID lock on the [src].</span>")
+		to_chat(user, "<span class='warning'>You override the ID lock on the [src].</span>")
 		trigger_alarm()
 
 		emagged = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds the ability to emag display cases bypassing their access requirement such as the case containing the Captain's antique laser. Note, this does still set off an alarm
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The inability to emag a display case is arguably confusing, unlike every other "locked" object or structure on the primary station display cases can only be opened with a corresponding ID, or by breaking them open which sets off an alarm if it has one built in, it's rather inconsistent. Adding the option to emag the case brings it in line with every other access restricted structure on station and adds an option for a slightly more stealthy avenue if one so wishes to take it,
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
add: Display cases can now be emagged to remove the access requirement for opening
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
