### PR TITLE
Adds a station alert level display to the join game menu

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -449,7 +449,7 @@
 
 	var/dat = "<html><body><center>"
 	dat += "Round Duration: [round(hours)]h [round(mins)]m<br>"
-	dat += "<b>The station alert level is: [get_security_level_colours()]</b><br>"
+	dat += "<b>The station alert level is: [get_security_level_colors()]</b><br>"
 
 	if(SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
 		dat += "<font color='red'><b>The station has been evacuated.</b></font><br>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -449,6 +449,7 @@
 
 	var/dat = "<html><body><center>"
 	dat += "Round Duration: [round(hours)]h [round(mins)]m<br>"
+	dat += "<b>The station alert level is: [get_security_level_colours()]</b><br>"
 
 	if(SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
 		dat += "<font color='red'><b>The station has been evacuated.</b></font><br>"

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -174,7 +174,7 @@ GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/secur
 		if("delta")
 			return SEC_LEVEL_DELTA
 
-/proc/get_security_level_colours()
+/proc/get_security_level_colors()
 	switch(GLOB.security_level)
 		if(SEC_LEVEL_GREEN)
 			return "<font color='limegreen'>Green</font>"

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -173,3 +173,18 @@ GLOBAL_DATUM_INIT(security_announcement_down, /datum/announcement/priority/secur
 			return SEC_LEVEL_EPSILON
 		if("delta")
 			return SEC_LEVEL_DELTA
+
+/proc/get_security_level_colours()
+	switch(GLOB.security_level)
+		if(SEC_LEVEL_GREEN)
+			return "<font color='limegreen'>Green</font>"
+		if(SEC_LEVEL_BLUE)
+			return "<font color='dodgerblue'>Blue</font>"
+		if(SEC_LEVEL_RED)
+			return "<font color='red'>Red</font>"
+		if(SEC_LEVEL_GAMMA)
+			return "<font color='gold'>Gamma</font>"
+		if(SEC_LEVEL_EPSILON)
+			return "<font color='blueviolet'>Epsilon</font>"
+		if(SEC_LEVEL_DELTA)
+			return "<font color='orangered'>Delta</font>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Adds a station alert level display to the latejoin 'Join Game!' menu, which shows a coloured display of the current alert level on the station. (Green, Blue, Red, Gamma, Epsilon, Delta)
This uses more or less the same system as the description on the hub, I've just added some colours.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The majority of players (I'd assume, anyway) connect to the server via the hub, so they would get this information anyway. Adding it here is really just a QOL thing.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
<details>
<summary><b>Lots of pictures:</b></summary>

### Current:
![0](https://user-images.githubusercontent.com/57483089/119744481-08f27500-be84-11eb-8a14-4b1c855d806c.png)
**Reference hub images:**
![image](https://user-images.githubusercontent.com/57483089/119745384-ecefd300-be85-11eb-9a5b-db0c7b506d91.png)
![image](https://user-images.githubusercontent.com/57483089/119745778-b9617880-be86-11eb-95a8-7f099cae77bf.png)

<hr>

### New:
![1](https://user-images.githubusercontent.com/57483089/119744486-0bed6580-be84-11eb-8e51-57fafadbc873.png)
![2](https://user-images.githubusercontent.com/57483089/119744489-0db72900-be84-11eb-95db-c08fdcb64ade.png)
![3](https://user-images.githubusercontent.com/57483089/119744491-0ee85600-be84-11eb-9e7b-675a0624afd9.png)
![4](https://user-images.githubusercontent.com/57483089/119744494-10198300-be84-11eb-98ff-e24a732f35eb.png)
![5](https://user-images.githubusercontent.com/57483089/119744499-114ab000-be84-11eb-8bd0-5a2dfb7cc20c.png)
![6](https://user-images.githubusercontent.com/57483089/119744772-9d5cd780-be84-11eb-9501-28ec71e520ee.png)

</details>

## Changelog
:cl:
add: Added a 'Station alert level' display to the 'Join Game' job select menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
