### PR TITLE
Fixes soulstones ignoring DNR or AntagHUD settings

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -178,12 +178,10 @@
 /mob/living/carbon/med_hud_set_status()
 	var/image/holder = hud_list[STATUS_HUD]
 	var/mob/living/simple_animal/borer/B = has_brain_worms()
-	var/dead = stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH)
 	// To the right of health bar
-	if(dead)
-		var/mob/dead/observer/ghost = get_ghost(TRUE)
+	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/revivable
-		if(ghost && !ghost.can_reenter_corpse) // DNR or AntagHUD
+		if(!ghost_can_reenter()) // DNR or AntagHUD
 			revivable = FALSE
 		else if(timeofdeath && (round(world.time - timeofdeath) < DEFIB_TIME_LIMIT))
 			revivable = TRUE

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -595,7 +595,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 			return
 		sacrifices_used += SOULS_TO_REVIVE
 		mob_to_revive.revive()
-		mob_to_revive.grab_ghost()
+		if(mob_to_revive.ghost_can_reenter())
+			mob_to_revive.grab_ghost()
 
 	if(!mob_to_revive.client || mob_to_revive.client.is_afk())
 		set waitfor = FALSE

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -257,17 +257,17 @@
 		return ..()
 
 ////////////////////////////Proc for moving soul in and out off stone//////////////////////////////////////
-
+// this whole proc is pain
 /obj/item/soulstone/proc/transfer_soul(choice, target, mob/user)
 	switch(choice)
 		if("FORCE")
 			var/mob/living/T = target
-			if(T.client != null)
+			if(T.client && T.ghost_can_reenter()) // Haven't DC'd or ahudded
 				init_shade(T, user)
-			else
+			else // Poll ghosts
 				to_chat(user, "<span class='userdanger'>Capture failed!</span> The soul has already fled its mortal frame. You attempt to bring it back...")
 				T.Paralyse(20)
-				if(!get_cult_ghost(T, user))
+				if(!get_cult_ghost(T, user, TRUE))
 					T.dust() //If we can't get a ghost, kill the sacrifice anyway.
 
 		if("VICTIM")
@@ -280,7 +280,10 @@
 				else
 					if(T.client == null)
 						to_chat(user, "<span class='userdanger'>Capture failed!</span> The soul has already fled its mortal frame. You attempt to bring it back...")
-						get_cult_ghost(T, user)
+						if(T.ghost_can_reenter())
+							get_cult_ghost(T, user)
+						else
+							get_cult_ghost(T, user, TRUE)
 					else
 						if(length(contents))
 							to_chat(user, "<span class='danger'>Capture failed!</span> The soul stone is full! Use or free an existing soul to make room.")
@@ -417,13 +420,14 @@
 		return /mob/living/simple_animal/shade/holy
 	return /mob/living/simple_animal/shade/cult
 
-/obj/item/soulstone/proc/get_cult_ghost(mob/living/M, mob/user)
+/obj/item/soulstone/proc/get_cult_ghost(mob/living/M, mob/user, get_new_player = FALSE)
 	var/mob/dead/observer/chosen_ghost
 
-	for(var/mob/dead/observer/ghost in GLOB.player_list) // We put them back in their body
-		if(ghost.mind && ghost.mind.current == M && ghost.client)
-			chosen_ghost = ghost
-			break
+	if(!get_new_player)
+		for(var/mob/dead/observer/ghost in GLOB.player_list) // We put them back in their body
+			if(ghost.mind && ghost.mind.current == M && ghost.client)
+				chosen_ghost = ghost
+				break
 
 	if(!chosen_ghost) // Failing that, we grab a ghost
 		var/list/consenting_candidates

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -280,10 +280,7 @@
 				else
 					if(T.client == null)
 						to_chat(user, "<span class='userdanger'>Capture failed!</span> The soul has already fled its mortal frame. You attempt to bring it back...")
-						if(T.ghost_can_reenter())
-							get_cult_ghost(T, user)
-						else
-							get_cult_ghost(T, user, TRUE)
+						get_cult_ghost(T, user, get_new_player = !T.ghost_can_reenter())
 					else
 						if(length(contents))
 							to_chat(user, "<span class='danger'>Capture failed!</span> The soul stone is full! Use or free an existing soul to make room.")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -132,8 +132,7 @@ REAGENT SCANNER
 	var/BR = H.getBruteLoss() > 50 	? 	"<b>[H.getBruteLoss()]</b>" 	: H.getBruteLoss()
 
 	var/status = "<font color='red'>Dead</font>" // Dead by default to make it simpler
-	var/mob/dead/observer/ghost = H.get_ghost(TRUE)
-	var/DNR = (ghost && !ghost.can_reenter_corpse)
+	var/DNR = !H.ghost_can_reenter() // If the ghost can't reenter
 	if(H.stat == DEAD)
 		if(DNR)
 			status = "<font color='red'>Dead <b>\[DNR]</b></font>"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -509,6 +509,17 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 						alert_overlay.plane = FLOAT_PLANE
 						A.overlays += alert_overlay
 
+/**
+  * Checks if a mob's ghost can reenter their body or not. Used to check for DNR or AntagHUD.
+  *
+  * Returns FALSE if the ghost can't reenter the body, and TRUE if they can.
+  */
+/mob/proc/ghost_can_reenter()
+	var/mob/dead/observer/ghost = get_ghost(TRUE)
+	if(ghost && !ghost.can_reenter_corpse)
+		return FALSE
+	return TRUE
+
 /mob/proc/switch_to_camera(obj/machinery/camera/C)
 	if(!C.can_use() || incapacitated() || (get_dist(C, src) > 1 || machine != src || !has_vision()))
 		return FALSE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -512,7 +512,7 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 /**
   * Checks if a mob's ghost can reenter their body or not. Used to check for DNR or AntagHUD.
   *
-  * Returns FALSE if the ghost can't reenter the body, and TRUE if they can.
+  * Returns FALSE if there is a ghost, and it can't reenter the body. Returns TRUE otherwise.
   */
 /mob/proc/ghost_can_reenter()
 	var/mob/dead/observer/ghost = get_ghost(TRUE)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -774,8 +774,7 @@
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
 					M.delayed_gib()
 					return
-				var/mob/dead/observer/ghost = M.get_ghost(TRUE)
-				if(ghost && !ghost.can_reenter_corpse) // DNR or AntagHUD
+				if(!M.ghost_can_reenter())
 					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
 					return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Fixes ghosts with DNR or AntagHUD enabled being forced back into their body when soulstoned. The soulstone will instead poll ghosts for a new player.
Also added `ghost_can_reenter()` in order to make the code more compact, and added it to all the locations from #15934.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Knowing who the antags are on a cult or wizard round right before you join their side isn't going to be particularly useful, but consistency is important.

## Changelog
:cl:
fix: Fixed DNR/Antaghudded ghosts being forced back into their body when soulstoned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
