### PR TITLE
Stops disconnected ghosts showing on the orbit menu

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -66,7 +66,7 @@
 		if(istype(M))
 			if(isnewplayer(M))  // People in the lobby screen; only have their ckey as a name.
 				continue
-			if(isobserver(M))
+			if(isobserver(M) && M.client)
 				ghosts += list(serialized)
 			else if(M.mind == null)
 				npcs += list(serialized)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Stops observers/ghosts who have disconnected from showing on the orbit menu.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
No reason to have them listed if they're not actually there, and it helps reduce the clutter on the menu near the end of the round.

## Changelog
:cl:
tweak: Observers who have disconnected no longer show in the orbit menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
