### PR TITLE
Fixes sentience potions threatening to ban players

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -188,7 +188,7 @@
 		return
 	if(being_used || !ismob(M))
 		return
-	if(!isanimal(M) || M.ckey) //only works on animals that aren't player controlled
+	if(!isanimal(M) || M.mind) //only works on animals that aren't player controlled
 		to_chat(user, "<span class='warning'>[M] is already too intelligent for this to work!</span>")
 		return ..()
 	if(M.stat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Changes the intelligence test on xenobiology sentience potions from checking the `ckey` to checking the `mind`.
This shouldn't change anything ingame other than making sure that SSD sentient mobs can't be potion'd again, since the `mind` variable doesn't get deleted.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Prevents this chain of events from happening:
- Scientist uses a sentience potion on a mob.
- Player 1 joins as the mob, and later disconnects.
- Scientists uses a potion on the same mob again.
- Player 2 joins as the mob.
- Player 1 connects again, and kicks player 2 out.
- Player 2 gets this message and admins are warned:
![image](https://user-images.githubusercontent.com/57483089/119890882-41e82380-bf30-11eb-9ade-c5d28a5257da.png)

## Changelog
:cl:
fix: Fixed xenobio sentience potions working on disconnected player mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
