### PR TITLE
Enforces nukies to wait at least 10 minutes after war before heading to station

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -55,6 +55,7 @@
 
 	for(var/obj/machinery/computer/shuttle/syndicate/S in GLOB.machines)
 		S.challenge = TRUE
+		S.challenge_time = world.time
 
 	 // No. of player - Min. Player to dec, divided by player per bonus, then multipled by TC per bonus. Rounded.
 	total_tc = CHALLENGE_TELECRYSTALS + round((((GLOB.player_list.len - CHALLENGE_MIN_PLAYERS)/CHALLENGE_SCALE_PLAYER) * CHALLENGE_SCALE_BONUS))

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -12,6 +12,7 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags = NODECONSTRUCT
 	var/challenge = FALSE
+	var/challenge_time = 0 //When was war declared?
 
 /obj/machinery/computer/shuttle/syndicate/recall
 	name = "syndicate shuttle recall terminal"
@@ -19,9 +20,10 @@
 	possible_destinations = "syndicate_away"
 
 /obj/machinery/computer/shuttle/syndicate/can_call_shuttle(user, action)
+	var/time_to_go = max(SYNDICATE_CHALLENGE_TIMER, (challenge_time + 10 MINUTES))
 	if(action == "move")
-		if(challenge && world.time < SYNDICATE_CHALLENGE_TIMER)
-			to_chat(user, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least [round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] more minutes to allow them to prepare.</span>")
+		if(challenge && world.time < time_to_go)
+			to_chat(user, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least [round(((time_to_go - world.time) / 10) / 60)] more minutes to allow them to prepare.</span>")
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

This PR modifies the timer on the nuclear team shuttle, to wait for either the usual 20 minutes round time to launch the war shuttle, or the time war was declared +10 minutes, whichever is longer

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Nukies should not be trying to wait to the last possible second to declare war to give them less time than usual. This PR means that there will always be 10+ minutes before the nukies can head to the station, to ensure at least 10 minutes for crew to have a fair amount of time to prepare

## Changelog
:cl:
tweak: The nuclear shuttle can not be launched on war for 20 minutes, or 10 minutes after war was declared, whichever is longer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
